### PR TITLE
[RPC] Findserial

### DIFF
--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -11,6 +11,7 @@
 #include "main.h"
 #include "rpcserver.h"
 #include "sync.h"
+#include "txdb.h"
 #include "util.h"
 #include "utilmoneystr.h"
 
@@ -932,5 +933,34 @@ UniValue getinvalid (const UniValue& params, bool fHelp)
     obj.push_back(Pair("total_valid_used", FormatMoney(nMixedValid)));
 
     ret.push_back(obj);
+    return ret;
+}
+
+UniValue findserial(const UniValue& params, bool fHelp)
+{
+    if(fHelp || params.size() != 1)
+        throw runtime_error(
+            "findserial \"serial\"\n"
+                "\nSearches the zerocoin database for a zerocoin spend transaction that contains the specified serial\n"
+                "\nArguments:\n"
+                "1. serial   (string, required) the serial of a zerocoin spend to search for.\n"
+                "\nResult:\n"
+                "{\n"
+                "  \"success\": true/false        (boolean) Whether the serial was found\n"
+                "  \"txid\": xxxxx                (numeric) The transaction that contains the spent serial\n"
+                "}\n"
+                "\nExamples:\n" +
+            HelpExampleCli("findserial", "\"serial\"") + HelpExampleRpc("findserial", "\"serial\""));
+
+    std::string strSerial = params[0].get_str();
+    CBigNum bnSerial(strSerial);
+
+    uint256 txid = 0;
+    bool fSuccess = zerocoinDB->ReadCoinSpend(bnSerial, txid);
+
+    UniValue ret(UniValue::VOBJ);
+    ret.push_back(Pair("success", fSuccess));
+    ret.push_back(Pair("txid", txid.GetHex()));
+
     return ret;
 }

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -271,6 +271,7 @@ static const CRPCCommand vRPCCommands[] =
         {"network", "ping", &ping, true, false, false},
 
         /* Block chain and UTXO */
+        {"blockchain", "findserial", &findserial, true, false, false},
         {"blockchain", "getblockchaininfo", &getblockchaininfo, true, false, false},
         {"blockchain", "getbestblockhash", &getbestblockhash, true, false, false},
         {"blockchain", "getblockcount", &getblockcount, true, false, false},
@@ -280,14 +281,14 @@ static const CRPCCommand vRPCCommands[] =
         {"blockchain", "getchaintips", &getchaintips, true, false, false},
         {"blockchain", "getdifficulty", &getdifficulty, true, false, false},
         {"blockchain", "getfeeinfo", &getfeeinfo, true, false, false},
+        {"blockchain", "getinvalid", &getinvalid, true, true, false},
         {"blockchain", "getmempoolinfo", &getmempoolinfo, true, true, false},
         {"blockchain", "getrawmempool", &getrawmempool, true, false, false},
         {"blockchain", "gettxout", &gettxout, true, false, false},
         {"blockchain", "gettxoutsetinfo", &gettxoutsetinfo, true, false, false},
-        {"blockchain", "verifychain", &verifychain, true, false, false},
         {"blockchain", "invalidateblock", &invalidateblock, true, true, false},
         {"blockchain", "reconsiderblock", &reconsiderblock, true, true, false},
-        {"blockchain", "getinvalid", &getinvalid, true, true, false},
+        {"blockchain", "verifychain", &verifychain, true, false, false},
 
         /* Mining */
         {"mining", "getblocktemplate", &getblocktemplate, true, false, false},

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -238,7 +238,8 @@ extern UniValue decodescript(const UniValue& params, bool fHelp);
 extern UniValue signrawtransaction(const UniValue& params, bool fHelp);
 extern UniValue sendrawtransaction(const UniValue& params, bool fHelp);
 
-extern UniValue getblockcount(const UniValue& params, bool fHelp); // in rpcblockchain.cpp
+extern UniValue findserial(const UniValue& params, bool fHelp); // in rpcblockchain.cpp
+extern UniValue getblockcount(const UniValue& params, bool fHelp);
 extern UniValue getbestblockhash(const UniValue& params, bool fHelp);
 extern UniValue getdifficulty(const UniValue& params, bool fHelp);
 extern UniValue settxfee(const UniValue& params, bool fHelp);


### PR DESCRIPTION
Search the zerocoin database for a zerocoinspend transaction that contains the given serial. This will be a helpful tool for the PIVX support group, which often times sees users say "I didn't spend that zPIV". This RPC call allows for support to grab the serial, and then find the spend tx on the chain.