### PR TITLE
Add unit test for budget value.

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -48,6 +48,7 @@ BITCOIN_TESTS =\
   test/base32_tests.cpp \
   test/base58_tests.cpp \
   test/base64_tests.cpp \
+  test/budget_tests.cpp \
   test/checkblock_tests.cpp \
   test/Checkpoints_tests.cpp \
   test/coins_tests.cpp \

--- a/src/test/budget_tests.cpp
+++ b/src/test/budget_tests.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2018 The PIVX developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <boost/test/unit_test.hpp>
+#include <tinyformat.h>
+#include <utilmoneystr.h>
+#include "masternode-budget.h"
+
+BOOST_AUTO_TEST_SUITE(budget_tests)
+
+void CheckBudgetValue(int nHeight, std::string strNetwork, CAmount nExpectedValue)
+{
+    CBudgetManager budget;
+    CAmount nBudget = budget.GetTotalBudget(nHeight);
+    std::string strError = strprintf("Budget is not as expected for %s. Result: %s, Expected: %s", strNetwork, FormatMoney(nBudget), FormatMoney(nExpectedValue));
+    BOOST_CHECK_MESSAGE(nBudget == nExpectedValue, strError);
+}
+
+BOOST_AUTO_TEST_CASE(budget_value)
+{
+    SelectParams(CBaseChainParams::MAIN);
+    int nHeightTest = Params().Zerocoin_Block_V2_Start() + 1;
+    CheckBudgetValue(nHeightTest, "mainnet", 43200*COIN);
+
+    SelectParams(CBaseChainParams::TESTNET);
+    nHeightTest = Params().Zerocoin_Block_V2_Start() + 1;
+    CheckBudgetValue(nHeightTest, "testnet", 7300*COIN);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Prevent any future issues with calculated budget value by adding a unit test.