### PR TITLE
[RPC] Ensure that a numeric is being passed to AmmountFromValue

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -113,6 +113,9 @@ static inline int64_t roundint64(double d)
 
 CAmount AmountFromValue(const UniValue& value)
 {
+    if (!value.isNum())
+        throw JSONRPCError(RPC_TYPE_ERROR, "Amount is not a number");
+
     double dAmount = value.get_real();
     if (dAmount <= 0.0 || dAmount > 21000000.0)
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");


### PR DESCRIPTION
Return a more descriptive type error when the input paramater is not a
numeric.

This clarifies the response message a bit and allows for a faster exit
response by not needing to do subsequent mathematical or external
function checks.

NOTE: This isn't a functional change, since non-numeric input values
would previously fail anyways, returning only an "Invalid amount" error
message.