### PR TITLE
[Qt] SwiftX - intuitiveness

### DIFF
--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -898,7 +898,7 @@
              <x>0</x>
              <y>0</y>
              <width>944</width>
-             <height>68</height>
+             <height>69</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,1">
@@ -975,7 +975,7 @@
             <number>0</number>
            </property>
            <item>
-            <layout class="QVBoxLayout" name="verticalLayoutFee2" stretch="0,0,0">
+            <layout class="QVBoxLayout" name="verticalLayoutFee2" stretch="0,0,0,0">
              <property name="spacing">
               <number>0</number>
              </property>
@@ -989,7 +989,178 @@
               <number>6</number>
              </property>
              <item>
+              <layout class="QVBoxLayout" name="verticalLayout_feeConf">
+               <property name="spacing">
+                <number>0</number>
+               </property>
+               <property name="leftMargin">
+                <number>10</number>
+               </property>
+               <property name="rightMargin">
+                <number>10</number>
+               </property>
+               <property name="bottomMargin">
+                <number>5</number>
+               </property>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayoutFee9">
+                 <item>
+                  <widget class="QCheckBox" name="checkSwiftTX">
+                   <property name="enabled">
+                    <bool>true</bool>
+                   </property>
+                   <property name="minimumSize">
+                    <size>
+                     <width>85</width>
+                     <height>0</height>
+                    </size>
+                   </property>
+                   <property name="toolTip">
+                    <string>SwiftX technology allows for near instant transactions - A flat fee of 0.01 PIV applies</string>
+                   </property>
+                   <property name="text">
+                    <string>SwiftX</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="labelSmartFee3">
+                   <property name="text">
+                    <string>Confirmation time:</string>
+                   </property>
+                   <property name="margin">
+                    <number>2</number>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="labelSmartFeeNormal">
+                   <property name="text">
+                    <string>normal</string>
+                   </property>
+                   <property name="margin">
+                    <number>8</number>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QSlider" name="sliderSmartFee">
+                   <property name="minimumSize">
+                    <size>
+                     <width>0</width>
+                     <height>24</height>
+                    </size>
+                   </property>
+                   <property name="minimum">
+                    <number>0</number>
+                   </property>
+                   <property name="maximum">
+                    <number>24</number>
+                   </property>
+                   <property name="pageStep">
+                    <number>1</number>
+                   </property>
+                   <property name="value">
+                    <number>0</number>
+                   </property>
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="invertedAppearance">
+                    <bool>false</bool>
+                   </property>
+                   <property name="invertedControls">
+                    <bool>false</bool>
+                   </property>
+                   <property name="tickPosition">
+                    <enum>QSlider::NoTicks</enum>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="labelSmartFeeFast">
+                   <property name="text">
+                    <string>fast</string>
+                   </property>
+                   <property name="margin">
+                    <number>8</number>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayout_recommended_texts">
+                 <property name="spacing">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <spacer name="horizontalSpacer_8">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="labelFeeEstimation">
+                   <property name="text">
+                    <string/>
+                   </property>
+                   <property name="margin">
+                    <number>2</number>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="labelSmartFee2">
+                   <property name="text">
+                    <string>(Smart fee not initialized yet. This usually takes a few blocks...)</string>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                   </property>
+                   <property name="wordWrap">
+                    <bool>false</bool>
+                   </property>
+                   <property name="margin">
+                    <number>2</number>
+                   </property>
+                   <property name="indent">
+                    <number>-1</number>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer_3">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>40</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
+               </item>
+              </layout>
+             </item>
+             <item>
               <layout class="QHBoxLayout" name="horizontalLayoutFee1">
+               <property name="leftMargin">
+                <number>10</number>
+               </property>
+               <property name="rightMargin">
+                <number>10</number>
+               </property>
                <property name="bottomMargin">
                 <number>0</number>
                </property>
@@ -998,22 +1169,6 @@
                  <property name="spacing">
                   <number>0</number>
                  </property>
-                 <item>
-                  <spacer name="verticalSpacerSmartFee">
-                   <property name="orientation">
-                    <enum>Qt::Vertical</enum>
-                   </property>
-                   <property name="sizeType">
-                    <enum>QSizePolicy::Fixed</enum>
-                   </property>
-                   <property name="sizeHint" stdset="0">
-                    <size>
-                     <width>1</width>
-                     <height>4</height>
-                    </size>
-                   </property>
-                  </spacer>
-                 </item>
                  <item>
                   <layout class="QHBoxLayout" name="horizontalLayoutSmartFee">
                    <property name="spacing">
@@ -1289,8 +1444,31 @@
                     </property>
                    </widget>
                   </item>
+                  <item row="1" column="2">
+                   <widget class="QLabel" name="labelSmartFee">
+                    <property name="text">
+                     <string/>
+                    </property>
+                    <property name="margin">
+                     <number>2</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QRadioButton" name="radioSmartFee">
+                    <property name="text">
+                     <string/>
+                    </property>
+                    <property name="checked">
+                     <bool>true</bool>
+                    </property>
+                    <attribute name="buttonGroup">
+                     <string notr="true">groupFee</string>
+                    </attribute>
+                   </widget>
+                  </item>
                   <item row="0" column="4" rowspan="3">
