### PR TITLE
[UI] Add address to the payment request history

### DIFF
--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -39,18 +39,21 @@ ReceiveCoinsDialog::ReceiveCoinsDialog(QWidget* parent) : QDialog(parent, Qt::Wi
     QAction* copyLabelAction = new QAction(tr("Copy label"), this);
     QAction* copyMessageAction = new QAction(tr("Copy message"), this);
     QAction* copyAmountAction = new QAction(tr("Copy amount"), this);
+    QAction* copyAddressAction = new QAction(tr("Copy address"), this);
 
     // context menu
     contextMenu = new QMenu();
     contextMenu->addAction(copyLabelAction);
     contextMenu->addAction(copyMessageAction);
     contextMenu->addAction(copyAmountAction);
+    contextMenu->addAction(copyAddressAction);
 
     // context menu signals
     connect(ui->recentRequestsView, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(showMenu(QPoint)));
     connect(copyLabelAction, SIGNAL(triggered()), this, SLOT(copyLabel()));
     connect(copyMessageAction, SIGNAL(triggered()), this, SLOT(copyMessage()));
     connect(copyAmountAction, SIGNAL(triggered()), this, SLOT(copyAmount()));
+    connect(copyAddressAction, SIGNAL(triggered()), this, SLOT(copyAddress()));
 
     connect(ui->clearButton, SIGNAL(clicked()), this, SLOT(clear()));
 }
@@ -254,4 +257,10 @@ void ReceiveCoinsDialog::copyMessage()
 void ReceiveCoinsDialog::copyAmount()
 {
     copyColumnToClipboard(RecentRequestsTableModel::Amount);
+}
+
+// context menu action: copy address
+void ReceiveCoinsDialog::copyAddress()
+{
+    copyColumnToClipboard(RecentRequestsTableModel::Address);
 }

--- a/src/qt/receivecoinsdialog.h
+++ b/src/qt/receivecoinsdialog.h
@@ -73,6 +73,7 @@ private slots:
     void copyLabel();
     void copyMessage();
     void copyAmount();
+    void copyAddress();
 };
 
 #endif // BITCOIN_QT_RECEIVECOINSDIALOG_H

--- a/src/qt/recentrequeststablemodel.cpp
+++ b/src/qt/recentrequeststablemodel.cpp
@@ -25,7 +25,7 @@ RecentRequestsTableModel::RecentRequestsTableModel(CWallet* wallet, WalletModel*
         addNewRequest(request);
 
     /* These columns must match the indices in the ColumnIndex enumeration */
-    columns << tr("Date") << tr("Label") << tr("Message") << getAmountTitle();
+    columns << tr("Date") << tr("Label") << tr("Address") << tr("Message") << getAmountTitle();
 
     connect(walletModel->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
 }
@@ -66,6 +66,8 @@ QVariant RecentRequestsTableModel::data(const QModelIndex& index, int role) cons
             } else {
                 return rec->recipient.label;
             }
+        case Address:
+            return rec->recipient.address;
         case Message:
             if (rec->recipient.message.isEmpty() && role == Qt::DisplayRole) {
                 return tr("(no message)");
@@ -218,6 +220,8 @@ bool RecentRequestEntryLessThan::operator()(RecentRequestEntry& left, RecentRequ
         return pLeft->date.toTime_t() < pRight->date.toTime_t();
     case RecentRequestsTableModel::Label:
         return pLeft->recipient.label < pRight->recipient.label;
+    case RecentRequestsTableModel::Address:
+        return pLeft->recipient.address < pRight->recipient.address;
     case RecentRequestsTableModel::Message:
         return pLeft->recipient.message < pRight->recipient.message;
     case RecentRequestsTableModel::Amount:

--- a/src/qt/recentrequeststablemodel.h
+++ b/src/qt/recentrequeststablemodel.h
@@ -68,8 +68,9 @@ public:
     enum ColumnIndex {
         Date = 0,
         Label = 1,
-        Message = 2,
-        Amount = 3,
+        Address = 2,
+        Message = 3,
+        Amount = 4,
         NUMBER_OF_COLUMNS
     };
 


### PR DESCRIPTION
This is a small change in direction of #678. Simply allowing to get the address from a past payment request. (new column and right-click -> copy).
Before:
![capture d ecran de 2018-08-15 13-35-19](https://user-images.githubusercontent.com/835098/44146538-52a35c10-a090-11e8-97e4-ac6e502374bb.png)

After:
![capture d ecran de 2018-08-15 13-30-04](https://user-images.githubusercontent.com/835098/44146440-ca4bf232-a08f-11e8-886a-afce9e1f794f.png)
