### PR TITLE
[Net] Revert #599 and #606

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -693,7 +693,7 @@ std::string CMasternodeBroadcast::GetOldStrMessage()
 
     std::string vchPubKey(pubKeyCollateralAddress.begin(), pubKeyCollateralAddress.end());
     std::string vchPubKey2(pubKeyMasternode.begin(), pubKeyMasternode.end());
-    strMessage = addr.ToString(false) + boost::lexical_cast<std::string>(sigTime) + vchPubKey + vchPubKey2 + boost::lexical_cast<std::string>(protocolVersion);
+    strMessage = addr.ToString() + boost::lexical_cast<std::string>(sigTime) + vchPubKey + vchPubKey2 + boost::lexical_cast<std::string>(protocolVersion);
 
     return strMessage;
 }
@@ -702,7 +702,7 @@ std:: string CMasternodeBroadcast::GetNewStrMessage()
 {
     std::string strMessage;
 
-    strMessage = addr.ToString(false) + boost::lexical_cast<std::string>(sigTime) + pubKeyCollateralAddress.GetID().ToString() + pubKeyMasternode.GetID().ToString() + boost::lexical_cast<std::string>(protocolVersion);
+    strMessage = addr.ToString() + boost::lexical_cast<std::string>(sigTime) + pubKeyCollateralAddress.GetID().ToString() + pubKeyMasternode.GetID().ToString() + boost::lexical_cast<std::string>(protocolVersion);
 
     return strMessage;
 }

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -874,20 +874,17 @@ enum Network CNetAddr::GetNetwork() const
     return NET_IPV6;
 }
 
-std::string CNetAddr::ToStringIP(bool fUseGetnameinfo) const
+std::string CNetAddr::ToStringIP() const
 {
     if (IsTor())
         return EncodeBase32(&ip[6], 10) + ".onion";
-    if (fUseGetnameinfo)
-    {
-        CService serv(*this, 0);
-        struct sockaddr_storage sockaddr;
-        socklen_t socklen = sizeof(sockaddr);
-        if (serv.GetSockAddr((struct sockaddr*)&sockaddr, &socklen)) {
-            char name[1025] = "";
-            if (!getnameinfo((const struct sockaddr*)&sockaddr, socklen, name, sizeof(name), NULL, 0, NI_NUMERICHOST))
-                return std::string(name);
-        }
+    CService serv(*this, 0);
+    struct sockaddr_storage sockaddr;
+    socklen_t socklen = sizeof(sockaddr);
+    if (serv.GetSockAddr((struct sockaddr*)&sockaddr, &socklen)) {
+        char name[1025] = "";
+        if (!getnameinfo((const struct sockaddr*)&sockaddr, socklen, name, sizeof(name), NULL, 0, NI_NUMERICHOST))
+            return std::string(name);
     }
     if (IsIPv4())
         return strprintf("%u.%u.%u.%u", GetByte(3), GetByte(2), GetByte(1), GetByte(0));
@@ -1234,18 +1231,18 @@ std::string CService::ToStringPort() const
     return strprintf("%u", port);
 }
 
-std::string CService::ToStringIPPort(bool fUseGetnameinfo) const
+std::string CService::ToStringIPPort() const
 {
     if (IsIPv4() || IsTor()) {
-        return ToStringIP(fUseGetnameinfo) + ":" + ToStringPort();
+        return ToStringIP() + ":" + ToStringPort();
     } else {
-        return "[" + ToStringIP(fUseGetnameinfo) + "]:" + ToStringPort();
+        return "[" + ToStringIP() + "]:" + ToStringPort();
     }
 }
 
-std::string CService::ToString(bool fUseGetnameinfo) const
+std::string CService::ToString() const
 {
-    return ToStringIPPort(fUseGetnameinfo);
+    return ToStringIPPort();
 }
 
 void CService::SetPort(unsigned short portIn)

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -82,7 +82,7 @@ public:
     bool IsMulticast() const;
     enum Network GetNetwork() const;
     std::string ToString() const;
-    std::string ToStringIP(bool fUseGetnameinfo = true) const;
+    std::string ToStringIP() const;
     unsigned int GetByte(int n) const;
     uint64_t GetHash() const;
     bool GetInAddr(struct in_addr* pipv4Addr) const;
@@ -167,9 +167,9 @@ public:
     friend bool operator!=(const CService& a, const CService& b);
     friend bool operator<(const CService& a, const CService& b);
     std::vector<unsigned char> GetKey() const;
-    std::string ToString(bool fUseGetnameinfo = true) const;
+    std::string ToString() const;
     std::string ToStringPort() const;
-    std::string ToStringIPPort(bool fUseGetnameinfo = true) const;
+    std::string ToStringIPPort() const;
 
     CService(const struct in6_addr& ipv6Addr, unsigned short port);
     CService(const struct sockaddr_in6& addr);

--- a/src/obfuscation.cpp
+++ b/src/obfuscation.cpp
@@ -2174,13 +2174,10 @@ bool CObfuScationSigner::VerifyMessage(CPubKey pubkey, vector<unsigned char>& vc
         return false;
     }
 
-    if (pubkey2.GetID() != pubkey.GetID()) {
-        errorMessage = strprintf("keys don't match - input: %s, recovered: %s, sig: %s\n",
-                pubkey.GetID().ToString(), pubkey2.GetID().ToString(), EncodeBase64(&vchSig[0], vchSig.size()));
-        return false;
-    }
+    if (fDebug && pubkey2.GetID() != pubkey.GetID())
+        LogPrintf("CObfuScationSigner::VerifyMessage -- keys don't match: %s %s\n", pubkey2.GetID().ToString(), pubkey.GetID().ToString());
 
-    return true;
+    return (pubkey2.GetID() == pubkey.GetID());
 }
 
 bool CObfuscationQueue::Sign()
@@ -2325,4 +2322,3 @@ void ThreadCheckObfuScationPool()
         }
     }
 }
-


### PR DESCRIPTION
This reverts the changes introduced with:
- https://github.com/PIVX-Project/PIVX/pull/599/commits/0ec1fd5577ca5f75aa7681b282283c2d1ab3c023 (https://github.com/PIVX-Project/PIVX/pull/599)
- https://github.com/PIVX-Project/PIVX/pull/606/commits/37c6e7db5834a643a13deb3c012ac68e0afe5987 (https://github.com/PIVX-Project/PIVX/pull/606)

that are causing excessive peer banning, due to the change in `strMessage` which makes signatures created prior `#599` fail validation after `#599` merge.
(included `#606` because it built on top of `#599`)