### PR TITLE
[Qt] Feature: Explanation of zPIV autominting at first-time PIVX wallet startup OR new wallet creation (only one or the other)

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -482,7 +482,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-budgetvotemode=<mode>", _("Change automatic finalized budget voting behavior. mode=auto: Vote for only exact finalized budget match to my generated budget. (string, default: auto)"));
 
     strUsage += HelpMessageGroup(_("Zerocoin options:"));
-    strUsage += HelpMessageOpt("-enablezeromint=<n>", strprintf(_("Enable automatic Zerocoin minting (0-1, default: %u)"), 1));
+    strUsage += HelpMessageOpt("-enablezeromint=<n>", strprintf(_("Enable automatic Zerocoin minting (0-1, default: %u)"), 0));
     strUsage += HelpMessageOpt("-zeromintpercentage=<n>", strprintf(_("Percentage of automatically minted Zerocoin  (10-100, default: %u)"), 10));
     strUsage += HelpMessageOpt("-preferredDenom=<n>", strprintf(_("Preferred Denomination for automatically minted Zerocoin  (1/5/10/50/100/500/1000/5000), 0 for no preference. default: %u)"), 0));
     strUsage += HelpMessageOpt("-backupzpiv=<n>", strprintf(_("Enable automatic wallet backups triggered after each zPiv minting (0-1, default: %u)"), 1));
@@ -1693,7 +1693,7 @@ bool AppInit2(boost::thread_group& threadGroup)
         }
     }
 
-    fEnableZeromint = GetBoolArg("-enablezeromint", true);
+    fEnableZeromint = GetBoolArg("-enablezeromint", false);
 
     nZeromintPercentage = GetArg("-zeromintpercentage", 10);
     if (nZeromintPercentage > 100) nZeromintPercentage = 100;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1693,7 +1693,7 @@ bool AppInit2(boost::thread_group& threadGroup)
         }
     }
 
-    fEnableZeromint = GetBoolArg("-enablezeromint", false);
+    fEnableZeromint = GetBoolArg("-enablezeromint", true);
 
     nZeromintPercentage = GetArg("-zeromintpercentage", 10);
     if (nZeromintPercentage > 100) nZeromintPercentage = 100;

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -131,6 +131,27 @@
         </spacer>
        </item>
        <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <item>
+          <widget class="QLabel" name="labelEnablezPIVAutoMint">
+           <property name="text">
+            <string>Enable PIV to zPIV Automint</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="cbEnableAutoMint">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
         <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
           <widget class="QLabel" name="percentage_label">

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>960</width>
-    <height>615</height>
+    <height>648</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -429,6 +429,9 @@
              <layout class="QGridLayout" name="gridLayout_2" columnstretch="0">
               <item row="0" column="0">
                <widget class="QLabel" name="labelPIV2zPIVAutoMintText">
+                <property name="toolTip">
+                 <string>Current percentage of zPIV autominting.</string>
+                </property>
                 <property name="text">
                  <string>zPIV Auto-Minting:</string>
                 </property>

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -409,6 +409,69 @@
         </widget>
        </item>
        <item>
+        <widget class="QFrame" name="frame_5">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="frameShape">
+          <enum>QFrame::StyledPanel</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Raised</enum>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_6">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
+            <item>
+             <layout class="QGridLayout" name="gridLayout_2" columnstretch="0">
+              <item row="0" column="0">
+               <widget class="QLabel" name="labelPIV2zPIVAutoMintText">
+                <property name="text">
+                 <string>zPIV Auto-Minting:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="QLabel" name="labelPIV2zPIVAutoMint">
+              <property name="text">
+               <string>Unknown</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="pushButtonUpdateZeromint">
+              <property name="text">
+               <string>Update</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_9">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QFrame" name="frameObfuscation">
          <property name="minimumSize">
           <size>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -79,7 +79,7 @@ OptionsDialog::OptionsDialog(QWidget* parent, bool enableWallet) : QDialog(paren
         digits.setNum(index);
         ui->digits->addItem(digits, digits);
     }
-    
+
     /* Theme selector static themes */
     ui->theme->addItem(QString("Default"), QVariant("default"));
 
@@ -213,7 +213,7 @@ void OptionsDialog::setMapper()
     mapper->addMapping(ui->proxyIp, OptionsModel::ProxyIP);
     mapper->addMapping(ui->proxyPort, OptionsModel::ProxyPort);
 
