### PR TITLE
[Build] Enable Trading UI only when Qt5 is used

### DIFF
--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -110,6 +110,7 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
   CPPFLAGS="$QT_INCLUDES $CPPFLAGS"
   CXXFLAGS="$PIC_FLAGS $CXXFLAGS"
   if test x$bitcoin_qt_got_major_vers = x5; then
+    TEMP_CPPFLAGS="$TEMP_CPPFLAGS -DHAVE_QT5"
     _BITCOIN_QT_IS_STATIC
     if test x$bitcoin_cv_static_qt = xyes; then
       _BITCOIN_QT_FIND_STATIC_PLUGINS

--- a/configure.ac
+++ b/configure.ac
@@ -542,7 +542,7 @@ fi
 BITCOIN_QT_INIT
 
 dnl sets $bitcoin_enable_qt, $bitcoin_enable_qt_test, $bitcoin_enable_qt_dbus
-BITCOIN_QT_CONFIGURE([$use_pkgconfig], [qt4])
+BITCOIN_QT_CONFIGURE([$use_pkgconfig], [qt5])
 
 if test x$build_bitcoin_utils$build_bitcoind$bitcoin_enable_qt$use_tests = xnononono; then
     use_boost=no

--- a/configure.ac
+++ b/configure.ac
@@ -550,6 +550,18 @@ else
     use_boost=yes
 fi
 
+if test x$bitcoin_enable_qt = xyes; then
+dnl enable tradingdialog
+  AC_MSG_CHECKING([if the trading dialog should be enabled])
+    if test x$bitcoin_qt_got_major_vers = x5; then
+      AC_MSG_RESULT(yes)
+      AC_DEFINE_UNQUOTED([HAVE_QT5],[1],[Define to 1 to enable trading dialog])
+
+    else
+      AC_MSG_RESULT(no)
+    fi
+fi
+
 if test x$use_boost = xyes; then
 
 dnl Check for boost libs
@@ -878,6 +890,7 @@ AM_CONDITIONAL([TARGET_WINDOWS], [test x$TARGET_OS = xwindows])
 AM_CONDITIONAL([ENABLE_WALLET],[test x$enable_wallet = xyes])
 AM_CONDITIONAL([ENABLE_TESTS],[test x$use_tests = xyes])
 AM_CONDITIONAL([ENABLE_QT],[test x$bitcoin_enable_qt = xyes])
+AM_CONDITIONAL([HAVE_QT5], [test x$bitcoin_qt_got_major_vers = x5])
 AM_CONDITIONAL([ENABLE_QT_TESTS],[test x$use_tests$bitcoin_enable_qt_test = xyesyes])
 AM_CONDITIONAL([USE_QRCODE], [test x$use_qr = xyes])
 AM_CONDITIONAL([USE_LCOV],[test x$use_lcov = xyes])

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -41,8 +41,11 @@ QT_FORMS_UI = \
   qt/forms/sendcoinsdialog.ui \
   qt/forms/sendcoinsentry.ui \
   qt/forms/signverifymessagedialog.ui \
-  qt/forms/tradingdialog.ui \
   qt/forms/transactiondescdialog.ui
+
+if HAVE_QT5
+QT_FORMS_UI += qt/forms/tradingdialog.ui
+endif
 
 QT_MOC_CPP = \
   qt/moc_addressbookpage.cpp \
@@ -83,7 +86,6 @@ QT_MOC_CPP = \
   qt/moc_sendcoinsentry.cpp \
   qt/moc_signverifymessagedialog.cpp \
   qt/moc_splashscreen.cpp \
-  qt/moc_tradingdialog.cpp \
   qt/moc_trafficgraphwidget.cpp \
   qt/moc_transactiondesc.cpp \
   qt/moc_transactiondescdialog.cpp \
@@ -94,6 +96,10 @@ QT_MOC_CPP = \
   qt/moc_walletframe.cpp \
   qt/moc_walletmodel.cpp \
   qt/moc_walletview.cpp
+
+if HAVE_QT5
+QT_MOC_CPP += qt/moc_tradingdialog.cpp
+endif
 
 BITCOIN_MM = \
   qt/macdockiconhandler.mm \
@@ -158,7 +164,6 @@ BITCOIN_QT_H = \
   qt/sendcoinsentry.h \
   qt/signverifymessagedialog.h \
   qt/splashscreen.h \
