### PR TITLE
[Depends] Add gmp bignum support for zerocoin lib

### DIFF
--- a/build-aux/m4/gmp.m4
+++ b/build-aux/m4/gmp.m4
@@ -1,0 +1,16 @@
+dnl Copyright (c) 2018 The PIVX Core developers
+dnl Distributed under the MIT software license, see the accompanying
+dnl file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+dnl
+AC_DEFUN([GMP_CHECK],[
+if test x"$has_gmp" != x"yes"; then
+  AC_CHECK_HEADER(gmp.h,[
+    AC_CHECK_LIB(gmp, __gmpz_init,[
+      has_gmp=yes;
+      GMP_LIBS="$GMP_LIBS -lgmp";
+      AC_DEFINE(HAVE_LIBGMP, 1, [Define this symbol if libgmp is installed])
+    ])
+  ])
+fi
+])

--- a/configure.ac
+++ b/configure.ac
@@ -1031,27 +1031,30 @@ if test "x$use_ccache" = "xyes"; then
 fi
 
 dnl bignum value
-if test x"$req_bignum" = x"auto"; then
+set_bignum=$req_bignum
+case $req_bignum in
+auto)
   GMP_CHECK
-  if test x"$has_gmp" = x"yes"; then
+  if test x"$has_gmp" != x"yes"; then
+    AC_MSG_ERROR([gmp bignum automatically selected but libgmp is not available. Use depends,
+    install libgmp or select an other bignum implementation (ONLY gmp is fully SUPPORTED)])
+  else
     set_bignum=gmp
   fi
-else
-  set_bignum=$req_bignum
-  case $set_bignum in
-  gmp)
-    GMP_CHECK
-    if test x"$has_gmp" != x"yes"; then
-      AC_MSG_ERROR([gmp bignum explicitly requested but libgmp not available])
-    fi
-    ;;
-  openssl)
-    ;;
-  *)
-    AC_MSG_ERROR([invalid bignum implementation selection])
-    ;;
-  esac
-fi
+  ;;
+gmp)
+  GMP_CHECK
+  if test x"$has_gmp" != x"yes"; then
+    AC_MSG_ERROR([gmp bignum explicitly requested but libgmp is not available])
+  fi
+  ;;
+openssl)
+    AC_MSG_WARN([openssl bignum explicitly requested. This is DEPRECATED.])
+  ;;
+*)
+  AC_MSG_ERROR([invalid bignum implementation selection])
+  ;;
+esac
 
 dnl enable wallet
 AC_MSG_CHECKING([if wallet should be enabled])

--- a/configure.ac
+++ b/configure.ac
@@ -174,8 +174,13 @@ AC_ARG_WITH([system-univalue],
   [AS_HELP_STRING([--with-system-univalue],
   [Build with system UniValue (default is no)])],
   [system_univalue=$withval],
-  [system_univalue=no]
-)
+  [system_univalue=no])
+
+AC_ARG_WITH([zerocoin-bignum],
+  [AS_HELP_STRING([--with-zerocoin-bignum=gmp|openssl|auto],
+  [Specify Bignum Implementation. Default is auto])],
+  [req_bignum=$withval],
+  [req_bignum=auto])
 
 AC_ARG_WITH([protoc-bindir],[AS_HELP_STRING([--with-protoc-bindir=BIN_DIR],[specify protoc bin path])], [protoc_bin_path=$withval], [])
 
@@ -1025,6 +1030,29 @@ if test "x$use_ccache" = "xyes"; then
     AX_CHECK_PREPROC_FLAG([-Qunused-arguments],[CPPFLAGS="-Qunused-arguments $CPPFLAGS"])
 fi
 
+dnl bignum value
+if test x"$req_bignum" = x"auto"; then
+  GMP_CHECK
+  if test x"$has_gmp" = x"yes"; then
+    set_bignum=gmp
+  fi
+else
+  set_bignum=$req_bignum
+  case $set_bignum in
+  gmp)
+    GMP_CHECK
+    if test x"$has_gmp" != x"yes"; then
+      AC_MSG_ERROR([gmp bignum explicitly requested but libgmp not available])
+    fi
+    ;;
+  openssl)
+    ;;
+  *)
+    AC_MSG_ERROR([invalid bignum implementation selection])
+    ;;
+  esac
+fi
+
 dnl enable wallet
 AC_MSG_CHECKING([if wallet should be enabled])
 if test x$enable_wallet != xno; then
@@ -1104,6 +1132,19 @@ fi
 
 AM_CONDITIONAL([ENABLE_ZMQ], [test "x$use_zmq" = "xyes"])
 
