### PR TITLE
[Build] libevent-dev dependency added to build-documentation

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -33,6 +33,7 @@ These dependencies are required:
  ------------|------------------|----------------------
  libssl      | SSL Support      | Secure communications
  libboost    | Boost            | C++ Library
+ libevent    | Events           | Asynchronous event notification
 
 Optional dependencies:
 
@@ -58,7 +59,7 @@ Dependency Build Instructions: Ubuntu & Debian
 ----------------------------------------------
 Build requirements:
 
-	sudo apt-get install build-essential libtool autotools-dev autoconf pkg-config libssl-dev
+	sudo apt-get install build-essential libtool autotools-dev autoconf pkg-config libssl-dev libevent-dev
 
 For Ubuntu 12.04 and later or Debian 7 and later libboost-all-dev has to be installed:
 


### PR DESCRIPTION
I had to install libevent-dev on both an Ubuntu Ubuntu 16.04.2 LTS and a LinuxMint 18.2 to build the wallet, so I guess others will need this as well.
