### PR TITLE
[Qt] Standardize and clean up new UI elements

### DIFF
--- a/src/qt/bip38tooldialog.cpp
+++ b/src/qt/bip38tooldialog.cpp
@@ -171,6 +171,12 @@ void Bip38ToolDialog::on_clearButton_ENC_clicked()
 }
 
 CKey key;
+void Bip38ToolDialog::on_pasteButton_DEC_clicked()
+{
+    // Paste text from clipboard into recipient field
+    ui->encryptedKeyIn_DEC->setText(QApplication::clipboard()->text());
+}
+
 void Bip38ToolDialog::on_decryptKeyButton_DEC_clicked()
 {
     string strPassphrase = ui->passphraseIn_DEC->text().toStdString();

--- a/src/qt/bip38tooldialog.cpp
+++ b/src/qt/bip38tooldialog.cpp
@@ -194,7 +194,7 @@ void Bip38ToolDialog::on_decryptKeyButton_DEC_clicked()
     CPubKey pubKey = key.GetPubKey();
     CBitcoinAddress address(pubKey.GetID());
 
-    ui->decryptedKeyOut_DEC->setText(QString::fromStdString(HexStr(privKey)));
+    ui->decryptedKeyOut_DEC->setText(QString::fromStdString(CBitcoinSecret(key).ToString()));
     ui->addressOut_DEC->setText(QString::fromStdString(address.ToString()));
 }
 

--- a/src/qt/bip38tooldialog.h
+++ b/src/qt/bip38tooldialog.h
@@ -44,6 +44,7 @@ private slots:
     void on_copyKeyButton_ENC_clicked();
     void on_clearButton_ENC_clicked();
     /* decrypt key */
+    void on_pasteButton_DEC_clicked();
     void on_decryptKeyButton_DEC_clicked();
     void on_importAddressButton_DEC_clicked();
     void on_clearButton_DEC_clicked();

--- a/src/qt/forms/bip38tooldialog.ui
+++ b/src/qt/forms/bip38tooldialog.ui
@@ -80,9 +80,6 @@
            <property name="shortcut">
             <string>Alt+A</string>
            </property>
-           <property name="autoDefault">
-            <bool>false</bool>
-           </property>
           </widget>
          </item>
          <item>
@@ -99,9 +96,6 @@
            </property>
            <property name="shortcut">
             <string>Alt+P</string>
-           </property>
-           <property name="autoDefault">
-            <bool>false</bool>
            </property>
           </widget>
          </item>
@@ -178,9 +172,6 @@
            <property name="icon">
             <iconset resource="../pivx.qrc">
              <normaloff>:/icons/editcopy</normaloff>:/icons/editcopy</iconset>
-           </property>
-           <property name="autoDefault">
-            <bool>false</bool>
            </property>
           </widget>
          </item>

--- a/src/qt/forms/bip38tooldialog.ui
+++ b/src/qt/forms/bip38tooldialog.ui
@@ -61,12 +61,12 @@
          <item>
           <widget class="QValidatedLineEdit" name="addressIn_ENC">
            <property name="toolTip">
-            <string>The PIVX address to sign the message with</string>
+            <string>The PIVX address to encrypt</string>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="addressBookButton_ENC">
+          <widget class="QToolButton" name="addressBookButton_ENC">
            <property name="toolTip">
             <string>Choose previously used address</string>
            </property>
@@ -182,7 +182,7 @@
          <item>
           <widget class="QPushButton" name="encryptKeyButton_ENC">
            <property name="toolTip">
-            <string>Sign the message to prove you own this PIVX address</string>
+            <string>Encrypt the private key for this PIVX address</string>
            </property>
            <property name="text">
             <string>Encrypt &amp;Key</string>
@@ -199,7 +199,7 @@
          <item>
           <widget class="QPushButton" name="clearButton_ENC">
            <property name="toolTip">
-            <string>Reset all sign message fields</string>
+            <string>Reset all fields</string>
            </property>
            <property name="text">
             <string>Clear &amp;All</string>
@@ -298,7 +298,7 @@
          <item>
           <widget class="QValidatedLineEdit" name="encryptedKeyIn_DEC">
            <property name="toolTip">
-            <string>The PIVX address the message was signed with</string>
+            <string>The encrypted private key</string>
            </property>
           </widget>
          </item>
@@ -353,7 +353,7 @@
          <item>
           <widget class="QPushButton" name="decryptKeyButton_DEC">
            <property name="toolTip">