+# select bignum implementation
+case $set_bignum in
+gmp)
+  AC_DEFINE(USE_NUM_GMP, 1, [Define this symbol to use the gmp implementation])
+  ;;
+openssl)
+  AC_DEFINE(USE_NUM_OPENSSL, 1, [Define this symbol to use openssl implementation])
+  ;;
+*)
+  AC_MSG_ERROR([invalid bignum implementation])
+  ;;
+esac
+
 AC_MSG_CHECKING([whether to build test_pivx])
 if test x$use_tests = xyes; then
   AC_MSG_RESULT([yes])
@@ -1181,6 +1222,8 @@ AC_SUBST(EVENT_PTHREADS_LIBS)
 AC_SUBST(ZMQ_LIBS)
 AC_SUBST(PROTOBUF_LIBS)
 AC_SUBST(QR_LIBS)
+AC_SUBST(USE_NUM_GMP)
+AC_SUBST(USE_NUM_OPENSSL)
 AC_CONFIG_FILES([Makefile src/Makefile share/setup.nsi share/qt/Info.plist src/test/buildenv.py])
 AC_CONFIG_FILES([qa/pull-tester/run-bitcoind-for-test.sh],[chmod +x qa/pull-tester/run-bitcoind-for-test.sh])
 AC_CONFIG_FILES([qa/pull-tester/tests-config.sh],[chmod +x qa/pull-tester/tests-config.sh])
@@ -1246,6 +1289,7 @@ if test x$bitcoin_enable_qt != xno; then
     echo "    with qr     = $use_qr"
 fi
 echo "  with zmq      = $use_zmq"
+echo "  with bignum   = $set_bignum"
 echo "  with test     = $use_tests"
 dnl echo "  with bench    = $use_bench"
 echo "  with upnp     = $use_upnp"

--- a/depends/packages/gmp.mk
+++ b/depends/packages/gmp.mk
@@ -1,0 +1,24 @@
+package=gmp
+$(package)_version=6.1.2
+$(package)_download_path=https://gmplib.org/download/gmp
+$(package)_file_name=$(package)-$($(package)_version).tar.bz2
+$(package)_sha256_hash=5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2
+
+define $(package)_set_vars
+$(package)_config_opts=--disable-shared
+$(package)_config_opts_mingw32=--enable-mingw
+$(package)_config_opts_linux=--with-pic
+endef
+
+define $(package)_config_cmds
+  $($(package)_autoconf)
+endef
+
+define $(package)_build_cmds
+  $(MAKE)
+endef
+
+define $(package)_stage_cmds
+  $(MAKE) DESTDIR=$($(package)_staging_dir) install
+endef
+

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,4 +1,4 @@
-packages:=boost openssl libevent zeromq
+packages:=boost openssl libevent zeromq gmp
 native_packages := native_ccache
 
 qt_native_packages = native_protobuf

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -309,8 +309,8 @@ crypto_libbitcoin_crypto_a_SOURCES = \
   crypto/sph_types.h
 
 # libzerocoin library
-libzerocoin_libbitcoin_zerocin_a_CPPFLAGS = $(AM_CPPFLAGS) $(BOOST_CPPFLAGS)
-libzerocoin_libbitcoin_zerocin_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+libzerocoin_libbitcoin_zerocoin_a_CPPFLAGS = $(AM_CPPFLAGS) $(BOOST_CPPFLAGS)
+libzerocoin_libbitcoin_zerocoin_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libzerocoin_libbitcoin_zerocoin_a_SOURCES = \
   libzerocoin/Accumulator.h \
   libzerocoin/AccumulatorProofOfKnowledge.h \

--- a/src/libzerocoin/bignum.h
+++ b/src/libzerocoin/bignum.h
@@ -3,16 +3,26 @@
 // Copyright (c) 2017-2018 The PIVX developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
 #ifndef BITCOIN_BIGNUM_H
 #define BITCOIN_BIGNUM_H
 
+#if defined HAVE_CONFIG_H
+#include "pivx-config.h"
+#endif
+
 #include <stdexcept>
 #include <vector>
+#if defined(USE_NUM_GMP)
+#include <gmp.h>
+#endif
+#if defined(USE_NUM_OPENSSL)
 #include <openssl/bn.h>
+#endif
+
 #include "serialize.h"
 #include "uint256.h"
 #include "version.h"
+#include "random.h"
 
 /** Errors thrown by the bignum class */
 class bignum_error : public std::runtime_error
@@ -20,6 +30,8 @@ class bignum_error : public std::runtime_error
 public:
     explicit bignum_error(const std::string& str) : std::runtime_error(str) {}
 };
+
+#if defined(USE_NUM_OPENSSL)
 
 
 /** RAII encapsulated BN_CTX (OpenSSL bignum context) */
