### PR TITLE
[RPC] Make 'masternode status' more verbose

### DIFF
--- a/src/rpcmasternode.cpp
+++ b/src/rpcmasternode.cpp
@@ -443,7 +443,8 @@ Value masternode(const Array& params, bool fHelp)
             mnObj.push_back(Pair("message", activeMasternode.GetStatus()));
             return mnObj;
         }
-        throw runtime_error("Masternode not found\n");
+        throw runtime_error("Masternode not found in the list of available masternodes. Current status: " 
+                            + activeMasternode.GetStatus() + "\n");
     }
 
     if (strCommand == "winners") {


### PR DESCRIPTION
If a masternode isn't yet activated the current error message ("Masternode not found") confuses every masternode owner but one.

The error message now includes the status of the (not-yet-activated) masternode, in this case "Node just started, not yet activated".