### PR TITLE
qt: Avoid OpenSSL certstore-related memory leak

### DIFF
--- a/src/qt/paymentserver.h
+++ b/src/qt/paymentserver.h
@@ -83,7 +83,7 @@ public:
     static void LoadRootCAs(X509_STORE* store = NULL);
 
     // Return certificate store
-    static X509_STORE* getCertStore() { return certStore; }
+    static X509_STORE* getCertStore();
 
     // OptionsModel is used for getting proxy settings and display unit
     void setOptionsModel(OptionsModel* optionsModel);
@@ -132,12 +132,7 @@ private:
 
     bool saveURIs; // true during startup
     QLocalServer* uriServer;
-
-    static X509_STORE* certStore; // Trusted root certificates
-    static void freeCertStore();
-
-    QNetworkAccessManager* netManager; // Used to fetch payment requests
-
+    QNetworkAccessManager* netManager;  // Used to fetch payment requests
     OptionsModel* optionsModel;
 };
 


### PR DESCRIPTION
- Correctly manage the X509 and X509_STORE objects lifetime.