@@ -48,7 +60,6 @@ public:
     BN_CTX** operator&() { return &pctx; }
     bool operator!() { return (pctx == NULL); }
 };
-
 
 /** C++ wrapper for BIGNUM (OpenSSL bignum) */
 class CBigNum
@@ -87,7 +98,7 @@ public:
     CBigNum(short n)            { bn = BN_new(); if (n >= 0) setulong(n); else setint64(n); }
     CBigNum(int n)              { bn = BN_new(); if (n >= 0) setulong(n); else setint64(n); }
     CBigNum(long n)             { bn = BN_new(); if (n >= 0) setulong(n); else setint64(n); }
-#ifdef __APPLE__	
+#ifdef __APPLE__
     CBigNum(int64_t n)            { bn = BN_new(); setint64(n); }
 #endif
     CBigNum(unsigned char n)    { bn = BN_new(); setulong(n); }
@@ -501,7 +512,7 @@ public:
    /**
     * Miller-Rabin primality test on this element
     * @param checks: optional, the number of Miller-Rabin tests to run
-    * 			 	default causes error rate of 2^-80.
+    *                          default causes error rate of 2^-80.
     * @return true if prime
     */
     bool isPrime(const int checks=BN_prime_checks) const {
@@ -534,7 +545,7 @@ public:
     CBigNum& operator-=(const CBigNum& b)
     {
         if (!BN_sub(bn, bn, b.bn))
-	    throw bignum_error("CBigNum::operator-= : BN_sub failed");
+            throw bignum_error("CBigNum::operator-= : BN_sub failed");
         return *this;
     }
 
@@ -632,8 +643,6 @@ public:
     friend inline bool operator>(const CBigNum& a, const CBigNum& b);
 };
 
