### PR TITLE
[Travis] Add separate job to check doc/logprint/subtree

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,13 @@ cache:
   - depends/built
   - depends/sdk-sources
   - $HOME/.ccache
+stages:
+  - lint
+  - test
 env:
   global:
     - MAKEJOBS=-j3
     - RUN_TESTS=false
-    - CHECK_DOC=0
-    - CHECK_LOGPRINT=0
     - BOOST_TEST_RANDOM=1$TRAVIS_BUILD_ID
     - CCACHE_SIZE=100M
     - CCACHE_TEMPDIR=/tmp/.ccache-temp
@@ -22,7 +23,7 @@ env:
     - WINEDEBUG=fixme-all
   matrix:
 # ARM
-    - HOST=arm-linux-gnueabihf PACKAGES="g++-arm-linux-gnueabihf" CHECK_DOC=1 CHECK_LOGPRINT=1 GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
+    - HOST=arm-linux-gnueabihf PACKAGES="g++-arm-linux-gnueabihf" GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
 # Win32
     - HOST=i686-w64-mingw32 DPKG_ADD_ARCH="i386" DEP_OPTS="NO_QT=1" PACKAGES="python3 nsis g++-mingw-w64-i686 wine1.6 bc" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-reduce-exports"
 # 32-bit + dash
@@ -44,8 +45,6 @@ install:
     - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get update; fi
     - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get install --no-install-recommends --no-upgrade -qq $PACKAGES; fi
 before_script:
