### PR TITLE
[Wallet] Combine fees when possible and fix autocombine insufficient funds

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -2720,7 +2720,7 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, CAmount> >& vecSend,
                         scriptChange = GetScriptForDestination(coinControl->destChange);
 
                         vector<CTxOut>::iterator it = txNew.vout.begin();
-                        for (; it != txNew.vout.end();) {
+                        while (it != txNew.vout.end()) {
                             if (scriptChange == it->scriptPubKey) {
                                 it->nValue += nChange;
                                 nChange = 0;
@@ -4075,7 +4075,7 @@ void CWallet::AutoCombineDust()
         }
 
         //we don't combine below the threshold unless the fees are 0 to avoid paying fees over fees over fees
-        if (vecSend[0].second < nAutoCombineThreshold * COIN && nFeeRet > 0)
+        if (nTotalRewardsValue < nAutoCombineThreshold * COIN && nFeeRet > 0)
             continue;
 
         if (!CommitTransaction(wtx, keyChange)) {

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -4003,6 +4003,8 @@ void CWallet::AutoCombineDust()
         CCoinControl* coinControl = new CCoinControl();
         CAmount nTotalRewardsValue = 0;
         BOOST_FOREACH (const COutput& out, vCoins) {
+            if (!out.fSpendable)
+                continue;
             //no coins should get this far if they dont have proper maturity, this is double checking
             if (out.tx->IsCoinStake() && out.tx->GetDepthInMainChain() < COINBASE_MATURITY + 1)
                 continue;
@@ -4040,10 +4042,8 @@ void CWallet::AutoCombineDust()
         string strErr;
         CAmount nFeeRet = 0;
 
-        //get the fee amount
-        CWalletTx wtxdummy;
-        CreateTransaction(vecSend, wtxdummy, keyChange, nFeeRet, strErr, coinControl, ALL_COINS, false, CAmount(0));
-        vecSend[0].second = nTotalRewardsValue - nFeeRet - 500;
+        // 10% safety margin to avoid "Insufficient funds" errors
+        vecSend[0].second = nTotalRewardsValue - (nTotalRewardsValue / 10);
 
         if (!CreateTransaction(vecSend, wtx, keyChange, nFeeRet, strErr, coinControl, ALL_COINS, false, CAmount(0))) {
             LogPrintf("AutoCombineDust createtransaction failed, reason: %s\n", strErr);


### PR DESCRIPTION
This is firstly to fix #496. Ensuring autocombine stops failing with `Insufficient funds` error messages. (Thanks to @Mrs-X for the help)
It also ensure that when a change address is provided in coin control the change is going to this address in an already existing output.
Last, it gives autocombine transactions the address being combined as a change address. Thus lowering TX size and avoiding generating new change addresses when trying to reduce UTXO fragmentation.