### PR TITLE
Fix the major block corruption issues

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1226,7 +1226,7 @@ bool AppInit2(boost::thread_group& threadGroup)
 
                 uiInterface.InitMessage(_("Verifying blocks..."));
                 if (!CVerifyDB().VerifyDB(pcoinsdbview, GetArg("-checklevel", 3),
-                              GetArg("-checkblocks", 288))) {
+                              GetArg("-checkblocks", 500))) {
                     strLoadError = _("Corrupted block database detected");
                     break;
                 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -191,6 +191,9 @@ void PrepareShutdown()
         LOCK(cs_main);
         if (pcoinsTip != NULL) {
             FlushStateToDisk();
+
+            //record that client took the proper shutdown procedure
+            pblocktree->WriteFlag("shutdown", true);
         }
         delete pcoinsTip;
         pcoinsTip = NULL;
@@ -280,7 +283,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += "  -alertnotify=<cmd>     " + _("Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)") + "\n";
     strUsage += "  -alerts                " + strprintf(_("Receive and display P2P network alerts (default: %u)"), DEFAULT_ALERTS);
     strUsage += "  -blocknotify=<cmd>     " + _("Execute command when the best block changes (%s in cmd is replaced by block hash)") + "\n";
-    strUsage += "  -checkblocks=<n>       " + strprintf(_("How many blocks to check at startup (default: %u, 0 = all)"), 288) + "\n";
+    strUsage += "  -checkblocks=<n>       " + strprintf(_("How many blocks to check at startup (default: %u, 0 = all)"), 500) + "\n";
     strUsage += "  -checklevel=<n>        " + strprintf(_("How thorough the block verification of -checkblocks is (0-4, default: %u)"), 3) + "\n";
     strUsage += "  -conf=<file>           " + strprintf(_("Specify configuration file (default: %s)"), "pivx.conf") + "\n";
     if (mode == HMM_BITCOIND)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2765,7 +2765,7 @@ bool static DisconnectTip(CValidationState &state) {
     }
     LogPrint("bench", "- Disconnect block: %.2fms\n", (GetTimeMicros() - nStart) * 0.001);
     // Write the chain state to disk, if necessary.
-    if (!FlushStateToDisk(state, FLUSH_STATE_IF_NEEDED))
+    if (!FlushStateToDisk(state, FLUSH_STATE_ALWAYS))
         return false;
     // Resurrect mempool transactions from the disconnected block.
     BOOST_FOREACH(const CTransaction &tx, block.vtx) {
@@ -2831,7 +2831,7 @@ bool static ConnectTip(CValidationState &state, CBlockIndex *pindexNew, CBlock *
     int64_t nTime4 = GetTimeMicros(); nTimeFlush += nTime4 - nTime3;
     LogPrint("bench", "  - Flush: %.2fms [%.2fs]\n", (nTime4 - nTime3) * 0.001, nTimeFlush * 0.000001);
     // Write the chain state to disk, if necessary.
-    if (!FlushStateToDisk(state, FLUSH_STATE_IF_NEEDED))
+    if (!FlushStateToDisk(state, FLUSH_STATE_ALWAYS))
         return false;
     int64_t nTime5 = GetTimeMicros(); nTimeChainState += nTime5 - nTime4;
     LogPrint("bench", "  - Writing chainstate: %.2fms [%.2fs]\n", (nTime5 - nTime4) * 0.001, nTimeChainState * 0.000001);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4094,13 +4094,13 @@ bool static LoadBlockIndexDB()
     }
 
     //Check for inconsistency with block file info and internal state
-    if(vSortedByHeight.size() != vinfoBlockFile[nLastBlockFile].nBlocks && vinfoBlockFile[nLastBlockFile].nBlocks != 0)
+    if(vSortedByHeight.size() != vinfoBlockFile[nLastBlockFile].nHeightLast + 1 && vinfoBlockFile[nLastBlockFile].nHeightLast != 0)
     {
         //The database is in a state where a block has been accepted and written to disk, but not
         //all of the block has perculated through the code. The block and the index should both be
         //intact (although assertions are added if they are not), and the block will be reprocessed
         //to ensure all data will be accounted for.
-        LogPrintf("%s: Inconsistent State Detected mapBlockIndex.size()=%d blockFileBlocks=%d\n", __func__, vSortedByHeight.size(), vinfoBlockFile[nLastBlockFile].nBlocks);
+        LogPrintf("%s: Inconsistent State Detected mapBlockIndex.size()=%d blockFileBlocks=%d\n", __func__, vSortedByHeight.size(), vinfoBlockFile[nLastBlockFile].nHeightLast + 1);
         LogPrintf("%s: lastIndexPos=%d blockFileSize=%d\n", __func__, vSortedByHeight[vSortedByHeight.size() - 1].second->GetBlockPos().nPos,
                   vinfoBlockFile[nLastBlockFile].nSize);
 
@@ -4143,7 +4143,7 @@ bool static LoadBlockIndexDB()
         }
         LogPrintf("%s: last block file info: %s\n", __func__, vinfoBlockFile[nLastBlockFile].ToString());
     }
-    assert(mapBlockIndex.size() == vinfoBlockFile[nLastBlockFile].nBlocks);
+    assert(mapBlockIndex.size() == vinfoBlockFile[nLastBlockFile].nHeightLast + 1);
     
     // Check whether we need to continue reindexing
     bool fReindexing = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4099,11 +4099,11 @@ bool static LoadBlockIndexDB()
     bool fLastShutdownWasPrepared = true;
     pblocktree->ReadFlag("shutdown", fLastShutdownWasPrepared);
     LogPrintf("%s: Last shutdown was prepared: %s\n", __func__, fLastShutdownWasPrepared);
-
-    //assert(mapBlockIndex.size() == vinfoBlockFile[nLastBlockFile].nHeightLast + 1);
+    
     //Check for inconsistency with block file info and internal state
     if(!fLastShutdownWasPrepared
        && !GetBoolArg("-forcestart", false)
+       && !GetBoolArg("-reindex", false)
        && (vSortedByHeight.size() != vinfoBlockFile[nLastBlockFile].nHeightLast + 1)
        && (vinfoBlockFile[nLastBlockFile].nHeightLast != 0))
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1607,7 +1607,10 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex)
     if (!ReadBlockFromDisk(block, pindex->GetBlockPos()))
         return false;
     if (block.GetHash() != pindex->GetBlockHash())
