### PR TITLE
[Gitian] bump version to 3.0

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -1,5 +1,5 @@
 ---
-name: "pivx-linux-2.3"
+name: "pivx-linux-3.0"
 enable_cache: true
 suites:
 - "trusty"

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -1,5 +1,5 @@
 ---
-name: "pivx-osx-2.3"
+name: "pivx-osx-3.0"
 enable_cache: true
 suites:
 - "trusty"

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -1,5 +1,5 @@
 ---
-name: "pivx-win-2.3"
+name: "pivx-win-3.0"
 enable_cache: true
 suites:
 - "trusty"


### PR DESCRIPTION
Now that 2.3 branch has been split off, bump gitian descriptor
versions to 3.0 preemptively to avoid having to rebuild caches
at the last minute.