### PR TITLE
[Utils] Fix update-translations.py to allow % at end of string

### DIFF
--- a/contrib/devtools/update-translations.py
+++ b/contrib/devtools/update-translations.py
@@ -51,7 +51,10 @@ def find_format_specifiers(s):
         percent = s.find('%', pos)
         if percent < 0:
             break
-        specifiers.append(s[percent+1])
+        try:
+            specifiers.append(s[percent+1])
+        except:
+            print('Failed to get specifier')
         pos = percent+2
     return specifiers
 


### PR DESCRIPTION
Prior to this, strings coming in from transifex that had a `%` at the end would cause the script to error out.