### PR TITLE
[Wallet/RPC] Add argument to mint zerocoin from specific UTXO

### DIFF
--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -125,6 +125,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
         {"listspentzerocoins", 0},
         {"listzerocoinamounts", 0},
         {"mintzerocoin", 0},
+        {"mintzerocoin", 1},
         {"spendzerocoin", 0},
         {"spendzerocoin", 1},
         {"spendzerocoin", 2},

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -2481,16 +2481,31 @@ UniValue listspentzerocoins(const UniValue& params, bool fHelp)
 
 UniValue mintzerocoin(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
+    if (fHelp || params.size() < 1 || params.size() > 2)
         throw runtime_error(
-            "mintzerocoin <amount>\n"
-            "Usage: Enter an amount of Piv to convert to zPiv"
+            "mintzerocoin <amount> [UTXOs]\n"
+            "amount: Enter an amount of Piv to convert to zPiv\n"
+            "UTXOs: (string, optional) A json array of objects. Each object the txid (string) vout (numeric)\n"
+            "     [           (json array of json objects)\n"
+            "       {\n"
+            "         \"txid\":\"id\",    (string) The transaction id\n"
+            "         \"vout\": n         (numeric) The output number\n"
+            "       }\n"
+            "       ,...\n"
+            "     ]\n"
             + HelpRequiringPassphrase());
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
-    int64_t nTime = GetTimeMillis();
+    if (params.size() == 1)
+    {
+        RPCTypeCheck(params, boost::assign::list_of(UniValue::VNUM));
+    } else
+    {
+        RPCTypeCheck(params, boost::assign::list_of(UniValue::VNUM)(UniValue::VARR));
+    }
 
+    int64_t nTime = GetTimeMillis();
     if(GetAdjustedTime() > GetSporkValue(SPORK_16_ZEROCOIN_MAINTENANCE_MODE))
         throw JSONRPCError(RPC_WALLET_ERROR, "zPIV is currently disabled due to maintenance.");
 
@@ -2501,7 +2516,36 @@ UniValue mintzerocoin(const UniValue& params, bool fHelp)
 
     CWalletTx wtx;
     vector<CZerocoinMint> vMints;
-    string strError = pwalletMain->MintZerocoin(nAmount, wtx, vMints);
+    string strError;
+    vector<COutPoint> vOutpts;
+
+    if (params.size() == 2)
+    {
+        UniValue outputs = params[1].get_array();
+        for (unsigned int idx = 0; idx < outputs.size(); idx++) {
+            const UniValue& output = outputs[idx];
+            if (!output.isObject())
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, expected object");
+            const UniValue& o = output.get_obj();
+
+            RPCTypeCheckObj(o, boost::assign::map_list_of("txid", UniValue::VSTR)("vout", UniValue::VNUM));
+
+            string txid = find_value(o, "txid").get_str();
+            if (!IsHex(txid))
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, expected hex txid");
+
+            int nOutput = find_value(o, "vout").get_int();
+            if (nOutput < 0)
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, vout must be positive");
+
+            COutPoint outpt(uint256(txid), nOutput);
+            vOutpts.push_back(outpt);
+        }
+        strError = pwalletMain->MintZerocoinFromOutPoint(nAmount, wtx, vMints, vOutpts);
+    } else
+    {
+        strError = pwalletMain->MintZerocoin(nAmount, wtx, vMints);
+    }
 
     if (strError != "")
         throw JSONRPCError(RPC_WALLET_ERROR, strError);

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -2483,9 +2483,9 @@ UniValue mintzerocoin(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() < 1 || params.size() > 2)
         throw runtime_error(
-            "mintzerocoin <amount> [UTXOs]\n"
-            "amount: Enter an amount of Piv to convert to zPiv\n"
-            "UTXOs: (string, optional) A json array of objects. Each object the txid (string) vout (numeric)\n"
+            "mintzerocoin amount ( UTXOs )\n"
+            "amount: (numeric, required) Enter an amount of Piv to convert to zPiv\n"
+            "UTXOs: (string, optional) A json array of objects. Each object needs the txid (string) and vout (numeric)\n"
             "     [           (json array of json objects)\n"
             "       {\n"
             "         \"txid\":\"id\",    (string) The transaction id\n"
@@ -2493,6 +2493,13 @@ UniValue mintzerocoin(const UniValue& params, bool fHelp)
             "       }\n"
             "       ,...\n"
             "     ]\n"
+            "\nExamples:\n"
+            "\nMint 50 from anywhere\n" +
+            HelpExampleCli("mintzerocoin", "50") +
+            "\nMint 13 from a specific output\n" + 
+            HelpExampleCli("mintzerocoin", "13 \"[{\\\"txid\\\":\\\"a08e6907dbbd3d809776dbfc5d82e371b764ed838b5655e72f463568df1aadf0\\\",\\\"vout\\\":1}]\"") +
+            "\nAs a json rpc call\n" + 
+            HelpExampleRpc("mintzerocoin", "13, \"[{\\\"txid\\\":\\\"a08e6907dbbd3d809776dbfc5d82e371b764ed838b5655e72f463568df1aadf0\\\",\\\"vout\\\":1}]\"")
             + HelpRequiringPassphrase());
 
     LOCK2(cs_main, pwalletMain->cs_wallet);

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -4906,6 +4906,22 @@ void CWallet::ZPivBackupWallet()
     BackupWallet(*this, backupPath.string());
 }
 
