### PR TITLE
[Build] Revert #402 "Change git info in genbuild.sh"

### DIFF
--- a/share/genbuild.sh
+++ b/share/genbuild.sh
@@ -21,9 +21,14 @@ if [ -e "$(which git 2>/dev/null)" -a "$(git rev-parse --is-inside-work-tree 2>/
     git diff >/dev/null 2>/dev/null 
 
     # if latest commit is tagged and not dirty, then override using the tag name
-    DESC=$(git describe 2>/dev/null)
     RAWDESC=$(git describe --abbrev=0 2>/dev/null)
-    git diff-index --quiet HEAD -- || DESC="$DESC-dirty"
+    if [ "$(git rev-parse HEAD)" = "$(git rev-list -1 $RAWDESC)" ]; then
+        git diff-index --quiet HEAD -- && DESC=$RAWDESC
+    fi
+
+    # otherwise generate suffix from git, i.e. string like "59887e8-dirty"
+    SUFFIX=$(git rev-parse --short HEAD)
+    git diff-index --quiet HEAD -- || SUFFIX="$SUFFIX-dirty"
 
     # get a string like "2012-04-10 16:27:19 +0200"
     LAST_COMMIT_DATE="$(git log -n 1 --format="%ci")"
@@ -31,6 +36,8 @@ fi
 
 if [ -n "$DESC" ]; then
     NEWINFO="#define BUILD_DESC \"$DESC\""
+elif [ -n "$SUFFIX" ]; then
+    NEWINFO="#define BUILD_SUFFIX $SUFFIX"
 else
     NEWINFO="// No build information available"
 fi


### PR DESCRIPTION
The previous change required tagging on `master`, which we don't do. As
a result, the version string displayed in-wallet was always displaying
based off of a dummy tag that was pushed during the review of #402.

This PR restores the functionality to generate the version string
without relying on superficial tags.

This reverts commit 8fa5f125e558bc4951e8af0ecea4f066813e4a66.