### PR TITLE
Fix spending for v1 zPIV created before block 1050020. 

### DIFF
--- a/src/accumulators.cpp
+++ b/src/accumulators.cpp
@@ -402,7 +402,7 @@ bool GetAccumulatorValue(int& nHeight, const libzerocoin::CoinDenomination denom
         //Start at the first zerocoin
         libzerocoin::Accumulator accumulator(Params().Zerocoin_Params(false), denom);
         bnAccValue = accumulator.getValue();
-        nHeight = Params().Zerocoin_Block_V2_Start() + 10;
+        nHeight = Params().Zerocoin_StartHeight() + 10;
         return true;
     }
 
@@ -437,6 +437,10 @@ bool GenerateAccumulatorWitness(const PublicCoin &coin, Accumulator& accumulator
     if (!GetTransaction(txid, txMinted, hashBlock))
         return error("%s failed to read tx", __func__);
 
+    int nHeightTest;
+    if (!IsTransactionInChain(txid, nHeightTest))
+        return error("%s: mint tx %s is not in chain", __func__, txid.GetHex());
+
     int nHeightMintAdded = mapBlockIndex[hashBlock]->nHeight;
 
     //get the checkpoint added at the next multiple of 10
@@ -467,6 +471,8 @@ bool GenerateAccumulatorWitness(const PublicCoin &coin, Accumulator& accumulator
     nMintsAdded = 0;
     RandomizeSecurityLevel(nSecurityLevel); //make security level not always the same and predictable
     libzerocoin::Accumulator witnessAccumulator = accumulator;
+
+    bool fDoubleCounted = false;
     while (pindex) {
         if (pindex->nHeight != nAccStartHeight && pindex->pprev->nAccumulatorCheckpoint != pindex->nAccumulatorCheckpoint)
             ++nCheckpointsAdded;
@@ -488,8 +494,17 @@ bool GenerateAccumulatorWitness(const PublicCoin &coin, Accumulator& accumulator
         }
 
         nMintsAdded += AddBlockMintsToAccumulator(coin, nHeightMintAdded, pindex, &witnessAccumulator, true);
+
+        // 10 blocks were accumulated twice when zPIV v2 was activated
+        if (pindex->nHeight == 1050010 && !fDoubleCounted) {
+            pindex = chainActive[1050000];
+            fDoubleCounted = true;
+            continue;
+        }
+
         pindex = chainActive.Next(pindex);
     }
+
     witness.resetValue(witnessAccumulator, coin);
     if (!witness.VerifyWitness(accumulator, coin))
         return error("%s: failed to verify witness", __func__);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1068,7 +1068,7 @@ bool TxOutToPublicCoin(const CTxOut txout, PublicCoin& pubCoin, CValidationState
     publicZerocoin.setvch(vchZeroMint);
 
     CoinDenomination denomination = AmountToZerocoinDenomination(txout.nValue);
-    LogPrint("zero", "%s ZCPRINT denomination %d pubcoin %s\n", __func__, denomination, publicZerocoin.GetHex());
+    //LogPrint("zero", "%s ZCPRINT denomination %d pubcoin %s\n", __func__, denomination, publicZerocoin.GetHex());
     if (denomination == ZQ_ERROR)
         return state.DoS(100, error("TxOutToPublicCoin : txout.nValue is not correct"));
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -15,6 +15,7 @@
 #include "util.h"
 #include "utilmoneystr.h"
 #include "accumulatormap.h"
+#include "accumulators.h"
 
 #include <stdint.h>
 #include <univalue.h>
@@ -929,6 +930,38 @@ UniValue findserial(const UniValue& params, bool fHelp)
     UniValue ret(UniValue::VOBJ);
     ret.push_back(Pair("success", fSuccess));
     ret.push_back(Pair("txid", txid.GetHex()));
+    return ret;
+}
+
+UniValue getaccumulatorvalues(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() != 1)
+        throw runtime_error(
+            "getaccumulatorvalues \"height\"\n"
+                    "\nReturns the accumulator values associated with a block height\n"
+
+                    "\nArguments:\n"
+                    "1. height   (numeric, required) the height of the checkpoint.\n"
+
+                    "\nExamples:\n" +
+            HelpExampleCli("getaccumulatorvalues", "\"height\"") + HelpExampleRpc("getaccumulatorvalues", "\"height\""));
+
+    int nHeight = params[0].get_int();
+
+    CBlockIndex* pindex = chainActive[nHeight];
+    if (!pindex)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "invalid block height");
+
+    UniValue ret(UniValue::VARR);
+    for (libzerocoin::CoinDenomination denom : libzerocoin::zerocoinDenomList) {
+        CBigNum bnValue;
+        if(!GetAccumulatorValueFromDB(pindex->nAccumulatorCheckpoint, denom, bnValue))
+            throw JSONRPCError(RPC_DATABASE_ERROR, "failed to find value in database");
+
+        UniValue obj(UniValue::VOBJ);
+        obj.push_back(Pair(std::to_string(denom), bnValue.GetHex()));
+        ret.push_back(obj);
+    }
 
     return ret;
 }

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -140,6 +140,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
         {"searchdzpiv", 0},
         {"searchdzpiv", 1},
         {"searchdzpiv", 2},
