### PR TITLE
[Qt] Remove Growl support

### DIFF
--- a/src/qt/macnotificationhandler.h
+++ b/src/qt/macnotificationhandler.h
@@ -7,7 +7,7 @@
 
 #include <QObject>
 
-/** Macintosh-specific notification handler (supports UserNotificationCenter and Growl).
+/** Macintosh-specific notification handler (supports UserNotificationCenter).
  */
 class MacNotificationHandler : public QObject
 {

--- a/src/qt/macnotificationhandler.mm
+++ b/src/qt/macnotificationhandler.mm
@@ -48,20 +48,6 @@ void MacNotificationHandler::showNotification(const QString &title, const QStrin
     }
 }
 
-// sendAppleScript just take a QString and executes it as apple script
-void MacNotificationHandler::sendAppleScript(const QString &script)
-{
-    QByteArray utf8 = script.toUtf8();
-    char* cString = (char *)utf8.constData();
-    NSString *scriptApple = [[NSString alloc] initWithUTF8String:cString];
-
-    NSAppleScript *as = [[NSAppleScript alloc] initWithSource:scriptApple];
-    NSDictionary *err = nil;
-    [as executeAndReturnError:&err];
-    [as release];
-    [scriptApple release];
-}
-
 bool MacNotificationHandler::hasUserNotificationCenterSupport(void)
 {
     Class possibleClass = NSClassFromString(@"NSUserNotificationCenter");

--- a/src/qt/notificator.cpp
+++ b/src/qt/notificator.cpp
@@ -57,21 +57,6 @@ Notificator::Notificator(const QString& programName, QSystemTrayIcon* trayicon, 
     // check if users OS has support for NSUserNotification
     if (MacNotificationHandler::instance()->hasUserNotificationCenterSupport()) {
         mode = UserNotificationCenter;
-    } else {
-        // Check if Growl is installed (based on Qt's tray icon implementation)
-        CFURLRef cfurl;
-        OSStatus status = LSGetApplicationForInfo(kLSUnknownType, kLSUnknownCreator, CFSTR("growlTicket"), kLSRolesAll, 0, &cfurl);
-        if (status != kLSApplicationNotFoundErr) {
-            CFBundleRef bundle = CFBundleCreate(0, cfurl);
-            if (CFStringCompare(CFBundleGetIdentifier(bundle), CFSTR("com.Growl.GrowlHelperApp"), kCFCompareCaseInsensitive | kCFCompareBackwards) == kCFCompareEqualTo) {
-                if (CFStringHasSuffix(CFURLGetString(cfurl), CFSTR("/Growl.app/")))
-                    mode = Growl13;
-                else
-                    mode = Growl12;
-            }
-            CFRelease(cfurl);
-            CFRelease(bundle);
-        }
     }
 #endif
 }
@@ -245,55 +230,6 @@ void Notificator::notifySystray(Class cls, const QString& title, const QString& 
 
 // Based on Qt's tray icon implementation
 #ifdef Q_OS_MAC
-void Notificator::notifyGrowl(Class cls, const QString& title, const QString& text, const QIcon& icon)
-{
-    const QString script(
-        "tell application \"%5\"\n"
-        "  set the allNotificationsList to {\"Notification\"}\n"                                                                   // -- Make a list of all the notification types (all)
-        "  set the enabledNotificationsList to {\"Notification\"}\n"                                                               // -- Make a list of the notifications (enabled)
-        "  register as application \"%1\" all notifications allNotificationsList default notifications enabledNotificationsList\n" // -- Register our script with Growl
-        "  notify with name \"Notification\" title \"%2\" description \"%3\" application name \"%1\"%4\n"                          // -- Send a Notification
-        "end tell");
-
-    QString notificationApp(QApplication::applicationName());
-    if (notificationApp.isEmpty())
-        notificationApp = "Application";
-
-    QPixmap notificationIconPixmap;
-    if (icon.isNull()) { // If no icon specified, set icon based on class
-        QStyle::StandardPixmap sicon = QStyle::SP_MessageBoxQuestion;
-        switch (cls) {
-        case Information:
-            sicon = QStyle::SP_MessageBoxInformation;
-            break;
-        case Warning:
-            sicon = QStyle::SP_MessageBoxWarning;
-            break;
-        case Critical:
-            sicon = QStyle::SP_MessageBoxCritical;
-            break;
-        }
-        notificationIconPixmap = QApplication::style()->standardPixmap(sicon);
-    } else {
-        QSize size = icon.actualSize(QSize(48, 48));
-        notificationIconPixmap = icon.pixmap(size);
-    }
-
-    QString notificationIcon;
-    QTemporaryFile notificationIconFile;
-    if (!notificationIconPixmap.isNull() && notificationIconFile.open()) {
-        QImageWriter writer(&notificationIconFile, "PNG");
-        if (writer.write(notificationIconPixmap.toImage()))
-            notificationIcon = QString(" image from location \"file://%1\"").arg(notificationIconFile.fileName());
-    }
-
-    QString quotedTitle(title), quotedText(text);
-    quotedTitle.replace("\\", "\\\\").replace("\"", "\\");
-    quotedText.replace("\\", "\\\\").replace("\"", "\\");
-    QString growlApp(this->mode == Notificator::Growl13 ? "Growl" : "GrowlHelperApp");
-    MacNotificationHandler::instance()->sendAppleScript(script.arg(notificationApp, quotedTitle, quotedText, notificationIcon, growlApp));
-}
-
 void Notificator::notifyMacUserNotificationCenter(Class cls, const QString& title, const QString& text, const QIcon& icon)
 {
     // icon is not supported by the user notification center yet. OSX will use the app icon.
@@ -316,10 +252,6 @@ void Notificator::notify(Class cls, const QString& title, const QString& text, c
 #ifdef Q_OS_MAC
     case UserNotificationCenter:
         notifyMacUserNotificationCenter(cls, title, text, icon);
-        break;
-    case Growl12:
-    case Growl13:
-        notifyGrowl(cls, title, text, icon);
         break;
 #endif
     default:

--- a/src/qt/notificator.h
+++ b/src/qt/notificator.h
@@ -56,8 +56,6 @@ private:
         None,                  /**< Ignore informational notifications, and show a modal pop-up dialog for Critical notifications. */
         Freedesktop,           /**< Use DBus org.freedesktop.Notifications */
         QSystemTray,           /**< Use QSystemTray::showMessage */
-        Growl12,               /**< Use the Growl 1.2 notification system (Mac only) */
-        Growl13,               /**< Use the Growl 1.3 notification system (Mac only) */
         UserNotificationCenter /**< Use the 10.8+ User Notification Center (Mac only) */
     };
     QString programName;
@@ -70,7 +68,6 @@ private:
 #endif
     void notifySystray(Class cls, const QString& title, const QString& text, const QIcon& icon, int millisTimeout);
 #ifdef Q_OS_MAC
-    void notifyGrowl(Class cls, const QString& title, const QString& text, const QIcon& icon);
     void notifyMacUserNotificationCenter(Class cls, const QString& title, const QString& text, const QIcon& icon);
 #endif
 };


### PR DESCRIPTION
Growl hasn't been free nor needed for many years. MacOS versions since
10.8 have the OS notification center, which is still supported after
this.