### PR TITLE
[GUI/RPC] Changed bubblehelp text + RPC startmasternode help text fixed

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -314,7 +314,7 @@ void BitcoinGUI::createActions(const NetworkStyle* networkStyle)
     tabGroup->addAction(receiveCoinsAction);
 
     privacyAction = new QAction(QIcon(":/icons/privacy"), tr("&Privacy"), this);
-    privacyAction->setStatusTip(tr("Privacy Action for zPIV and Obfuscation"));
+    privacyAction->setStatusTip(tr("Privacy Actions for zPIV"));
     privacyAction->setToolTip(privacyAction->statusTip());
     privacyAction->setCheckable(true);
 #ifdef Q_OS_MAC

--- a/src/rpcmasternode.cpp
+++ b/src/rpcmasternode.cpp
@@ -479,7 +479,7 @@ Value startmasternode (const Array& params, bool fHelp)
             "  ]\n"
             "}\n"
             "\nExamples:\n" +
-            HelpExampleCli("masternodestart", "\"alias\" \"my_mn\"") + HelpExampleRpc("masternodestart", "\"alias\" \"my_mn\""));
+            HelpExampleCli("startmasternode", "\"alias\" \"0\" \"my_mn\"") + HelpExampleRpc("startmasternode", "\"alias\" \"0\" \"my_mn\""));
 
     bool fLock = (params[1].get_str() == "true" ? true : false);
 


### PR DESCRIPTION
![privtab](https://user-images.githubusercontent.com/22873440/31318307-67c6a3de-ac50-11e7-90b3-b75d2dbd5519.png)