-            <string>Verify the message to ensure it was signed with the specified PIVX address</string>
+            <string>Decrypt the entered key using the passphrase</string>
            </property>
            <property name="text">
             <string>Decrypt &amp;Key</string>
@@ -370,7 +370,7 @@
          <item>
           <widget class="QPushButton" name="clearButton_DEC">
            <property name="toolTip">
-            <string>Reset all verify message fields</string>
+            <string>Reset all fields</string>
            </property>
            <property name="text">
             <string>Clear &amp;All</string>

--- a/src/qt/forms/bip38tooldialog.ui
+++ b/src/qt/forms/bip38tooldialog.ui
@@ -42,11 +42,17 @@
        </item>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_1_ENC">
-         <property name="spacing">
-          <number>0</number>
-         </property>
          <item>
           <widget class="QLabel" name="label_5">
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>85</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="text">
             <string>Address:</string>
            </property>
@@ -80,7 +86,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="pasteButton_ENC">
+          <widget class="QToolButton" name="pasteButton_ENC">
            <property name="toolTip">
             <string>Paste address from clipboard</string>
            </property>
@@ -105,6 +111,15 @@
         <layout class="QHBoxLayout" name="horizontalLayout_5">
          <item>
           <widget class="QLabel" name="label_6">
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>85</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="text">
             <string>Passphrase: </string>
            </property>
@@ -121,11 +136,17 @@
        </item>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_2_ENC">
-         <property name="spacing">
-          <number>0</number>
-         </property>
          <item>
           <widget class="QLabel" name="encryptedKeyLabel_ENC">
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>85</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="text">
             <string>Encrypted Key:</string>
            </property>
@@ -147,7 +168,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="copyKeyButton_ENC">
+          <widget class="QToolButton" name="copyKeyButton_ENC">
            <property name="toolTip">
             <string>Copy the current signature to the system clipboard</string>
            </property>
@@ -260,9 +281,6 @@
          <property name="textFormat">
           <enum>Qt::PlainText</enum>
          </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-         </property>
          <property name="wordWrap">
           <bool>true</bool>
          </property>
@@ -272,6 +290,15 @@
         <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
           <widget class="QLabel" name="label_2">
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>85</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="text">
             <string>Encrypted Key:</string>
            </property>
@@ -290,6 +317,15 @@
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
           <widget class="QLabel" name="label">
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>85</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="text">
             <string>Passphrase: </string>
            </property>

--- a/src/qt/forms/bip38tooldialog.ui
+++ b/src/qt/forms/bip38tooldialog.ui
@@ -311,6 +311,23 @@
            </property>
           </widget>
          </item>
+         <item>
+          <widget class="QToolButton" name="pasteButton_DEC">
+           <property name="toolTip">
+            <string>Paste address from clipboard</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="../pivx.qrc">
+             <normaloff>:/icons/editpaste</normaloff>:/icons/editpaste</iconset>
+           </property>
+           <property name="shortcut">
+            <string>Alt+P</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
        <item>

--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -477,11 +477,11 @@
      </column>
      <column>
       <property name="text">
-	<string>Type</string>
+       <string>Type</string>
       </property>
      </column>
      <column>
-      <property name="text">	 
+      <property name="text">
        <string>Date</string>
       </property>
      </column>

--- a/src/qt/forms/multisenddialog.ui
+++ b/src/qt/forms/multisenddialog.ui
@@ -148,7 +148,7 @@ MultiSend will not be activated unless you have clicked Activate</string>
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="addressBookButton">
+          <widget class="QToolButton" name="addressBookButton">
            <property name="maximumSize">
             <size>
              <width>16777215</width>
@@ -167,9 +167,6 @@ MultiSend will not be activated unless you have clicked Activate</string>
            </property>
            <property name="shortcut">
             <string>Alt+A</string>
-           </property>
-           <property name="autoDefault">
-            <bool>false</bool>
            </property>
           </widget>
          </item>

--- a/src/qt/forms/privacydialog.ui
+++ b/src/qt/forms/privacydialog.ui
@@ -573,9 +573,6 @@
                         <property name="backgroundVisible">
                          <bool>true</bool>
                         </property>
-                        <property name="placeholderText">
-                         <string/>
-                        </property>
                        </widget>
                       </item>
                       <item>

--- a/src/qt/forms/privacydialog.ui
+++ b/src/qt/forms/privacydialog.ui
@@ -25,7 +25,7 @@
     <height>0</height>
    </size>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_8" stretch="0,0">
