### PR TITLE
[Core] Missing seesaw value for block 325000

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1870,7 +1870,7 @@ CAmount GetSeeSaw(const CAmount& blockValue, int nMasternodeCount, int nHeight)
     CAmount ret = 0;
     if (mNodeCoins == 0) {
         ret = 0;
-    } else if (nHeight < 325000) {
+    } else if (nHeight <= 325000) {
         if (mNodeCoins <= (nMoneySupply * .05) && mNodeCoins > 0) {
             ret = blockValue * .85;
         } else if (mNodeCoins <= (nMoneySupply * .1) && mNodeCoins > (nMoneySupply * .05)) {


### PR DESCRIPTION
Fixes #623, sister commit to a03edf6/#460