+string CWallet::MintZerocoinFromOutPoint(CAmount nValue, CWalletTx& wtxNew, vector<CZerocoinMint>& vMints, const vector<COutPoint> vOutpts)
+{
+    CCoinControl* coinControl = new CCoinControl();
+    for (const COutPoint& outpt : vOutpts) {
+        coinControl->Select(outpt);
+    }
+    if (!coinControl->HasSelected()){
+        string strError = _("Error: No valid utxo!");
+        LogPrintf("MintZerocoin() : %s", strError.c_str());
+        return strError;
+    }
+    string strError = MintZerocoin(nValue, wtxNew, vMints, coinControl);
+    delete coinControl;
+    return strError;
+}
+
 string CWallet::MintZerocoin(CAmount nValue, CWalletTx& wtxNew, vector<CZerocoinMint>& vMints, const CCoinControl* coinControl)
 {
     // Check amount

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -202,6 +202,7 @@ public:
     bool CreateZerocoinMintTransaction(const CAmount nValue, CMutableTransaction& txNew, vector<CZerocoinMint>& vMints, CReserveKey* reservekey, int64_t& nFeeRet, std::string& strFailReason, const CCoinControl* coinControl = NULL, const bool isZCSpendChange = false);
     bool CreateZerocoinSpendTransaction(CAmount nValue, int nSecurityLevel, CWalletTx& wtxNew, CReserveKey& reserveKey, CZerocoinSpendReceipt& receipt, vector<CZerocoinMint>& vSelectedMints, vector<CZerocoinMint>& vNewMints, bool fMintChange,  bool fMinimizeChange, CBitcoinAddress* address = NULL);
     bool MintToTxIn(CZerocoinMint zerocoinSelected, int nSecurityLevel, const uint256& hashTxOut, CTxIn& newTxIn, CZerocoinSpendReceipt& receipt);
+    std::string MintZerocoinFromOutPoint(CAmount nValue, CWalletTx& wtxNew, vector<CZerocoinMint>& vMints, const vector<COutPoint> vOutpts);
     std::string MintZerocoin(CAmount nValue, CWalletTx& wtxNew, vector<CZerocoinMint>& vMints, const CCoinControl* coinControl = NULL);
     bool SpendZerocoin(CAmount nValue, int nSecurityLevel, CWalletTx& wtxNew, CZerocoinSpendReceipt& receipt, vector<CZerocoinMint>& vMintsSelected, bool fMintChange, bool fMinimizeChange, CBitcoinAddress* addressTo = NULL);
     std::string ResetMintZerocoin(bool fExtendedSearch);


### PR DESCRIPTION
This PR allows to use an extra argument when calling the `mintzerocoin` RPC function. 
The argument is optional and takes a json formated array of UTXOs. If the argument is provided, the minting will only use inputs from this UTXO set.