### PR TITLE
Fix OS X Native deploy target

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -287,6 +287,7 @@ case $host in
          fi
        fi
 
+       AC_PATH_PROGS([RSVG_CONVERT], [rsvg-convert rsvg],rsvg-convert)
        AC_CHECK_PROG([BREW],brew, brew)
        if test x$BREW = xbrew; then
          dnl These Homebrew packages may be keg-only, meaning that they won't be found
@@ -320,7 +321,6 @@ case $host in
            AC_PATH_TOOL([INSTALLNAMETOOL], [install_name_tool], install_name_tool)
            AC_PATH_TOOL([OTOOL], [otool], otool)
            AC_PATH_PROGS([GENISOIMAGE], [genisoimage mkisofs],genisoimage)
-           AC_PATH_PROGS([RSVG_CONVERT], [rsvg-convert rsvg],rsvg-convert)
            AC_PATH_PROGS([IMAGEMAGICK_CONVERT], [convert],convert)
            AC_PATH_PROGS([TIFFCP], [tiffcp],tiffcp)
 

--- a/contrib/macdeploy/fancy.plist
+++ b/contrib/macdeploy/fancy.plist
@@ -10,7 +10,7 @@
 		<integer>620</integer>
 	</array>
 	<key>background_picture</key>
-	<string>background.png</string>
+	<string>background.tiff</string>
 	<key>icon_size</key>
 	<integer>96</integer>
 	<key>applications_symlink</key>


### PR DESCRIPTION
Followup to #53 

Natively compiling on OS X needed some special hand-holding to generate the background image properly. ;)