### PR TITLE
[Trivial] clean logs from CObfuScationSigner::VerifyMessage

### DIFF
--- a/src/obfuscation.cpp
+++ b/src/obfuscation.cpp
@@ -2175,9 +2175,8 @@ bool CObfuScationSigner::VerifyMessage(CPubKey pubkey, vector<unsigned char>& vc
     }
 
     if (pubkey2.GetID() != pubkey.GetID()) {
-        errorMessage = strprintf("keys don't match - input: %s, recovered: %s, message: %s, sig: %s\n",
-                pubkey.GetID().ToString(), pubkey2.GetID().ToString(), strMessage,
-                EncodeBase64(&vchSig[0], vchSig.size()));
+        errorMessage = strprintf("keys don't match - input: %s, recovered: %s, sig: %s\n",
+                pubkey.GetID().ToString(), pubkey2.GetID().ToString(), EncodeBase64(&vchSig[0], vchSig.size()));
         return false;
     }
 
@@ -2326,3 +2325,4 @@ void ThreadCheckObfuScationPool()
         }
     }
 }
+


### PR DESCRIPTION
minor change to https://github.com/PIVX-Project/PIVX/pull/599 to have cleaner logs.