### PR TITLE
[QT Wallet] Correctly sort by "Active" duration in mn tab

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -590,6 +590,34 @@ TableViewLastColumnResizingFixer::TableViewLastColumnResizingFixer(QTableView* t
     setViewHeaderResizeMode(lastColumnIndex, QHeaderView::Interactive);
 }
 
+/**
+ * Class constructor.
+ * @param[in] seconds   Number of seconds to convert to a DHMS string
+ */
+DHMSTableWidgetItem::DHMSTableWidgetItem(const int64_t seconds) :
+    QTableWidgetItem(),
+    value(seconds)
+{
+    this->setText(QString::fromStdString(DurationToDHMS(seconds)));
+}
+
+/**
+ * Comparator overload to ensure that the "DHMS"-type durations as used in
+ * the "active-since" list in the masternode tab are sorted by the elapsed
+ * duration (versus the string value being sorted).
+ * @param[in] item      Right hand side of the less than operator
+ */
+bool DHMSTableWidgetItem::operator <(QTableWidgetItem const &item) const
+{
+    DHMSTableWidgetItem const *rhs =
+        dynamic_cast<DHMSTableWidgetItem const *>(&item);
+
+    if (!rhs)
+        return QTableWidgetItem::operator<(item);
+
+    return value < rhs->value;
+}
+
 #ifdef WIN32
 boost::filesystem::path static StartupShortcutPath()
 {
@@ -823,7 +851,7 @@ QString loadStyleSheet()
     QSettings settings;
     QString cssName;
     QString theme = settings.value("theme", "").toString();
-    
+
     if(isExternal(theme)){
         // External CSS
         settings.setValue("fCSSexternal", true);
@@ -837,12 +865,12 @@ QString loadStyleSheet()
             cssName = QString(":/css/") + theme;
         }
         else {
-            cssName = QString(":/css/default");  
+            cssName = QString(":/css/default");
             settings.setValue("theme", "default");
         }
     }
 
-    QFile qFile(cssName);      
+    QFile qFile(cssName);
     if (qFile.open(QFile::ReadOnly)) {
         styleSheet = QLatin1String(qFile.readAll());
     }

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -14,6 +14,7 @@
 #include <QProgressBar>
 #include <QString>
 #include <QTableView>
+#include <QTableWidget>
 
 #include <boost/filesystem.hpp>
 
@@ -105,10 +106,10 @@ namespace GUIUtil
 
     // Open debug.log
     void openDebugLogfile();
-	
+
     // Open pivx.conf
-    void openConfigfile();	
-    
+    void openConfigfile();
+
     // Browse backup folder
     void showBackups();
 
@@ -172,6 +173,21 @@ namespace GUIUtil
             void on_geometriesChanged();
     };
 
+    /**
+     * Extension to QTableWidgetItem that facilitates proper ordering for "DHMS"
+     * strings (primarily used in the masternode's "active" listing).
+     */
+    class DHMSTableWidgetItem : public QTableWidgetItem
+    {
+    public:
+        DHMSTableWidgetItem(const int64_t seconds);
+        virtual bool operator <(QTableWidgetItem const &item) const;
+
+    private:
+        // Private backing value for DHMS string, used for sorting.
+        int64_t value;
+    };
+
     bool GetStartOnSystemStartup();
     bool SetStartOnSystemStartup(bool fAutoStart);
 
@@ -200,7 +216,7 @@ namespace GUIUtil
 
     /* Format a CNodeCombinedStats.dPingTime into a user-readable string or display N/A, if 0*/
     QString formatPingTime(double dPingTime);
-    
+
 #if defined(Q_OS_MAC) && QT_VERSION >= 0x050000
     // workaround for Qt OSX Bug:
     // https://bugreports.qt-project.org/browse/QTBUG-15631
@@ -214,7 +230,7 @@ namespace GUIUtil
 #else
     typedef QProgressBar ProgressBar;
 #endif
-    
+
 } // namespace GUIUtil
 
 #endif // BITCOIN_QT_GUIUTIL_H

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -186,7 +186,7 @@ void MasternodeList::updateMyMasternodeInfo(QString strAlias, QString strAddr, C
     QTableWidgetItem *addrItem = new QTableWidgetItem(pmn ? QString::fromStdString(pmn->addr.ToString()) : strAddr);
     QTableWidgetItem *protocolItem = new QTableWidgetItem(QString::number(pmn ? pmn->protocolVersion : -1));
     QTableWidgetItem *statusItem = new QTableWidgetItem(QString::fromStdString(pmn ? pmn->GetStatus() : "MISSING"));
-    QTableWidgetItem *activeSecondsItem = new QTableWidgetItem(QString::fromStdString(DurationToDHMS(pmn ? (pmn->lastPing.sigTime - pmn->sigTime) : 0)));
+    GUIUtil::DHMSTableWidgetItem *activeSecondsItem = new GUIUtil::DHMSTableWidgetItem(pmn ? (pmn->lastPing.sigTime - pmn->sigTime) : 0);
     QTableWidgetItem *lastSeenItem = new QTableWidgetItem(QString::fromStdString(DateTimeStrFormat("%Y-%m-%d %H:%M", pmn ? pmn->lastPing.sigTime : 0)));
     QTableWidgetItem *pubkeyItem = new QTableWidgetItem(QString::fromStdString(pmn ? CBitcoinAddress(pmn->pubKeyCollateralAddress.GetID()).ToString() : ""));
 
@@ -257,7 +257,7 @@ void MasternodeList::updateNodeList()
         QTableWidgetItem *addressItem = new QTableWidgetItem(QString::fromStdString(mn.addr.ToString()));
         QTableWidgetItem *protocolItem = new QTableWidgetItem(QString::number(mn.protocolVersion));
         QTableWidgetItem *statusItem = new QTableWidgetItem(QString::fromStdString(mn.GetStatus()));
-        QTableWidgetItem *activeSecondsItem = new QTableWidgetItem(QString::fromStdString(DurationToDHMS(mn.lastPing.sigTime - mn.sigTime)));
+        GUIUtil::DHMSTableWidgetItem *activeSecondsItem = new GUIUtil::DHMSTableWidgetItem(mn.lastPing.sigTime - mn.sigTime);
         QTableWidgetItem *lastSeenItem = new QTableWidgetItem(QString::fromStdString(DateTimeStrFormat("%Y-%m-%d %H:%M", mn.lastPing.sigTime)));
         QTableWidgetItem *pubkeyItem = new QTableWidgetItem(QString::fromStdString(CBitcoinAddress(mn.pubKeyCollateralAddress.GetID()).ToString()));
 


### PR DESCRIPTION
**Summary**: Fixes #92 

**Details:**
1.  The Masternodes tab in the qt wallet had a small bug where
    the "Active" time listed for each node was being sorted by
    the string value of the human friendly elapsed time which
    typically reads DDd:HHh:MMh:SSs versus the harder to read
    XYZWABCD seconds.  However the QTableWidgetItem was blindly
    sorting this list by it's textual representation.
2.  This change adds a simple subclass of QTableWidgetItem that
    is specifically used for DHMS-type time specifications which
    require ordering.  The subclass is constructed with the elapsed
    time, and sets the appropriate human friendly text.  It then
    stores the time as an elapsed amount of seconds and uses that
    for the overloaded < operator (sort et al).