### PR TITLE
[UI] Balance fix + bubble-help + usability improvements

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -922,39 +922,14 @@
              <property name="spacing">
               <number>12</number>
              </property>
-             <item row="2" column="1">
-              <widget class="QLabel" name="labelzBalancez">
-               <property name="font">
-                <font>
-                 <weight>75</weight>
-                 <bold>true</bold>
-                </font>
-               </property>
-               <property name="cursor">
-                <cursorShape>IBeamCursor</cursorShape>
-               </property>
-               <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-               </property>
-               <property name="text">
-                <string notr="true">0.000 000 00 PIV</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-               </property>
-               <property name="textInteractionFlags">
-                <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="0" colspan="2">
+             <item row="7" column="0" colspan="2">
               <widget class="Line" name="lineSpendableBalance_3">
                <property name="orientation">
                 <enum>Qt::Horizontal</enum>
                </property>
               </widget>
              </item>
-             <item row="4" column="2">
+             <item row="7" column="2">
               <widget class="Line" name="lineWatchBalance_3">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -973,8 +948,8 @@
                </property>
               </widget>
              </item>
-             <item row="3" column="1">
-              <widget class="QLabel" name="labelTotalz">
+             <item row="4" column="1">
+              <widget class="QLabel" name="labelzBalancez">
                <property name="font">
                 <font>
                  <weight>75</weight>
@@ -985,7 +960,7 @@
                 <cursorShape>IBeamCursor</cursorShape>
                </property>
                <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Total Balance, including unconfirmed and immature coins.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</string>
                </property>
                <property name="text">
                 <string notr="true">0.000 000 00 PIV</string>
@@ -998,7 +973,32 @@
                </property>
               </widget>
              </item>
-             <item row="2" column="3">
+             <item row="6" column="1">
+              <widget class="QLabel" name="labelTotalz">
+               <property name="font">
+                <font>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="cursor">
+                <cursorShape>IBeamCursor</cursorShape>
+               </property>
+               <property name="toolTip">
+                <string>Total Balance, including unconfirmed and immature coins.</string>
+               </property>
+               <property name="text">
+                <string notr="true">0.000 000 00 PIV</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
+               <property name="textInteractionFlags">
+                <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="3">
               <spacer name="horizontalSpacer_6">
                <property name="orientation">
                 <enum>Qt::Horizontal</enum>
@@ -1011,7 +1011,7 @@
                </property>
               </spacer>
              </item>
-             <item row="3" column="0">
+             <item row="6" column="0">
               <widget class="QLabel" name="labelTotalTextz">
                <property name="text">
                 <string>Total:</string>
@@ -1050,18 +1050,22 @@
                </property>
               </widget>
              </item>
-             <item row="2" column="0">
+             <item row="4" column="0">
               <widget class="QLabel" name="labelzBalanceTextz">
                <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string/>
                </property>
                <property name="text">
                 <string>zPIV:</string>
                </property>
               </widget>
              </item>
-             <item row="1" column="2">
-              <widget class="QLabel" name="labelPIVPercent">
+             <item row="4" column="2">
+              <widget class="QLabel" name="labelzPIVPercent">
+               <property name="toolTip">
+                <string>Current percentage of zPIV.
+If AutoMint is enabled this percentage will settle around the configured AutoMint percentage (default = 10%)</string>
+               </property>
                <property name="text">
                 <string>0 %</string>
                </property>
@@ -1070,13 +1074,56 @@
                </property>
               </widget>
              </item>
-             <item row="2" column="2">
-              <widget class="QLabel" name="labelzPIVPercent">
+             <item row="6" column="2">
+              <widget class="QLabel" name="label100Percent">
+               <property name="text">
+                <string/>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QLabel" name="labelLockedBalance">
                <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Current percentage of zPIV.&lt;/p&gt;&lt;p&gt;If AutoMint is enabled this percentage will settle around the configured AutoMint percentage (default = &lt;span style=&quot; font-weight:600;&quot;&gt;10&lt;/span&gt;%)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string>Locked PIV or Masternode collaterals. These are excluded from zPIV minting.</string>
                </property>
                <property name="text">
-                <string>0 %</string>
+                <string>0.000 000 00 PIV</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="labelLockedBalanceText">
+               <property name="toolTip">
+                <string>Locked PIV or Masternode collaterals. These are excluded from zPIV minting.</string>
+               </property>
+               <property name="text">
+                <string>Locked:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0">
+              <widget class="QLabel" name="labelUnLockedBalanceText">
+               <property name="toolTip">
+                <string>Unlocked PIVs. These can be used for zPIV minting.</string>
+               </property>
+               <property name="text">
+                <string>Unlocked:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <widget class="QLabel" name="labelUnLockedBalance">
+               <property name="toolTip">
+                <string>Unlocked PIVs. These can be used for zPIV minting.</string>
+               </property>
+               <property name="text">
+                <string>0.000 000 00 PIV</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -1084,9 +1131,9 @@
               </widget>
              </item>
              <item row="3" column="2">
-              <widget class="QLabel" name="label100Percent">
+              <widget class="QLabel" name="labelPIVPercent">
                <property name="text">
-                <string/>
+                <string>0 %</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -1157,7 +1204,8 @@
              <item row="4" column="0">
               <widget class="QLabel" name="labelzBalanceMatureText">
                <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Mature:&lt;/span&gt; confirmed, and 3 or more &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after it was minted.&lt;/p&gt;&lt;p&gt;These are spendable.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string>Mature: more than 20 confirmation and more than 3 mints of the same denomination after it was minted.
+These zPIV are spendable.</string>
                </property>
                <property name="text">
                 <string>Mature:</string>
@@ -1183,7 +1231,7 @@
                 <cursorShape>IBeamCursor</cursorShape>
                </property>
                <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;All available zPIV, unconfirmed and immature zPIV included.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string>All available zPIV, unconfirmed and immature zPIV included.</string>
                </property>
                <property name="text">
                 <string notr="true">0.000 000 00 PIV</string>
@@ -1218,10 +1266,10 @@
              <item row="1" column="0">
               <widget class="QLabel" name="labelzBalanceText">
                <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;All available zPIV, unconfirmed and immature zPIV included.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string>All available zPIV, unconfirmed and immature zPIV included.</string>
                </property>
                <property name="text">
-                <string>Available:</string>
+                <string>Total:</string>
                </property>
               </widget>
              </item>
@@ -1259,6 +1307,10 @@
                  <bold>true</bold>
                 </font>
                </property>
+               <property name="toolTip">
+                <string>Mature: more than 20 confirmation and more than 3 mints of the same denomination after it was minted.
+These zPIV are spendable.</string>
+               </property>
                <property name="text">
                 <string>0.000 000 00 PIV</string>
                </property>
@@ -1270,7 +1322,8 @@
              <item row="2" column="0">
               <widget class="QLabel" name="labelzBalanceUnconfirmedText">
                <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Unconfirmed:&lt;/span&gt; less than &lt;span style=&quot; font-weight:600;&quot;&gt;20&lt;/span&gt; confirmations&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Immature:&lt;/span&gt; confirmed, but less than &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after it was minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string>Unconfirmed: less than 20 confirmations
+Immature: confirmed, but less than 3 mints of the same denomination after it was minted</string>
                </property>
                <property name="text">
                 <string>Unconfirmed:</string>
@@ -1286,7 +1339,8 @@
                 </font>
                </property>
                <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Unconfirmed:&lt;/span&gt; less than &lt;span style=&quot; font-weight:600;&quot;&gt;20&lt;/span&gt; confirmations&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Immature:&lt;/span&gt; confirmed, but less than &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after it was minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string>Unconfirmed: less than 20 confirmations
+Immature: confirmed, but less than 3 mints of the same denomination after it was minted</string>
                </property>
                <property name="text">
                 <string>0.000 000 00 PIV</string>
@@ -1312,7 +1366,8 @@
              <item row="3" column="0">
               <widget class="QLabel" name="labelzBalanceImmatureText">
                <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Unconfirmed:&lt;/span&gt; less than &lt;span style=&quot; font-weight:600;&quot;&gt;20&lt;/span&gt; confirmations&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Immature:&lt;/span&gt; confirmed, but less than &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after it was minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string>Unconfirmed: less than 20 confirmations
