### PR TITLE
[Qt] Privacy dialog: hide/show denominations

### DIFF
--- a/src/qt/forms/privacydialog.ui
+++ b/src/qt/forms/privacydialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>991</width>
-    <height>737</height>
+    <height>766</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -153,12 +153,12 @@
             <number>0</number>
            </property>
            <item>
-            <layout class="QVBoxLayout" name="verticalLayout_Content" stretch="1">
+            <layout class="QVBoxLayout" name="verticalLayout_Content" stretch="0">
              <property name="spacing">
               <number>2</number>
              </property>
              <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_Content" stretch="1,1">
+              <layout class="QHBoxLayout" name="horizontalLayout_Content" stretch="0,0">
                <property name="spacing">
                 <number>6</number>
                </property>
@@ -239,6 +239,132 @@
                         <property name="orientation">
                          <enum>Qt::Horizontal</enum>
                         </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QFrame" name="balanceSupplyFrame">
+                        <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0,0,1,0">
+                         <property name="rightMargin">
+                          <number>0</number>
+                         </property>
+                         <item>
+                          <layout class="QHBoxLayout" name="horizontalLayout_34">
+                           <item>
+                            <widget class="QLabel" name="labelzAvailableText_3">
+                             <property name="font">
+                              <font>
+                               <weight>75</weight>
+                               <bold>true</bold>
+                              </font>
+                             </property>
+                             <property name="toolTip">
+                              <string>Total Balance including unconfirmed and immature zPIV</string>
+                             </property>
+                             <property name="text">
+                              <string>Total Zerocoin  Balance:</string>
+                             </property>
+                             <property name="alignment">
+                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                             </property>
+                            </widget>
+                           </item>
+                           <item>
+                            <widget class="QLabel" name="labelzAvailableAmount_4">
+                             <property name="minimumSize">
+                              <size>
+                               <width>40</width>
+                               <height>0</height>
+                              </size>
+                             </property>
+                             <property name="font">
+                              <font>
+                               <weight>75</weight>
+                               <bold>true</bold>
+                              </font>
+                             </property>
+                             <property name="toolTip">
+                              <string>Total Balance including unconfirmed and immature zPIV</string>
+                             </property>
+                             <property name="text">
+                              <string>0 zPIV</string>
+                             </property>
+                             <property name="alignment">
+                              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                             </property>
+                            </widget>
+                           </item>
+                          </layout>
+                         </item>
+                         <item>
+                          <spacer name="horizontalSpacer_32">
+                           <property name="orientation">
+                            <enum>Qt::Horizontal</enum>
+                           </property>
+                           <property name="sizeHint" stdset="0">
+                            <size>
+                             <width>40</width>
+                             <height>20</height>
+                            </size>
+                           </property>
+                          </spacer>
+                         </item>
+                         <item>
+                          <layout class="QHBoxLayout" name="horizontalLayout_35">
+                           <item>
+                            <widget class="QLabel" name="labelZsupplyText_2">
+                             <property name="font">
+                              <font>
+                               <weight>75</weight>
+                               <bold>true</bold>
+                              </font>
+                             </property>
+                             <property name="text">
+                              <string>Global Supply:</string>
+                             </property>
+                             <property name="alignment">
+                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                             </property>
+                            </widget>
+                           </item>
+                           <item>
+                            <widget class="QLabel" name="labelZsupplyAmount_2">
+                             <property name="font">
+                              <font>
+                               <weight>75</weight>
+                               <bold>true</bold>
+                              </font>
+                             </property>
+                             <property name="text">
+                              <string>0 zPIV</string>
+                             </property>
+                            </widget>
+                           </item>
+                          </layout>
+                         </item>
+                         <item>
+                          <spacer name="horizontalSpacer_31">
+                           <property name="orientation">
+                            <enum>Qt::Horizontal</enum>
+                           </property>
+                           <property name="sizeHint" stdset="0">
+                            <size>
+                             <width>40</width>
+                             <height>20</height>
+                            </size>
+                           </property>
+                          </spacer>
+                         </item>
+                         <item>
+                          <widget class="QPushButton" name="pushButtonShowDenoms">
+                           <property name="toolTip">
+                            <string>Show zPIV denominations list</string>
+                           </property>
+                           <property name="text">
+                            <string>Show Denominations</string>
+                           </property>
+                          </widget>
+                         </item>
+                        </layout>
                        </widget>
                       </item>
                       <item>
@@ -1941,6 +2067,43 @@ To change the percentage (no restart required):
                          <size>
                           <width>20</width>
                           <height>40</height>
+                         </size>
+                        </property>
+                       </spacer>
+                      </item>
+                     </layout>
+                    </item>
+                    <item>
+                     <layout class="QHBoxLayout" name="horizontalLayout_8">
+                      <item>
+                       <spacer name="horizontalSpacer_33">
+                        <property name="orientation">
+                         <enum>Qt::Horizontal</enum>
+                        </property>
+                        <property name="sizeHint" stdset="0">
+                         <size>
+                          <width>40</width>
+                          <height>20</height>
+                         </size>
+                        </property>
+                       </spacer>
+                      </item>
+                      <item>
+                       <widget class="QPushButton" name="pushButtonHideDenoms">
+                        <property name="text">
+                         <string>Hide Denominations</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <spacer name="horizontalSpacer_34">
+                        <property name="orientation">
+                         <enum>Qt::Horizontal</enum>
+                        </property>
+                        <property name="sizeHint" stdset="0">
+                         <size>
+                          <width>40</width>
+                          <height>20</height>
                          </size>
                         </property>
                        </spacer>

--- a/src/qt/privacydialog.h
+++ b/src/qt/privacydialog.h
@@ -73,6 +73,7 @@ private:
     
     int nSecurityLevel = 0;
     bool fMinimizeChange = false;
+    bool fDenomsMinimized;
 
     int nDisplayUnit;
     bool updateLabel(const QString& address);
@@ -101,7 +102,10 @@ private slots:
     void on_pushButtonSpentReset_clicked();
     void on_pushButtonSpendzPIV_clicked();
     void on_pushButtonZPivControl_clicked();
+    void on_pushButtonHideDenoms_clicked();
+    void on_pushButtonShowDenoms_clicked();
     void on_pasteButton_clicked();
+    void minimizeDenomsSection(bool fMinimize);
     void updateDisplayUnit();
     void updateAutomintStatus();
     void updateSPORK16Status();


### PR DESCRIPTION
Minor UI change in response to issue https://github.com/PIVX-Project/PIVX/issues/676

To reduce ["information overload"](https://en.wikipedia.org/wiki/Information_overload) in the Privacy Dialog the user has now the option to minimize the zPIV denominations widget and have only the total values (own balance and total supply) printed in one row, thus making the interface much cleaner. 
The denominations list can be maximized again with a `Show Denominations` button.

<br>

The frame status (visible or hidden) is governed by a QSettings flag `fDenomsSectionMinimized` defaulted to `true` and updated in the destructor of the class.

![privatedialog_demo2](https://user-images.githubusercontent.com/18186894/43408888-b8bb958c-9422-11e8-9aac-b3846e46a964.gif)
