### PR TITLE
Do not use boost copy_file if Boost < 1.58

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -38,6 +38,7 @@
 #include "keepass.h"
 #endif
 
+#include <fstream>
 #include <stdint.h>
 #include <stdio.h>
 
@@ -929,12 +930,18 @@ bool AppInit2(boost::thread_group& threadGroup)
                 sourceFile.make_preferred();
                 backupFile.make_preferred();
                 if(boost::filesystem::exists(sourceFile)) {
+#if BOOST_VERSION >= 158000
                     try {
                         boost::filesystem::copy_file(sourceFile, backupFile);
                         LogPrintf("Creating backup of %s -> %s\n", sourceFile, backupFile);
                     } catch(boost::filesystem::filesystem_error &error) {
                         LogPrintf("Failed to create backup %s\n", error.what());
                     }
+#else
+                    std::ifstream  src(sourceFile.string(), std::ios::binary);
+                    std::ofstream  dst(backupFile.string(), std::ios::binary);
+                    dst << src.rdbuf();
+#endif
                 }
                 // Keep only the last 10 backups, including the new one of course
                 typedef std::multimap<std::time_t, boost::filesystem::path> folder_set_t;

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -15,6 +15,7 @@
 #include "utiltime.h"
 #include "wallet.h"
 
+#include <fstream>
 #include <boost/filesystem.hpp>
 #include <boost/foreach.hpp>
 #include <boost/scoped_ptr.hpp>
@@ -986,10 +987,12 @@ bool BackupWallet(const CWallet& wallet, const string& strDest)
                     pathDest /= wallet.strWalletFile;
 
                 try {
-#if BOOST_VERSION >= 104000
+#if BOOST_VERSION >= 158000
                     filesystem::copy_file(pathSrc, pathDest, filesystem::copy_option::overwrite_if_exists);
 #else
-                    filesystem::copy_file(pathSrc, pathDest);
+                    std::ifstream  src(pathSrc.string(), std::ios::binary);
+                    std::ofstream  dst(pathDest.string(),   std::ios::binary);
+                    dst << src.rdbuf();
 #endif
                     LogPrintf("copied wallet.dat to %s\n", pathDest.string());
                     return true;


### PR DESCRIPTION
For older versions of Boost, which tend to be linked differently, use std::ifstream and std::ofstream to backup the wallet file instead of using boost copy_file which produces compile errors https://github.com/PIVX-Project/PIVX/issues/65