+Immature: confirmed, but less than 3 mints of the same denomination after it was minted</string>
                </property>
                <property name="text">
                 <string>Immature:</string>
@@ -1328,7 +1383,8 @@
                 </font>
                </property>
                <property name="toolTip">
-                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Unconfirmed:&lt;/span&gt; less than &lt;span style=&quot; font-weight:600;&quot;&gt;20&lt;/span&gt; confirmations&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Immature:&lt;/span&gt; confirmed, but less than &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after it was minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <string>Unconfirmed: less than 20 confirmations
+Immature: confirmed, but less than 3 mints of the same denomination after it was minted</string>
                </property>
                <property name="text">
                 <string>0.000 000 00 PIV</string>

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -118,7 +118,7 @@
                <string>Unconfirmed transactions to watch-only addresses</string>
               </property>
               <property name="text">
-               <string notr="true">0.000 000 00 BTC</string>
+               <string notr="true">0.000 000 00 PIV</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -143,7 +143,7 @@
                <string>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</string>
               </property>
               <property name="text">
-               <string notr="true">0.000 000 00 BTC</string>
+               <string notr="true">0.000 000 00 PIV</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -168,7 +168,7 @@
                <string>Staked or masternode rewards in watch-only addresses that has not yet matured</string>
               </property>
               <property name="text">
-               <string notr="true">0.000 000 00 BTC</string>
+               <string notr="true">0.000 000 00 PIV</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -226,7 +226,7 @@
                <string>Staked or masternode rewards that has not yet matured</string>
               </property>
               <property name="text">
-               <string notr="true">0.000 000 00 BTC</string>
+               <string notr="true">0.000 000 00 PIV</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -271,7 +271,7 @@
                <string>Your current total balance</string>
               </property>
               <property name="text">
-               <string notr="true">0.000 000 00 BTC</string>
+               <string notr="true">0.000 000 00 PIV</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -296,7 +296,7 @@
                <string>Current total balance in watch-only addresses</string>
               </property>
               <property name="text">
-               <string notr="true">0.000 000 00 BTC</string>
+               <string notr="true">0.000 000 00 PIV</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -338,7 +338,7 @@
                <string>Your current spendable balance</string>
               </property>
               <property name="text">
-               <string notr="true">0.000 000 00 BTC</string>
+               <string notr="true">0.000 000 00 PIV</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -363,7 +363,7 @@
                <string>Your current balance in watch-only addresses</string>
               </property>
               <property name="text">
-               <string notr="true">0.000 000 00 BTC</string>
+               <string notr="true">0.000 000 00 PIV</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -393,7 +393,7 @@
            </layout>
           </item>
           <item>
-           <spacer name="verticalSpacer">
+           <spacer name="verticalSpacer_4">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>
@@ -879,7 +879,7 @@
           <property name="geometry">
            <rect>
             <x>0</x>
-            <y>20</y>
+            <y>150</y>
             <width>465</width>
             <height>201</height>
            </rect>
@@ -891,22 +891,6 @@
            <enum>QFrame::Raised</enum>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_5">
-           <item>
-            <spacer name="verticalSpacer_4">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeType">
-              <enum>QSizePolicy::Expanding</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>10</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
            <item>
             <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="0">
              <item>
@@ -923,8 +907,11 @@
                  <bold>true</bold>
                 </font>
                </property>
+               <property name="toolTip">
+                <string>Combined Balances (including unconfirmed and immature coins)</string>
+               </property>
                <property name="text">
-                <string>Combined Balances (including immature coins)</string>
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Combined Balances&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                </property>
               </widget>
              </item>
@@ -947,10 +934,10 @@
                 <cursorShape>IBeamCursor</cursorShape>
                </property>
                <property name="toolTip">
-                <string>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</string>
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                </property>
                <property name="text">
-                <string notr="true">0.000 000 00 BTC</string>
+                <string notr="true">0.000 000 00 PIV</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -998,10 +985,10 @@
                 <cursorShape>IBeamCursor</cursorShape>
                </property>
                <property name="toolTip">
-                <string>Staked or masternode rewards that has not yet matured</string>
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Total Balance, including unconfirmed and immature coins.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                </property>
                <property name="text">
-                <string notr="true">0.000 000 00 BTC</string>
+                <string notr="true">0.000 000 00 PIV</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -1053,7 +1040,7 @@
                 <string>Your current spendable balance</string>
                </property>
                <property name="text">
-                <string notr="true">0.000 000 00 BTC</string>
+                <string notr="true">0.000 000 00 PIV</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -1065,6 +1052,9 @@
              </item>
              <item row="2" column="0">
               <widget class="QLabel" name="labelzBalanceTextz">
+               <property name="toolTip">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
                <property name="text">
                 <string>zPIV:</string>
                </property>
@@ -1082,6 +1072,9 @@
              </item>
              <item row="2" column="2">
               <widget class="QLabel" name="labelzPIVPercent">
+               <property name="toolTip">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Current percentage of zPIV.&lt;/p&gt;&lt;p&gt;If AutoMint is enabled this percentage will settle around the configured AutoMint percentage (default = &lt;span style=&quot; font-weight:600;&quot;&gt;10&lt;/span&gt;%)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
                <property name="text">
                 <string>0 %</string>
                </property>
@@ -1102,15 +1095,28 @@
              </item>
             </layout>
            </item>
+           <item>
+            <spacer name="verticalSpacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
           </layout>
          </widget>
          <widget class="QFrame" name="frame_4">
           <property name="geometry">
            <rect>
             <x>0</x>
-            <y>-110</y>
+            <y>0</y>
             <width>465</width>
-            <height>201</height>
+            <height>171</height>
            </rect>
           </property>
           <property name="frameShape">
@@ -1120,22 +1126,6 @@
            <enum>QFrame::Raised</enum>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_7">
-           <item>
-            <spacer name="verticalSpacer_6">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeType">
-              <enum>QSizePolicy::Expanding</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>10</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
            <item>
             <layout class="QHBoxLayout" name="horizontalLayout_8" stretch="0">
              <item>
@@ -1164,6 +1154,23 @@
              <property name="spacing">
               <number>12</number>
              </property>
+             <item row="4" column="0">
+              <widget class="QLabel" name="labelzBalanceMatureText">
+               <property name="toolTip">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Mature:&lt;/span&gt; confirmed, and 3 or more &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after it was minted.&lt;/p&gt;&lt;p&gt;These are spendable.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="text">
+                <string>Mature:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="0" colspan="2">
+              <widget class="Line" name="lineSpendableBalance_5">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+              </widget>
+             </item>
              <item row="1" column="1">
               <widget class="QLabel" name="labelzBalance">
                <property name="font">
@@ -1176,10 +1183,10 @@
                 <cursorShape>IBeamCursor</cursorShape>
                </property>
                <property name="toolTip">
-                <string>Your current spendable balance</string>
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;All available zPIV, unconfirmed and immature zPIV included.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                </property>
                <property name="text">
-                <string notr="true">0.000 000 00 BTC</string>
+                <string notr="true">0.000 000 00 PIV</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -1189,14 +1196,7 @@
                </property>
               </widget>
              </item>
-             <item row="3" column="0" colspan="2">
-              <widget class="Line" name="lineSpendableBalance_5">
-               <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="2">
+             <item row="5" column="2">
               <widget class="Line" name="lineWatchBalance_5">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -1217,13 +1217,129 @@
              </item>
              <item row="1" column="0">
               <widget class="QLabel" name="labelzBalanceText">
+               <property name="toolTip">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;All available zPIV, unconfirmed and immature zPIV included.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
                <property name="text">
-                <string>zPIV:</string>
+                <string>Available:</string>
                </property>
               </widget>
              </item>
              <item row="1" column="2">
               <spacer name="horizontalSpacer_8">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item row="4" column="2">