+  <layout class="QVBoxLayout" name="verticalLayout_1" stretch="0,0">
    <item>
     <layout class="QVBoxLayout" name="verticalLayout_Master" stretch="0,1">
      <property name="spacing">
@@ -75,7 +75,7 @@
            </widget>
           </item>
           <item>
-           <spacer name="horizontalSpacer_3">
+           <spacer name="horizontalSpacer_1">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
@@ -790,8 +790,11 @@ zPIV are mature when they have more than 20 confirmations AND more than 2 mints 
                        </layout>
                       </item>
                       <item>
-                       <layout class="QHBoxLayout" name="horizontalLayout_7">
-                        <item>
+                       <layout class="QGridLayout" name="gridLayout_7">
+                        <property name="spacing">
+                         <number>12</number>
+                        </property>
+                        <item row="0" column="0">
                          <widget class="QLabel" name="payToLabel">
                           <property name="minimumSize">
                            <size>
@@ -810,7 +813,7 @@ zPIV are mature when they have more than 20 confirmations AND more than 2 mints 
                           </property>
                          </widget>
                         </item>
-                        <item>
+                        <item row="0" column="1">
                          <layout class="QHBoxLayout" name="payToLayout">
                           <property name="spacing">
                            <number>0</number>
@@ -867,11 +870,7 @@ zPIV are mature when they have more than 20 confirmations AND more than 2 mints 
                           </item>
                          </layout>
                         </item>
-                       </layout>
-                      </item>
-                      <item>
-                       <layout class="QHBoxLayout" name="horizontalLayout_8">
-                        <item>
+                        <item row="1" column="0">
                          <widget class="QLabel" name="labelLabel">
                           <property name="minimumSize">
                            <size>
@@ -890,18 +889,14 @@ zPIV are mature when they have more than 20 confirmations AND more than 2 mints 
                           </property>
                          </widget>
                         </item>
-                        <item>
+                        <item row="1" column="1">
                          <widget class="QLineEdit" name="addAsLabel">
                           <property name="toolTip">
                            <string>Enter a label for this address to add it to the list of used addresses</string>
                           </property>
                          </widget>
                         </item>
-                       </layout>
-                      </item>
-                      <item>
-                       <layout class="QHBoxLayout" name="horizontalLayout_9">
-                        <item>
+                        <item row="2" column="0">
                          <widget class="QLabel" name="amountLabel">
                           <property name="minimumSize">
                            <size>
@@ -920,77 +915,87 @@ zPIV are mature when they have more than 20 confirmations AND more than 2 mints 
                           </property>
                          </widget>
                         </item>
-                        <item>
-                         <widget class="QLineEdit" name="zPIVpayAmount"/>
+                        <item row="2" column="1">
+                         <layout class="QHBoxLayout" name="horizontalLayout_9">
+                          <property name="spacing">
+                           <number>0</number>
+                          </property>
+                          <item>
+                           <widget class="QLineEdit" name="zPIVpayAmount"/>
+                          </item>
+                          <item>
+                           <widget class="QLabel" name="labelzPIV">
+                            <property name="alignment">
+                             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                            </property>
+                            <property name="minimumSize">
+                             <size>
+                              <width>55</width>
+                              <height>0</height>
+                             </size>
+                            </property>
+                            <property name="text">
+                             <string>zPIV</string>
+                            </property>
+                           </widget>
+                          </item>
+                         </layout>
                         </item>
