### PR TITLE
[Qt] Fix Missing Explorer Icon

### DIFF
--- a/src/qt/pivx.qrc
+++ b/src/qt/pivx.qrc
@@ -56,6 +56,7 @@
         <file alias="staking_active">res/icons/staking_active.png</file>
         <file alias="staking_inactive">res/icons/staking_inactive.png</file>
         <file alias="automint_active">res/icons/automint_active.png</file>
+        <file alias="explorer">res/icons/explorer.png</file>
         <file alias="automint_inactive">res/icons/automint_inactive.png</file>
         <file alias="onion">res/icons/onion.png</file>
     </qresource>


### PR DESCRIPTION
The icon for block explorer is missing. 

![image](https://user-images.githubusercontent.com/31908995/50721129-1f67be00-1088-11e9-93f4-e90a54214d48.png)
