### PR TITLE
[Tests] Fix chain ordering in budget tests

### DIFF
--- a/src/test/budget_tests.cpp
+++ b/src/test/budget_tests.cpp
@@ -2,10 +2,11 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <boost/test/unit_test.hpp>
-#include <tinyformat.h>
-#include <utilmoneystr.h>
 #include "masternode-budget.h"
+#include "tinyformat.h"
+#include "utilmoneystr.h"
+
+#include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(budget_tests)
 
@@ -19,13 +20,13 @@ void CheckBudgetValue(int nHeight, std::string strNetwork, CAmount nExpectedValu
 
 BOOST_AUTO_TEST_CASE(budget_value)
 {
-    SelectParams(CBaseChainParams::MAIN);
-    int nHeightTest = Params().Zerocoin_Block_V2_Start() + 1;
-    CheckBudgetValue(nHeightTest, "mainnet", 43200*COIN);
-
     SelectParams(CBaseChainParams::TESTNET);
-    nHeightTest = Params().Zerocoin_Block_V2_Start() + 1;
+    int nHeightTest = Params().Zerocoin_Block_V2_Start() + 1;
     CheckBudgetValue(nHeightTest, "testnet", 7300*COIN);
+
+    SelectParams(CBaseChainParams::MAIN);
+    nHeightTest = Params().Zerocoin_Block_V2_Start() + 1;
+    CheckBudgetValue(nHeightTest, "mainnet", 43200*COIN);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
check testnet params first, then check mainnet so as to not interfere
with subsequent unit tests that rely on mainnet params.

Also clean up include ordering.