### PR TITLE
[RPC] Fix `importzercoins` for use with UniValue

### DIFF
--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -2747,7 +2747,10 @@ UniValue importzerocoins(const UniValue& params, bool fHelp)
         const UniValue &val = arrMints[idx];
         const UniValue &o = val.get_obj();
 
-        int d = ParseInt(o, "d");
+        const UniValue& vDenom = find_value(o, "d");
+        if (!vDenom.isNum())
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, missing d key");
+        int d = vDenom.get_int();
         if (d < 0)
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, d must be positive");
 
@@ -2757,11 +2760,11 @@ UniValue importzerocoins(const UniValue& params, bool fHelp)
         CBigNum bnRandom = CBigNum(find_value(o, "r").get_str());
         uint256 txid(find_value(o, "t").get_str());
 
-        int nHeight = ParseInt(o, "h");
+        int nHeight = find_value(o, "h").get_int();
         if (nHeight < 0)
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, h must be positive");
 
-        bool fUsed = ParseBool(o, "u");
+        bool fUsed = find_value(o, "u").get_bool();
         CZerocoinMint mint(denom, bnValue, bnRandom, bnSerial, fUsed);
         mint.SetTxHash(txid);
         mint.SetHeight(nHeight);


### PR DESCRIPTION
UniValue doesn't like `ParseInt()` or `ParseBool()` when reading JSON
arrays or objects as part of user-submitted data. Use native `get_int()`
and `get_bool()` instead.

Also add a pre-check for `d` to make sure it is a number value.