### PR TITLE
[Qt] Fix warning dialog popup for the Blockchain Explorer

### DIFF
--- a/src/qt/blockexplorer.cpp
+++ b/src/qt/blockexplorer.cpp
@@ -472,7 +472,7 @@ void BlockExplorer::showEvent(QShowEvent*)
         m_History.push_back(text);
         updateNavButtons();
 
-        if (!GetBoolArg("-txindex", false)) {
+        if (!GetBoolArg("-txindex", true)) {
             QString Warning = tr("Not all transactions will be shown. To view all transactions you need to set txindex=1 in the configuration file (pivx.conf).");
             QMessageBox::warning(this, "PIVX Core Blockchain Explorer", Warning, QMessageBox::Ok);
         }


### PR DESCRIPTION
We have `txindex` enabled by default, but the check here was expecting
it to be disabled by default so the warning dialog was being displayed
informing users that they would need to enable a setting that was
already enabled.

Trivial change.