### PR TITLE
[UI] Wallet repair option to resync from scratch

### DIFF
--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -1077,10 +1077,23 @@
       <attribute name="title">
        <string>&amp;Wallet Repair</string>
       </attribute>
-      <layout class="QGridLayout" name="gridLayout_4" columnstretch="0,1,0,2">
+      <layout class="QGridLayout" name="gridLayout_4" columnstretch="0,0,0,0">
        <property name="horizontalSpacing">
         <number>12</number>
        </property>
+       <item row="10" column="0" colspan="2">
+        <widget class="QPushButton" name="btn_resync">
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>23</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Delete local Blockchain Folders</string>
+         </property>
+        </widget>
+       </item>
        <item row="0" column="0" colspan="4">
         <widget class="QLabel" name="label_repair_header">
          <property name="font">
@@ -1326,7 +1339,7 @@
          </property>
         </widget>
        </item>
-       <item row="10" column="0">
+       <item row="11" column="0">
         <spacer name="verticalSpacer_repair2">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -1338,6 +1351,23 @@
           </size>
          </property>
         </spacer>
+       </item>
+       <item row="10" column="2">
+        <widget class="QLabel" name="label_repair_resync_command">
+         <property name="text">
+          <string>-resync:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="3">
+        <widget class="QLabel" name="label_repair_resync">
+         <property name="text">
+          <string>Deletes all local blockchain folders so the wallet synchronizes from scratch.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -52,6 +52,7 @@ const QString ZAPTXES1("-zapwallettxes=1");
 const QString ZAPTXES2("-zapwallettxes=2");
 const QString UPGRADEWALLET("-upgradewallet");
 const QString REINDEX("-reindex");
+const QString RESYNC("-resync");
 
 const struct {
     const char* url;
@@ -244,6 +245,7 @@ RPCConsole::RPCConsole(QWidget* parent) : QDialog(parent),
     connect(ui->btn_zapwallettxes2, SIGNAL(clicked()), this, SLOT(walletZaptxes2()));
     connect(ui->btn_upgradewallet, SIGNAL(clicked()), this, SLOT(walletUpgrade()));
     connect(ui->btn_reindex, SIGNAL(clicked()), this, SLOT(walletReindex()));
+    connect(ui->btn_resync, SIGNAL(clicked()), this, SLOT(walletResync()));
 
     // set library version labels
     ui->openSSLVersion->setText(SSLeay_version(SSLEAY_VERSION));
@@ -427,6 +429,27 @@ void RPCConsole::walletUpgrade()
 void RPCConsole::walletReindex()
 {
     buildParameterlist(REINDEX);
+}
+
+/** Restart wallet with "-resync" */
+void RPCConsole::walletResync()
+{
+    QString resyncWarning = tr("This will delete your local blockchain folders and the wallet will synchronize the complete Blockchain from scratch.<br /><br />");
+        resyncWarning +=   tr("This needs quite some time and downloads a lot of data.<br /><br />");
+        resyncWarning +=   tr("Your transactions and funds will be visible again after the download has completed.<br /><br />");
+        resyncWarning +=   tr("Do you want to continue?.<br />");
+    QMessageBox::StandardButton retval = QMessageBox::question(this, tr("Confirm resync Blockchain"),
+        resyncWarning,
+        QMessageBox::Yes | QMessageBox::Cancel,
+        QMessageBox::Cancel);
+
+    if (retval != QMessageBox::Yes) {
+        // Resync canceled
+        return;
+    }
+
+    // Restart and resync
+    buildParameterlist(RESYNC);
 }
 
 /** Build command-line parameter list for restart */

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -69,6 +69,7 @@ public slots:
     void walletZaptxes2();
     void walletUpgrade();
     void walletReindex();
+    void walletResync();
 
     void reject();
     void message(int category, const QString& message, bool html = false);


### PR DESCRIPTION
This option was requested by @s3v3nh4cks , so blame him if you don't like it :-)

When executed, this repair option restarts the wallet with the parameter `-resync` and will delete the folders `blocks`, `chainstate`, `sporks` and `zerocoin` and the wallet starts to synchronize from scratch.
This should help users to reinitialize their local blockchain-data into a consistent state without the need to explain where those folders are and which folders to delete.

It's also available as command line parameter `-resync` if the wallet-UI isn't usable for whatever reasons.

**Please(!) test this on OSX and Windows and report back (both positive and negative results)**

Since resync needs a lot of time and temporary missing funds might scare users I've added an appropriate warning:

![resync](https://user-images.githubusercontent.com/22873440/32022897-0a072f26-b9d8-11e7-8cf8-d47e3e334bf5.png)
