### PR TITLE
[Build] Add compile/link summary to configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1034,3 +1034,28 @@ case $host in
      chmod 755 libtool
    ;;
 esac
+
+echo
+echo "Options used to compile and link:"
+echo "  with wallet   = $enable_wallet"
+echo "  with gui / qt = $bitcoin_enable_qt"
+if test x$bitcoin_enable_qt != xno; then
+    echo "    qt version  = $bitcoin_qt_got_major_vers"
+    echo "    with qr     = $use_qr"
+fi
+echo "  with zmq      = $use_zmq"
+echo "  with test     = $use_tests"
+dnl echo "  with bench    = $use_bench"
+echo "  with upnp     = $use_upnp"
+echo "  debug enabled = $enable_debug"
+echo
+echo "  target os     = $TARGET_OS"
+echo "  build os      = $BUILD_OS"
+echo
+echo "  CC            = $CC"
+echo "  CFLAGS        = $CFLAGS"
+echo "  CPPFLAGS      = $CPPFLAGS"
+echo "  CXX           = $CXX"
+echo "  CXXFLAGS      = $CXXFLAGS"
+echo "  LDFLAGS       = $LDFLAGS"
+echo


### PR DESCRIPTION
This adds a summary of compiler and linker flags, as well as information
about which features are enabled/disabled to the end of the configure
script.

Doesn't change any functionality, and is strictly informational.

Example Output:
```
Options used to compile and link:
  with wallet   = yes
  with gui / qt = yes
    qt version  = 5
    with qr     = yes
  with zmq      = yes
  with test     = yes
  with upnp     = yes
  debug enabled = no

  target os     = darwin
  build os      = darwin

  CC            = /usr/local/bin/ccache gcc
  CFLAGS        = -g -O2
  CPPFLAGS      = -Qunused-arguments -I/usr/local/opt/openssl/include -DBOOST_SPIRIT_THREADSAFE -DHAVE_BUILD_INFO -D__STDC_FORMAT_MACROS -I/usr/local/opt/berkeley-db@4/include -DMAC_OSX  -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -DHAVE_QT5
  CXX           = /usr/local/bin/ccache g++ -std=c++11
  CXXFLAGS      = -g -O2 -Wall -Wextra -Wformat -Wformat-security -Wno-unused-parameter  -Wstack-protector -fstack-protector-all -fPIC -fvisibility=hidden
  LDFLAGS       = -L/usr/local/opt/openssl/lib -Wl,-headerpad_max_install_names  -Wl,-dead_strip
```