### PR TITLE
[Qt] Fix segfault when running with `-help`

### DIFF
--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -145,14 +145,14 @@ QString Intro::getDefaultDataDirectory()
     return GUIUtil::boostPathToQString(GetDefaultDataDir());
 }
 
-void Intro::pickDataDirectory()
+bool Intro::pickDataDirectory()
 {
     namespace fs = boost::filesystem;
     QSettings settings;
     /* If data directory provided on command line, no need to look at settings
        or show a picking dialog */
     if (!GetArg("-datadir", "").empty())
-        return;
+        return true;
     /* 1) Default data directory for operating system */
     QString dataDir = getDefaultDataDirectory();
     /* 2) Allow QSettings to override default dir */
@@ -167,7 +167,7 @@ void Intro::pickDataDirectory()
         while (true) {
             if (!intro.exec()) {
                 /* Cancel clicked */
-                exit(0);
+                return false;
             }
             dataDir = intro.getDataDirectory();
             try {
@@ -188,6 +188,7 @@ void Intro::pickDataDirectory()
      */
     if (dataDir != getDefaultDataDirectory())
         SoftSetArg("-datadir", GUIUtil::qstringToBoostPath(dataDir).string()); // use OS locale for path setting
+    return true;
 }
 
 void Intro::setStatus(int status, const QString& message, quint64 bytesAvailable)

--- a/src/qt/intro.h
+++ b/src/qt/intro.h
@@ -36,10 +36,13 @@ public:
     /**
      * Determine data directory. Let the user choose if the current one doesn't exist.
      *
+     * @returns true if a data directory was selected, false if the user cancelled the selection
+     * dialog.
+     *
      * @note do NOT call global GetDataDir() before calling this function, this
      * will cause the wrong path to be cached.
      */
-    static void pickDataDirectory();
+    static bool pickDataDirectory();
 
     /**
      * Determine default data directory for operating system.

--- a/src/qt/pivx.cpp
+++ b/src/qt/pivx.cpp
@@ -356,7 +356,7 @@ BitcoinApplication::~BitcoinApplication()
 #endif
     // Delete Qt-settings if user clicked on "Reset Options"
     QSettings settings;
-    if (optionsModel->resetSettings) {
+    if (optionsModel && optionsModel->resetSettings) {
         settings.clear();
         settings.sync();
     }
@@ -577,7 +577,8 @@ int main(int argc, char* argv[])
 
     /// 5. Now that settings and translations are available, ask user for data directory
     // User language is set up: pick a data directory
-    Intro::pickDataDirectory();
+    if (!Intro::pickDataDirectory())
+        return 0;
 
     /// 6. Determine availability of data directory and parse pivx.conf
     /// - Do not call GetDataDir(true) before this step finishes


### PR DESCRIPTION
When running pivx-qt with the `-help` flag, the intended operation
is to output the help contents then exit cleanly. However, this is
currently resulting in a segfault due to the return status of a
method in intro.

This Fixes the segfaulting behavior and now cleanly exits after
displaying the help contents.