### PR TITLE
Change git info in genbuild.sh

### DIFF
--- a/share/genbuild.sh
+++ b/share/genbuild.sh
@@ -21,14 +21,9 @@ if [ -e "$(which git 2>/dev/null)" -a "$(git rev-parse --is-inside-work-tree 2>/
     git diff >/dev/null 2>/dev/null 
 
     # if latest commit is tagged and not dirty, then override using the tag name
+    DESC=$(git describe 2>/dev/null)
     RAWDESC=$(git describe --abbrev=0 2>/dev/null)
-    if [ "$(git rev-parse HEAD)" = "$(git rev-list -1 $RAWDESC)" ]; then
-        git diff-index --quiet HEAD -- && DESC=$RAWDESC
-    fi
-
-    # otherwise generate suffix from git, i.e. string like "59887e8-dirty"
-    SUFFIX=$(git rev-parse --short HEAD)
-    git diff-index --quiet HEAD -- || SUFFIX="$SUFFIX-dirty"
+    git diff-index --quiet HEAD -- || DESC="$DESC-dirty"
 
     # get a string like "2012-04-10 16:27:19 +0200"
     LAST_COMMIT_DATE="$(git log -n 1 --format="%ci")"
@@ -36,8 +31,6 @@ fi
 
 if [ -n "$DESC" ]; then
     NEWINFO="#define BUILD_DESC \"$DESC\""
-elif [ -n "$SUFFIX" ]; then
-    NEWINFO="#define BUILD_SUFFIX $SUFFIX"
 else
     NEWINFO="// No build information available"
 fi


### PR DESCRIPTION
This slightly changes the usage of git calls in genbuild.sh to get a better description of what is built during development / building. Rather than just always get 3.0.99-g8fa5f125e, you'll get something more descriptive such as '3.0.5.1-branchpoint-1-g8fa5f125e', where the '1' is the number of commits after the "3.0.5.1-branchpoint" tag. This also makes it easier to locate the commit in the git tree and compare to others who are using slightly different versions.
Since this is only using git calls from a shell script it should work on all of the same platforms as the current script.
As before, when we build from a tag for releases then you should simply get something like "v3.0.6" without the extra fields.
Finally I believe this tag/description just goes to the splash screen and for internal usage - not to other peers.
This is a simpler change than PR #310 
