### PR TITLE
[Zerocoin] Remove explicit copy assignement operator from Accumulator

### DIFF
--- a/src/libzerocoin/Accumulator.cpp
+++ b/src/libzerocoin/Accumulator.cpp
@@ -88,11 +88,6 @@ Accumulator& Accumulator::operator += (const PublicCoin& c) {
     return *this;
 }
 
-Accumulator& Accumulator::operator = (Accumulator rhs) {
-    if (this != &rhs) std::swap(*this, rhs);
-    return *this;
-}
-
 bool Accumulator::operator == (const Accumulator rhs) const {
     return this->value == rhs.value;
 }
@@ -139,13 +134,6 @@ bool AccumulatorWitness::VerifyWitness(const Accumulator& a, const PublicCoin &p
 AccumulatorWitness& AccumulatorWitness::operator +=(
     const PublicCoin& rhs) {
     this->AddElement(rhs);
-    return *this;
-}
-
-AccumulatorWitness& AccumulatorWitness::operator =(AccumulatorWitness rhs) {
-    // Not pretty, but seems to work (SPOCK)
-    if (&witness != &rhs.witness) this->witness = rhs.witness;
-    if (&element != &rhs.element) std::swap(element, rhs.element);
     return *this;
 }
 

--- a/src/libzerocoin/Accumulator.h
+++ b/src/libzerocoin/Accumulator.h
@@ -87,7 +87,6 @@ public:
      * @return a refrence to the updated accumulator.
      */
     Accumulator& operator +=(const PublicCoin& c);
-    Accumulator& operator =(Accumulator rhs);
     bool operator==(const Accumulator rhs) const;
     ADD_SERIALIZE_METHODS;
     template <typename Stream, typename Operation>  inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
@@ -149,8 +148,6 @@ public:
      * @return
      */
     AccumulatorWitness& operator +=(const PublicCoin& rhs);
-
-    AccumulatorWitness& operator =(AccumulatorWitness rhs);
 private:
     Accumulator witness;
     PublicCoin element; // was const but changed to use setting in assignment


### PR DESCRIPTION
The default compiler function does just fine.
And having this function but no explicit default destructor or copy constructor
is bad practice.