### PR TITLE
[Qt] Feature: Added controls to the overview page for enable or disable auto-minting and set required level

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -582,6 +582,59 @@
                    </widget>
                   </item>
                   <item>
+                   <widget class="QFrame" name="frame_AutoMinting">
+                    <property name="frameShape">
+                     <enum>QFrame::StyledPanel</enum>
+                    </property>
+                    <property name="frameShadow">
+                     <enum>QFrame::Raised</enum>
+                    </property>
+                    <layout class="QVBoxLayout" name="verticalLayout_2">
+                     <item>
+                      <layout class="QGridLayout" name="gridLayout_2">
+                       <item row="0" column="1">
+                        <widget class="QLabel" name="labelPIV2zPIVAutoMint">
+                         <property name="text">
+                          <string>Unknown</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="0">
+                        <widget class="QLabel" name="labelPIV2zPIVAutoMintText">
+                         <property name="toolTip">
+                          <string>Current percentage of zPIV autominting.</string>
+                         </property>
+                         <property name="text">
+                          <string>zPIV Auto-Minting:</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="2">
+                        <widget class="QPushButton" name="pushButtonUpdateZeromint">
+                         <property name="text">
+                          <string>Update</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="3">
+                        <spacer name="horizontalSpacer_9">
+                         <property name="orientation">
+                          <enum>Qt::Horizontal</enum>
+                         </property>
+                         <property name="sizeHint" stdset="0">
+                          <size>
+                           <width>40</width>
+                           <height>20</height>
+                          </size>
+                         </property>
+                        </spacer>
+                       </item>
+                      </layout>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
                    <widget class="QFrame" name="frame_ZerocoinBalances">
                     <property name="frameShape">
                      <enum>QFrame::StyledPanel</enum>

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -19,6 +19,8 @@
 #include "transactionrecord.h"
 #include "transactiontablemodel.h"
 #include "walletmodel.h"
+#include "optionsdialog.h"
+#include "util.h"
 
 #include <QAbstractItemDelegate>
 #include <QPainter>
@@ -140,6 +142,7 @@ OverviewPage::OverviewPage(QWidget* parent) : QWidget(parent),
     ui->listTransactions->setAttribute(Qt::WA_MacShowFocusRect, false);
 
     connect(ui->listTransactions, SIGNAL(clicked(QModelIndex)), this, SLOT(handleTransactionClicked(QModelIndex)));
+    connect(ui->pushButtonUpdateZeromint, SIGNAL(released()), this, SLOT(handleUpdateClicked()));
 
     // init "out of sync" warning labels
     ui->labelWalletStatus->setText("(" + tr("out of sync") + ")");
@@ -237,13 +240,14 @@ void OverviewPage::setBalance(const CAmount& balance, const CAmount& unconfirmed
 
     // Adjust bubble-help according to AutoMint settings
     QString automintHelp = tr("Current percentage of zPIV.\nIf AutoMint is enabled this percentage will settle around the configured AutoMint percentage (default = 10%).\n");
-    bool fEnableZeromint = GetBoolArg("-enablezeromint", true);
-    int nZeromintPercentage = GetArg("-zeromintpercentage", 10);
+
     if (fEnableZeromint) {
+        ui->labelPIV2zPIVAutoMint->setText(QString::number(nZeromintPercentage) + "%");
         automintHelp += tr("AutoMint is currently enabled and set to ") + QString::number(nZeromintPercentage) + "%.\n";
         automintHelp += tr("To disable AutoMint add 'enablezeromint=0' in pivx.conf.");
     }
     else {
+        ui->labelPIV2zPIVAutoMint->setText(tr("Disabled"));
         automintHelp += tr("AutoMint is currently disabled.\nTo enable AutoMint change 'enablezeromint=0' to 'enablezeromint=1' in pivx.conf");
     }
     ui->labelzPIVPercent->setToolTip(automintHelp);
@@ -323,6 +327,9 @@ void OverviewPage::setWalletModel(WalletModel* model)
 
         updateWatchOnlyLabels(model->haveWatchOnly());
         connect(model, SIGNAL(notifyWatchonlyChanged(bool)), this, SLOT(updateWatchOnlyLabels(bool)));
+
+        connect(model->getOptionsModel(), SIGNAL(zeromintEnableChanged(bool)), this, SLOT(updateZeromintOptionEnabled(bool)));
+        connect(model->getOptionsModel(), SIGNAL(zeromintPercentageChanged(int)), this, SLOT(updateZeromintOptionPercentage(int)));
     }
 
     // update the display unit, to not use the default ("PIV")
