### PR TITLE
[UI] Add address field in receive tab

### DIFF
--- a/src/qt/forms/receivecoinsdialog.ui
+++ b/src/qt/forms/receivecoinsdialog.ui
@@ -136,53 +136,6 @@
           <layout class="QVBoxLayout" name="verticalLayout_3">
            <item>
             <layout class="QGridLayout" name="gridLayout">
-             <item row="7" column="2">
-              <widget class="QCheckBox" name="reuseAddress">
-               <property name="toolTip">
-                <string>Reuse one of the previously used receiving addresses.&lt;br&gt;Reusing addresses has security and privacy issues.&lt;br&gt;Do not use this unless re-generating a payment request made before.</string>
-               </property>
-               <property name="text">
-                <string>R&amp;euse an existing receiving address (not recommended)</string>
-               </property>
-              </widget>
-             </item>
-             <item row="7" column="0">
-              <widget class="QLabel" name="label_4">
-               <property name="text">
-                <string/>
-               </property>
-              </widget>
-             </item>
-             <item row="6" column="0">
-              <widget class="QLabel" name="label_3">
-               <property name="toolTip">
-                <string>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the PIVX network.</string>
-               </property>
-               <property name="text">
-                <string>&amp;Message:</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-               </property>
-               <property name="buddy">
-                <cstring>reqMessage</cstring>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="2">
-              <widget class="QLineEdit" name="reqLabel">
-               <property name="toolTip">
-                <string>An optional label to associate with the new receiving address.</string>
-               </property>
-              </widget>
-             </item>
-             <item row="6" column="2">
-              <widget class="QLineEdit" name="reqMessage">
-               <property name="toolTip">
-                <string>An optional message to attach to the payment request, which will be displayed when the request is opened.&lt;br&gt;Note: The message will not be sent with the payment over the PIVX network.</string>
-               </property>
-              </widget>
-             </item>
              <item row="2" column="2">
               <widget class="QLabel" name="label_5">
                <property name="text">
@@ -206,13 +159,52 @@
                </property>
               </widget>
              </item>
+             <item row="4" column="2">
+              <widget class="QLineEdit" name="reqLabel">
+               <property name="toolTip">
+                <string>An optional label to associate with the new receiving address.</string>
+               </property>
+              </widget>
+             </item>
              <item row="5" column="0">
+              <widget class="QLabel" name="label">
+               <property name="toolTip">
+                <string>Your receiving address. You can copy and use it to receive coins on this wallet. A new one will be generated once it is used.</string>
+               </property>
+               <property name="text">
+                <string>&amp;Address:</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
+               <property name="buddy">
+                <cstring>reqAddress</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="5" column="2">
+              <widget class="QLineEdit" name="reqAddress">
+               <property name="readOnly">
+                <bool>true</bool>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>80</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="toolTip">
+                <string>Your receiving address. You can copy and use it to receive coins on this wallet. A new one will be generated once it is used.</string>
+               </property>
+              </widget>
+             </item>
+             <item row="6" column="0">
               <widget class="QLabel" name="label">
                <property name="toolTip">
                 <string>An optional amount to request. Leave this empty or zero to not request a specific amount.</string>
                </property>
                <property name="text">
-                <string>&amp;Amount:</string>
+                <string>A&amp;mount:</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -222,7 +214,7 @@
                </property>
               </widget>
              </item>
-             <item row="5" column="2">
+             <item row="6" column="2">
               <widget class="BitcoinAmountField" name="reqAmount">
                <property name="minimumSize">
                 <size>
@@ -235,14 +227,54 @@
                </property>
               </widget>
              </item>
+             <item row="7" column="0">
+              <widget class="QLabel" name="label_3">
+               <property name="toolTip">
+                <string>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the PIVX network.</string>
+               </property>
+               <property name="text">
+                <string>&amp;Message:</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
+               <property name="buddy">
+                <cstring>reqMessage</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="7" column="2">
+              <widget class="QLineEdit" name="reqMessage">
+               <property name="toolTip">
+                <string>An optional message to attach to the payment request, which will be displayed when the request is opened.&lt;br&gt;Note: The message will not be sent with the payment over the PIVX network.</string>
+               </property>
+              </widget>
+             </item>
              <item row="8" column="0">
-              <widget class="QLabel" name="label_7">
+              <widget class="QLabel" name="label_4">
                <property name="text">
                 <string/>
                </property>
               </widget>
              </item>
              <item row="8" column="2">
+              <widget class="QCheckBox" name="reuseAddress">
+               <property name="toolTip">
+                <string>Reuse one of the previously used receiving addresses.&lt;br&gt;Reusing addresses has security and privacy issues.&lt;br&gt;Do not use this unless re-generating a payment request made before.</string>
+               </property>
+               <property name="text">
+                <string>R&amp;euse an existing receiving address (not recommended)</string>
+               </property>
+              </widget>
+             </item>
+             <item row="9" column="0">
+              <widget class="QLabel" name="label_7">
+               <property name="text">
+                <string/>
+               </property>
+              </widget>
+             </item>
+             <item row="9" column="2">
               <layout class="QHBoxLayout" name="horizontalLayout">
                <item>
                 <widget class="QPushButton" name="receiveButton">
