### PR TITLE
[Main] Refactor Accumulator Code

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -77,6 +77,8 @@ endif
 # pivx core #
 BITCOIN_CORE_H = \
   activemasternode.h \
+  accumulators.h \
+  accumulatormap.h \
   addrman.h \
   alert.h \
   allocators.h \
@@ -169,7 +171,6 @@ BITCOIN_CORE_H = \
   zmq/zmqconfig.h \
   zmq/zmqnotificationinterface.h \
   zmq/zmqpublishnotifier.h \
-  accumulators.h \
   compat/sanity.h
 
 JSON_H = \
@@ -334,6 +335,8 @@ libzerocoin_libbitcoin_zerocoin_a_SOURCES = \
 # common: shared between pivxd, and pivx-qt and non-server tools
 libbitcoin_common_a_CPPFLAGS = $(BITCOIN_INCLUDES)
 libbitcoin_common_a_SOURCES = \
+  accumulators.cpp \
+  accumulatormap.cpp \
   allocators.cpp \
   amount.cpp \
   base58.cpp \
@@ -361,7 +364,6 @@ libbitcoin_common_a_SOURCES = \
   script/script_error.cpp \
   spork.cpp \
   sporkdb.cpp \
-  accumulators.cpp \
   $(BITCOIN_CORE_H)
 
 # util: shared between all executables.