-    /* Window */
+/* Window */
 #ifndef Q_OS_MAC
     mapper->addMapping(ui->minimizeToTray, OptionsModel::MinimizeToTray);
     mapper->addMapping(ui->minimizeOnClose, OptionsModel::MinimizeOnClose);

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -194,6 +194,8 @@ void OptionsDialog::setMapper()
     mapper->addMapping(ui->bitcoinAtStartup, OptionsModel::StartAtStartup);
     mapper->addMapping(ui->threadsScriptVerif, OptionsModel::ThreadsScriptVerif);
     mapper->addMapping(ui->databaseCache, OptionsModel::DatabaseCache);
+    // Zerocoin mint enabled
+    mapper->addMapping(ui->cbEnableAutoMint, OptionsModel::EnableZeromint);
     // Zerocoin mint percentage
     mapper->addMapping(ui->zeromintPercentage, OptionsModel::ZeromintPercentage);
     // Zerocoin preferred denomination

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -73,7 +73,7 @@ void OptionsModel::Init()
     fCoinControlFeatures = settings.value("fCoinControlFeatures", false).toBool();
 
     if (!settings.contains("fEnableZeromint"))
-        settings.setValue("fEnableZeromint", false);  // by default zeromintEnabled is 'off'
+        settings.setValue("fEnableZeromint", true);
     fEnableZeromint = settings.value("fEnableZeromint").toBool();
     if (!settings.contains("nPreferredDenom"))
         settings.setValue("nPreferredDenom", 0);

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -72,6 +72,9 @@ void OptionsModel::Init()
         settings.setValue("fCoinControlFeatures", false);
     fCoinControlFeatures = settings.value("fCoinControlFeatures", false).toBool();
 
+    if (!settings.contains("fEnableZeromint"))
+        settings.setValue("fEnableZeromint", false);  // by default zeromintEnabled is 'off'
+    fEnableZeromint = settings.value("fEnableZeromint").toBool();
     if (!settings.contains("nPreferredDenom"))
         settings.setValue("nPreferredDenom", 0);
     nPreferredDenom = settings.value("nPreferredDenom", "0").toLongLong();
@@ -147,6 +150,8 @@ void OptionsModel::Init()
     if (!SoftSetArg("-lang", settings.value("language").toString().toStdString()))
         addOverriddenOption("-lang");
 
+    if (settings.contains("fEnableZeromint"))
+        SoftSetBoolArg("-enablezeromint", settings.value("fEnableZeromint").toBool());
     if (settings.contains("nZeromintPercentage"))
         SoftSetArg("-zeromintpercentage", settings.value("nZeromintPercentage").toString().toStdString());
     if (settings.contains("nPreferredDenom"))
@@ -230,6 +235,8 @@ QVariant OptionsModel::data(const QModelIndex& index, int role) const
             return settings.value("nDatabaseCache");
         case ThreadsScriptVerif:
             return settings.value("nThreadsScriptVerif");
+        case EnableZeromint:
+            return QVariant(fEnableZeromint);
         case ZeromintPercentage:
             return QVariant(nZeromintPercentage);
         case ZeromintPrefDenom:
@@ -339,6 +346,11 @@ bool OptionsModel::setData(const QModelIndex& index, const QVariant& value, int 
                 setRestartRequired(true);
             }
             break;
+        case EnableZeromint:
+            fEnableZeromint = value.toBool();
+            settings.setValue("fEnableZeromint", fEnableZeromint);
+            emit zeromintEnabledChanged(fEnableZeromint);
+            break;
         case ZeromintPercentage:
             nZeromintPercentage = value.toInt();
             settings.setValue("nZeromintPercentage", nZeromintPercentage);
@@ -419,6 +431,7 @@ bool OptionsModel::getProxySettings(QNetworkProxy& proxy) const
 void OptionsModel::setRestartRequired(bool fRequired)
 {
     QSettings settings;
+    // XXX: why 'return' here?  either remove or change function return type
     return settings.setValue("fRestartRequired", fRequired);
 }
 

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -43,6 +43,7 @@ public:
         ThreadsScriptVerif,  // int
         DatabaseCache,       // int
         SpendZeroConfChange, // bool
+        EnableZeromint,      // bool
         ZeromintPercentage,  // int
         ZeromintPrefDenom,   // int
         AnonymizePivxAmount, //int
@@ -90,6 +91,7 @@ private:
 
 signals:
     void displayUnitChanged(int unit);