+              <spacer name="horizontalSpacer_4">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item row="4" column="1">
+              <widget class="QLabel" name="labelzBalanceMature">
+               <property name="font">
+                <font>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="text">
+                <string>0.000 000 00 PIV</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QLabel" name="labelzBalanceUnconfirmedText">
+               <property name="toolTip">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Unconfirmed:&lt;/span&gt; less than &lt;span style=&quot; font-weight:600;&quot;&gt;20&lt;/span&gt; confirmations&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Immature:&lt;/span&gt; confirmed, but less than &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after it was minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="text">
+                <string>Unconfirmed:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QLabel" name="labelzBalanceUnconfirmed">
+               <property name="font">
+                <font>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="toolTip">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Unconfirmed:&lt;/span&gt; less than &lt;span style=&quot; font-weight:600;&quot;&gt;20&lt;/span&gt; confirmations&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Immature:&lt;/span&gt; confirmed, but less than &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after it was minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="text">
+                <string>0.000 000 00 PIV</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="2">
+              <spacer name="horizontalSpacer_5">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item row="3" column="0">
+              <widget class="QLabel" name="labelzBalanceImmatureText">
+               <property name="toolTip">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Unconfirmed:&lt;/span&gt; less than &lt;span style=&quot; font-weight:600;&quot;&gt;20&lt;/span&gt; confirmations&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Immature:&lt;/span&gt; confirmed, but less than &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after it was minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="text">
+                <string>Immature:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <widget class="QLabel" name="labelzBalanceImmature">
+               <property name="font">
+                <font>
+                 <weight>75</weight>
+                 <bold>true</bold>
+                </font>
+               </property>
+               <property name="toolTip">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Unconfirmed:&lt;/span&gt; less than &lt;span style=&quot; font-weight:600;&quot;&gt;20&lt;/span&gt; confirmations&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Immature:&lt;/span&gt; confirmed, but less than &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after it was minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="text">
+                <string>0.000 000 00 PIV</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="2">
+              <spacer name="horizontalSpacer_7">
                <property name="orientation">
                 <enum>Qt::Horizontal</enum>
                </property>

--- a/src/qt/forms/privacydialog.ui
+++ b/src/qt/forms/privacydialog.ui
@@ -556,6 +556,9 @@
                </item>
                <item>
                 <widget class="QLabel" name="labelzPIVBalanceText">
+                 <property name="toolTip">
+                  <string>Available (mature and spendable) zPIV for spending</string>
+                 </property>
                  <property name="text">
                   <string>Available Balance:</string>
                  </property>
@@ -571,6 +574,9 @@
                    <weight>75</weight>
                    <bold>true</bold>
                   </font>
+                 </property>
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Available (mature and spendable) zPIV for spending&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;zPIV are mature when they have more than &lt;span style=&quot; font-weight:600;&quot;&gt;20&lt;/span&gt; confirmations &lt;span style=&quot; font-weight:600;&quot;&gt;AND&lt;/span&gt; more than &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after them were minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
                  <property name="text">
                   <string>0 zPIV</string>
@@ -949,7 +955,7 @@
                   </font>
                  </property>
                  <property name="toolTip">
-                  <string>Available Funds</string>
+                  <string>Avialable Balance including immature zPIV</string>
                  </property>
                  <property name="text">
                   <string>Available Zerocoin  Balance:</string>
@@ -985,6 +991,9 @@
                    <weight>75</weight>
                    <bold>true</bold>
                   </font>
+                 </property>
+                 <property name="toolTip">
+                  <string>Avialable Balance including immature zPIV</string>
                  </property>
                  <property name="text">
                   <string>0 zPIV</string>
@@ -1031,6 +1040,9 @@
                    <width>40</width>
                    <height>0</height>
                   </size>
+                 </property>
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Unconfirmed:&lt;/span&gt; less than &lt;span style=&quot; font-weight:600;&quot;&gt;20&lt;/span&gt; confirmations&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Immature:&lt;/span&gt; confirmed, but less than &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after it was minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
                  <property name="text">
                   <string>0 x</string>
@@ -1081,6 +1093,9 @@
                    <height>0</height>
                   </size>
                  </property>
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Unconfirmed:&lt;/span&gt; less than &lt;span style=&quot; font-weight:600;&quot;&gt;20&lt;/span&gt; confirmations&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Immature:&lt;/span&gt; confirmed, but less than &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after it was minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
                  <property name="text">
                   <string>0 x</string>
                  </property>
@@ -1129,6 +1144,9 @@
                    <width>40</width>
                    <height>0</height>
                   </size>
+                 </property>
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Unconfirmed:&lt;/span&gt; less than &lt;span style=&quot; font-weight:600;&quot;&gt;20&lt;/span&gt; confirmations&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Immature:&lt;/span&gt; confirmed, but less than &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after it was minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
                  <property name="text">
                   <string>0 x</string>
@@ -1179,6 +1197,9 @@
                    <height>0</height>
                   </size>
                  </property>
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Unconfirmed:&lt;/span&gt; less than &lt;span style=&quot; font-weight:600;&quot;&gt;20&lt;/span&gt; confirmations&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Immature:&lt;/span&gt; confirmed, but less than &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after it was minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
                  <property name="text">
                   <string>0 x</string>
                  </property>
@@ -1227,6 +1248,9 @@
                    <width>40</width>
                    <height>0</height>
                   </size>
+                 </property>
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Unconfirmed:&lt;/span&gt; less than &lt;span style=&quot; font-weight:600;&quot;&gt;20&lt;/span&gt; confirmations&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Immature:&lt;/span&gt; confirmed, but less than &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after it was minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
                  <property name="text">
                   <string>0 x</string>
@@ -1277,6 +1301,9 @@
                    <height>0</height>
                   </size>
                  </property>
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Unconfirmed:&lt;/span&gt; less than &lt;span style=&quot; font-weight:600;&quot;&gt;20&lt;/span&gt; confirmations&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Immature:&lt;/span&gt; confirmed, but less than &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after it was minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
                  <property name="text">
                   <string>0 x</string>
                  </property>
@@ -1326,6 +1353,9 @@
                    <height>0</height>
                   </size>
                  </property>
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Unconfirmed:&lt;/span&gt; less than &lt;span style=&quot; font-weight:600;&quot;&gt;20&lt;/span&gt; confirmations&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Immature:&lt;/span&gt; confirmed, but less than &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after it was minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
                  <property name="text">
                   <string>0 x</string>
                  </property>
@@ -1374,6 +1404,9 @@
                    <width>40</width>
                    <height>0</height>
                   </size>
+                 </property>
+                 <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Unconfirmed:&lt;/span&gt; less than &lt;span style=&quot; font-weight:600;&quot;&gt;20&lt;/span&gt; confirmations&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Immature:&lt;/span&gt; confirmed, but less than &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after it was minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                  </property>
                  <property name="text">
                   <string>0 x</string>

--- a/src/qt/forms/privacydialog.ui
+++ b/src/qt/forms/privacydialog.ui
@@ -177,6 +177,9 @@
                </item>
                <item>
                 <widget class="QLabel" name="labelzPIVAmountText">
+                 <property name="toolTip">
+                  <string>Available for minting are coins which are confirmed and not locked or Masternode collaterals.</string>
+                 </property>
                  <property name="text">
                   <string>Available for Minting:</string>
                  </property>
@@ -576,7 +579,9 @@
                   </font>
                  </property>
                  <property name="toolTip">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Available (mature and spendable) zPIV for spending&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;zPIV are mature when they have more than &lt;span style=&quot; font-weight:600;&quot;&gt;20&lt;/span&gt; confirmations &lt;span style=&quot; font-weight:600;&quot;&gt;AND&lt;/span&gt; more than &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after them were minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  <string>Available (mature and spendable) zPIV for spending
+
+zPIV are mature when they have more than 20 confirmations AND more than 3 mints of the same denomination after them were minted</string>
                  </property>
                  <property name="text">
                   <string>0 zPIV</string>
@@ -955,10 +960,10 @@
                   </font>
                  </property>
                  <property name="toolTip">
