### PR TITLE
[wallet] Fixes an autocombinerewards bug with above max size TXs

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -3644,6 +3644,10 @@ void CWallet::AutoCombineDust()
         vector<COutput> vCoins, vRewardCoins;
         vCoins = it->second;
 
+        // We don't want the tx to be refused for being too large
+        // we use 50 bytes as a base tx size (2 output: 2*34 + overhead: 10 -> 90 to be certain)
+        unsigned int txSizeEstimate = 90;
+
         //find masternode rewards that need to be combined
         CCoinControl* coinControl = new CCoinControl();
         CAmount nTotalRewardsValue = 0;
@@ -3659,6 +3663,10 @@ void CWallet::AutoCombineDust()
             coinControl->Select(outpt);
             vRewardCoins.push_back(out);
             nTotalRewardsValue += out.Value();
+            // Around 180 bytes per input. We use 190 to be certain
+            txSizeEstimate += 190;
+            if (txSizeEstimate >= MAX_STANDARD_TX_SIZE - 200)
+                break;
         }
 
         //if no inputs found then return


### PR DESCRIPTION
This PR fixes #487 
The problem was that activating autocombinerewards after cumulating a lot of rewards was generating TXs above the max size. They were refused and the wallet was looping trying to generate them.
Here we limit the number of input in an autocombinereward TX. 
Using this code I got my wallet back to normal in a few seconds. See testnet block 349533 to check the generated TXs.