### PR TITLE
[RPC] Don't allow backupwallet to overwrite the wallet-in-use

### DIFF
--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -1019,6 +1019,10 @@ bool AttemptBackupWallet(const CWallet& wallet, const filesystem::path& pathSrc,
     bool retStatus;
     string strMessage;
     try {
+        if (boost::filesystem::equivalent(pathSrc, pathDest)) {
+            LogPrintf("cannot backup to wallet source file %s\n", pathDest.string());
+            return false;
+        }
 #if BOOST_VERSION >= 105800 /* BOOST_LIB_VERSION 1_58 */
         filesystem::copy_file(pathSrc.c_str(), pathDest, filesystem::copy_option::overwrite_if_exists);
 #else
@@ -1512,7 +1516,7 @@ std::list<CBigNum> CWalletDB::ListSpentCoinsSerial()
 {
     std::list<CBigNum> listPubCoin;
     std::list<CZerocoinSpend> listCoins = ListSpentCoins();
-    
+
     for ( auto& coin : listCoins) {
         listPubCoin.push_back(coin.GetSerial());
     }


### PR DESCRIPTION
Prevent file access collisions and possible file corruption by refusing
to overwrite the current wallet in use.

On the off chance that a user attempts to use `backupwallet` in a way that the destination is the same as the source, an error will be returned instead of an attempted backup.