-                  <string>Avialable Balance including immature zPIV</string>
+                  <string>Total Balance including unconfirmed and immature zPIV</string>
                  </property>
                  <property name="text">
-                  <string>Available Zerocoin  Balance:</string>
+                  <string>Total Zerocoin  Balance:</string>
                  </property>
                  <property name="alignment">
                   <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -993,7 +998,7 @@
                   </font>
                  </property>
                  <property name="toolTip">
-                  <string>Avialable Balance including immature zPIV</string>
+                  <string>Total Balance including unconfirmed and immature zPIV</string>
                  </property>
                  <property name="text">
                   <string>0 zPIV</string>
@@ -1042,7 +1047,8 @@
                   </size>
                  </property>
                  <property name="toolTip">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Unconfirmed:&lt;/span&gt; less than &lt;span style=&quot; font-weight:600;&quot;&gt;20&lt;/span&gt; confirmations&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Immature:&lt;/span&gt; confirmed, but less than &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after it was minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  <string>Unconfirmed: less than 20 confirmations
+Immature: confirmed, but less than 3 mints of the same denomination after it was minted</string>
                  </property>
                  <property name="text">
                   <string>0 x</string>
@@ -1094,7 +1100,8 @@
                   </size>
                  </property>
                  <property name="toolTip">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Unconfirmed:&lt;/span&gt; less than &lt;span style=&quot; font-weight:600;&quot;&gt;20&lt;/span&gt; confirmations&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Immature:&lt;/span&gt; confirmed, but less than &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after it was minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  <string>Unconfirmed: less than 20 confirmations
+Immature: confirmed, but less than 3 mints of the same denomination after it was minted</string>
                  </property>
                  <property name="text">
                   <string>0 x</string>
@@ -1146,7 +1153,8 @@
                   </size>
                  </property>
                  <property name="toolTip">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Unconfirmed:&lt;/span&gt; less than &lt;span style=&quot; font-weight:600;&quot;&gt;20&lt;/span&gt; confirmations&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Immature:&lt;/span&gt; confirmed, but less than &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after it was minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  <string>Unconfirmed: less than 20 confirmations
+Immature: confirmed, but less than 3 mints of the same denomination after it was minted</string>
                  </property>
                  <property name="text">
                   <string>0 x</string>
@@ -1198,7 +1206,8 @@
                   </size>
                  </property>
                  <property name="toolTip">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Unconfirmed:&lt;/span&gt; less than &lt;span style=&quot; font-weight:600;&quot;&gt;20&lt;/span&gt; confirmations&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Immature:&lt;/span&gt; confirmed, but less than &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after it was minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  <string>Unconfirmed: less than 20 confirmations
+Immature: confirmed, but less than 3 mints of the same denomination after it was minted</string>
                  </property>
                  <property name="text">
                   <string>0 x</string>
@@ -1250,7 +1259,8 @@
                   </size>
                  </property>
                  <property name="toolTip">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Unconfirmed:&lt;/span&gt; less than &lt;span style=&quot; font-weight:600;&quot;&gt;20&lt;/span&gt; confirmations&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Immature:&lt;/span&gt; confirmed, but less than &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after it was minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  <string>Unconfirmed: less than 20 confirmations
+Immature: confirmed, but less than 3 mints of the same denomination after it was minted</string>
                  </property>
                  <property name="text">
                   <string>0 x</string>
@@ -1302,7 +1312,8 @@
                   </size>
                  </property>
                  <property name="toolTip">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Unconfirmed:&lt;/span&gt; less than &lt;span style=&quot; font-weight:600;&quot;&gt;20&lt;/span&gt; confirmations&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Immature:&lt;/span&gt; confirmed, but less than &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after it was minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  <string>Unconfirmed: less than 20 confirmations
+Immature: confirmed, but less than 3 mints of the same denomination after it was minted</string>
                  </property>
                  <property name="text">
                   <string>0 x</string>
@@ -1354,7 +1365,8 @@
                   </size>
                  </property>
                  <property name="toolTip">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Unconfirmed:&lt;/span&gt; less than &lt;span style=&quot; font-weight:600;&quot;&gt;20&lt;/span&gt; confirmations&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Immature:&lt;/span&gt; confirmed, but less than &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after it was minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  <string>Unconfirmed: less than 20 confirmations
+Immature: confirmed, but less than 3 mints of the same denomination after it was minted</string>
                  </property>
                  <property name="text">
                   <string>0 x</string>
@@ -1406,7 +1418,8 @@
                   </size>
                  </property>
                  <property name="toolTip">
-                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Unconfirmed:&lt;/span&gt; less than &lt;span style=&quot; font-weight:600;&quot;&gt;20&lt;/span&gt; confirmations&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Immature:&lt;/span&gt; confirmed, but less than &lt;span style=&quot; font-weight:600;&quot;&gt;3&lt;/span&gt; mints of the same denomination after it was minted&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                  <string>Unconfirmed: less than 20 confirmations
+Immature: confirmed, but less than 3 mints of the same denomination after it was minted</string>
                  </property>
                  <property name="text">
                   <string>0 x</string>

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -37,7 +37,9 @@ public:
     void showOutOfSyncWarning(bool fShow);
 
 public slots:
-    void setBalance(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance, const CAmount& zerocoinBalance, const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance);
+    void setBalance(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance, 
+                    const CAmount& zerocoinBalance, const CAmount& unconfirmedZerocoinBalance, const CAmount& immatureZerocoinBalance,
+                    const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance);
 
 signals:
     void transactionClicked(const QModelIndex& index);
@@ -51,6 +53,8 @@ private:
     CAmount currentUnconfirmedBalance;
     CAmount currentImmatureBalance;
     CAmount currentZerocoinBalance;
+    CAmount currentUnconfirmedZerocoinBalance;
+    CAmount currentimmatureZerocoinBalance;
     CAmount currentWatchOnlyBalance;
     CAmount currentWatchUnconfBalance;
     CAmount currentWatchImmatureBalance;

--- a/src/qt/privacydialog.cpp
+++ b/src/qt/privacydialog.cpp
@@ -103,12 +103,12 @@ void PrivacyDialog::setModel(WalletModel* walletModel)
 
     if (walletModel && walletModel->getOptionsModel()) {
         // Keep up to date with wallet
-        setBalance(walletModel->getBalance(),         walletModel->getUnconfirmedBalance(), walletModel->getImmatureBalance(), 
-                   walletModel->getZerocoinBalance(), walletModel->getWatchBalance(),       walletModel->getWatchUnconfirmedBalance(), 
-                   walletModel->getWatchImmatureBalance());
+        setBalance(walletModel->getBalance(), walletModel->getUnconfirmedBalance(), walletModel->getImmatureBalance(),
+                   walletModel->getZerocoinBalance(), walletModel->getUnconfirmedZerocoinBalance(), walletModel->getImmatureZerocoinBalance(),
+                   walletModel->getWatchBalance(), walletModel->getWatchUnconfirmedBalance(), walletModel->getWatchImmatureBalance());
         
-        connect(walletModel, SIGNAL(balanceChanged(CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount)), this, 
-                               SLOT(setBalance(CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount)));
+        connect(walletModel, SIGNAL(balanceChanged(CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount)), this, 
+                               SLOT(setBalance(CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount)));
         ui->securityLevel->setValue(nSecurityLevel);
     }
 }
@@ -200,9 +200,9 @@ void PrivacyDialog::on_pushButtonMintzPIV_clicked()
     }
 
     // Available balance isn't always updated, so force it.
-    setBalance(walletModel->getBalance(),         walletModel->getUnconfirmedBalance(), walletModel->getImmatureBalance(), 
-               walletModel->getZerocoinBalance(), walletModel->getWatchBalance(),       walletModel->getWatchUnconfirmedBalance(), 
-               walletModel->getWatchImmatureBalance());
+    setBalance(walletModel->getBalance(), walletModel->getUnconfirmedBalance(), walletModel->getImmatureBalance(), 
+               walletModel->getZerocoinBalance(), walletModel->getUnconfirmedZerocoinBalance(), walletModel->getImmatureZerocoinBalance(),
+               walletModel->getWatchBalance(), walletModel->getWatchUnconfirmedBalance(), walletModel->getWatchImmatureBalance());
     coinControlUpdateLabels();
 
     return;
