### PR TITLE
[Init] Remove gen command

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -384,10 +384,7 @@ std::string HelpMessage(HelpMessageMode mode)
     if (mode == HMM_BITCOIN_QT)
         strUsage += ", qt";
     strUsage += ".\n";
-#ifdef ENABLE_WALLET
-    strUsage += "  -gen                   " + strprintf(_("Generate coins (default: %u)"), 0) + "\n";
-    strUsage += "  -genproclimit=<n>      " + strprintf(_("Set the number of threads for coin generation if enabled (-1 = all cores, default: %d)"), 1) + "\n";
-#endif
+    
     strUsage += "  -help-debug            " + _("Show all debugging options (usage: --help -help-debug)") + "\n";
     strUsage += "  -logips                " + strprintf(_("Include IP addresses in debug output (default: %u)"), 0) + "\n";
     strUsage += "  -logtimestamps         " + strprintf(_("Prepend debug output with timestamp (default: %u)"), 1) + "\n";
@@ -1620,15 +1617,8 @@ bool AppInit2(boost::thread_group& threadGroup)
 #endif
 
     StartNode(threadGroup);
-
-#ifdef ENABLE_WALLET
-    // Generate coins in the background
-    if (pwalletMain)
-        GenerateBitcoins(GetBoolArg("-gen", false), pwalletMain, GetArg("-genproclimit", 1));
-#endif
-
+    
     // ********************************************************* Step 12: finished
-
     SetRPCWarmupFinished();
     uiInterface.InitMessage(_("Done loading"));
 


### PR DESCRIPTION
Since PoW is inactive, `-gen` is depreciated so it should be removed from the wallet.

Fixes issue https://github.com/PIVX-Project/PIVX/issues/81