-                   <layout class="QVBoxLayout" name="verticalLayoutFee3" stretch="0,0,0,0,1,0">
+                   <layout class="QVBoxLayout" name="verticalLayoutFee3" stretch="0,0,0,0">
                     <property name="spacing">
                      <number>6</number>
                     </property>
@@ -1300,133 +1478,6 @@
                     <property name="bottomMargin">
                      <number>20</number>
                     </property>
-                    <item>
-                     <layout class="QHBoxLayout" name="horizontalLayoutFee9">
-                      <item>
-                       <widget class="QLabel" name="labelSmartFee3">
-                        <property name="text">
-                         <string>Confirmation time:</string>
-                        </property>
-                        <property name="margin">
-                         <number>2</number>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QLabel" name="labelSmartFeeNormal">
-                        <property name="text">
-                         <string>normal</string>
-                        </property>
-                        <property name="margin">
-                         <number>2</number>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QSlider" name="sliderSmartFee">
-                        <property name="minimumSize">
-                         <size>
-                          <width>0</width>
-                          <height>24</height>
-                         </size>
-                        </property>
-                        <property name="minimum">
-                         <number>0</number>
-                        </property>
-                        <property name="maximum">
-                         <number>24</number>
-                        </property>
-                        <property name="pageStep">
-                         <number>1</number>
-                        </property>
-                        <property name="value">
-                         <number>0</number>
-                        </property>
-                        <property name="orientation">
-                         <enum>Qt::Horizontal</enum>
-                        </property>
-                        <property name="invertedAppearance">
-                         <bool>false</bool>
-                        </property>
-                        <property name="invertedControls">
-                         <bool>false</bool>
-                        </property>
-                        <property name="tickPosition">
-                         <enum>QSlider::NoTicks</enum>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QLabel" name="labelSmartFeeFast">
-                        <property name="text">
-                         <string>fast</string>
-                        </property>
-                       </widget>
-                      </item>
-                     </layout>
-                    </item>
-                    <item>
-                     <layout class="QHBoxLayout" name="horizontalLayout_recommended_texts">
-                      <property name="spacing">
-                       <number>0</number>
-                      </property>
-                      <item>
-                       <spacer name="horizontalSpacer_8">
-                        <property name="orientation">
-                         <enum>Qt::Horizontal</enum>
-                        </property>
-                        <property name="sizeHint" stdset="0">
-                         <size>
-                          <width>40</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                       </spacer>
-                      </item>
-                      <item>
-                       <widget class="QLabel" name="labelFeeEstimation">
-                        <property name="text">
-                         <string/>
-                        </property>
-                        <property name="margin">
-                         <number>2</number>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <widget class="QLabel" name="labelSmartFee2">
-                        <property name="text">
-                         <string>(Smart fee not initialized yet. This usually takes a few blocks...)</string>
-                        </property>
-                        <property name="alignment">
-                         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-                        </property>
-                        <property name="wordWrap">
-                         <bool>false</bool>
-                        </property>
-                        <property name="margin">
-                         <number>2</number>
-                        </property>
-                        <property name="indent">
-                         <number>-1</number>
-                        </property>
-                       </widget>
-                      </item>
-                      <item>
-                       <spacer name="horizontalSpacer_3">
-                        <property name="orientation">
-                         <enum>Qt::Horizontal</enum>
-                        </property>
-                        <property name="sizeHint" stdset="0">
-                         <size>
-                          <width>40</width>
-                          <height>20</height>
-                         </size>
-                        </property>
-                       </spacer>
-                      </item>
-                     </layout>
-                    </item>
                     <item>
                      <widget class="Line" name="line_2">
                       <property name="minimumSize">
@@ -1490,29 +1541,6 @@
                      </spacer>
                     </item>
                    </layout>
-                  </item>
-                  <item row="1" column="2">
-                   <widget class="QLabel" name="labelSmartFee">
-                    <property name="text">
-                     <string/>
-                    </property>
-                    <property name="margin">
-                     <number>2</number>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="0">
-                   <widget class="QRadioButton" name="radioSmartFee">
-                    <property name="text">
-                     <string/>
-                    </property>
-                    <property name="checked">
-                     <bool>true</bool>
-                    </property>
-                    <attribute name="buttonGroup">
-                     <string notr="true">groupFee</string>
-                    </attribute>
-                   </widget>
                   </item>
                  </layout>
                 </item>
@@ -1687,22 +1715,6 @@
                </property>
                <property name="text">
                 <string>Anonymized PIV</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QCheckBox" name="checkSwiftTX">
-               <property name="enabled">
-                <bool>true</bool>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>85</width>
-                 <height>0</height>
-                </size>
-               </property>
-               <property name="text">
-                <string>SwiftX</string>
                </property>
               </widget>
              </item>


### PR DESCRIPTION
Minor clean up of the sendcoinsdialog for improved usability of fee control and SwiftX feature in response to the issues raised in https://github.com/PIVX-Project/PIVX/issues/672.

The smartFee slider is now on its own row for better visualization and is disabled when SwiftX is selected.
The SwiftX checkbox is put next to it, has now a tooltip, and when it's checked it:
- updates the fee label
- brings the slider to the max value before disabling it
- hides the choose button for the smart fee
- minimizes the smart fee box if already maximized
- updates the labelFeeEstimation with an explicative message.

<br>

![swiftx_demo](https://user-images.githubusercontent.com/18186894/43352894-bd286f80-922b-11e8-86a4-429f71845761.gif)
