### PR TITLE
[UI] Sort numbers correctly in zPIV and coin control dialogs

### DIFF
--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -19,6 +19,7 @@
 #include <QPoint>
 #include <QPushButton>
 #include <QSystemTrayIcon>
+#include <QTreeWidgetItem>
 
 class ClientModel;
 class NetworkStyle;
@@ -287,6 +288,26 @@ private slots:
     void updateDisplayUnit(int newUnits);
     /** Tells underlying optionsModel to update its current display unit. */
     void onMenuSelection(QAction* action);
+};
+
+
+class TreeWidgetItem : public QTreeWidgetItem {
+public:
+    TreeWidgetItem() : QTreeWidgetItem(){}
+    TreeWidgetItem(QTreeWidgetItem* item) : QTreeWidgetItem(item){}
+    TreeWidgetItem(QTreeWidget* parent) : QTreeWidgetItem(parent){}
+private:
+    bool operator<(const QTreeWidgetItem &other)const {
+        int column = treeWidget()->sortColumn();
+        bool isNumber;
+        double item1 = text(column).toDouble(&isNumber);
+        if (isNumber) {
+            double item2 = other.text(column).toDouble(&isNumber);
+            if (isNumber)
+                return item1 < item2;
+        }
+        return text(column) < other.text(column);
+  }
 };
 
 #endif // BITCOIN_QT_BITCOINGUI_H

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -8,6 +8,7 @@
 #include "ui_coincontroldialog.h"
 
 #include "addresstablemodel.h"
+#include "bitcoingui.h" //TreeWidgetItem
 #include "bitcoinunits.h"
 #include "guiutil.h"
 #include "init.h"
@@ -31,7 +32,7 @@
 #include <QSettings>
 #include <QString>
 #include <QTreeWidget>
-#include <QTreeWidgetItem>
+
 
 using namespace std;
 QList<CAmount> CoinControlDialog::payAmounts;
@@ -171,15 +172,6 @@ void CoinControlDialog::setModel(WalletModel* model)
         CoinControlDialog::updateLabels(model, this);
         updateDialogLabels();
     }
-}
-
-// helper function str_pad
-QString CoinControlDialog::strPad(QString s, int nPadLength, QString sPadding)
-{
-    while (s.length() < nPadLength)
-        s = sPadding + s;
-
-    return s;
 }
 
 // ok button
@@ -745,7 +737,7 @@ void CoinControlDialog::updateView()
     model->listCoins(mapCoins);
 
     BOOST_FOREACH (PAIRTYPE(QString, vector<COutput>) coins, mapCoins) {
-        QTreeWidgetItem* itemWalletAddress = new QTreeWidgetItem();
+        TreeWidgetItem* itemWalletAddress = new TreeWidgetItem();
         itemWalletAddress->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);
         QString sWalletAddress = coins.first;
         QString sWalletLabel = model->getAddressTableModel()->labelForAddress(sWalletAddress);
@@ -782,11 +774,11 @@ void CoinControlDialog::updateView()
             nSum += out.tx->vout[out.i].nValue;
             nChildren++;
 
-            QTreeWidgetItem* itemOutput;
+            TreeWidgetItem* itemOutput;
             if (treeMode)
-                itemOutput = new QTreeWidgetItem(itemWalletAddress);
+                itemOutput = new TreeWidgetItem(itemWalletAddress);
             else
-                itemOutput = new QTreeWidgetItem(ui->treeWidget);
+                itemOutput = new TreeWidgetItem(ui->treeWidget);
             itemOutput->setFlags(flgCheckbox);
             itemOutput->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);
 
@@ -838,20 +830,20 @@ void CoinControlDialog::updateView()
             // amount
             itemOutput->setText(COLUMN_AMOUNT, BitcoinUnits::format(nDisplayUnit, out.tx->vout[out.i].nValue));
             itemOutput->setToolTip(COLUMN_AMOUNT, BitcoinUnits::format(nDisplayUnit, out.tx->vout[out.i].nValue));
-            itemOutput->setText(COLUMN_AMOUNT_INT64, strPad(QString::number(out.tx->vout[out.i].nValue), 15, " ")); // padding so that sorting works correctly
+            itemOutput->setText(COLUMN_AMOUNT_INT64, QString::number(out.tx->vout[out.i].nValue)); // padding so that sorting works correctly
 
             // date
             itemOutput->setText(COLUMN_DATE, GUIUtil::dateTimeStr(out.tx->GetTxTime()));
             itemOutput->setToolTip(COLUMN_DATE, GUIUtil::dateTimeStr(out.tx->GetTxTime()));
-            itemOutput->setText(COLUMN_DATE_INT64, strPad(QString::number(out.tx->GetTxTime()), 20, " "));
+            itemOutput->setText(COLUMN_DATE_INT64, QString::number(out.tx->GetTxTime()));
 
             // confirmations