@@ -524,14 +524,17 @@ bool PrivacyDialog::updateLabel(const QString& address)
     return false;
 }
 
-void PrivacyDialog::setBalance(const CAmount& balance,         const CAmount& unconfirmedBalance, const CAmount& immatureBalance, 
-                               const CAmount& zerocoinBalance, const CAmount& watchOnlyBalance,   const CAmount& watchUnconfBalance, 
-                               const CAmount& watchImmatureBalance)
+void PrivacyDialog::setBalance(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance, 
+                               const CAmount& zerocoinBalance, const CAmount& unconfirmedZerocoinBalance, const CAmount& immatureZerocoinBalance,
+                               const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance)
 {
+
     currentBalance = balance;
     currentUnconfirmedBalance = unconfirmedBalance;
     currentImmatureBalance = immatureBalance;
     currentZerocoinBalance = zerocoinBalance;
+    currentUnconfirmedZerocoinBalance = unconfirmedZerocoinBalance;
+    currentImmatureZerocoinBalance = immatureZerocoinBalance;
     currentWatchOnlyBalance = watchOnlyBalance;
     currentWatchUnconfBalance = watchUnconfBalance;
     currentWatchImmatureBalance = watchImmatureBalance;
@@ -541,36 +544,65 @@ void PrivacyDialog::setBalance(const CAmount& balance,         const CAmount& un
  
     std::map<libzerocoin::CoinDenomination, CAmount> mapDenomBalances;
     std::map<libzerocoin::CoinDenomination, int> mapUnconfirmed;
+    std::map<libzerocoin::CoinDenomination, int> mapImmature;
     for (const auto& denom : libzerocoin::zerocoinDenomList){
         mapDenomBalances.insert(make_pair(denom, 0));
         mapUnconfirmed.insert(make_pair(denom, 0));
+        mapImmature.insert(make_pair(denom, 0));
     }
 
     for (auto& mint : listMints){
+        // All denominations
         mapDenomBalances.at(mint.GetDenomination())++;
 
-        if (!mint.GetHeight() || mint.GetHeight() > chainActive.Height() - Params().Zerocoin_MintRequiredConfirmations())
+        if (!mint.GetHeight() || mint.GetHeight() > chainActive.Height() - Params().Zerocoin_MintRequiredConfirmations()) {
+            // All unconfirmed denominations
             mapUnconfirmed.at(mint.GetDenomination())++;
+        }
+        else {
+            // After a denomination is confirmed it might still be immature because < 3 of the same denomination were minted after it
+            CBlockIndex *pindex = chainActive[mint.GetHeight()];
+            int nMintsAdded = 0;
+            while(pindex->nHeight < chainActive.Height() - 30) { // 30 just to make sure that its at least 2 checkpoints from the top block
+                nMintsAdded += count(pindex->vMintDenominationsInBlock.begin(), pindex->vMintDenominationsInBlock.end(), mint.GetDenomination());
+                if(nMintsAdded >= 3)
+                    break;
+                pindex = chainActive[pindex->nHeight + 1];
+            }
+            if(nMintsAdded < 3){
+                // Immature denominations
+                mapImmature.at(mint.GetDenomination())++;
+            }
+        }
     }
-    
+
     int64_t nCoins = 0;
     int64_t nSumPerCoin = 0;
     int64_t nUnconfirmed = 0;
+    int64_t nImmature = 0;
     QString strDenomStats, strUnconfirmed = "";
-    
+
     for (const auto& denom : libzerocoin::zerocoinDenomList) {
         nCoins = libzerocoin::ZerocoinDenominationToInt(denom);
         nSumPerCoin = nCoins * mapDenomBalances.at(denom);
         nUnconfirmed = mapUnconfirmed.at(denom);
-        if (nUnconfirmed)
-            strUnconfirmed = QString("(") + QString::number(nUnconfirmed) + QString(" unconfirmed) ");
-        else
-            strUnconfirmed = "";
+        nImmature = mapImmature.at(denom);
+
+        strUnconfirmed = "";
+        if (nUnconfirmed) {
+            strUnconfirmed += QString::number(nUnconfirmed) + QString(" unconf. ");
+        }
+        if(nImmature) {
+            strUnconfirmed += QString::number(nImmature) + QString(" immature ");
+        }
+        if(nImmature || nUnconfirmed) {
+            strUnconfirmed = QString("( ") + strUnconfirmed + QString(") ");
+        }
 
         strDenomStats = strUnconfirmed + QString::number(mapDenomBalances.at(denom)) + " x " +
                         QString::number(nCoins) + " = <b>" + 
                         QString::number(nSumPerCoin) + " zPIV </b>";
-        
+
         switch (nCoins) {
             case libzerocoin::CoinDenomination::ZQ_ONE: 
                 ui->labelzDenom1Amount->setText(strDenomStats);
@@ -601,8 +633,9 @@ void PrivacyDialog::setBalance(const CAmount& balance,         const CAmount& un
                 break;
         }
     }
+    CAmount matureZerocoinBalance = zerocoinBalance - immatureZerocoinBalance;
     ui->labelzAvailableAmount->setText(QString::number(zerocoinBalance/COIN) + QString(" zPIV "));
-    ui->labelzAvailableAmount_2->setText(QString::number(zerocoinBalance/COIN) + QString(" zPIV "));
+    ui->labelzAvailableAmount_2->setText(QString::number(matureZerocoinBalance/COIN) + QString(" zPIV "));
     ui->labelzPIVAmountValue->setText(BitcoinUnits::floorHtmlWithUnit(nDisplayUnit, balance - immatureBalance, false, BitcoinUnits::separatorAlways));
 }
 
@@ -611,7 +644,8 @@ void PrivacyDialog::updateDisplayUnit()
     if (walletModel && walletModel->getOptionsModel()) {
         nDisplayUnit = walletModel->getOptionsModel()->getDisplayUnit();
         if (currentBalance != -1)
-            setBalance(currentBalance, currentUnconfirmedBalance, currentImmatureBalance, currentZerocoinBalance, 
+            setBalance(currentBalance, currentUnconfirmedBalance, currentImmatureBalance,
+                       currentZerocoinBalance, currentUnconfirmedZerocoinBalance, currentImmatureZerocoinBalance,
                        currentWatchOnlyBalance, currentWatchUnconfBalance, currentWatchImmatureBalance);
     }
 }

--- a/src/qt/privacydialog.cpp
+++ b/src/qt/privacydialog.cpp
@@ -634,9 +634,14 @@ void PrivacyDialog::setBalance(const CAmount& balance, const CAmount& unconfirme
         }
     }
     CAmount matureZerocoinBalance = zerocoinBalance - immatureZerocoinBalance;
+    CAmount nLockedBalance = 0;
+    if (walletModel) {
+        nLockedBalance = walletModel->getLockedBalance();
+    }
+
     ui->labelzAvailableAmount->setText(QString::number(zerocoinBalance/COIN) + QString(" zPIV "));
     ui->labelzAvailableAmount_2->setText(QString::number(matureZerocoinBalance/COIN) + QString(" zPIV "));
-    ui->labelzPIVAmountValue->setText(BitcoinUnits::floorHtmlWithUnit(nDisplayUnit, balance - immatureBalance, false, BitcoinUnits::separatorAlways));
+    ui->labelzPIVAmountValue->setText(BitcoinUnits::floorHtmlWithUnit(nDisplayUnit, balance - immatureBalance - nLockedBalance, false, BitcoinUnits::separatorAlways));
 }
 
 void PrivacyDialog::updateDisplayUnit()

--- a/src/qt/privacydialog.h
+++ b/src/qt/privacydialog.h
@@ -49,9 +49,9 @@ public:
     void setZPivControlLabels(int64_t nAmount, int nQuantity);
 
 public slots:
