### PR TITLE
[Build] compile/link winshutdownmonitor.cpp on Windows only

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -271,8 +271,11 @@ BITCOIN_QT_CPP = \
   qt/rpcconsole.cpp \
   qt/splashscreen.cpp \
   qt/trafficgraphwidget.cpp \
-  qt/utilitydialog.cpp \
-  qt/winshutdownmonitor.cpp
+  qt/utilitydialog.cpp
+
+if TARGET_WINDOWS
+BITCOIN_QT_CPP += qt/winshutdownmonitor.cpp
+endif
 
 if ENABLE_WALLET
 BITCOIN_QT_CPP += \


### PR DESCRIPTION
The file `qt/winshutdownmonitor.cpp` is for Windows only. Excluding it on other systems prevents a linker warning about missing/no symbols at compile time such as:
```
/usr/bin/ranlib: file: qt/libbitcoinqt.a(qt_libbitcoinqt_a-winshutdownmonitor.o) has no symbols
```