-                        <item>
-                         <widget class="QLabel" name="labelzPIV">
-                          <property name="minimumSize">
-                           <size>
-                            <width>55</width>
-                            <height>0</height>
-                           </size>
-                          </property>
-                          <property name="text">
-                           <string>zPIV</string>
-                          </property>
-                         </widget>
-                        </item>
-                       </layout>
-                      </item>
-                      <item>
-                       <layout class="QHBoxLayout" name="horizontalLayout_10">
-                        <item>
-                         <spacer name="horizontalSpacer_5">
-                          <property name="orientation">
-                           <enum>Qt::Horizontal</enum>
-                          </property>
-                          <property name="sizeHint" stdset="0">
-                           <size>
-                            <width>40</width>
-                            <height>20</height>
-                           </size>
-                          </property>
-                         </spacer>
-                        </item>
-                        <item>
-                         <widget class="QCheckBox" name="checkBoxMintChange">
-                          <property name="sizePolicy">
-                           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                           </sizepolicy>
-                          </property>
-                          <property name="layoutDirection">
-                           <enum>Qt::LeftToRight</enum>
-                          </property>
-                          <property name="text">
-                           <string>Convert Change to Zerocoin (might cost additional fees)</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item>
-                         <widget class="QCheckBox" name="checkBoxMinimizeChange">
-                          <property name="toolTip">
-                           <string>If checked, the wallet tries to minimize the returning change instead of minimizing the number of spent denominations.</string>
-                          </property>
-                          <property name="text">
-                           <string>Minimize Change</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item>
-                         <spacer name="horizontalSpacer_6">
-                          <property name="orientation">
-                           <enum>Qt::Horizontal</enum>
-                          </property>
-                          <property name="sizeHint" stdset="0">
-                           <size>
-                            <width>40</width>
-                            <height>20</height>
-                           </size>
-                          </property>
-                         </spacer>
+                        <item row="3" column="0" colspan="2">
+                         <layout class="QHBoxLayout" name="horizontalLayout_10">
+                          <item>
+                           <spacer name="horizontalSpacer_5">
+                            <property name="orientation">
+                             <enum>Qt::Horizontal</enum>
+                            </property>
+                            <property name="sizeHint" stdset="0">
+                             <size>
+                              <width>40</width>
+                              <height>20</height>
+                             </size>
+                            </property>
+                           </spacer>
+                          </item>
+                          <item>
+                           <widget class="QCheckBox" name="checkBoxMintChange">
+                            <property name="sizePolicy">
+                             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                              <horstretch>0</horstretch>
+                              <verstretch>0</verstretch>
+                             </sizepolicy>
+                            </property>
+                            <property name="layoutDirection">
+                             <enum>Qt::LeftToRight</enum>
+                            </property>
+                            <property name="text">
+                             <string>Convert Change to Zerocoin (might cost additional fees)</string>
+                            </property>
+                           </widget>
+                          </item>
+                          <item>
+                           <widget class="QCheckBox" name="checkBoxMinimizeChange">
+                            <property name="toolTip">
+                             <string>If checked, the wallet tries to minimize the returning change instead of minimizing the number of spent denominations.</string>
+                            </property>
+                            <property name="text">
+                             <string>Minimize Change</string>
+                            </property>
+                           </widget>
+                          </item>
+                          <item>
+                           <spacer name="horizontalSpacer_6">
+                            <property name="orientation">
+                             <enum>Qt::Horizontal</enum>
+                            </property>
+                            <property name="sizeHint" stdset="0">
+                             <size>
+                              <width>40</width>
+                              <height>20</height>
+                             </size>
+                            </property>
+                           </spacer>
+                          </item>
+                         </layout>
                         </item>
                        </layout>
                       </item>

--- a/src/qt/forms/signverifymessagedialog.ui
+++ b/src/qt/forms/signverifymessagedialog.ui
@@ -42,9 +42,6 @@
        </item>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_1_SM">
-         <property name="spacing">
-          <number>0</number>
-         </property>
          <item>
           <widget class="QValidatedLineEdit" name="addressIn_SM">
            <property name="toolTip">
@@ -53,7 +50,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="addressBookButton_SM">
+          <widget class="QToolButton" name="addressBookButton_SM">
            <property name="toolTip">
             <string>Choose previously used address</string>
            </property>
@@ -67,13 +64,10 @@
            <property name="shortcut">
             <string>Alt+A</string>
            </property>
-           <property name="autoDefault">
-            <bool>false</bool>
-           </property>
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="pasteButton_SM">
+          <widget class="QToolButton" name="pasteButton_SM">
            <property name="toolTip">
             <string>Paste address from clipboard</string>
            </property>
@@ -86,9 +80,6 @@
            </property>
            <property name="shortcut">
             <string>Alt+P</string>
-           </property>
-           <property name="autoDefault">
-            <bool>false</bool>
            </property>
           </widget>
          </item>
@@ -113,9 +104,6 @@
        </item>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_2_SM">
-         <property name="spacing">
-          <number>0</number>
-         </property>
          <item>
           <widget class="QLineEdit" name="signatureOut_SM">
            <property name="font">
@@ -129,7 +117,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="copySignatureButton_SM">
+          <widget class="QToolButton" name="copySignatureButton_SM">
            <property name="toolTip">
             <string>Copy the current signature to the system clipboard</string>
            </property>
@@ -139,9 +127,6 @@
            <property name="icon">
             <iconset resource="../pivx.qrc">
              <normaloff>:/icons/editcopy</normaloff>:/icons/editcopy</iconset>
-           </property>
-           <property name="autoDefault">
-            <bool>false</bool>
            </property>
           </widget>
          </item>
