### PR TITLE
Add IsNull and SetNull interfaces to uint256 and use them where possi…

### DIFF
--- a/src/addrman.h
+++ b/src/addrman.h
@@ -452,7 +452,7 @@ public:
 
     ~CAddrMan()
     {
-        nKey = uint256(0);
+        nKey = uint256();
     }
 
     //! Return the number of (unique) addresses in all tables.

--- a/src/chain.h
+++ b/src/chain.h
@@ -199,7 +199,7 @@ public:
         nStakeTime = 0;
 
         nVersion = 0;
-        hashMerkleRoot = 0;
+        hashMerkleRoot = uint256();
         nTime = 0;
         nBits = 0;
         nNonce = 0;
@@ -221,13 +221,13 @@ public:
         nNonce = block.nNonce;
 
         //Proof of Stake
-        bnChainTrust = 0;
+        bnChainTrust = uint256();
         nMint = 0;
         nMoneySupply = 0;
         nFlags = 0;
         nStakeModifier = 0;
         nStakeModifierChecksum = 0;
-        hashProofOfStake = 0;
+        hashProofOfStake = uint256();
 
         if (block.IsProofOfStake()) {
             SetProofOfStake();
@@ -397,13 +397,13 @@ public:
 
     CDiskBlockIndex()
     {
-        hashPrev = 0;
-        hashNext = 0;
+        hashPrev = uint256();
+        hashNext = uint256();
     }
 
     explicit CDiskBlockIndex(CBlockIndex* pindex) : CBlockIndex(*pindex)
     {
-        hashPrev = (pprev ? pprev->GetBlockHash() : 0);
+        hashPrev = (pprev ? pprev->GetBlockHash() : uint256());
     }
 
     ADD_SERIALIZE_METHODS;
@@ -435,7 +435,7 @@ public:
         } else {
             const_cast<CDiskBlockIndex*>(this)->prevoutStake.SetNull();
             const_cast<CDiskBlockIndex*>(this)->nStakeTime = 0;
-            const_cast<CDiskBlockIndex*>(this)->hashProofOfStake = 0;
+            const_cast<CDiskBlockIndex*>(this)->hashProofOfStake = uint256();
         }
 
         // block header

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -77,7 +77,7 @@ uint256 CBlock::BuildMerkleTree(bool* fMutated) const
     if (fMutated) {
         *fMutated = mutated;
     }
-    return (vMerkleTree.empty() ? 0 : vMerkleTree.back());
+    return (vMerkleTree.empty() ? uint256() : vMerkleTree.back());
 }
 
 std::vector<uint256> CBlock::GetMerkleBranch(int nIndex) const
@@ -99,7 +99,7 @@ std::vector<uint256> CBlock::GetMerkleBranch(int nIndex) const
 uint256 CBlock::CheckMerkleBranch(uint256 hash, const std::vector<uint256>& vMerkleBranch, int nIndex)
 {
     if (nIndex == -1)
-        return 0;
+		return uint256();
     for (std::vector<uint256>::const_iterator it(vMerkleBranch.begin()); it != vMerkleBranch.end(); ++it)
     {
         if (nIndex & 1)

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -54,8 +54,8 @@ public:
     void SetNull()
     {
         nVersion = CBlockHeader::CURRENT_VERSION;
-        hashPrevBlock = 0;
-        hashMerkleRoot = 0;
+        hashPrevBlock.SetNull();
+        hashMerkleRoot.SetNull();
         nTime = 0;
         nBits = 0;
         nNonce = 0;

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -113,7 +113,7 @@ void CTransaction::UpdateHash() const
     *const_cast<uint256*>(&hash) = SerializeHash(*this);
 }
 
-CTransaction::CTransaction() : hash(0), nVersion(CTransaction::CURRENT_VERSION), vin(), vout(), nLockTime(0) { }
+CTransaction::CTransaction() : hash(), nVersion(CTransaction::CURRENT_VERSION), vin(), vout(), nLockTime(0) { }
 
 CTransaction::CTransaction(const CMutableTransaction &tx) : nVersion(tx.nVersion), vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime) {
     UpdateHash();

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -30,8 +30,8 @@ public:
         READWRITE(FLATDATA(*this));
     }
 
-    void SetNull() { hash = 0; n = (uint32_t) -1; }
-    bool IsNull() const { return (hash == 0 && n == (uint32_t) -1); }
+    void SetNull() { hash.SetNull(); n = (uint32_t) -1; }
+    bool IsNull() const { return (hash.IsNull() && n == (uint32_t) -1); }
     bool IsMasternodeReward(const CTransaction* tx) const;
 
     friend bool operator<(const COutPoint& a, const COutPoint& b)

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -20,7 +20,7 @@ class CScript;
 class CScriptID : public uint160
 {
 public:
-    CScriptID() : uint160(0) {}
+    CScriptID() : uint160() {}
     CScriptID(const CScript& in);
     CScriptID(const uint160& in) : uint160(in) {}
 };

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -42,6 +42,21 @@ public:
             pn[i] = b.pn[i];
     }
 
+
+    bool IsNull() const
+    {
+        for (int i = 0; i < WIDTH; i++)
+            if (pn[i] != 0)
+                return false;
+        return true;
+    }
+
+    void SetNull()
+    {
+        memset(pn, 0, sizeof(pn));
+    }
+
+
     base_uint& operator=(const base_uint& b)
     {
         for (int i = 0; i < WIDTH; i++)


### PR DESCRIPTION
…ble. This helps future upgrade to bitcoin 0.13 code
uint256 is primarily used as a hashing class in 0.13.
arith_uint256 is used as the arithmetic class
Swapping out the underlying implementations of these caused issues previously but this step worked ok.
Currently doing a complete resync of mainnet with this change. Got to block 406860 so far. Will cancel this PR if full sync fails