### PR TITLE
[P2P] Enable Bloom filter and add new nService for light clients.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -879,7 +879,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     fAlerts = GetBoolArg("-alerts", DEFAULT_ALERTS);
 
 
-    if (GetBoolArg("-peerbloomfilters", false))
+    if (GetBoolArg("-peerbloomfilters", DEFAULT_PEERBLOOMFILTERS))
         nLocalServices |= NODE_BLOOM;
 
     // ********************************************************* Step 4: application initialization: dir lock, daemonize, pidfile, debug log

--- a/src/main.h
+++ b/src/main.h
@@ -99,6 +99,9 @@ static const unsigned int DATABASE_WRITE_INTERVAL = 3600;
 /** Maximum length of reject messages. */
 static const unsigned int MAX_REJECT_MESSAGE_LENGTH = 111;
 
+/** Enable bloom filter */
+ static const bool DEFAULT_PEERBLOOMFILTERS = true;
+
 /** "reject" message codes */
 static const unsigned char REJECT_MALFORMED = 0x01;
 static const unsigned char REJECT_INVALID = 0x10;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1716,9 +1716,11 @@ void RelayTransactionLockReq(const CTransaction& tx, bool relayToAll)
 void RelayInv(CInv& inv)
 {
     LOCK(cs_vNodes);
-    BOOST_FOREACH (CNode* pnode, vNodes)
+    BOOST_FOREACH (CNode* pnode, vNodes){
+    		if((pnode->nServices==NODE_BLOOM_WITHOUT_MN) && inv.IsMasterNodeType())return;
         if (pnode->nVersion >= ActiveProtocol())
             pnode->PushInventory(inv);
+    }
 }
 
 void CNode::RecordBytesRecv(uint64_t bytes)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1717,7 +1717,7 @@ void RelayInv(CInv& inv)
 {
     LOCK(cs_vNodes);
     BOOST_FOREACH (CNode* pnode, vNodes){
-    		if((pnode->nServices==NODE_BLOOM_WITHOUT_MN) && inv.IsMasterNodeType())return;
+    		if((pnode->nServices==NODE_BLOOM_WITHOUT_MN) && inv.IsMasterNodeType())continue;
         if (pnode->nVersion >= ActiveProtocol())
             pnode->PushInventory(inv);
     }

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -136,6 +136,10 @@ bool CInv::IsKnownType() const
     return (type >= 1 && type < (int)ARRAYLEN(ppszTypeName));
 }
 
+bool CInv::IsMasterNodeType() const{
+ 	return (type >= 6);
+}
+
 const char* CInv::GetCommand() const
 {
     if (!IsKnownType())

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -72,6 +72,11 @@ enum {
     // but no longer do as of protocol version 70011 (= NO_BLOOM_VERSION)
     NODE_BLOOM = (1 << 2),
 
+	// NODE_BLOOM_WITHOUT_MN means the node has the same features as NODE_BLOOM with the only difference
+	// that the node doens't want to receive master nodes messages. (the 1<<3 was not picked as constant because on bitcoin 0.14 is witness and we want that update here )
+
+	 NODE_BLOOM_WITHOUT_MN = (1 << 4),
+
     // Bits 24-31 are reserved for temporary experiments. Just pick a bit that
     // isn't getting used, or one not being used much, and notify the
     // bitcoin-development mailing list. Remember that service bits are just
@@ -137,6 +142,7 @@ public:
     friend bool operator<(const CInv& a, const CInv& b);
 
     bool IsKnownType() const;
+    bool IsMasterNodeType() const;
     const char* GetCommand() const;
     std::string ToString() const;
 


### PR DESCRIPTION
As the title says:

- Bloom filter enabled by default.
- New nService for light clients added, NODE_BLOOM_WITHOUT_MN means that the node doesn't want to receive master nodes related messages (The amount of messages flood light client if it's not controlled and in some cases client doesn't need that information.)