@@ -313,7 +345,7 @@
                </item>
               </layout>
              </item>
-             <item row="9" column="2">
+             <item row="10" column="2">
               <spacer name="verticalSpacer">
                <property name="orientation">
                 <enum>Qt::Vertical</enum>
@@ -486,6 +518,7 @@
  </customwidgets>
  <tabstops>
   <tabstop>reqLabel</tabstop>
+  <tabstop>reqAddress</tabstop>
   <tabstop>reqAmount</tabstop>
   <tabstop>reqMessage</tabstop>
   <tabstop>reuseAddress</tabstop>

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -84,6 +84,10 @@ void ReceiveCoinsDialog::setModel(WalletModel* model)
             SLOT(recentRequestsView_selectionChanged(QItemSelection, QItemSelection)));
         // Last 2 columns are set by the columnResizingFixer, when the table geometry is ready.
         columnResizingFixer = new GUIUtil::TableViewLastColumnResizingFixer(tableView, AMOUNT_MINIMUM_COLUMN_WIDTH, DATE_COLUMN_WIDTH);
+
+        // Init address field
+        ui->reqAddress->setText(getAddress());
+
     }
 }
 
@@ -95,6 +99,7 @@ ReceiveCoinsDialog::~ReceiveCoinsDialog()
 void ReceiveCoinsDialog::clear()
 {
     ui->reqAmount->clear();
+    ui->reqAddress->setText(getAddress());
     ui->reqLabel->setText("");
     ui->reqMessage->setText("");
     ui->reuseAddress->setChecked(false);
@@ -118,29 +123,34 @@ void ReceiveCoinsDialog::updateDisplayUnit()
     }
 }
 
-void ReceiveCoinsDialog::on_receiveButton_clicked()
+QString ReceiveCoinsDialog::getAddress(QString label)
 {
-    if (!model || !model->getOptionsModel() || !model->getAddressTableModel() || !model->getRecentRequestsTableModel())
-        return;
-
-    QString address;
-    QString label = ui->reqLabel->text();
     if (ui->reuseAddress->isChecked()) {
         /* Choose existing receiving address */
         AddressBookPage dlg(AddressBookPage::ForSelection, AddressBookPage::ReceivingTab, this);
         dlg.setModel(model->getAddressTableModel());
         if (dlg.exec()) {
-            address = dlg.getReturnValue();
-            if (label.isEmpty()) /* If no label provided, use the previously used label */
-            {
-                label = model->getAddressTableModel()->labelForAddress(address);
-            }
+            return dlg.getReturnValue();
         } else {
-            return;
+            return "";
         }
     } else {
         /* Generate new receiving address */
-        address = model->getAddressTableModel()->addRow(AddressTableModel::Receive, label, "");
+        return model->getAddressTableModel()->addRow(AddressTableModel::Receive, label, "");
+    }
+}
+
+void ReceiveCoinsDialog::on_receiveButton_clicked()
+{
+    if (!model || !model->getOptionsModel() || !model->getAddressTableModel() || !model->getRecentRequestsTableModel())
+        return;
+
+    QString label = ui->reqLabel->text();
+    QString address = getAddress(label);
+    if (address.isEmpty())
+        return;
+    if (ui->reuseAddress->isChecked() && label.isEmpty()) {
+        label = model->getAddressTableModel()->labelForAddress(address);
     }
     SendCoinsRecipient info(address, label,
         ui->reqAmount->value(), ui->reqMessage->text());

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -86,8 +86,10 @@ void ReceiveCoinsDialog::setModel(WalletModel* model)
         columnResizingFixer = new GUIUtil::TableViewLastColumnResizingFixer(tableView, AMOUNT_MINIMUM_COLUMN_WIDTH, DATE_COLUMN_WIDTH);
 
         // Init address field
-        ui->reqAddress->setText(getAddress());
+        address = getAddress();
+        ui->reqAddress->setText(address);
 
+        connect(model, SIGNAL(notifyReceiveAddressChanged()), this, SLOT(receiveAddressUsed()));
     }
 }
 
