### PR TITLE
significantly increased the verification cycle for staking.

### DIFF
--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -315,7 +315,7 @@ bool Stake(CStakeInput* stakeInput, unsigned int nBits, unsigned int nTimeBlockF
     bool fSuccess = false;
     unsigned int nTryTime = 0;
     int nHeightStart = chainActive.Height();
-    int nHashDrift = 30;
+    int nHashDrift = 60;
     CDataStream ssUniqueID = stakeInput->GetUniqueness();
     CAmount nValueIn = stakeInput->GetValue();
     for (int i = 0; i < nHashDrift; i++) //iterate the hashing

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -580,6 +580,7 @@ void BitcoinMiner(CWallet* pwallet, bool fProofOfStake)
     // Each thread has its own key and counter
     CReserveKey reservekey(pwallet);
     unsigned int nExtraNonce = 0;
+    int nHeightLast = 0;
 
     while (fGenerateBitcoins || fProofOfStake) {
         if (fProofOfStake) {
@@ -610,14 +611,16 @@ void BitcoinMiner(CWallet* pwallet, bool fProofOfStake)
                     continue;
             }
 
-            if (mapHashedBlocks.count(chainActive.Tip()->nHeight)) //search our map of hashed blocks, see if bestblock has been hashed yet
+            if (nHeightLast == chainActive.Tip()->nHeight)
             {
                 if (GetTime() - mapHashedBlocks[chainActive.Tip()->nHeight] < max(pwallet->nHashInterval, (unsigned int)1)) // wait half of the nHashDrift with max wait of 3 minutes
                 {
-                    MilliSleep(5000);
+                    MilliSleep(1000);
                     continue;
                 }
             }
+
+            nHeightLast = chainActive.Tip()->nHeight;
         }
 
         //

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -2959,11 +2959,13 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
         return false;
 
     if (GetAdjustedTime() - chainActive.Tip()->GetBlockTime() < 60)
-        MilliSleep(10000);
+        MilliSleep(100);
 
     CAmount nCredit = 0;
     CScript scriptPubKeyKernel;
     bool fKernelFound = false;
+    int nHeightStart = chainActive.Height();
+
     for (std::unique_ptr<CStakeInput>& stakeInput : listInputs) {
         // Make sure the wallet is unlocked and shutdown hasn't been requested
         if (IsLocked() || ShutdownRequested())
@@ -2974,6 +2976,10 @@ bool CWallet::CreateCoinStake(const CKeyStore& keystore, unsigned int nBits, int
         if (!pindex || pindex->nHeight < 1) {
             LogPrintf("*** no pindexfrom\n");
             continue;
+        }
+
+        if (chainActive.Height() != nHeightStart) {
+            return false;
         }
 
         // Read block header

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -304,9 +304,9 @@ public:
         fBackupMints = false;
 
         // Stake Settings
-        nHashDrift = 45;
+        nHashDrift = 60;
         nStakeSplitThreshold = 2000;
-        nHashInterval = 22;
+        nHashInterval = 2;
         nStakeSetUpdateTime = 300; // 5 minutes
 
         //MultiSend


### PR DESCRIPTION
The following information is intended to reduce the search interval.

Change " nHashInterval "
- there is a large delay in spending after " kernel found ". Must decrease.
- The search interval should be as small as possible.
- BlockTime and StakeModifier in " zpos Stake " change intermittently.

Change " nHashDrift "
- It is not a good idea to lower the setting to reduce orphans.
- It is right to increase it.

Result
- All errors are resolved except below.
- Except is "ContextualCheckZerocoinStake: accumulator checksum is different than the block 200 blocks previous."
- Unable to resolve because StakeModifier is changing. So the interval was lowered to 1000 ms for testing.

I did a test at " main-net ".

Test environment (tested on Guest)
Host : Intel I-7000 CPU, 16 gb ram, windows 10 64bit.
Guest : ubuntu 64bit on hyper - v (1core 4gb ram)
Network : 1GB BPS, peer connection set 256

I want you to know that I don't have as much time to understand the code as the core team.