-    - if [ "$CHECK_DOC" = 1 ]; then contrib/devtools/check-doc.py; fi
-    - if [ "$CHECK_LOGPRINT" = 1 ]; then contrib/devtools/logprint-scanner.py; fi
     - unset CC; unset CXX
     - mkdir -p depends/SDKs depends/sdk-sources
     - if [ -n "$OSX_SDK" -a ! -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then curl --location --fail $SDK_URL/MacOSX${OSX_SDK}.sdk.tar.gz -o depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi
@@ -69,6 +68,26 @@ script:
 after_script:
     - echo $TRAVIS_COMMIT_RANGE
     - echo $TRAVIS_COMMIT_LOG
-notifications:
-  slack:
-    secure: w22XjHoG/3xplxWzddS9Ma7i99Q/hq4FA3Q56xS+RtO2vlFgDT+eDzCppstdx96mn2/4e+/V1aiQ4E6GVEvJMeldqSUhPv9OBnKR0KJVAOwu4haNXt+0ZeQFt8lIndKB5cMVyOJkoq6peGoHNXslClM0lGuBn7g7VC2QPQYNWrJNrrGL7IiVb6fNOIKHWcC4URkzSvXAhO/WIqSSlmKxAAx0B2oEsM8LhdAbcjbp7Sm7zH87TIVGBZ7iTVuMc6B9+SfClbE8bBuRtvjTX57Q4UUZzn0zDtKdPdCte0oXdaQF4RdVim9mDodBGIpDo+avW4WL7EE+AK33fs94pwH5bu0LEandR/aeEvVpbSpQ2XsEKSe+6woizgl5i4GXFVZduJF62y/o1f+S/zC3qW9lIEEpiZc4PpX7pDy30X3p6S5nMrW7T/zNh+SjLhS1VP6XKdQtpD3WRCY4GKZYammZhk5RbOy3jTXAahIXuttWdhl/Q3Rb5VqfFJWlrG/qQXt73qOk2/DgJnABxXE6gnWO4MpHAq+kdomNR+nod4HeXI3DOk1wRuQRVoW1rSjiqQd6Db+TP56RKYgt4M4csOD0DG9G+W0AOtZkuKHTeoEtmQfkKFPZLYAQumv41cDN2UE9gKIECmvJSevj4sMCDTWtozKWqay/W4n2+cmhbzmGflY=
+
+jobs:
+  include:
+    - stage: lint
+      sudo: false
+      cache: false
+      addons:
+        apt:
+          packages:
+            - python3-pip
+            - shellcheck
+      install:
+        - travis_retry pip3 install flake8 --user
+      before_script:
+        - git fetch --unshallow
+      script:
+        - contrib/devtools/git-subtree-check.sh src/univalue
+        # Remove this comment and the `#` from the following two lines when we merge proper subtree implementations for secp256k1 and leveldb
+        #- contrib/devtools/git-subtree-check.sh src/secp256k1
+        #- contrib/devtools/git-subtree-check.sh src/leveldb
+        - contrib/devtools/check-doc.py
+        - contrib/devtools/logprint-scanner.py
+        - if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then contrib/devtools/lint-whitespace.sh; fi

--- a/contrib/devtools/git-subtree-check.sh
+++ b/contrib/devtools/git-subtree-check.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+# Copyright (c) 2015 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C
+DIR="$1"
+COMMIT="$2"
+if [ -z "$COMMIT" ]; then
+    COMMIT=HEAD
+fi
+
+# Taken from git-subtree (Copyright (C) 2009 Avery Pennarun <apenwarr@gmail.com>)
+find_latest_squash()
+{
+	dir="$1"
+	sq=
+	main=
+	sub=
+	git log --grep="^git-subtree-dir: $dir/*\$" \
+		--pretty=format:'START %H%n%s%n%n%b%nEND%n' "$COMMIT" |
+	while read a b _; do
+		case "$a" in
+			START) sq="$b" ;;
+			git-subtree-mainline:) main="$b" ;;
+			git-subtree-split:) sub="$b" ;;
+			END)
+				if [ -n "$sub" ]; then
+					if [ -n "$main" ]; then
+						# a rejoin commit?
+						# Pretend its sub was a squash.
+						sq="$sub"
+					fi
+					echo "$sq" "$sub"
+					break
+				fi
+				sq=
+				main=
+				sub=
+				;;
+		esac
+	done
+}
+
+# find latest subtree update
+latest_squash="$(find_latest_squash "$DIR")"
+if [ -z "$latest_squash" ]; then
+    echo "ERROR: $DIR is not a subtree" >&2
+    exit 2
+fi
+set $latest_squash
+old=$1
+rev=$2
+
+# get the tree in the current commit
+tree_actual=$(git ls-tree -d "$COMMIT" "$DIR" | head -n 1)
+if [ -z "$tree_actual" ]; then
+    echo "FAIL: subtree directory $DIR not found in $COMMIT" >&2
+    exit 1
+fi
+set $tree_actual
+tree_actual_type=$2
+tree_actual_tree=$3
+echo "$DIR in $COMMIT currently refers to $tree_actual_type $tree_actual_tree"
+if [ "d$tree_actual_type" != "dtree" ]; then
+    echo "FAIL: subtree directory $DIR is not a tree in $COMMIT" >&2
+    exit 1
+fi
+
+# get the tree at the time of the last subtree update
+tree_commit=$(git show -s --format="%T" $old)
+echo "$DIR in $COMMIT was last updated in commit $old (tree $tree_commit)"
+
+# ... and compare the actual tree with it
+if [ "$tree_actual_tree" != "$tree_commit" ]; then
+    git diff $tree_commit $tree_actual_tree >&2
+    echo "FAIL: subtree directory was touched without subtree merge" >&2
+    exit 1
+fi
+
+# get the tree in the subtree commit referred to
+if [ "d$(git cat-file -t $rev 2>/dev/null)" != dcommit ]; then
+    echo "subtree commit $rev unavailable: cannot compare" >&2
+    exit
+fi
+tree_subtree=$(git show -s --format="%T" $rev)
+echo "$DIR in $COMMIT was last updated to upstream commit $rev (tree $tree_subtree)"
+
+# ... and compare the actual tree with it
+if [ "$tree_actual_tree" != "$tree_subtree" ]; then
+    echo "FAIL: subtree update commit differs from upstream tree!" >&2
+    exit 1
+fi
+
+echo "GOOD"

