### PR TITLE
Avoid minting private coin that will be overwritten

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -4598,7 +4598,7 @@ bool CWallet::MintToTxIn(CZerocoinMint zerocoinSelected, int nSecurityLevel, con
     }
 
     // Construct the CoinSpend object. This acts like a signature on the transaction.
-    libzerocoin::PrivateCoin privateCoin(paramsCoin, denomination);
+    libzerocoin::PrivateCoin privateCoin(paramsCoin, denomination, false);
     privateCoin.setPublicCoin(pubCoinSelected);
     privateCoin.setRandomness(zerocoinSelected.GetRandomness());
     privateCoin.setSerialNumber(zerocoinSelected.GetSerialNumber());


### PR DESCRIPTION
This was fixed by jonspock, in PR #628, but this includes the white space removal that it required to get the fix to build with Travis. 