### PR TITLE
[Wallet] Add a check on zPIV spend to avoid a segfault

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -4677,7 +4677,13 @@ bool CWallet::CreateZerocoinSpendTransaction(CAmount nValue, int nSecurityLevel,
             CScript scriptZerocoinSpend;
             CScript scriptChange;
             CAmount nChange = nValueSelected - nValue;
-            if (nChange && !address) {
+
+            if (nChange < 0) {
+                receipt.SetStatus(_("Selected coins value is less than payment target"), nStatus);
+                return false;
+            }
+
+            if (nChange > 0 && !address) {
                 receipt.SetStatus(_("Need address because change is not exact"), nStatus);
                 return false;
             }


### PR DESCRIPTION
I stumbled upon a segmentation fault yesterday while trying to get rid of my zPIVs V1 on testnet. Turns out I did a mistake and was trying to make a spend with a value above the sum of selected coins.
This should result on a warning and stop the transaction instead of segfaulting, hence this fix.