### PR TITLE
[UI] Open related options tab when clicking automint icon

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -761,6 +761,7 @@ void BitcoinGUI::optionsClicked()
 
     OptionsDialog dlg(this, enableWallet);
     dlg.setModel(clientModel->getOptionsModel());
+    dlg.setCurrentIndex(0);
     dlg.exec();
 }
 

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -344,3 +344,8 @@ bool OptionsDialog::eventFilter(QObject* object, QEvent* event)
     }
     return QDialog::eventFilter(object, event);
 }
+
+void OptionsDialog::setCurrentIndex(int index)
+{
+    ui->tabWidget->setCurrentIndex(index);
+}

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -32,6 +32,7 @@ public:
 
     void setModel(OptionsModel* model);
     void setMapper();
+    void setCurrentIndex(int index);
 
 protected:
     bool eventFilter(QObject* object, QEvent* event);


### PR DESCRIPTION
Opening the option dialog defaults to its last tab. This changes selects the first tab (containing zerocoin minting related options) when clicking the zerocoin autominting icon.