### PR TITLE
[QT] Clear PrivacyDialog "zPiv Selected" labels after sending.

### DIFF
--- a/src/qt/privacydialog.cpp
+++ b/src/qt/privacydialog.cpp
@@ -449,6 +449,8 @@ void PrivacyDialog::sendzPIV()
 
     // Clear zpiv selector in case it was used
     ZPivControlDialog::listSelectedMints.clear();
+    ui->labelzPivSelected_int->setText(QString("0"));
+    ui->labelQuantitySelected_int->setText(QString("0"));
 
     // Some statistics for entertainment
     QString strStats = "";


### PR DESCRIPTION
Currently if you use the zPIV Control Dialog to select the zPIV units to send, then it does not clear the associated "zPIV selected" labels after sending.