### PR TITLE
Do not stringify beyond OP_ZEROCOINSPEND for CScript::ToString()

### DIFF
--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -297,10 +297,16 @@ std::string CScript::ToString() const
             str += "[error]";
             return str;
         }
-        if (0 <= opcode && opcode <= OP_PUSHDATA4)
+        if (0 <= opcode && opcode <= OP_PUSHDATA4) {
             str += ValueString(vch);
-        else
+        } else {
             str += GetOpName(opcode);
+            if (opcode == OP_ZEROCOINSPEND) {
+                //Zerocoinspend has no further op codes.
+                break;
+            }
+        }
+
     }
     return str;
 }


### PR DESCRIPTION
https://github.com/PIVX-Project/PIVX/issues/363

There are no further op codes in zerocoinspends. When parsing through the data, the ToString() method often see's the zPiv spend data as an OP code. Since RPC getrawtransaction prints the hex of the CScript anyways, it is redundant to print all of the spend data in this to string and then again in the hex dump.

Before:
```
"vin" : [
        {
            "txid" : "0000000000000000000000000000000000000000000000000000000000000000",
            "vout" : 4294967295,
            "scriptSig" : {
                "asm" : "OP_ZEROCOINSPEND 20776 000000ee19dc8cb8dc008d72c1cd6256efb534834f3e9e8f383a600ee753b6b65a820b8635e34b466f0e33477b6c37508870 OP_OVER OP_UNKNOWN OP_EQUAL 5feae073134555cc765f5e5566b8 OP_NOT 6d9f52375fc78ca85b4440c5e0f251316d1033d2aba5643d389b484f1232dac7976a OP_RIPEMD160 8fd70002818c981e76a519fb 97b9af67a9bef577596f72b9981dc4e93e08e6c8a13ad1d2c0cffc9d3af48f04867bd1f5a134 04d204fa08400347b10bbf01e2f5cb9a42844f4416f44aa61d191997 OP_UNKNOWN 1 OP_CAT OP_UNKNOWN ab5343b405de3dac2c37aaa3364ffb229fd967237e1e1c902c3e812e2e1990a2c0fc5dbcfdc52dc9d8b364c349dda6212e21caf6091a5b5652f67acba2ef7075615014b456 5ed34cc1e29cde619e10dd4f01fd690218110d2ebfbfedec32 OP_UNKNOWN bfeb53027e244beda171a587e645f833ebc890f87827e7dc0d68e15a43cadc4876b1cceb11d6f1660f100e3f24 OP_FROMALTSTACK aa779ffe86197c5ad133e5f4e000746d53849c074d36b73f1e4fd6552d4a47af050523fd29bcee0610bb0a90ecacf15432b767c379b1c87266d4578ea8 OP_CHECKMULTISIGVERIFY 834e484eb263e94e0f73267517ae76a579225fdc6365ca36552500dd6a3b418a14aa8d4f5e4c5f88b713dba5d9f1ed6fbb6a9e477195b7a1d951f221a29fcacf823f OP_UNKNOWN OP_UNKNOWN 7bf717791d77071f085ad9d97c40714349ada02f93dc2a4deece0303815092254cb24326718870dcc64a0534329d09def1d2b86879 OP_3DUP OP_VERIFY OP_SWAP OP_2MUL 51d1e09cfa37e21b3d 8bc977417b13919620390b32e01e7b5b76859172f60503717a898f2378a810126358d1b83882fbad8d82bf195405862303fed24212 7126ca8ae4b6 OP_SWAP OP_RIPEMD160 2 OP_UNKNOWN OP_UNKNOWN OP_NOP3 OP_UNKNOWN d4076e8fff1be379e5854bbd7f556bd0b58c686b7d91c91c1620868d0282c77568ff00439b0c4ee2cc0e82fd8d6fd9142e61280a68292d9d034706db2bbcbd9f90cbbe9cb828019d592645554384f9d8fba606ed5850a442640c2e78f2c1fa987dbcb5c4f913c50975bd32b04309b1d1aa60445295fb2abd37137be9d5f6bd3bc49291343c448e7ee089b8bfd48825b08d705059474aa36fb71e8d56876f24275ee1625c47173e543a80c86bec6da24e3bf221394a2e34b0d2157ea5ba6c0fdf449b c1e5d8d272066a7652541ce8f5909517918a73b19038c7bdc33f07e67afcd96d0b122f77b6 OP_UNKNOWN OP_UNKNOWN OP_UNKNOWN 15 OP_SUBSTR OP_UNKNOWN OP_UNKNOWN OP_CHECKMULTISIG OP_UNKNOWN OP_2DIV OP_UNKNOWN OP_UNKNOWN OP_ADD 45b81d06ea1ad55651c11b4aaec3d36d59d9aca7d28506aa7e54e5f53dc01177599a85 OP_UNKNOWN OP_UNKNOWN OP_UNKNOWN OP_UNKNOWN 03548702fd6902b9b2649e533d3b8e8a OP_ENDIF f51f5cd23d1f18db34fef28cfc6ce1 OP_LESSTHANOREQUAL OP_NOP7 OP_UNKNOWN OP_UNKNOWN OP_BOOLOR OP_WITHIN e3a99c32cc2c2ffdbe8b2831ac7c3b688a33073a8e10f096580422c54d9efac3d2ad05e8f09a9f4a7d164f2ae734a6 OP_OVER OP_SIZE 15 OP_UNKNOWN [error]",
                "hex" : "c20228..."
```

After:
```
"vin" : [
        {
            "txid" : "0000000000000000000000000000000000000000000000000000000000000000",
            "vout" : 4294967295,
            "scriptSig" : {
                "asm" : "OP_ZEROCOINSPEND",
                "hex" : "c20228..."
```