### PR TITLE
[Qt] Feature: setstakesplitthreshold value set in Qt GUI

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -204,6 +204,27 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_Wallet">
        <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_2_Wallet">
+         <item>
+          <widget class="QLabel" name="labelStakeSplitThresholdText">
+           <property name="text">
+            <string>Stake split threshold:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="spinBoxStakeSplitThreshold">
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>999999</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
         <widget class="QGroupBox" name="groupBox">
          <property name="title">
           <string>Expert</string>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -202,6 +202,7 @@ void OptionsDialog::setMapper()
     /* Wallet */
     mapper->addMapping(ui->spendZeroConfChange, OptionsModel::SpendZeroConfChange);
     mapper->addMapping(ui->coinControlFeatures, OptionsModel::CoinControlFeatures);
+    mapper->addMapping(ui->spinBoxStakeSplitThreshold, OptionsModel::StakeSplitThreshold);
 
     /* Network */
     mapper->addMapping(ui->mapPortUpnp, OptionsModel::MapPortUPnP);

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -48,6 +48,7 @@ public:
         AnonymizePivxAmount, //int
         ShowMasternodesTab,  // bool
         Listen,              // bool
+        StakeSplitThreshold, // int
         OptionIDRowCount,
     };
 
@@ -59,6 +60,8 @@ public:
     bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole);
     /** Updates current unit in memory, settings and emits displayUnitChanged(newUnit) signal */
     void setDisplayUnit(const QVariant& value);
+    /* Update StakeSplitThreshold's value in wallet */
+    void setStakeSplitThreshold(int value);
 
     /* Explicit getters */
     bool getMinimizeToTray() { return fMinimizeToTray; }

--- a/src/qt/res/css/default.css
+++ b/src/qt/res/css/default.css
@@ -854,6 +854,10 @@ QDialog#OptionsDialog QCheckBox#displayAddresses {
 min-height:33px;
 }
 
+QDialog#OptionsDialog QLabel#labelStakeSplitThresholdText {
+font-size:16px;
+}
+
 /**************************** TOOLS MENU ************************************************/
 
 QDialog#RPCConsole QWidget#tab_info QLabel#label_11, QDialog#RPCConsole QWidget#tab_info QLabel#label_10 { /* Margin between Network and Block Chain headers */


### PR DESCRIPTION
This is the implementation of the feature request #424 
 
![image](https://user-images.githubusercontent.com/34844617/34443717-aad08070-ecd1-11e7-89de-00b4d6612691.png)

Requested feature has been completed considering current architecture of CWallet class.

This architecture raised few concerns that we would like to bring to everyone's attention. We believe some attention should be paid to the future possibility of refactoring done for this class and setting up a separate issue if approved by core team task specifically for that purpose.

We would like to bring current implementation with public fields in this class to core team's attention. The way it's currently implemented may result in the possibility of future unstable code and ultimately bugs in application in general.

CWallet class as a Base class allows the derived classes to get direct access to CWallet class fields and alter their status without regard for its inner implementation. Getter/setter allows to solve this issue by means of controlling input parameters in the Base class.

It is required to check the existing public fields and in cases where it is necessary to make class fields private and accessible through setter/getter, which will allow to control their alteration.

This task will also require additional work on tests coverage in addition to refactoring.

**This is an updated PR, previous discussion [here](https://github.com/PIVX-Project/PIVX/pull/456)**
