### PR TITLE
[Qt] Improve checkbox visibility 

### DIFF
--- a/src/qt/res/css/default.css
+++ b/src/qt/res/css/default.css
@@ -135,11 +135,9 @@ color:#333333;
 
 .QCheckBox { /* Checkbox Labels */
 color:#333333;
-background-color:transparent;
 }
 
 .QCheckBox:hover {
-background-color:transparent;
 }
 
 .QValidatedLineEdit, .QLineEdit { /* Text Entry Fields */
@@ -1336,7 +1334,6 @@ border:1px solid #9e9e9e;
 QDialog#SendCoinsDialog .QCheckBox#checkUseObfuscation { /* Obfuscation Checkbox */
 color:#616161;
 font-weight:bold;
-background:transparent;
 /*background: qradialgradient(cx:0.5, cy:0.5, radius: 0.5, fx:0.5, fy:0.5, stop:0 rgba(248, 246, 246, 128), stop: 1 rgba(0, 0, 0, 0));*/
 border-radius:5px;
 padding-top:20px;
@@ -1346,7 +1343,6 @@ padding-bottom:18px;
 QDialog#SendCoinsDialog .QCheckBox#checkSwiftTX { /* SwiftTX Checkbox */
 color:#616161;
 font-weight:bold;
-background:transparent;
 /*background: qradialgradient(cx:0.5, cy:0.5, radius: 0.5, fx:0.5, fy:0.5, stop:0 rgba(248, 246, 246, 128), stop: 1 rgba(0, 0, 0, 0));*/
 border-radius:5px;
 padding-top:20px;


### PR DESCRIPTION
CheckBox outlines are not visible on lubuntu 16.04 (and possibly other platforms, not tested). This fix removes the background transparency from default.css and improves visibility of checkboxes.
Also Fixes #127  

Before:
![01-before-clip](https://user-images.githubusercontent.com/31125485/34078523-5fb214d2-e31c-11e7-885a-0d96c846f880.png)

After:
![02-after-clip](https://user-images.githubusercontent.com/31125485/34078527-62c0c7b8-e31c-11e7-9ee6-c97c11cacc12.png)




