### PR TITLE
refactor CBlockIndex constructor

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -202,7 +202,7 @@ public:
         SetNull();
     }
 
-    CBlockIndex(const CBlockHeader& block)
+    CBlockIndex(const CBlock& block)
     {
         SetNull();
 
@@ -220,12 +220,12 @@ public:
         nStakeModifier = 0;
         nStakeModifierChecksum = 0;
         hashProofOfStake = 0;
-        CBlock block2(block);
-        if (block2.IsProofOfStake())
+
+        if (block.IsProofOfStake())
         {
             SetProofOfStake();
-            prevoutStake = block2.vtx[1].vin[0].prevout;
-            nStakeTime = block2.nTime;
+            prevoutStake = block.vtx[1].vin[0].prevout;
+            nStakeTime = block.nTime;
         }
         else
         {

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -165,6 +165,7 @@ public:
         fMineBlocksOnDemand = false;
         fSkipProofOfWorkCheck = false;
         fTestnetToBeDeprecatedFieldRPC = false;
+        fHeadersFirstSyncingActive = false;
 
         nPoolMaxTransactions = 3;
         strSporkKey = "0484698d3ba6ba6e7423fa5cbd6a89e0a9a5348f88d332b44a5cb1a8b7ed2c1eaa335fc8dc4f012cb8241cc0bdafd6ca70c5f5448916e4e6f511bcd746ed57dc50";

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -60,6 +60,8 @@ public:
     bool RequireRPCPassword() const { return fRequireRPCPassword; }
     /** Make miner wait to have peers to avoid wasting work */
     bool MiningRequiresPeers() const { return fMiningRequiresPeers; }
+    /** Headers first syncing is disabled */
+    bool HeadersFirstSyncingActive() const { return fHeadersFirstSyncingActive; };
     /** Default value for -checkmempool and -checkblockindex argument */
     bool DefaultConsistencyChecks() const { return fDefaultConsistencyChecks; }
     /** Allow mining of a min-difficulty block */
@@ -122,6 +124,7 @@ protected:
     bool fMineBlocksOnDemand;
     bool fSkipProofOfWorkCheck;
     bool fTestnetToBeDeprecatedFieldRPC;
+    bool fHeadersFirstSyncingActive;
     int nPoolMaxTransactions;
     std::string strSporkKey;
     std::string strMasternodePaymentsPubKey;


### PR DESCRIPTION
This addresses https://github.com/PIVX-Project/PIVX/issues/51 in which CBlockIndex is improperly downcast to CBlockHeader upon construction. This lead to some issues downstream, such as the blockindex being considered to be PoW for part of its life. 

Note that Block Header syncing is not currently part of pivx, because it is incompatible with PoS unless we make some heavy modifications. Some of this code touched headers syncing code, which needed to be changed in order for this to compile. I added HeadersFirstSyncingActive() to Params().