### PR TITLE
[Build] Make sure Boost headers are included for libzerocoin

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -324,7 +324,7 @@ crypto_libbitcoin_crypto_a_SOURCES = \
   crypto/sph_types.h
 
 # libzerocoin library
-libzerocoin_libbitcoin_zerocin_a_CPPFLAGS = $(AM_CPPFLAGS)
+libzerocoin_libbitcoin_zerocin_a_CPPFLAGS = $(AM_CPPFLAGS) $(BOOST_CPPFLAGS)
 libzerocoin_libbitcoin_zerocin_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libzerocoin_libbitcoin_zerocoin_a_SOURCES = \
   libzerocoin/Accumulator.h \


### PR DESCRIPTION
Custom boost locations not using pkg_config can result in a header
include not being found when compiling the libzerocoin library. This
quick fix ensures that the `BOOST_CPPFLAGS` are explicitely included.

This should fix #621