### PR TITLE
Wipe zerocoin DB on reindex.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1311,8 +1311,10 @@ bool AppInit2(boost::thread_group& threadGroup)
                 delete zerocoinDB;
                 delete pSporkDB;
 
-                zerocoinDB = new CZerocoinDB(0, false, false);
+                //PIVX specific: zerocoin and spork DB's
+                zerocoinDB = new CZerocoinDB(0, false, fReindex);
                 pSporkDB = new CSporkDB(0, false, false);
+
                 pblocktree = new CBlockTreeDB(nBlockTreeDBCache, false, fReindex);
                 pcoinsdbview = new CCoinsViewDB(nCoinDBCache, false, fReindex);
                 pcoinscatcher = new CCoinsViewErrorCatcher(pcoinsdbview);


### PR DESCRIPTION
The zerocoin database should be wiped on reindex. If leftover information from a fork is left in the db it can lead to potential validation issues in the future and isolated forks.