### PR TITLE
[RPC] Add getfeeinfo RPC.

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -130,7 +130,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
         {"exportzerocoins", 0},
         {"exportzerocoins", 1},
         {"resetmintzerocoin", 0},
-        {"getspentzerocoinamount", 1}
+        {"getspentzerocoinamount", 1},
+        {"getfeeinfo", 0}
     };
 
 class CRPCConvertTable

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -279,6 +279,7 @@ static const CRPCCommand vRPCCommands[] =
         {"blockchain", "getblockheader", &getblockheader, false, false, false},
         {"blockchain", "getchaintips", &getchaintips, true, false, false},
         {"blockchain", "getdifficulty", &getdifficulty, true, false, false},
+        {"blockchain", "getfeeinfo", &getfeeinfo, true, false, false},
         {"blockchain", "getmempoolinfo", &getmempoolinfo, true, true, false},
         {"blockchain", "getrawmempool", &getrawmempool, true, false, false},
         {"blockchain", "gettxout", &gettxout, true, false, false},
@@ -286,7 +287,7 @@ static const CRPCCommand vRPCCommands[] =
         {"blockchain", "verifychain", &verifychain, true, false, false},
         {"blockchain", "invalidateblock", &invalidateblock, true, true, false},
         {"blockchain", "reconsiderblock", &reconsiderblock, true, true, false},
-        {"getinvalid", "getinvalid", &getinvalid, true, true, false},
+        {"blockchain", "getinvalid", &getinvalid, true, true, false},
 
         /* Mining */
         {"mining", "getblocktemplate", &getblocktemplate, true, false, false},

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -247,6 +247,7 @@ extern UniValue getrawmempool(const UniValue& params, bool fHelp);
 extern UniValue getblockhash(const UniValue& params, bool fHelp);
 extern UniValue getblock(const UniValue& params, bool fHelp);
 extern UniValue getblockheader(const UniValue& params, bool fHelp);
+extern UniValue getfeeinfo(const UniValue& params, bool fHelp);
 extern UniValue gettxoutsetinfo(const UniValue& params, bool fHelp);
 extern UniValue gettxout(const UniValue& params, bool fHelp);
 extern UniValue verifychain(const UniValue& params, bool fHelp);


### PR DESCRIPTION
This allows for a user (such as a third party integration) to query the blockchain for the current fee rate per kb, and also get a suggested rate per kb for high priority tx's that need to get added to the blockchain asap.