-            itemOutput->setText(COLUMN_CONFIRMATIONS, strPad(QString::number(out.nDepth), 8, " "));
+            itemOutput->setText(COLUMN_CONFIRMATIONS, QString::number(out.nDepth));
 
             // priority
             double dPriority = ((double)out.tx->vout[out.i].nValue / (nInputSize + 78)) * (out.nDepth + 1); // 78 = 2 * 34 + 10
             itemOutput->setText(COLUMN_PRIORITY, CoinControlDialog::getPriorityLabel(dPriority, mempoolEstimatePriority));
-            itemOutput->setText(COLUMN_PRIORITY_INT64, strPad(QString::number((int64_t)dPriority), 20, " "));
+            itemOutput->setText(COLUMN_PRIORITY_INT64, QString::number((int64_t)dPriority));
             dPrioritySum += (double)out.tx->vout[out.i].nValue * (out.nDepth + 1);
             nInputSum += nInputSize;
 
@@ -881,9 +873,9 @@ void CoinControlDialog::updateView()
             itemWalletAddress->setText(COLUMN_CHECKBOX, "(" + QString::number(nChildren) + ")");
             itemWalletAddress->setText(COLUMN_AMOUNT, BitcoinUnits::format(nDisplayUnit, nSum));
             itemWalletAddress->setToolTip(COLUMN_AMOUNT, BitcoinUnits::format(nDisplayUnit, nSum));
-            itemWalletAddress->setText(COLUMN_AMOUNT_INT64, strPad(QString::number(nSum), 15, " "));
+            itemWalletAddress->setText(COLUMN_AMOUNT_INT64, QString::number(nSum));
             itemWalletAddress->setText(COLUMN_PRIORITY, CoinControlDialog::getPriorityLabel(dPrioritySum, mempoolEstimatePriority));
-            itemWalletAddress->setText(COLUMN_PRIORITY_INT64, strPad(QString::number((int64_t)dPrioritySum), 20, " "));
+            itemWalletAddress->setText(COLUMN_PRIORITY_INT64, QString::number((int64_t)dPrioritySum));
         }
     }
 

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -60,7 +60,6 @@ private:
     QAction* lockAction;
     QAction* unlockAction;
 
-    QString strPad(QString, int, QString);
     void sortView(int, Qt::SortOrder);
     void updateView();
 

--- a/src/qt/zpivcontroldialog.cpp
+++ b/src/qt/zpivcontroldialog.cpp
@@ -42,6 +42,15 @@ void ZPivControlDialog::setModel(WalletModel *model)
     updateList();
 }
 
+// helper function str_pad
+QString ZPivControlDialog::strPad(QString s, int nPadLength, QString sPadding)
+{
+    while (s.length() < nPadLength)
+        s = sPadding + s;
+
+    return s;
+}
+
 //Update the tree widget
 void ZPivControlDialog::updateList()
 {
@@ -60,7 +69,7 @@ void ZPivControlDialog::updateList()
         mapDenomPosition[denom] = ui->treeWidget->indexOfTopLevelItem(itemDenom);
 
         itemDenom->setFlags(flgTristate);
-        itemDenom->setText(COLUMN_DENOMINATION, QString::number(denom));
+        itemDenom->setText(COLUMN_DENOMINATION, strPad(QString::number(denom), 5, " "));
     }
 
     // select all unused coins - including not mature. Update status of coins too.
@@ -84,9 +93,9 @@ void ZPivControlDialog::updateList()
         else
             itemMint->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);
 
-        itemMint->setText(COLUMN_DENOMINATION, QString::number(mint.denom));
+        itemMint->setText(COLUMN_DENOMINATION, strPad(QString::number(mint.denom), 5, " "));
         itemMint->setText(COLUMN_PUBCOIN, QString::fromStdString(strPubCoinHash));
-        itemMint->setText(COLUMN_VERSION, QString::number(mint.nVersion));
+        itemMint->setText(COLUMN_VERSION, strPad(QString::number(mint.nVersion), 3, " "));
 
         int nConfirmations = (mint.nHeight ? nBestHeight - mint.nHeight : 0);
         if (nConfirmations < 0) {
@@ -94,7 +103,7 @@ void ZPivControlDialog::updateList()
             nConfirmations = 0;
         }
 
-        itemMint->setText(COLUMN_CONFIRMATIONS, QString::number(nConfirmations));
+        itemMint->setText(COLUMN_CONFIRMATIONS, strPad(QString::number(nConfirmations), 15, " "));
 
         // check for maturity
         bool isMature = false;

--- a/src/qt/zpivcontroldialog.cpp
+++ b/src/qt/zpivcontroldialog.cpp
@@ -6,6 +6,7 @@
 #include "ui_zpivcontroldialog.h"
 
 #include "accumulators.h"
+#include "bitcoingui.h" //TreeWidgetItem
 #include "main.h"
 #include "walletmodel.h"
 
