### PR TITLE
Reindex zPiv blocks and correct stats.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -120,11 +120,14 @@ public:
         nMinerThreads = 0;
         nTargetTimespan = 1 * 60; // PIVX: 1 day
         nTargetSpacing = 1 * 60;  // PIVX: 1 minute
-        nLastPOWBlock = 259200;
         nMaturity = 100;
         nMasternodeCountDrift = 20;
-        nModifierUpdateBlock = 615800;
         nMaxMoneyOut = 21000000 * COIN;
+
+        /** Height or Time Based Activations **/
+        nLastPOWBlock = 259200;
+        nModifierUpdateBlock = 615800;
+        nZerocoinStartHeight = 863787;
 
         /**
          * Build the genesis block. Note that the output of the genesis coinbase cannot

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -76,9 +76,7 @@ public:
     int64_t TargetTimespan() const { return nTargetTimespan; }
     int64_t TargetSpacing() const { return nTargetSpacing; }
     int64_t Interval() const { return nTargetTimespan / nTargetSpacing; }
-    int LAST_POW_BLOCK() const { return nLastPOWBlock; }
     int COINBASE_MATURITY() const { return nMaturity; }
-    int ModifierUpgradeBlock() const { return nModifierUpdateBlock; }
     CAmount MaxMoneyOut() const { return nMaxMoneyOut; }
     /** The masternode count that we will allow the see-saw reward payments to be off by */
     int MasternodeCountDrift() const { return nMasternodeCountDrift; }
@@ -109,6 +107,11 @@ public:
     int Zerocoin_MintRequiredConfirmations() const { return nMintRequiredConfirmations; }
     int Zerocoin_DefaultSpendSecurity() const { return nDefaultSecurityLevel; }
     int Zerocoin_HeaderVersion() const { return nZerocoinHeaderVersion; }
+
+    /** Height or Time Based Activations **/
+    int ModifierUpgradeBlock() const { return nModifierUpdateBlock; }
+    int LAST_POW_BLOCK() const { return nLastPOWBlock; }
+    int Zerocoin_StartHeight() const { return nZerocoinStartHeight; }
 
 protected:
     CChainParams() {}
@@ -160,6 +163,7 @@ protected:
     int nDefaultSecurityLevel;
     int nZerocoinHeaderVersion;
     int64_t nBudget_Fee_Confirmations;