@@ -252,9 +237,6 @@
        </item>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_1_VM">
-         <property name="spacing">
-          <number>0</number>
-         </property>
          <item>
           <widget class="QValidatedLineEdit" name="addressIn_VM">
            <property name="toolTip">
@@ -263,7 +245,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="addressBookButton_VM">
+          <widget class="QToolButton" name="addressBookButton_VM">
            <property name="toolTip">
             <string>Choose previously used address</string>
            </property>
@@ -276,9 +258,6 @@
            </property>
            <property name="shortcut">
             <string>Alt+A</string>
-           </property>
-           <property name="autoDefault">
-            <bool>false</bool>
            </property>
           </widget>
          </item>

--- a/src/qt/forms/zpivcontroldialog.ui
+++ b/src/qt/forms/zpivcontroldialog.ui
@@ -7,121 +7,184 @@
     <x>0</x>
     <y>0</y>
     <width>681</width>
-    <height>384</height>
+    <height>450</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>681</width>
-    <height>384</height>
+    <height>450</height>
    </size>
   </property>
   <property name="windowTitle">
    <string>Select zPiv to Spend</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <layout class="QFormLayout" name="formLayout">
-     <property name="sizeConstraint">
-      <enum>QLayout::SetDefaultConstraint</enum>
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0">
+     <property name="spacing">
+      <number>-1</number>
      </property>
-     <item row="0" column="0">
-      <widget class="QLabel" name="labelQuantity">
-       <property name="text">
-        <string>Quantity</string>
+     <property name="bottomMargin">
+      <number>10</number>
+     </property>
+     <item>
+      <layout class="QFormLayout" name="formLayout">
+       <property name="horizontalSpacing">
+        <number>10</number>
        </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLabel" name="labelQuantity_int">
-       <property name="text">
-        <string>0</string>
+       <property name="verticalSpacing">
+        <number>10</number>
        </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="labelZPiv">
-       <property name="text">
-        <string>zPiv</string>
+       <property name="leftMargin">
+        <number>6</number>
        </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLabel" name="labelZPiv_int">
-       <property name="text">
-        <string>0</string>
+       <property name="rightMargin">
+        <number>6</number>
        </property>
-      </widget>
+       <item row="0" column="0">
+        <widget class="QLabel" name="labelQuantity">
+         <property name="text">
+          <string>Quantity</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLabel" name="labelQuantity_int">
+         <property name="text">
+          <string>0</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="labelZPiv">
+         <property name="text">
+          <string>zPiv</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLabel" name="labelZPiv_int">
+         <property name="text">
+          <string>0</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
-     <item row="2" column="0">
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout3" stretch="0,0">
+     <property name="spacing">
+      <number>14</number>
+     </property>
+     <property name="bottomMargin">
+      <number>10</number>
+     </property>
+     <item>
       <widget class="QPushButton" name="pushButtonAll">
        <property name="text">
         <string>Select/Deselect All</string>
        </property>
       </widget>
      </item>
-    </layout>
-   </item>
-   <item row="1" column="0">
-    <layout class="QVBoxLayout" name="verticalLayout">
      <item>
-      <widget class="QTreeWidget" name="treeWidget">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>250</height>
-        </size>
-       </property>
-       <property name="alternatingRowColors">
-        <bool>true</bool>
-       </property>
-       <property name="sortingEnabled">
-        <bool>true</bool>
-       </property>
-       <property name="columnCount">
-        <number>5</number>
-       </property>
-       <attribute name="headerDefaultSectionSize">
-        <number>100</number>
-       </attribute>
-       <column>
-        <property name="text">
-         <string notr="true">Select</string>
-        </property>
-       </column>
-       <column>
-        <property name="text">
-         <string notr="true">Denomination</string>
-        </property>
-       </column>
-       <column>
-        <property name="text">
-         <string notr="true">zPiv Public ID</string>
-        </property>
-       </column>
-       <column>
-        <property name="text">
-         <string notr="true">Confirmations</string>
-        </property>
-       </column>
-       <column>
-        <property name="text">
-         <string>Is Spendable</string>
-        </property>
-       </column>
-      </widget>
-     </item>
-     <item>
-      <widget class="QDialogButtonBox" name="buttonBox">
+      <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
-       <property name="standardButtons">
-        <set>QDialogButtonBox::Ok</set>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
        </property>
-      </widget>
+      </spacer>
      </item>
     </layout>
