### PR TITLE
[Build] Don't (re)delcare be32enc on FreeBSD

### DIFF
--- a/src/crypto/scrypt.cpp
+++ b/src/crypto/scrypt.cpp
@@ -36,6 +36,7 @@
 #include <string.h>
 #include <stdint.h>
 
+#ifndef __FreeBSD__
 static inline void be32enc(void *pp, uint32_t x)
 {
     uint8_t *p = (uint8_t *)pp;
@@ -44,6 +45,7 @@ static inline void be32enc(void *pp, uint32_t x)
     p[1] = (x >> 16) & 0xff;
     p[0] = (x >> 24) & 0xff;
 }
+#endif
 
 typedef struct HMAC_SHA256Context {
     SHA256_CTX ictx;


### PR DESCRIPTION
FreeBSD declares be32enc natively, causing a build error when attempting
to declare it again.

This PR explicitely excludes FreeBSD from the in-tree declaration
and instead uses the system declaration.

Fixes #73