-//    void setBalance(const CAmount& balance, const CAmount& anonymizedBalance);
-    void setBalance(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance, const CAmount& zerocoinBalance, const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance);
-
+    void setBalance(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance, 
+                    const CAmount& zerocoinBalance, const CAmount& unconfirmedZerocoinBalance, const CAmount& immatureZerocoinBalance,
+                    const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance);
 protected:
     virtual void keyPressEvent(QKeyEvent* event);
 
@@ -65,6 +65,8 @@ private:
     CAmount currentUnconfirmedBalance;
     CAmount currentImmatureBalance;
     CAmount currentZerocoinBalance;
+    CAmount currentUnconfirmedZerocoinBalance;
+    CAmount currentImmatureZerocoinBalance;
     CAmount currentWatchOnlyBalance;
     CAmount currentWatchUnconfBalance;
     CAmount currentWatchImmatureBalance;

--- a/src/qt/res/css/default.css
+++ b/src/qt/res/css/default.css
@@ -786,7 +786,6 @@ padding-bottom:8px;
 }
 
 QDialog#OptionsDialog QCheckBox {
-qproperty-alignment: 'AlignVCenter';
 min-height:20px;
 }
 
@@ -1142,6 +1141,46 @@ QWidget .QFrame#frame_3 .QLabel#labelzBalancez { /* Available zPIV Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
 font-size:12px;
 font-weight:bold;
+color:#5B4C7C;
+margin-left:0px;
+}
+
+QWidget .QFrame#frame_3 .QLabel#labelLockedBalanceText { /* Available zPIV Label */
+qproperty-alignment: 'AlignVCenter | AlignRight';
+min-width:160px;
+background-color:#5B4C7C;
+color:#fff;
+margin-right:5px;
+padding-right:5px;
+font-weight:bold;
+font-size:14px;
+/* min-height:35px; */
+}
+
+QWidget .QFrame#frame_3 .QLabel#labelLockedBalance { /* Available zPIV Balance */
+qproperty-alignment: 'AlignVCenter | AlignLeft';
+font-size:12px;
+font-weight:normal;
+color:#5B4C7C;
+margin-left:0px;
+}
+
+QWidget .QFrame#frame_3 .QLabel#labelUnLockedBalanceText { /* Available zPIV Label */
+qproperty-alignment: 'AlignVCenter | AlignRight';
+min-width:160px;
+background-color:#5B4C7C;
+color:#fff;
+margin-right:5px;
+padding-right:5px;
+font-weight:bold;
+font-size:14px;
+/* min-height:35px; */
+}
+
+QWidget .QFrame#frame_3 .QLabel#labelUnLockedBalance { /* Available zPIV Balance */
+qproperty-alignment: 'AlignVCenter | AlignLeft';
+font-size:12px;
+font-weight:normal;
 color:#5B4C7C;
 margin-left:0px;
 }

--- a/src/qt/res/css/default.css
+++ b/src/qt/res/css/default.css
@@ -1035,6 +1035,66 @@ color:#5B4C7C;
 margin-left:0px;
 }
 
+QWidget .QFrame#frame_4 .QLabel#labelzBalanceUnconfirmedText { /* Unconfirmed zPIV Label */
+qproperty-alignment: 'AlignVCenter | AlignRight';
+min-width:160px;
+background-color:#5B4C7C;
+color:#fff;
+margin-right:5px;
+padding-right:5px;
+font-weight:bold;
+font-size:14px;
+/* min-height:35px; */
+}
+
+QWidget .QFrame#frame_4 .QLabel#labelzBalanceUnconfirmed { /* Unconfirmed zPIV Balance */
+qproperty-alignment: 'AlignVCenter | AlignLeft';
+font-size:12px;
+font-weight:bold;
+color:#5B4C7C;
+margin-left:0px;
+}
+
+QWidget .QFrame#frame_4 .QLabel#labelzBalanceMatureText { /* Mature zPIV Label */
+qproperty-alignment: 'AlignVCenter | AlignRight';
+min-width:160px;
+background-color:#5B4C7C;
+color:#fff;
+margin-right:5px;
+padding-right:5px;
+font-weight:bold;
+font-size:14px;
+/* min-height:35px; */
+}
+
+QWidget .QFrame#frame_4 .QLabel#labelzBalanceMature { /* Mature zPIV Balance */
+qproperty-alignment: 'AlignVCenter | AlignLeft';
+font-size:12px;
+font-weight:bold;
+color:#5B4C7C;
+margin-left:0px;
+}
+
+QWidget .QFrame#frame_4 .QLabel#labelzBalanceImmatureText { /* Immature zPIV Label */
+qproperty-alignment: 'AlignVCenter | AlignRight';
+min-width:160px;
+background-color:#5B4C7C;
+color:#fff;
+margin-right:5px;
+padding-right:5px;
+font-weight:bold;
+font-size:14px;
+/* min-height:35px; */
+}
+
+QWidget .QFrame#frame_4 .QLabel#labelzBalanceImmature { /* Immature zPIV Balance */
+qproperty-alignment: 'AlignVCenter | AlignLeft';
+font-size:12px;
+font-weight:bold;
+color:#5B4C7C;
+margin-left:0px;
+}
+
 QWidget .QFrame#frame_3 .QLabel#label_5z { /* Combined Balance Label */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
 min-width:160px;

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -159,9 +159,11 @@ void SendCoinsDialog::setModel(WalletModel* model)
             }
         }
 
-        setBalance(model->getBalance(), model->getUnconfirmedBalance(), model->getImmatureBalance(), model->getZerocoinBalance (),
-            model->getWatchBalance(), model->getWatchUnconfirmedBalance(), model->getWatchImmatureBalance());
-        connect(model, SIGNAL(balanceChanged(CAmount, CAmount,  CAmount, CAmount, CAmount, CAmount, CAmount)), this, SLOT(setBalance(CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount)));
+        setBalance(model->getBalance(), model->getUnconfirmedBalance(), model->getImmatureBalance(),
+                   model->getZerocoinBalance (), model->getUnconfirmedZerocoinBalance (), model->getImmatureZerocoinBalance (),
+                   model->getWatchBalance(), model->getWatchUnconfirmedBalance(), model->getWatchImmatureBalance());
+        connect(model, SIGNAL(balanceChanged(CAmount, CAmount,  CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount)), this, 
+                         SLOT(setBalance(CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount)));
         connect(model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
         updateDisplayUnit();
 
@@ -542,11 +544,15 @@ bool SendCoinsDialog::handlePaymentRequest(const SendCoinsRecipient& rv)
     return true;
 }
 
-void SendCoinsDialog::setBalance(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance, const CAmount& zerocoinBalance, const CAmount& watchBalance, const CAmount& watchUnconfirmedBalance, const CAmount& watchImmatureBalance)
+void SendCoinsDialog::setBalance(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance, 
+                                 const CAmount& zerocoinBalance, const CAmount& unconfirmedZerocoinBalance, const CAmount& immatureZerocoinBalance,
+                                 const CAmount& watchBalance, const CAmount& watchUnconfirmedBalance, const CAmount& watchImmatureBalance)
 {
     Q_UNUSED(unconfirmedBalance);
     Q_UNUSED(immatureBalance);
     Q_UNUSED(zerocoinBalance);
+    Q_UNUSED(unconfirmedZerocoinBalance);
+    Q_UNUSED(immatureZerocoinBalance);
     Q_UNUSED(watchBalance);
     Q_UNUSED(watchUnconfirmedBalance);
     Q_UNUSED(watchImmatureBalance);
@@ -563,8 +569,9 @@ void SendCoinsDialog::updateDisplayUnit()
     TRY_LOCK(cs_main, lockMain);
     if (!lockMain) return;
 
-    setBalance(model->getBalance(), model->getUnconfirmedBalance(), model->getImmatureBalance(), model->getZerocoinBalance (), 
-        model->getWatchBalance(), model->getWatchUnconfirmedBalance(), model->getWatchImmatureBalance());
+    setBalance(model->getBalance(), model->getUnconfirmedBalance(), model->getImmatureBalance(), 
+               model->getZerocoinBalance (), model->getUnconfirmedZerocoinBalance (), model->getImmatureZerocoinBalance (),
+               model->getWatchBalance(), model->getWatchUnconfirmedBalance(), model->getWatchImmatureBalance());
     coinControlUpdateLabels();
     ui->customFee->setDisplayUnit(model->getOptionsModel()->getDisplayUnit());
     updateMinFeeLabel();

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -53,7 +53,9 @@ public slots:
     void accept();
     SendCoinsEntry* addEntry();
     void updateTabsAndLabels();
-    void setBalance(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance, const CAmount& zerocoinBalance, const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance);
+    void setBalance(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance, 
+                    const CAmount& zerocoinBalance, const CAmount& unconfirmedZerocoinBalance, const CAmount& immatureZerocoinBalance,
+                    const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance);
 
 private:
     Ui::SendCoinsDialog* ui;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -82,6 +82,11 @@ CAmount WalletModel::getImmatureBalance() const
     return wallet->GetImmatureBalance();
 }
 