--- a/src/accumulatormap.cpp
+++ b/src/accumulatormap.cpp
@@ -68,6 +68,9 @@ CBigNum AccumulatorMap::GetValue(CoinDenomination denom)
 uint256 AccumulatorMap::GetCheckpoint()
 {
     uint256 nCheckpoint;
+
+    //Prevent possible overflows from future changes to the list and forgetting to update this code
+    assert(zerocoinDenomList.size() == 8);
     for (auto& denom : zerocoinDenomList) {
         CBigNum bnValue = mapAccumulators.at(denom)->getValue();
         uint32_t nCheckSum = GetChecksum(bnValue);

--- a/src/accumulatormap.cpp
+++ b/src/accumulatormap.cpp
@@ -1,0 +1,80 @@
+// Copyright (c) 2017 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "accumulatormap.h"
+#include "accumulators.h"
+#include "main.h"
+#include "txdb.h"
+#include "libzerocoin/Denominations.h"
+
+using namespace libzerocoin;
+using namespace std;
+
+AccumulatorMap::AccumulatorMap()
+{
+    //construct accumulators for all denominations
+    for (auto& denom : zerocoinDenomList) {
+        unique_ptr<Accumulator> uptr(new Accumulator(Params().Zerocoin_Params(), denom));
+        mapAccumulators.insert(make_pair(denom, std::move(uptr)));
+    }
+}
+
+void AccumulatorMap::Reset()
+{
+    mapAccumulators.clear();
+    for (auto& denom : zerocoinDenomList) {
+        unique_ptr<Accumulator> uptr(new Accumulator(Params().Zerocoin_Params(), denom));
+        mapAccumulators.insert(make_pair(denom, std::move(uptr)));
+    }
+}
+
+bool AccumulatorMap::Load(uint256 nCheckpoint)
+{
+    for (auto& denom : zerocoinDenomList) {
+        uint32_t nChecksum = ParseChecksum(nCheckpoint, denom);
+
+        CBigNum bnValue;
+        if (!zerocoinDB->ReadAccumulatorValue(nChecksum, bnValue)) {
+            LogPrintf("%s : cannot find checksum %d", __func__, nChecksum);
+            return false;
+        }
+
+        mapAccumulators.at(denom)->setValue(bnValue);
+    }
+    return true;
+}
+
+bool AccumulatorMap::Accumulate(PublicCoin pubCoin, bool fSkipValidation)
+{
+    CoinDenomination denom = pubCoin.getDenomination();
+    if (denom == CoinDenomination::ZQ_ERROR)
+        return false;
+
+    if (fSkipValidation)
+        mapAccumulators.at(denom)->increment(pubCoin.getValue());
+    else
+        mapAccumulators.at(denom)->accumulate(pubCoin);
+    return true;
+}
+
+CBigNum AccumulatorMap::GetValue(CoinDenomination denom)
+{
+    if (denom == CoinDenomination::ZQ_ERROR)
+        return CBigNum(0);
+    return mapAccumulators.at(denom)->getValue();
+}
+
+uint256 AccumulatorMap::GetCheckpoint()
+{
+    uint256 nCheckpoint;
+    for (auto& denom : zerocoinDenomList) {
+        CBigNum bnValue = mapAccumulators.at(denom)->getValue();
+        uint32_t nCheckSum = GetChecksum(bnValue);
+        nCheckpoint = nCheckpoint << 32 | nCheckSum;
+    }
+
+    return nCheckpoint;
+}
+
+

--- a/src/accumulatormap.cpp
+++ b/src/accumulatormap.cpp
@@ -11,15 +11,16 @@
 using namespace libzerocoin;
 using namespace std;
 
+//Construct accumulators for all denominations
 AccumulatorMap::AccumulatorMap()
 {
-    //construct accumulators for all denominations
     for (auto& denom : zerocoinDenomList) {
         unique_ptr<Accumulator> uptr(new Accumulator(Params().Zerocoin_Params(), denom));
         mapAccumulators.insert(make_pair(denom, std::move(uptr)));
     }
 }
 
+//Reset each accumulator to its default state
 void AccumulatorMap::Reset()
 {
     mapAccumulators.clear();
@@ -29,6 +30,7 @@ void AccumulatorMap::Reset()
     }
 }
 
+//Load a checkpoint containing 8 32bit checksums of accumulator values.
 bool AccumulatorMap::Load(uint256 nCheckpoint)
 {
     for (auto& denom : zerocoinDenomList) {
@@ -45,6 +47,7 @@ bool AccumulatorMap::Load(uint256 nCheckpoint)
     return true;
 }
 
+//Add a zerocoin to the accumulator of its denomination.
 bool AccumulatorMap::Accumulate(PublicCoin pubCoin, bool fSkipValidation)
 {
     CoinDenomination denom = pubCoin.getDenomination();
@@ -58,6 +61,7 @@ bool AccumulatorMap::Accumulate(PublicCoin pubCoin, bool fSkipValidation)
     return true;
 }
 
+//Get the value of a specific accumulator
 CBigNum AccumulatorMap::GetValue(CoinDenomination denom)
 {
     if (denom == CoinDenomination::ZQ_ERROR)
@@ -65,6 +69,7 @@ CBigNum AccumulatorMap::GetValue(CoinDenomination denom)
     return mapAccumulators.at(denom)->getValue();
 }
 
+//Calculate a 32bit checksum of each accumulator value. Concatenate checksums into uint256
 uint256 AccumulatorMap::GetCheckpoint()
 {
     uint256 nCheckpoint;

--- a/src/accumulatormap.h
+++ b/src/accumulatormap.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2017 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#ifndef PIVX_ACCUMULATORMAP_H
+#define PIVX_ACCUMULATORMAP_H
+
+#include "libzerocoin/Accumulator.h"
+#include "libzerocoin/Coin.h"
+
+//A map with an accumulator for each denomination
+class AccumulatorMap
+{
+private:
+    std::map<libzerocoin::CoinDenomination, std::unique_ptr<libzerocoin::Accumulator> > mapAccumulators;
+public:
+    AccumulatorMap();
+    bool Load(uint256 nCheckpoint);
+    bool Accumulate(libzerocoin::PublicCoin pubCoin, bool fSkipValidation = false);
+    CBigNum GetValue(libzerocoin::CoinDenomination denom);
+    uint256 GetCheckpoint();
+    void Reset();
+};
+#endif //PIVX_ACCUMULATORMAP_H

--- a/src/accumulators.cpp
+++ b/src/accumulators.cpp
@@ -32,8 +32,16 @@ uint32_t GetChecksum(const CBigNum &bnValue)
     return hash.Get32();
 }
 
-bool GetAccumulatorValueFromChecksum(uint32_t nChecksum, CBigNum& bnAccValue)
+bool GetAccumulatorValueFromChecksum(uint32_t nChecksum, bool fMemoryOnly, CBigNum& bnAccValue)
 {
+    if (mapAccumulatorValues.count(nChecksum)) {
+        bnAccValue = mapAccumulatorValues.at(nChecksum);
+        return true;
+    }
+
+    if (fMemoryOnly)
+        return false;
+
     if (!zerocoinDB->ReadAccumulatorValue(nChecksum, bnAccValue)) {
         bnAccValue = 0;
     }
@@ -44,7 +52,7 @@ bool GetAccumulatorValueFromChecksum(uint32_t nChecksum, CBigNum& bnAccValue)
 bool GetAccumulatorValueFromDB(uint256 nCheckpoint, CoinDenomination denom, CBigNum& bnAccValue)
 {
     uint32_t nChecksum = ParseChecksum(nCheckpoint, denom);
-    return GetAccumulatorValueFromChecksum(nChecksum, bnAccValue);
+    return GetAccumulatorValueFromChecksum(nChecksum, false, bnAccValue);
 }
 
 void AddAccumulatorChecksum(const uint32_t nChecksum, const CBigNum &bnValue, bool fMemoryOnly)

--- a/src/accumulators.cpp
+++ b/src/accumulators.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "accumulators.h"
+#include "accumulatormap.h"
 #include "chainparams.h"
 #include "main.h"
 #include "txdb.h"
@@ -11,34 +12,18 @@
 
 using namespace libzerocoin;
 
-void CAccumulators::Setup()
+std::map<uint32_t, CBigNum> mapAccumulatorValues;
+std::list<uint256> listAccCheckpointsNoDB;
+
+uint32_t ParseChecksum(uint256 nChecksum, CoinDenomination denomination)
 {
-    //construct accumulators for all denominations
-    for (auto& denom : zerocoinDenomList) {
-        unique_ptr<Accumulator> uptr(new Accumulator(Params().Zerocoin_Params(), denom));
-        mapAccumulators.insert(make_pair(denom, std::move(uptr)));
-    }
+    //shift to the beginning bit of this denomination and trim any remaining bits by returning 32 bits only
+    int pos = distance(zerocoinDenomList.begin(), find(zerocoinDenomList.begin(), zerocoinDenomList.end(), denomination));
+    nChecksum = nChecksum >> (32*((zerocoinDenomList.size() - 1) - pos));
+    return nChecksum.Get32();
 }
 
-Accumulator CAccumulators::Get(CoinDenomination denomination)
-{
-    return Accumulator(Params().Zerocoin_Params(), denomination, mapAccumulators.at(denomination)->getValue());
-}
-
-bool CAccumulators::AddPubCoinToAccumulator(const PublicCoin& publicCoin)
-{
-    CoinDenomination denomination = publicCoin.getDenomination();
-    if(mapAccumulators.find(denomination) == mapAccumulators.end()) {
-        LogPrintf("%s: failed to find accumulator for %d\n", __func__, denomination);
-        return false;
-    }
-
-    mapAccumulators.at(denomination)->accumulate(publicCoin);
-    LogPrint("zero", "%s: Accumulated %d\n", __func__, denomination);
-    return true;
-}
-
-uint32_t CAccumulators::GetChecksum(const CBigNum &bnValue)
+uint32_t GetChecksum(const CBigNum &bnValue)
 {
     CDataStream ss(SER_GETHASH, 0);
     ss << bnValue;
@@ -47,51 +32,40 @@ uint32_t CAccumulators::GetChecksum(const CBigNum &bnValue)
     return hash.Get32();
 }
 
-uint32_t CAccumulators::GetChecksum(const Accumulator &accumulator)
+bool GetAccumulatorValueFromChecksum(uint32_t nChecksum, CBigNum& bnAccValue)
 {
-    return GetChecksum(accumulator.getValue());
-}
-
-void CAccumulators::DatabaseChecksums(const uint256& nCheckpoint)
-{
-    uint256 nCheckpointCalculated = 0;
-    for (auto& denom : zerocoinDenomList) {
-        CBigNum bnValue = mapAccumulators.at(denom)->getValue();
-        uint32_t nCheckSum = GetChecksum(bnValue);
-        AddAccumulatorChecksum(nCheckSum, bnValue);
-        nCheckpointCalculated = nCheckpointCalculated << 32 | nCheckSum;
+    if (!zerocoinDB->ReadAccumulatorValue(nChecksum, bnAccValue)) {
+        bnAccValue = 0;
     }
+
+    return true;
 }
 
-void CAccumulators::AddAccumulatorChecksum(const uint32_t nChecksum, const CBigNum &bnValue, bool fMemoryOnly)
+bool GetAccumulatorValueFromDB(uint256 nCheckpoint, CoinDenomination denom, CBigNum& bnAccValue)
+{
+    uint32_t nChecksum = ParseChecksum(nCheckpoint, denom);
+    return GetAccumulatorValueFromChecksum(nChecksum, bnAccValue);
+}
+
+void AddAccumulatorChecksum(const uint32_t nChecksum, const CBigNum &bnValue, bool fMemoryOnly)
 {
     if(!fMemoryOnly)
         zerocoinDB->WriteAccumulatorValue(nChecksum, bnValue);
     mapAccumulatorValues.insert(make_pair(nChecksum, bnValue));
-
-    LogPrint("zero", "%s checksum %d val %s\n", __func__, nChecksum, bnValue.GetHex());
-    LogPrint("zero", "%s map val %s\n", __func__, mapAccumulatorValues[nChecksum].GetHex());
 }
 
-bool CAccumulators::LoadAccumulatorValuesFromDB(const uint256 nCheckpoint)
+void DatabaseChecksums(AccumulatorMap& mapAccumulators)
 {
-    for (auto& denomination : zerocoinDenomList) {
-        uint32_t nChecksum = ParseChecksum(nCheckpoint, denomination);
-
-        //if read is not successful then we are not in a state to verify zerocoin transactions
-        CBigNum bnValue;
-        if (!zerocoinDB->ReadAccumulatorValue(nChecksum, bnValue)) {
-            LogPrint("zero","%s : Missing databased value for checksum %d\n", __func__, nChecksum);
-            if (!count(listAccCheckpointsNoDB.begin(), listAccCheckpointsNoDB.end(), nCheckpoint))
-                listAccCheckpointsNoDB.push_back(nCheckpoint);
-            return false;
-        }
-        mapAccumulatorValues.insert(make_pair(nChecksum, bnValue));
+    uint256 nCheckpoint = 0;
+    for (auto& denom : zerocoinDenomList) {
+        CBigNum bnValue = mapAccumulators.GetValue(denom);
+        uint32_t nCheckSum = GetChecksum(bnValue);
+        AddAccumulatorChecksum(nCheckSum, bnValue, false);
+        nCheckpoint = nCheckpoint << 32 | nCheckSum;
     }
-    return true;
 }
 
-bool CAccumulators::EraseAccumulatorValues(const uint256& nCheckpointErase, const uint256& nCheckpointPrevious)
+bool EraseAccumulatorValues(const uint256& nCheckpointErase, const uint256& nCheckpointPrevious)
 {
     for (auto& denomination : zerocoinDenomList) {
         uint32_t nChecksumErase = ParseChecksum(nCheckpointErase, denomination);
@@ -110,82 +84,28 @@ bool CAccumulators::EraseAccumulatorValues(const uint256& nCheckpointErase, cons
     return true;
 }
 
-bool CAccumulators::EraseCoinMint(const CBigNum& bnPubCoin)
+bool LoadAccumulatorValuesFromDB(const uint256 nCheckpoint)
 {
-    return zerocoinDB->EraseCoinMint(bnPubCoin);
-}
+    for (auto& denomination : zerocoinDenomList) {
+        uint32_t nChecksum = ParseChecksum(nCheckpoint, denomination);
 
-bool CAccumulators::EraseCoinSpend(const CBigNum& bnSerial)
-{
-    mapSerials.erase(bnSerial);
-    return zerocoinDB->EraseCoinSpend(bnSerial);
-}
-
-uint32_t ParseChecksum(uint256 nChecksum, CoinDenomination denomination)
-{
-    //shift to the beginning bit of this denomination and trim any remaining bits by returning 32 bits only
-    int pos = distance(zerocoinDenomList.begin(), find(zerocoinDenomList.begin(), zerocoinDenomList.end(), denomination));
-    nChecksum = nChecksum >> (32*((zerocoinDenomList.size() - 1) - pos));
-    return nChecksum.Get32();
-}
-
-CBigNum CAccumulators::GetAccumulatorValueFromCheckpoint(const uint256& nCheckpoint, CoinDenomination denomination)
-{
-    uint32_t nDenominationChecksum = ParseChecksum(nCheckpoint, denomination);
-    LogPrint("zero", "%s checkpoint:%d\n", __func__, nCheckpoint.GetHex());
-    LogPrint("zero", "%s checksum:%d\n", __func__, nDenominationChecksum);
-
-    return GetAccumulatorValueFromChecksum(nDenominationChecksum);
-}
-
-CBigNum CAccumulators::GetAccumulatorValueFromChecksum(const uint32_t& nChecksum)
-{
-    if(!mapAccumulatorValues.count(nChecksum))
-        return CBigNum(0);
-
-    return mapAccumulatorValues[nChecksum];
-}
-
-//set all of the accumulators held by mapAccumulators to a certain checkpoint
-bool CAccumulators::ResetToCheckpoint(const uint256& nCheckpoint)
-{
-    for (auto& denom : zerocoinDenomList) {
-        CBigNum bnValue = GetAccumulatorValueFromCheckpoint(nCheckpoint, denom);
-        if (bnValue == 0) {
-            //if the value is zero, then this is an unused accumulator and must be reinitialized
-            unique_ptr<Accumulator> uptr(new Accumulator(Params().Zerocoin_Params(), denom));
-            mapAccumulators.at(denom) = std::move(uptr);
-            continue;
+        //if read is not successful then we are not in a state to verify zerocoin transactions
+        CBigNum bnValue;
+        if (!zerocoinDB->ReadAccumulatorValue(nChecksum, bnValue)) {
+            LogPrint("zero","%s : Missing databased value for checksum %d\n", __func__, nChecksum);
+            if (!count(listAccCheckpointsNoDB.begin(), listAccCheckpointsNoDB.end(), nCheckpoint))
+                listAccCheckpointsNoDB.push_back(nCheckpoint);
+            return false;
         }
-
-        mapAccumulators.at(denom)->setValue(bnValue);
+        mapAccumulatorValues.insert(make_pair(nChecksum, bnValue));
     }
-
     return true;
 }
 
-//Get checkpoint value from the current state of our accumulator map
-uint256 CAccumulators::GetCheckpoint()
-{
-    uint256 nCheckpoint;
-    for (auto& denom : zerocoinDenomList) {
-        CBigNum bnValue = mapAccumulators.at(denom)->getValue();
-        uint32_t nCheckSum = GetChecksum(bnValue);
-        AddAccumulatorChecksum(nCheckSum, bnValue);
-        nCheckpoint = nCheckpoint << 32 | nCheckSum;
-
-        LogPrint("zero", "%s: Acc value:%s\n", __func__, bnValue.GetHex());
-        LogPrint("zero", "%s: checksum value:%d\n", __func__, nCheckSum);
-        LogPrint("zero", "%s: checkpoint %s\n", __func__, nCheckpoint.GetHex());
-    }
-
-    return nCheckpoint;
-}
-
 //Get checkpoint value for a specific block height
-bool CAccumulators::GetCheckpoint(int nHeight, uint256& nCheckpoint)
+bool CalculateAccumulatorCheckpoint(int nHeight, uint256& nCheckpoint)
 {
-    if (nHeight <= chainActive.Height() && chainActive[nHeight]->GetBlockHeader().nVersion < Params().Zerocoin_HeaderVersion()) {
+    if (nHeight < Params().Zerocoin_StartHeight()) {
         nCheckpoint = 0;
         return true;
     }
@@ -197,9 +117,15 @@ bool CAccumulators::GetCheckpoint(int nHeight, uint256& nCheckpoint)
     }
 
     //set the accumulators to last checkpoint value
-    if(!ResetToCheckpoint(chainActive[nHeight - 1]->nAccumulatorCheckpoint)) {
-        LogPrint("zero","%s: failed to reset to previous checkpoint\n", __func__);
-        return false;
+    AccumulatorMap mapAccumulators;
+    if(!mapAccumulators.Load(chainActive[nHeight - 1]->nAccumulatorCheckpoint)) {
+        if (chainActive[nHeight - 1]->nAccumulatorCheckpoint == 0) {
+            //Before zerocoin is fully activated so set to init state
+            mapAccumulators.Reset();
+        } else {
+            LogPrintf("%s: failed to reset to previous checkpoint\n", __func__);
+            return false;
+        }
     }
 
     //Accumulate all coins over the last ten blocks that havent been accumulated (height - 20 through height - 11)
@@ -212,7 +138,7 @@ bool CAccumulators::GetCheckpoint(int nHeight, uint256& nCheckpoint)
         }
 
         //make sure this block is eligible for accumulation
-        if (pindex->GetBlockHeader().nVersion < Params().Zerocoin_HeaderVersion()) {
+        if (pindex->nHeight < Params().Zerocoin_StartHeight()) {
             pindex = chainActive[pindex->nHeight + 1];
             continue;
         }
@@ -234,29 +160,29 @@ bool CAccumulators::GetCheckpoint(int nHeight, uint256& nCheckpoint)
 
         //add the pubcoins to accumulator
         for(const PublicCoin pubcoin : listPubcoins) {
-            if(!AddPubCoinToAccumulator(pubcoin)) {
-                LogPrint("zero","%s: failed to add pubcoin to accumulator at height %n\n", __func__, pindex->nHeight);
+            if(!mapAccumulators.Accumulate(pubcoin, true)) {
+                LogPrintf("%s: failed to add pubcoin to accumulator at height %n\n", __func__, pindex->nHeight);
                 return false;
             }
         }
-        pindex = chainActive[pindex->nHeight + 1];
+        pindex = chainActive.Next(pindex);
     }
 
     // if there were no new mints found, the accumulator checkpoint will be the same as the last checkpoint
     if (nTotalMintsFound == 0) {
         nCheckpoint = chainActive[nHeight - 1]->nAccumulatorCheckpoint;
-
-        // make sure that these values are databased because reorgs may have deleted the checksums from DB
-        DatabaseChecksums(nCheckpoint);
     }
     else
-        nCheckpoint = GetCheckpoint();
+        nCheckpoint = mapAccumulators.GetCheckpoint();
+
+    // make sure that these values are databased because reorgs may have deleted the checksums from DB
+    DatabaseChecksums(mapAccumulators);
 
     LogPrint("zero", "%s checkpoint=%s\n", __func__, nCheckpoint.GetHex());
     return true;
 }
 
-bool CAccumulators::IntializeWitnessAndAccumulator(const PublicCoin &coin, Accumulator& accumulator, AccumulatorWitness& witness, int nSecurityLevel, int& nMintsAdded, string& strError)
+bool GenerateAccumulatorWitness(const PublicCoin &coin, Accumulator& accumulator, AccumulatorWitness& witness, int nSecurityLevel, int& nMintsAdded, string& strError)
 {
     uint256 txid;
     if (!zerocoinDB->ReadCoinMint(coin.getValue(), txid)) {
@@ -272,7 +198,7 @@ bool CAccumulators::IntializeWitnessAndAccumulator(const PublicCoin &coin, Accum
     }
 
     int nHeightMintAdded= mapBlockIndex[hashBlock]->nHeight;
-    uint256 nChecksumBeforeMint = 0, nChecksumContainingMint = 0;
+    uint256 nCheckpointBeforeMint = 0, nCheckpointContainingMint = 0;
     CBlockIndex* pindex = chainActive[nHeightMintAdded];
     int nChanges = 0;
 
@@ -286,11 +212,11 @@ bool CAccumulators::IntializeWitnessAndAccumulator(const PublicCoin &coin, Accum
 
         //check if the next checksum was generated
         if (pindex->nHeight % 10 == 0) {
-            nChecksumContainingMint = pindex->nAccumulatorCheckpoint;
+            nCheckpointContainingMint = pindex->nAccumulatorCheckpoint;
             nChanges++;
 
             if (nChanges == 1)
-                nChecksumBeforeMint = pindex->nAccumulatorCheckpoint;
+                nCheckpointBeforeMint = pindex->nAccumulatorCheckpoint;
             else if (nChanges == 2)
                 break;
         }
@@ -301,8 +227,8 @@ bool CAccumulators::IntializeWitnessAndAccumulator(const PublicCoin &coin, Accum
     int nAccStartHeight = nHeightMintAdded - (nHeightMintAdded % 10);
 
     //Get the accumulator that is right before the cluster of blocks containing our mint was added to the accumulator
-    CBigNum bnAccValue = GetAccumulatorValueFromCheckpoint(nChecksumBeforeMint, coin.getDenomination());
-    if (bnAccValue != 0) {
+    CBigNum bnAccValue = 0;
+    if (GetAccumulatorValueFromDB(nCheckpointBeforeMint, coin.getDenomination(), bnAccValue)) {
         accumulator.setValue(bnAccValue);
         witness.resetValue(accumulator, coin);
     }
@@ -333,7 +259,12 @@ bool CAccumulators::IntializeWitnessAndAccumulator(const PublicCoin &coin, Accum
         //if a new checkpoint was generated on this block, and we have added the specified amount of checkpointed accumulators,
         //then initialize the accumulator at this point and break
         if (pindex->nHeight == nHeightStop || (nSecurityLevel != 100 && nCheckpointsAdded >= nSecurityLevel)) {
-            CBigNum bnAccValue = GetAccumulatorValueFromCheckpoint(chainActive[pindex->nHeight + 10]->nAccumulatorCheckpoint, coin.getDenomination());
+            uint32_t nChecksum = ParseChecksum(chainActive[pindex->nHeight + 10]->nAccumulatorCheckpoint, coin.getDenomination());
+            CBigNum bnAccValue = 0;
+            if (!zerocoinDB->ReadAccumulatorValue(nChecksum, bnAccValue)) {
+                LogPrintf("%s : failed to find checksum in database for accumulator\n", __func__);
+                return false;
+            }
             accumulator.setValue(bnAccValue);
             break;
         }
@@ -379,7 +310,7 @@ bool CAccumulators::IntializeWitnessAndAccumulator(const PublicCoin &coin, Accum
         nMintsAdded += count(pindex->vMintDenominationsInBlock.begin(), pindex->vMintDenominationsInBlock.end(), coin.getDenomination());
         pindex = chainActive[pindex->nHeight + 1];
     }
-    
+
     LogPrint("zero","%s : %d mints added to witness\n", __func__, nMintsAdded);
     return true;
 }

--- a/src/accumulators.h
+++ b/src/accumulators.h
@@ -13,7 +13,7 @@
 
 bool GenerateAccumulatorWitness(const libzerocoin::PublicCoin &coin, libzerocoin::Accumulator& accumulator, libzerocoin::AccumulatorWitness& witness, int nSecurityLevel, int& nMintsAdded, std::string& strError);
 bool GetAccumulatorValueFromDB(uint256 nCheckpoint, libzerocoin::CoinDenomination denom, CBigNum& bnAccValue);
-bool GetAccumulatorValueFromChecksum(uint32_t nChecksum, CBigNum& bnAccValue);
+bool GetAccumulatorValueFromChecksum(uint32_t nChecksum, bool fMemoryOnly, CBigNum& bnAccValue);
 void AddAccumulatorChecksum(const uint32_t nChecksum, const CBigNum &bnValue, bool fMemoryOnly);
 bool CalculateAccumulatorCheckpoint(int nHeight, uint256& nCheckpoint);
 bool LoadAccumulatorValuesFromDB(const uint256 nCheckpoint);

--- a/src/accumulators.h
+++ b/src/accumulators.h
@@ -11,50 +11,14 @@
 #include "primitives/zerocoin.h"
 #include "uint256.h"
 
-class CAccumulators
-{
-public:
-    static CAccumulators& getInstance()
-    {
-        static CAccumulators instance;
-        return instance;
-    }
-private:
-    std::map<libzerocoin::CoinDenomination, std::unique_ptr<libzerocoin::Accumulator> > mapAccumulators;
-    std::map<CBigNum, uint256> mapSerials;
-    std::map<uint32_t, CBigNum> mapAccumulatorValues;
-    std::list<uint256> listAccCheckpointsNoDB;
-
-    CAccumulators() { Setup(); }
-    void Setup();
-
-public:
-    CAccumulators(CAccumulators const&) = delete;
-    void operator=(CAccumulators const&) = delete;
-
-    libzerocoin::Accumulator Get(libzerocoin::CoinDenomination denomination);
-    bool AddPubCoinToAccumulator(const libzerocoin::PublicCoin& publicCoin);
-    bool IntializeWitnessAndAccumulator(const libzerocoin::PublicCoin &coin, libzerocoin::Accumulator& accumulator, libzerocoin::AccumulatorWitness& witness, int nSecurityLevel, int& nMintsAdded, std::string& strError);
-    bool EraseCoinSpend(const CBigNum& bnSerial);
-    bool EraseCoinMint(const CBigNum& bnPubCoin);
-
-    //checksum/checkpoint
-    void DatabaseChecksums(const uint256& nCheckpoint);
-    void AddAccumulatorChecksum(const uint32_t nChecksum, const CBigNum &bnValue, bool fMemoryOnly = false);
-    bool LoadAccumulatorValuesFromDB(const uint256 nCheckpoint);
-    bool EraseAccumulatorValues(const uint256& nCheckpointErase, const uint256& nCheckpointPrevious);
-    uint32_t GetChecksum(const CBigNum &bnValue);
-    uint32_t GetChecksum(const libzerocoin::Accumulator &accumulator);
-    uint256 GetCheckpoint();
-    bool GetCheckpoint(int nHeight, uint256& nCheckpoint);
-    CBigNum GetAccumulatorValueFromChecksum(const uint32_t& nChecksum);
-    CBigNum GetAccumulatorValueFromCheckpoint(const uint256& nCheckpoint, libzerocoin::CoinDenomination denomination);
-    bool ResetToCheckpoint(const uint256& nCheckpoint);
-    std::list<uint256> GetAccCheckpointsNoDB() { return listAccCheckpointsNoDB; };
-    void ClearAccCheckpointsNoDB() { listAccCheckpointsNoDB.clear(); }
-};
-
+bool GenerateAccumulatorWitness(const libzerocoin::PublicCoin &coin, libzerocoin::Accumulator& accumulator, libzerocoin::AccumulatorWitness& witness, int nSecurityLevel, int& nMintsAdded, std::string& strError);
+bool GetAccumulatorValueFromDB(uint256 nCheckpoint, libzerocoin::CoinDenomination denom, CBigNum& bnAccValue);
+bool GetAccumulatorValueFromChecksum(uint32_t nChecksum, CBigNum& bnAccValue);
+void AddAccumulatorChecksum(const uint32_t nChecksum, const CBigNum &bnValue, bool fMemoryOnly);
+bool CalculateAccumulatorCheckpoint(int nHeight, uint256& nCheckpoint);
+bool LoadAccumulatorValuesFromDB(const uint256 nCheckpoint);
+bool EraseAccumulatorValues(const uint256& nCheckpointErase, const uint256& nCheckpointPrevious);
 uint32_t ParseChecksum(uint256 nChecksum, libzerocoin::CoinDenomination denomination);
-
+uint32_t GetChecksum(const CBigNum &bnValue);
 
 #endif //PIVX_ACCUMULATORS_H

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -205,6 +205,7 @@ public:
         nMaxZerocoinSpendsPerTransaction = 7; // Assume about 20kb each
         nMinZerocoinMintFee = 1 * CENT; //high fee required for zerocoin mints
         nMintRequiredConfirmations = 20; //the maximum amount of confirmations until accumulated in 19
+        nRequiredAccumulation = 2;
         nDefaultSecurityLevel = 100; //full security level for accumulators
         nZerocoinHeaderVersion = 4; //Block headers must be this version once zerocoin is active
         nBudget_Fee_Confirmations = 6; // Number of confirmations for the finalization fee
@@ -244,6 +245,7 @@ public:
         nMasternodeCountDrift = 4;
         nModifierUpdateBlock = 51197; //approx Mon, 17 Apr 2017 04:00:00 GMT
         nMaxMoneyOut = 43199500 * COIN;
+        nZerocoinStartHeight = 201576;
 
         //! Modify the testnet genesis block so the timestamp is valid for a later start.
         genesis.nTime = 1454124731;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -105,6 +105,7 @@ public:
     int Zerocoin_MaxSpendsPerTransaction() const { return nMaxZerocoinSpendsPerTransaction; }
     CAmount Zerocoin_MintFee() const { return nMinZerocoinMintFee; }
     int Zerocoin_MintRequiredConfirmations() const { return nMintRequiredConfirmations; }
+    int Zerocoin_RequiredAccumulation() const { return nRequiredAccumulation; }
     int Zerocoin_DefaultSpendSecurity() const { return nDefaultSecurityLevel; }
     int Zerocoin_HeaderVersion() const { return nZerocoinHeaderVersion; }
 
@@ -160,6 +161,7 @@ protected:
     int nMaxZerocoinSpendsPerTransaction;
     CAmount nMinZerocoinMintFee;
     int nMintRequiredConfirmations;
+    int nRequiredAccumulation;
     int nDefaultSecurityLevel;
     int nZerocoinHeaderVersion;
     int64_t nBudget_Fee_Confirmations;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -405,7 +405,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, 
         pblock->nBits = GetNextWorkRequired(pindexPrev, pblock);
         pblock->nNonce = 0;
         uint256 nCheckpoint = 0;
-        if(fZerocoinActive && !CAccumulators::getInstance().GetCheckpoint(nHeight, nCheckpoint)){
+        if(fZerocoinActive && !CalculateAccumulatorCheckpoint(nHeight, nCheckpoint)){
             LogPrintf("%s: failed to get accumulator checkpoint\n", __func__);
         }
         pblock->nAccumulatorCheckpoint = nCheckpoint;

--- a/src/qt/forms/privacydialog.ui
+++ b/src/qt/forms/privacydialog.ui
@@ -581,7 +581,7 @@
                  <property name="toolTip">
                   <string>Available (mature and spendable) zPIV for spending
 
-zPIV are mature when they have more than 20 confirmations AND more than 3 mints of the same denomination after them were minted</string>
+zPIV are mature when they have more than 20 confirmations AND more than 2 mints of the same denomination after them were minted</string>
                  </property>
                  <property name="text">
                   <string>0 zPIV</string>
@@ -1048,7 +1048,7 @@ zPIV are mature when they have more than 20 confirmations AND more than 3 mints 
                  </property>
                  <property name="toolTip">
                   <string>Unconfirmed: less than 20 confirmations
-Immature: confirmed, but less than 3 mints of the same denomination after it was minted</string>
+Immature: confirmed, but less than 2 mints of the same denomination after it was minted</string>
                  </property>
                  <property name="text">
                   <string>0 x</string>
@@ -1101,7 +1101,7 @@ Immature: confirmed, but less than 3 mints of the same denomination after it was
                  </property>
                  <property name="toolTip">
                   <string>Unconfirmed: less than 20 confirmations
-Immature: confirmed, but less than 3 mints of the same denomination after it was minted</string>
+Immature: confirmed, but less than 2 mints of the same denomination after it was minted</string>
                  </property>
                  <property name="text">
                   <string>0 x</string>
@@ -1154,7 +1154,7 @@ Immature: confirmed, but less than 3 mints of the same denomination after it was
                  </property>
                  <property name="toolTip">
                   <string>Unconfirmed: less than 20 confirmations
-Immature: confirmed, but less than 3 mints of the same denomination after it was minted</string>
+Immature: confirmed, but less than 2 mints of the same denomination after it was minted</string>
                  </property>
                  <property name="text">
                   <string>0 x</string>
@@ -1207,7 +1207,7 @@ Immature: confirmed, but less than 3 mints of the same denomination after it was
                  </property>
                  <property name="toolTip">
                   <string>Unconfirmed: less than 20 confirmations
-Immature: confirmed, but less than 3 mints of the same denomination after it was minted</string>
+Immature: confirmed, but less than 2 mints of the same denomination after it was minted</string>
                  </property>
                  <property name="text">
                   <string>0 x</string>
@@ -1260,7 +1260,7 @@ Immature: confirmed, but less than 3 mints of the same denomination after it was
                  </property>
                  <property name="toolTip">
                   <string>Unconfirmed: less than 20 confirmations
-Immature: confirmed, but less than 3 mints of the same denomination after it was minted</string>
+Immature: confirmed, but less than 2 mints of the same denomination after it was minted</string>
                  </property>
                  <property name="text">
                   <string>0 x</string>
@@ -1313,7 +1313,7 @@ Immature: confirmed, but less than 3 mints of the same denomination after it was
                  </property>
                  <property name="toolTip">
                   <string>Unconfirmed: less than 20 confirmations
-Immature: confirmed, but less than 3 mints of the same denomination after it was minted</string>
+Immature: confirmed, but less than 2 mints of the same denomination after it was minted</string>
                  </property>
                  <property name="text">
                   <string>0 x</string>
@@ -1366,7 +1366,7 @@ Immature: confirmed, but less than 3 mints of the same denomination after it was
                  </property>
                  <property name="toolTip">
                   <string>Unconfirmed: less than 20 confirmations
-Immature: confirmed, but less than 3 mints of the same denomination after it was minted</string>
+Immature: confirmed, but less than 2 mints of the same denomination after it was minted</string>
                  </property>
                  <property name="text">
                   <string>0 x</string>
@@ -1419,7 +1419,7 @@ Immature: confirmed, but less than 3 mints of the same denomination after it was
                  </property>
                  <property name="toolTip">
                   <string>Unconfirmed: less than 20 confirmations
-Immature: confirmed, but less than 3 mints of the same denomination after it was minted</string>
+Immature: confirmed, but less than 2 mints of the same denomination after it was minted</string>
                  </property>
                  <property name="text">
                   <string>0 x</string>

--- a/src/qt/privacydialog.cpp
+++ b/src/qt/privacydialog.cpp
@@ -555,21 +555,21 @@ void PrivacyDialog::setBalance(const CAmount& balance, const CAmount& unconfirme
         // All denominations
         mapDenomBalances.at(mint.GetDenomination())++;
 
-        if (!mint.GetHeight() || mint.GetHeight() > chainActive.Height() - Params().Zerocoin_MintRequiredConfirmations()) {
+        if (!mint.GetHeight() || chainActive.Height() - mint.GetHeight() <= Params().Zerocoin_MintRequiredConfirmations()) {
             // All unconfirmed denominations
             mapUnconfirmed.at(mint.GetDenomination())++;
         }
         else {
             // After a denomination is confirmed it might still be immature because < 3 of the same denomination were minted after it
-            CBlockIndex *pindex = chainActive[mint.GetHeight()];
+            CBlockIndex *pindex = chainActive[mint.GetHeight() + 1];
             int nMintsAdded = 0;
-            while(pindex->nHeight < chainActive.Height() - 30) { // 30 just to make sure that its at least 2 checkpoints from the top block
+            while (pindex->nHeight < chainActive.Height() - 30) { // 30 just to make sure that its at least 2 checkpoints from the top block
                 nMintsAdded += count(pindex->vMintDenominationsInBlock.begin(), pindex->vMintDenominationsInBlock.end(), mint.GetDenomination());
-                if(nMintsAdded >= 3)
+                if (nMintsAdded >= Params().Zerocoin_RequiredAccumulation())
                     break;
                 pindex = chainActive[pindex->nHeight + 1];
             }
-            if(nMintsAdded < 3){
+            if (nMintsAdded < Params().Zerocoin_RequiredAccumulation()){
                 // Immature denominations
                 mapImmature.at(mint.GetDenomination())++;
             }

--- a/src/qt/zpivcontroldialog.cpp
+++ b/src/qt/zpivcontroldialog.cpp
@@ -95,14 +95,14 @@ void ZPivControlDialog::updateList()
             CBlockIndex *pindex = chainActive[mint.GetHeight() + 1];
             while(pindex->nHeight < chainActive.Height() - 30) { // 30 just to make sure that its at least 2 checkpoints from the top block
                 nMintsAdded += count(pindex->vMintDenominationsInBlock.begin(), pindex->vMintDenominationsInBlock.end(), mint.GetDenomination());
-                if(nMintsAdded >= 3)
+                if(nMintsAdded >= Params().Zerocoin_RequiredAccumulation())
                     break;
                 pindex = chainActive[pindex->nHeight + 1];
             }
         }
 
         // disable selecting this mint if it is not spendable - also display a reason why
-        bool fSpendable = nMintsAdded >= 3 && nConfirmations >= Params().Zerocoin_MintRequiredConfirmations();
+        bool fSpendable = nMintsAdded >= Params().Zerocoin_RequiredAccumulation() && nConfirmations >= Params().Zerocoin_MintRequiredConfirmations();
         if(!fSpendable) {
             itemMint->setDisabled(true);
             itemMint->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);
@@ -117,7 +117,7 @@ void ZPivControlDialog::updateList()
             if(nConfirmations < Params().Zerocoin_MintRequiredConfirmations())
                 strReason = strprintf("Needs %d more confirmations", Params().Zerocoin_MintRequiredConfirmations() - nConfirmations);
             else
-                strReason = strprintf("Needs %d more mints added to network", 3 - nMintsAdded);
+                strReason = strprintf("Needs %d more mints added to network", Params().Zerocoin_RequiredAccumulation() - nMintsAdded);
 
             itemMint->setText(COLUMN_ISSPENDABLE, QString::fromStdString(strReason));
         } else {

--- a/src/test/zerocoin_implementation_tests.cpp
+++ b/src/test/zerocoin_implementation_tests.cpp
@@ -134,8 +134,8 @@ bool CheckZerocoinSpendNoDB(const CTransaction tx, string& strError)
 //        }
 
         //see if we have record of the accumulator used in the spend tx
-        CBigNum bnAccumulatorValue = CAccumulators::getInstance().GetAccumulatorValueFromChecksum(newSpend.getAccumulatorChecksum());
-        if(bnAccumulatorValue == 0) {
+        CBigNum bnAccumulatorValue = 0;
+        if (!GetAccumulatorValueFromChecksum(newSpend.getAccumulatorChecksum(), bnAccumulatorValue)) {
             strError = "Zerocoinspend could not find accumulator associated with checksum";
             return false;
         }
@@ -213,8 +213,8 @@ BOOST_AUTO_TEST_CASE(checkzerocoinspend_test)
     privateCoin.setSerialNumber(zerocoinMint.GetSerialNumber());
 
     //Get the checksum of the accumulator we use for the spend and also add it to our checksum map
-    uint32_t nChecksum = CAccumulators::getInstance().GetChecksum(accumulator);
-    CAccumulators::getInstance().AddAccumulatorChecksum(nChecksum, accumulator.getValue(), true);
+    uint32_t nChecksum = GetChecksum(accumulator.getValue());
+    AddAccumulatorChecksum(nChecksum, accumulator.getValue(), true);
     CoinSpend coinSpend(Params().Zerocoin_Params(), privateCoin, accumulator, nChecksum, witness, 0);
 
     CBigNum serial = coinSpend.getCoinSerialNumber();

--- a/src/test/zerocoin_implementation_tests.cpp
+++ b/src/test/zerocoin_implementation_tests.cpp
@@ -135,7 +135,7 @@ bool CheckZerocoinSpendNoDB(const CTransaction tx, string& strError)
 
         //see if we have record of the accumulator used in the spend tx
         CBigNum bnAccumulatorValue = 0;
-        if (!GetAccumulatorValueFromChecksum(newSpend.getAccumulatorChecksum(), bnAccumulatorValue)) {
+        if (!GetAccumulatorValueFromChecksum(newSpend.getAccumulatorChecksum(), true, bnAccumulatorValue)) {
             strError = "Zerocoinspend could not find accumulator associated with checksum";
             return false;
         }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -271,7 +271,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
 
                 //populate accumulator checksum map in memory
                 if(pindexNew->nAccumulatorCheckpoint != 0 && pindexNew->nAccumulatorCheckpoint != nPreviousCheckpoint) {
-                    CAccumulators::getInstance().LoadAccumulatorValuesFromDB(pindexNew->nAccumulatorCheckpoint);
+                    LoadAccumulatorValuesFromDB(pindexNew->nAccumulatorCheckpoint);
                     nPreviousCheckpoint = pindexNew->nAccumulatorCheckpoint;
                 }
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -4035,7 +4035,7 @@ bool CWallet::MintToTxIn(CZerocoinMint zerocoinSelected, int nSecurityLevel, con
     libzerocoin::AccumulatorWitness witness(Params().Zerocoin_Params(), accumulator, pubCoinSelected);
     string strFailReason = "";
     int nMintsAdded = 0;
-    if (!CAccumulators::getInstance().IntializeWitnessAndAccumulator(pubCoinSelected, accumulator, witness, nSecurityLevel, nMintsAdded, strFailReason)) {
+    if (!GenerateAccumulatorWitness(pubCoinSelected, accumulator, witness, nSecurityLevel, nMintsAdded, strFailReason)) {
         receipt.SetStatus("Try to spend with a higher security level to include more coins", ZPIV_FAILED_ACCUMULATOR_INITIALIZATION);
         return false;
     }
@@ -4045,7 +4045,7 @@ bool CWallet::MintToTxIn(CZerocoinMint zerocoinSelected, int nSecurityLevel, con
     privateCoin.setPublicCoin(pubCoinSelected);
     privateCoin.setRandomness(zerocoinSelected.GetRandomness());
     privateCoin.setSerialNumber(zerocoinSelected.GetSerialNumber());
-    uint32_t nChecksum = CAccumulators::getInstance().GetChecksum(accumulator);
+    uint32_t nChecksum = GetChecksum(accumulator.getValue());
 
     try {
         libzerocoin::CoinSpend spend(Params().Zerocoin_Params(), privateCoin, accumulator, nChecksum, witness, hashTxOut);
@@ -4099,7 +4099,7 @@ bool CWallet::MintToTxIn(CZerocoinMint zerocoinSelected, int nSecurityLevel, con
             }
         }
 
-        uint32_t nAccumulatorChecksum = CAccumulators::getInstance().GetChecksum(accumulator);
+        uint32_t nAccumulatorChecksum = GetChecksum(accumulator.getValue());
         CZerocoinSpend zcSpend(spend.getCoinSerialNumber(), 0, zerocoinSelected.GetValue(), zerocoinSelected.GetDenomination(), nAccumulatorChecksum);
         zcSpend.SetMintCount(nMintsAdded);
         receipt.AddSpend(zcSpend);

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -4037,6 +4037,7 @@ bool CWallet::MintToTxIn(CZerocoinMint zerocoinSelected, int nSecurityLevel, con
     int nMintsAdded = 0;
     if (!GenerateAccumulatorWitness(pubCoinSelected, accumulator, witness, nSecurityLevel, nMintsAdded, strFailReason)) {
         receipt.SetStatus("Try to spend with a higher security level to include more coins", ZPIV_FAILED_ACCUMULATOR_INITIALIZATION);
+        LogPrintf("%s : %s \n", __func__, receipt.GetStatusMessage());
         return false;
     }
 

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -1166,12 +1166,12 @@ std::list<CZerocoinMint> CWalletDB::ListMintedCoins(bool fUnusedOnly, bool fMatu
                 int nMintsAdded = 0;
                 while(pindex->nHeight < chainActive.Height() - 30) { // 30 just to make sure that its at least 2 checkpoints from the top block
                     nMintsAdded += count(pindex->vMintDenominationsInBlock.begin(), pindex->vMintDenominationsInBlock.end(), mint.GetDenomination());
-                    if(nMintsAdded >= 3)
+                    if(nMintsAdded >= Params().Zerocoin_RequiredAccumulation())
                         break;
                     pindex = chainActive[pindex->nHeight + 1];
                 }
 
-                if(nMintsAdded < 3)
+                if(nMintsAdded < Params().Zerocoin_RequiredAccumulation())
                     continue;
             }
         }


### PR DESCRIPTION
This refactors the accumulator code. It removes the singleton structure that was used before and replaces it with a new class `AccumulatorMap` which is comprised of an accumulator for each zerocoin denomination.

This also reconfigures when `PublicCoin`'s are verified. Instead of having them verified everytime you pull them out of the blockchain, it is only necessary to verify them when they are being checked before being placed into the blockchain. Once it is in the chain, it is fair to assume it is valid. This saves a large amount of computation, by some tests it speeds up accumulator checkpointing by 5x.