### PR TITLE
[RPC] Require password when using UnlockAnonymizeOnly

### DIFF
--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -40,7 +40,7 @@ std::string HelpRequiringPassphrase()
 
 void EnsureWalletIsUnlocked()
 {
-    if (pwalletMain->IsLocked())
+    if (pwalletMain->IsLocked() || pwalletMain->fWalletUnlockAnonymizeOnly)
         throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Please enter the wallet passphrase with walletpassphrase first.");
 }
 


### PR DESCRIPTION
Currently you can dump private keys and perform other wallet actions that should be forbidden if the wallet is unlocked for anonymization only/staking only.

This is a big security risk for active stakers.