+    void zeromintEnabledChanged(bool);
     void zeromintPercentageChanged(int);
     void preferredDenomChanged(int);
     void anonymizePivxAmountChanged(int);

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -18,8 +18,8 @@
 #include "optionsmodel.h"
 #include "transactionfilterproxy.h"
 #include "transactiontablemodel.h"
-#include "walletmodel.h"
 #include "util.h"
+#include "walletmodel.h"
 
 #include <QAbstractItemDelegate>
 #include <QPainter>
@@ -157,28 +157,23 @@ void OverviewPage::getPercentage(CAmount nUnlockedBalance, CAmount nZerocoinBala
     int nPrecision = 2;
     double dzPercentage = 0.0;
 
-    if (nZerocoinBalance <= 0){
+    if (nZerocoinBalance <= 0) {
         dzPercentage = 0.0;
-    }
-    else{
-        if (nUnlockedBalance <= 0){
+    } else {
+        if (nUnlockedBalance <= 0) {
             dzPercentage = 100.0;
-        }
-        else{
+        } else {
             dzPercentage = 100.0 * (double)(nZerocoinBalance / (double)(nZerocoinBalance + nUnlockedBalance));
         }
     }
 
     double dPercentage = 100.0 - dzPercentage;
-    
+
     szPIVPercentage = "(" + QLocale(QLocale::system()).toString(dzPercentage, 'f', nPrecision) + " %)";
     sPIVPercentage = "(" + QLocale(QLocale::system()).toString(dPercentage, 'f', nPrecision) + " %)";
-    
 }
 
-void OverviewPage::setBalance(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance, 
-                              const CAmount& zerocoinBalance, const CAmount& unconfirmedZerocoinBalance, const CAmount& immatureZerocoinBalance,
-                              const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance)
+void OverviewPage::setBalance(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance, const CAmount& zerocoinBalance, const CAmount& unconfirmedZerocoinBalance, const CAmount& immatureZerocoinBalance, const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance)
 {
     currentBalance = balance;
     currentUnconfirmedBalance = unconfirmedBalance;
@@ -233,8 +228,7 @@ void OverviewPage::setBalance(const CAmount& balance, const CAmount& unconfirmed
         ui->labelPIV2zPIVAutoMint->setText(QString::number(nZeromintPercentage) + "%");
         automintHelp += tr("AutoMint is currently enabled and set to ") + QString::number(nZeromintPercentage) + "%.\n";
         automintHelp += tr("To disable AutoMint add 'enablezeromint=0' in pivx.conf.");
-    }
-    else {
+    } else {
         ui->labelPIV2zPIVAutoMint->setText(tr("Disabled"));
         automintHelp += tr("AutoMint is currently disabled.\nTo enable AutoMint change 'enablezeromint=0' to 'enablezeromint=1' in pivx.conf");
     }
@@ -306,10 +300,10 @@ void OverviewPage::setWalletModel(WalletModel* model)
 
         // Keep up to date with wallet
         setBalance(model->getBalance(), model->getUnconfirmedBalance(), model->getImmatureBalance(),
-                   model->getZerocoinBalance(), model->getUnconfirmedZerocoinBalance(), model->getImmatureZerocoinBalance(), 
-                   model->getWatchBalance(), model->getWatchUnconfirmedBalance(), model->getWatchImmatureBalance());
-        connect(model, SIGNAL(balanceChanged(CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount)), this, 
-                         SLOT(setBalance(CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount)));
+            model->getZerocoinBalance(), model->getUnconfirmedZerocoinBalance(), model->getImmatureZerocoinBalance(),
+            model->getWatchBalance(), model->getWatchUnconfirmedBalance(), model->getWatchImmatureBalance());
+        connect(model, SIGNAL(balanceChanged(CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount)), this,
+            SLOT(setBalance(CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount)));
 
         connect(model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
 
@@ -353,32 +347,31 @@ void OverviewPage::showOutOfSyncWarning(bool fShow)
 
 void OverviewPage::updateZeromintOptionStatus()
 {
-
-  if (fEnableZeromint) {
-    ui->labelPIV2zPIVAutoMint->setText(QString::number(nZeromintPercentage) + "%");
-  } else {
-    ui->labelPIV2zPIVAutoMint->setText(tr("Disabled"));
-  }
+    if (fEnableZeromint) {
+        ui->labelPIV2zPIVAutoMint->setText(QString::number(nZeromintPercentage) + "%");
+    } else {
+        ui->labelPIV2zPIVAutoMint->setText(tr("Disabled"));
+    }
 }
 
 void OverviewPage::updateZeromintOptionEnabled(bool fEnabled)
 {
-  updateZeromintOptionStatus();
+    updateZeromintOptionStatus();
 }
 
 void OverviewPage::updateZeromintOptionPercentage(int p)
 {
-  updateZeromintOptionStatus();
+    updateZeromintOptionStatus();
 }
 
 void OverviewPage::handleUpdateClicked()
 {
-//  BitcoinGUI::optionsClicked();
-  if (!this->clientModel || !clientModel->getOptionsModel())
-      return;
+    //  BitcoinGUI::optionsClicked();
+    if (!this->clientModel || !clientModel->getOptionsModel())
+        return;
 
-  // can we assume enableWallet true here ?
-  OptionsDialog dlg(this, true);
-  dlg.setModel(clientModel->getOptionsModel());
-  dlg.exec();
+    // can we assume enableWallet true here ?
+    OptionsDialog dlg(this, true);
+    dlg.setModel(clientModel->getOptionsModel());
+    dlg.exec();
 }

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -231,12 +231,12 @@ void OverviewPage::setBalance(const CAmount& balance, const CAmount& unconfirmed
     bool fEnableZeromint = GetBoolArg("-enablezeromint", true);
     int nZeromintPercentage = GetArg("-zeromintpercentage", 10);
     if (fEnableZeromint) {
-	ui->labelPIV2zPIVAutoMint->setText(QString::number(nZeromintPercentage) + "%");
+        ui->labelPIV2zPIVAutoMint->setText(QString::number(nZeromintPercentage) + "%");
         automintHelp += tr("AutoMint is currently enabled and set to ") + QString::number(nZeromintPercentage) + "%.\n";
         automintHelp += tr("To disable AutoMint add 'enablezeromint=0' in pivx.conf.");
     }
     else {
-	ui->labelPIV2zPIVAutoMint->setText(tr("Disabled"));
+        ui->labelPIV2zPIVAutoMint->setText(tr("Disabled"));
         automintHelp += tr("AutoMint is currently disabled.\nTo enable AutoMint change 'enablezeromint=0' to 'enablezeromint=1' in pivx.conf");
     }
     ui->labelzPIVPercent->setToolTip(automintHelp);
@@ -316,6 +316,9 @@ void OverviewPage::setWalletModel(WalletModel* model)
 
         updateWatchOnlyLabels(model->haveWatchOnly());
         connect(model, SIGNAL(notifyWatchonlyChanged(bool)), this, SLOT(updateWatchOnlyLabels(bool)));
+
+        connect(model->getOptionsModel(), SIGNAL(zeromintEnabledChanged(bool)), this, SLOT(updateZeromintOptionEnabled(bool)));
+        connect(model->getOptionsModel(), SIGNAL(zeromintPercentageChanged(int)), this, SLOT(updateZeromintOptionPercentage(int)));
     }
 
     // update the display unit, to not use the default ("PIV")
@@ -347,6 +350,28 @@ void OverviewPage::showOutOfSyncWarning(bool fShow)
 {
     ui->labelWalletStatus->setVisible(fShow);
     ui->labelTransactionsStatus->setVisible(fShow);
+}
+
+void OverviewPage::updateZeromintOptionStatus()
+{
+  bool fEnableZeromint = GetBoolArg("-enablezeromint", true);
+  int nZeromintPercentage = GetArg("-zeromintpercentage", 10);
+
+  if (fEnableZeromint) {
+    ui->labelPIV2zPIVAutoMint->setText(QString::number(nZeromintPercentage) + "%");
+  } else {
+    ui->labelPIV2zPIVAutoMint->setText(tr("Disabled"));
+  }
+}
+
+void OverviewPage::updateZeromintOptionEnabled(bool fEnabled)
+{
+  updateZeromintOptionStatus();
+}
+
+void OverviewPage::updateZeromintOptionPercentage(int p)
+{
+  updateZeromintOptionStatus();
 }
 
 void OverviewPage::handleUpdateClicked()

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -14,6 +14,7 @@
 #include "init.h"
 #include "obfuscation.h"
 #include "obfuscationconfig.h"
+#include "optionsdialog.h"
 #include "optionsmodel.h"
 #include "transactionfilterproxy.h"
 #include "transactiontablemodel.h"
@@ -129,7 +130,7 @@ OverviewPage::OverviewPage(QWidget* parent) : QWidget(parent),
     ui->listTransactions->setAttribute(Qt::WA_MacShowFocusRect, false);
 
     connect(ui->listTransactions, SIGNAL(clicked(QModelIndex)), this, SLOT(handleTransactionClicked(QModelIndex)));
-
+    connect(ui->pushButtonUpdateZeromint, SIGNAL(released()), this, SLOT(handleUpdateClicked()));
 
     // init "out of sync" warning labels
     ui->labelWalletStatus->setText("(" + tr("out of sync") + ")");
@@ -230,10 +231,12 @@ void OverviewPage::setBalance(const CAmount& balance, const CAmount& unconfirmed
     bool fEnableZeromint = GetBoolArg("-enablezeromint", true);
     int nZeromintPercentage = GetArg("-zeromintpercentage", 10);
     if (fEnableZeromint) {
+	ui->labelPIV2zPIVAutoMint->setText(QString::number(nZeromintPercentage) + "%");
         automintHelp += tr("AutoMint is currently enabled and set to ") + QString::number(nZeromintPercentage) + "%.\n";
         automintHelp += tr("To disable AutoMint add 'enablezeromint=0' in pivx.conf.");
     }
     else {
+	ui->labelPIV2zPIVAutoMint->setText(tr("Disabled"));
         automintHelp += tr("AutoMint is currently disabled.\nTo enable AutoMint change 'enablezeromint=0' to 'enablezeromint=1' in pivx.conf");
     }
     ui->labelzPIVPercent->setToolTip(automintHelp);
@@ -344,4 +347,16 @@ void OverviewPage::showOutOfSyncWarning(bool fShow)
 {
     ui->labelWalletStatus->setVisible(fShow);
     ui->labelTransactionsStatus->setVisible(fShow);
+}
+
+void OverviewPage::handleUpdateClicked()
+{
+//  BitcoinGUI::optionsClicked();
+  if (!this->clientModel || !clientModel->getOptionsModel())
+      return;
+
+  // can we assume enableWallet true here ?
+  OptionsDialog dlg(this, true);
+  dlg.setModel(clientModel->getOptionsModel());
+  dlg.exec();
 }

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -19,6 +19,7 @@
 #include "transactionfilterproxy.h"
 #include "transactiontablemodel.h"
 #include "walletmodel.h"
+#include "util.h"
 
 #include <QAbstractItemDelegate>
 #include <QPainter>
@@ -228,8 +229,6 @@ void OverviewPage::setBalance(const CAmount& balance, const CAmount& unconfirmed
 
     // Adjust bubble-help according to AutoMint settings
     QString automintHelp = tr("Current percentage of zPIV.\nIf AutoMint is enabled this percentage will settle around the configured AutoMint percentage (default = 10%).\n");
-    bool fEnableZeromint = GetBoolArg("-enablezeromint", true);
-    int nZeromintPercentage = GetArg("-zeromintpercentage", 10);
     if (fEnableZeromint) {
         ui->labelPIV2zPIVAutoMint->setText(QString::number(nZeromintPercentage) + "%");
         automintHelp += tr("AutoMint is currently enabled and set to ") + QString::number(nZeromintPercentage) + "%.\n";
@@ -354,8 +353,6 @@ void OverviewPage::showOutOfSyncWarning(bool fShow)
 
 void OverviewPage::updateZeromintOptionStatus()
 {
-  bool fEnableZeromint = GetBoolArg("-enablezeromint", true);
-  int nZeromintPercentage = GetArg("-zeromintpercentage", 10);
 
   if (fEnableZeromint) {
     ui->labelPIV2zPIVAutoMint->setText(QString::number(nZeromintPercentage) + "%");

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -228,7 +228,7 @@ void OverviewPage::setBalance(const CAmount& balance, const CAmount& unconfirmed
 
     // Adjust bubble-help according to AutoMint settings
     QString automintHelp = tr("Current percentage of zPIV.\nIf AutoMint is enabled this percentage will settle around the configured AutoMint percentage (default = 10%).\n");
-    bool fEnableZeromint = GetBoolArg("-enablezeromint", true);
+    bool fEnableZeromint = GetBoolArg("-enablezeromint", false);
     int nZeromintPercentage = GetArg("-zeromintpercentage", 10);
     if (fEnableZeromint) {
         ui->labelPIV2zPIVAutoMint->setText(QString::number(nZeromintPercentage) + "%");
@@ -354,7 +354,7 @@ void OverviewPage::showOutOfSyncWarning(bool fShow)
 
 void OverviewPage::updateZeromintOptionStatus()
 {
-  bool fEnableZeromint = GetBoolArg("-enablezeromint", true);
+  bool fEnableZeromint = GetBoolArg("-enablezeromint", false);
   int nZeromintPercentage = GetArg("-zeromintpercentage", 10);
 
   if (fEnableZeromint) {

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -228,7 +228,7 @@ void OverviewPage::setBalance(const CAmount& balance, const CAmount& unconfirmed
 
     // Adjust bubble-help according to AutoMint settings
     QString automintHelp = tr("Current percentage of zPIV.\nIf AutoMint is enabled this percentage will settle around the configured AutoMint percentage (default = 10%).\n");
-    bool fEnableZeromint = GetBoolArg("-enablezeromint", false);
+    bool fEnableZeromint = GetBoolArg("-enablezeromint", true);
     int nZeromintPercentage = GetArg("-zeromintpercentage", 10);
     if (fEnableZeromint) {
         ui->labelPIV2zPIVAutoMint->setText(QString::number(nZeromintPercentage) + "%");
@@ -354,7 +354,7 @@ void OverviewPage::showOutOfSyncWarning(bool fShow)
 
 void OverviewPage::updateZeromintOptionStatus()
 {
-  bool fEnableZeromint = GetBoolArg("-enablezeromint", false);
+  bool fEnableZeromint = GetBoolArg("-enablezeromint", true);
   int nZeromintPercentage = GetArg("-zeromintpercentage", 10);
 
   if (fEnableZeromint) {

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -37,9 +37,7 @@ public:
     void showOutOfSyncWarning(bool fShow);
 
 public slots:
-    void setBalance(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance, 
-                    const CAmount& zerocoinBalance, const CAmount& unconfirmedZerocoinBalance, const CAmount& immatureZerocoinBalance,
-                    const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance);
+    void setBalance(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance, const CAmount& zerocoinBalance, const CAmount& unconfirmedZerocoinBalance, const CAmount& immatureZerocoinBalance, const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance);
 
 signals:
     void transactionClicked(const QModelIndex& index);

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -70,6 +70,9 @@ private slots:
     void updateAlerts(const QString& warnings);
     void updateWatchOnlyLabels(bool showWatchOnly);
     void handleUpdateClicked();
+    void updateZeromintOptionStatus();
+    void updateZeromintOptionEnabled(bool);
+    void updateZeromintOptionPercentage(int);
 };
 
 #endif // BITCOIN_QT_OVERVIEWPAGE_H

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -69,6 +69,7 @@ private slots:
     void handleTransactionClicked(const QModelIndex& index);
     void updateAlerts(const QString& warnings);
     void updateWatchOnlyLabels(bool showWatchOnly);
+    void handleUpdateClicked();
 };
 
 #endif // BITCOIN_QT_OVERVIEWPAGE_H

--- a/src/qt/res/css/default.css
+++ b/src/qt/res/css/default.css
@@ -1026,6 +1026,24 @@ font-size:14px;
 /* min-height:35px; */
 }
 
+QWidget .QFrame#frame_5 .QLabel#labelPIV2zPIVAutoMintText { /* PIV to zPIV Auto-Minting Label */
+qproperty-alignment: 'AlignVCenter | AlignRight';
+min-width:160px;
+background-color:#5B4C7C;
+color:#fff;
+margin-right:5px;
+padding-right:5px;
+font-weight:bold;
+font-size:14px;
+/* min-height:35px; */
+}
+
+QWidget .QFrame#frame_5 .QLabel#labelPIV2zPIVAutoMint { /* PIV to zPIV Auto-Minting */
+min-width: 75px;
+font-size: 12px;
+margin-right: 5px;
+}
+
 QWidget .QFrame#frame_4 .QLabel#labelzBalance { /* Available zPIV Balance */
 qproperty-alignment: 'AlignVCenter | AlignLeft';
 font-size:12px;


### PR DESCRIPTION
This is the implementation of the feature request [#433](https://github.com/PIVX-Project/PIVX/issues/433)

PIV to zPIV auto-minting control featured on overview page to additionally promote zPIV auto conversion. Implantation has a button to open up options and enable or disable auto-minting and set required level.

![screenshot_20171227_213015](https://user-images.githubusercontent.com/34844617/34395166-ecc45f18-eb66-11e7-89db-d09f78032108.png)
![screenshot_20171227_214847](https://user-images.githubusercontent.com/34844617/34395172-f432323e-eb66-11e7-944b-69d9b789054c.png)
![screenshot_20171227_213351](https://user-images.githubusercontent.com/34844617/34395177-f8d92842-eb66-11e7-8005-c5f5bb92c414.png)
