### PR TITLE
[UI] Send popup simplified + SwiftTX -> SwiftX

### DIFF
--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -1702,7 +1702,7 @@
                 </size>
                </property>
                <property name="text">
-                <string>SwiftTX</string>
+                <string>SwiftX</string>
                </property>
               </widget>
              </item>
@@ -1762,7 +1762,7 @@
  </resources>
  <connections/>
  <buttongroups>
-  <buttongroup name="groupFee"/>
   <buttongroup name="groupCustomFee"/>
+  <buttongroup name="groupFee"/>
  </buttongroups>
 </ui>

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -262,15 +262,14 @@ void SendCoinsDialog::on_sendButton_clicked()
     if (CoinControlDialog::coinControl->fSplitBlock)
         CoinControlDialog::coinControl->nSplitBlock = int(ui->splitBlockLineEdit->text().toInt());
 
-    QString strFunds = tr("using") + " <b>" + tr("anonymous funds") + "</b>";
+    QString strFunds = "";
     QString strFee = "";
     recipients[0].inputType = ALL_COINS;
-    strFunds = tr("using") + " <b>" + tr("any available funds (not recommended)") + "</b>";
 
     if (ui->checkSwiftTX->isChecked()) {
         recipients[0].useSwiftTX = true;
         strFunds += " ";
-        strFunds += tr("and SwiftX");
+        strFunds += tr("using SwiftX");
     } else {
         recipients[0].useSwiftTX = false;
     }

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -306,7 +306,7 @@ void SendCoinsDialog::on_sendButton_clicked()
             recipientElement = tr("%1 to %2").arg(amount, address);
         }
 
-        if (fSplitBlock) {
+        if (CoinControlDialog::coinControl->fSplitBlock) {
             recipientElement.append(tr(" split into %1 outputs using the UTXO splitter.").arg(CoinControlDialog::coinControl->nSplitBlock));
         }
 


### PR DESCRIPTION
This addresses https://github.com/PIVX-Project/PIVX/issues/404

Since Obfuscation was replaced by the Zerocoin protocol the additional warning is obsolete now and was removed.

New popups:

1: **Normal Send**:
![send1](https://user-images.githubusercontent.com/22873440/35158490-8b20ca0c-fd37-11e7-87f7-b4f5669516a1.png)

2: **SwiftX**:
![send2](https://user-images.githubusercontent.com/22873440/35158517-9d583f0c-fd37-11e7-804e-0dbf9c54f9e5.png)

Additionally one forgotten `SwiftTX` was changed to `SwiftX`.