### PR TITLE
[Qt] Enable support for Qt's HighDpiScaling

### DIFF
--- a/src/qt/pivx.cpp
+++ b/src/qt/pivx.cpp
@@ -543,6 +543,9 @@ int main(int argc, char* argv[])
     // Generate high-dpi pixmaps
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
+#if QT_VERSION >= 0x050600
+    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
 #ifdef Q_OS_MAC
     QApplication::setAttribute(Qt::AA_DontShowIconsInMenus);
 #endif


### PR DESCRIPTION
This was missed in the bump to Qt 5.6 and should resolve issues
with window/text scaling on High DPI devices such as #228.