### PR TITLE
[Build] Remove unnecessary BOOST dependency

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -5051,11 +5051,10 @@ void CWallet::ReconsiderZerocoins(std::list<CZerocoinMint>& listMintsRestored, s
 
 string CWallet::GetUniqueWalletBackupName(bool fzpivAuto) const
 {
-    posix_time::ptime timeLocal = posix_time::second_clock::local_time();
     stringstream ssDateTime;
+    std::string strWalletBackupName = strprintf("%s", DateTimeStrFormat(".%Y-%m-%d-%H-%M", GetTime()));
+    ssDateTime << strWalletBackupName;
 
-
-    ssDateTime << gregorian::to_iso_extended_string(timeLocal.date()) << "-" << timeLocal.time_of_day();
     return strprintf("wallet%s.dat%s", fzpivAuto ? "-autozpivbackup" : "", DateTimeStrFormat(".%Y-%m-%d-%H-%M", GetTime()));
 }
 


### PR DESCRIPTION
When build with `--enable-debug` the linker complains about a missing `boost::gregorian` dependency which is not really needed.

This PR removes this dependency, because, as we all know, with each BOOST-dependency somewhere a Unicorn dies...

It also addresses https://github.com/PIVX-Project/PIVX/issues/601
Thanks and kudos to @FornaxA for finding the problem!