--- a/contrib/devtools/lint-whitespace.sh
+++ b/contrib/devtools/lint-whitespace.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Check for new lines in diff that introduce trailing whitespace.
+
+# We can't run this check unless we know the commit range for the PR.
+
+export LC_ALL=C
+while getopts "?" opt; do
+  case $opt in
+    ?)
+      echo "Usage: .lint-whitespace.sh [N]"
+      echo "       TRAVIS_COMMIT_RANGE='<commit range>' .lint-whitespace.sh"
+      echo "       .lint-whitespace.sh -?"
+      echo "Checks unstaged changes, the previous N commits, or a commit range."
+      echo "TRAVIS_COMMIT_RANGE='47ba2c3...ee50c9e' .lint-whitespace.sh"
+      exit 0
+    ;;
+  esac
+done
+
+if [ -z "${TRAVIS_COMMIT_RANGE}" ]; then
+  if [ "$1" ]; then
+    TRAVIS_COMMIT_RANGE="HEAD~$1...HEAD"
+  else
+    TRAVIS_COMMIT_RANGE="HEAD"
+  fi
+fi
+
+showdiff() {
+  if ! git diff -U0 "${TRAVIS_COMMIT_RANGE}" -- "." ":(exclude)depends/patches/" ":(exclude)src/leveldb/" ":(exclude)src/secp256k1/" ":(exclude)src/univalue/" ":(exclude)doc/release-notes/"; then
+    echo "Failed to get a diff"
+    exit 1
+  fi
+}
+
+showcodediff() {
+  if ! git diff -U0 "${TRAVIS_COMMIT_RANGE}" -- *.cpp *.h *.md *.py *.sh ":(exclude)src/leveldb/" ":(exclude)src/secp256k1/" ":(exclude)src/univalue/" ":(exclude)doc/release-notes/"; then
+    echo "Failed to get a diff"
+    exit 1
+  fi
+}
+
+RET=0
+
+# Check if trailing whitespace was found in the diff.
+if showdiff | grep -E -q '^\+.*\s+$'; then
+  echo "This diff appears to have added new lines with trailing whitespace."
+  echo "The following changes were suspected:"
+  FILENAME=""
+  SEEN=0
+  SEENLN=0
+  while read -r line; do
+    if [[ "$line" =~ ^diff ]]; then
+      FILENAME="$line"
+      SEEN=0
+    elif [[ "$line" =~ ^@@ ]]; then
+      LINENUMBER="$line"
+      SEENLN=0
+    else
+      if [ "$SEEN" -eq 0 ]; then
+        # The first time a file is seen with trailing whitespace, we print the
+        # filename (preceded by a newline).
+        echo
+        echo "$FILENAME"
+        SEEN=1
+      fi
+      if [ "$SEENLN" -eq 0 ]; then
+        echo "$LINENUMBER"
+        SEENLN=1
+      fi
+      echo "$line"
+    fi
+  done < <(showdiff | grep -E '^(diff --git |@@|\+.*\s+$)')
+  RET=1
+fi
+
+# Check if tab characters were found in the diff.
+if showcodediff | perl -nle '$MATCH++ if m{^\+.*\t}; END{exit 1 unless $MATCH>0}' > /dev/null; then
+  echo "This diff appears to have added new lines with tab characters instead of spaces."
+  echo "The following changes were suspected:"
+  FILENAME=""
+  SEEN=0
+  SEENLN=0
+  while read -r line; do
+    if [[ "$line" =~ ^diff ]]; then
+      FILENAME="$line"
+      SEEN=0
+    elif [[ "$line" =~ ^@@ ]]; then
+      LINENUMBER="$line"
+      SEENLN=0
+    else
+      if [ "$SEEN" -eq 0 ]; then
+        # The first time a file is seen with a tab character, we print the
+        # filename (preceded by a newline).
+        echo
+        echo "$FILENAME"
+        SEEN=1
+      fi
+      if [ "$SEENLN" -eq 0 ]; then
+        echo "$LINENUMBER"
+        SEENLN=1
+      fi
+      echo "$line"
+    fi
+  done < <(showcodediff | perl -nle 'print if m{^(diff --git |@@|\+.*\t)}')
+  RET=1
+fi
+
+exit $RET


### PR DESCRIPTION
Break out a new job to do the basic linting that check-dock.py and
logprint-scanner.py did.

Also add new scripts to check the sanity of
any git subtrees and to check that new pull requests don't contain any
trailing whitespace.

Also, remove the outdated slack notification callback