+CAmount WalletModel::getLockedBalance() const
+{
+    return wallet->GetLockedCoins();
+}
+
 CAmount WalletModel::getZerocoinBalance() const
 {
     return wallet->GetZerocoinBalance(false);
@@ -150,6 +155,14 @@ void WalletModel::pollBalanceChanged()
             transactionTableModel->updateConfirmations();
         }
     }
+}
+
+void WalletModel::emitBalanceChanged()
+{
+    // Force update of UI elements even when no values have changed
+    emit balanceChanged(cachedBalance, cachedUnconfirmedBalance, cachedImmatureBalance, 
+                        cachedZerocoinBalance, cachedUnconfirmedZerocoinBalance, cachedImmatureZerocoinBalance,
+                        cachedWatchOnlyBalance, cachedWatchUnconfBalance, cachedWatchImmatureBalance);
 }
 
 void WalletModel::checkBalanceChanged()

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -31,8 +31,8 @@ using namespace std;
 WalletModel::WalletModel(CWallet* wallet, OptionsModel* optionsModel, QObject* parent) : QObject(parent), wallet(wallet), optionsModel(optionsModel), addressTableModel(0),
                                                                                          transactionTableModel(0),
                                                                                          recentRequestsTableModel(0),
-                                                                                         cachedBalance(0), cachedUnconfirmedBalance(0), 
-                                                                                         cachedImmatureBalance(0), cachedZerocoinBalance(0),
+                                                                                         cachedBalance(0), cachedUnconfirmedBalance(0), cachedImmatureBalance(0),
+                                                                                         cachedZerocoinBalance(0), cachedUnconfirmedZerocoinBalance(0), cachedImmatureZerocoinBalance(0),
                                                                                          cachedEncryptionStatus(Unencrypted),
                                                                                          cachedNumBlocks(0)
 {
@@ -72,11 +72,6 @@ CAmount WalletModel::getBalance(const CCoinControl* coinControl) const
     return wallet->GetBalance();
 }
 
-CAmount WalletModel::getZerocoinBalance() const
-{
-    return wallet->GetZerocoinBalance(true);
-}
-
 CAmount WalletModel::getUnconfirmedBalance() const
 {
     return wallet->GetUnconfirmedBalance();
@@ -86,6 +81,22 @@ CAmount WalletModel::getImmatureBalance() const
 {
     return wallet->GetImmatureBalance();
 }
+
+CAmount WalletModel::getZerocoinBalance() const
+{
+    return wallet->GetZerocoinBalance(false);
+}
+
+CAmount WalletModel::getUnconfirmedZerocoinBalance() const
+{
+    return wallet->GetUnconfirmedZerocoinBalance();
+}
+
+CAmount WalletModel::getImmatureZerocoinBalance() const
+{
+    return wallet->GetImmatureZerocoinBalance();
+}
+
 
 bool WalletModel::haveWatchOnly() const
 {
@@ -150,6 +161,8 @@ void WalletModel::checkBalanceChanged()
     CAmount newUnconfirmedBalance = getUnconfirmedBalance();
     CAmount newImmatureBalance = getImmatureBalance();
     CAmount newZerocoinBalance = getZerocoinBalance();
+    CAmount newUnconfirmedZerocoinBalance = getUnconfirmedZerocoinBalance();
+    CAmount newImmatureZerocoinBalance = getImmatureZerocoinBalance();
     CAmount newWatchOnlyBalance = 0;
     CAmount newWatchUnconfBalance = 0;
     CAmount newWatchImmatureBalance = 0;
@@ -159,19 +172,23 @@ void WalletModel::checkBalanceChanged()
         newWatchImmatureBalance = getWatchImmatureBalance();
     }
 
-    if (cachedBalance != newBalance || cachedUnconfirmedBalance != newUnconfirmedBalance || cachedImmatureBalance != newImmatureBalance || 
-        cachedZerocoinBalance != newZerocoinBalance || cachedTxLocks != nCompleteTXLocks || cachedWatchOnlyBalance != newWatchOnlyBalance ||
-        cachedWatchUnconfBalance != newWatchUnconfBalance || cachedWatchImmatureBalance != newWatchImmatureBalance) {
+    if (cachedBalance != newBalance || cachedUnconfirmedBalance != newUnconfirmedBalance || cachedImmatureBalance != newImmatureBalance ||
+        cachedZerocoinBalance != newZerocoinBalance || cachedUnconfirmedZerocoinBalance != newUnconfirmedZerocoinBalance || cachedImmatureZerocoinBalance != newImmatureZerocoinBalance ||
+        cachedWatchOnlyBalance != newWatchOnlyBalance || cachedWatchUnconfBalance != newWatchUnconfBalance || cachedWatchImmatureBalance != newWatchImmatureBalance ||
+        cachedTxLocks != nCompleteTXLocks ) {
         cachedBalance = newBalance;
         cachedUnconfirmedBalance = newUnconfirmedBalance;
         cachedImmatureBalance = newImmatureBalance;
         cachedZerocoinBalance = newZerocoinBalance;
+        cachedUnconfirmedZerocoinBalance = newUnconfirmedZerocoinBalance;
+        cachedImmatureZerocoinBalance = newImmatureZerocoinBalance;
         cachedTxLocks = nCompleteTXLocks;
         cachedWatchOnlyBalance = newWatchOnlyBalance;
         cachedWatchUnconfBalance = newWatchUnconfBalance;
         cachedWatchImmatureBalance = newWatchImmatureBalance;
-        emit balanceChanged(newBalance, newUnconfirmedBalance, newImmatureBalance, newZerocoinBalance,
-            newWatchOnlyBalance, newWatchUnconfBalance, newWatchImmatureBalance);
+        emit balanceChanged(newBalance, newUnconfirmedBalance, newImmatureBalance, 
+                            newZerocoinBalance, newUnconfirmedZerocoinBalance, newImmatureZerocoinBalance,
+                            newWatchOnlyBalance, newWatchUnconfBalance, newWatchImmatureBalance);
     }
 }
 

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -133,6 +133,7 @@ public:
     CAmount getBalance(const CCoinControl* coinControl = NULL) const;
     CAmount getUnconfirmedBalance() const;
     CAmount getImmatureBalance() const;
+    CAmount getLockedBalance() const;
     CAmount getZerocoinBalance() const;
     CAmount getUnconfirmedZerocoinBalance() const;
     CAmount getImmatureZerocoinBalance() const;
@@ -145,6 +146,7 @@ public:
     bool setAddressBook(const CTxDestination& address, const string& strName, const string& strPurpose);
     void encryptKey(const CKey key, const std::string& pwd, const std::string& slt, std::vector<unsigned char>& crypted);
     void decryptKey(const std::vector<unsigned char>& crypted, const std::string& slt, const std::string& pwd, CKey& key);
+    void emitBalanceChanged(); // Force update of UI-elements even when no values have changed
 
     // Check address for validity
     bool validateAddress(const QString& address);

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -134,6 +134,8 @@ public:
     CAmount getUnconfirmedBalance() const;
     CAmount getImmatureBalance() const;
     CAmount getZerocoinBalance() const;
+    CAmount getUnconfirmedZerocoinBalance() const;
+    CAmount getImmatureZerocoinBalance() const;
     bool haveWatchOnly() const;
     CAmount getWatchBalance() const;
     CAmount getWatchUnconfirmedBalance() const;
@@ -229,6 +231,8 @@ private:
     CAmount cachedUnconfirmedBalance;
     CAmount cachedImmatureBalance;
     CAmount cachedZerocoinBalance;
+    CAmount cachedUnconfirmedZerocoinBalance;
+    CAmount cachedImmatureZerocoinBalance;
     CAmount cachedWatchOnlyBalance;
     CAmount cachedWatchUnconfBalance;
     CAmount cachedWatchImmatureBalance;
@@ -245,7 +249,9 @@ private:
 
 signals:
     // Signal that balance in wallet changed
-    void balanceChanged(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance, const CAmount& zerocoinBalance, const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance);
+    void balanceChanged(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance, 
+                        const CAmount& zerocoinBalance, const CAmount& unconfirmedZerocoinBalance, const CAmount& immatureZerocoinBalance, 
+                        const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance);
 
     // Encryption status of wallet changed
     void encryptionStatusChanged(int status);

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -195,6 +195,8 @@ void WalletView::processNewTransaction(const QModelIndex& parent, int start, int
 void WalletView::gotoOverviewPage()
 {
     setCurrentWidget(overviewPage);
+    // Refresh UI-elements in case coins were locked/unlocked in CoinControl
+    walletModel->emitBalanceChanged();
 }
 
 void WalletView::gotoHistoryPage()
@@ -224,6 +226,8 @@ void WalletView::gotoReceiveCoinsPage()
 void WalletView::gotoPrivacyPage()
 {
     setCurrentWidget(privacyPage);
+    // Refresh UI-elements in case coins were locked/unlocked in CoinControl
+    walletModel->emitBalanceChanged();
 }
 
 void WalletView::gotoSendCoinsPage(QString addr)

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1339,6 +1339,24 @@ CAmount CWallet::GetUnlockedCoins() const
     return nTotal;
 }
 
+CAmount CWallet::GetLockedCoins() const
+{
+    if (fLiteMode) return 0;
+
+    CAmount nTotal = 0;
+    {
+        LOCK2(cs_main, cs_wallet);
+        for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it) {
+            const CWalletTx* pcoin = &(*it).second;
+
+            if (pcoin->IsTrusted() && pcoin->GetDepthInMainChain() > 0)
+                nTotal += pcoin->GetLockedCredit();
+        }
+    }
+
+    return nTotal;
+}
+
 // Get a Map pairing the Denominations with the amount of Zerocoin for each Denomination
 std::map<libzerocoin::CoinDenomination, CAmount> CWallet::GetMyZerocoinDistribution() const
 {

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1283,9 +1283,42 @@ CAmount CWallet::GetZerocoinBalance(bool fMatureOnly) const
     return nTotal;
 }
 
