### PR TITLE
Reposition the Block Explorer menu items

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -502,7 +502,6 @@ void BitcoinGUI::createMenuBar()
 
     QMenu *trading = appMenuBar->addMenu(tr("&Trade"));
     trading->addAction(openTradingwindowAction);
-    trading->addAction(openBlockExplorerAction);
 
     if(walletFrame)
     {
@@ -515,6 +514,7 @@ void BitcoinGUI::createMenuBar()
         tools->addSeparator();
         tools->addAction(openConfEditorAction);
         tools->addAction(showBackupsAction);
+        tools->addAction(openBlockExplorerAction);
     }
 
     QMenu *help = appMenuBar->addMenu(tr("&Help"));
@@ -687,7 +687,7 @@ void BitcoinGUI::createTrayIconMenu()
     trayIconMenu->addSeparator();
     trayIconMenu->addAction(optionsAction);
     trayIconMenu->addAction(openTradingwindowAction);
-    trayIconMenu->addAction(openBlockExplorerAction);
+    trayIconMenu->addSeparator();
     trayIconMenu->addAction(openInfoAction);
     trayIconMenu->addAction(openRPCConsoleAction);
     trayIconMenu->addAction(openNetworkAction);
@@ -696,6 +696,7 @@ void BitcoinGUI::createTrayIconMenu()
     trayIconMenu->addSeparator();
     trayIconMenu->addAction(openConfEditorAction);
     trayIconMenu->addAction(showBackupsAction);
+    trayIconMenu->addAction(openBlockExplorerAction);
 #ifndef Q_OS_MAC // This is built-in on Mac
     trayIconMenu->addSeparator();
     trayIconMenu->addAction(quitAction);


### PR DESCRIPTION
Having the block explorer menu items associated with the "Trade"
menu didn't make much sense to me, so I've relocated it to the
"Tools" menu.

Also adjusted positioning in the dock/tray icon menu to match.

fixes #61