+    int nZerocoinStartHeight;
 };
 
 /**

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1308,6 +1308,113 @@ bool AppInit2(boost::thread_group& threadGroup)
                     break;
                 }
 
+                // Recalculate money supply for blocks that are impacted by accounting issue after zerocoin activation
+                bool fVecFixed = false;
+                pblocktree->ReadFlag("msvecfix", fVecFixed);
+                bool fReindexRange = chainActive.Tip()->pprev && chainActive.Height() > GetZerocoinStartHeight();
+                if (fReindexRange && !fVecFixed) {
+                    uiInterface.InitMessage(_("Recalculating supply statistics may take 30-60 minutes..."));
+                    LogPrintf("%s : Recalculating supply statistics\n", __func__);
+
+                    //If recalculation was exited before it was finished, then start where it left off
+                    int nStartHeight = 0;
+                    if (!pblocktree->ReadInt("msvecindex", nStartHeight))
+                        nStartHeight = GetZerocoinStartHeight();
+                    CBlockIndex *pindex = chainActive[nStartHeight];
+                    int nHeightEnd = chainActive.Height();
+                    while (true) {
+                        if (ShutdownRequested())
+                            return false;
+
+                        double dPercent = 1 - ((nHeightEnd - pindex->nHeight) / (double)(nHeightEnd - nStartHeight));
+                        string strMessage = strprintf("Recalculating supply statistics may take 30-60 minutes block %d...", pindex->nHeight);
+                        uiInterface.ShowProgress(_(strMessage.c_str()), (int)(dPercent * 100));
+
+                        //overwrite possibly wrong vMintsInBlock data
+                        CBlock block;
+                        if (!ReadBlockFromDisk(block, pindex)) {
+                            return InitError(_("Failed to read block index"));
+                        }
+
+                        std::list<CZerocoinMint> listMints;
+                        BlockToZerocoinMintList(block, listMints);
+
+                        pindex->vMintDenominationsInBlock.clear();
+                        for (auto mint : listMints) {
+                            pindex->vMintDenominationsInBlock.emplace_back(mint.GetDenomination());
+                        }
+
+                        if (!pblocktree->WriteBlockIndex(CDiskBlockIndex(pindex))) {
+                            return InitError(_("Failed to write block index"));
+                        }
+
+                        LogPrintf("%s : rewrote vMintDenominationsInBlock for %d\n", __func__, pindex->nHeight);
+
+                        //Track progress in case of shutdown
+                        pblocktree->WriteInt("msvecindex", pindex->nHeight);
+
+                        if (pindex->nHeight < nHeightEnd)
+                            pindex = chainActive.Next(pindex);
+                        else
+                            break;
+                    }
+
+                    //This flag indicates that the fix has already been done and not needed in the future
+                    pblocktree->WriteFlag("msvecfix", true);
+                }
+
+                bool msIndexFixed = false;
+                pblocktree->ReadFlag("msindexfix", msIndexFixed);
+                if (fReindexRange && !msIndexFixed){
+                    uiInterface.InitMessage(_("Recalculating coin supply may take 30-60 minutes..."));
+                    LogPrintf("%s : Recalculating money supply statistics\n", __func__);
+
+                    //If recalculation was exited before it was finished, then start where it left off
+                    int nStartHeight = 0;
+                    if (!pblocktree->ReadInt("msindex", nStartHeight))
+                        nStartHeight = GetZerocoinStartHeight();
+                    CBlockIndex *pindex = chainActive[nStartHeight];
+                    int nHeightEnd = chainActive.Height();
+
+                    // Remove possible zPiv spends from the supply
+                    CAmount nzPivSpent = 0;
+                    while (true) {
+                        // get each blocks amount of zPiv minted and the zpiv money supply change for that block
+                        // figure out amount spent by difference in zpiv supply per denom and the amount minted per denom
+                        CAmount nBlockzPivSpent = 0;
+                        for (auto denom : libzerocoin::zerocoinDenomList) {
+                            int nDenomAdded = count(pindex->vMintDenominationsInBlock.begin(), pindex->vMintDenominationsInBlock.end(), denom);
+                            int64_t nDenomMinted = nDenomAdded * denom;
+
+                            //note zPiv supply is quantity of zPiv for the denom, not the amount
+                            int64_t nSupplyZPivLast = pindex->pprev->mapZerocoinSupply.at(denom) * denom;
+                            int64_t nSupplyZPiv = pindex->mapZerocoinSupply.at(denom) * denom;
+                            int64_t nDenomZPivSpent = (nSupplyZPivLast + nDenomMinted) - nSupplyZPiv;
+                            nBlockzPivSpent += nDenomZPivSpent * COIN;
+                        }
+
+                        //Total zPiv spent up to and including this block
+                        nzPivSpent += nBlockzPivSpent;
+
+                        //Rewrite money supply
+                        pindex->nMoneySupply = pindex->nMoneySupply - nzPivSpent;
+                        if (!pblocktree->WriteBlockIndex(CDiskBlockIndex(pindex))) {
+                            return InitError(_("Failed to write block index"));
+                        }
+
+                        //Track progress in case of shutdown
+                        pblocktree->WriteInt("msindex", pindex->nHeight);
+
+                        if (pindex->nHeight < nHeightEnd)
+                            pindex = chainActive.Next(pindex);
+                        else
+                            break;
+                    }
+
+                    //Mark reindexing as done, and not needed again in the futures
+                    pblocktree->WriteFlag("msindexfix", true);
+                }
+
                 list<uint256> listAccCheckpointsNoDB = CAccumulators::getInstance().GetAccCheckpointsNoDB();
                 // PIVX: recalculate Accumulator Checkpoints that failed to database properly
                 if (!listAccCheckpointsNoDB.empty() && chainActive.Tip()->GetBlockHeader().nVersion >= Params().Zerocoin_HeaderVersion()) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1311,7 +1311,7 @@ bool AppInit2(boost::thread_group& threadGroup)
                 // Recalculate money supply for blocks that are impacted by accounting issue after zerocoin activation
                 bool fVecFixed = false;
                 pblocktree->ReadFlag("msvecfix", fVecFixed);
-                bool fReindexRange = chainActive.Tip()->pprev && chainActive.Height() > GetZerocoinStartHeight();
+                bool fReindexRange = chainActive.Height() > GetZerocoinStartHeight();
                 if (fReindexRange && !fVecFixed) {
                     uiInterface.InitMessage(_("Recalculating supply statistics may take 30-60 minutes..."));
                     LogPrintf("%s : Recalculating supply statistics\n", __func__);

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -198,6 +198,16 @@ bool CBlockTreeDB::ReadFlag(const std::string& name, bool& fValue)
     return true;
 }
 
+bool CBlockTreeDB::WriteInt(const std::string& name, int nValue)
+{
+    return Write(std::make_pair('I', name), nValue);
+}
+
+bool CBlockTreeDB::ReadInt(const std::string& name, int& nValue)
+{
+    return Read(std::make_pair('I', name), nValue);
+}
+
 bool CBlockTreeDB::LoadBlockIndexGuts()
 {
     boost::scoped_ptr<leveldb::Iterator> pcursor(NewIterator());

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -64,6 +64,8 @@ public:
     bool WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos> >& list);
     bool WriteFlag(const std::string& name, bool fValue);
     bool ReadFlag(const std::string& name, bool& fValue);
+    bool WriteInt(const std::string& name, int nValue);
+    bool ReadInt(const std::string& name, int& nValue);
     bool LoadBlockIndexGuts();
 };
 


### PR DESCRIPTION
-Coin supply incorrectly was counting spent zPiv as newly minted coins that are added to the coin supply, thus resulting in innacurate coin supply data.
-CBlockIndex.vMintDenominationsInBlock was not being cleared before having mints added to it. This caused it to have a bad accounting of mint meta data if any blocks go through ConnectBlock() more than once.
-Reindex both aspects of all block indexes from zerocoin start block until chain tip. Trigger this indexing on first client start with new wallet, and track progress of reindexing in case wallet client is shutdown so that it will not lose its progress.