### PR TITLE
Typo fix for pubKeyMasternode

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -316,7 +316,7 @@ CMasternodeBroadcast::CMasternodeBroadcast()
     vin = CTxIn();
     addr = CService();
     pubKeyCollateralAddress = CPubKey();
-    pubKeyMasternode1 = CPubKey();
+    pubKeyMasternode = CPubKey();
     sig = std::vector<unsigned char>();
     activeState = MASTERNODE_ENABLED;
     sigTime = GetAdjustedTime();

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -127,8 +127,6 @@ public:
     CService addr;
     CPubKey pubKeyCollateralAddress;
     CPubKey pubKeyMasternode;
-    CPubKey pubKeyCollateralAddress1;
-    CPubKey pubKeyMasternode1;
     std::vector<unsigned char> sig;
     int activeState;
     int64_t sigTime; //mnb message time


### PR DESCRIPTION
It's actually part of my MN-syncing fix, but it doesn't hurt to have it now.