+   </item>
+   <item>
+    <widget class="QTreeWidget" name="treeWidget">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>250</height>
+      </size>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
+     <property name="columnCount">
+      <number>5</number>
+     </property>
+     <attribute name="headerDefaultSectionSize">
+      <number>100</number>
+     </attribute>
+     <column>
+      <property name="text">
+       <string notr="true">Select</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string notr="true">Denomination</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string notr="true">zPiv Public ID</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string notr="true">Confirmations</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Is Spendable</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/qt/multisigdialog.cpp
+++ b/src/qt/multisigdialog.cpp
@@ -27,6 +27,7 @@
 #include <QtWidgets/QHBoxLayout>
 #include <QtWidgets/QLabel>
 #include <QtWidgets/QPushButton>
+#include <QtWidgets/QToolButton>
 #include <QtWidgets/QSpinBox>
 #include <QClipboard>
 #include <QDebug>
@@ -855,7 +856,7 @@ void MultisigDialog::on_addAddressButton_clicked()
     frameLayout->setContentsMargins(6, 6, 6, 6);
 
     QHBoxLayout* addressLayout = new QHBoxLayout();
-    addressLayout->setSpacing(0);
+    addressLayout->setSpacing(2);
     addressLayout->setObjectName(QStringLiteral("addressLayout"));
 
     QLabel* addressLabel = new QLabel(addressFrame);
@@ -867,32 +868,29 @@ void MultisigDialog::on_addAddressButton_clicked()
     address->setObjectName(QStringLiteral("address"));
     addressLayout->addWidget(address);
 
-    QPushButton* addressBookButton = new QPushButton(addressFrame);
+    QToolButton* addressBookButton = new QToolButton(addressFrame);
     addressBookButton->setObjectName(QStringLiteral("addressBookButton"));
     QIcon icon3;
     icon3.addFile(QStringLiteral(":/icons/address-book"), QSize(), QIcon::Normal, QIcon::Off);
     addressBookButton->setIcon(icon3);
-    addressBookButton->setAutoDefault(false);
     connect(addressBookButton, SIGNAL(clicked()), this, SLOT(addressBookButtonReceiving()));
 
     addressLayout->addWidget(addressBookButton);
 
-    QPushButton* addressPasteButton = new QPushButton(addressFrame);
+    QToolButton* addressPasteButton = new QToolButton(addressFrame);
     addressPasteButton->setObjectName(QStringLiteral("addressPasteButton"));
     QIcon icon4;
     icon4.addFile(QStringLiteral(":/icons/editpaste"), QSize(), QIcon::Normal, QIcon::Off);
     addressPasteButton->setIcon(icon4);
-    addressPasteButton->setAutoDefault(false);
     connect(addressPasteButton, SIGNAL(clicked()), this, SLOT(pasteText()));
 
     addressLayout->addWidget(addressPasteButton);
 
-    QPushButton* addressDeleteButton = new QPushButton(addressFrame);
+    QToolButton* addressDeleteButton = new QToolButton(addressFrame);
     addressDeleteButton->setObjectName(QStringLiteral("addressDeleteButton"));
     QIcon icon5;
     icon5.addFile(QStringLiteral(":/icons/remove"), QSize(), QIcon::Normal, QIcon::Off);
     addressDeleteButton->setIcon(icon5);
-    addressDeleteButton->setAutoDefault(false);
     connect(addressDeleteButton, SIGNAL(clicked()), this, SLOT(deleteFrame()));
 
     addressLayout->addWidget(addressDeleteButton);
@@ -930,6 +928,7 @@ void MultisigDialog::on_addInputButton_clicked()
     frameLayout->setContentsMargins(6, 6, 6, 6);
 
     QHBoxLayout* txInputLayout = new QHBoxLayout();
+    txInputLayout->setSpacing(2);
     txInputLayout->setObjectName(QStringLiteral("txInputLayout"));
 
     QLabel* txInputIdLabel = new QLabel(txInputFrame);
@@ -957,12 +956,11 @@ void MultisigDialog::on_addInputButton_clicked()
     txInputVout->setSizePolicy(sizePolicy);
     txInputLayout->addWidget(txInputVout);
 
-    QPushButton* inputDeleteButton = new QPushButton(txInputFrame);
+    QToolButton* inputDeleteButton = new QToolButton(txInputFrame);
     inputDeleteButton->setObjectName(QStringLiteral("inputDeleteButton"));
     QIcon icon;
     icon.addFile(QStringLiteral(":/icons/remove"), QSize(), QIcon::Normal, QIcon::Off);
     inputDeleteButton->setIcon(icon);