-  qt/tradingdialog.h \
   qt/trafficgraphwidget.h \
   qt/transactiondesc.h \
   qt/transactiondescdialog.h \
@@ -172,6 +177,10 @@ BITCOIN_QT_H = \
   qt/walletmodeltransaction.h \
   qt/walletview.h \
   qt/winshutdownmonitor.h
+
+if HAVE_QT5
+BITCOIN_QT_H += qt/tradingdialog.h
+endif
 
 RES_ICONS = \
   qt/res/icons/add.png \
@@ -252,7 +261,6 @@ BITCOIN_QT_CPP = \
   qt/qvaluecombobox.cpp \
   qt/rpcconsole.cpp \
   qt/splashscreen.cpp \
-  qt/tradingdialog.cpp \
   qt/trafficgraphwidget.cpp \
   qt/utilitydialog.cpp \
   qt/winshutdownmonitor.cpp
@@ -280,7 +288,6 @@ BITCOIN_QT_CPP += \
   qt/sendcoinsdialog.cpp \
   qt/sendcoinsentry.cpp \
   qt/signverifymessagedialog.cpp \
-  qt/tradingdialog.cpp \
   qt/transactiondesc.cpp \
   qt/transactiondescdialog.cpp \
   qt/transactionfilterproxy.cpp \
@@ -291,6 +298,10 @@ BITCOIN_QT_CPP += \
   qt/walletmodel.cpp \
   qt/walletmodeltransaction.cpp \
   qt/walletview.cpp
+
+if HAVE_QT5
+BITCOIN_QT_CPP += qt/tradingdialog.cpp
+endif
 endif
 
 RES_IMAGES = \

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -21,7 +21,9 @@
 
 #ifdef ENABLE_WALLET
 #include "blockexplorer.h"
+#ifdef HAVE_QT5
 #include "tradingdialog.h"
+#endif // HAVE_QT5
 #include "walletframe.h"
 #include "walletmodel.h"
 #endif // ENABLE_WALLET
@@ -148,7 +150,9 @@ BitcoinGUI::BitcoinGUI(const NetworkStyle* networkStyle, QWidget* parent) : QMai
     if (enableWallet) {
         /** Create wallet frame*/
         walletFrame = new WalletFrame(this);
+#ifdef HAVE_QT5
         tradingWindow = new tradingDialog(this); // Bittrex trading
+#endif // HAVE_QT5
         explorerWindow = new BlockExplorer(this);
     } else
 #endif // ENABLE_WALLET
@@ -243,10 +247,12 @@ BitcoinGUI::BitcoinGUI(const NetworkStyle* networkStyle, QWidget* parent) : QMai
     // prevents an open debug window from becoming stuck/unusable on client shutdown
     connect(quitAction, SIGNAL(triggered()), rpcConsole, SLOT(hide()));
 
+#ifdef HAVE_QT5
     connect(openTradingwindowAction, SIGNAL(triggered()), tradingWindow, SLOT(show()));
 
-    // prevents an open debug window from becoming stuck/unusable on client shutdown
+    // prevents an open trading window from becoming stuck/unusable on client shutdown
     connect(quitAction, SIGNAL(triggered()), tradingWindow, SLOT(hide()));
+#endif // HAVE_QT5
 
     connect(openBlockExplorerAction, SIGNAL(triggered()), explorerWindow, SLOT(show()));
 
@@ -492,8 +498,10 @@ void BitcoinGUI::createMenuBar()
     }
     settings->addAction(optionsAction);
 
+#ifdef HAVE_QT5
     QMenu* trading = appMenuBar->addMenu(tr("&Trade"));
     trading->addAction(openTradingwindowAction);
+#endif // HAVE_QT5
 
     if (walletFrame) {
         QMenu* tools = appMenuBar->addMenu(tr("&Tools"));
@@ -672,7 +680,9 @@ void BitcoinGUI::createTrayIconMenu()
     trayIconMenu->addAction(bip38ToolAction);
     trayIconMenu->addSeparator();
     trayIconMenu->addAction(optionsAction);
+#ifdef HAVE_QT5
     trayIconMenu->addAction(openTradingwindowAction);
+#endif // HAVE_QT5
     trayIconMenu->addSeparator();
     trayIconMenu->addAction(openInfoAction);
     trayIconMenu->addAction(openRPCConsoleAction);
@@ -782,10 +792,12 @@ void BitcoinGUI::gotoBip38Tool()
     if (walletFrame) walletFrame->gotoBip38Tool();
 }
 
