### PR TITLE
[TESTS] Fixed compilation errors

### DIFF
--- a/src/test/scriptnum_tests.cpp
+++ b/src/test/scriptnum_tests.cpp
@@ -10,7 +10,7 @@
 BOOST_AUTO_TEST_SUITE(scriptnum_tests)
 
 static const long values[] = \
-{ 0, 1, CHAR_MIN, CHAR_MAX, UCHAR_MAX, SHRT_MIN, USHRT_MAX, INT_MIN, INT_MAX, UINT_MAX, LONG_MIN, LONG_MAX };
+{ 0, 1, CHAR_MIN, CHAR_MAX, UCHAR_MAX, SHRT_MIN, USHRT_MAX, INT_MIN, INT_MAX, static_cast<long>UINT_MAX, LONG_MIN, LONG_MAX };
 static const long offsets[] = { 1, 0x79, 0x80, 0x81, 0xFF, 0x7FFF, 0x8000, 0xFFFF, 0x10000};
 
 static bool verify(const CBigNum& bignum, const CScriptNum& scriptnum)


### PR DESCRIPTION
Fixed compilation errors in pivx-3.0.6 [#450](https://github.com/PIVX-Project/PIVX/issues/450)
Instead of simply casting UINT_MAX to long (which may be as large as int), it is probably better to replace all types with a 64bit ones as it is in dash [https://github.com/dashpay/dash/blob/master/src/test/scriptnum_tests.cpp](https://github.com/dashpay/dash/blob/master/src/test/scriptnum_tests.cpp) .