### PR TITLE
[Wallet] Reduce usage of atoi to comply with CWE-190

### DIFF
--- a/src/masternodeconfig.cpp
+++ b/src/masternodeconfig.cpp
@@ -78,3 +78,15 @@ bool CMasternodeConfig::read(std::string& strErr)
     streamConfig.close();
     return true;
 }
+
+bool CMasternodeConfig::CMasternodeEntry::castOutputIndex(int &n)
+{
+    try {
+        n = std::stoi(outputIndex);
+    } catch (const std::exception e) {
+        LogPrintf("%s: %s on getOutputIndex\n", __func__, e.what());
+        return false;
+    }
+
+    return true;
+}

--- a/src/masternodeconfig.h
+++ b/src/masternodeconfig.h
@@ -53,6 +53,8 @@ public:
             return outputIndex;
         }
 
+        bool castOutputIndex(int& n);
+
         void setOutputIndex(const std::string& outputIndex)
         {
             this->outputIndex = outputIndex;

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -131,7 +131,11 @@ void MasternodeList::StartAll(std::string strCommand)
         std::string strError;
         CMasternodeBroadcast mnb;
 
-        CTxIn txin = CTxIn(uint256S(mne.getTxHash()), uint32_t(atoi(mne.getOutputIndex().c_str())));
+        int nIndex;
+        if(!mne.castOutputIndex(nIndex))
+            continue;
+
+        CTxIn txin = CTxIn(uint256S(mne.getTxHash()), uint32_t(nIndex));
         CMasternode* pmn = mnodeman.Find(txin);
 
         if (strCommand == "start-missing" && pmn) continue;
@@ -212,7 +216,11 @@ void MasternodeList::updateMyNodeList(bool fForce)
 
     ui->tableWidgetMasternodes->setSortingEnabled(false);
     BOOST_FOREACH (CMasternodeConfig::CMasternodeEntry mne, masternodeConfig.getEntries()) {
-        CTxIn txin = CTxIn(uint256S(mne.getTxHash()), uint32_t(atoi(mne.getOutputIndex().c_str())));
+        int nIndex;
+        if(!mne.castOutputIndex(nIndex))
+            continue;
+
+        CTxIn txin = CTxIn(uint256S(mne.getTxHash()), uint32_t(nIndex));
         CMasternode* pmn = mnodeman.Find(txin);
 
         updateMyMasternodeInfo(QString::fromStdString(mne.getAlias()), QString::fromStdString(mne.getIp()), pmn);

--- a/src/rpcmasternode.cpp
+++ b/src/rpcmasternode.cpp
@@ -344,8 +344,10 @@ Value masternode(const Array& params, bool fHelp)
 
         BOOST_FOREACH (CMasternodeConfig::CMasternodeEntry mne, masternodeConfig.getEntries()) {
             std::string errorMessage;
-
-            CTxIn vin = CTxIn(uint256(mne.getTxHash()), uint32_t(atoi(mne.getOutputIndex().c_str())));
+            int nIndex;
+            if(!mne.castOutputIndex(nIndex))
+                continue;
+            CTxIn vin = CTxIn(uint256(mne.getTxHash()), uint32_t(nIndex));
             CMasternode* pmn = mnodeman.Find(vin);
 
             if (strCommand == "start-missing" && pmn) continue;
@@ -393,7 +395,10 @@ Value masternode(const Array& params, bool fHelp)
         Object resultObj;
 
         BOOST_FOREACH (CMasternodeConfig::CMasternodeEntry mne, masternodeConfig.getEntries()) {
-            CTxIn vin = CTxIn(uint256(mne.getTxHash()), uint32_t(atoi(mne.getOutputIndex().c_str())));
+            int nIndex;
+            if(!mne.castOutputIndex(nIndex))
+                continue;
+            CTxIn vin = CTxIn(uint256(mne.getTxHash()), uint32_t(nIndex));
             CMasternode* pmn = mnodeman.Find(vin);
 
             std::string strStatus = pmn ? pmn->Status() : "MISSING";
@@ -440,7 +445,11 @@ Value masternode(const Array& params, bool fHelp)
         int nLast = 10;
 
         if (params.size() >= 2) {
-            nLast = atoi(params[1].get_str());
+            try {
+                nLast = std::stoi(params[1].get_str());
+            } catch (const std::exception& e) {
+                throw runtime_error("Exception on param 2");
+            }
         }
 
         Object obj;
@@ -459,7 +468,11 @@ Value masternode(const Array& params, bool fHelp)
         int nLast = 10;
 
         if (params.size() >= 2) {
-            nLast = atoi(params[1].get_str());
+            try {
+                nLast = std::stoi(params[1].get_str());
+            } catch (const boost::bad_lexical_cast &) {
+                throw runtime_error("Exception on param 2");
+            }
         }
         Object obj;
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -349,8 +349,16 @@ std::string GetArg(const std::string& strArg, const std::string& strDefault)
 
 int64_t GetArg(const std::string& strArg, int64_t nDefault)
 {
-    if (mapArgs.count(strArg))
-        return atoi64(mapArgs[strArg]);
+    if (mapArgs.count(strArg)) {
+        int64_t n;
+        try {
+            n = std::stoi(mapArgs[strArg]);
+        } catch (const std::exception& e) {
+            return nDefault;
+        }
+
+        return n;
+    }
     return nDefault;
 }
 
@@ -359,7 +367,14 @@ bool GetBoolArg(const std::string& strArg, bool fDefault)
     if (mapArgs.count(strArg)) {
         if (mapArgs[strArg].empty())
             return true;
-        return (atoi(mapArgs[strArg]) != 0);
+
+        int n;
+        try {
+            n = std::stoi(mapArgs[strArg]);
+        } catch (const std::exception& e) {
+            return fDefault;
+        }
+        return n;
     }
     return fDefault;
 }

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -479,7 +479,14 @@ bool CWallet::GetMasternodeVinAndKeys(CTxIn& txinRet, CPubKey& pubKeyRet, CKey& 
 
     // Find specific vin
     uint256 txHash = uint256S(strTxHash);
-    int nOutputIndex = atoi(strOutputIndex.c_str());
+
+    int nOutputIndex;
+    try {
+        nOutputIndex = std::stoi(strOutputIndex.c_str());
+    } catch (const std::exception& e) {
+        LogPrintf("%s: %s on strOutputIndex\n", __func__, e.what());
+        return false;
+    }
 
     BOOST_FOREACH (COutput& out, vPossibleCoins)
         if (out.tx->GetHash() == txHash && out.i == nOutputIndex) // found it!


### PR DESCRIPTION
CWE-190: Integer Overflow or Wrap around https://cwe.mitre.org/data/definitions/190.html

example from FlawFinder:
`
../pivx/src/activemasternode.cpp:375:  [2] (integer) atoi:
  Unless checked, the resulting number can exceed the expected range
  (CWE-190). If source untrusted, check both minimum and maximum, even if the
  input had no minus sign (large numbers can roll over into negative number;
  consider saving to an unsigned value if that is intended).
../pivx/src/activemasternode.cpp:442:  [2] (integer) atoi:
  Unless checked, the resulting number can exceed the expected range
  (CWE-190). If source untrusted, check both minimum and maximum, even if the
  input had no minus sign (large numbers can roll over into negative number;
  consider saving to an unsigned value if that is intended).
`

Using boost::lexical_cast lets us cast to int while being able to throw exceptions, atoi does not have exceptions.

