### PR TITLE
[Utils] Update linters for python3

### DIFF
--- a/contrib/devtools/check-doc.py
+++ b/contrib/devtools/check-doc.py
@@ -1,44 +1,47 @@
-#!/usr/bin/env python
-# Copyright (c) 2015-2016 The Bitcoin Core developers
+#!/usr/bin/env python3
+# Copyright (c) 2015-2018 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 '''
 This checks if all command line args are documented.
 Return value is 0 to indicate no error.
+
 Author: @MarcoFalke
 '''
 
 from subprocess import check_output
 import re
+import sys
 
 FOLDER_GREP = 'src'
 FOLDER_TEST = 'src/test/'
-CMD_ROOT_DIR = '`git rev-parse --show-toplevel`/%s' % FOLDER_GREP
-CMD_GREP_ARGS = r"egrep -r -I '(map(Multi)?Args(\.count\(|\[)|Get(Bool)?Arg\()\"\-[^\"]+?\"' %s | grep -v '%s'" % (CMD_ROOT_DIR, FOLDER_TEST)
-CMD_GREP_DOCS = r"egrep -r -I 'HelpMessageOpt\(\"\-[^\"=]+?(=|\")' %s" % (CMD_ROOT_DIR)
+CMD_ROOT_DIR = '`git rev-parse --show-toplevel`/{}'.format(FOLDER_GREP)
+CMD_GREP_ARGS = r"egrep -r -I '(map(Multi)?Args(\.count\(|\[)|Get(Bool)?Arg\()\"\-[^\"]+?\"' {} | grep -v '{}'".format(CMD_ROOT_DIR, FOLDER_TEST)
+CMD_GREP_DOCS = r"egrep -r -I 'HelpMessageOpt\(\"\-[^\"=]+?(=|\")' {}".format(CMD_ROOT_DIR)
 REGEX_ARG = re.compile(r'(?:map(?:Multi)?Args(?:\.count\(|\[)|Get(?:Bool)?Arg\()\"(\-[^\"]+?)\"')
 REGEX_DOC = re.compile(r'HelpMessageOpt\(\"(\-[^\"=]+?)(?:=|\")')
 # list unsupported, deprecated and duplicate args as they need no documentation
 SET_DOC_OPTIONAL = set(['-rpcssl', '-benchmark', '-h', '-help', '-socks', '-tor', '-debugnet', '-whitelistalwaysrelay', '-prematurewitness', '-walletprematurewitness', '-promiscuousmempoolflags', '-blockminsize', '-sendfreetransactions', '-checklevel', '-liquidityprovider', '-anonymizepivxamount'])
 
 def main():
-  used = check_output(CMD_GREP_ARGS, shell=True)
-  docd = check_output(CMD_GREP_DOCS, shell=True)
+    used = check_output(CMD_GREP_ARGS, shell=True, universal_newlines=True)
+    docd = check_output(CMD_GREP_DOCS, shell=True, universal_newlines=True)
 
-  args_used = set(re.findall(REGEX_ARG,used))
-  args_docd = set(re.findall(REGEX_DOC,docd)).union(SET_DOC_OPTIONAL)
-  args_need_doc = args_used.difference(args_docd)
-  args_unknown = args_docd.difference(args_used)
+    args_used = set(re.findall(re.compile(REGEX_ARG), used))
+    args_docd = set(re.findall(re.compile(REGEX_DOC), docd)).union(SET_DOC_OPTIONAL)
+    args_need_doc = args_used.difference(args_docd)
+    args_unknown = args_docd.difference(args_used)
 
-  print "Args used        : %s" % len(args_used)
-  print "Args documented  : %s" % len(args_docd)
-  print "Args undocumented: %s" % len(args_need_doc)
-  print args_need_doc
-  print "Args unknown     : %s" % len(args_unknown)
-  print args_unknown
+    print("Args used        : {}".format(len(args_used)))
+    print("Args documented  : {}".format(len(args_docd)))
+    print("Args undocumented: {}".format(len(args_need_doc)))
+    print(args_need_doc)
+    print("Args unknown     : {}".format(len(args_unknown)))
+    print(args_unknown)
 
-  exit(len(args_need_doc))
+    sys.exit(len(args_need_doc))
+
 
 if __name__ == "__main__":
     main()

--- a/contrib/devtools/lint-whitespace.sh
+++ b/contrib/devtools/lint-whitespace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2017 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying

--- a/contrib/devtools/logprint-scanner.py
+++ b/contrib/devtools/logprint-scanner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2017-2018 The PIVX developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -27,14 +27,14 @@ def countRelevantCommas(line):
     return numRelevantCommas
 
 if __name__ == "__main__":
-    out = check_output(["git", "rev-parse", "--show-toplevel"])
+    out = check_output("git rev-parse --show-toplevel", shell=True, universal_newlines=True)
     srcDir = out.rstrip() + "/src/"
 
     filelist = [os.path.join(dp, f) for dp, dn, filenames in os.walk(srcDir) for f in filenames if os.path.splitext(f)[1] == '.cpp' or os.path.splitext(f)[1] == '.h' ]
     incorrectInstanceCounter = 0
 
     for file in filelist:
-        f = open(file,"r")
+        f = open(file,"r", encoding="utf-8")
         data = f.read()
         rows = data.split("\n")
         count = 0
@@ -77,11 +77,11 @@ if __name__ == "__main__":
                         numPercents = tempLine.count('%') - numExtraPercents - 2*tempLine.count('%%')
 
                         if numPercents != numCommas:
-                            print "Incorrect number of arguments for LogPrint(f) statement found."
+                            print("Incorrect number of arguments for LogPrint(f) statement found.")
                             print(str(file) + ":" + str(lineCounter - tempCount))
-                            print "Line = " + tempLine
+                            print("Line = " + tempLine)
                             print("numRelevantCommas = " + str(numCommas) + ", numRelevantPercents = " + str(numPercents))
-                            print ""
+                            print("")
 
                             incorrectInstanceCounter += 1
 


### PR DESCRIPTION
check-doc and logprint-scanner were still using python2 conventions.
This updates the two scripts to use pyhon3 instead and be consistent
with the rest of our python utility scripts.

Also, use a more widely accessible bash path in lint-whitespace.sh