### PR TITLE
#642 change COINBASE_MATURITY to Params().COINBASE_MATURITY()

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -4103,7 +4103,7 @@ void CWallet::AutoCombineDust()
             if (!out.fSpendable)
                 continue;
             //no coins should get this far if they dont have proper maturity, this is double checking
-            if (out.tx->IsCoinStake() && out.tx->GetDepthInMainChain() < COINBASE_MATURITY + 1)
+            if (out.tx->IsCoinStake() && out.tx->GetDepthInMainChain() < Params().COINBASE_MATURITY() + 1)
                 continue;
 
             COutPoint outpt(out.tx->GetHash(), out.i);


### PR DESCRIPTION
A trivial fix for issue #642 