### PR TITLE
[Core] Don't send not-validated blocks

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5312,7 +5312,8 @@ void static ProcessGetData(CNode* pfrom)
                         }
                     }
                 }
-                if (send) {
+                // Don't send not-validated blocks
+                if (send && (mi->second->nStatus & BLOCK_HAVE_DATA)) {
                     // Send block from disk
                     CBlock block;
                     if (!ReadBlockFromDisk(block, (*mi).second))


### PR DESCRIPTION
Reference: https://github.com/PIVX-Project/PIVX/issues/305

When investigating the issue above I found an upstream-change (https://github.com/dashpay/dash/blob/v0.12.2.x/src/net_processing.cpp#L839) which we should implement as well, even when this issue most probably was just a corrupt block-file, not a missing block.

