### PR TITLE
Append BIP38 encrypted key with an 4 byte Base58 Checksum

### DIFF
--- a/src/bip38.cpp
+++ b/src/bip38.cpp
@@ -77,7 +77,7 @@ std::string AddressToBip38Hash(std::string address)
     return HexStr(addrCheck).substr(0, 8);
 }
 
-std::string BIP38_Encrypt(std::string strAddress, std::string strPassphrase, uint256 privKey)
+std::string BIP38_Encrypt(std::string strAddress, std::string strPassphrase, uint256 privKey, bool fCompressed)
 {
     string strAddressHash = AddressToBip38Hash(strAddress);
 
@@ -106,7 +106,10 @@ std::string BIP38_Encrypt(std::string strAddress, std::string strPassphrase, uin
     uint512 encrypted2;
     AES_encrypt(block2.begin(), encrypted2.begin(), &key);
 
-    uint512 encryptedKey(ReverseEndianString("0142E0" + strAddressHash));
+    string strPrefix = "0142";
+    strPrefix += (fCompressed ? "E0" : "C0");
+
+    uint512 encryptedKey(ReverseEndianString(strPrefix + strAddressHash));
 
     //add encrypted1 to the end of encryptedKey
     encryptedKey = encryptedKey | (encrypted1 << 56);
@@ -114,7 +117,14 @@ std::string BIP38_Encrypt(std::string strAddress, std::string strPassphrase, uin
     //add encrypted2 to the end of encryptedKey
     encryptedKey = encryptedKey | (encrypted2 << (56 + 128));
 
-    //TODO: ensure +43 works on different OS
+    //Base58 checksum is the 4 bytes of dSHA256 hash of the encrypted key
+    uint256 hashChecksum = Hash(encryptedKey.begin(), encryptedKey.begin() + 39);
+    uint512 b58Checksum(hashChecksum.ToString().substr(64 - 8, 8));
+
+    // append the encrypted key with checksum (currently occupies 312 bits)
+    encryptedKey = encryptedKey | (b58Checksum << 312);
+
+    //43 bytes is the total size that we are encoding
     return EncodeBase58(encryptedKey.begin(), encryptedKey.begin() + 43);
 }
 

--- a/src/bip38.h
+++ b/src/bip38.h
@@ -32,7 +32,7 @@ void ComputeSeedBPass(CPubKey passpoint, std::string strAddressHash, std::string
 
 void ComputeFactorB(uint256 seedB, uint256& factorB);
 
-std::string BIP38_Encrypt(std::string strAddress, std::string strPassphrase, uint256 privKey);
+std::string BIP38_Encrypt(std::string strAddress, std::string strPassphrase, uint256 privKey, bool fCompressed);
 bool BIP38_Decrypt(std::string strPassphrase, std::string strEncryptedKey, uint256& privKey, bool& fCompressed);
 
 std::string AddressToBip38Hash(std::string address);

--- a/src/qt/bip38tooldialog.cpp
+++ b/src/qt/bip38tooldialog.cpp
@@ -151,7 +151,7 @@ void Bip38ToolDialog::on_encryptKeyButton_ENC_clicked()
         return;
     }
 
-    std::string encryptedKey = BIP38_Encrypt(addr.ToString(), qstrPassphrase.toStdString(), key.GetPrivKey_256());
+    std::string encryptedKey = BIP38_Encrypt(addr.ToString(), qstrPassphrase.toStdString(), key.GetPrivKey_256(), key.IsCompressed());
     ui->encryptedKeyOut_ENC->setText(QString::fromStdString(encryptedKey));
 }
 

--- a/src/rpcdump.cpp
+++ b/src/rpcdump.cpp
@@ -421,7 +421,7 @@ Value bip38encrypt(const Array& params, bool fHelp)
         throw JSONRPCError(RPC_WALLET_ERROR, "Private key for address " + strAddress + " is not known");
 
     uint256 privKey = vchSecret.GetPrivKey_256();
-    string encryptedOut = BIP38_Encrypt(strAddress, strPassphrase, privKey);
+    string encryptedOut = BIP38_Encrypt(strAddress, strPassphrase, privKey, vchSecret.IsCompressed());
 
     Object result;
     result.push_back(Pair("Addess", strAddress));


### PR DESCRIPTION
Previously BIP38 tool was leaving the final 4 bytes of the encrypted key blank. These 4 bytes are where the base58 checksum is supposed to be inserted. Tools that check the base58 checksum of the encrypted key were finding the key invalid because of the blank checksum.

Also add an additional check for address compression.