### PR TITLE
[UI] Update MultiSend GUI to allow address labels

### DIFF
--- a/src/qt/forms/multisenddialog.ui
+++ b/src/qt/forms/multisenddialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>594</width>
-    <height>523</height>
+    <height>526</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -30,7 +30,7 @@
     <number>6</number>
    </property>
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout_Main" stretch="1,1,1,1,1,1">
+    <layout class="QVBoxLayout" name="verticalLayout_Main" stretch="1,1,1,0,1,1,1">
      <item>
       <widget class="QLabel" name="label_2">
        <property name="lineWidth">
@@ -174,6 +174,30 @@ MultiSend will not be activated unless you have clicked Activate</string>
           </widget>
          </item>
         </layout>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <item>
+        <widget class="QLabel" name="label_3">
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Label:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="labelAddressLabelEdit">
+         <property name="placeholderText">
+          <string>Enter a label for this address to add it to your address book</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </item>

--- a/src/qt/multisenddialog.cpp
+++ b/src/qt/multisenddialog.cpp
@@ -1,5 +1,6 @@
 #include "multisenddialog.h"
 #include "addressbookpage.h"
+#include "addresstablemodel.h"
 #include "base58.h"
 #include "init.h"
 #include "ui_multisenddialog.h"
@@ -54,6 +55,13 @@ void MultiSendDialog::on_addressBookButton_clicked()
         dlg.setModel(model->getAddressTableModel());
         if (dlg.exec())
             setAddress(dlg.getReturnValue(), ui->multiSendAddressEdit);
+
+        //Update the label text box with the label in the addressbook
+        QString associatedLabel = model->getAddressTableModel()->labelForAddress(dlg.getReturnValue());
+        if (!associatedLabel.isEmpty())
+            ui->labelAddressLabelEdit->setText(associatedLabel);
+        else
+            ui->labelAddressLabelEdit->setText(tr("(no label)"));
     }
 }
 
@@ -71,6 +79,12 @@ void MultiSendDialog::on_viewButton_clicked()
 
     for (int i = 0; i < (int)pwalletMain->vMultiSend.size(); i++) {
         pMultiSend = pwalletMain->vMultiSend[i];
+        if (model && model->getAddressTableModel()) {
+            std::string associatedLabel;
+            associatedLabel = model->getAddressTableModel()->labelForAddress(pMultiSend.first.c_str()).toStdString();
+            strMultiSendPrint += associatedLabel.c_str();
+            strMultiSendPrint += " - ";
+        }
         strMultiSendPrint += pMultiSend.first.c_str();
         strMultiSendPrint += " - ";
         strMultiSendPrint += boost::lexical_cast<string>(pMultiSend.second);
@@ -125,8 +139,23 @@ void MultiSendDialog::on_addButton_clicked()
         strMultiSendPrint += boost::lexical_cast<string>(pMultiSend.second);
         strMultiSendPrint += "% \n";
     }
+
+    // update the address book with the label given or no label if none was given.
+    CBitcoinAddress address(strAddress);
+    std::string userInputLabel = ui->labelAddressLabelEdit->text().toStdString();
+    if (!userInputLabel.empty())
+        pwalletMain->SetAddressBook(address.Get(), userInputLabel, "send");
+    else
+        pwalletMain->SetAddressBook(address.Get(), "(no label)", "send");
+
     CWalletDB walletdb(pwalletMain->strWalletFile);
-    walletdb.WriteMultiSend(pwalletMain->vMultiSend);
+    if(!walletdb.WriteMultiSend(pwalletMain->vMultiSend)) {
+        ui->message->setProperty("status", "error");
+        ui->message->style()->polish(ui->message);
+        ui->message->setText(tr("Saved the MultiSend to memory, but failed saving properties to the database.\n"));
+        ui->multiSendAddressEdit->setFocus();
+        return;
+    }
     ui->message->setText(tr("MultiSend Vector\n") + QString(strMultiSendPrint.c_str()));
     return;
 }


### PR DESCRIPTION
#446 
Added a Label section to the MultiSend GUI
MultiSend GUI will now show labels if address is selected from addressbook
MultiSend GUI now allows users to add or change the label to the address they are creating a multisend for
View MultiSend Button now displays the label in the print out along with the address and percentage