### PR TITLE
Handle debug.log "CWalletTx::GetAmounts: Unknown transaction type" spam.

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1073,9 +1073,12 @@ void CWalletTx::GetAmounts(list<COutputEntry>& listReceived,
 
         // In either case, we need to get the destination address
         CTxDestination address;
-        if (!ExtractDestination(txout.scriptPubKey, address)) {
-            LogPrintf("CWalletTx::GetAmounts: Unknown transaction type found, txid %s\n",
-                this->GetHash().ToString());
+        if (txout.scriptPubKey.IsZerocoinMint()) {
+            address = CNoDestination();
+        } else if (!ExtractDestination(txout.scriptPubKey, address)) {
+            if (!IsCoinStake() && !IsCoinBase()) {
+                LogPrintf("CWalletTx::GetAmounts: Unknown transaction type found, txid %s\n", this->GetHash().ToString());
+            }
             address = CNoDestination();
         }
 


### PR DESCRIPTION
`CWalletTx::GetAmounts` needs to check if a tx is a zerocoinmint, coinbase, and coinstake before it prints this warning to log `CWalletTx::GetAmounts: Unknown transaction type found, txid`.