### PR TITLE
[Budget] Make sorting of finalized budgets deterministic

### DIFF
--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -844,10 +844,13 @@ std::vector<CBudgetProposal*> CBudgetManager::GetBudget()
     return vBudgetProposalsRet;
 }
 
+// Sort by votes, if there's a tie sort by their feeHash TX
 struct sortFinalizedBudgetsByVotes {
     bool operator()(const std::pair<CFinalizedBudget*, int>& left, const std::pair<CFinalizedBudget*, int>& right)
     {
-        return left.second > right.second;
+        if (left.second != right.second)
+            return left.second > right.second;
+        return (left.first->nFeeTXHash > right.first->nFeeTXHash);
     }
 };
 


### PR DESCRIPTION
When there are 2 (or more) finalized(!) budgets (that's a valid condition) and both have the same voting count it's not deterministic which one is used to pay the monthly budgets and the network might not agree on a payment at all.

The worst possible result of this race-condition is that the network gets stuck one block before the budgets payments start, because one half of the network rejects the budgets payments of the other half.

This PR makes sorting and therefore the selection of the finalized budget deterministic and avoids this scenario.
