### PR TITLE
Only require 1 mint to be added before spending zPIV.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -212,7 +212,7 @@ public:
         nMaxZerocoinSpendsPerTransaction = 7; // Assume about 20kb each
         nMinZerocoinMintFee = 1 * CENT; //high fee required for zerocoin mints
         nMintRequiredConfirmations = 20; //the maximum amount of confirmations until accumulated in 19
-        nRequiredAccumulation = 2;
+        nRequiredAccumulation = 1;
         nDefaultSecurityLevel = 100; //full security level for accumulators
         nZerocoinHeaderVersion = 4; //Block headers must be this version once zerocoin is active
         nBudget_Fee_Confirmations = 6; // Number of confirmations for the finalization fee

--- a/src/qt/privacydialog.cpp
+++ b/src/qt/privacydialog.cpp
@@ -564,6 +564,7 @@ void PrivacyDialog::setBalance(const CAmount& balance, const CAmount& unconfirme
         mapImmature.insert(make_pair(denom, 0));
     }
 
+    int nBestHeight = chainActive.Height();
     for (auto& mint : listMints){
         // All denominations
         mapDenomBalances.at(mint.GetDenomination())++;
@@ -575,8 +576,9 @@ void PrivacyDialog::setBalance(const CAmount& balance, const CAmount& unconfirme
         else {
             // After a denomination is confirmed it might still be immature because < 3 of the same denomination were minted after it
             CBlockIndex *pindex = chainActive[mint.GetHeight() + 1];
+            int nHeight2CheckpointsDeep = nBestHeight - (nBestHeight % 10) - 20;
             int nMintsAdded = 0;
-            while (pindex->nHeight < chainActive.Height() - 30) { // 30 just to make sure that its at least 2 checkpoints from the top block
+            while (pindex->nHeight < nHeight2CheckpointsDeep) { //at least 2 checkpoints from the top block
                 nMintsAdded += count(pindex->vMintDenominationsInBlock.begin(), pindex->vMintDenominationsInBlock.end(), mint.GetDenomination());
                 if (nMintsAdded >= Params().Zerocoin_RequiredAccumulation())
                     break;

--- a/src/qt/zpivcontroldialog.cpp
+++ b/src/qt/zpivcontroldialog.cpp
@@ -67,6 +67,7 @@ void ZPivControlDialog::updateList()
     this->listMints = list;
 
     //populate rows with mint info
+    int nBestHeight = chainActive.Height();
     for(const CZerocoinMint mint : listMints) {
         // assign this mint to the correct denomination in the tree view
         libzerocoin::CoinDenomination denom = mint.GetDenomination();
@@ -81,7 +82,7 @@ void ZPivControlDialog::updateList()
         itemMint->setText(COLUMN_DENOMINATION, QString::number(mint.GetDenomination()));
         itemMint->setText(COLUMN_PUBCOIN, QString::fromStdString(strPubCoin));
 
-        int nConfirmations = (mint.GetHeight() ? chainActive.Height() - mint.GetHeight() : 0);
+        int nConfirmations = (mint.GetHeight() ? nBestHeight - mint.GetHeight() : 0);
         if (nConfirmations < 0) {
             // Sanity check
             nConfirmations = 0;
@@ -91,9 +92,11 @@ void ZPivControlDialog::updateList()
 
         // check to make sure there are at least 3 other mints added to the accumulators after this
         int nMintsAdded = 0;
-        if(mint.GetHeight() != 0 && mint.GetHeight() < chainActive.Height() - 2) {
+        if(mint.GetHeight() != 0 && mint.GetHeight() < nBestHeight - 2) {
             CBlockIndex *pindex = chainActive[mint.GetHeight() + 1];
-            while(pindex->nHeight < chainActive.Height() - 30) { // 30 just to make sure that its at least 2 checkpoints from the top block
+
+            int nHeight2CheckpointsDeep = nBestHeight - (nBestHeight % 10) - 20;
+            while (pindex->nHeight < nHeight2CheckpointsDeep) { // 20 just to make sure that its at least 2 checkpoints from the top block
                 nMintsAdded += count(pindex->vMintDenominationsInBlock.begin(), pindex->vMintDenominationsInBlock.end(), mint.GetDenomination());
                 if(nMintsAdded >= Params().Zerocoin_RequiredAccumulation())
                     break;


### PR DESCRIPTION
Require 1 mint to be accumulated to the same accumulator after making a zPIV spendable. Also require that the 'second' mint is at least two checkpoints deep in the chain (this was already the case, but the logic was not as precise and just used a value of `chainActive.Height() - 30`).

For example:
- I mint 5 zPIV on block 105
- Fuzz mints 5 zPIV on block 115
- My mint becomes *confirmed* at block 125 (20 confs)
- My mint becomes *spendable* at block 140 (1 checkpoint after the checkpoint which contains Fuzz's mint)