### PR TITLE
[Trivial] Fix errant LogPrint in UpdateZPIVSupply

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3235,7 +3235,7 @@ bool UpdateZPIVSupply(const CBlock& block, CBlockIndex* pindex)
     }
 
     for (auto& denom : zerocoinDenomList)
-        LogPrint("zero" "%s coins for denomination %d pubcoin %s\n", __func__, pindex->mapZerocoinSupply.at(denom), denom);
+        LogPrint("zero", "%s coins for denomination %d pubcoin %s\n", __func__, denom, pindex->mapZerocoinSupply.at(denom));
 
     return true;
 }


### PR DESCRIPTION
The `LogPrint()` at the end of this function was missing a `,` separator
between the category and the message, as well as returning the two
paramaters in reverse order when compared to similar log prints.

The missing `,` was causing a segfault when running with `-debug` or
`-debug=zero`