### PR TITLE
[Bug] Segfault with -enableswifttx=0 / -enableswifttx=false

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -827,7 +827,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     }
 
     if (!GetBoolArg("-enableswifttx", fEnableSwiftTX)) {
-        if (SoftSetArg("-swifttxdepth", 0))
+        if (SoftSetArg("-swifttxdepth", "0"))
             LogPrintf("AppInit2 : parameter interaction: -enableswifttx=false -> setting -nSwiftTXDepth=0\n");
     }
 


### PR DESCRIPTION
String references with a value of `(int) 0` considered harmful.