### PR TITLE
[UI] Better error message when too much inputs are used for spending zPIV

### DIFF
--- a/src/denomination_functions.cpp
+++ b/src/denomination_functions.cpp
@@ -409,11 +409,13 @@ int calculateChange(
 // 'spends' are required
 // -------------------------------------------------------------------------------------------------------
 std::vector<CZerocoinMint> SelectMintsFromList(const CAmount nValueTarget, CAmount& nSelectedValue, int nMaxNumberOfSpends, bool fMinimizeChange,
-                                               int& nCoinsReturned, const std::list<CZerocoinMint>& listMints, const std::map<CoinDenomination, CAmount> mapOfDenomsHeld)
+                                               int& nCoinsReturned, const std::list<CZerocoinMint>& listMints, 
+                                               const std::map<CoinDenomination, CAmount> mapOfDenomsHeld, int& nNeededSpends)
 {
     std::vector<CZerocoinMint> vSelectedMints;
     std::map<CoinDenomination, CAmount> mapOfDenomsUsed;
 
+    nNeededSpends = 0;
     bool fCanMeetExactly = getIdealSpends(nValueTarget, listMints, mapOfDenomsHeld, mapOfDenomsUsed);
     if (fCanMeetExactly) {
         nCoinsReturned = 0;
@@ -422,6 +424,9 @@ std::vector<CZerocoinMint> SelectMintsFromList(const CAmount nValueTarget, CAmou
         // If true, we are good and done!
         if (vSelectedMints.size() <= (size_t)nMaxNumberOfSpends) {
             return vSelectedMints;
+        }
+        else {
+            nNeededSpends = vSelectedMints.size();
         }
     }
     // Since either too many spends needed or can not spend the exact amount,

--- a/src/denomination_functions.h
+++ b/src/denomination_functions.h
@@ -19,7 +19,8 @@ std::vector<CZerocoinMint> SelectMintsFromList(const CAmount nValueTarget, CAmou
                                                bool fMinimizeChange,
                                                int& nCoinsReturned,
                                                const std::list<CZerocoinMint>& listMints,
-                                               const std::map<libzerocoin::CoinDenomination, CAmount> mapDenomsHeld
+                                               const std::map<libzerocoin::CoinDenomination, CAmount> mapDenomsHeld,
+                                               int& nNeededSpends
                                                );
 
 int calculateChange(

--- a/src/primitives/zerocoin.cpp
+++ b/src/primitives/zerocoin.cpp
@@ -14,10 +14,11 @@ std::vector<CZerocoinSpend> CZerocoinSpendReceipt::GetSpends()
     return vSpends;
 }
 
-void CZerocoinSpendReceipt::SetStatus(std::string strStatus, int nStatus)
+void CZerocoinSpendReceipt::SetStatus(std::string strStatus, int nStatus, int nNeededSpends)
 {
     strStatusMessage = strStatus;
     this->nStatus = nStatus;
+    this->nNeededSpends = nNeededSpends;
 }
 
 std::string CZerocoinSpendReceipt::GetStatusMessage()
@@ -28,4 +29,9 @@ std::string CZerocoinSpendReceipt::GetStatusMessage()
 int CZerocoinSpendReceipt::GetStatus()
 {
     return nStatus;
+}
+
+int CZerocoinSpendReceipt::GetNeededSpends()
+{
+    return nNeededSpends;
 }

--- a/src/primitives/zerocoin.h
+++ b/src/primitives/zerocoin.h
@@ -177,14 +177,16 @@ class CZerocoinSpendReceipt
 private:
     std::string strStatusMessage;
     int nStatus;
+    int nNeededSpends;
     std::vector<CZerocoinSpend> vSpends;
 
 public:
     void AddSpend(const CZerocoinSpend& spend);
     std::vector<CZerocoinSpend> GetSpends();
-    void SetStatus(std::string strStatus, int nStatus);
+    void SetStatus(std::string strStatus, int nStatus, int nNeededSpends = 0);
     std::string GetStatusMessage();
     int GetStatus();
+    int GetNeededSpends();
 };
 
 #endif //PIVX_ZEROCOIN_H

--- a/src/qt/forms/privacydialog.ui
+++ b/src/qt/forms/privacydialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>991</width>
-    <height>552</height>
+    <height>568</height>
    </rect>
   </property>
   <property name="sizePolicy">

--- a/src/test/zerocoin_denomination_tests.cpp
+++ b/src/test/zerocoin_denomination_tests.cpp
@@ -114,6 +114,7 @@ BOOST_AUTO_TEST_CASE(zerocoin_spend_test241)
     CAmount OneCoinAmount = ZerocoinDenominationToAmount(ZQ_ONE);
     CAmount nValueTarget = OneCoinAmount;
     int nCoinsReturned;
+    int nNeededSpends = 0;  // Number of spends which would be needed if selection failed
 
     bool fDebug = 0;
 
@@ -124,7 +125,8 @@ BOOST_AUTO_TEST_CASE(zerocoin_spend_test241)
                                                                  fMinimizeChange,
                                                                  nCoinsReturned,
                                                                  listMints,
-                                                                 mapDenom);
+                                                                 mapDenom,
+                                                                 nNeededSpends);
         
         if (fDebug) {
             if (vSpends.size() > 0) {
@@ -190,13 +192,15 @@ BOOST_AUTO_TEST_CASE(zerocoin_spend_test115)
 
     bool fDebug = 0;
     int nCoinsReturned;
+    int nNeededSpends = 0;  // Number of spends which would be needed if selection failed
 
     std::vector<CZerocoinMint> vSpends = SelectMintsFromList(nValueTarget, nSelectedValue,
                                                              nMaxNumberOfSpends,
                                                              fMinimizeChange,
                                                              nCoinsReturned,
                                                              listMints,
-                                                             mapDenom);
+                                                             mapDenom,
+                                                             nNeededSpends);
 
     if (fDebug) {
         if (vSpends.size() > 0) {
@@ -267,6 +271,7 @@ BOOST_AUTO_TEST_CASE(zerocoin_spend_test_from_245)
 
     bool fDebug = 0;
     int nCoinsReturned;
+    int nNeededSpends = 0;  // Number of spends which would be needed if selection failed
     
     // Go through all possible spend between 1 and 241 and see if it's possible or not
     for (int i = 0; i < CoinsHeld; i++) {
@@ -275,7 +280,8 @@ BOOST_AUTO_TEST_CASE(zerocoin_spend_test_from_245)
                                                                  false,
                                                                  nCoinsReturned,
                                                                  listMints,
-                                                                 mapOfDenomsHeld);
+                                                                 mapOfDenomsHeld,
+                                                                 nNeededSpends);
         
         if (fDebug) {
             if (vSpends.size() > 0) {
@@ -296,7 +302,8 @@ BOOST_AUTO_TEST_CASE(zerocoin_spend_test_from_245)
                                                                     true,
                                                                     nCoinsReturned,
                                                                     listMints,
-                                                                    mapOfDenomsHeld);
+                                                                    mapOfDenomsHeld,
+                                                                    nNeededSpends);
         
         
         if (fDebug) {
@@ -364,6 +371,7 @@ BOOST_AUTO_TEST_CASE(zerocoin_spend_test_from_145)
 
     bool fDebug = 0;
     int nCoinsReturned;
+    int nNeededSpends = 0;  // Number of spends which would be needed if selection failed
     
     // Go through all possible spend between 1 and 241 and see if it's possible or not
     for (int i = 0; i < CoinsHeld; i++) {
@@ -372,7 +380,8 @@ BOOST_AUTO_TEST_CASE(zerocoin_spend_test_from_145)
                                                                  false,
                                                                  nCoinsReturned,
                                                                  listMints,
-                                                                 mapOfDenomsHeld);
+                                                                 mapOfDenomsHeld,
+                                                                 nNeededSpends);
         
         if (fDebug) {
             if (vSpends.size() > 0) {
@@ -393,7 +402,8 @@ BOOST_AUTO_TEST_CASE(zerocoin_spend_test_from_145)
                                                                     true,
                                                                     nCoinsReturned,
                                                                     listMints,
-                                                                    mapOfDenomsHeld);
+                                                                    mapOfDenomsHeld,
+                                                                    nNeededSpends);
         
         
         if (fDebug) {
@@ -459,13 +469,15 @@ BOOST_AUTO_TEST_CASE(zerocoin_spend_test99)
 
     bool fDebug = 0;
     int nCoinsReturned;
+    int nNeededSpends = 0;  // Number of spends which would be needed if selection failed
 
     std::vector<CZerocoinMint> vSpends = SelectMintsFromList(nValueTarget, nSelectedValue,
                                                              nMaxNumberOfSpends,
                                                              fMinimizeChange,
                                                              nCoinsReturned,
                                                             listMints,
-                                                             mapOfDenomsHeld);
+                                                             mapOfDenomsHeld,
+                                                             nNeededSpends);
 
     if (fDebug) {
         if (vSpends.size() > 0) {


### PR DESCRIPTION
This should give the user a better idea why a zPIV transaction failed.

Additional error in spending to local address (with empty 'Pay To' field) fixed.

New error message:
![max-inputs](https://user-images.githubusercontent.com/22873440/31970136-501b9180-b917-11e7-8412-09bc98e9438d.png)
