### PR TITLE
[Wallet] Write new transactions to wtxOrdered properly

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -659,6 +659,7 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFromLoadWallet)
             if (!wtx.nTimeReceived)
                 wtx.nTimeReceived = GetAdjustedTime();
             wtx.nOrderPos = IncOrderPosNext();
+            wtxOrdered.insert(make_pair(wtx.nOrderPos, TxPair(&wtx, (CAccountingEntry*)0)));
             wtx.nTimeSmart = ComputeTimeSmart(wtx);
             AddToSpends(hash);
         }


### PR DESCRIPTION
This addresses an issue where new incoming transactions aren't recorded,
 and subsequently, not returned with `listtransactions` in the same
 session.

fixes #578