### PR TITLE
Bad CBlockHeader copy.

### DIFF
--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -135,6 +135,7 @@ public:
         block.nTime          = nTime;
         block.nBits          = nBits;
         block.nNonce         = nNonce;
+        block.nAccumulatorCheckpoint = nAccumulatorCheckpoint;
         return block;
     }
 


### PR DESCRIPTION
nAccumulatorCheckpoint added to the CBlockHeader copy.