### PR TITLE
[Qt] Remove green on tab pressed

### DIFF
--- a/src/qt/res/css/default.css
+++ b/src/qt/res/css/default.css
@@ -103,7 +103,7 @@ background-color: #372f44; /* Do not highlight placeholder on hover */
 }
 
 QToolBar > QToolButton:pressed {
-background-color: qlineargradient(x1:0, x2: 1, stop: 0 #00a300, stop: 0.07 #00a300, stop: 0.0701 #372f44, stop: 1 #372f44);
+background-color: qlineargradient(x1:0, x2: 1, stop: 0 #372f44, stop: 0.07 #372f44, stop: 0.0701 #372f44, stop: 1 #372f44);
 color:#fff;
 }
 


### PR DESCRIPTION
Buttons from the left menu are showing a green part when pressed. 
This removes it by showing the same purple as background, blending in. The click still offers a feedback since it goes from white to purple while pressed and back to white when released.