-    inputDeleteButton->setAutoDefault(false);
     connect(inputDeleteButton, SIGNAL(clicked()), this, SLOT(deleteFrame()));
     txInputLayout->addWidget(inputDeleteButton);
 
@@ -1009,12 +1007,11 @@ void MultisigDialog::on_addDestinationButton_clicked()
 
     destinationLayout->addWidget(destinationAmount);
 
-    QPushButton* destinationDeleteButton = new QPushButton(destinationFrame);
+    QToolButton* destinationDeleteButton = new QToolButton(destinationFrame);
     destinationDeleteButton->setObjectName(QStringLiteral("destinationDeleteButton"));
     QIcon icon;
     icon.addFile(QStringLiteral(":/icons/remove"), QSize(), QIcon::Normal, QIcon::Off);
     destinationDeleteButton->setIcon(icon);
-    destinationDeleteButton->setAutoDefault(false);
     connect(destinationDeleteButton, SIGNAL(clicked()), this, SLOT(deleteFrame()));
     destinationLayout->addWidget(destinationDeleteButton);
 
@@ -1055,12 +1052,11 @@ void MultisigDialog::on_addPrivKeyButton_clicked()
     key->setEchoMode(QLineEdit::Password);
     keyLayout->addWidget(key);
 
-    QPushButton* keyDeleteButton = new QPushButton(keyFrame);
+    QToolButton* keyDeleteButton = new QToolButton(keyFrame);
     keyDeleteButton->setObjectName(QStringLiteral("keyDeleteButton"));
     QIcon icon;
     icon.addFile(QStringLiteral(":/icons/remove"), QSize(), QIcon::Normal, QIcon::Off);
     keyDeleteButton->setIcon(icon);
-    keyDeleteButton->setAutoDefault(false);
     connect(keyDeleteButton, SIGNAL(clicked()), this, SLOT(deleteFrame()));
     keyLayout->addWidget(keyDeleteButton);
 

--- a/src/qt/res/css/default.css
+++ b/src/qt/res/css/default.css
@@ -1407,33 +1407,11 @@ padding-right:5px;
 
 /* QStackedWidget#SendCoinsEntry .QValidatedLineEdit#payTo { /* Pay To Input Field */
 /* QStackedWidget#SendCoinsEntry .QValidatedLineEdit#payTo:!focus { /* Pay To Input Field */
-
-QStackedWidget#SendCoinsEntry .QToolButton { /* General Settings for Pay To Icons */
-background-color: #5c4c7c; 
-border-width: 1px;
-border-style: outset;
-border-color: #382f44;
-border-radius: 2px;
-color:#ffffff;
-font-size:12px;
-font-weight:bold;
-margin: 2px;
-}    
-
-QStackedWidget#SendCoinsEntry .QToolButton:hover { /* General Settings for Pay To Icons */
-background-color: qlineargradient(y1:0, y2: 1, stop: 0 #ffffff, stop: 0.1 #ffffff, stop: 0.101 #6f5ca3, stop: 0.9 #6f5ca3, stop: 0.901 #ffffff, stop: 1 #ffffff);
-}    
-
-QStackedWidget#SendCoinsEntry .QToolButton:focus { /* General Settings for Pay To Icons */
-
-}    
-
-QStackedWidget#SendCoinsEntry .QToolButton:pressed { /* General Settings for Pay To Icons */
-border:1px solid #ffffff;
-}    
-    
+/* QStackedWidget#SendCoinsEntry .QToolButton { /* Pay To Custom ToolButton */
+/* QStackedWidget#SendCoinsEntry .QToolButton:hover { /* Pay To Custom ToolButton */
+/* QStackedWidget#SendCoinsEntry .QToolButton:focus { /* Pay To Custom ToolButton */
+/* QStackedWidget#SendCoinsEntry .QToolButton:pressed { /* Pay To Custom ToolButton */
 /* QStackedWidget#SendCoinsEntry .QToolButton#addressBookButton { /* Address Book Button */
-/* QStackedWidget#SendCoinsEntry .QToolButton#addressBookButton { */
 /* QStackedWidget#SendCoinsEntry .QToolButton#pasteButton { */
 /* QStackedWidget#SendCoinsEntry .QToolButton#deleteButton { */
 /* QStackedWidget#SendCoinsEntry .QLineEdit#addAsLabel { /* Pay To Input Field */
@@ -1578,6 +1556,12 @@ QDialog#CoinControlDialog .CoinControlTreeWidget#treeWidget::indicator { /* Coin
 
 }
 
