### PR TITLE
[Build] GCC-7 and glibc-2.27 back compat

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -523,6 +523,8 @@ if test x$use_glibc_compat != xno; then
     [ fdelt_type="long int"])
   AC_MSG_RESULT($fdelt_type)
   AC_DEFINE_UNQUOTED(FDELT_TYPE, $fdelt_type,[parameter and return value type for __fdelt_chk])
+  AX_CHECK_LINK_FLAG([[-Wl,--wrap=__divmoddi4]], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=__divmoddi4"])
+  AX_CHECK_LINK_FLAG([[-Wl,--wrap=log2f]], [COMPAT_LDFLAGS="$COMPAT_LDFLAGS -Wl,--wrap=log2f"])
 else
   AC_SEARCH_LIBS([clock_gettime],[rt])
 fi
@@ -1156,6 +1158,7 @@ AC_SUBST(BITCOIN_CLI_NAME)
 AC_SUBST(BITCOIN_TX_NAME)
 
 AC_SUBST(RELDFLAGS)
+AC_SUBST(COMPAT_LDFLAGS)
 AC_SUBST(ERROR_CXXFLAGS)
 AC_SUBST(HARDENED_CXXFLAGS)
 AC_SUBST(HARDENED_CPPFLAGS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -395,6 +395,7 @@ libbitcoin_util_a_SOURCES = \
 
 if GLIBC_BACK_COMPAT
 libbitcoin_util_a_SOURCES += compat/glibc_compat.cpp
+AM_LDFLAGS += $(COMPAT_LDFLAGS)
 endif
 
 # cli: shared between pivx-cli and pivx-qt

--- a/src/compat/glibc_compat.cpp
+++ b/src/compat/glibc_compat.cpp
@@ -8,6 +8,7 @@
 #endif
 
 #include <cstddef>
+#include <cstdint>
 
 #if defined(HAVE_SYS_SELECT_H)
 #include <sys/select.h>
@@ -28,3 +29,47 @@ extern "C" FDELT_TYPE __fdelt_warn(FDELT_TYPE a)
     return a / __NFDBITS;
 }
 extern "C" FDELT_TYPE __fdelt_chk(FDELT_TYPE) __attribute__((weak, alias("__fdelt_warn")));
+
+#if defined(__i386__) || defined(__arm__)
+
+extern "C" int64_t __udivmoddi4(uint64_t u, uint64_t v, uint64_t* rp);
+
+extern "C" int64_t __wrap___divmoddi4(int64_t u, int64_t v, int64_t* rp)
+{
+    int32_t c1 = 0, c2 = 0;
+    int64_t uu = u, vv = v;
+    int64_t w;
+    int64_t r;
+
+    if (uu < 0) {
+        c1 = ~c1, c2 = ~c2, uu = -uu;
+    }
+    if (vv < 0) {
+        c1 = ~c1, vv = -vv;
+    }
+
+    w = __udivmoddi4(uu, vv, (uint64_t*)&r);
+    if (c1)
+        w = -w;
+    if (c2)
+        r = -r;
+
+    *rp = r;
+    return w;
+}
+#endif
+
+extern "C" float log2f_old(float x);
+#ifdef __i386__
+__asm(".symver log2f_old,log2f@GLIBC_2.1");
+#elif defined(__amd64__)
+__asm(".symver log2f_old,log2f@GLIBC_2.2.5");
+#elif defined(__arm__)
+__asm(".symver log2f_old,log2f@GLIBC_2.4");
+#elif defined(__aarch64__)
+__asm(".symver log2f_old,log2f@GLIBC_2.17");
+#endif
+extern "C" float __wrap_log2f(float x)
+{
+    return log2f_old(x);
+}

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1305,7 +1305,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         } else {
             struct in_addr inaddr_any;
             inaddr_any.s_addr = INADDR_ANY;
-            fBound |= Bind(CService(in6addr_any, GetListenPort()), BF_NONE);
+            fBound |= Bind(CService((in6_addr)IN6ADDR_ANY_INIT, GetListenPort()), BF_NONE);
             fBound |= Bind(CService(inaddr_any, GetListenPort()), !fBound ? BF_REPORT_ERROR : BF_NONE);
         }
         if (!fBound)


### PR DESCRIPTION
This adds glibc 2.27 backwards compatibility to GCC 7, which is used on Ubuntu Bionic (a future gitian/TravisCI build host) to maintain the existing minimum supported ABI specs.

testability/enforcement with gitian builds will come in it's own PR later.

(Rebased from bitcoin/bitcoin#13177)