### PR TITLE
[Qt] remove trailing output-index from transaction-id

### DIFF
--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -253,7 +253,8 @@ QString TransactionDesc::toHTML(CWallet* wallet, CWalletTx& wtx, TransactionReco
     if (wtx.mapValue.count("comment") && !wtx.mapValue["comment"].empty())
         strHTML += "<br><b>" + tr("Comment") + ":</b><br>" + GUIUtil::HtmlEscape(wtx.mapValue["comment"], true) + "<br>";
 
-    strHTML += "<b>" + tr("Transaction ID") + ":</b> " + TransactionRecord::formatSubTxId(wtx.GetHash(), rec->idx) + "<br>";
+    strHTML += "<b>" + tr("Transaction ID") + ":</b> " + rec->getTxID() + "<br>";
+    strHTML += "<b>" + tr("Output index") + ":</b> " + QString::number(rec->getOutputIndex()) + "<br>";
 
     // Message from normal pivx:URI (pivx:XyZ...?message=example)
     foreach (const PAIRTYPE(string, string) & r, wtx.vOrderForm)

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -292,10 +292,10 @@ bool TransactionRecord::statusUpdateNeeded()
 
 QString TransactionRecord::getTxID() const
 {
-    return formatSubTxId(hash, idx);
+    return QString::fromStdString(hash.ToString());
 }
 
-QString TransactionRecord::formatSubTxId(const uint256& hash, int vout)
+int TransactionRecord::getOutputIndex() const
 {
-    return QString::fromStdString(hash.ToString() + strprintf("-%03d", vout));
+    return idx;
 }

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -133,8 +133,8 @@ public:
     /** Return the unique identifier for this transaction (part) */
     QString getTxID() const;
 
-    /** Format subtransaction id */
-    static QString formatSubTxId(const uint256& hash, int vout);
+    /** Return the output index of the subtransaction  */
+    int getOutputIndex() const;
 
     /** Update status from core wallet tx.
      */


### PR DESCRIPTION
The trailing output-index can lead to cases where the user can't
look-up the transaction ID with  various systems.

The context menu item to copy the transaction ID will also only put the transaction hash into the user's clipboard with this change.

Before:
![screen shot 2017-04-13 at 8 49 35 pm](https://cloud.githubusercontent.com/assets/7393257/25032672/f45913f6-208a-11e7-848e-542abef9b1ea.png)

After:
![screen shot 2017-04-13 at 9 04 41 pm](https://cloud.githubusercontent.com/assets/7393257/25032879/e9874e64-208c-11e7-8ef7-81f30bd30786.png)