+QDialog#ZPivControlDialog .QTreeWidget#treeWidget { /* zPIV Control Widget Container */
+outline:0;
+background-color:#ffffff;
+border:1px solid #333;
+}
+
 /**************************** RECEIVE COINS *********************************************/
 
 QWidget#ReceiveCoinsDialog {
@@ -1680,6 +1664,12 @@ background-color:#ffffff;
 
 QWidget#PrivacyDialog .QFrame#verticalFrameRight {
 background-color:#ffffff;
+}
+
+QWidget#PrivacyDialog .QToolButton {
+margin:2px;
+min-height: 24px;
+min-width: 24px;
 }
 
 /**************************** MASTERNODE LIST *******************************************/


### PR DESCRIPTION
This pulls out some UI refactoring and unrelated additions from #509 so they don't get held back.

- Standardize the use of QToolButton over QPushButton in instances where the button was being 
   used as a utility button (copy/paste/addressbook) buttons interacting with text inputs.
- Standardize the CSS styling of all QToolButton elements.
- Remove nefarious (empty) `placeholderText` properties from `.ui` files.
- Update strings in BIP38 dialog to match the functionality there.
- Change from returning Hex to returning WIF private key for decrypted BIP38 key.
- Update MultiSig/MultiSend UI's to use QToolButton

 See individual commit comments for full details.

### Rational for using a different button color for Tool Buttons
Tool buttons are never required to be used. They merely offer a shortcut (copy/paste/delete) or a utility to pull an address from the address book. Their scope is narrowly limited to a single UI element, usually a single text entry element.

In contrast, Push Buttons are actionable in a larger scope such as initiating a transaction, confirming a form, or showing coin control. They are typically required in one form or the other to have a user press them to complete the task at hand.



Screenshots Before:
![screen shot 2018-02-08 at 11 22 24 pm](https://user-images.githubusercontent.com/7393257/36019430-274701ce-0d34-11e8-948b-2a25f22a7a65.png)
![screen shot 2018-02-08 at 11 22 04 pm](https://user-images.githubusercontent.com/7393257/36019431-278681aa-0d34-11e8-8061-93c64977694b.png)
![screen shot 2018-02-08 at 11 24 56 pm](https://user-images.githubusercontent.com/7393257/36019442-375f9634-0d34-11e8-90ee-1023643e0442.png)
![screen shot 2018-02-08 at 11 24 45 pm](https://user-images.githubusercontent.com/7393257/36019443-377a1cfc-0d34-11e8-985c-e95db0a242c6.png)
![screen shot 2018-02-08 at 11 24 41 pm](https://user-images.githubusercontent.com/7393257/36019444-37951dd6-0d34-11e8-909d-750f894e8d10.png)
![screen shot 2018-02-08 at 11 24 00 pm](https://user-images.githubusercontent.com/7393257/36019445-37aee590-0d34-11e8-82e3-ebe89a57fc7e.png)
![screen shot 2018-02-08 at 11 23 47 pm](https://user-images.githubusercontent.com/7393257/36019446-37c7c68c-0d34-11e8-83ee-395a5bfed5af.png)


Screenshots After:
![screen shot 2018-02-09 at 12 09 18 am](https://user-images.githubusercontent.com/7393257/36019483-50f921a0-0d34-11e8-8449-32c61de35a9b.png)
![screen shot 2018-02-09 at 12 09 14 am](https://user-images.githubusercontent.com/7393257/36019484-5112b6a6-0d34-11e8-8729-713bd083ba4f.png)
![screen shot 2018-02-09 at 12 08 32 am](https://user-images.githubusercontent.com/7393257/36019485-512c54a8-0d34-11e8-962e-d17c3f0a8205.png)
![screen shot 2018-02-09 at 12 08 29 am](https://user-images.githubusercontent.com/7393257/36019486-5157ef00-0d34-11e8-8209-00f531385fed.png)
![screen shot 2018-02-09 at 12 09 35 am](https://user-images.githubusercontent.com/7393257/36019494-5868f0d2-0d34-11e8-8c62-2df53debd46b.png)
![screen shot 2018-02-09 at 12 09 24 am](https://user-images.githubusercontent.com/7393257/36019499-5b2feb72-0d34-11e8-99bd-8513ef98752d.png)
![screen shot 2018-02-09 at 12 09 51 am](https://user-images.githubusercontent.com/7393257/36019541-7d472b30-0d34-11e8-8e5a-7f2d7b4d3cf9.png)
