### PR TITLE
[Build] Selectively suppress depreciation warnings

### DIFF
--- a/src/qt/paymentrequestplus.h
+++ b/src/qt/paymentrequestplus.h
@@ -5,7 +5,10 @@
 #ifndef BITCOIN_QT_PAYMENTREQUESTPLUS_H
 #define BITCOIN_QT_PAYMENTREQUESTPLUS_H
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include "paymentrequest.pb.h"
+#pragma GCC diagnostic pop
 
 #include "base58.h"
 


### PR DESCRIPTION
Mac/clang complains about LSSharedFileListItemResolve() being
depreciated during the build process, but it must be retained for
backwards compatibility. 

So selectively suppress these warnings and also
introduce the updated function call when applicable.