### PR TITLE
[RPC] Add proposal name to removal log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ src/config/pivx-config.h.in
 src/config/stamp-h1
 share/setup.nsi
 share/qt/Info.plist
+contrib/devtools/split-debug.sh
 
 src/univalue/gen
 

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -411,6 +411,7 @@ bool CBudgetManager::AddProposal(CBudgetProposal& budgetProposal)
     }
 
     mapProposals.insert(make_pair(budgetProposal.GetHash(), budgetProposal));
+    LogPrintf("CBudgetManager::AddProposal - proposal %s added\n", budgetProposal.GetName ().c_str ());
     return true;
 }
 

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -440,7 +440,7 @@ void CBudgetManager::CheckAndRemove()
         CBudgetProposal* pbudgetProposal = &((*it2).second);
         pbudgetProposal->fValid = pbudgetProposal->IsValid(strError);
         if (!strError.empty ()) {
-            LogPrintf("CBudgetManager::CheckAndRemove - invalid budget proposal - %s\n", strError);
+            LogPrintf("CBudgetManager::CheckAndRemove - invalid budget proposal %s - %s\n", pbudgetProposal->GetName().c_str (), strError);
             strError = "";
         }
         ++it2;

--- a/src/rpcmasternode-budget.cpp
+++ b/src/rpcmasternode-budget.cpp
@@ -446,6 +446,7 @@ Value mnbudget(const Array& params, bool fHelp)
 
         std::string strError = "";
         obj.push_back(Pair("IsValid", pbudgetProposal->IsValid(strError)));
+        obj.push_back(Pair("IsValidReason", strError.c_str()));
         obj.push_back(Pair("fValid", pbudgetProposal->fValid));
 
         return obj;

--- a/src/rpcmasternode-budget.cpp
+++ b/src/rpcmasternode-budget.cpp
@@ -196,9 +196,11 @@ Value mnbudget(const Array& params, bool fHelp)
 
         budget.mapSeenMasternodeBudgetProposals.insert(make_pair(budgetProposalBroadcast.GetHash(), budgetProposalBroadcast));
         budgetProposalBroadcast.Relay();
-        budget.AddProposal(budgetProposalBroadcast);
-
-        return budgetProposalBroadcast.GetHash().ToString();
+        if(budget.AddProposal(budgetProposalBroadcast)) {
+            return budgetProposalBroadcast.GetHash().ToString();
+        }
+        return "Invalid proposal, see debug.log for details.";
+        
     }
 
     if (strCommand == "vote-many") {


### PR DESCRIPTION
So far when a proposal was removed from the proposal list the reason was logged, but not the name of the proposal itself. Proposal name is now logged as well.

'IsValidReason' was also added to 'mnbudget getinfo' output to make it a bit more verbose.

(...the update of .gitignore is not related to this PR, but needed...)