### PR TITLE
[Trivial] Updated texts referencing slack to point to discord instead

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--- Remove this description and sections that do not apply -->
 
 This issue tracker is only for technical issues related to PIVX Core.
-General PIVX questions and/or support requests and are best directed to the [PIVX Slack](http://pivx.slack.com).
+General PIVX questions and/or support requests and are best directed to the [PIVX Discord](https://discord.pivx.org).
 
 ### Describe the issue
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -29,7 +29,8 @@ Drag PIVX-Qt to your applications folder, and then run PIVX-Qt.
 * See the documentation at the [PIVX Wiki](https://en.bitcoin.it/wiki/Main_Page) ***TODO***
 for help and more information.
 * Ask for help on [BitcoinTalk](https://bitcointalk.org/index.php?topic=1262920.0) or on the [PIVX Forum](http://forum.pivx.org/).
-* Join one of our Slack groups [PIVX Slack Groups](https://pivx.org/slack-logins/).
+* Join our Discord server [Discord Server](https://discord.pivx.org)
+* Join one of our Slack groups [PIVX Slack Groups](https://pivx.org/slack-logins/) (Main community is replaced by Discord).
 
 Building
 ---------------------

--- a/doc/translation_process.md
+++ b/doc/translation_process.md
@@ -106,6 +106,6 @@ To create a new language template, you will need to edit the languages manifest 
 **Note:** that the language translation file **must end in `.qm`** (the compiled extension), and not `.ts`.
 
 ### Questions and general assistance
-The PIVX Core translation maintainers include *Fuzzbawls and s3v3nh4cks*. You can find them, and others, in the [PIVX Slack](https://pivx.slack.com).
+The PIVX Core translation maintainers include *Fuzzbawls and s3v3nh4cks*. You can find them, and others, in the [PIVX Discord](https://discord.pivx.org).
 
 Announcements will be posted during application pre-releases to notify translators to check for updates.


### PR DESCRIPTION
Being connected on the main Slack you only get the bot telling you it's no longer supported and to head to discord. Code documentation should do the same.