### PR TITLE
[Refactor] remove CPubKey::GetHex

### DIFF
--- a/src/blocksignature.cpp
+++ b/src/blocksignature.cpp
@@ -84,7 +84,7 @@ bool CheckBlockSignature(const CBlock& block)
     }
 
     if (!pubkey.IsValid())
-        return error("%s: invalid pubkey %s", __func__, pubkey.GetHex());
+        return error("%s: invalid pubkey %s", __func__, HexStr(pubkey));
 
     return pubkey.Verify(block.GetHash(), block.vchBlockSig);
 }

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -204,11 +204,6 @@ public:
         return std::vector<unsigned char>(vch, vch + size());
     }
 
-    std::string GetHex()
-    {
-        std::string my_std_string(reinterpret_cast<const char*>(vch), 65);
-        return my_std_string;
-    }
 };
 
 struct CExtPubKey {


### PR DESCRIPTION
This method is not returning the public key as hex string as the name implies.