### PR TITLE
[Qt] Don't allow the Esc key to close the privacy tab

### DIFF
--- a/src/qt/privacydialog.cpp
+++ b/src/qt/privacydialog.cpp
@@ -597,3 +597,13 @@ void PrivacyDialog::showOutOfSyncWarning(bool fShow)
 {
     ui->labelzPIVSyncStatus->setVisible(fShow);
 }
+
+void PrivacyDialog::keyPressEvent(QKeyEvent* event)
+{
+    if (event->key() != Qt::Key_Escape) // press esc -> ignore
+    {
+        this->QDialog::keyPressEvent(event);
+    } else {
+        event->ignore();
+    }
+}

--- a/src/qt/privacydialog.h
+++ b/src/qt/privacydialog.h
@@ -52,6 +52,9 @@ public slots:
 //    void setBalance(const CAmount& balance, const CAmount& anonymizedBalance);
     void setBalance(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance, const CAmount& zerocoinBalance, const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance);
 
+protected:
+    virtual void keyPressEvent(QKeyEvent* event);
+
 private:
     Ui::PrivacyDialog* ui;
     QTimer* timer;


### PR DESCRIPTION
Previously, pressing the `Esc` key while on the Privacy tab would
destroy the tab. This is due to the tab being a `QDialog` object that
naturally inherits this behavior.

Fix by ignoring the keyevent generated by the `Esc` key.

fixes #285