### PR TITLE
[Qt] Remove duplicate code for updating address book labels.

### DIFF
--- a/src/qt/multisenddialog.cpp
+++ b/src/qt/multisenddialog.cpp
@@ -140,13 +140,15 @@ void MultiSendDialog::on_addButton_clicked()
         strMultiSendPrint += "% \n";
     }
 
-    // update the address book with the label given or no label if none was given.
-    CBitcoinAddress address(strAddress);
-    std::string userInputLabel = ui->labelAddressLabelEdit->text().toStdString();
-    if (!userInputLabel.empty())
-        pwalletMain->SetAddressBook(address.Get(), userInputLabel, "send");
-    else
-        pwalletMain->SetAddressBook(address.Get(), "(no label)", "send");
+    if (model && model->getAddressTableModel()) {
+        // update the address book with the label given or no label if none was given.
+        CBitcoinAddress address(strAddress);
+        std::string userInputLabel = ui->labelAddressLabelEdit->text().toStdString();
+        if (!userInputLabel.empty())
+            model->updateAddressBookLabels(address.Get(), userInputLabel, "send");
+        else
+            model->updateAddressBookLabels(address.Get(), "(no label)", "send");
+    }
 
     CWalletDB walletdb(pwalletMain->strWalletFile);
     if(!walletdb.WriteMultiSend(pwalletMain->vMultiSend)) {

--- a/src/qt/privacydialog.cpp
+++ b/src/qt/privacydialog.cpp
@@ -144,8 +144,9 @@ void PrivacyDialog::on_pasteButton_clicked()
 
 void PrivacyDialog::on_addressBookButton_clicked()
 {
-    if (!walletModel)
+    if (!walletModel || !walletModel->getOptionsModel())
         return;
+
     AddressBookPage dlg(AddressBookPage::ForSelection, AddressBookPage::SendingTab, this);
     dlg.setModel(walletModel->getAddressTableModel());
     if (dlg.exec()) {
@@ -235,9 +236,6 @@ void PrivacyDialog::on_pushButtonMintzPIV_clicked()
 
 void PrivacyDialog::on_pushButtonMintReset_clicked()
 {
-    if (!walletModel || !walletModel->getOptionsModel())
-        return;
-
     ui->TEMintStatus->setPlainText(tr("Starting ResetMintZerocoin: rescanning complete blockchain, this will need up to 30 minutes depending on your hardware. \nPlease be patient..."));
     ui->TEMintStatus->repaint ();
 
@@ -252,9 +250,6 @@ void PrivacyDialog::on_pushButtonMintReset_clicked()
 
 void PrivacyDialog::on_pushButtonSpentReset_clicked()
 {
-    if (!walletModel || !walletModel->getOptionsModel())
-        return;
-
     ui->TEMintStatus->setPlainText(tr("Starting ResetSpentZerocoin: "));
     ui->TEMintStatus->repaint ();
     int64_t nTime = GetTimeMillis();
@@ -296,6 +291,9 @@ void PrivacyDialog::on_pushButtonSpendzPIV_clicked()
 
 void PrivacyDialog::on_pushButtonZPivControl_clicked()
 {
+    if (!walletModel || !walletModel->getOptionsModel())
+        return;
+
     ZPivControlDialog* zPivControl = new ZPivControlDialog(this);
     zPivControl->setModel(walletModel);
     zPivControl->exec();
@@ -447,6 +445,15 @@ void PrivacyDialog::sendzPIV()
         return;
     }
 
+    if (walletModel && walletModel->getAddressTableModel()) {
+        // If zPiv was spent successfully update the addressbook with the label
+        std::string labelText = ui->addAsLabel->text().toStdString();
+        if (!labelText.empty())
+            walletModel->updateAddressBookLabels(address.Get(), labelText, "send");
+        else
+            walletModel->updateAddressBookLabels(address.Get(), "(no label)", "send");
+    }
+
     // Clear zpiv selector in case it was used
     ZPivControlDialog::listSelectedMints.clear();
     ui->labelzPivSelected_int->setText(QString("0"));
@@ -513,6 +520,9 @@ void PrivacyDialog::coinControlClipboardAmount()
 // Coin Control: button inputs -> show actual coin control dialog
 void PrivacyDialog::coinControlButtonClicked()
 {
+    if (!walletModel || !walletModel->getOptionsModel())
+        return;
+
     CoinControlDialog dlg;
     dlg.setModel(walletModel);
     dlg.exec();

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -242,6 +242,20 @@ bool WalletModel::validateAddress(const QString& address)
     return addressParsed.IsValid();
 }
 
+void WalletModel::updateAddressBookLabels(const CTxDestination& dest, const string& strName, const string& strPurpose)
+{
+    LOCK(wallet->cs_wallet);
+
+    std::map<CTxDestination, CAddressBookData>::iterator mi = wallet->mapAddressBook.find(dest);
+
+    // Check if we have a new address or an updated label
+    if (mi == wallet->mapAddressBook.end()) {
+        wallet->SetAddressBook(dest, strName, strPurpose);
+    } else if (mi->second.name != strName) {
+        wallet->SetAddressBook(dest, strName, ""); // "" means don't change purpose
+    }
+}
+
 WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransaction& transaction, const CCoinControl* coinControl)
 {
     CAmount total = 0;
@@ -389,21 +403,12 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(WalletModelTransaction& tran
     foreach (const SendCoinsRecipient& rcp, transaction.getRecipients()) {
         // Don't touch the address book when we have a payment request
         if (!rcp.paymentRequest.IsInitialized()) {
+
             std::string strAddress = rcp.address.toStdString();
             CTxDestination dest = CBitcoinAddress(strAddress).Get();
             std::string strLabel = rcp.label.toStdString();
-            {
-                LOCK(wallet->cs_wallet);
 
-                std::map<CTxDestination, CAddressBookData>::iterator mi = wallet->mapAddressBook.find(dest);
-
-                // Check if we have a new address or an updated label
-                if (mi == wallet->mapAddressBook.end()) {
-                    wallet->SetAddressBook(dest, strLabel, "send");
-                } else if (mi->second.name != strLabel) {
-                    wallet->SetAddressBook(dest, strLabel, ""); // "" means don't change purpose
-                }
-            }
+            updateAddressBookLabels(dest, strLabel, "send");
         }
         emit coinsSent(wallet, rcp, transaction_array);
     }

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -293,6 +293,8 @@ public slots:
     void updateMultiSigFlag(bool fHaveMultiSig);
     /* Current, immature or unconfirmed balance might have changed - emit 'balanceChanged' if so */
     void pollBalanceChanged();
+    /* Update address book labels in teh database */
+    void updateAddressBookLabels(const CTxDestination& address, const string& strName, const string& strPurpose);
 };
 
 #endif // BITCOIN_QT_WALLETMODEL_H

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -3328,7 +3328,6 @@ DBErrors CWallet::ZapWalletTx(std::vector<CWalletTx>& vWtx)
     return DB_LOAD_OK;
 }
 
-
 bool CWallet::SetAddressBook(const CTxDestination& address, const string& strName, const string& strPurpose)
 {
     bool fUpdated = false;


### PR DESCRIPTION
#493 - Link to issue. 
While working on updating the labels in the address book. I saw that we were using duplicate code to complete the same task which was to "Updating the address book labels in the database"

Created a function in the wallet model class that you can call and it will update the address book labels. Then replaced the duplicate code with a call to the function. 