### PR TITLE
[UI] zPIV-Control: disable negative confirmation numbers.

### DIFF
--- a/src/qt/zpivcontroldialog.cpp
+++ b/src/qt/zpivcontroldialog.cpp
@@ -82,6 +82,11 @@ void ZPivControlDialog::updateList()
         itemMint->setText(COLUMN_PUBCOIN, QString::fromStdString(strPubCoin));
 
         int nConfirmations = (mint.GetHeight() ? chainActive.Height() - mint.GetHeight() : 0);
+        if (nConfirmations < 0) {
+            // Sanity check
+            nConfirmations = 0;
+        }
+
         itemMint->setText(COLUMN_CONFIRMATIONS, QString::number(nConfirmations));
 
         // check to make sure there are at least 3 other mints added to the accumulators after this

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -3917,7 +3917,7 @@ bool CWallet::CreateZerocoinMintTransaction(const CAmount nValue, CMutableTransa
     } else {
         // select UTXO's to use
         if (!SelectCoins(nTotalValue, setCoins, nValueIn, coinControl)) {
-            strFailReason = _("Insufficient funds");
+            strFailReason = _("Insufficient or insufficient confirmed funds, you might need to wait a few minutes and try again.");
             return false;
         }
 


### PR DESCRIPTION
Additionally the "Insufficient Funds" error message when minting zPIV was made more verbose so the user knows why he seems to have enough PIV for minting but can't.