### PR TITLE
MN-Sync-Fix

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -137,7 +137,7 @@ bool CMasternode::UpdateFromNewBroadcast(CMasternodeBroadcast& mnb)
 {
     if(mnb.sigTime > sigTime) {    
         pubKeyMasternode = mnb.pubKeyMasternode;
-        pubKeyCollateralAddress = mnb.pubKeyCollateralAddress;
+// XYX       pubKeyCollateralAddress = mnb.pubKeyCollateralAddress;
         sigTime = mnb.sigTime;
         sig = mnb.sig;
         protocolVersion = mnb.protocolVersion;
@@ -316,7 +316,7 @@ CMasternodeBroadcast::CMasternodeBroadcast()
     vin = CTxIn();
     addr = CService();
     pubKeyCollateralAddress = CPubKey();
-    pubKeyMasternode1 = CPubKey();
+    pubKeyMasternode = CPubKey();
     sig = std::vector<unsigned char>();
     activeState = MASTERNODE_ENABLED;
     sigTime = GetAdjustedTime();

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -127,8 +127,6 @@ public:
     CService addr;
     CPubKey pubKeyCollateralAddress;
     CPubKey pubKeyMasternode;
-    CPubKey pubKeyCollateralAddress1;
-    CPubKey pubKeyMasternode1;
     std::vector<unsigned char> sig;
     int activeState;
     int64_t sigTime; //mnb message time


### PR DESCRIPTION
1 copy&paste error fix and obsolete testing variable removed.
src/masternodeman.cpp: 2 local variable-names changed to be consistent with global renaming