### PR TITLE
[Wallet] Fix zPIV spend when too much mints are selected

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -4761,8 +4761,18 @@ bool CWallet::CreateZerocoinSpendTransaction(CAmount nValue, int nSecurityLevel,
             vSelectedMints.emplace_back(mint);
         }
     } else {
-        for (const CZerocoinMint& mint : vSelectedMints)
-            nValueSelected += ZerocoinDenominationToAmount(mint.GetDenomination());
+        unsigned int mintsCount = 0;
+        for (const CZerocoinMint& mint : vSelectedMints) {
+            if (nValueSelected < nValue) {
+                nValueSelected += ZerocoinDenominationToAmount(mint.GetDenomination());
+                mintsCount ++;
+            }
+            else
+                break;
+        }
+        if (mintsCount < vSelectedMints.size()) {
+            vSelectedMints.resize(mintsCount);
+        }
     }
 
     int nArchived = 0;


### PR DESCRIPTION
This avoids the situation where selecting too much zPIV for a spend (example: ten 1 denom to spend 3 PIV) would result in the message `Failed to find coin set amongst held coins with less than maxNumber of Spends`.