### PR TITLE
[Qt] Refresh zPIV balance after resetting mints or spends

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -567,6 +567,12 @@ static void NotifyZerocoinChanged(WalletModel* walletmodel, CWallet* wallet, con
                               Q_ARG(int, status));
 }
 
+static void NotifyzPIVReset(WalletModel* walletmodel)
+{
+    qDebug() << "NotifyzPIVReset";
+    QMetaObject::invokeMethod(walletmodel, "checkBalanceChanged", Qt::QueuedConnection);
+}
+
 void WalletModel::subscribeToCoreSignals()
 {
     // Connect signals to wallet
@@ -577,6 +583,7 @@ void WalletModel::subscribeToCoreSignals()
     wallet->NotifyWatchonlyChanged.connect(boost::bind(NotifyWatchonlyChanged, this, _1));
     wallet->NotifyMultiSigChanged.connect(boost::bind(NotifyMultiSigChanged, this, _1));
     wallet->NotifyZerocoinChanged.connect(boost::bind(NotifyZerocoinChanged, this, _1, _2, _3, _4));
+    wallet->NotifyzPIVReset.connect(boost::bind(NotifyzPIVReset, this));
 }
 
 void WalletModel::unsubscribeFromCoreSignals()
@@ -589,6 +596,7 @@ void WalletModel::unsubscribeFromCoreSignals()
     wallet->NotifyWatchonlyChanged.disconnect(boost::bind(NotifyWatchonlyChanged, this, _1));
     wallet->NotifyMultiSigChanged.disconnect(boost::bind(NotifyMultiSigChanged, this, _1));
     wallet->NotifyZerocoinChanged.disconnect(boost::bind(NotifyZerocoinChanged, this, _1, _2, _3, _4));
+    wallet->NotifyzPIVReset.disconnect(boost::bind(NotifyzPIVReset, this));
 }
 
 // WalletModel::UnlockContext implementation

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -249,7 +249,7 @@ private:
 
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();
-    void checkBalanceChanged();
+    Q_INVOKABLE void checkBalanceChanged();
 
 signals:
     // Signal that balance in wallet changed

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -4791,6 +4791,8 @@ string CWallet::ResetMintZerocoin(bool fExtendedSearch)
         walletdb.ArchiveMintOrphan(mint);
     }
 
+    NotifyzPIVReset();
+
     string strResult = _("ResetMintZerocoin finished: ") + to_string(updates) + _(" mints updated, ") + to_string(deletions) + _(" mints deleted\n");
     return strResult;
 }
@@ -4829,6 +4831,8 @@ string CWallet::ResetSpentZerocoin()
             }
         }
     }
+
+    NotifyzPIVReset();
 
     string strResult = _("ResetSpentZerocoin finished: ") + to_string(removed) + _(" unconfirmed transactions removed\n");
     return strResult;

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -642,6 +642,9 @@ public:
 
     /** MultiSig address added */
     boost::signals2::signal<void(bool fHaveMultiSig)> NotifyMultiSigChanged;
+
+    /** zPIV reset */
+    boost::signals2::signal<void()> NotifyzPIVReset;
 };
 
 


### PR DESCRIPTION
What the title says. When hitting the reset or rescan button, zPIV balance will be updated accordingly without the need to change view and come back.