+        {"getaccumulatorvalues", 0},
         {"getfeeinfo", 0}
     };
 

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -298,6 +298,7 @@ static const CRPCCommand vRPCCommands[] =
 
         /* Block chain and UTXO */
         {"blockchain", "findserial", &findserial, true, false, false},
+        {"blockchain", "getaccumulatorvalues", &getaccumulatorvalues, true, false, false},
         {"blockchain", "getblockchaininfo", &getblockchaininfo, true, false, false},
         {"blockchain", "getbestblockhash", &getbestblockhash, true, false, false},
         {"blockchain", "getblockcount", &getblockcount, true, false, false},

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -291,6 +291,7 @@ extern UniValue verifychain(const UniValue& params, bool fHelp);
 extern UniValue getchaintips(const UniValue& params, bool fHelp);
 extern UniValue invalidateblock(const UniValue& params, bool fHelp);
 extern UniValue reconsiderblock(const UniValue& params, bool fHelp);
+extern UniValue getaccumulatorvalues(const UniValue& params, bool fHelp);
 
 extern UniValue getpoolinfo(const UniValue& params, bool fHelp); // in rpcmasternode.cpp
 extern UniValue masternode(const UniValue& params, bool fHelp);

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -4563,9 +4563,9 @@ bool CWallet::MintToTxIn(CZerocoinMint zerocoinSelected, int nSecurityLevel, con
 {
     // Default error status if not changed below
     receipt.SetStatus(_("Transaction Mint Started"), ZPIV_TXMINT_GENERAL);
-    libzerocoin::ZerocoinParams* paramsAccumulator = Params().Zerocoin_Params(chainActive.Height() < Params().Zerocoin_Block_V2_Start());
+    libzerocoin::ZerocoinParams* paramsAccumulator = Params().Zerocoin_Params(false);
 
-    bool isV1Coin = zerocoinSelected.GetVersion() < libzerocoin::PrivateCoin::PUBKEY_VERSION;
+    bool isV1Coin = libzerocoin::ExtractVersionFromSerial(zerocoinSelected.GetSerialNumber()) < libzerocoin::PrivateCoin::PUBKEY_VERSION;
     libzerocoin::ZerocoinParams* paramsCoin = Params().Zerocoin_Params(isV1Coin);
     //LogPrintf("%s: *** using v1 coin params=%b, using v1 acc params=%b\n", __func__, isV1Coin, chainActive.Height() < Params().Zerocoin_Block_V2_Start());
 

--- a/src/zpivtracker.cpp
+++ b/src/zpivtracker.cpp
@@ -149,10 +149,6 @@ CAmount CzPIVTracker::GetBalance(bool fConfirmedOnly, bool fUnconfirmedOnly) con
             myZerocoinSupply.at(meta.denom)++;
         }
     }
-    for (auto& denom : libzerocoin::zerocoinDenomList) {
-        LogPrint("zero","%s My coins for denomination %d pubcoin %s\n", __func__,denom, myZerocoinSupply.at(denom));
-    }
-    LogPrint("zero","Total value of coins %d\n",nTotal);
 
     if (nTotal < 0 ) nTotal = 0; // Sanity never hurts
 


### PR DESCRIPTION
The transition to v2 zPIV and reset of the accumulators caused blocks 1050000 - 1050010 to be accumulated twice. This was causing many v1 zPIV to not create valid witnesses. This problem is fixed by double accumulating blocks 1050000-1050010 when creating the witness.