### PR TITLE
Include SendToSelf in COMMON_TYPES Tx filter

### DIFF
--- a/src/qt/transactionfilterproxy.h
+++ b/src/qt/transactionfilterproxy.h
@@ -25,7 +25,7 @@ public:
     /** Type filter bit field (all types) */
     static const quint32 ALL_TYPES = 0xFFFFFFFF;
     /** Type filter bit field (all types but Obfuscation-SPAM) */
-    static const quint32 COMMON_TYPES = 4223;
+    static const quint32 COMMON_TYPES = 4479;
 
     static quint32 TYPE(int type) { return 1<<type; }
 


### PR DESCRIPTION
Needs thorough testing with wallets that have a wide range of existing transaction types.

fixes #78