### PR TITLE
[Utils] Add ExecStop= to example systemd service

### DIFF
--- a/contrib/init/pivxd.service
+++ b/contrib/init/pivxd.service
@@ -8,8 +8,12 @@ Group=pivx
 
 Type=forking
 PIDFile=/var/lib/pivxd/pivxd.pid
+
 ExecStart=/usr/bin/pivxd -daemon -pid=/var/lib/pivxd/pivxd.pid \
--conf=/etc/pivx/pivx.conf -datadir=/var/lib/pivxd
+          -conf=/etc/pivx/pivx.conf -datadir=/var/lib/pivxd
+
+ExecStop=-/usr/bin/pivx-cli -conf=/etc/pivx/pivx.conf \
+         -datadir=/var/lib/pivxd stop
 
 Restart=always
 PrivateTmp=true


### PR DESCRIPTION
With no stop command defined `systemctl stop pivxd` will send SIGTERM
which can cause database corruption. With this change `pivx-cli stop`
will be used to stop the daemon process gracefully.