### PR TITLE
[RPC] Add active/incative flag to getstakingstatus RPC call

### DIFF
--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -475,6 +475,7 @@ Value getstakingstatus(const Array& params, bool fHelp)
             "  \"mintablecoins\": true|false,      (boolean) if the wallet has mintable coins\n"
             "  \"enoughcoins\": true|false,        (boolean) if available coins are greater than reserve balance\n"
             "  \"mnsync\": true|false,             (boolean) if masternode data is synced\n"
+            "  \"staking status\": true|false,     (boolean) if the wallet is staking or not\n"
             "}\n"
             "\nExamples:\n" +
             HelpExampleCli("getstakingstatus", "") + HelpExampleRpc("getstakingstatus", ""));
@@ -488,6 +489,14 @@ Value getstakingstatus(const Array& params, bool fHelp)
         obj.push_back(Pair("enoughcoins", nReserveBalance <= pwalletMain->GetBalance()));
     }
     obj.push_back(Pair("mnsync", masternodeSync.IsSynced()));
+
+    bool nStaking = false;
+    if (mapHashedBlocks.count(chainActive.Tip()->nHeight))
+        nStaking = true;
+    else if (mapHashedBlocks.count(chainActive.Tip()->nHeight - 1) && nLastCoinStakeSearchInterval)
+        nStaking = true;
+    obj.push_back(Pair("staking status", nStaking));
+
     return obj;
 }
 #endif // ENABLE_WALLET


### PR DESCRIPTION
The `getstakingstatus` RPC call showed everything BUT the staking-status.

That's fixed now:
![getstakingstatus](https://user-images.githubusercontent.com/22873440/26994246-1cf70eae-4d67-11e7-83e8-95a4077c5676.png)