+    {
+        LogPrintf("%s : block=%s index=%s\n", __func__, block.GetHash().ToString().c_str(), pindex->GetBlockHash().ToString().c_str());
         return error("ReadBlockFromDisk(CBlock&, CBlockIndex*) : GetHash() doesn't match index");
+    }
     return true;
 }
 
@@ -3419,7 +3422,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
                              REJECT_INVALID, "bad-header", true);
 
     // Check timestamp
-    LogPrintf("block time=%d adjusted time=%d is proof of stake=%d\n", block.GetBlockTime(), GetAdjustedTime(), block.IsProofOfStake());
+    LogPrintf("%s: block=%s  is proof of stake=%d\n", __func__, block.GetHash().ToString().c_str(), block.IsProofOfStake());
     if (block.GetBlockTime() > GetAdjustedTime() + (block.IsProofOfStake() ? 180 : 7200)) // 3 minute future drift for PoS
         return state.Invalid(error("CheckBlock() : block timestamp too far in the future"),
                              REJECT_INVALID, "time-too-new");
@@ -3890,14 +3893,16 @@ bool ProcessNewBlock(CValidationState &state, CNode* pfrom, CBlock* pblock, CDis
         }
     }
 
-    // If turned on MultiSend will send a transaction (or more) on the after maturity of a stake
-     if (pwalletMain->isMultiSendEnabled())
-        pwalletMain->MultiSend();
+    if(pwalletMain)
+    {
+        // If turned on MultiSend will send a transaction (or more) on the after maturity of a stake
+        if (pwalletMain->isMultiSendEnabled())
+            pwalletMain->MultiSend();
 
-     //If turned on Auto Combine will scan wallet for dust to combine
-     if(pwalletMain->fCombineDust)
-         pwalletMain->AutoCombineDust();
-
+        //If turned on Auto Combine will scan wallet for dust to combine
+        if (pwalletMain->fCombineDust)
+            pwalletMain->AutoCombineDust();
+    }
 
     LogPrintf("%s : ACCEPTED\n", __func__);
 
