### PR TITLE
getspentzerocoinamount RPC call. 

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -126,7 +126,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
         {"importzerocoins", 0},
         {"exportzerocoins", 0},
         {"exportzerocoins", 1},
-        {"resetmintzerocoin", 0}
+        {"resetmintzerocoin", 0},
+        {"getspentzerocoinamount", 1}
     };
 
 class CRPCConvertTable

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -17,6 +17,7 @@
 #include "script/sign.h"
 #include "script/standard.h"
 #include "uint256.h"
+#include "utilmoneystr.h"
 #ifdef ENABLE_WALLET
 #include "wallet.h"
 #endif
@@ -730,4 +731,40 @@ Value sendrawtransaction(const Array& params, bool fHelp)
     RelayTransaction(tx);
 
     return hashTx.GetHex();
+}
+
+Value getspentzerocoinamount(const Array& params, bool fHelp)
+{
+    if (fHelp || params.size() != 2)
+        throw runtime_error(
+            "getspentzerocoinamount hexstring index\n"
+            "\nReturns value of spent zerocoin output designated by transaction hash and input index.\n"
+            "\nArguments:\n"
+            "1. hash          (hexstring) Transaction hash\n"
+            "2. index         (int) Input index\n"
+            "\nResult:\n"
+            "\"value\"        (int) Spent output value, -1 if error\n"
+            "\nExamples:\n" +
+            HelpExampleCli("getspentzerocoinamount", "78021ebf92a80dfccef1413067f1222e37535399797cce029bb40ad981131706 0"));
+
+    uint256 txHash = ParseHashV(params[0], "parameter 1");
+    int inputIndex = params[1].get_int();
+    if (inputIndex < 0)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter for transaction input");
+
+    CTransaction tx;
+    uint256 hashBlock = 0;
+    if (!GetTransaction(txHash, tx, hashBlock, true))
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available about transaction");
+
+    if (inputIndex >= (int)tx.vin.size())
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter for transaction input");
+
+    const CTxIn& input = tx.vin[inputIndex];
+    if (!input.scriptSig.IsZerocoinSpend())
+        return -1;
+
+    libzerocoin::CoinSpend spend = TxInToZerocoinSpend(input);
+    CAmount nValue = libzerocoin::ZerocoinDenominationToAmount(spend.getDenomination());
+    return FormatMoney(nValue); 
 }

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -408,7 +408,8 @@ static const CRPCCommand vRPCCommands[] =
         {"zerocoin", "getarchivedzerocoin", &getarchivedzerocoin, false, false, true},
         {"zerocoin", "importzerocoins", &importzerocoins, false, false, true},
         {"zerocoin", "exportzerocoins", &exportzerocoins, false, false, true},
-        {"zerocoin", "reconsiderzerocoins", &reconsiderzerocoins, false, false, true}
+        {"zerocoin", "reconsiderzerocoins", &reconsiderzerocoins, false, false, true},
+        {"zerocoin", "getspentzerocoinamount", &getspentzerocoinamount, false, false, false}
 
 #endif // ENABLE_WALLET
 };

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -226,6 +226,7 @@ extern json_spirit::Value getarchivedzerocoin(const json_spirit::Array& params, 
 extern json_spirit::Value importzerocoins(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value exportzerocoins(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value reconsiderzerocoins(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value getspentzerocoinamount(const json_spirit::Array& params, bool fHelp);
 
 extern json_spirit::Value getrawtransaction(const json_spirit::Array& params, bool fHelp); // in rcprawtransaction.cpp
 extern json_spirit::Value listunspent(const json_spirit::Array& params, bool fHelp);


### PR DESCRIPTION
Accepts transaction hash and input index as parameters and returns amount of spent zerocoin input (if input is not zerocoin spend, returns -1).