### PR TITLE
[UI] Consistent trx colors for Overview + Transaction tabs

### DIFF
--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -22,7 +22,7 @@ static const bool DEFAULT_SPLASHSCREEN = true;
 #define STYLE_INVALID "background:#FF8080"
 
 /* Transaction list -- unconfirmed transaction */
-#define COLOR_UNCONFIRMED QColor(135, 214, 48)
+#define COLOR_UNCONFIRMED QColor(91, 76, 134)
 /* Transaction list -- negative amount */
 #define COLOR_NEGATIVE QColor(206, 0, 188)
 /* Transaction list -- bare address (without label) */

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -65,6 +65,10 @@ public:
         if (nStatus == TransactionStatus::Conflicted || nStatus == TransactionStatus::NotAccepted) {
             fConflicted = true; // Most probably orphaned, but could have other reasons as well
         }
+        bool fImmature = false;
+        if (nStatus == TransactionStatus::Immature) {
+            fImmature = true;
+        }
 
         QVariant value = index.data(Qt::ForegroundRole);
         QColor foreground = COLOR_BLACK;
@@ -85,10 +89,10 @@ public:
 
         if(fConflicted) { // No need to check anything else for conflicted transactions
             foreground = COLOR_CONFLICTED;
+        } else if (!confirmed || fImmature) {
+            foreground = COLOR_UNCONFIRMED;
         } else if (amount < 0) {
             foreground = COLOR_NEGATIVE;
-        } else if (!confirmed) {
-            foreground = COLOR_UNCONFIRMED;
         } else {
             foreground = COLOR_BLACK;
         }

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -568,11 +568,11 @@ QVariant TransactionTableModel::data(const QModelIndex& index, int role) const
         return column_alignments[index.column()];
     case Qt::ForegroundRole:
         // Conflicted, most probably orphaned
-        if (rec->status.status == TransactionStatus::NotAccepted) {
+        if (rec->status.status == TransactionStatus::Conflicted || rec->status.status == TransactionStatus::NotAccepted) {
             return COLOR_CONFLICTED;
         }
-        // Non-confirmed (but not immature) as transactions are grey
-        if (!rec->status.countsForBalance && rec->status.status != TransactionStatus::Immature) {
+        // Unconfimed or immature
+        if ((rec->status.status == TransactionStatus::Unconfirmed) || (rec->status.status == TransactionStatus::Immature)) {
             return COLOR_UNCONFIRMED;
         }
         if (index.column() == Amount && (rec->credit + rec->debit) < 0) {


### PR DESCRIPTION
Colors changed and both Overview tab and Transaction tab have now the same colors for the individual transaction types.

How the colors are chosen (in that order, first matching rule decides the color): 
- if a transaction is conflicted or orphaned: red 
- if a transaction is unconfirmed or immature: dark purple with [bracket] around it 
- if it's a spent transaction: fuchsia (don't ask)
- everything else: black