-
-
 inline const CBigNum operator+(const CBigNum& a, const CBigNum& b)
 {
     CBigNum r;
@@ -706,5 +715,487 @@ inline bool operator>=(const CBigNum& a, const CBigNum& b) { return (BN_cmp(a.bn
 inline bool operator<(const CBigNum& a, const CBigNum& b)  { return (BN_cmp(a.bn, b.bn) < 0); }
 inline bool operator>(const CBigNum& a, const CBigNum& b)  { return (BN_cmp(a.bn, b.bn) > 0); }
 inline std::ostream& operator<<(std::ostream &strm, const CBigNum &b) { return strm << b.ToString(10); }
+
+#endif
+#if defined(USE_NUM_GMP)
+/** C++ wrapper for BIGNUM (Gmp bignum) */
+class CBigNum
+{
+    mpz_t bn;
+public:
+    CBigNum()
+    {
+        mpz_init(bn);
+    }
+
+    CBigNum(const CBigNum& b)
+    {
+        mpz_init(bn);
+        mpz_set(bn, b.bn);
+    }
+
+    CBigNum& operator=(const CBigNum& b)
+    {
+        mpz_set(bn, b.bn);
+        return (*this);
+    }
+
+    ~CBigNum()
+    {
+        mpz_clear(bn);
+    }
+
+    //CBigNum(char n) is not portable.  Use 'signed char' or 'unsigned char'.
+    CBigNum(signed char n)      { mpz_init(bn); if (n >= 0) mpz_set_ui(bn, n); else mpz_set_si(bn, n); }
+    CBigNum(short n)            { mpz_init(bn); if (n >= 0) mpz_set_ui(bn, n); else mpz_set_si(bn, n); }
+    CBigNum(int n)              { mpz_init(bn); if (n >= 0) mpz_set_ui(bn, n); else mpz_set_si(bn, n); }
+    CBigNum(long n)             { mpz_init(bn); if (n >= 0) mpz_set_ui(bn, n); else mpz_set_si(bn, n); }
+    CBigNum(long long n)        { mpz_init(bn); mpz_set_si(bn, n); }
+    CBigNum(unsigned char n)    { mpz_init(bn); mpz_set_ui(bn, n); }
+    CBigNum(unsigned short n)   { mpz_init(bn); mpz_set_ui(bn, n); }
+    CBigNum(unsigned int n)     { mpz_init(bn); mpz_set_ui(bn, n); }
+    CBigNum(unsigned long n)    { mpz_init(bn); mpz_set_ui(bn, n); }
+
+    explicit CBigNum(uint256 n) { mpz_init(bn); setuint256(n); }
+
+    explicit CBigNum(const std::vector<unsigned char>& vch)
+    {
+        mpz_init(bn);
+        setvch(vch);
+    }
+
+    /** Generates a cryptographically secure random number between zero and range exclusive
+    * i.e. 0 < returned number < range
+    * @param range The upper bound on the number.
+    * @return
+    */
+    static CBigNum randBignum(const CBigNum& range) {
+        size_t size = (mpz_sizeinbase (range.bn, 2) + CHAR_BIT-1) / CHAR_BIT;
+        std::vector<unsigned char> buf(size);
+
+        RandAddSeed();
+        GetRandBytes(buf.data(), size);
+
+        CBigNum ret(buf);
+        if (ret < 0)
+            mpz_neg(ret.bn, ret.bn);
+        return ret;
+    }
+
+    /** Generates a cryptographically secure random k-bit number
+    * @param k The bit length of the number.
+    * @return
+    */
+    static CBigNum RandKBitBigum(const uint32_t k){
+        std::vector<unsigned char> buf((k+7)/8);
+
+        RandAddSeed();
+        GetRandBytes(buf.data(), (k+7)/8);
+
+        CBigNum ret(buf);
+        if (ret < 0)
+            mpz_neg(ret.bn, ret.bn);
+        return ret;
+    }
+
+    /**Returns the size in bits of the underlying bignum.
+     *
+     * @return the size
+     */
+    int bitSize() const{
+        return  mpz_sizeinbase(bn, 2);
+    }
+
+    void setulong(unsigned long n)
+    {
+        mpz_set_ui(bn, n);
+    }
+
+    unsigned long getulong() const
+    {
+        return mpz_get_ui(bn);
+    }
+
+    unsigned int getuint() const
+    {
+        return mpz_get_ui(bn);
+    }
+
+    int getint() const
+    {
+        unsigned long n = getulong();
+        if (mpz_cmp(bn, CBigNum(0).bn) >= 0) {
+            return (n > (unsigned long)std::numeric_limits<int>::max() ? std::numeric_limits<int>::max() : n);
+        } else {
+            return (n > (unsigned long)std::numeric_limits<int>::max() ? std::numeric_limits<int>::min() : -(int)n);
+        }
+    }
+
+    void setuint256(uint256 n)
+    {
+        mpz_import(bn, n.size(), -1, 1, 0, 0, (unsigned char*)&n);
+    }
+
+    uint256 getuint256() const
+    {
+        uint256 n = 0;
+        mpz_export((unsigned char*)&n, NULL, -1, 1, 0, 0, bn);
+        return n;
+    }
+
+    void setvch(const std::vector<unsigned char>& vch)
+    {
+        std::vector<unsigned char> vch2 = vch;
+        unsigned char sign = 0;
+        if (vch2.size() > 0) {
+            sign = vch2[vch2.size()-1] & 0x80;
+            vch2[vch2.size()-1] = vch2[vch2.size()-1] & 0x7f;
+            mpz_import(bn, vch2.size(), -1, 1, 0, 0, &vch2[0]);
+            if (sign)
+                mpz_neg(bn, bn);
+        }
+        else {
+            mpz_set_si(bn, 0);
+        }
+    }
+
+    std::vector<unsigned char> getvch() const
+    {
+        if (mpz_cmp(bn, CBigNum(0).bn) == 0) {
+            return std::vector<unsigned char>(0);
+        }
+        size_t size = (mpz_sizeinbase (bn, 2) + CHAR_BIT-1) / CHAR_BIT;
+        if (size <= 0)
+            return std::vector<unsigned char>();
+        std::vector<unsigned char> v(size + 1);
+        mpz_export(&v[0], &size, -1, 1, 0, 0, bn);
+        if (v[v.size()-2] & 0x80) {
+            if (mpz_sgn(bn)<0) {
+                v[v.size()-1] = 0x80;
+            } else {
+                v[v.size()-1] = 0x00;
+            }
+        } else {
+            v.pop_back();
+            if (mpz_sgn(bn)<0) {
+                v[v.size()-1] |= 0x80;
+            }
+        }
+        return v;
+    }
+
+    void SetDec(const std::string& str)
+    {
+        const char* psz = str.c_str();
+        mpz_set_str(bn, psz, 10);
+    }
+
+    void SetHex(const std::string& str)
+    {
+        SetHexBool(str);
+    }
+
+    bool SetHexBool(const std::string& str)
+    {
+        const char* psz = str.c_str();
+        int ret = 1 + mpz_set_str(bn, psz, 16);
+        return (bool) ret;
+    }
+
+    std::string ToString(int nBase=10) const
+    {
+        char* c_str = mpz_get_str(NULL, nBase, bn);
+        std::string str(c_str);
+        return str;
+    }
+
+    std::string GetHex() const
+    {
+        return ToString(16);
+    }
+
+    std::string GetDec() const
+    {
+        return ToString(10);
+    }
+
+    unsigned int GetSerializeSize(int nType=0, int nVersion=PROTOCOL_VERSION) const
+    {
+        return ::GetSerializeSize(getvch(), nType, nVersion);
+    }
+
+    template<typename Stream>
+    void Serialize(Stream& s, int nType=0, int nVersion=PROTOCOL_VERSION) const
+    {
+        ::Serialize(s, getvch(), nType, nVersion);
+    }
+
+    template<typename Stream>
+    void Unserialize(Stream& s, int nType=0, int nVersion=PROTOCOL_VERSION)
+    {
+        std::vector<unsigned char> vch;
+        ::Unserialize(s, vch, nType, nVersion);
+        setvch(vch);
+    }
+
+    /**
+        * exponentiation with an int. this^e
+        * @param e the exponent as an int
+        * @return
+        */
+    CBigNum pow(const int e) const {
+        return this->pow(CBigNum(e));
+    }
+
+    /**
+     * exponentiation this^e
+     * @param e the exponent
+     * @return
+     */
+    CBigNum pow(const CBigNum& e) const {
+        CBigNum ret;
+        long unsigned int ei = mpz_get_ui (e.bn);
+        mpz_pow_ui(ret.bn, bn, ei);
+        return ret;
+    }
+
+    /**
+     * modular multiplication: (this * b) mod m
+     * @param b operand
+     * @param m modulus
+     */
+    CBigNum mul_mod(const CBigNum& b, const CBigNum& m) const {
+        CBigNum ret;
+        mpz_mul (ret.bn, bn, b.bn);
+        mpz_mod (ret.bn, ret.bn, m.bn);
+        return ret;
+    }
+
+    /**
+     * modular exponentiation: this^e mod n
+     * @param e exponent
+     * @param m modulus
+     */
+    CBigNum pow_mod(const CBigNum& e, const CBigNum& m) const {
+        CBigNum ret;
+        if (e > CBigNum(0) && mpz_odd_p(m.bn))
+            mpz_powm_sec (ret.bn, bn, e.bn, m.bn);
+        else
+            mpz_powm (ret.bn, bn, e.bn, m.bn);
+        return ret;
+    }
+
+   /**
+    * Calculates the inverse of this element mod m.
+    * i.e. i such this*i = 1 mod m
+    * @param m the modu
+    * @return the inverse
+    */
+    CBigNum inverse(const CBigNum& m) const {
+        CBigNum ret;
+        mpz_invert(ret.bn, bn, m.bn);
+        return ret;
+    }
+
+    /**
+     * Generates a random (safe) prime of numBits bits
+     * @param numBits the number of bits
+     * @param safe true for a safe prime
+     * @return the prime
+     */
+    static CBigNum generatePrime(const unsigned int numBits, bool safe = false) {
+        CBigNum rand = RandKBitBigum(numBits);
+        CBigNum prime;
+        mpz_nextprime(prime.bn, rand.bn);
+        return prime;
+    }
+
+    /**
+     * Calculates the greatest common divisor (GCD) of two numbers.
+     * @param m the second element
+     * @return the GCD
+     */
+    CBigNum gcd( const CBigNum& b) const{
+        CBigNum ret;
+        mpz_gcd(ret.bn, bn, b.bn);
+        return ret;
+    }
+
+   /**
+    * Miller-Rabin primality test on this element
+    * @param checks: optional, the number of Miller-Rabin tests to run
+    *               default causes error rate of 2^-80.
+    * @return true if prime
+    */
+    bool isPrime(const int checks=15) const {
+        int ret = mpz_probab_prime_p(bn, checks);
+        return ret;
+    }
+
+    bool isOne() const
+    {
+        return mpz_cmp(bn, CBigNum(1).bn) == 0;
+    }
+
+    bool operator!() const
+    {
+        return mpz_cmp(bn, CBigNum(0).bn) == 0;
+    }
+
+    CBigNum& operator+=(const CBigNum& b)
+    {
+        mpz_add(bn, bn, b.bn);
+        return *this;
+    }
+
+    CBigNum& operator-=(const CBigNum& b)
+    {
+        mpz_sub(bn, bn, b.bn);
+        return *this;
+    }
+
+    CBigNum& operator*=(const CBigNum& b)
+    {
+        mpz_mul(bn, bn, b.bn);
+        return *this;
+    }
+
+    CBigNum& operator/=(const CBigNum& b)
+    {
+        *this = *this / b;
+        return *this;
+    }
+
+    CBigNum& operator%=(const CBigNum& b)
+    {
+        *this = *this % b;
+        return *this;
+    }
+
+    CBigNum& operator<<=(unsigned int shift)
+    {
+        mpz_mul_2exp(bn, bn, shift);
+        return *this;
+    }
+
+    CBigNum& operator>>=(unsigned int shift)
+    {
+        mpz_div_2exp(bn, bn, shift);
+        return *this;
+    }
+
+
+    CBigNum& operator++()
+    {
+        // prefix operator
+        mpz_add(bn, bn, CBigNum(1).bn);
+        return *this;
+    }
+
+    const CBigNum operator++(int)
+    {
+        // postfix operator
+        const CBigNum ret = *this;
+        ++(*this);
+        return ret;
+    }
+
+    CBigNum& operator--()
+    {
+        // prefix operator
+        mpz_sub(bn, bn, CBigNum(1).bn);
+        return *this;
+    }
+
+    const CBigNum operator--(int)
+    {
+        // postfix operator
+        const CBigNum ret = *this;
+        --(*this);
+        return ret;
+    }
+
+    friend inline const CBigNum operator+(const CBigNum& a, const CBigNum& b);
+    friend inline const CBigNum operator-(const CBigNum& a, const CBigNum& b);
+    friend inline const CBigNum operator/(const CBigNum& a, const CBigNum& b);
+    friend inline const CBigNum operator%(const CBigNum& a, const CBigNum& b);
+    friend inline const CBigNum operator*(const CBigNum& a, const CBigNum& b);
+    friend inline const CBigNum operator<<(const CBigNum& a, unsigned int shift);
+    friend inline const CBigNum operator-(const CBigNum& a);
+    friend inline bool operator==(const CBigNum& a, const CBigNum& b);
+    friend inline bool operator!=(const CBigNum& a, const CBigNum& b);
+    friend inline bool operator<=(const CBigNum& a, const CBigNum& b);
+    friend inline bool operator>=(const CBigNum& a, const CBigNum& b);
+    friend inline bool operator<(const CBigNum& a, const CBigNum& b);
+    friend inline bool operator>(const CBigNum& a, const CBigNum& b);
+};
+
+inline const CBigNum operator+(const CBigNum& a, const CBigNum& b)
+{
+    CBigNum r;
+    mpz_add(r.bn, a.bn, b.bn);
+    return r;
+}
+
+inline const CBigNum operator-(const CBigNum& a, const CBigNum& b)
+{
+    CBigNum r;
+    mpz_sub(r.bn, a.bn, b.bn);
+    return r;
+}
+
+inline const CBigNum operator-(const CBigNum& a)
+{
+    CBigNum r;
+    mpz_neg(r.bn, a.bn);
+    return r;
+}
+
+inline const CBigNum operator*(const CBigNum& a, const CBigNum& b)
+{
+    CBigNum r;
+    mpz_mul(r.bn, a.bn, b.bn);
+    return r;
+}
+
+inline const CBigNum operator/(const CBigNum& a, const CBigNum& b)
+{
+    CBigNum r;
+    mpz_tdiv_q(r.bn, a.bn, b.bn);
+    return r;
+}
+
+inline const CBigNum operator%(const CBigNum& a, const CBigNum& b)
+{
+    CBigNum r;
+    mpz_mmod(r.bn, a.bn, b.bn);
+    return r;
+}
+
+inline const CBigNum operator<<(const CBigNum& a, unsigned int shift)
+{
+    CBigNum r;
+    mpz_mul_2exp(r.bn, a.bn, shift);
+    return r;
+}
+
+inline const CBigNum operator>>(const CBigNum& a, unsigned int shift)
+{
+    CBigNum r = a;
+    r >>= shift;
+    return r;
+}
+
+inline bool operator==(const CBigNum& a, const CBigNum& b) { return (mpz_cmp(a.bn, b.bn) == 0); }
+inline bool operator!=(const CBigNum& a, const CBigNum& b) { return (mpz_cmp(a.bn, b.bn) != 0); }
+inline bool operator<=(const CBigNum& a, const CBigNum& b) { return (mpz_cmp(a.bn, b.bn) <= 0); }
+inline bool operator>=(const CBigNum& a, const CBigNum& b) { return (mpz_cmp(a.bn, b.bn) >= 0); }
+inline bool operator<(const CBigNum& a, const CBigNum& b)  { return (mpz_cmp(a.bn, b.bn) < 0); }
+inline bool operator>(const CBigNum& a, const CBigNum& b)  { return (mpz_cmp(a.bn, b.bn) > 0); }
+inline std::ostream& operator<<(std::ostream &strm, const CBigNum &b) { return strm << b.ToString(10); }
+#endif
+
+typedef CBigNum Bignum;
+
 
 #endif

--- a/src/test/zerocoin_implementation_tests.cpp
+++ b/src/test/zerocoin_implementation_tests.cpp
@@ -47,6 +47,47 @@ std::string zerocoinModulus = "2519590847565789349402718324004839857142928212620
 "8441436038339044149526344321901146575444541784240209246165157233507787077498171257724679629263863563732899121548"
 "31438167899885040445364023527381951378636564391212010397122822120720357";
 
+std::string strHexModulus = "c7970ceedcc3b0754490201a7aa613cd73911081c790f5f1a8726f463550bb5b7ff0db8e1ea1189ec72f93d1650011bd721aeeacc2acde32a04107f0648c2813a31f5b0b7765ff8b44b4b6ffc93384b646eb09c7cf5e8592d40ea33c80039f35b4f14a04b51f7bfd781be4d1673164ba8eb991c2c4d730bbbe35f592bdef524af7e8daefd26c66fc02c479af89d64d373f442709439de66ceb955f3ea37d5159f6135809f85334b5cb1813addc80cd05609f10ac6a95ad65872c909525bdad32bc729592642920f24c61dc5b3c3b7923e56b16a4d9d373d8721f24a3fc0f1b3131f55615172866bccc30f95054c824e733a5eb6817f7bc16399d48c6361cc7e5";
+
+BOOST_AUTO_TEST_CASE(bignum_setdecimal)
+{
+    CBigNum bnDec;
+    bnDec.SetDec(zerocoinModulus);
+    CBigNum bnHex;
+    bnHex.SetHex(strHexModulus);
+    BOOST_CHECK_MESSAGE(bnDec == bnHex, "CBigNum.SetDec() does not work correctly");
+}
+
+std::string negstrHexModulus = "-c7970ceedcc3b0754490201a7aa613cd73911081c790f5f1a8726f463550bb5b7ff0db8e1ea1189ec72f93d1650011bd721aeeacc2acde32a04107f0648c2813a31f5b0b7765ff8b44b4b6ffc93384b646eb09c7cf5e8592d40ea33c80039f35b4f14a04b51f7bfd781be4d1673164ba8eb991c2c4d730bbbe35f592bdef524af7e8daefd26c66fc02c479af89d64d373f442709439de66ceb955f3ea37d5159f6135809f85334b5cb1813addc80cd05609f10ac6a95ad65872c909525bdad32bc729592642920f24c61dc5b3c3b7923e56b16a4d9d373d8721f24a3fc0f1b3131f55615172866bccc30f95054c824e733a5eb6817f7bc16399d48c6361cc7e5";
+std::string str_a = "775897c5463939bf29a02816aba7b1741162e1f6b052cd32fec36c44dfee7d4b5162de78bb0b448cb305b0a9bd7e006aec62d7c1e94a31003c2decbdc6fd7c9b261cb88801c51e7cee71a215ff113ccbd02069cf29671e6302944ca5780a2f626eb9046fa6872968addc93c74d09cf6b2872bc4c6bd08e89324cc7e9fb921488";
+std::string str_b = "-775897c5463939bf29a02816aba7b1741162e1f6b052cd32fec36c44dfee7d4b5162de78bb0b448cb305b0a9bd7e006aec62d7c1e94a31003c2decbdc6fd7c9b261cb88801c51e7cee71a215ff113ccbd02069cf29671e6302944ca5780a2f626eb9046fa6872968addc93c74d09cf6b2872bc4c6bd08e89324cc7e9fb921488";
+
+BOOST_AUTO_TEST_CASE(bignum_basic_tests)
+{
+    CBigNum bn, bn2;
+    std::vector<unsigned char> vch;
+
+    bn.SetHex(strHexModulus);
+    vch = bn.getvch();
+    bn2.setvch(vch);
+    BOOST_CHECK_MESSAGE(bn2 == bn, "CBigNum.setvch() or CBigNum.getvch() does not work correctly");
+
+    bn.SetHex(negstrHexModulus);
+    vch = bn.getvch();
+    bn2.setvch(vch);
+    BOOST_CHECK_MESSAGE(bn2 == bn, "CBigNum.setvch() or CBigNum.getvch() does not work correctly");
+
+    bn.SetHex(str_a);
+    vch = bn.getvch();
+    bn2.setvch(vch);
+    BOOST_CHECK_MESSAGE(bn2 == bn, "CBigNum.setvch() or CBigNum.getvch() does not work correctly");
+
+    bn.SetHex(str_b);
+    vch = bn.getvch();
+    bn2.setvch(vch);
+    BOOST_CHECK_MESSAGE(bn2 == bn, "CBigNum.setvch() or CBigNum.getvch() does not work correctly");
+}
+
 //ZQ_ONE mints
 std::string rawTx1 = "0100000001983d5fd91685bb726c0ebc3676f89101b16e663fd896fea53e19972b95054c49000000006a473044022010fbec3e78f9c46e58193d481caff715ceb984df44671d30a2c0bde95c54055f0220446a97d9340da690eaf2658e5b2bf6a0add06f1ae3f1b40f37614c7079ce450d012103cb666bd0f32b71cbf4f32e95fa58e05cd83869ac101435fcb8acee99123ccd1dffffffff0200e1f5050000000086c10280004c80c3a01f94e71662f2ae8bfcd88dfc5b5e717136facd6538829db0c7f01e5fd793cccae7aa1958564518e0223d6d9ce15b1e38e757583546e3b9a3f85bd14408120cd5192a901bb52152e8759fdd194df230d78477706d0e412a66398f330be38a23540d12ab147e9fb19224913f3fe552ae6a587fb30a68743e52577150ff73042c0f0d8f000000001976a914d6042025bd1fff4da5da5c432d85d82b3f26a01688ac00000000";
 std::string rawTxpub1 = "473ff507157523e74680ab37f586aae52e53f3f912492b19f7e14ab120d54238ae30b338f39662a410e6d707784d730f24d19dd9f75e85221b51b902a19d50c120844d15bf8a3b9e346355857e7381e5be19c6d3d22e01845565819aae7cacc93d75f1ef0c7b09d823865cdfa3671715e5bfc8dd8fc8baef26216e7941fa0c3";
@@ -452,17 +493,6 @@ BOOST_AUTO_TEST_CASE(checksum_tests)
         BOOST_CHECK_MESSAGE(checksumParsed == vChecksums[i], "checksum parse failed");
         i++;
     }
-}
-
-string strHexModulus = "0xc7970ceedcc3b0754490201a7aa613cd73911081c790f5f1a8726f463550bb5b7ff0db8e1ea1189ec72f93d1650011bd721aeeacc2acde32a04107f0648c2813a31f5b0b7765ff8b44b4b6ffc93384b646eb09c7cf5e8592d40ea33c80039f35b4f14a04b51f7bfd781be4d1673164ba8eb991c2c4d730bbbe35f592bdef524af7e8daefd26c66fc02c479af89d64d373f442709439de66ceb955f3ea37d5159f6135809f85334b5cb1813addc80cd05609f10ac6a95ad65872c909525bdad32bc729592642920f24c61dc5b3c3b7923e56b16a4d9d373d8721f24a3fc0f1b3131f55615172866bccc30f95054c824e733a5eb6817f7bc16399d48c6361cc7e5";
-
-BOOST_AUTO_TEST_CASE(bignum_setdecimal)
-{
-    CBigNum bnDec;
-    bnDec.SetDec(zerocoinModulus);
-    CBigNum bnHex;
-    bnHex.SetHex(strHexModulus);
-    BOOST_CHECK_MESSAGE(bnDec == bnHex, "CBigNum.SetDec() does not work correctly");
 }
 
 BOOST_AUTO_TEST_CASE(test_checkpoints)


### PR DESCRIPTION
This PR adds support for a new `CBigNum` implementation and switches to it by default. This class is used in the zerocoin library and underlies all of its cryptography.

We add a new configure option which accepts 3 values `--with-zerocoin-bignum` can either be set to `auto`, `gmp`, or `openssl`. Auto being the default one and resolving to gmp.

There are 2 goal in switching from OpenSSL to gmp:
* Move away from OpenSSL which is not a simple arithmetic library but a full fledged cryptographic library which brings its own suite of faults. We are using it in various places of the code but moving away from it everywhere possible seems to be a good approach.
* Improve performances. On this front, here are my tests results:
```
                              gmp                          openssl

500 V2 spends              220ms per                      314ms per
500 deterministic mint     106ms per                      204ms per
verify them ^               40ms per                       34ms per

paramgen                   286ms                          528ms
500 mints                  133ms per                      244ms per
500 accumulations           42ms per                       35ms per
500 witness                 42ms per                       36ms per
1 spend from ^             231ms                          243ms
serialize time              <1ms                          <1ms
spend verify               174ms                          200ms
```
As you can see, some areas are the same (or in the error margin) while others seem vastly improved (x2 for deterministic minting for example). 

My tests were done on a Debian 9, 64 bits on a medium/high end PC. I encourage you to test it on different hardware and OS if you can.

EDIT: There are some concerns that using gmp instead of OpenSSL might open us up to side-channel timing attacks. Indeed, since OpenSSL is targeting cryptography while gmp is a general purpose arithmetic library, the former is designed towards security while the latter targets speed. 
I added 8cba58b to guard against some of them. Given that Bitcoin core offers the possibility to use gmp as the underlying bignum library for libsecp256k1, I'd be inclined to believe it's safe to do so here. If anyone has inputs, numbers or studies on the matter, they are more than welcome.