### PR TITLE
[Doc] Update OSX build notes: zmq, libevent, and notes to handle possible glibtoolize error

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -38,7 +38,7 @@ Instructions: Homebrew
 
 #### Install dependencies using Homebrew
 
-        brew install autoconf automake berkeley-db4 libtool boost miniupnpc openssl pkg-config protobuf qt5 libzmq
+        brew install autoconf automake berkeley-db4 libtool boost miniupnpc openssl pkg-config protobuf qt5 zmq libevent
 
 ### Building `pivxd`
 


### PR DESCRIPTION
`brew install libzmq` fails with 
`
Error: No available formula with the name "libzmq" 
`
but `brew install zmq` resolves the issue. Also, `libevent` is missing from the brew install list. Finally added notes to handle the possible `/usr/local/bin/glibtoolize: line 406: /usr/local/Library/ENV/4.3/sed: No such file or directory` error.