### PR TITLE
[Wallet] Masternode config check: wallet must be enabled

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1446,6 +1446,16 @@ bool AppInit2(boost::thread_group& threadGroup)
     }
 
     if (fMasterNode) {
+#ifdef ENABLE_WALLET
+        if (fDisableWallet) {
+            return InitError("Enabling Masternode support requires wallet functionality. "
+                             "Please remove disablewallet from your configuration.");
+        }
+#else
+        return InitError("Enabling Masternode support requires wallet functionality. "
+                         "Please recompile or use a different binary with wallet support enabled.");
+#endif
+
         LogPrintf("IS OBFUSCATION MASTER NODE\n");
         strMasterNodeAddr = GetArg("-masternodeaddr", "");
 


### PR DESCRIPTION
Fixes #158

Adds a check to init.cpp which verifies that wallet support is compiled
and enabled for masternodes.