### PR TITLE
[Docs] Update historic release notes

### DIFF
--- a/doc/release-notes/release-notes-3.0.4.md
+++ b/doc/release-notes/release-notes-3.0.4.md
@@ -1,0 +1,123 @@
+PIVX Core version 3.0.4 is now available from:
+
+  <https://github.com/pivx-project/pivx/releases>
+
+This is a new minor-revision version release, including various bug fixes and
+performance improvements, as well as updated translations.
+
+Please report bugs using the issue tracker at github:
+
+  <https://github.com/pivx-project/pivx/issues>
+
+
+Mandatory Update
+==============
+
+PIVX Core v3.0.4 is a mandatory update for all users. This release contains various updates/fixes pertaining to the zPIV protocol, supply tracking, block transmission and relaying, as well as usability and quality-of-life updates to the GUI.
+
+Users will have a grace period to update their clients before versions prior to this release are no longer allowed to connect to this (and future) version(s).
+
+
+How to Upgrade
+==============
+
+If you are running an older version, shut it down. Wait until it has completely shut down (which might take a few minutes for older versions), then run the installer (on Windows) or just copy over /Applications/PIVX-Qt (on Mac) or pivxd/pivx-qt (on Linux).
+
+
+Compatibility
+==============
+
+PIVX Core is extensively tested on multiple operating systems using
+the Linux kernel, macOS 10.8+, and Windows Vista and later.
+
+Microsoft ended support for Windows XP on [April 8th, 2014](https://www.microsoft.com/en-us/WindowsForBusiness/end-of-xp-support),
+No attempt is made to prevent installing or running the software on Windows XP, you
+can still do so at your own risk but be aware that there are known instabilities and issues.
+Please do not report issues about Windows XP to the issue tracker.
+
+PIVX Core should also work on most other Unix-like systems but is not
+frequently tested on them.
+
+### :exclamation::exclamation::exclamation: MacOS 10.13 High Sierra :exclamation::exclamation::exclamation:
+
+**Currently there are issues with the 3.0.x gitian releases on MacOS version 10.13 (High Sierra), no reports of issues on older versions of MacOS. As such, a High Sierra Only version is included below.**
+
+
+Notable Changes
+===============
+
+Refactoring of zPiv Spend Validation Code
+---------------------
+zPiv spend validation was too rigid and did not give enough slack for reorganizations. Many staking wallets were unable to reorganize back to the correct blockchain when they had an orphan stake which contained a zPiv spend. zPiv double spending validation has been refactored to properly account for reorganization.
+
+Money Supply Calculation Fix
+---------------------
+Coin supply incorrectly was counting spent zPiv as newly minted coins that are added to the coin supply, thus resulting in innacurate coin supply data.
+
+The coin supply is now correctly calculated. If a new wallet client is synced from scratch or if `-reindex=1` is used then the correct money supply will be calculated. If neither of these two options are used, the wallet client will automatically reindex the money supply calculations upon the first time opening the software after updating to v3.0.4. The reindex takes approximately 10-60 minutes depending on the hardware used. If the reindex is exited mid-process, it will continue where it left off upon restart.
+
+Better Filtering of Transactions in Stake Miner
+---------------------
+The stake miner code now filters out zPiv double spends that were on rare occasions being slipped into blocks (and being rejected by peers when broadcast to the network).
+
+More Responsive Shutdown Requests
+---------------------
+When computationally expensive accumulator calculations are being performed and the user requests to close the application, the wallet will exit much sooner than before.
+
+More Extensive Display of zPiv Confirmation/Maturity Status
+---------------------
+Within the Privacy Dialog of the QT wallet, the _Zerocoin Stats_ section now displays both the confirmation and maturity status of minted zPiv's. Previously this was only able to be viewed within the zPiv Control dialog. The main Overview tab of the QT wallet now splits zPiv balance into subcategories: _Unconfirmed_, _Immature_, and _Mature_.
+
+3.0.4 Change log
+=================
+
+Detailed release notes follow. This overview includes changes that affect
+behavior, not code moves, refactors and string updates. For convenience in locating
+the code changes and accompanying discussion, both the pull request and
+git merge commit are mentioned.
+
+### P2P Protocol and Network Code
+- #294 `27c0943` Add additional checks for txid for zpiv spend. (presstab)
+- #301 `b8392cd` Refactor zPiv tx counting code. Add a final check in ConnectBlock() (presstab)
+- #306 `77dd55c` [Core] Don't send not-validated blocks (Mrs-X)
+- #312 `5d79bea` [Main] Update last checkpoint data (Fuzzbawls)
+- #325 `7d98ebe` Reindex zPiv blocks and correct stats. (presstab)
+- #327 `aa1235a` [Main] Don't limit zPIV spends from getting into the mempool (Fuzzbawls)
+- #329 `19b38b2` Update checkpoints. (presstab)
+- #331 `b1fb710` [Consensus] Bump protocol. Activate via Spork 15. (rejectedpromise)
+
+### Wallet
+- #308 `bd8a982` [Minting] Clear mempool after invalid block from miner (presstab)
+- #316 `ed192cf` [Minting] Better filtering of zPiv serials in miner. (presstab)
+
+### GUI
+- #309 `f560ffc` [UI] Better error message when too much inputs are used for spending zPIV (Mrs-X)
+- #317 `b27cb72` [UI] Wallet repair option to resync from scratch (Mrs-X)
+- #323 `2b648be` [UI] Balance fix + bubble-help + usability improvements (Mrs-X)
+- #324 `8cdbb5d` disable negative confirmation numbers. (Mrs-X)
+
+### Build System
+- #322 `a91feb3` [Build] Add compile/link summary to configure (Fuzzbawls)
+
+### Miscellaneous
+- #298 `3580394` Reorg help to stop travis errors (Jon Spock)
+- #302 `efb648b` [Cleanup] Remove unused variables (rejectedpromise)
+- #307 `dbd801d` Remove hard-coded GIT_ARCHIVE define (Jon Spock)
+- #314 `f1c830a` Fix issue causing crash when pivxd --help was invoked (Jon Spock)
+- #326 `8b6a13e` Combine 2 LogPrintf statement to reduce debug.log clutter (Jon Spock)
+- #328 `a6c18c8` [Main] PIVX not responding on user quitting app (Aaron Langford)
+
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+- Fuzzbawls
+- Jon Spock
+- Mrs-X
+- furszy
+- presstab
+- rejectedpromise
+- aaronlangford31
+
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/pivx-project-translations/).