-CAmount CWallet::GetPendingZerocoinBalance() const
+CAmount CWallet::GetImmatureZerocoinBalance() const
 {
     return GetZerocoinBalance(false) - GetZerocoinBalance(true);
+}
+
+CAmount CWallet::GetUnconfirmedZerocoinBalance() const
+{
+    CAmount nUnconfirmed = 0;
+    CWalletDB walletdb(pwalletMain->strWalletFile);
+    list<CZerocoinMint> listMints = walletdb.ListMintedCoins(true, false, true);
+ 
+    std::map<libzerocoin::CoinDenomination, int> mapUnconfirmed;
+    for (const auto& denom : libzerocoin::zerocoinDenomList){
+        mapUnconfirmed.insert(make_pair(denom, 0));
+    }
+
+    {
+        LOCK2(cs_main, cs_wallet);
+        for (auto& mint : listMints){
+            if (!mint.GetHeight() || mint.GetHeight() > chainActive.Height() - Params().Zerocoin_MintRequiredConfirmations()) {
+                libzerocoin::CoinDenomination denom = mint.GetDenomination();
+                nUnconfirmed += libzerocoin::ZerocoinDenominationToAmount(denom);
+                mapUnconfirmed.at(denom)++;
+            }
+        }
+    }
+
+    for (auto& denom : libzerocoin::zerocoinDenomList) {
+        LogPrint("zero","%s My unconfirmed coins for denomination %d pubcoin %s\n", __func__,denom, mapUnconfirmed.at(denom));
+    }
+
+    LogPrint("zero","Total value of unconfirmed coins %ld\n", nUnconfirmed);
+
+    if (nUnconfirmed < 0 ) nUnconfirmed = 0; // Sanity never hurts
+
+    return nUnconfirmed;
 }
 
 CAmount CWallet::GetUnlockedCoins() const

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -438,7 +438,8 @@ public:
     void ResendWalletTransactions();
     CAmount GetBalance() const;
     CAmount GetZerocoinBalance(bool fMatureOnly) const;
-    CAmount GetPendingZerocoinBalance() const;
+    CAmount GetUnconfirmedZerocoinBalance() const;
+    CAmount GetImmatureZerocoinBalance() const;
     CAmount GetUnlockedCoins() const;
     std::map<libzerocoin::CoinDenomination, CAmount> GetMyZerocoinDistribution() const;
     CAmount GetUnconfirmedBalance() const;

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -440,6 +440,7 @@ public:
     CAmount GetZerocoinBalance(bool fMatureOnly) const;
     CAmount GetUnconfirmedZerocoinBalance() const;
     CAmount GetImmatureZerocoinBalance() const;
+    CAmount GetLockedCoins() const;
     CAmount GetUnlockedCoins() const;
     std::map<libzerocoin::CoinDenomination, CAmount> GetMyZerocoinDistribution() const;
     CAmount GetUnconfirmedBalance() const;
@@ -1110,6 +1111,41 @@ public:
             nCredit += pwallet->GetCredit(txout, ISMINE_SPENDABLE);
             if (!MoneyRange(nCredit))
                 throw std::runtime_error("CWalletTx::GetUnlockedCredit() : value out of range");
+        }
+
+        return nCredit;
+    }
+
+        // Return sum of unlocked coins
+    CAmount GetLockedCredit() const
+    {
+        if (pwallet == 0)
+            return 0;
+
+        // Must wait until coinbase is safely deep enough in the chain before valuing it
+        if (IsCoinBase() && GetBlocksToMaturity() > 0)
+            return 0;
+
+        CAmount nCredit = 0;
+        uint256 hashTx = GetHash();
+        for (unsigned int i = 0; i < vout.size(); i++) {
+            const CTxOut& txout = vout[i];
+
+            // Skip spent coins
+            if (pwallet->IsSpent(hashTx, i)) continue;
+
+            // Add locked coins
+            if (pwallet->IsLockedCoin(hashTx, i)) {
+                nCredit += pwallet->GetCredit(txout, ISMINE_SPENDABLE);
+            }
+
+            // Add masternode collaterals which are handled likc locked coins
+            if (fMasterNode && vout[i].nValue == 10000 * COIN) {
+                nCredit += pwallet->GetCredit(txout, ISMINE_SPENDABLE);
+            }
+
+            if (!MoneyRange(nCredit))
+                throw std::runtime_error("CWalletTx::GetLockedCredit() : value out of range");
         }
 
         return nCredit;


### PR DESCRIPTION
Includes:
- fix of wrong/inconsistent display of balances
- tons of bubble-help to explain what's displayed to the end user
- include unconfirmed/immature/mature zPIV balances on the Overview-tab
- distinguish between unconfirmed and immature zPIV on Privacy-tab
- general usability improvements

Visuals:
Overview-Tab:
![overview-tab](https://user-images.githubusercontent.com/22873440/32110859-f9c18960-bb38-11e7-8f7d-469777bcbddf.png)

Privacy-Tab:
![privacy-tab](https://user-images.githubusercontent.com/22873440/32110871-083e4848-bb39-11e7-8e4a-5a89274a86e6.png)

Please check spelling, grammar and lyrical virtue and report back...