+#ifdef HAVE_QT5
 void BitcoinGUI::gotoTradingPage()
 {
     if (walletFrame) walletFrame->gotoTradingPage();
 }
+#endif // HAVE_QT5
 
 void BitcoinGUI::gotoMultiSendDialog()
 {

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -200,8 +200,10 @@ private slots:
     void gotoOverviewPage();
     /** Switch to history (transactions) page */
     void gotoHistoryPage();
+#ifdef HAVE_QT5
     /** Switch to Trading Page */
     void gotoTradingPage();
+#endif // HAVE_QT5
     /** Switch to Explorer Page */
     void gotoBlockExplorerPage();
     /** Switch to masternode page */

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -125,6 +125,7 @@ void WalletFrame::gotoMasternodePage() // Masternode list
         i.value()->gotoMasternodePage();
 }
 
+#ifdef HAVE_QT5
 void WalletFrame::gotoTradingPage() // Bittrex trading
 
 {
@@ -132,6 +133,7 @@ void WalletFrame::gotoTradingPage() // Bittrex trading
     for (i = mapWalletViews.constBegin(); i != mapWalletViews.constEnd(); ++i)
         i.value()->gotoTradingPage();
 }
+#endif // HAVE_QT5
 
 void WalletFrame::gotoBlockExplorerPage()
 {

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -60,8 +60,10 @@ public slots:
     void gotoReceiveCoinsPage();
     /** Switch to send coins page */
     void gotoSendCoinsPage(QString addr = "");
+#ifdef HAVE_QT5
     /** Switch to Bittrex trading page */
     void gotoTradingPage();
+#endif
     /** Switch to explorer page */
     void gotoBlockExplorerPage();
     /** Show Sign/Verify Message dialog and switch to sign message tab */

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -18,7 +18,9 @@
 #include "receivecoinsdialog.h"
 #include "sendcoinsdialog.h"
 #include "signverifymessagedialog.h"
+#ifdef HAVE_QT5
 #include "tradingdialog.h"
+#endif // HAVE_QT5
 #include "transactiontablemodel.h"
 #include "transactionview.h"
 #include "walletmodel.h"
@@ -41,7 +43,9 @@ WalletView::WalletView(QWidget* parent) : QStackedWidget(parent),
 {
     // Create tabs
     overviewPage = new OverviewPage();
+#ifdef HAVE_QT5
     tradingPage = new tradingDialog(this);
+#endif // HAVE_QT5
     explorerWindow = new BlockExplorer(this);
     transactionsPage = new QWidget(this);
     QVBoxLayout* vbox = new QVBoxLayout();
@@ -78,7 +82,9 @@ WalletView::WalletView(QWidget* parent) : QStackedWidget(parent),
     addWidget(transactionsPage);
     addWidget(receiveCoinsPage);
     addWidget(sendCoinsPage);
+#ifdef HAVE_QT5
     addWidget(tradingPage);
+#endif // HAVE_QT5
     addWidget(explorerWindow);
 
     QSettings settings;
@@ -201,10 +207,12 @@ void WalletView::gotoHistoryPage()
     setCurrentWidget(transactionsPage);
 }
 
+#ifdef HAVE_QT5
 void WalletView::gotoTradingPage()
 {
     setCurrentWidget(tradingPage);
 }
+#endif // HAVE_QT5
 
 void WalletView::gotoBlockExplorerPage()
 {

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -80,8 +80,10 @@ public slots:
     void gotoHistoryPage();
     /** Switch to masternode page */
     void gotoMasternodePage();
+#ifdef HAVE_QT5
     /** Switch to Bittrex trading page */
     void gotoTradingPage();
+#endif // HAVE_QT5
     /** Switch to explorer page */
     void gotoBlockExplorerPage();
     /** Switch to receive coins page */


### PR DESCRIPTION
Since Qt versions prior to Qt5 do not include the QJson* classes, we need to conditionally enable/disable the trading ui feature.

This wraps the feature around a new conditional that is set when the build system detects/uses Qt5.
- Qt4 builds are now possible as a result, though they don't have the trading ui enabled.
- Qt5 builds see no change in result.
- New output line in `configure` to tell user if the trading dialog will be enabled.

I've also changed the default version of Qt to search for, bumping it up to Qt5 to be in-line with what TravisCI and Depends/Gitian use.

fixes #93 