### PR TITLE
[Qt] Adjust masternode count in information UI

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -72,7 +72,9 @@ QString ClientModel::getMasternodeCountString() const
 {
     int ipv4 = 0, ipv6 = 0, onion = 0;
     mnodeman.CountNetworks(ActiveProtocol(), ipv4, ipv6, onion);
-    return tr("Total: %1 (IPv4: %2 / IPv6: %3 / Tor: %4)").arg(QString::number((int)mnodeman.size())).arg(QString::number((int)ipv4)).arg(QString::number((int)ipv6)).arg(QString::number((int)onion));
+    int nUnknown = mnodeman.size() - ipv4 - ipv6 - onion;
+    if(nUnknown < 0) nUnknown = 0;
+    return tr("Total: %1 (IPv4: %2 / IPv6: %3 / Tor: %4 / Unknown: %5)").arg(QString::number((int)mnodeman.size())).arg(QString::number((int)ipv4)).arg(QString::number((int)ipv6)).arg(QString::number((int)onion)).arg(QString::number((int)nUnknown));
 }
 
 int ClientModel::getNumBlocks() const

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -70,7 +70,9 @@ int ClientModel::getNumConnections(unsigned int flags) const
 
 QString ClientModel::getMasternodeCountString() const
 {
-    return tr("Total: %1 (OBF compatible: %2 / Enabled: %3)").arg(QString::number((int)mnodeman.size())).arg(QString::number((int)mnodeman.CountEnabled(ActiveProtocol()))).arg(QString::number((int)mnodeman.CountEnabled()));
+    int ipv4 = 0, ipv6 = 0, onion = 0;
+    mnodeman.CountNetworks(ActiveProtocol(), ipv4, ipv6, onion);
+    return tr("Total: %1 (IPv4: %2 / IPv6: %3 / Tor: %4)").arg(QString::number((int)mnodeman.size())).arg(QString::number((int)ipv4)).arg(QString::number((int)ipv6)).arg(QString::number((int)onion));
 }
 
 int ClientModel::getNumBlocks() const

--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -252,8 +252,17 @@
        </item>
        <item row="10" column="1">
         <widget class="QLabel" name="masternodeCount">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
          <property name="text">
           <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
Line no longer displays the OBF compat / enabled count, but rather shows
the count of each network protocol (IPv4 / IPv6 / Tor).

Also makes the line contents selectable with the mouse :)

New layout:
![screen shot 2017-08-29 at 12 25 05 am](https://user-images.githubusercontent.com/7393257/30149318-095da08e-935c-11e7-8d32-51bb01742a3a.png)