@@ -99,7 +101,8 @@ ReceiveCoinsDialog::~ReceiveCoinsDialog()
 void ReceiveCoinsDialog::clear()
 {
     ui->reqAmount->clear();
-    ui->reqAddress->setText(getAddress());
+    address = getAddress();
+    ui->reqAddress->setText(address);
     ui->reqLabel->setText("");
     ui->reqMessage->setText("");
     ui->reuseAddress->setChecked(false);
@@ -146,7 +149,7 @@ void ReceiveCoinsDialog::on_receiveButton_clicked()
         return;
 
     QString label = ui->reqLabel->text();
-    QString address = getAddress(label);
+    address = getAddress(label);
     if (address.isEmpty())
         return;
     if (ui->reuseAddress->isChecked() && label.isEmpty()) {
@@ -284,3 +287,11 @@ void ReceiveCoinsDialog::copyAddress()
 {
     copyColumnToClipboard(RecentRequestsTableModel::Address);
 }
+
+void ReceiveCoinsDialog::receiveAddressUsed()
+{
+    if (model && model->isUsed(CBitcoinAddress(address.toStdString()))) {
+        clear();
+    }
+}
+

--- a/src/qt/receivecoinsdialog.h
+++ b/src/qt/receivecoinsdialog.h
@@ -59,6 +59,8 @@ private:
     GUIUtil::TableViewLastColumnResizingFixer* columnResizingFixer;
     WalletModel* model;
     QMenu* contextMenu;
+
+    QString getAddress(QString label = "");
     void copyColumnToClipboard(int column);
     virtual void resizeEvent(QResizeEvent* event);
 

--- a/src/qt/receivecoinsdialog.h
+++ b/src/qt/receivecoinsdialog.h
@@ -59,6 +59,7 @@ private:
     GUIUtil::TableViewLastColumnResizingFixer* columnResizingFixer;
     WalletModel* model;
     QMenu* contextMenu;
+    QString address;
 
     QString getAddress(QString label = "");
     void copyColumnToClipboard(int column);
@@ -77,6 +78,7 @@ private slots:
     void copyMessage();
     void copyAmount();
     void copyAddress();
+    void receiveAddressUsed();
 };
 
 #endif // BITCOIN_QT_RECEIVECOINSDIALOG_H

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -155,6 +155,9 @@ void WalletModel::pollBalanceChanged()
         if (transactionTableModel) {
             transactionTableModel->updateConfirmations();
         }
+
+        // Address in receive tab may have been used
+        emit notifyReceiveAddressChanged();
     }
 }
 
@@ -790,4 +793,9 @@ bool WalletModel::saveReceiveRequest(const std::string& sAddress, const int64_t 
 bool WalletModel::isMine(CBitcoinAddress address)
 {
     return IsMine(*wallet, address.Get());
+}
+
+bool WalletModel::isUsed(CBitcoinAddress address)
+{
+    return wallet->IsUsed(address);
 }

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -204,6 +204,7 @@ public:
 
     bool getPubKey(const CKeyID& address, CPubKey& vchPubKeyOut) const;
     bool isMine(CBitcoinAddress address);
+    bool isUsed(CBitcoinAddress address);
     void getOutputs(const std::vector<COutPoint>& vOutpoints, std::vector<COutput>& vOutputs);
     bool isSpent(const COutPoint& outpoint) const;
     void listCoins(std::map<QString, std::vector<COutput> >& mapCoins) const;
@@ -282,6 +283,9 @@ signals:
 
     // MultiSig address added
     void notifyMultiSigChanged(bool fHaveMultiSig);
+
+    // Receive tab address may have changed
+    void notifyReceiveAddressChanged();
 
 public slots:
     /* Wallet status might have changed */

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -757,7 +757,6 @@ void CWallet::EraseFromWallet(const uint256& hash)
     return;
 }
 
-
 isminetype CWallet::IsMine(const CTxIn& txin) const
 {
     {
@@ -770,6 +769,27 @@ isminetype CWallet::IsMine(const CTxIn& txin) const
         }
     }
     return ISMINE_NO;
+}
+
+bool CWallet::IsUsed(const CBitcoinAddress address) const
+{
+    LOCK(cs_wallet);
+    CScript scriptPubKey = GetScriptForDestination(address.Get());
+    if (!::IsMine(*this, scriptPubKey)) {
+        return false;
+    }
+
+    for (map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it) {
+        const CWalletTx& wtx = (*it).second;
+        if (wtx.IsCoinBase()) {
+            continue;
+        }
+        for (const CTxOut& txout : wtx.vout) {
+            if (txout.scriptPubKey == scriptPubKey)
+                return true;
+        }
+    }
+    return false;
 }
 
 bool CWallet::IsMyZerocoinSpend(const CBigNum& bnSerial) const

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -540,6 +540,8 @@ public:
 
     bool IsDenominatedAmount(CAmount nInputAmount) const;
 
+    bool IsUsed(const CBitcoinAddress address) const;
+
     isminetype IsMine(const CTxIn& txin) const;
     CAmount GetDebit(const CTxIn& txin, const isminefilter& filter) const;
     isminetype IsMine(const CTxOut& txout) const


### PR DESCRIPTION
This adds an address field to the receive tab.
IMO this, in combination with #683 and #693 should allow to close #678. I feel it correctly addresses the concern raised there, without too much changes into our UI and still following common best practices.
FYI The new address field will automatically change when the address in question receives any payment.

**Before:**
![capture d ecran de 2018-09-30 13-38-38](https://user-images.githubusercontent.com/835098/46257195-3362b900-c4b6-11e8-8450-17a496cad3a8.png)

**After:**
![capture d ecran de 2018-09-30 13-16-55](https://user-images.githubusercontent.com/835098/46257029-4e7ff980-c4b3-11e8-85dd-f324064d5b9b.png)
