### PR TITLE
[Trivial] Pre-release warning message fixed.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4436,7 +4436,7 @@ string GetWarnings(string strFor)
     string strRPC;
 
     if (!CLIENT_VERSION_IS_RELEASE)
-        strStatusBar = _("This is a pre-release test build - use at your own risk - do not use for mining or merchant applications");
+        strStatusBar = _("This is a pre-release test build - use at your own risk - do not use for staking or merchant applications!");
 
     if (GetBoolArg("-testsafemode", false))
         strStatusBar = strRPC = "testsafemode enabled";


### PR DESCRIPTION
Old text was _"do not use for mining or ..."_

Mining is sooo 2016....