--- a/doc/release-notes/release-notes-3.0.5.1.md
+++ b/doc/release-notes/release-notes-3.0.5.1.md
@@ -1,0 +1,12 @@
+We have found that a runtime error that has caused the PIVX wallet on certain operating systems to get stuck at block 908000. This build of the wallet fixes the runtime error.
+
+If you are stuck on block 908000:
+- Download the 3.0.5.1 wallet (the file names do not display the "build" version and cutoff the 1)
+- Start the wallet. Block 908000 and 908001 have some computation that occurs and it is normal for them to take longer to process than a typical block would.
+
+If you are stuck on a block before 908000:
+- Download the 3.0.5.1 wallet (the file names do not display the "build" version and cutoff the 1)
+- Start the wallet with `reindexaccumulators=1` in your `pivx.conf` file (you can figure out the location of your `pivx.conf` [here](https://pivx.freshdesk.com/support/solutions/articles/30000004664-where-are-my-wallet-dat-blockchain-and-configuration-conf-files-located-) )
+- After starting the wallet, remove `reindexaccumulators=1` from your `pivx.conf` or else it will perform this operation each time you start your wallet.
+
+If both of those solutions failed you can use the [blockchain snapshot](http://178.254.23.111/~pub/PIVX/Daily-Snapshots-Html/PIVX-Daily-Snapshots.html). If using the snapshot, please carefully follow the instructions on the snapshot page.

--- a/doc/release-notes/release-notes-3.0.5.md
+++ b/doc/release-notes/release-notes-3.0.5.md
@@ -1,0 +1,111 @@
+PIVX Core version 3.0.5 is now available from:
+
+  <https://github.com/pivx-project/pivx/releases>
+
+This is a new minor-revision version release, including various bug fixes and
+performance improvements, as well as updated translations.
+
+Please report bugs using the issue tracker at github:
+
+  <https://github.com/pivx-project/pivx/issues>
+
+
+Mandatory Update
+==============
+
+PIVX Core v3.0.5 is a mandatory update for all users. This release contains various updates/fixes pertaining to the zPIV protocol, supply tracking, block transmission and relaying, as well as usability and quality-of-life updates to the GUI. Users are required to update before block `908000` which is when the accumulators will be refactored. Shortly after that block, zPIV transactions will be enabled. **When zPIV is enabled, autominting will also be enabled.** If you would like to disable automatic conversion of 10% of your PIV balance to zPIV, then you will need to add `enablezeromint=0` to your `pivx.conf` file. For information about where to find your pivx.conf you can visit this link from [PIVX Support](https://pivx.freshdesk.com/support/solutions/articles/30000004664-where-are-my-wallet-dat-blockchain-and-configuration-conf-files-located-).
+
+Users will have a grace period to update their clients before versions prior to this release are no longer allowed to connect to this (and future) version(s).
+
+
+How to Upgrade
+==============
+
+If you are running an older version, shut it down. Wait until it has completely shut down (which might take a few minutes for older versions), then run the installer (on Windows) or just copy over /Applications/PIVX-Qt (on Mac) or pivxd/pivx-qt (on Linux).
+
+
+Compatibility
+==============
+
+PIVX Core is extensively tested on multiple operating systems using
+the Linux kernel, macOS 10.8+, and Windows Vista and later.
+
+Microsoft ended support for Windows XP on [April 8th, 2014](https://www.microsoft.com/en-us/WindowsForBusiness/end-of-xp-support),
+No attempt is made to prevent installing or running the software on Windows XP, you
+can still do so at your own risk but be aware that there are known instabilities and issues.
+Please do not report issues about Windows XP to the issue tracker.
+
+PIVX Core should also work on most other Unix-like systems but is not
+frequently tested on them.
+
+### :exclamation::exclamation::exclamation: MacOS 10.13 High Sierra :exclamation::exclamation::exclamation:
+
+**Currently there are issues with the 3.0.x gitian releases on MacOS version 10.13 (High Sierra), no reports of issues on older versions of MacOS. As such, a High Sierra Only version is included below.**
+
+
+Notable Changes
+===============
+
+Accumulator Code Refactor
+---------------------
+The zPIV accumulator code has undergone a major refactor. Accumulators are one of the most essential components of the zerocoin protocol, and also one of the most computationally expensive parts of the protocol. This refactoring speeds up syncing and spending of zPIV by over 5x. The new code also allows for spending of zPIV with only 2 required mints occurring on the network after your mint has been added, whereas before 3 were required. This refactor allows for lighter resource load and a smoother user experience.
+
+libzerocoin Exploit Fix
+---------------------
+zPIV relies on a 3rd party library called libzerocoin. All currencies that utilize the zerocoin protocol use libzerocoin, and many of those currencies have been exposed to an exploit which allowed for the creation of multiple zero-knowledge spending proofs for one single zerocoin mint. The PIVX developers were able properly identify the exploit, track down any fraudulent spending proofs, link the fraudulent spending proofs with their one valid proof that they were mutated from, and remove any mints from the accumulators that were derived from the invalid spends. 
+
+zPIV Maintenance Mode Spork
+---------------------
+Handling the above noted libzerocoin exploit required the PIVX team to immediately release a patched wallet to as many users as possible which rejected bad spends and also disabled all zPIV transactions in general. The process of releasing a patched wallet in such a small time frame is frustrating and difficult for all members of the PIVX team and especially users of PIVX. The PIVX developers have added a new spork which allows for zPIV transacting to be turned on/off without having to release a patched wallet. This will allow much smoother operation if any problems occur in the future, and should also allow exchanges and 3rd party services to continue to operate even if zPIV is in maintenance mode.
+
+Money Supply Indexing
+---------------------
+The exploit in libzerocoin threw off some of the wallet's internal money supply calculations for both the zPIV supply and the PIV supply. User's wallet's will automatically recalculate the supply on block `908001`. User's also have the ability to recalculate supply using the startup flag `reindexmoneysupply`.
+
+More Extensive Tracking of zPIV Supply Through RPC
+---------------------
+More information has been added to the `getinfo` and `getblock` RPC calls, which now display the total zPIV supply as well as the balance for each zPIV accumulator.
+
+Multisig GUI
+---------------------
+Provides functionality which is currently only available through raw transactions. Multisignature addresses require signatures from multiple parties before coins belonging to the address are spent. Accessed through the File dropdown menu.
+
+
+3.0.5 Change log
+=================
+
+Detailed release notes follow. This overview includes changes that affect
+behavior, not code moves, refactors and string updates. For convenience in locating
+the code changes and accompanying discussion, both the pull request and
+git merge commit are mentioned.
+
+### P2P Protocol and Network Code
+- #339 `559492a` [Main] Refactor Accumulator Code (presstab)
+- #390 `TBD` [MAIN] Libzerocoin patch (presstab)
+
+### Wallet
+- #308 `bd8a982` [Minting] Clear mempool after invalid block from miner (presstab)
+- #316 `ed192cf` [Minting] Better filtering of zPiv serials in miner. (presstab)
+
+### GUI
+- #278 `46f4960` [QT] Multisignature GUI (rejectedpromise)
+- #340 `6a4eef1` [QT] Show the current block in the progress bar. (presstab)
+- #365 `c66d015` [UI] Rename SwiftTX -> SwiftX (Mrs-X)
+
+### Build System
+- #382 `4a412d4` Gitian hack so gitian Mac builds notify user about incompatibility on High Sierra (Jon Spock)
+
+### Miscellaneous
+- #332 `0c2cd61` [Docs] Add missing archived release notes (Fuzzbawls)
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+- Fuzzbawls
+- Jon Spock
+- Mrs-X
+- presstab
+- rejectedpromise
+
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/pivx-project-translations/).

--- a/doc/release-notes/release-notes-3.0.6.md
+++ b/doc/release-notes/release-notes-3.0.6.md
@@ -1,0 +1,119 @@
+PIVX Core version 3.0.6 is now available from:
+
+  <https://github.com/pivx-project/pivx/releases>
+
+This is a new minor-revision version release, including various bug fixes and
+performance improvements, as well as updated translations.
+
+Please report bugs using the issue tracker at github:
+
+  <https://github.com/pivx-project/pivx/issues>
+
+
+How to Upgrade
+==============
+
+If you are running an older version, shut it down. Wait until it has completely shut down (which might take a few minutes for older versions), then run the installer (on Windows) or just copy over /Applications/PIVX-Qt (on Mac) or pivxd/pivx-qt (on Linux).
+
+
+Compatibility
+==============
+
+PIVX Core is extensively tested on multiple operating systems using
+the Linux kernel, macOS 10.8+, and Windows Vista and later.
+
+Microsoft ended support for Windows XP on [April 8th, 2014](https://www.microsoft.com/en-us/WindowsForBusiness/end-of-xp-support),
+No attempt is made to prevent installing or running the software on Windows XP, you
+can still do so at your own risk but be aware that there are known instabilities and issues.
+Please do not report issues about Windows XP to the issue tracker.
+
+PIVX Core should also work on most other Unix-like systems but is not
+frequently tested on them.
+
+### :exclamation::exclamation::exclamation: MacOS 10.13 High Sierra :exclamation::exclamation::exclamation:
+
+**Currently there are issues with the 3.0.x gitian releases on MacOS version 10.13 (High Sierra), no reports of issues on older versions of MacOS. As such, a High Sierra Only version is included below.**
+
+
+Notable Changes
+===============
+
+Automated Database Corruption Repair
+---------------------
+There have been cases of blockchain database corruption that can occur when PIVX client is not closed gracefully. The most common cases of corruption have been identified and the wallet will now automatically fix most of these corruptions. Certain corruption states are still unable to be fixed, but now provide more detailed error messages to the user as well as prompting the user to reindex their database.
+
+More Accurate Error Messages
+---------------------
+Some error messages in the wallet have been too vague and done little to help developers and the support team properly identify issues. Error messages have been refined and are now more specific.
+
+Reduction of Debug Log Spam
+---------------------
+Many 3rd party services have reported that their debug logs have been overloaded with messages about unknown transaction types. This log spam has been fixed.
+
+Removal of Heavy Running Transaction Search Code
+---------------------
+Many areas of the block validation code use a "slow" transaction search, which searches redundantly for transactions. This "slow" search has been removed upstream in Bitcoin and is now removed in PIVX. This provides a more efficient syncing process and generally better performing wallet.
+
+Sync Fix for Block 908000
+---------------------
+Many wallets were having trouble getting past block 908000. This block recalculates certain aspects of the money supply and zPIV transactions, and is known to take longer to sync. Code has been added to allow block 908000 to be validated without the user needing to enter any special commands into the debug console.
+
+Working Testnet
+---------------------
+Testnet is now accessible with this release of the wallet. Testnet can be accessed using the `-testnet` startup flag.
+
+zPIV Spending Fix
+---------------------
+zPIV that were minted between block 891730 and 895400 were experiencing an error initializing the accumulator witness data correctly, causing an inability to spend those mints. This has been fixed.
+
+
+3.0.6 Change log
+=================
+
+Detailed release notes follow. This overview includes changes that affect
+behavior, not code moves, refactors and string updates. For convenience in locating
+the code changes and accompanying discussion, both the pull request and
+git merge commit are mentioned.
+
+### RPC and other APIs
+- #366 `f361344` Do not stringify beyond OP_ZEROCOINSPEND for CScript::ToString() (presstab)
+- #385 `732bfb0` getspentzerocoinamount RPC call. (whateverpal)
+- #417 `f97b409` [RPC] Fix typo for `obfuscation` RPC command (Patrick Collins)
+
+### Block and Transaction Handling
+- #395 `5c5a9c6` [Main] Avoid slow transaction search with txindex enabled (Fuzzbawls)
+- #405 `e415420` [Main] Automate database corruption fix caused by out of sync txdb. (presstab)
+- #408 `beae959` Fix "accumulator does not verify" when spending zPIV. (presstab)
+- #418 `90b0310` Fix edge case segfault. (presstab)
+
+### P2P Protocol and Network Code
+- #393 `58ec23f` [Testnet] Adjust testnet chainparams to new hard coded values. (presstab)
+
+### Wallet
+- #412 `2fb5f17` Double check tx size when creating zPIV tx's. (presstab)
+
+### GUI
+- #384 `7897f60` [Qt] Periodic make translate (Fuzzbawls)
+
+### Build System
+- #402 `e383b94` Change git info in genbuild.sh (Jon Spock)
+- #419 `79956d4` [Travis] Add logprint-scanner.py to TravisCI (Fuzzbawls)
+
+### Miscellaneous
+- #401 `f30d9b7` [Scripts] LogPrint(f) scanner script (Sonic, PeterL73)
+- #409 `4f78e67` Handle debug.log "CWalletTx::GetAmounts: Unknown transaction type" spam. (presstab)
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+- Fuzzbawls
+- Jon Spock
+- Mrs-X
+- Patrick Collins
+- PeterL73
+- presstab
+- sonic
+- whateverpal
+
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/pivx-project-translations/).

--- a/doc/release-notes/release-notes-3.1.0.1.md
+++ b/doc/release-notes/release-notes-3.1.0.1.md
@@ -1,15 +1,8 @@
-(note: this is a temporary file, to be added-to by anybody, and moved to release-notes at release time)
+PIVX Core version *3.1.0.1* is now available from:  <https://github.com/pivx-project/pivx/releases>
 
-PIVX Core version *version* is now available from:  <https://github.com/pivx-project/pivx/releases>
-
-This is a new major version release, including various bug fixes and performance improvements, as well as updated translations.
+This is a new bugfix release, specifically addressing a bug with windows OS masternode control wallets. Users upgrading to this version are encouraged to also read the detailed release notes for the previous [3.1.0](https://github.com/PIVX-Project/PIVX/releases/tag/v3.1.0) release as information will not be duplicated here.
 
 Please report bugs using the issue tracker at github: <https://github.com/pivx-project/pivx/issues>
-
-
-Mandatory Update
-==============
-
 
 How to Upgrade
 ==============
@@ -34,30 +27,28 @@ PIVX Core should also work on most other Unix-like systems but is not frequently
 Notable Changes
 ==============
 
+Windows masternode.conf bug
+--------------
 
-*version* Change log
+Windows Masternode Controller wallets were experiencing an issue with reading the `masternode.conf` file during startup that prevented the wallet from opening properly. 
+
+Windows file icons
+-------------
+
+The Windows program icons and installer images were of less than ideal quality, often appearing grainy or distorted. These icons/images have now been recreated to meet higher standards.
+
+*3.1.0.1* Change log
 ==============
 
 Detailed release notes follow. This overview includes changes that affect behavior, not code moves, refactors and string updates. For convenience in locating the code changes and accompanying discussion, both the pull request and git merge commit are mentioned.
 
-### Core Features
-
-### Build System
- 
-### P2P Protocol and Network Code
-
-### GUI
- 
-### RPC/REST
-
-### Wallet
- 
 ### Miscellaneous
- 
- 
+- #586 `fc211bfdf` [Bug] Fix CMasternodeConfig::read (Fuzzbawls)
+- #587 `69498104f` [Bug] Fix Windows icon files (Fuzzbawls)
+
 ## Credits
 
 Thanks to everyone who directly contributed to this release:
-
+- Fuzzbawls
 
 As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/pivx-project-translations/), the QA team during Testing and the Node hosts supporting our Testnet.

--- a/doc/release-notes/release-notes-3.1.0.md
+++ b/doc/release-notes/release-notes-3.1.0.md
@@ -1,0 +1,408 @@
+PIVX Core version *3.1.0* is now available from:  <https://github.com/pivx-project/pivx/releases>
+
+This is a new major version release, including various bug fixes and performance improvements, as well as updated translations.
+
+Please report bugs using the issue tracker at github: <https://github.com/pivx-project/pivx/issues>
+
+
+Mandatory Update
+==============
+
+PIVX Core v3.1.0 is a mandatory update for all users. This release contains new consensus rules and improvements that are not backwards compatible with older versions. Users will have a grace period of one week to update their clients before enforcement of this update is enabled.
+
+Users updating from a previous version after Tuesday, May 8, 2018 12:00:00 AM GMT will require a full resync of their local blockchain from either the P2P network or by way of the bootstrap.
+
+How to Upgrade
+==============
+
+If you are running an older version, shut it down. Wait until it has completely shut down (which might take a few minutes for older versions), then run the installer (on Windows) or just copy over /Applications/PIVX-Qt (on Mac) or pivxd/pivx-qt (on Linux).
+
+
+Compatibility
+==============
+
+PIVX Core is extensively tested on multiple operating systems using
+the Linux kernel, macOS 10.8+, and Windows Vista and later.
+
+Microsoft ended support for Windows XP on [April 8th, 2014](https://www.microsoft.com/en-us/WindowsForBusiness/end-of-xp-support),
+No attempt is made to prevent installing or running the software on Windows XP, you
+can still do so at your own risk but be aware that there are known instabilities and issues.
+Please do not report issues about Windows XP to the issue tracker.
+
+PIVX Core should also work on most other Unix-like systems but is not
+frequently tested on them.
+
+### :exclamation::exclamation::exclamation: MacOS 10.13 High Sierra :exclamation::exclamation::exclamation:
+
+**Currently there are issues with the 3.x gitian release on MacOS version 10.13 (High Sierra), no reports of issues on older versions of MacOS.**
+
+ 
+Notable Changes
+==============
+
+zPIV Updates
+--------------
+
+### zPIV Staking
+
+zPIV Staking is here! zPIV staking will be activated on the morning of the 8th of May 2018. With the release of zPIV staking, there are effectively 2 versions of zPIV, zPIV minted on the 3.0.6 PIVX wallet or lower, and zPIV minted on PIVX wallet version or higher. New features in this release will require the use of zPIV v2, zPIV minted on this wallet release 3.1.0 or later. If you currently hold zPIV v1 and wish to take advantage of zPIV staking and deterministic zPIV, you will need to spend the zPIV v1 to yourself and remint zPIV v2.
+Note: To find your zPIV version, click the privacy tab, then the zPIV Control button then expand the arrows next to the desired denomination.
+
+
+### Deterministic zPIV Seed Keys
+
+zPIV is now associated with a deterministic seed key. With this seed key, users are able to securely backup their zPIV outside of the wallet that the zPIV had been minted on. zPIV can also be transferred from wallet to wallet without the need of transferring the wallet data file.
+
+
+### Updated zPIV minting
+
+zPIV minting now only requires 1 further mint (down from 2) to mature. zPIV mints still require 20 confirmations.  Mints also require that the 'second' mint is at least two checkpoints deep in the chain (this was already the case, but the logic was not as precise).
+
+
+### zPIV Search
+
+Users will now have the ability to search the blockchain for a specific serial # to see if a zPIV denomination has been spent or not.
+
+
+
+PIV/zPIV Staking and Masternode Rewards
+--------------
+
+### PIV, zPIV and Masternode Payment Schedule
+
+To encourage the use of zPIV and increase the PIVX zerocoin anonymity set, the PIVX payment schedule has been changed to the following:
+
+If a user staking zPIV wins the reward for their block, the following zPIV reward will be: 
+- 3 zPIV (3 x 1 denominations) rewarded to the staker, 2 PIV rewarded to the masternode owner and 1 PIV available for the budget. This is a total block reward of 6 PIV, up from 5.
+
+If a user staking PIV wins the reward, the following amounts will be rewarded: 
+- 2 PIV to the PIV staker, 3 PIV to the Masternode owner and 1 PIV available for the budget. This is a total block reward of 6 PIV, up from 5.
+
+
+### Return change to sender when minting zPIV
+
+Previously, zPIV minting would send any change to a newly generated "change address". This has caused confusion among some users, and in some cases insufficient backups of the wallet. The wallet will now find the contributing address which contained the most PIV and return the change from a zPIV mint to that address.
+
+
+User Experience
+--------------
+
+### Graphical User Interface
+
+The visual layout of the PIVX Qt wallet has undergone a near-complete overhaul.
+A new 'vertical tab' layout is now being used instead of the prior 'horizontal tab' layout, as well as a completely new icon set.
+The overview tab has been simplified greatly to display only balances that are active or relevant, zero-balance line items are hidden by default to avoid clutter.
+
+
+### Wallet Options
+
+There have been a number of changes to the tasks that you are able to perform from the wallet options. Users will now have the ability to do the following: 
+-	Enable and disable the auto zPIV minting feature. This is enabled by default and the enablezeromint=0 setting in the pivx.conf file will overwrite the GUI option.
+-	The percentage of autominted zPIV can now be set from 1 to 100, changed from 10 – 100.
+-	The stake split threshold can now be set VIA the wallet options. This setting is an advanced feature for those wishing to remain staking regular PIV.
+-	“Unlock for staking and anonymization only” is now selected by default when unlocking the wallet from the User Interface
+
+
+### In-wallet Ban Management
+
+Peer bans are now manageable through the Peers tab of the tools window. Peers can be banned/unbanned at will without the need to restart the wallet client. No changes have been made to the conditions resulting in automatic peer bans.
+
+
+Backup to external devices / locations
+--------------
+
+### Summary
+
+ The PIVX wallet can now have user selected directories for automatic backups of the wallet data file (wallet.dat). This can be set by adding the following lines to the pivx.conf file, found in the PIVX data directory.
+- backuppath = <directory / full path>
+- zpivbackuppath = <directory / full path>
+- custombackupthreshold = <backup limit>
+Note: System write permissions must be appropriate for the location the wallet is being saved to.
+
+* Configured variables display in the _Wallet Repair_ tab inside the _Tools Window / Dropdown Menu_
+* Allows for backing up wallet.dat to the user set path, simultaneous to other backups
+* Allows backing up to directories and files, with a limit (_threshold_) on how many files can be saved in the directory before it begins overwriting the oldest wallet file copy.
+
+
+### Details:
+
+* If path is set to directory, the backup will be named `wallet.dat-<year>-<month>-<day>-<hour>-<minute>-<second>`
+* If zPIV backup, auto generated name is `wallet-autozpivbackup.dat-<year>-<month>-<day>-<hour>-<minute>-<second>`
+* If path set to file, backup will be named `<filename>.dat`
+* walletbackupthreshold enables the user to select the maximum count of backup files to be written before overwriting existing backups.
+
+
+### Example:
+
+* -backuppath=/\<mynewdir>/        
+* -walletbackupthreshold=2
+
+Backing up 4 times will result as shown below
+
+
+                date/time
+    backup #1 - 2018-04-20-00-04-00  
+    backup #2 - 2018-04-21-04-20-00  
+    backup #3 - 2018-04-22-00-20-04  
+    backup #4 - 2018-04-23-20-04-00  
+    
+    1.
+        /<mynewdir>/
+            wallet.dat-2018-04-20-00-04-00
+    2.
+        /<mynewdir>/
+            wallet.dat-2018-04-20-00-04-00
+            wallet.dat-2018-04-21-04-20-00
+    3.
+        /<mynewdir>/
+            wallet.dat-2018-04-22-00-20-04
+            wallet.dat-2018-04-21-04-20-00
+    4.
+        /<mynewdir>/
+            wallet.dat-2018-04-22-00-20-04
+            wallet.dat-2018-04-23-20-04-00
+            
+
+
+PIVX Daemon & Client (RPC Changes)
+--------------
+
+### RPC Ban Management
+
+The PIVX client peer bans now have additional RPC commands to manage peers. Peers can be banned and unbanned at will without the need to restart the wallet client. No changes have been made to the conditions resulting in automatic peer bans. New RPC commands: `setban`, `listbanned`, `clearbanned`, and `disconnectnode`
+
+
+### Random-cookie RPC authentication
+
+When no `-rpcpassword` is specified, the daemon now uses a special 'cookie' file for authentication. This file is generated with random content when the daemon starts, and deleted when it exits. Its contents are used as authentication token. Read access to this file controls who can access through RPC. By default it is stored in the data directory but its location can be overridden with the option `-rpccookiefile`.
+This is similar to Tor's CookieAuthentication: see https://www.torproject.org/docs/tor-manual.html.en 
+This allows running pivxd without having to do any manual configuration.
+
+
+### New RPC command
+`getfeeinfo`
+
+This allows for a user (such as a third party integration) to query the blockchain for the current fee rate per kb, and also get a suggested rate per kb for high priority tx's that need to get added to the blockchain asap.
+
+
+### New RPC command 
+`findserial`
+
+Search the zerocoin database for a zerocoinspend transaction that contains the given serial. This will be a helpful tool for the PIVX support group, which often times sees users say "I didn't spend that zPIV". This RPC call allows for support to grab the serial, and then find the spend tx on the chain.
+
+
+### New RPC commands 
+`createmasternodebroadcast`
+
+`decodemasternodebroadcast`
+
+`relaymasternodebroadcast`
+
+A new set of rpc commands masternodebroadcast to create masternode broadcast messages offline and relay them from online node later (messages expire in ~1 hour). 
+
+
+Network Layer 2 Changes (Proposals / Budgets / SwiftX)
+--------------
+
+### Monthly Budget Increase
+
+As voted on by the PIVX masternodes, the monthly budget available to be utilised has been increased to 42,000 PIV / month. This PIV only has the opportunity to be raised once per month (paid to winning proposals) with any unused PIV not created by the blockchain.
+
+### Budget Finalization Fee
+
+The PIVX finalization fee for successful proposals has now been reduced, this fee is now 5 PIV down from 50 PIV. The total fee outlay for a successful proposal is now a total of 55 PIV.
+
+
+### SwiftX Raw Transactions
+
+ When creating a raw transaction, it is now possible to create the transaction as a SwiftX transaction. See the updated help documentation for the `createrawtransaction` RPC command.
+
+Technical Changes
+--------------
+
+### Migration to libevent based http server
+
+The RPC and REST interfaces are now initialized and controlled using standard libevent instead of the ad-hoc pseudo httpd interface that was used previously. This change introduces a more resource friendly and effective interface.
+
+
+### New Notification Path 
+`blocksizenotify`
+
+A new notification path has been added to allow a script to be executed when receiving blocks larger than the 1MB legacy size. This functions similar to the other notification listeners (`blocknotify`, `walletnotify`, etc).
+
+
+### Removed Growl Support
+
+Growl hasn't been free nor needed for many years. MacOS versions since 10.8 have the OS notification center, which is still supported after this.
+
+
+### Autocombine changes
+
+The autocombine feature was carrying a bug leading to a significant CPU overhead when being used. The function is now called only once initial blockchain download is finished. It's also now avoiding to combine several times while under the threshold in order to avoid additional transaction fees. Last but not least, the fee computation has been changed and the dust from fee provisioning is returned in the main output.
+
+
+### SOCKS5 Proxy bug
+
+When inputting wrong data into the GUI for a SOCKS5 proxy, the wallet would crash and be unable to restart without accessing hidden configuration. This crash has been fixed.
+
+Minor Enhancements
+--------------
+
+-	Enforced v1 zPIV spends to require a security level of 100
+-	Updates to zPIV spends to avoid segfaults
+-	Updates to configuration will now reflect on the privacy tab
+-	Fixed a  bug that would not start masternodes from the PIVX-Qt masternodes tab
+-	Updated PIVX-Qt tooltips
+-	Icon added to the wallet GUI to reflect the status of autominting (active / inactive)
+-	Updated errors causing the blockchain to corrupt when experiencing unexpected wallet shutdowns
+-	Updated RPC help outputs & removed the deprecated obfuscation. 
+-	Refactored code
+-	Various bug fixes
+-	Updated documentation
+
+Further Reading: Version 2 Zerocoins
+==============
+
+Several critical security flaws in the zerocoin protocol and PIVX's zerocoin implementation have been patched. Enough has changed that new zerocoins are distinct from old zerocoins, and have been labelled as *version 2*. When using the zPIV Control dialog in the QT wallet, a user is able to see zPIV marked as version 1 or 2.
+
+zPoS (zPIV staking)
+--------------
+
+Once a zPIV has over 200 confirmations it becomes available to stake. Staking zPIV will consume the exact zerocoin that is staked and replace it with a freshly minted zerocoin of the same denomination as well as a reward of three 1 denomination zPIV. So for example if a 1,000 zPIV denomination is staked, the protocol replaces that with a fresh 1,000 denomination and three1 denomination zPIVs.
+
+Secure Spending
+--------------
+
+Version 1 zerocoins, as implemented by [Miers et. al](http://zerocoin.org/media/pdf/ZerocoinOakland.pdf), allow for something we describe as *serial trolling*. Spending zerocoins requires that the spender reveal their serial number associated with the zerocoin, and in turn that serial number is used to check for double spending. There is a fringe situation (which is very unlikely to happen within PIVX's zerocoin implementation due to delayed coin accumulation) where the spender sends the spending transaction, but the transaction does not immediately make it into the blockchain and remains in the mempool for a long enough duration that a *troll* has enough time to see the spender's serial number, mint a new zerocoin with the same serial number, and spend the new zerocoin before the original spender's transaction becomes confirmed. If the timing of this fringe situation worked, then the original spender's coin would be seen as invalid because the troll was able to have the serial recorded into the blockchain first, thus making the original spender's serial appear as a double spend.
+
+The serial troll situation is mitigated in version 2 by requiring that the serial number be a hash of a public key. The spend requires an additional signature signed by the private key associated with the public key hash matching the serial number. This work around was conceived by Tim Ruffing, a cryptographer that has studied the zerocoin protocol and done consulting work for the ZCoin project.
+
+Deterministic Zerocoin Generation
+--------------
+
+Zerocoins, or zPIV, are now deterministically generated using a unique 256 bit seed. Each wallet will generate a new seed on its first run. The deterministic seed is used to generate a string of zPIV that can be recalculated at any time using the seed. Deterministic zPIV allows for users to backup all of their future zPIV by simply recording their seed and keeping it in a safe place (similar to backing up a private key for PIV). The zPIV seed needs to remain in the wallet in order to spend the zPIV after it is generated, if the seed is changed then the coins will not be spendable because the wallet will not have the ability to regenerate all of the private zPIV data from the seed. It is important that users record & backup their seed after their first run of the wallet. If the wallet is locked during the first run, then the seed will be generated the first time the wallet is unlocked.
+
+Zerocoin Modulus
+--------------
+
+PIVX's zerocoin implementation used the same code from the ZCoin project to import the modulus use for the zerocoin protocol. The chosen modulus is the 2048 bit RSA number created for the RSA factoring challenge. The ZCoin project's implementation (which PIVX used) improperly imported the modulus into the code. This flaw was discovered by user GOAT from the [Civitas Project](https://github.com/eastcoastcrypto/Civitas/), and reported to PIVX using the bug bounty program. The modulus is now correctly imported and PIVX's accumulators have been changed to use the new proper modulus.
+
+
+*3.1.0* Change log
+--------------
+
+Detailed release notes follow. This overview includes changes that affect behavior, not code moves, refactors and string updates. For convenience in locating the code changes and accompanying discussion, both the pull request and git merge commit are mentioned.
+
+### Core Features
+ - #582 `cb1632520` [Core] zPIV v2: zPoS dzPIV ezPIV external backup and budget fixes (too many to list)
+ - #558 `c7e6f0f7f` [Core] Remove Gitan-OSX warning for High Sierra builds (Mrs-X)
+ - #523 `926c073ea` [Core] Give high priority to zerocoinspends to make it into the next block. (presstab)
+ - #535 `5e8875feb` [Core] Minor refacturing + unused variable removed (Mrs-X)
+ - #526 `0e034d62f` [Core] Refactor ConnectBlock() to segregate state tracking items (presstab)
+ - #513 `27cdf61f2` [Core] Fix masternode broadcast for networks != MAINNET (Mrs-X)
+ - #261 `29611a5fd` [Core] Switch from local to main signals for the validation interface (Nitya Sattva)
+ - #460 `ae4b6a135` [Core] (testnet-) blockchain stuck at block 325000 (Mrs-X)
+ - #428 `3de6b6f3e` [Core] Wipe zerocoin DB on reindex. (presstab)
+ - #447 `8d3407ae4` [Consensus] Fix compilation with OpenSSL 1.1 (warrows)
+ - #551 `94b9bc937` [Consensus] Require standard transactions for testnet (Fuzzbawls)
+
+### Build System
+ - #532 `9071bfe2f` [Depends] Update depends package versions. (Fuzzbawls)
+ - #402 `a471f7020` [Build] Revert #402 "Change git info in genbuild.sh" (Fuzzbawls)
+ - #541 `2f6b58cf1` [Build] Fix typo in Qt test makefile (Fuzzbawls)
+ - #536 `5c44f40e9` [Build] Update build system from upstream (Fuzzbawls)
+ - #480 `72d8c7d67` [Build] compile/link winshutdownmonitor.cpp on Windows only (Fuzzbawls)
+ - #461 `55ec19af0` [Build] libevent-dev dependency added to build-documentation (Mrs-X)
+ 
+### P2P Protocol and Network Code
+ - #542 `61156def7` [Network] Remove vfReachable and modify IsReachable to only use vfLimited. (Patrick Strateman)
+
+### GUI
+ - #572 `d9b23fe60` [Qt] Refresh zPIV balance after resetting mints or spends (warrows)
+ - #571 `1c8e7cb7b` [Qt] Update privacy tab info about zeromint on config change (warrows)
+ - #568 `f226de09e` [Qt] Connect automint icon to the UI automint setting change (warrows)
+ - #566 `84f43857c` [Qt] Add automint status bar icon (Fuzzbawls)
+ - #567 `e12914d85` [Qt] Optimize PNGs (Fuzzbawls)
+ - #537 `653115e9b` [Qt] Standardize and clean up new UI elements (Fuzzbawls)
+ - #538 `24f581842` [Qt] Fix warning dialog popup for the Blockchain Explorer (Fuzzbawls)
+ - #529 `c649ba7e2` [Qt] Remove Growl support (Fuzzbawls)
+ - #521 `fbb105a00` [Qt] Make "For anonymization and staking only" checked by default (Mrs-X)
+ - #508 `2cf3be6bb` [Qt] Fix crash when inputting wrong port for network proxy (warrows)
+ - #500 `4c01ba65d` [Qt] Remove duplicate code for updating address book labels. (blondfrogs)
+ - #506 `ae72bf4e2` [Qt] Autoscroll to end of zPIV status output (Mrs-X)
+ - #499 `6305264f2` [Qt] Send popup simplified + SwiftTX -> SwiftX (Mrs-X)
+ - #490 `ba777e4ef` [Qt] Update MultiSend GUI to allow address labels (blondfrogs)
+ - #483 `5b1070365` [Qt] Fixed Dynamic Screen Elements Issue for Multisig (blondfrogs)
+ - #479 `818c0c79e` [Qt] Rework of overview page (warrows)
+ - #478 `98ca7bc90` [Qt] Implement Ban Management in GUI Wallet (Fuzzbawls)
+ - #473 `9e2ed8f0f` [Qt] Make toolbar icons bigger (Mrs-X)
+ - #462 `c62eabe7b` [Qt] Consistent trx colors for Overview + Transaction tabs (Mrs-X)
+ - #472 `b7929bdcf` [Qt] Minor changes and fixes (Mrs-X)
+ - #467 `7099831bd` [Qt] Clear PrivacyDialog "zPiv Selected" labels after sending. (presstab)
+ - #465 `d8e21774d` [Qt] Added controls to the options dialog for enable or disable auto-minting and set required level (lex-dev3)
+ - #464 `59fd7d378` [Qt] setstakesplitthreshold value set in Qt GUI (lex-dev3)
+ - #452 `219b68dc9` [Qt] Complete re-design of Qt-wallet (Mrs-X)
+ - #440 `011408474` [Qt] Fix empty system tray menu (PeterL73)
+ - #442 `248316647` [Qt] Improve checkbox visibility (PeterL73)
+ 
+### RPC/REST
+ - #562 `772160b1b` [Wallet/RPC] Add argument to mint zerocoin from specific UTXO (warrows)
+ - #539 `b6a02e9d6` [RPC] Allow watchonly coins to be shown for listunspent (blondfrogs)
+ - #543 `e4522ff07` [RPC] Segfault pivx-cli getinfo while loading block index (Mrs-X)
+ - #524 `2541b5001` [RPC] Add blocksizenotify command (Mrs-X)
+ - #495 `4946224c1` [RPC] Show script verification errors in signrawtransaction result (Fuzzbawls)
+ - #468 `00b8b8e72` [RPC/REST] Migrate to libevent based httpd server (Fuzzbawls)
+ - #381 `6f91fb734` [RPC] Allow in-wallet management of peer bans (Fuzzbawls)
+ - #441 `6ae17c52d` [RPC] Implement random-cookie based authentication (Fuzzbawls)
+ - #443 `0a991d8ba` [RPC] Findserial (presstab)
+ - #438 `f701337e7` [RPC] Fix `importzercoins` for use with UniValue (Fuzzbawls)
+ - #429 `17fdde1d1` [RPC] Add getfeeinfo RPC. (presstab)
+ - #423 `5dfb48ee6` [RPC] Add SwiftX to rpcrawtransaction. (presstab)
+ - #170 `027f16c64` [RPC] Convert source tree from json_spirit to UniValue (Fuzzbawls)
+
+### Wallet
+ - #570 `8c8350b59` [Wallet] Add a check on zPIV spend to avoid a segfault (warrows)
+ - #565 `80b803201` [Wallet] Increase valid range for automint percentage (Fuzzbawls)
+ - #518 `9f6449a70` [Wallet] Combine fees when possible and fix autocombine insufficient funds (warrows)
+ - #497 `f21e4456b` [Wallet] Call AutocombineDust less often (warrows)
+ - #498 `bfad2a1df` [Wallet] Change the way transaction list is handled (warrows)
+ - #477 `93c5f9ff5` [Wallet] Remove potential memory leak (blondfrogs)
+ - #488 `d09cf916a` [Wallet] Fixes an autocombinerewards bug with above max size TXs (warrows)
+ - #448 `222ef6e6b` [Wallet] Return change to sender when minting zPIV. (presstab)
+ - #445 `fc570fc1e` [Wallet] Only require 1 mint to be added before spending zPIV. (presstab)
+ 
+### Miscellaneous
+ - #559 `d2b017217` [Bug] Segfault with -enableswifttx=0 / -enableswifttx=false (Mrs-X)
+ - #494 `8180b7884` [Bug] remove use of variable length buffer (rejectedpromise)
+ - #469 `6bd265c5e` [Tests] Fix util_tests compiler warnings with clang (Fuzzbawls)
+ - #463 `22f2bb623` [Tests] Fixed compilation errors (lex-dev3)
+ - #569 `aedf80b07` [Docs] OSX Build - Instructions on how to make the Homebrew OpenSSL headers visible (gpdionisio)
+ - #554 `8cecb3435` [Docs] Added release notes for autocombine and proxy GUI. (warrows)
+ - #533 `ad3edb9fa` [Docs] Update OSX build notes: zmq, libevent, and notes to handle possible glibtoolize error (Tim Uy)
+ - #530 `fd8aa8991` [Docs] Update README.md (Warrows)
+ - #528 `1c1412246` [Docs] Readme changes (Sieres)
+ - #471 `18e5accb6` [Docs] Readme SeeSaw reward mechanism reference. (Dexaran)
+ - #426 `3418a64d2` [Docs] Use mainnet port for example in masternode.conf file (Fuzzbawls)
+ 
+ 
+## Credits
+
+Thanks to everyone who directly contributed to this release:
+- gpdionisio
+- warrows
+- Fuzzbawls
+- Mrs-X
+- presstab
+- blondfrogs
+- Patrick Strateman
+- Tim Uy
+- Sieres
+- Nitya Sattva
+- turtleflax
+- rejectedpromise
+- Dexaran
+- lex-dev3
+- PeterL73
+- Anthony Posselli
+
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/pivx-project-translations/), the QA team during Testing and the Node hosts supporting our Testnet.


### PR DESCRIPTION
This adds historic release notes for versions 3.0.5 through 3.1.0.1 into
 the `doc/release-notes/` path and also clears out the transitory
 `/doc/release-notes.md` file so it can once again be used to tracking
 new changes moving forward.