@@ -354,4 +361,35 @@ void OverviewPage::showOutOfSyncWarning(bool fShow)
 {
     ui->labelWalletStatus->setVisible(fShow);
     ui->labelTransactionsStatus->setVisible(fShow);
+}
+
+void OverviewPage::updateZeromintOptionStatus()
+{
+    if (fEnableZeromint) {
+        ui->labelPIV2zPIVAutoMint->setText(QString::number(nZeromintPercentage) + "%");
+    } else {
+        ui->labelPIV2zPIVAutoMint->setText(tr("Disabled"));
+    }
+}
+
+void OverviewPage::updateZeromintOptionEnabled(bool fEnabled)
+{
+    updateZeromintOptionStatus();
+}
+
+void OverviewPage::updateZeromintOptionPercentage(int p)
+{
+    updateZeromintOptionStatus();
+}
+
+void OverviewPage::handleUpdateClicked()
+{
+    // XXX: copy of BitcoinGUI::optionsClicked().  reuse original method somehow ?
+    if (!this->clientModel || !clientModel->getOptionsModel())
+        return;
+
+    // XXX: can we assume enableWallet true here ?
+    OptionsDialog dlg(this, true);
+    dlg.setModel(clientModel->getOptionsModel());
+    dlg.exec();
 }

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -69,6 +69,10 @@ private slots:
     void handleTransactionClicked(const QModelIndex& index);
     void updateAlerts(const QString& warnings);
     void updateWatchOnlyLabels(bool showWatchOnly);
+    void handleUpdateClicked();
+    void updateZeromintOptionStatus();
+    void updateZeromintOptionEnabled(bool);
+    void updateZeromintOptionPercentage(int);
 };
 
 #endif // BITCOIN_QT_OVERVIEWPAGE_H

--- a/src/qt/res/css/default.css
+++ b/src/qt/res/css/default.css
@@ -972,6 +972,29 @@ min-width:400px;
 background-color:#ffffff;
 }
 
+QWidget .QFrame#frame_AutoMinting { /* Center left side */
+min-width:400px;
+background-color:#ffffff;
+}
+
+QWidget .QFrame#frame_AutoMinting .QLabel#labelPIV2zPIVAutoMintText { /* Available zPIV Label */
+qproperty-alignment: 'AlignVCenter | AlignLeft';
+min-width:160px;
+color:#372f44;
+margin-right:5px;
+padding-right:5px;
+font-weight:bold;
+font-size:12px;
+}
+
+QWidget .QFrame#frame_AutoMinting .QLabel#labelPIV2zPIVAutoMint { /* Available zPIV Balance */
+qproperty-alignment: 'AlignVCenter | AlignLeft';
+font-size:12px;
+font-weight:bold;
+color:#5c4c7c;
+margin-left:0px;
+}
+
 QWidget .QFrame#frame_ZerocoinBalances { /* Lower left side */
 min-width:400px;
 background-color:#ffffff;
@@ -1134,6 +1157,24 @@ margin-right:5px;
 padding-right:5px;
 font-weight:bold;
 font-size:12px;
+}
+
+QWidget .QFrame#frame_5 .QLabel#labelPIV2zPIVAutoMintText { /* PIV to zPIV Auto-Minting Label */
+qproperty-alignment: 'AlignVCenter | AlignRight';
+min-width:160px;
+background-color:#5B4C7C;
+color:#fff;
+margin-right:5px;
+padding-right:5px;
+font-weight:bold;
+font-size:14px;
+/* min-height:35px; */
+}
+
+QWidget .QFrame#frame_5 .QLabel#labelPIV2zPIVAutoMint { /* PIV to zPIV Auto-Minting */
+min-width: 75px;
+font-size: 12px;
+margin-right: 5px;
 }
 
 QWidget .QFrame#frame_ZerocoinBalances .QLabel#labelzBalance { /* Available zPIV Balance */


### PR DESCRIPTION
This is the implementation of the feature request #433. Solution has control in the overview page for enable or disable auto-minting and set required level.

![image](https://user-images.githubusercontent.com/34844617/34449181-65081314-ecfe-11e7-9b6e-40b9c52e323a.png)

This is an updated PR, previous discussion [here](https://github.com/PIVX-Project/PIVX/pull/457)