### PR TITLE
[RPC] Add missing 'vote-alias' implementation

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -94,7 +94,6 @@ static const CRPCConvertParam vRPCConvertParams[] =
         {"prioritisetransaction", 1},
         {"prioritisetransaction", 2},
         {"spork", 1},
-        {"mnbudget", 3},
         {"mnbudget", 4},
         {"mnbudget", 6},
         {"mnbudget", 8},

--- a/src/rpcmasternode-budget.cpp
+++ b/src/rpcmasternode-budget.cpp
@@ -277,7 +277,7 @@ Value mnbudget(const Array& params, bool fHelp)
 if(strCommand == "vote-alias")
     {
         if(params.size() != 4)
-            throw runtime_error("Correct usage is 'mnbudget vote-alias <proposal-hash> <yes|no> <alias-name>'");
+            throw runtime_error("Correct usage is 'mnbudget vote-alias proposal-hash yes|no alias-name'");
 
         uint256 hash;
         std::string strVote;


### PR DESCRIPTION
For whatever reasons `vote-alias` was in the RPC help for quite some time, but never implemented.

Please test.