### PR TITLE
[Main] Avoid slow transaction search with txindex enabled

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2055,6 +2055,9 @@ bool GetTransaction(const uint256& hash, CTransaction& txOut, uint256& hashBlock
                     return error("%s : txid mismatch", __func__);
                 return true;
             }
+
+            // transaction not found in the index, nothing more can be done
+            return false;
         }
 
         if (fAllowSlow) { // use coin database to locate block that contains transaction, and scan it


### PR DESCRIPTION
There is no point in doing a "slow" search for a transaction if it isn't
found in the txindex (if enabled).

We run with txindex enabled by default, so this could see some performance increase in the form of faster response times when searching for a transaction that doesn't exist.