### PR TITLE
Fixed Multisend dialog to show settings properly

### DIFF
--- a/src/qt/multisenddialog.cpp
+++ b/src/qt/multisenddialog.cpp
@@ -71,7 +71,7 @@ void MultiSendDialog::on_viewButton_clicked()
     std::string strMultiSendPrint = "";
     if (pwalletMain->isMultiSendEnabled()) {
         if (pwalletMain->fMultiSendStake && pwalletMain->fMultiSendMasternodeReward)
-            strMultiSendPrint += "MultiSend Active for Stakes and Masternode Reward\n";
+            strMultiSendPrint += "MultiSend Active for Stakes and Masternode Rewards\n";
         else if (pwalletMain->fMultiSendStake)
             strMultiSendPrint += "MultiSend Active for Stakes\n";
         else if (pwalletMain->fMultiSendMasternodeReward)

--- a/src/qt/multisenddialog.cpp
+++ b/src/qt/multisenddialog.cpp
@@ -70,9 +70,11 @@ void MultiSendDialog::on_viewButton_clicked()
     std::pair<std::string, int> pMultiSend;
     std::string strMultiSendPrint = "";
     if (pwalletMain->isMultiSendEnabled()) {
-        if (pwalletMain->fMultiSendStake)
-            strMultiSendPrint += "MultiSend Active for Stakes\n";
+        if (pwalletMain->fMultiSendStake && pwalletMain->fMultiSendMasternodeReward)
+            strMultiSendPrint += "MultiSend Active for Stakes and Masternode Reward\n";
         else if (pwalletMain->fMultiSendStake)
+            strMultiSendPrint += "MultiSend Active for Stakes\n";
+        else if (pwalletMain->fMultiSendMasternodeReward)
             strMultiSendPrint += "MultiSend Active for Masternode Rewards\n";
     } else
         strMultiSendPrint += "MultiSend Not Active\n";


### PR DESCRIPTION
Multisend will display a message if it has only been enabled for masternodes and if its enabled for both (Displaying this didnt work if multisend was only enabled for masternodes)