@@ -4088,6 +4093,58 @@ bool static LoadBlockIndexDB()
         }
     }
 
+    //Check for inconsistency with block file info and internal state
+    if(vSortedByHeight.size() != vinfoBlockFile[nLastBlockFile].nBlocks && vinfoBlockFile[nLastBlockFile].nBlocks != 0)
+    {
+        //The database is in a state where a block has been accepted and written to disk, but not
+        //all of the block has perculated through the code. The block and the index should both be
+        //intact (although assertions are added if they are not), and the block will be reprocessed
+        //to ensure all data will be accounted for.
+        LogPrintf("%s: Inconsistent State Detected mapBlockIndex.size()=%d blockFileBlocks=%d\n", __func__, vSortedByHeight.size(), vinfoBlockFile[nLastBlockFile].nBlocks);
+        LogPrintf("%s: lastIndexPos=%d blockFileSize=%d\n", __func__, vSortedByHeight[vSortedByHeight.size() - 1].second->GetBlockPos().nPos,
+                  vinfoBlockFile[nLastBlockFile].nSize);
+
+        //try reading the block from the last index we have
+        LogPrintf("%s: Attempting to re-add last block that was recorded to disk\n", __func__);
+        CBlockIndex * pindexBestKnown = vSortedByHeight[vSortedByHeight.size() - 1].second;
+        CBlock checkBlock;
+        assert(ReadBlockFromDisk(checkBlock, pindexBestKnown));
+        assert(checkBlock.GetHash() == pindexBestKnown->GetBlockHash());
+
+        LogPrintf("%s: bestBlock=%s prev=%s\n", __func__, pindexBestKnown->GetBlockHash().ToString().c_str(),
+                  pindexBestKnown->pprev->GetBlockHash().ToString().c_str());
+
+        //Double check that the new index does not contain the previous block's hash
+        assert(pindexBestKnown->GetBlockHash() != pindexBestKnown->pprev->GetBlockHash());
+
+        //set the chain to the previous block that has been completely accepted
+        chainActive.SetTip(pindexBestKnown->pprev);
+
+        //Process the bestBlock again, using the known location on disk
+        CDiskBlockPos blockPos = pindexBestKnown->GetBlockPos();
+        CValidationState state;
+        ProcessNewBlock(state, NULL, &checkBlock, &blockPos);
+
+        //ensure that everything is as it should be
+        assert(pcoinsTip->GetBestBlock() == checkBlock.GetHash());
+
+        //force the block file to update or else the bestBlock will be overwritten by the next block
+        vinfoBlockFile[nLastBlockFile].AddBlock(pindexBestKnown->nHeight, pindexBestKnown->nTime);
+        vinfoBlockFile[nLastBlockFile].nSize += checkBlock.GetSerializeSize(SER_DISK, CLIENT_VERSION);
+        setDirtyFileInfo.insert(nLastBlockFile);
+        FlushStateToDisk();
+
+        //Print out file info again
+        pblocktree->ReadLastBlockFile(nLastBlockFile);
+        vinfoBlockFile.resize(nLastBlockFile + 1);
+        LogPrintf("%s: last block file = %i\n", __func__, nLastBlockFile);
+        for (int nFile = 0; nFile <= nLastBlockFile; nFile++) {
+            pblocktree->ReadBlockFileInfo(nFile, vinfoBlockFile[nFile]);
+        }
+        LogPrintf("%s: last block file info: %s\n", __func__, vinfoBlockFile[nLastBlockFile].ToString());
+    }
+    assert(mapBlockIndex.size() == vinfoBlockFile[nLastBlockFile].nBlocks);
+    
     // Check whether we need to continue reindexing
     bool fReindexing = false;
     pblocktree->ReadReindexing(fReindexing);


### PR DESCRIPTION
When the client is not properly shutdown it can cause the database to get into a state where a block and index have been written to disk, but the corresponding metadata has not been written to disk. This adds various assertions and attempts to correct the faulty state when the client is initialized. This addresses https://github.com/PIVX-Project/PIVX/issues/69 