### PR TITLE
Gitian hack so gitian Mac builds notify user about incompatibility on High Sierra

### DIFF
--- a/src/qt/pivx.cpp
+++ b/src/qt/pivx.cpp
@@ -570,6 +570,18 @@ int main(int argc, char* argv[])
     initTranslations(qtTranslatorBase, qtTranslator, translatorBase, translator);
     uiInterface.Translate.connect(Translate);
 
+#ifdef Q_OS_MAC
+#if __clang_major__ < 4
+    QString s = QSysInfo::kernelVersion();
+    std::string ver_info = s.toStdString();
+    // ver_info will be like 17.2.0 for High Sierra. Check if true and exit if build via cross-compile
+    if (ver_info[0] == '1' && ver_info[1] == '7') {
+        QMessageBox::critical(0, "Unsupported", BitcoinGUI::tr("High Sierra not supported with this build") + QString("\n\n"));
+        ::exit(1);
+    }
+#endif
+#endif
+    
     // Show help message immediately after parsing command-line options (for "-lang") and setting locale,
     // but before showing splash screen.
     if (mapArgs.count("-?") || mapArgs.count("-help") || mapArgs.count("-version")) {


### PR DESCRIPTION
With this change, if a user tries to open on High Sierra from official gitian build, they'll see the following
![screen shot 2017-11-10 at 2 50 21 pm](https://user-images.githubusercontent.com/25382027/32681883-8ab910b2-c626-11e7-822c-dccda276fb57.png)

However, could will let users on High Sierra still build and use as long as they are using Clang version 4 or higher