@@ -42,14 +43,6 @@ void ZPivControlDialog::setModel(WalletModel *model)
     updateList();
 }
 
-// helper function str_pad
-QString ZPivControlDialog::strPad(QString s, int nPadLength, QString sPadding)
-{
-    while (s.length() < nPadLength)
-        s = sPadding + s;
-
-    return s;
-}
 
 //Update the tree widget
 void ZPivControlDialog::updateList()
@@ -62,14 +55,14 @@ void ZPivControlDialog::updateList()
     QFlags<Qt::ItemFlag> flgTristate = Qt::ItemIsEnabled | Qt::ItemIsUserCheckable | Qt::ItemIsTristate;
     map<libzerocoin::CoinDenomination, int> mapDenomPosition;
     for (auto denom : libzerocoin::zerocoinDenomList) {
-        QTreeWidgetItem* itemDenom(new QTreeWidgetItem);
+        TreeWidgetItem* itemDenom(new TreeWidgetItem);
         ui->treeWidget->addTopLevelItem(itemDenom);
 
         //keep track of where this is positioned in tree widget
         mapDenomPosition[denom] = ui->treeWidget->indexOfTopLevelItem(itemDenom);
 
         itemDenom->setFlags(flgTristate);
-        itemDenom->setText(COLUMN_DENOMINATION, strPad(QString::number(denom), 5, " "));
+        itemDenom->setText(COLUMN_DENOMINATION, QString::number(denom));
     }
 
     // select all unused coins - including not mature. Update status of coins too.
@@ -83,7 +76,7 @@ void ZPivControlDialog::updateList()
     for (const CMintMeta& mint : setMints) {
         // assign this mint to the correct denomination in the tree view
         libzerocoin::CoinDenomination denom = mint.denom;
-        QTreeWidgetItem *itemMint = new QTreeWidgetItem(ui->treeWidget->topLevelItem(mapDenomPosition.at(denom)));
+        TreeWidgetItem *itemMint = new TreeWidgetItem(ui->treeWidget->topLevelItem(mapDenomPosition.at(denom)));
 
         // if the mint is already selected, then it needs to have the checkbox checked
         std::string strPubCoinHash = mint.hashPubcoin.GetHex();
@@ -93,9 +86,9 @@ void ZPivControlDialog::updateList()
         else
             itemMint->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);
 
-        itemMint->setText(COLUMN_DENOMINATION, strPad(QString::number(mint.denom), 5, " "));
+        itemMint->setText(COLUMN_DENOMINATION, QString::number(mint.denom));
         itemMint->setText(COLUMN_PUBCOIN, QString::fromStdString(strPubCoinHash));
-        itemMint->setText(COLUMN_VERSION, strPad(QString::number(mint.nVersion), 3, " "));
+        itemMint->setText(COLUMN_VERSION, QString::number(mint.nVersion));
 
         int nConfirmations = (mint.nHeight ? nBestHeight - mint.nHeight : 0);
         if (nConfirmations < 0) {
@@ -103,7 +96,7 @@ void ZPivControlDialog::updateList()
             nConfirmations = 0;
         }
 
-        itemMint->setText(COLUMN_CONFIRMATIONS, strPad(QString::number(nConfirmations), 15, " "));
+        itemMint->setText(COLUMN_CONFIRMATIONS, QString::number(nConfirmations));
 
         // check for maturity
         bool isMature = false;

--- a/src/qt/zpivcontroldialog.h
+++ b/src/qt/zpivcontroldialog.h
@@ -36,6 +36,7 @@ private:
     WalletModel* model;
     PrivacyDialog* privacyDialog;
 
+    QString strPad(QString, int, QString);
     void updateList();
     void updateLabels();
 

--- a/src/qt/zpivcontroldialog.h
+++ b/src/qt/zpivcontroldialog.h
@@ -36,7 +36,6 @@ private:
     WalletModel* model;
     PrivacyDialog* privacyDialog;
 
-    QString strPad(QString, int, QString);
     void updateList();
     void updateLabels();
 


### PR DESCRIPTION
Numeric sorting in this dialog was broken. It was following some kind of string rules. This is a simple fix, as used in the coin selector dialog.

**Before:**
![capture d ecran de 2018-09-30 14-54-58](https://user-images.githubusercontent.com/835098/46257837-4038da00-c4c1-11e8-9739-0eb7960f1bc4.png)
![capture d ecran de 2018-09-30 14-55-20](https://user-images.githubusercontent.com/835098/46257838-42029d80-c4c1-11e8-996a-48002282ca86.png)

**After:**
![capture d ecran de 2018-09-30 14-50-52](https://user-images.githubusercontent.com/835098/46257841-5181e680-c4c1-11e8-9183-fa44f7176222.png)
![capture d ecran de 2018-09-30 14-49-35](https://user-images.githubusercontent.com/835098/46257845-6494b680-c4c1-11e8-9e28-66bd37940ca0.png)

