### PR TITLE
[Bug] remove use of variable length buffer

### DIFF
--- a/src/qt/test/paymentservertests.cpp
+++ b/src/qt/test/paymentservertests.cpp
@@ -109,13 +109,17 @@ void PaymentServerTests::paymentServerTests()
     r.paymentRequest.getMerchant(caStore, merchant);
     QCOMPARE(merchant, QString(""));
 
+    unsigned long lDoSProtectionTrigger = (unsigned long) BIP70_MAX_PAYMENTREQUEST_SIZE + 1;
+    std::string randData(lDoSProtectionTrigger, '\0');
+
+    unsigned char* buff = reinterpret_cast<unsigned char *>(&randData[0]);
+
     // Just get some random data big enough to trigger BIP70 DoS protection
-    unsigned char randData[BIP70_MAX_PAYMENTREQUEST_SIZE + 1];
-    GetRandBytes(randData, sizeof(randData));
+    GetRandBytes(buff, sizeof(buff));
     // Write data to a temp file:
     QTemporaryFile tempFile;
     tempFile.open();
-    tempFile.write((const char*)randData, sizeof(randData));
+    tempFile.write((const char*)buff, sizeof(buff));
     tempFile.close();
     // Trigger BIP70 DoS protection
     QCOMPARE(PaymentServer::readPaymentRequestFromFile(tempFile.fileName(), r.paymentRequest), false);


### PR DESCRIPTION
Remove use of variable length buffer from `paymentservertests.cpp`.
This removes the warning of: 
`stack protector not protecting local variables: variable length buffer`
raised by the `-Wstack-protector` compilation flag.

As noted in issue: https://github.com/PIVX-Project/PIVX/issues/387