### PR TITLE
[Core] (testnet-) blockchain stuck at block 325000

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2254,7 +2254,7 @@ int64_t GetMasternodePayment(int nHeight, int64_t blockValue, int nMasternodeCou
 
         if (mNodeCoins == 0) {
             ret = 0;
-        } else if (nHeight < 325000) {
+        } else if (nHeight <= 325000) {
             if (mNodeCoins <= (nMoneySupply * .05) && mNodeCoins > 0) {
                 ret = blockValue * .85;
             } else if (mNodeCoins <= (nMoneySupply * .1) && mNodeCoins > (nMoneySupply * .05)) {


### PR DESCRIPTION
When you only check for `nHeight < 325000` and `nHeight > 325000` you obviously run into troubles when `nHeight == 325000` :-)

Fixes https://github.com/PIVX-Project/PIVX/issues/459

Successfully tested a sync from scratch on testnet.