### PR TITLE
[Test] Create new per-test fixtures

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -23,6 +23,7 @@ RAW_TEST_FILES = test/data/alertTests.raw
 GENERATED_TEST_FILES = $(JSON_TEST_FILES:.json=.json.h) $(RAW_TEST_FILES:.raw=.raw.h)
 
 BITCOIN_TEST_SUITE = \
+  test/test_pivx.h \
   test/test_pivx.cpp
 # test_pivx binary #
 BITCOIN_TESTS =\

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5294,10 +5294,31 @@ bool CVerifyDB::VerifyDB(CCoinsView* coinsview, int nCheckLevel, int nCheckDepth
 
 void UnloadBlockIndex()
 {
-    mapBlockIndex.clear();
+    LOCK(cs_main);
     setBlockIndexCandidates.clear();
     chainActive.SetTip(NULL);
     pindexBestInvalid = NULL;
+    pindexBestHeader = NULL;
+    mempool.clear();
+    mapOrphanTransactions.clear();
+    mapOrphanTransactionsByPrev.clear();
+    nSyncStarted = 0;
+    mapBlocksUnlinked.clear();
+    vinfoBlockFile.clear();
+    nLastBlockFile = 0;
+    nBlockSequenceId = 1;
+    mapBlockSource.clear();
+    mapBlocksInFlight.clear();
+    nQueuedValidatedHeaders = 0;
+    nPreferredDownload = 0;
+    setDirtyBlockIndex.clear();
+    setDirtyFileInfo.clear();
+    mapNodeState.clear();
+
+    for (BlockMap::value_type& entry : mapBlockIndex) {
+        delete entry.second;
+    }
+    mapBlockIndex.clear();
 }
 
 bool LoadBlockIndex(string& strError)

--- a/src/test/Checkpoints_tests.cpp
+++ b/src/test/Checkpoints_tests.cpp
@@ -16,7 +16,7 @@
 
 using namespace std;
 
-BOOST_FIXTURE_TEST_SUITE(Checkpoints_tests, TestingSetup)
+BOOST_FIXTURE_TEST_SUITE(Checkpoints_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(sanity)
 {

--- a/src/test/Checkpoints_tests.cpp
+++ b/src/test/Checkpoints_tests.cpp
@@ -10,12 +10,13 @@
 #include "checkpoints.h"
 
 #include "uint256.h"
+#include "test_pivx.h"
 
 #include <boost/test/unit_test.hpp>
 
 using namespace std;
 
-BOOST_AUTO_TEST_SUITE(Checkpoints_tests)
+BOOST_FIXTURE_TEST_SUITE(Checkpoints_tests, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(sanity)
 {

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -16,6 +16,8 @@
 #include "serialize.h"
 #include "util.h"
 
+#include "test/test_pivx.h"
+
 #include <stdint.h>
 
 #include <boost/assign/list_of.hpp> // for 'map_list_of()'
@@ -40,7 +42,7 @@ CService ip(uint32_t i)
     return CService(CNetAddr(s), Params().GetDefaultPort());
 }
 
-BOOST_AUTO_TEST_SUITE(DoS_tests)
+BOOST_FIXTURE_TEST_SUITE(DoS_tests, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(DoS_banning)
 {

--- a/src/test/accounting_tests.cpp
+++ b/src/test/accounting_tests.cpp
@@ -6,13 +6,15 @@
 #include "wallet/wallet.h"
 #include "wallet/walletdb.h"
 
+#include "test/test_pivx.h"
+
 #include <stdint.h>
 
 #include <boost/test/unit_test.hpp>
 
 extern CWallet* pwalletMain;
 
-BOOST_AUTO_TEST_SUITE(accounting_tests)
+BOOST_FIXTURE_TEST_SUITE(accounting_tests, TestingSetup)
 
 static void
 GetResults(CWalletDB& walletdb, std::map<CAmount, CAccountingEntry>& results)

--- a/src/test/alert_tests.cpp
+++ b/src/test/alert_tests.cpp
@@ -15,6 +15,8 @@
 #include "util.h"
 #include "utilstrencodings.h"
 
+#include "test/test_bitcoin.h"
+
 #include <fstream>
 
 #include <boost/filesystem/operations.hpp>
@@ -77,7 +79,7 @@
 }
 #endif
 
-struct ReadAlerts
+struct ReadAlerts : public TestingSetup
 {
     ReadAlerts()
     {

--- a/src/test/allocator_tests.cpp
+++ b/src/test/allocator_tests.cpp
@@ -5,10 +5,11 @@
 #include "util.h"
 
 #include "allocators.h"
+#include "test/test_pivx.h"
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_AUTO_TEST_SUITE(allocator_tests)
+BOOST_FIXTURE_TEST_SUITE(allocator_tests, BasicTestingSetup)
 
 // Dummy memory page locker for platform independent tests
 static const void *last_lock_addr, *last_unlock_addr;

--- a/src/test/arith_uint256_tests.cpp
+++ b/src/test/arith_uint256_tests.cpp
@@ -13,9 +13,9 @@
 #include "arith_uint256.h"
 #include <string>
 #include "version.h"
+#include "test/test_pivx.h"
 
-BOOST_AUTO_TEST_SUITE(arith_uint256_tests)
-///BOOST_FIXTURE_TEST_SUITE(arith_uint256_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(arith_uint256_tests, BasicTestingSetup)
 
 /// Convert vector to arith_uint256, via uint256 blob
 inline arith_uint256 arith_uint256V(const std::vector<unsigned char>& vch)

--- a/src/test/base32_tests.cpp
+++ b/src/test/base32_tests.cpp
@@ -3,10 +3,11 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "utilstrencodings.h"
+#include "test/test_pivx.h"
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_AUTO_TEST_SUITE(base32_tests)
+BOOST_FIXTURE_TEST_SUITE(base32_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(base32_testvectors)
 {

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -14,6 +14,7 @@
 #include "uint256.h"
 #include "util.h"
 #include "utilstrencodings.h"
+#include "test/test_pivx.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -21,7 +22,7 @@
 
 extern UniValue read_json(const std::string& jsondata);
 
-BOOST_AUTO_TEST_SUITE(base58_tests)
+BOOST_FIXTURE_TEST_SUITE(base58_tests, BasicTestingSetup)
 
 // Goal: test low-level base58 encoding functionality
 BOOST_AUTO_TEST_CASE(base58_EncodeBase58)

--- a/src/test/base64_tests.cpp
+++ b/src/test/base64_tests.cpp
@@ -3,10 +3,11 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "utilstrencodings.h"
+#include "test/test_pivx.h"
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_AUTO_TEST_SUITE(base64_tests)
+BOOST_FIXTURE_TEST_SUITE(base64_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(base64_testvectors)
 {

--- a/src/test/benchmark_zerocoin.cpp
+++ b/src/test/benchmark_zerocoin.cpp
@@ -25,6 +25,7 @@
 #include "libzerocoin/Coin.h"
 #include "libzerocoin/CoinSpend.h"
 #include "libzerocoin/Accumulator.h"
+#include "test_pivx.h"
 
 using namespace std;
 using namespace libzerocoin;
@@ -402,7 +403,8 @@ Testb_RunAllTests()
 	cout << ggSuccessfulTests << " out of " << ggNumTests << " tests passed." << endl << endl;
 	delete gg_Params;
 }
-BOOST_AUTO_TEST_SUITE(benchmark_zerocoin)
+
+BOOST_FIXTURE_TEST_SUITE(benchmark_zerocoin, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(benchmark_test)
 {

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -8,6 +8,7 @@
 #include "key.h"
 #include "uint256.h"
 #include "util.h"
+#include "test/test_bitcoin.h"
 
 #include <string>
 #include <vector>
@@ -107,7 +108,7 @@ void RunTest(const TestVector &test) {
     }
 }
 
-BOOST_AUTO_TEST_SUITE(bip32_tests)
+BOOST_FIXTURE_TEST_SUITE(bip32_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(bip32_test1) {
     RunTest(test1);

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -14,6 +14,7 @@
 #include "uint256.h"
 #include "util.h"
 #include "utilstrencodings.h"
+#include "test/test_pivx.h"
 
 #include <vector>
 
@@ -23,7 +24,7 @@
 using namespace std;
 using namespace boost::tuples;
 
-BOOST_AUTO_TEST_SUITE(bloom_tests)
+BOOST_FIXTURE_TEST_SUITE(bloom_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(bloom_create_insert_serialize)
 {

--- a/src/test/budget_tests.cpp
+++ b/src/test/budget_tests.cpp
@@ -5,10 +5,11 @@
 #include "masternode-budget.h"
 #include "tinyformat.h"
 #include "utilmoneystr.h"
+#include "test_pivx.h"
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_AUTO_TEST_SUITE(budget_tests)
+BOOST_FIXTURE_TEST_SUITE(budget_tests, TestingSetup)
 
 void CheckBudgetValue(int nHeight, std::string strNetwork, CAmount nExpectedValue)
 {

--- a/src/test/checkblock_tests.cpp
+++ b/src/test/checkblock_tests.cpp
@@ -11,6 +11,7 @@
 #include "clientversion.h"
 #include "main.h"
 #include "utiltime.h"
+#include "test/test_pivx.h"
 
 #include <cstdio>
 
@@ -19,7 +20,7 @@
 #include <boost/test/unit_test.hpp>
 
 
-BOOST_AUTO_TEST_SUITE(CheckBlock_tests)
+BOOST_FIXTURE_TEST_SUITE(CheckBlock_tests, BasicTestingSetup)
 
 bool read_block(const std::string& filename, CBlock& block)
 {

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -5,6 +5,7 @@
 #include "coins.h"
 #include "random.h"
 #include "uint256.h"
+#include "test/test_pivx.h"
 
 #include <vector>
 #include <map>
@@ -60,7 +61,7 @@ public:
 };
 }
 
-BOOST_AUTO_TEST_SUITE(coins_tests)
+BOOST_FIXTURE_TEST_SUITE(coins_tests, BasicTestingSetup)
 
 static const unsigned int NUM_SIMULATION_ITERATIONS = 40000;
 

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -4,6 +4,7 @@
 
 #include "compressor.h"
 #include "util.h"
+#include "test/test_pivx.h"
 
 #include <stdint.h>
 
@@ -21,7 +22,7 @@
 // amounts 50 .. 21000000
 #define NUM_MULTIPLES_50BTC 420000
 
-BOOST_AUTO_TEST_SUITE(compress_tests)
+BOOST_FIXTURE_TEST_SUITE(compress_tests, BasicTestingSetup)
 
 bool static TestEncode(uint64_t in) {
     return in == CTxOutCompressor::DecompressAmount(CTxOutCompressor::CompressAmount(in));

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -11,13 +11,14 @@
 #include "crypto/hmac_sha512.h"
 #include "random.h"
 #include "utilstrencodings.h"
+#include "test/test_pivx.h"
 
 #include <vector>
 
 #include <boost/assign/list_of.hpp>
 #include <boost/test/unit_test.hpp>
 
-BOOST_AUTO_TEST_SUITE(crypto_tests)
+BOOST_FIXTURE_TEST_SUITE(crypto_tests, BasicTestingSetup)
 
 template<typename Hasher, typename In, typename Out>
 void TestVector(const Hasher &h, const In &in, const Out &out) {

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -4,6 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "util.h"
+#include "test/test_pivx.h"
 
 #include <string>
 #include <vector>
@@ -11,7 +12,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/test/unit_test.hpp>
 
-BOOST_AUTO_TEST_SUITE(getarg_tests)
+BOOST_FIXTURE_TEST_SUITE(getarg_tests, BasicTestingSetup)
 
 static void ResetArgs(const std::string& strArg)
 {

--- a/src/test/hash_tests.cpp
+++ b/src/test/hash_tests.cpp
@@ -4,6 +4,7 @@
 
 #include "hash.h"
 #include "utilstrencodings.h"
+#include "test/test_pivx.h"
 
 #include <vector>
 
@@ -11,7 +12,7 @@
 
 using namespace std;
 
-BOOST_AUTO_TEST_SUITE(hash_tests)
+BOOST_FIXTURE_TEST_SUITE(hash_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(murmurhash3)
 {

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -59,7 +59,6 @@ void dumpKeyInfo(uint256 privkey)
 }
 #endif
 
-
 BOOST_FIXTURE_TEST_SUITE(key_tests, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(key_test1)

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -10,6 +10,7 @@
 #include "uint256.h"
 #include "util.h"
 #include "utilstrencodings.h"
+#include "test_pivx.h"
 
 #include <string>
 #include <vector>
@@ -59,7 +60,7 @@ void dumpKeyInfo(uint256 privkey)
 #endif
 
 
-BOOST_AUTO_TEST_SUITE(key_tests)
+BOOST_FIXTURE_TEST_SUITE(key_tests, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(key_test1)
 {

--- a/src/test/libzerocoin_tests.cpp
+++ b/src/test/libzerocoin_tests.cpp
@@ -24,6 +24,7 @@
 #include "libzerocoin/Coin.h"
 #include "libzerocoin/CoinSpend.h"
 #include "libzerocoin/Accumulator.h"
+#include "test_pivx.h"
 
 using namespace std;
 using namespace libzerocoin;
@@ -33,16 +34,16 @@ using namespace libzerocoin;
 #define COLOR_STR_RED     "\033[31m"
 
 #define TESTS_COINS_TO_ACCUMULATE   10
-#define NON_PRIME_TESTS				100
+#define NON_PRIME_TESTS                100
 
 // Global test counters
 uint32_t    gNumTests        = 0;
 uint32_t    gSuccessfulTests = 0;
 
 // Proof size
-uint32_t    gProofSize			= 0;
-uint32_t    gCoinSize			= 0;
-uint32_t	gSerialNumberSize	= 0;
+uint32_t    gProofSize            = 0;
+uint32_t    gCoinSize            = 0;
+uint32_t    gSerialNumberSize    = 0;
 
 // Global coin array
 PrivateCoin    *gCoins[TESTS_COINS_TO_ACCUMULATE];
@@ -57,42 +58,42 @@ ZerocoinParams *g_Params;
 void
 LogTestResult(string testName, bool (*testPtr)())
 {
-	string colorGreen(COLOR_STR_GREEN);
-	string colorNormal(COLOR_STR_NORMAL);
-	string colorRed(COLOR_STR_RED);
+    string colorGreen(COLOR_STR_GREEN);
+    string colorNormal(COLOR_STR_NORMAL);
+    string colorRed(COLOR_STR_RED);
 
-	cout << "Testing if " << testName << "..." << endl;
+    cout << "Testing if " << testName << "..." << endl;
 
-	bool testResult = testPtr();
+    bool testResult = testPtr();
 
-	if (testResult == true) {
-		cout << "\t" << colorGreen << "[PASS]"  << colorNormal << endl;
-		gSuccessfulTests++;
-	} else {
-		cout << colorRed << "\t[FAIL]" << colorNormal << endl;
-	}
+    if (testResult == true) {
+        cout << "\t" << colorGreen << "[PASS]"  << colorNormal << endl;
+        gSuccessfulTests++;
+    } else {
+        cout << colorRed << "\t[FAIL]" << colorNormal << endl;
+    }
 
-	gNumTests++;
+    gNumTests++;
 }
 
 CBigNum
 GetTestModulus()
 {
-	static CBigNum testModulus(0);
+    static CBigNum testModulus(0);
 
-	// TODO: should use a hard-coded RSA modulus for testing
-	if (!testModulus) {
-		CBigNum p, q;
+    // TODO: should use a hard-coded RSA modulus for testing
+    if (!testModulus) {
+        CBigNum p, q;
 
-		// Note: we are NOT using safe primes for testing because
-		// they take too long to generate. Don't do this in real
-		// usage. See the paramgen utility for better code.
-		p = CBigNum::generatePrime(1024, false);
-		q = CBigNum::generatePrime(1024, false);
-		testModulus = p * q;
-	}
+        // Note: we are NOT using safe primes for testing because
+        // they take too long to generate. Don't do this in real
+        // usage. See the paramgen utility for better code.
+        p = CBigNum::generatePrime(1024, false);
+        q = CBigNum::generatePrime(1024, false);
+        testModulus = p * q;
+    }
 
-	return testModulus;
+    return testModulus;
 }
 
 //////////
@@ -102,393 +103,393 @@ GetTestModulus()
 bool
 Test_GenRSAModulus()
 {
-	CBigNum result = GetTestModulus();
+    CBigNum result = GetTestModulus();
 
-	if (!result) {
-		return false;
-	}
-	else {
-		return true;
-	}
+    if (!result) {
+        return false;
+    }
+    else {
+        return true;
+    }
 }
 
 bool
 Test_CalcParamSizes()
 {
-	bool result = true;
+    bool result = true;
 #if 0
 
-	uint32_t pLen, qLen;
+    uint32_t pLen, qLen;
 
-	try {
-		calculateGroupParamLengths(4000, 80, &pLen, &qLen);
-		if (pLen < 1024 || qLen < 256) {
-			result = false;
-		}
-		calculateGroupParamLengths(4000, 96, &pLen, &qLen);
-		if (pLen < 2048 || qLen < 256) {
-			result = false;
-		}
-		calculateGroupParamLengths(4000, 112, &pLen, &qLen);
-		if (pLen < 3072 || qLen < 320) {
-			result = false;
-		}
-		calculateGroupParamLengths(4000, 120, &pLen, &qLen);
-		if (pLen < 3072 || qLen < 320) {
-			result = false;
-		}
-		calculateGroupParamLengths(4000, 128, &pLen, &qLen);
-		if (pLen < 3072 || qLen < 320) {
-			result = false;
-		}
-	} catch (exception &e) {
-		result = false;
-	}
+    try {
+        calculateGroupParamLengths(4000, 80, &pLen, &qLen);
+        if (pLen < 1024 || qLen < 256) {
+            result = false;
+        }
+        calculateGroupParamLengths(4000, 96, &pLen, &qLen);
+        if (pLen < 2048 || qLen < 256) {
+            result = false;
+        }
+        calculateGroupParamLengths(4000, 112, &pLen, &qLen);
+        if (pLen < 3072 || qLen < 320) {
+            result = false;
+        }
+        calculateGroupParamLengths(4000, 120, &pLen, &qLen);
+        if (pLen < 3072 || qLen < 320) {
+            result = false;
+        }
+        calculateGroupParamLengths(4000, 128, &pLen, &qLen);
+        if (pLen < 3072 || qLen < 320) {
+            result = false;
+        }
+    } catch (exception &e) {
+        result = false;
+    }
 #endif
 
-	return result;
+    return result;
 }
 
 bool
 Test_GenerateGroupParams()
 {
-	uint32_t pLen = 1024, qLen = 256, count;
-	IntegerGroupParams group;
+    uint32_t pLen = 1024, qLen = 256, count;
+    IntegerGroupParams group;
 
-	for (count = 0; count < 1; count++) {
+    for (count = 0; count < 1; count++) {
 
-		try {
-			group = deriveIntegerGroupParams(calculateSeed(GetTestModulus(), "test", ZEROCOIN_DEFAULT_SECURITYLEVEL, "TEST GROUP"), pLen, qLen);
-		} catch (std::runtime_error e) {
-			cout << "Caught exception " << e.what() << endl;
-			return false;
-		}
+        try {
+            group = deriveIntegerGroupParams(calculateSeed(GetTestModulus(), "test", ZEROCOIN_DEFAULT_SECURITYLEVEL, "TEST GROUP"), pLen, qLen);
+        } catch (std::runtime_error e) {
+            cout << "Caught exception " << e.what() << endl;
+            return false;
+        }
 
-		// Now perform some simple tests on the resulting parameters
-		if ((uint32_t)group.groupOrder.bitSize() < qLen || (uint32_t)group.modulus.bitSize() < pLen) {
-			return false;
-		}
+        // Now perform some simple tests on the resulting parameters
+        if ((uint32_t)group.groupOrder.bitSize() < qLen || (uint32_t)group.modulus.bitSize() < pLen) {
+            return false;
+        }
 
-		CBigNum c = group.g.pow_mod(group.groupOrder, group.modulus);
-		//cout << "g^q mod p = " << c << endl;
-		if (!(c.isOne())) return false;
+        CBigNum c = group.g.pow_mod(group.groupOrder, group.modulus);
+        //cout << "g^q mod p = " << c << endl;
+        if (!(c.isOne())) return false;
 
-		// Try at multiple parameter sizes
-		pLen = pLen * 1.5;
-		qLen = qLen * 1.5;
-	}
+        // Try at multiple parameter sizes
+        pLen = pLen * 1.5;
+        qLen = qLen * 1.5;
+    }
 
-	return true;
+    return true;
 }
 
 bool
 Test_ParamGen()
 {
-	bool result = true;
+    bool result = true;
 
-	try {
-		// Instantiating testParams runs the parameter generation code
-		ZerocoinParams testParams(GetTestModulus(),ZEROCOIN_DEFAULT_SECURITYLEVEL);
-	} catch (runtime_error e) {
-		cout << e.what() << endl;
-		result = false;
-	}
+    try {
+        // Instantiating testParams runs the parameter generation code
+        ZerocoinParams testParams(GetTestModulus(),ZEROCOIN_DEFAULT_SECURITYLEVEL);
+    } catch (runtime_error e) {
+        cout << e.what() << endl;
+        result = false;
+    }
 
-	return result;
+    return result;
 }
 
 bool
 Test_Accumulator()
 {
-	// This test assumes a list of coins were generated during
-	// the Test_MintCoin() test.
-	if (gCoins[0] == NULL) {
-		return false;
-	}
-	try {
-		// Accumulate the coin list from first to last into one accumulator
+    // This test assumes a list of coins were generated during
+    // the Test_MintCoin() test.
+    if (gCoins[0] == NULL) {
+        return false;
+    }
+    try {
+        // Accumulate the coin list from first to last into one accumulator
             Accumulator accOne(&g_Params->accumulatorParams, CoinDenomination::ZQ_ONE);
             Accumulator accTwo(&g_Params->accumulatorParams,CoinDenomination::ZQ_ONE);
             Accumulator accThree(&g_Params->accumulatorParams,CoinDenomination::ZQ_ONE);
             Accumulator accFour(&g_Params->accumulatorParams,CoinDenomination::ZQ_ONE);
-		AccumulatorWitness wThree(g_Params, accThree, gCoins[0]->getPublicCoin());
+        AccumulatorWitness wThree(g_Params, accThree, gCoins[0]->getPublicCoin());
 
-		for (uint32_t i = 0; i < TESTS_COINS_TO_ACCUMULATE; i++) {
-			accOne += gCoins[i]->getPublicCoin();
-			accTwo += gCoins[TESTS_COINS_TO_ACCUMULATE - (i+1)]->getPublicCoin();
-			accThree += gCoins[i]->getPublicCoin();
-			wThree += gCoins[i]->getPublicCoin();
-			if(i != 0) {
-				accFour += gCoins[i]->getPublicCoin();
-			}
-		}
+        for (uint32_t i = 0; i < TESTS_COINS_TO_ACCUMULATE; i++) {
+            accOne += gCoins[i]->getPublicCoin();
+            accTwo += gCoins[TESTS_COINS_TO_ACCUMULATE - (i+1)]->getPublicCoin();
+            accThree += gCoins[i]->getPublicCoin();
+            wThree += gCoins[i]->getPublicCoin();
+            if(i != 0) {
+                accFour += gCoins[i]->getPublicCoin();
+            }
+        }
 
-		// Compare the accumulated results
-		if (accOne.getValue() != accTwo.getValue() || accOne.getValue() != accThree.getValue()) {
-			cout << "Accumulators don't match" << endl;
-			return false;
-		}
+        // Compare the accumulated results
+        if (accOne.getValue() != accTwo.getValue() || accOne.getValue() != accThree.getValue()) {
+            cout << "Accumulators don't match" << endl;
+            return false;
+        }
 
-		if(accFour.getValue() != wThree.getValue()) {
-			cout << "Witness math not working," << endl;
-			return false;
-		}
+        if(accFour.getValue() != wThree.getValue()) {
+            cout << "Witness math not working," << endl;
+            return false;
+        }
 
-		// Verify that the witness is correct
-		if (!wThree.VerifyWitness(accThree, gCoins[0]->getPublicCoin()) ) {
-			cout << "Witness not valid" << endl;
-			return false;
-		}
+        // Verify that the witness is correct
+        if (!wThree.VerifyWitness(accThree, gCoins[0]->getPublicCoin()) ) {
+            cout << "Witness not valid" << endl;
+            return false;
+        }
 
-		// Serialization test: see if we can serialize the accumulator
-		CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-		ss << accOne;
+        // Serialization test: see if we can serialize the accumulator
+        CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+        ss << accOne;
 
-		// Deserialize it into a new object
-		Accumulator newAcc(g_Params, ss);
+        // Deserialize it into a new object
+        Accumulator newAcc(g_Params, ss);
 
-		// Compare the results
-		if (accOne.getValue() != newAcc.getValue()) {
-			return false;
-		}
+        // Compare the results
+        if (accOne.getValue() != newAcc.getValue()) {
+            return false;
+        }
 
-	} catch (runtime_error e) {
-		return false;
-	}
+    } catch (runtime_error e) {
+        return false;
+    }
 
-	return true;
+    return true;
 }
 
 bool
 Test_EqualityPoK()
 {
-	// Run this test 10 times
-	for (uint32_t i = 0; i < 10; i++) {
-		try {
-			// Generate a random integer "val"
-			CBigNum val = CBigNum::randBignum(g_Params->coinCommitmentGroup.groupOrder);
+    // Run this test 10 times
+    for (uint32_t i = 0; i < 10; i++) {
+        try {
+            // Generate a random integer "val"
+            CBigNum val = CBigNum::randBignum(g_Params->coinCommitmentGroup.groupOrder);
 
-			// Manufacture two commitments to "val", both
-			// under different sets of parameters
-			Commitment one(&g_Params->accumulatorParams.accumulatorPoKCommitmentGroup, val);
+            // Manufacture two commitments to "val", both
+            // under different sets of parameters
+            Commitment one(&g_Params->accumulatorParams.accumulatorPoKCommitmentGroup, val);
 
-			Commitment two(&g_Params->serialNumberSoKCommitmentGroup, val);
+            Commitment two(&g_Params->serialNumberSoKCommitmentGroup, val);
 
-			// Now generate a proof of knowledge that "one" and "two" are
-			// both commitments to the same value
-			CommitmentProofOfKnowledge pok(&g_Params->accumulatorParams.accumulatorPoKCommitmentGroup,
-			                               &g_Params->serialNumberSoKCommitmentGroup,
-			                               one, two);
+            // Now generate a proof of knowledge that "one" and "two" are
+            // both commitments to the same value
+            CommitmentProofOfKnowledge pok(&g_Params->accumulatorParams.accumulatorPoKCommitmentGroup,
+                                           &g_Params->serialNumberSoKCommitmentGroup,
+                                           one, two);
 
-			// Serialize the proof into a stream
-			CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-			ss << pok;
+            // Serialize the proof into a stream
+            CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+            ss << pok;
 
-			// Deserialize back into a PoK object
-			CommitmentProofOfKnowledge newPok(&g_Params->accumulatorParams.accumulatorPoKCommitmentGroup,
-			                                  &g_Params->serialNumberSoKCommitmentGroup,
-			                                  ss);
+            // Deserialize back into a PoK object
+            CommitmentProofOfKnowledge newPok(&g_Params->accumulatorParams.accumulatorPoKCommitmentGroup,
+                                              &g_Params->serialNumberSoKCommitmentGroup,
+                                              ss);
 
-			if (newPok.Verify(one.getCommitmentValue(), two.getCommitmentValue()) != true) {
-				return false;
-			}
+            if (newPok.Verify(one.getCommitmentValue(), two.getCommitmentValue()) != true) {
+                return false;
+            }
 
-			// Just for fun, deserialize the proof a second time
-			CDataStream ss2(SER_NETWORK, PROTOCOL_VERSION);
-			ss2 << pok;
+            // Just for fun, deserialize the proof a second time
+            CDataStream ss2(SER_NETWORK, PROTOCOL_VERSION);
+            ss2 << pok;
 
-			// This time tamper with it, then deserialize it back into a PoK
-			ss2[15] = 0;
-			CommitmentProofOfKnowledge newPok2(&g_Params->accumulatorParams.accumulatorPoKCommitmentGroup,
-			                                   &g_Params->serialNumberSoKCommitmentGroup,
-			                                   ss2);
+            // This time tamper with it, then deserialize it back into a PoK
+            ss2[15] = 0;
+            CommitmentProofOfKnowledge newPok2(&g_Params->accumulatorParams.accumulatorPoKCommitmentGroup,
+                                               &g_Params->serialNumberSoKCommitmentGroup,
+                                               ss2);
 
-			// If the tampered proof verifies, that's a failure!
-			if (newPok2.Verify(one.getCommitmentValue(), two.getCommitmentValue()) == true) {
-				return false;
-			}
+            // If the tampered proof verifies, that's a failure!
+            if (newPok2.Verify(one.getCommitmentValue(), two.getCommitmentValue()) == true) {
+                return false;
+            }
 
-		} catch (runtime_error &e) {
-			return false;
-		}
-	}
+        } catch (runtime_error &e) {
+            return false;
+        }
+    }
 
-	return true;
+    return true;
 }
 
 bool
 Test_MintCoin()
 {
-	gCoinSize = 0;
+    gCoinSize = 0;
 
-	try {
-		// Generate a list of coins
-		for (uint32_t i = 0; i < TESTS_COINS_TO_ACCUMULATE; i++) {
+    try {
+        // Generate a list of coins
+        for (uint32_t i = 0; i < TESTS_COINS_TO_ACCUMULATE; i++) {
             gCoins[i] = new PrivateCoin(g_Params,libzerocoin::CoinDenomination::ZQ_ONE);
 
-			PublicCoin pc = gCoins[i]->getPublicCoin();
-			CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-			ss << pc;
-			gCoinSize += ss.size();
-		}
+            PublicCoin pc = gCoins[i]->getPublicCoin();
+            CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+            ss << pc;
+            gCoinSize += ss.size();
+        }
 
-		gCoinSize /= TESTS_COINS_TO_ACCUMULATE;
+        gCoinSize /= TESTS_COINS_TO_ACCUMULATE;
 
-	} catch (exception &e) {
-		return false;
-	}
+    } catch (exception &e) {
+        return false;
+    }
 
-	return true;
+    return true;
 }
 
 bool Test_InvalidCoin()
 {
-	CBigNum coinValue;
-	
-	try {
-		// Pick a random non-prime CBigNum
-		for (uint32_t i = 0; i < NON_PRIME_TESTS; i++) {
-			coinValue = CBigNum::randBignum(g_Params->coinCommitmentGroup.modulus);
-			coinValue = coinValue * 2;
-			if (!coinValue.isPrime()) break;
-		}
-				
-		PublicCoin pubCoin(g_Params);
-		if (pubCoin.validate()) {
-			// A blank coin should not be valid!
-			return false;
-		}		
-		
-		PublicCoin pubCoin2(g_Params, coinValue, ZQ_ONE);
-		if (pubCoin2.validate()) {
-			// A non-prime coin should not be valid!
-			return false;
-		}
-		
-		PublicCoin pubCoin3 = pubCoin2;
-		if (pubCoin2.validate()) {
-			// A copy of a non-prime coin should not be valid!
-			return false;
-		}
-		
-		// Serialize and deserialize the coin
-		CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-		ss << pubCoin;
-		PublicCoin pubCoin4(g_Params, ss);
-		if (pubCoin4.validate()) {
-			// A deserialized copy of a non-prime coin should not be valid!
-			return false;
-		}
-		
-	} catch (runtime_error &e) {
-		cout << "Caught exception: " << e.what() << endl;
-		return false;
-	}
-	
-	return true;
+    CBigNum coinValue;
+
+    try {
+        // Pick a random non-prime CBigNum
+        for (uint32_t i = 0; i < NON_PRIME_TESTS; i++) {
+            coinValue = CBigNum::randBignum(g_Params->coinCommitmentGroup.modulus);
+            coinValue = coinValue * 2;
+            if (!coinValue.isPrime()) break;
+        }
+
+        PublicCoin pubCoin(g_Params);
+        if (pubCoin.validate()) {
+            // A blank coin should not be valid!
+            return false;
+        }
+
+        PublicCoin pubCoin2(g_Params, coinValue, ZQ_ONE);
+        if (pubCoin2.validate()) {
+            // A non-prime coin should not be valid!
+            return false;
+        }
+
+        PublicCoin pubCoin3 = pubCoin2;
+        if (pubCoin2.validate()) {
+            // A copy of a non-prime coin should not be valid!
+            return false;
+        }
+
+        // Serialize and deserialize the coin
+        CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+        ss << pubCoin;
+        PublicCoin pubCoin4(g_Params, ss);
+        if (pubCoin4.validate()) {
+            // A deserialized copy of a non-prime coin should not be valid!
+            return false;
+        }
+
+    } catch (runtime_error &e) {
+        cout << "Caught exception: " << e.what() << endl;
+        return false;
+    }
+
+    return true;
 }
 
 bool
 Test_MintAndSpend()
 {
-	try {
-		// This test assumes a list of coins were generated in Test_MintCoin()
-		if (gCoins[0] == NULL)
-		{
-			// No coins: mint some.
-			Test_MintCoin();
-			if (gCoins[0] == NULL) {
-				return false;
-			}
-		}
+    try {
+        // This test assumes a list of coins were generated in Test_MintCoin()
+        if (gCoins[0] == NULL)
+        {
+            // No coins: mint some.
+            Test_MintCoin();
+            if (gCoins[0] == NULL) {
+                return false;
+            }
+        }
 
-		// Accumulate the list of generated coins into a fresh accumulator.
-		// The first one gets marked as accumulated for a witness, the
-		// others just get accumulated normally.
+        // Accumulate the list of generated coins into a fresh accumulator.
+        // The first one gets marked as accumulated for a witness, the
+        // others just get accumulated normally.
         Accumulator acc(&g_Params->accumulatorParams,CoinDenomination::ZQ_ONE);
-		AccumulatorWitness wAcc(g_Params, acc, gCoins[0]->getPublicCoin());
+        AccumulatorWitness wAcc(g_Params, acc, gCoins[0]->getPublicCoin());
 
-		for (uint32_t i = 0; i < TESTS_COINS_TO_ACCUMULATE; i++) {
-			acc += gCoins[i]->getPublicCoin();
-			wAcc +=gCoins[i]->getPublicCoin();
-		}
+        for (uint32_t i = 0; i < TESTS_COINS_TO_ACCUMULATE; i++) {
+            acc += gCoins[i]->getPublicCoin();
+            wAcc +=gCoins[i]->getPublicCoin();
+        }
 
-		// Now spend the coin
-		//SpendMetaData m(1,1);
-		CDataStream cc(SER_NETWORK, PROTOCOL_VERSION);
-		cc << *gCoins[0];
-		PrivateCoin myCoin(g_Params,cc);
+        // Now spend the coin
+        //SpendMetaData m(1,1);
+        CDataStream cc(SER_NETWORK, PROTOCOL_VERSION);
+        cc << *gCoins[0];
+        PrivateCoin myCoin(g_Params,cc);
 
-		CoinSpend spend(g_Params, g_Params, myCoin, acc, 0, wAcc, 0, SpendType::SPEND);
+        CoinSpend spend(g_Params, g_Params, myCoin, acc, 0, wAcc, 0, SpendType::SPEND);
         spend.Verify(acc);
 
-		// Serialize the proof and deserialize into newSpend
-		CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-		ss << spend;
-		gProofSize = ss.size();
-		CoinSpend newSpend(g_Params, g_Params, ss);
+        // Serialize the proof and deserialize into newSpend
+        CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+        ss << spend;
+        gProofSize = ss.size();
+        CoinSpend newSpend(g_Params, g_Params, ss);
 
-		// See if we can verify the deserialized proof (return our result)
-		bool ret =  newSpend.Verify(acc);
-		
-		// Extract the serial number
-		CBigNum serialNumber = newSpend.getCoinSerialNumber();
-		gSerialNumberSize = ceil((double)serialNumber.bitSize() / 8.0);
-		
-		return ret;
-	} catch (runtime_error &e) {
-		cout << e.what() << endl;
-		return false;
-	}
+        // See if we can verify the deserialized proof (return our result)
+        bool ret =  newSpend.Verify(acc);
 
-	return false;
+        // Extract the serial number
+        CBigNum serialNumber = newSpend.getCoinSerialNumber();
+        gSerialNumberSize = ceil((double)serialNumber.bitSize() / 8.0);
+
+        return ret;
+    } catch (runtime_error &e) {
+        cout << e.what() << endl;
+        return false;
+    }
+
+    return false;
 }
 
 void
 Test_RunAllTests()
 {
-	// Make a new set of parameters from a random RSA modulus
-	g_Params = new ZerocoinParams(GetTestModulus());
+    // Make a new set of parameters from a random RSA modulus
+    g_Params = new ZerocoinParams(GetTestModulus());
 
-	gNumTests = gSuccessfulTests = gProofSize = 0;
-	for (uint32_t i = 0; i < TESTS_COINS_TO_ACCUMULATE; i++) {
-		gCoins[i] = NULL;
-	}
+    gNumTests = gSuccessfulTests = gProofSize = 0;
+    for (uint32_t i = 0; i < TESTS_COINS_TO_ACCUMULATE; i++) {
+        gCoins[i] = NULL;
+    }
 
-	// Run through all of the Zerocoin tests
-	LogTestResult("an RSA modulus can be generated", Test_GenRSAModulus);
-	LogTestResult("parameter sizes are correct", Test_CalcParamSizes);
-	LogTestResult("group/field parameters can be generated", Test_GenerateGroupParams);
-	LogTestResult("parameter generation is correct", Test_ParamGen);
-	LogTestResult("coins can be minted", Test_MintCoin);
-	LogTestResult("invalid coins will be rejected", Test_InvalidCoin);
-	LogTestResult("the accumulator works", Test_Accumulator);
-	LogTestResult("the commitment equality PoK works", Test_EqualityPoK);
-	LogTestResult("a minted coin can be spent", Test_MintAndSpend);
+    // Run through all of the Zerocoin tests
+    LogTestResult("an RSA modulus can be generated", Test_GenRSAModulus);
+    LogTestResult("parameter sizes are correct", Test_CalcParamSizes);
+    LogTestResult("group/field parameters can be generated", Test_GenerateGroupParams);
+    LogTestResult("parameter generation is correct", Test_ParamGen);
+    LogTestResult("coins can be minted", Test_MintCoin);
+    LogTestResult("invalid coins will be rejected", Test_InvalidCoin);
+    LogTestResult("the accumulator works", Test_Accumulator);
+    LogTestResult("the commitment equality PoK works", Test_EqualityPoK);
+    LogTestResult("a minted coin can be spent", Test_MintAndSpend);
 
-	cout << endl << "Average coin size is " << gCoinSize << " bytes." << endl;
-	cout << "Serial number size is " << gSerialNumberSize << " bytes." << endl;
-	cout << "Spend proof size is " << gProofSize << " bytes." << endl;
+    cout << endl << "Average coin size is " << gCoinSize << " bytes." << endl;
+    cout << "Serial number size is " << gSerialNumberSize << " bytes." << endl;
+    cout << "Spend proof size is " << gProofSize << " bytes." << endl;
 
-	// Summarize test results
-	if (gSuccessfulTests < gNumTests) {
-		cout << endl << "ERROR: SOME TESTS FAILED" << endl;
-	}
+    // Summarize test results
+    if (gSuccessfulTests < gNumTests) {
+        cout << endl << "ERROR: SOME TESTS FAILED" << endl;
+    }
 
-	// Clear any generated coins
-	for (uint32_t i = 0; i < TESTS_COINS_TO_ACCUMULATE; i++) {
-		delete gCoins[i];
-	}
+    // Clear any generated coins
+    for (uint32_t i = 0; i < TESTS_COINS_TO_ACCUMULATE; i++) {
+        delete gCoins[i];
+    }
 
-	cout << endl << gSuccessfulTests << " out of " << gNumTests << " tests passed." << endl << endl;
-	delete g_Params;
+    cout << endl << gSuccessfulTests << " out of " << gNumTests << " tests passed." << endl << endl;
+    delete g_Params;
 }
 
-BOOST_AUTO_TEST_SUITE(libzerocoin)
+BOOST_FIXTURE_TEST_SUITE(libzerocoin, TestingSetup)
 BOOST_AUTO_TEST_CASE(libzerocoin_tests)
 {
-	cout << "libzerocoin v" << ZEROCOIN_VERSION_STRING << " test utility." << endl << endl;
-	
-	Test_RunAllTests();
+    cout << "libzerocoin v" << ZEROCOIN_VERSION_STRING << " test utility." << endl << endl;
+
+    Test_RunAllTests();
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -6,10 +6,11 @@
 
 #include "primitives/transaction.h"
 #include "main.h"
+#include "test_pivx.h"
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_AUTO_TEST_SUITE(main_tests)
+BOOST_FIXTURE_TEST_SUITE(main_tests, TestingSetup)
 
 CAmount nMoneySupplyPoWEnd = 43199500 * COIN;
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -10,9 +10,11 @@
 #include "uint256.h"
 #include "util.h"
 
+#include "test/test_bitcoin.h"
+
 #include <boost/test/unit_test.hpp>
 
-BOOST_AUTO_TEST_SUITE(miner_tests)
+BOOST_FIXTURE_TEST_SUITE(miner_tests, TestingSetup)
 
 static
 struct {

--- a/src/test/mruset_tests.cpp
+++ b/src/test/mruset_tests.cpp
@@ -6,6 +6,7 @@
 
 #include "random.h"
 #include "util.h"
+#include "test/test_pivx.h"
 
 #include <set>
 
@@ -34,7 +35,7 @@ public:
     }
 };
 
-BOOST_AUTO_TEST_SUITE(mruset_tests)
+BOOST_FIXTURE_TEST_SUITE(mruset_tests, BasicTestingSetup)
 
 // Test that an mruset behaves like a set, as long as no more than MAX_SIZE elements are in it
 BOOST_AUTO_TEST_CASE(mruset_like_set)

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -10,6 +10,7 @@
 #include "script/interpreter.h"
 #include "script/sign.h"
 #include "uint256.h"
+#include "test_pivx.h"
 
 #ifdef ENABLE_WALLET
 #include "wallet/wallet_ismine.h"
@@ -23,7 +24,7 @@ using namespace boost::assign;
 
 typedef vector<unsigned char> valtype;
 
-BOOST_AUTO_TEST_SUITE(multisig_tests)
+BOOST_FIXTURE_TEST_SUITE(multisig_tests, TestingSetup)
 
 CScript
 sign_multisig(CScript scriptPubKey, vector<CKey> keys, CTransaction transaction, int whichIn)

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -5,6 +5,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "netbase.h"
+#include "test/test_pivx.h"
 
 #include <string>
 
@@ -12,7 +13,7 @@
 
 using namespace std;
 
-BOOST_AUTO_TEST_SUITE(netbase_tests)
+BOOST_FIXTURE_TEST_SUITE(netbase_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(netbase_networks)
 {

--- a/src/test/pmt_tests.cpp
+++ b/src/test/pmt_tests.cpp
@@ -8,6 +8,8 @@
 #include "streams.h"
 #include "uint256.h"
 #include "version.h"
+#include "random.h"
+#include "test/test_pivx.h"
 
 #include <vector>
 
@@ -27,7 +29,7 @@ public:
     }
 };
 
-BOOST_AUTO_TEST_SUITE(pmt_tests)
+BOOST_FIXTURE_TEST_SUITE(pmt_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(pmt_test1)
 {

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -10,6 +10,8 @@
 #include "netbase.h"
 #include "util.h"
 
+#include "test/test_pivx.h"
+
 #include <boost/algorithm/string.hpp>
 #include <boost/test/unit_test.hpp>
 
@@ -48,7 +50,7 @@ UniValue CallRPC(string args)
 }
 
 
-BOOST_AUTO_TEST_SUITE(rpc_tests)
+BOOST_FIXTURE_TEST_SUITE(rpc_tests, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(rpc_rawparams)
 {

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -9,6 +9,8 @@
 #include "base58.h"
 #include "wallet/wallet.h"
 
+#include "test/test_pivx.h"
+
 #include <boost/algorithm/string.hpp>
 #include <boost/test/unit_test.hpp>
 
@@ -21,7 +23,7 @@ extern UniValue CallRPC(string args);
 
 extern CWallet* pwalletMain;
 
-BOOST_AUTO_TEST_SUITE(rpc_wallet_tests)
+BOOST_FIXTURE_TEST_SUITE(rpc_wallet_tests, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(rpc_addmultisig)
 {

--- a/src/test/sanity_tests.cpp
+++ b/src/test/sanity_tests.cpp
@@ -4,9 +4,10 @@
 
 #include "compat/sanity.h"
 #include "key.h"
+#include "test_pivx.h"
 
 #include <boost/test/unit_test.hpp>
-BOOST_AUTO_TEST_SUITE(sanity_tests)
+BOOST_FIXTURE_TEST_SUITE(sanity_tests, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(basic_sanity)
 {

--- a/src/test/sanity_tests.cpp
+++ b/src/test/sanity_tests.cpp
@@ -7,6 +7,7 @@
 #include "test_pivx.h"
 
 #include <boost/test/unit_test.hpp>
+
 BOOST_FIXTURE_TEST_SUITE(sanity_tests, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(basic_sanity)

--- a/src/test/script_P2SH_tests.cpp
+++ b/src/test/script_P2SH_tests.cpp
@@ -8,6 +8,7 @@
 #include "script/script.h"
 #include "script/script_error.h"
 #include "script/sign.h"
+#include "test_pivx.h"
 
 #ifdef ENABLE_WALLET
 #include "wallet/wallet_ismine.h"
@@ -46,8 +47,7 @@ Verify(const CScript& scriptSig, const CScript& scriptPubKey, bool fStrict, Scri
     return VerifyScript(scriptSig, scriptPubKey, fStrict ? SCRIPT_VERIFY_P2SH : SCRIPT_VERIFY_NONE, MutableTransactionSignatureChecker(&txTo, 0), &err);
 }
 
-
-BOOST_AUTO_TEST_SUITE(script_P2SH_tests)
+BOOST_FIXTURE_TEST_SUITE(script_P2SH_tests, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(sign)
 {

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -14,6 +14,7 @@
 #include "script/script_error.h"
 #include "script/sign.h"
 #include "util.h"
+#include "test_pivx.h"
 
 #if defined(HAVE_CONSENSUS_LIB)
 #include "script/bitcoinconsensus.h"
@@ -58,7 +59,7 @@ read_json(const std::string& jsondata)
     return v.get_array();
 }
 
-BOOST_AUTO_TEST_SUITE(script_tests)
+BOOST_FIXTURE_TEST_SUITE(script_tests, TestingSetup)
 
 CMutableTransaction BuildCreditingTransaction(const CScript& scriptPubKey)
 {
@@ -826,7 +827,7 @@ BOOST_AUTO_TEST_CASE(script_CHECKMULTISIG23)
     CScript badsig6 = sign_multisig(scriptPubKey23, keys, txTo23);
     BOOST_CHECK(!VerifyScript(badsig6, scriptPubKey23, flags, MutableTransactionSignatureChecker(&txTo23, 0), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_INVALID_STACK_OPERATION, ScriptErrorString(err));
-}    
+}
 
 BOOST_AUTO_TEST_CASE(script_combineSigs)
 {

--- a/src/test/scriptnum_tests.cpp
+++ b/src/test/scriptnum_tests.cpp
@@ -5,10 +5,13 @@
 
 #include "libzerocoin/bignum.h"
 #include "script/script.h"
+#include "test/test_pivx.h"
+
 #include <boost/test/unit_test.hpp>
 #include <limits.h>
 #include <stdint.h>
-BOOST_AUTO_TEST_SUITE(scriptnum_tests)
+
+BOOST_FIXTURE_TEST_SUITE(scriptnum_tests, BasicTestingSetup)
 
 static const long values[] = \
 { 0, 1, CHAR_MIN, CHAR_MAX, UCHAR_MAX, SHRT_MIN, USHRT_MAX, INT_MIN, INT_MAX, static_cast<long>UINT_MAX, LONG_MIN, LONG_MAX };

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -4,6 +4,8 @@
 
 #include "serialize.h"
 #include "streams.h"
+#include "hash.h"
+#include "test/test_pivx.h"
 
 #include <stdint.h>
 
@@ -11,7 +13,7 @@
 
 using namespace std;
 
-BOOST_AUTO_TEST_SUITE(serialize_tests)
+BOOST_FIXTURE_TEST_SUITE(serialize_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(varints)
 {
@@ -70,8 +72,8 @@ static bool isCanonicalException(const std::ios_base::failure& ex)
 
     // The string returned by what() can be different for different platforms.
     // Instead of directly comparing the ex.what() with an expected string,
-    // create an instance of exception to see if ex.what() matches 
-    // the expected explanatory string returned by the exception instance. 
+    // create an instance of exception to see if ex.what() matches
+    // the expected explanatory string returned by the exception instance.
     return strcmp(expectedException.what(), ex.what()) == 0;
 }
 

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -114,7 +114,7 @@ void static RandomTransaction(CMutableTransaction &tx, bool fSingle) {
     }
 }
 
-BOOST_FIXTURE_TEST_SUITE(sighash_tests, TestingSetup)
+BOOST_FIXTURE_TEST_SUITE(sighash_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(sighash_test)
 {

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -11,6 +11,7 @@
 #include "script/interpreter.h"
 #include "util.h"
 #include "version.h"
+#include "test_pivx.h"
 
 #include <iostream>
 
@@ -113,7 +114,7 @@ void static RandomTransaction(CMutableTransaction &tx, bool fSingle) {
     }
 }
 
-BOOST_AUTO_TEST_SUITE(sighash_tests)
+BOOST_FIXTURE_TEST_SUITE(sighash_tests, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(sighash_test)
 {

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -24,7 +24,7 @@ Serialize(const CScript& s)
     return sSerialized;
 }
 
-BOOST_FIXTURE_TEST_SUITE(sigopcount_tests, TestingSetup)
+BOOST_FIXTURE_TEST_SUITE(sigopcount_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(GetSigOpCount)
 {

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -8,6 +8,7 @@
 #include "script/script.h"
 #include "script/standard.h"
 #include "uint256.h"
+#include "test_pivx.h"
 
 #include <vector>
 
@@ -23,7 +24,7 @@ Serialize(const CScript& s)
     return sSerialized;
 }
 
-BOOST_AUTO_TEST_SUITE(sigopcount_tests)
+BOOST_FIXTURE_TEST_SUITE(sigopcount_tests, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(GetSigOpCount)
 {

--- a/src/test/skiplist_tests.cpp
+++ b/src/test/skiplist_tests.cpp
@@ -6,6 +6,7 @@
 #include "main.h"
 #include "random.h"
 #include "util.h"
+#include "test/test_pivx.h"
 
 #include <vector>
 
@@ -13,7 +14,7 @@
 
 #define SKIPLIST_LENGTH 300000
 
-BOOST_AUTO_TEST_SUITE(skiplist_tests)
+BOOST_FIXTURE_TEST_SUITE(skiplist_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(skiplist_test)
 {

--- a/src/test/test_pivx.cpp
+++ b/src/test/test_pivx.cpp
@@ -25,14 +25,21 @@ CWallet* pwalletMain;
 extern bool fPrintToConsole;
 extern void noui_connect();
 
-TestingSetup::TestingSetup()
+BasicTestingSetup::BasicTestingSetup()
 {
         ECC_Start();
         SetupEnvironment();
         fPrintToDebugLog = false; // don't want to write to debug.log file
         fCheckBlockIndex = true;
         SelectParams(CBaseChainParams::UNITTEST);
-        noui_connect();
+}
+BasicTestingSetup::~BasicTestingSetup()
+{
+        ECC_Stop();
+}
+
+TestingSetup::TestingSetup()
+{
 #ifdef ENABLE_WALLET
         bitdb.MakeMock();
 #endif
@@ -75,7 +82,6 @@ TestingSetup::~TestingSetup()
         bitdb.Reset();
 #endif
         boost::filesystem::remove_all(pathTemp);
-        ECC_Stop();
 }
 
 void Shutdown(void* parg)

--- a/src/test/test_pivx.cpp
+++ b/src/test/test_pivx.cpp
@@ -5,6 +5,8 @@
 
 #define BOOST_TEST_MODULE Pivx Test Suite
 
+#include "test_pivx.h"
+
 #include "main.h"
 #include "random.h"
 #include "txdb.h"
@@ -15,9 +17,7 @@
 #include "wallet/wallet.h"
 #endif
 
-#include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
-#include <boost/thread.hpp>
 
 CClientUIInterface uiInterface;
 CWallet* pwalletMain;
@@ -25,13 +25,8 @@ CWallet* pwalletMain;
 extern bool fPrintToConsole;
 extern void noui_connect();
 
-struct TestingSetup {
-    CCoinsViewDB *pcoinsdbview;
-    boost::filesystem::path pathTemp;
-    boost::thread_group threadGroup;
-    ECCVerifyHandle globalVerifyHandle;
-
-    TestingSetup() {
+TestingSetup::TestingSetup()
+{
         ECC_Start();
         SetupEnvironment();
         fPrintToDebugLog = false; // don't want to write to debug.log file
@@ -41,6 +36,7 @@ struct TestingSetup {
 #ifdef ENABLE_WALLET
         bitdb.MakeMock();
 #endif
+        ClearDatadirCache();
         pathTemp = GetTempPath() / strprintf("test_pivx_%lu_%i", (unsigned long)GetTime(), (int)(GetRand(100000)));
         boost::filesystem::create_directories(pathTemp);
         mapArgs["-datadir"] = pathTemp.string();
@@ -58,28 +54,29 @@ struct TestingSetup {
         for (int i=0; i < nScriptCheckThreads-1; i++)
             threadGroup.create_thread(&ThreadScriptCheck);
         RegisterNodeSignals(GetNodeSignals());
-    }
-    ~TestingSetup()
-    {
+}
+
+TestingSetup::~TestingSetup()
+{
+        UnregisterNodeSignals(GetNodeSignals());
         threadGroup.interrupt_all();
         threadGroup.join_all();
-        UnregisterNodeSignals(GetNodeSignals());
 #ifdef ENABLE_WALLET
+        UnregisterValidationInterface(pwalletMain);
         delete pwalletMain;
         pwalletMain = NULL;
 #endif
+        UnloadBlockIndex();
         delete pcoinsTip;
         delete pcoinsdbview;
         delete pblocktree;
 #ifdef ENABLE_WALLET
         bitdb.Flush(true);
+        bitdb.Reset();
 #endif
         boost::filesystem::remove_all(pathTemp);
         ECC_Stop();
-    }
-};
-
-BOOST_GLOBAL_FIXTURE(TestingSetup);
+}
 
 void Shutdown(void* parg)
 {

--- a/src/test/test_pivx.h
+++ b/src/test/test_pivx.h
@@ -6,7 +6,19 @@
 #include <boost/filesystem.hpp>
 #include <boost/thread.hpp>
 
-struct TestingSetup {
+/** Basic testing setup.
+ * This just configures logging and chain parameters.
+ */
+struct BasicTestingSetup {
+    BasicTestingSetup();
+    ~BasicTestingSetup();
+};
+
+/** Testing setup that configures a complete environment.
+ * Included are data directory, coins database, script check threads
+ * and wallet (if enabled) setup.
+ */
+struct TestingSetup: public BasicTestingSetup {
     CCoinsViewDB *pcoinsdbview;
     boost::filesystem::path pathTemp;
     boost::thread_group threadGroup;

--- a/src/test/test_pivx.h
+++ b/src/test/test_pivx.h
@@ -1,0 +1,19 @@
+#ifndef PIVX_TEST_TEST_PIVX_H
+#define PIVX_TEST_TEST_PIVX_H
+
+#include "txdb.h"
+
+#include <boost/filesystem.hpp>
+#include <boost/thread.hpp>
+
+struct TestingSetup {
+    CCoinsViewDB *pcoinsdbview;
+    boost::filesystem::path pathTemp;
+    boost::thread_group threadGroup;
+    ECCVerifyHandle globalVerifyHandle;
+
+    TestingSetup();
+    ~TestingSetup();
+};
+
+#endif

--- a/src/test/timedata_tests.cpp
+++ b/src/test/timedata_tests.cpp
@@ -3,12 +3,13 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "timedata.h"
+#include "test/test_pivx.h"
 
 #include <boost/test/unit_test.hpp>
 
 using namespace std;
 
-BOOST_AUTO_TEST_SUITE(timedata_tests)
+BOOST_FIXTURE_TEST_SUITE(timedata_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(util_MedianFilter)
 {

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -5,6 +5,7 @@
 
 #include "data/tx_invalid.json.h"
 #include "data/tx_valid.json.h"
+#include "test/test_pivx.h"
 
 #include "clientversion.h"
 #include "key.h"

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -13,6 +13,7 @@
 #include "script/script.h"
 #include "script/script_error.h"
 #include "core_io.h"
+#include "test_pivx.h"
 
 #include <map>
 #include <string>
@@ -79,7 +80,7 @@ string FormatScriptFlags(unsigned int flags)
     return ret.substr(0, ret.size() - 1);
 }
 
-BOOST_AUTO_TEST_SUITE(transaction_tests)
+BOOST_FIXTURE_TEST_SUITE(transaction_tests, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(tx_valid)
 {

--- a/src/test/tutorial_zerocoin.cpp
+++ b/src/test/tutorial_zerocoin.cpp
@@ -24,6 +24,7 @@
 #include "libzerocoin/Coin.h"
 #include "libzerocoin/CoinSpend.h"
 #include "libzerocoin/Accumulator.h"
+#include "test_pivx.h"
 
 using namespace std;
 
@@ -128,7 +129,7 @@ ZerocoinTutorial()
 			// accepted as a valid transaction in the block chain.
 			cout << "Error: coin is not valid!";
 		}
-		
+
 		cout << "Deserialized and verified the coin." << endl;
 
 		/********************************************************************/
@@ -217,11 +218,11 @@ ZerocoinTutorial()
 			cout << "ERROR: Our new CoinSpend transaction did not verify!" << endl;
 			return false;
 		}
-		
+
 		// Serialize the CoinSpend object into a buffer.
 		CDataStream serializedCoinSpend(SER_NETWORK, PROTOCOL_VERSION);
 		serializedCoinSpend << spend;
-		
+
 		cout << "Successfully generated a coin spend transaction." << endl;
 
 		/********************************************************************/
@@ -241,7 +242,7 @@ ZerocoinTutorial()
 		// Create a new metadata object to contain the hash of the received
 		// ZEROCOIN_SPEND transaction. If we were a real client we'd actually
 		// compute the hash of the received transaction here.
-		
+
 		// If we were a real client we would now re-compute the Accumulator
 		// from the information given in the ZEROCOIN_SPEND transaction.
 		// For our purposes we'll just use the one we calculated above.
@@ -273,7 +274,7 @@ ZerocoinTutorial()
 	return false;
 }
 
-BOOST_AUTO_TEST_SUITE(tutorial_libzerocoin)
+BOOST_FIXTURE_TEST_SUITE(tutorial_libzerocoin, TestingSetup)
 BOOST_AUTO_TEST_CASE(tutorial_libzerocoin_tests)
 {
 	cout << "libzerocoin v" << ZEROCOIN_VERSION_STRING << " tutorial." << endl << endl;

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) 2011-2013 The Bitcoin Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
 #include <boost/test/unit_test.hpp>
 #include <stdint.h>
 #include <sstream>
@@ -11,20 +10,21 @@
 #include "uint256.h"
 #include <string>
 #include "version.h"
+#include "test/test_pivx.h"
 
-BOOST_AUTO_TEST_SUITE(uint256_tests)
- 
-const unsigned char R1Array[] = 
+BOOST_FIXTURE_TEST_SUITE(uint256_tests, BasicTestingSetup)
+
+const unsigned char R1Array[] =
     "\x9c\x52\x4a\xdb\xcf\x56\x11\x12\x2b\x29\x12\x5e\x5d\x35\xd2\xd2"
     "\x22\x81\xaa\xb5\x33\xf0\x08\x32\xd5\x56\xb1\xf9\xea\xe5\x1d\x7d";
 const char R1ArrayHex[] = "7D1DE5EAF9B156D53208F033B5AA8122D2d2355d5e12292b121156cfdb4a529c";
 const double R1Ldouble = 0.4887374590559308955; // R1L equals roughly R1Ldouble * 2^256
-const double R1Sdouble = 0.7096329412477836074; 
+const double R1Sdouble = 0.7096329412477836074;
 const uint256 R1L = uint256(std::vector<unsigned char>(R1Array,R1Array+32));
 const uint160 R1S = uint160(std::vector<unsigned char>(R1Array,R1Array+20));
 const uint64_t R1LLow64 = 0x121156cfdb4a529cULL;
 
-const unsigned char R2Array[] = 
+const unsigned char R2Array[] =
     "\x70\x32\x1d\x7c\x47\xa5\x6b\x40\x26\x7e\x0a\xc3\xa6\x9c\xb6\xbf"
     "\x13\x30\x47\xa3\x19\x2d\xda\x71\x49\x13\x72\xf0\xb4\xca\x81\xd7";
 const uint256 R2L = uint256(std::vector<unsigned char>(R2Array,R2Array+32));
@@ -32,19 +32,19 @@ const uint160 R2S = uint160(std::vector<unsigned char>(R2Array,R2Array+20));
 
 const char R1LplusR2L[] = "549FB09FEA236A1EA3E31D4D58F1B1369288D204211CA751527CFC175767850C";
 
-const unsigned char ZeroArray[] = 
+const unsigned char ZeroArray[] =
     "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
     "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
 const uint256 ZeroL = uint256(std::vector<unsigned char>(ZeroArray,ZeroArray+32));
 const uint160 ZeroS = uint160(std::vector<unsigned char>(ZeroArray,ZeroArray+20));
-                             
-const unsigned char OneArray[] = 
+
+const unsigned char OneArray[] =
     "\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
     "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
 const uint256 OneL = uint256(std::vector<unsigned char>(OneArray,OneArray+32));
 const uint160 OneS = uint160(std::vector<unsigned char>(OneArray,OneArray+20));
 
-const unsigned char MaxArray[] = 
+const unsigned char MaxArray[] =
     "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
     "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff";
 const uint256 MaxL = uint256(std::vector<unsigned char>(MaxArray,MaxArray+32));
@@ -56,10 +56,10 @@ std::string ArrayToString(const unsigned char A[], unsigned int width)
 {
     std::stringstream Stream;
     Stream << std::hex;
-    for (unsigned int i = 0; i < width; ++i) 
+    for (unsigned int i = 0; i < width; ++i)
     {
         Stream<<std::setw(2)<<std::setfill('0')<<(unsigned int)A[width-i-1];
-    }       
+    }
     return Stream.str();
 }
 
@@ -88,25 +88,25 @@ BOOST_AUTO_TEST_CASE( basics ) // constructors, equality, inequality
     BOOST_CHECK(~MaxL == ZeroL && ~MaxS == ZeroS);
     BOOST_CHECK( ((R1L ^ R2L) ^ R1L) == R2L);
     BOOST_CHECK( ((R1S ^ R2S) ^ R1S) == R2S);
-    
+
     uint64_t Tmp64 = 0xc4dab720d9c7acaaULL;
-    for (unsigned int i = 0; i < 256; ++i) 
+    for (unsigned int i = 0; i < 256; ++i)
     {
-        BOOST_CHECK(ZeroL != (OneL << i)); 
-        BOOST_CHECK((OneL << i) != ZeroL); 
+        BOOST_CHECK(ZeroL != (OneL << i));
+        BOOST_CHECK((OneL << i) != ZeroL);
         BOOST_CHECK(R1L != (R1L ^ (OneL << i)));
         BOOST_CHECK(((uint256(Tmp64) ^ (OneL << i) ) != Tmp64 ));
     }
-    BOOST_CHECK(ZeroL == (OneL << 256)); 
+    BOOST_CHECK(ZeroL == (OneL << 256));
 
-    for (unsigned int i = 0; i < 160; ++i) 
+    for (unsigned int i = 0; i < 160; ++i)
     {
-        BOOST_CHECK(ZeroS != (OneS << i)); 
-        BOOST_CHECK((OneS << i) != ZeroS); 
+        BOOST_CHECK(ZeroS != (OneS << i));
+        BOOST_CHECK((OneS << i) != ZeroS);
         BOOST_CHECK(R1S != (R1S ^ (OneS << i)));
         BOOST_CHECK(((uint160(Tmp64) ^ (OneS << i) ) != Tmp64 ));
     }
-    BOOST_CHECK(ZeroS == (OneS << 256)); 
+    BOOST_CHECK(ZeroS == (OneS << 256));
 
     // String Constructor and Copy Constructor
     BOOST_CHECK(uint256("0x"+R1L.ToString()) == R1L);
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE( basics ) // constructors, equality, inequality
     BOOST_CHECK(uint160("0x"+OneS.ToString()) == OneS);
     BOOST_CHECK(uint160("0x"+MaxS.ToString()) == MaxS);
     BOOST_CHECK(uint160(R1S.ToString()) == R1S);
-    BOOST_CHECK(uint160("   0x"+R1S.ToString()+"   ") == R1S); 
+    BOOST_CHECK(uint160("   0x"+R1S.ToString()+"   ") == R1S);
     BOOST_CHECK(uint160("") == ZeroS);
     BOOST_CHECK(R1S == uint160(R1ArrayHex));
 
@@ -167,25 +167,25 @@ BOOST_AUTO_TEST_CASE( basics ) // constructors, equality, inequality
     BOOST_CHECK_THROW(uint160(std::vector<unsigned char>(OneArray,OneArray+19)), uint_error);
 }
 
-void shiftArrayRight(unsigned char* to, const unsigned char* from, unsigned int arrayLength, unsigned int bitsToShift) 
+void shiftArrayRight(unsigned char* to, const unsigned char* from, unsigned int arrayLength, unsigned int bitsToShift)
 {
-    for (unsigned int T=0; T < arrayLength; ++T) 
+    for (unsigned int T=0; T < arrayLength; ++T)
     {
         unsigned int F = (T+bitsToShift/8);
-        if (F < arrayLength) 
+        if (F < arrayLength)
             to[T]  = from[F] >> (bitsToShift%8);
         else
             to[T] = 0;
-        if (F + 1 < arrayLength) 
+        if (F + 1 < arrayLength)
             to[T] |= from[(F+1)] << (8-bitsToShift%8);
     }
 }
 
-void shiftArrayLeft(unsigned char* to, const unsigned char* from, unsigned int arrayLength, unsigned int bitsToShift) 
+void shiftArrayLeft(unsigned char* to, const unsigned char* from, unsigned int arrayLength, unsigned int bitsToShift)
 {
-    for (unsigned int T=0; T < arrayLength; ++T) 
+    for (unsigned int T=0; T < arrayLength; ++T)
     {
-        if (T >= bitsToShift/8) 
+        if (T >= bitsToShift/8)
         {
             unsigned int F = T-bitsToShift/8;
             to[T]  = from[F] << (bitsToShift%8);
@@ -210,14 +210,14 @@ BOOST_AUTO_TEST_CASE( shifts ) { // "<<"  ">>"  "<<="  ">>="
         BOOST_CHECK((HalfL >> (255-i)) == (OneL << i));
         TmpL = HalfL; TmpL >>= (255-i);
         BOOST_CHECK(TmpL == (OneL << i));
-                    
+
         shiftArrayLeft(TmpArray, R1Array, 32, i);
         BOOST_CHECK(uint256(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (R1L << i));
         TmpL = R1L; TmpL <<= i;
         BOOST_CHECK(TmpL == (R1L << i));
 
         shiftArrayRight(TmpArray, R1Array, 32, i);
-        BOOST_CHECK(uint256(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (R1L >> i)); 
+        BOOST_CHECK(uint256(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (R1L >> i));
         TmpL = R1L; TmpL >>= i;
         BOOST_CHECK(TmpL == (R1L >> i));
 
@@ -250,14 +250,14 @@ BOOST_AUTO_TEST_CASE( shifts ) { // "<<"  ">>"  "<<="  ">>="
         BOOST_CHECK((HalfS >> (159-i)) == (OneS << i));
         TmpS = HalfS; TmpS >>= (159-i);
         BOOST_CHECK(TmpS == (OneS << i));
-                    
+
         shiftArrayLeft(TmpArray, R1Array, 20, i);
         BOOST_CHECK(uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (R1S << i));
         TmpS = R1S; TmpS <<= i;
         BOOST_CHECK(TmpS == (R1S << i));
 
         shiftArrayRight(TmpArray, R1Array, 20, i);
-        BOOST_CHECK(uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (R1S >> i)); 
+        BOOST_CHECK(uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (R1S >> i));
         TmpS = R1S; TmpS >>= i;
         BOOST_CHECK(TmpS == (R1S >> i));
 
@@ -285,27 +285,27 @@ BOOST_AUTO_TEST_CASE( unaryOperators ) // !    ~    -
 {
     BOOST_CHECK(!ZeroL);  BOOST_CHECK(!ZeroS);
     BOOST_CHECK(!(!OneL));BOOST_CHECK(!(!OneS));
-    for (unsigned int i = 0; i < 256; ++i) 
+    for (unsigned int i = 0; i < 256; ++i)
         BOOST_CHECK(!(!(OneL<<i)));
-    for (unsigned int i = 0; i < 160; ++i) 
+    for (unsigned int i = 0; i < 160; ++i)
         BOOST_CHECK(!(!(OneS<<i)));
     BOOST_CHECK(!(!R1L));BOOST_CHECK(!(!R1S));
-    BOOST_CHECK(!(!R2S));BOOST_CHECK(!(!R2S)); 
+    BOOST_CHECK(!(!R2S));BOOST_CHECK(!(!R2S));
     BOOST_CHECK(!(!MaxL));BOOST_CHECK(!(!MaxS));
 
     BOOST_CHECK(~ZeroL == MaxL); BOOST_CHECK(~ZeroS == MaxS);
 
     unsigned char TmpArray[32];
-    for (unsigned int i = 0; i < 32; ++i) { TmpArray[i] = ~R1Array[i]; } 
+    for (unsigned int i = 0; i < 32; ++i) { TmpArray[i] = ~R1Array[i]; }
     BOOST_CHECK(uint256(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (~R1L));
     BOOST_CHECK(uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (~R1S));
 
     BOOST_CHECK(-ZeroL == ZeroL); BOOST_CHECK(-ZeroS == ZeroS);
     BOOST_CHECK(-R1L == (~R1L)+1);
     BOOST_CHECK(-R1S == (~R1S)+1);
-    for (unsigned int i = 0; i < 256; ++i) 
+    for (unsigned int i = 0; i < 256; ++i)
         BOOST_CHECK(-(OneL<<i) == (MaxL << i));
-    for (unsigned int i = 0; i < 160; ++i) 
+    for (unsigned int i = 0; i < 160; ++i)
         BOOST_CHECK(-(OneS<<i) == (MaxS << i));
 }
 
@@ -322,10 +322,10 @@ BOOST_AUTO_TEST_CASE( unaryOperators ) // !    ~    -
     TmpL = _A_##L; TmpL _OP_##= _B_##L; BOOST_CHECK(TmpL == (_A_##L _OP_ _B_##L)); \
     TmpS = _A_##S; TmpS _OP_##= _B_##S; BOOST_CHECK(TmpS == (_A_##S _OP_ _B_##S));
 
-BOOST_AUTO_TEST_CASE( bitwiseOperators ) 
+BOOST_AUTO_TEST_CASE( bitwiseOperators )
 {
     unsigned char TmpArray[32];
-    
+
     CHECKBITWISEOPERATOR(R1,R2,|)
     CHECKBITWISEOPERATOR(R1,R2,^)
     CHECKBITWISEOPERATOR(R1,R2,&)
@@ -360,7 +360,7 @@ BOOST_AUTO_TEST_CASE( bitwiseOperators )
     CHECKASSIGNMENTOPERATOR(Max,R1,^)
     CHECKASSIGNMENTOPERATOR(Max,R1,&)
 
-    uint64_t Tmp64 = 0xe1db685c9a0b47a2ULL; 
+    uint64_t Tmp64 = 0xe1db685c9a0b47a2ULL;
     TmpL = R1L; TmpL |= Tmp64;  BOOST_CHECK(TmpL == (R1L | uint256(Tmp64)));
     TmpS = R1S; TmpS |= Tmp64;  BOOST_CHECK(TmpS == (R1S | uint160(Tmp64)));
     TmpL = R1L; TmpL |= 0; BOOST_CHECK(TmpL == R1L);
@@ -395,7 +395,7 @@ BOOST_AUTO_TEST_CASE( comparison ) // <= >= < >
     }
 }
 
-BOOST_AUTO_TEST_CASE( plusMinus ) 
+BOOST_AUTO_TEST_CASE( plusMinus )
 {
     uint256 TmpL = 0;
     BOOST_CHECK(R1L+R2L == uint256(R1LplusR2L));
@@ -412,7 +412,7 @@ BOOST_AUTO_TEST_CASE( plusMinus )
         BOOST_CHECK( TmpL == (HalfL >> (i-1)) );
         TmpL = (MaxL>>i); TmpL += 1;
         BOOST_CHECK( TmpL == (HalfL >> (i-1)) );
-        TmpL = (MaxL>>i); 
+        TmpL = (MaxL>>i);
         BOOST_CHECK( TmpL++ == (MaxL>>i) );
         BOOST_CHECK( TmpL == (HalfL >> (i-1)));
     }
@@ -454,7 +454,7 @@ BOOST_AUTO_TEST_CASE( plusMinus )
         BOOST_CHECK( TmpS == (HalfS >> (i-1)) );
         TmpS = (MaxS>>i); TmpS += 1;
         BOOST_CHECK( TmpS == (HalfS >> (i-1)) );
-        TmpS = (MaxS>>i); 
+        TmpS = (MaxS>>i);
         BOOST_CHECK( TmpS++ == (MaxS>>i) );
         BOOST_CHECK( TmpS == (HalfS >> (i-1)));
     }
@@ -553,7 +553,7 @@ BOOST_AUTO_TEST_CASE( divide )
 }
 
 
-bool almostEqual(double d1, double d2) 
+bool almostEqual(double d1, double d2)
 {
     return fabs(d1-d2) <= 4*fabs(d1)*std::numeric_limits<double>::epsilon();
 }
@@ -634,7 +634,7 @@ BOOST_AUTO_TEST_CASE( methods ) // GetHex SetHex begin() end() size() GetLow64 G
     BOOST_CHECK(MaxS.begin() + 20 == MaxS.end());
     BOOST_CHECK(TmpS.begin() + 20 == TmpS.end());
     BOOST_CHECK(R1S.GetLow64()  == R1LLow64);
-    BOOST_CHECK(HalfS.GetLow64() ==0x0000000000000000ULL); 
+    BOOST_CHECK(HalfS.GetLow64() ==0x0000000000000000ULL);
     BOOST_CHECK(OneS.GetLow64() ==0x0000000000000001ULL);
     BOOST_CHECK(R1S.GetSerializeSize(0,PROTOCOL_VERSION) == 20);
     BOOST_CHECK(ZeroS.GetSerializeSize(0,PROTOCOL_VERSION) == 20);
@@ -654,17 +654,17 @@ BOOST_AUTO_TEST_CASE( methods ) // GetHex SetHex begin() end() size() GetLow64 G
     TmpS.Unserialize(ss,0,PROTOCOL_VERSION);
     BOOST_CHECK(MaxS == TmpS);
     ss.str("");
-    
-    for (unsigned int i = 0; i < 255; ++i) 
+
+    for (unsigned int i = 0; i < 255; ++i)
     {
         BOOST_CHECK((OneL << i).getdouble() == ldexp(1.0,i));
         if (i < 160) BOOST_CHECK((OneS << i).getdouble() == ldexp(1.0,i));
     }
     BOOST_CHECK(ZeroL.getdouble() == 0.0);
     BOOST_CHECK(ZeroS.getdouble() == 0.0);
-    for (int i = 256; i > 53; --i) 
+    for (int i = 256; i > 53; --i)
         BOOST_CHECK(almostEqual((R1L>>(256-i)).getdouble(), ldexp(R1Ldouble,i)));
-    for (int i = 160; i > 53; --i) 
+    for (int i = 160; i > 53; --i)
         BOOST_CHECK(almostEqual((R1S>>(160-i)).getdouble(), ldexp(R1Sdouble,i)));
     uint64_t R1L64part = (R1L>>192).GetLow64();
     uint64_t R1S64part = (R1S>>96).GetLow64();
@@ -809,21 +809,21 @@ BOOST_AUTO_TEST_CASE( getmaxcoverage ) // some more tests just to get 100% cover
     // ~R1L give a base_uint<256>
     BOOST_CHECK((~~R1L >> 10) == (R1L >> 10)); BOOST_CHECK((~~R1S >> 10) == (R1S >> 10));
     BOOST_CHECK((~~R1L << 10) == (R1L << 10)); BOOST_CHECK((~~R1S << 10) == (R1S << 10));
-    BOOST_CHECK(!(~~R1L < R1L)); BOOST_CHECK(!(~~R1S < R1S)); 
-    BOOST_CHECK(~~R1L <= R1L); BOOST_CHECK(~~R1S <= R1S); 
-    BOOST_CHECK(!(~~R1L > R1L)); BOOST_CHECK(!(~~R1S > R1S)); 
-    BOOST_CHECK(~~R1L >= R1L); BOOST_CHECK(~~R1S >= R1S); 
-    BOOST_CHECK(!(R1L < ~~R1L)); BOOST_CHECK(!(R1S < ~~R1S)); 
-    BOOST_CHECK(R1L <= ~~R1L); BOOST_CHECK(R1S <= ~~R1S); 
-    BOOST_CHECK(!(R1L > ~~R1L)); BOOST_CHECK(!(R1S > ~~R1S)); 
-    BOOST_CHECK(R1L >= ~~R1L); BOOST_CHECK(R1S >= ~~R1S); 
-    
+    BOOST_CHECK(!(~~R1L < R1L)); BOOST_CHECK(!(~~R1S < R1S));
+    BOOST_CHECK(~~R1L <= R1L); BOOST_CHECK(~~R1S <= R1S);
+    BOOST_CHECK(!(~~R1L > R1L)); BOOST_CHECK(!(~~R1S > R1S));
+    BOOST_CHECK(~~R1L >= R1L); BOOST_CHECK(~~R1S >= R1S);
+    BOOST_CHECK(!(R1L < ~~R1L)); BOOST_CHECK(!(R1S < ~~R1S));
+    BOOST_CHECK(R1L <= ~~R1L); BOOST_CHECK(R1S <= ~~R1S);
+    BOOST_CHECK(!(R1L > ~~R1L)); BOOST_CHECK(!(R1S > ~~R1S));
+    BOOST_CHECK(R1L >= ~~R1L); BOOST_CHECK(R1S >= ~~R1S);
+
     BOOST_CHECK(~~R1L + R2L == R1L + ~~R2L);
     BOOST_CHECK(~~R1S + R2S == R1S + ~~R2S);
     BOOST_CHECK(~~R1L - R2L == R1L - ~~R2L);
     BOOST_CHECK(~~R1S - R2S == R1S - ~~R2S);
-    BOOST_CHECK(~R1L != R1L); BOOST_CHECK(R1L != ~R1L); 
-    BOOST_CHECK(~R1S != R1S); BOOST_CHECK(R1S != ~R1S); 
+    BOOST_CHECK(~R1L != R1L); BOOST_CHECK(R1L != ~R1L);
+    BOOST_CHECK(~R1S != R1S); BOOST_CHECK(R1S != ~R1S);
     unsigned char TmpArray[32];
     CHECKBITWISEOPERATOR(~R1,R2,|)
     CHECKBITWISEOPERATOR(~R1,R2,^)

--- a/src/test/univalue_tests.cpp
+++ b/src/test/univalue_tests.cpp
@@ -8,12 +8,13 @@
 #include <string>
 #include <map>
 #include <univalue.h>
+#include "test/test_pivx.h"
 
 #include <boost/test/unit_test.hpp>
 
 using namespace std;
 
-BOOST_AUTO_TEST_SUITE(univalue_tests)
+BOOST_FIXTURE_TEST_SUITE(univalue_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(univalue_constructor)
 {

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -11,6 +11,7 @@
 #include "sync.h"
 #include "utilstrencodings.h"
 #include "utilmoneystr.h"
+#include "test/test_pivx.h"
 
 #include <stdint.h>
 #include <vector>
@@ -19,7 +20,7 @@
 
 using namespace std;
 
-BOOST_AUTO_TEST_SUITE(util_tests)
+BOOST_FIXTURE_TEST_SUITE(util_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(util_criticalsection)
 {

--- a/src/test/zerocoin_coinspend_tests.cpp
+++ b/src/test/zerocoin_coinspend_tests.cpp
@@ -16,6 +16,7 @@
 #include "wallet/wallet.h"
 #include "wallet/walletdb.h"
 #include "txdb.h"
+#include "test/test_pivx.h"
 #include <boost/test/unit_test.hpp>
 #include <iostream>
 
@@ -23,7 +24,7 @@ using namespace libzerocoin;
 
 class CDeterministicMint;
 
-BOOST_AUTO_TEST_SUITE(zerocoin_coinspend_tests)
+BOOST_FIXTURE_TEST_SUITE(zerocoin_coinspend_tests, TestingSetup)
 
 /**
  * Check that wrapped serials pass and not pass using the new validation.

--- a/src/test/zerocoin_denomination_tests.cpp
+++ b/src/test/zerocoin_denomination_tests.cpp
@@ -10,13 +10,13 @@
 #include "txdb.h"
 #include "wallet/wallet.h"
 #include "wallet/walletdb.h"
+#include "test/test_pivx.h"
 #include <boost/test/unit_test.hpp>
 #include <iostream>
 
 using namespace libzerocoin;
 
-BOOST_AUTO_TEST_SUITE(zerocoin_denom_tests)
-
+BOOST_FIXTURE_TEST_SUITE(zerocoin_denom_tests, BasicTestingSetup)
 
 //translation from pivx quantity to zerocoin denomination
 BOOST_AUTO_TEST_CASE(amount_to_denomination_test)

--- a/src/test/zerocoin_implementation_tests.cpp
+++ b/src/test/zerocoin_implementation_tests.cpp
@@ -17,12 +17,13 @@
 #include "wallet/wallet.h"
 #include "zpiv/zpivwallet.h"
 #include "zpivchain.h"
+#include "test_pivx.h"
 
 using namespace libzerocoin;
 
 extern bool DecodeHexTx(CTransaction& tx, const std::string& strHexTx);
 
-BOOST_AUTO_TEST_SUITE(zerocoin_implementation_tests)
+BOOST_FIXTURE_TEST_SUITE(zerocoin_implementation_tests, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(zcparams_test)
 {

--- a/src/util.h
+++ b/src/util.h
@@ -119,7 +119,8 @@ void AllocateFileRange(FILE* file, unsigned int offset, unsigned int length);
 bool RenameOver(boost::filesystem::path src, boost::filesystem::path dest);
 bool TryCreateDirectory(const boost::filesystem::path& p);
 boost::filesystem::path GetDefaultDataDir();
-const boost::filesystem::path& GetDataDir(bool fNetSpecific = true);
+const boost::filesystem::path &GetDataDir(bool fNetSpecific = true);
+void ClearDatadirCache();
 boost::filesystem::path GetConfigFile();
 boost::filesystem::path GetMasternodeConfigFile();
 #ifndef WIN32

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -40,22 +40,31 @@ void CDBEnv::EnvShutdown()
         return;
 
     fDbEnvInit = false;
-    int ret = dbenv.close(0);
+    int ret = dbenv->close(0);
     if (ret != 0)
         LogPrintf("CDBEnv::EnvShutdown : Error %d shutting down database environment: %s\n", ret, DbEnv::strerror(ret));
     if (!fMockDb)
         DbEnv(0).remove(strPath.c_str(), 0);
 }
 
-CDBEnv::CDBEnv() : dbenv(DB_CXX_NO_EXCEPTIONS)
+void CDBEnv::Reset()
 {
+    delete dbenv;
+    dbenv = new DbEnv(DB_CXX_NO_EXCEPTIONS);
     fDbEnvInit = false;
     fMockDb = false;
+}
+
+CDBEnv::CDBEnv() : dbenv(NULL)
+{
+    Reset();
 }
 
 CDBEnv::~CDBEnv()
 {
     EnvShutdown();
+    delete dbenv;
+    dbenv = NULL;
 }
 
 void CDBEnv::Close()
@@ -80,17 +89,17 @@ bool CDBEnv::Open(const boost::filesystem::path& pathIn)
     if (GetBoolArg("-privdb", true))
         nEnvFlags |= DB_PRIVATE;
 
-    dbenv.set_lg_dir(pathLogDir.string().c_str());
-    dbenv.set_cachesize(0, 0x100000, 1); // 1 MiB should be enough for just the wallet
-    dbenv.set_lg_bsize(0x10000);
-    dbenv.set_lg_max(1048576);
-    dbenv.set_lk_max_locks(40000);
-    dbenv.set_lk_max_objects(40000);
-    dbenv.set_errfile(fopen(pathErrorFile.string().c_str(), "a")); /// debug
-    dbenv.set_flags(DB_AUTO_COMMIT, 1);
-    dbenv.set_flags(DB_TXN_WRITE_NOSYNC, 1);
-    dbenv.log_set_config(DB_LOG_AUTO_REMOVE, 1);
-    int ret = dbenv.open(strPath.c_str(),
+    dbenv->set_lg_dir(pathLogDir.string().c_str());
+    dbenv->set_cachesize(0, 0x100000, 1); // 1 MiB should be enough for just the wallet
+    dbenv->set_lg_bsize(0x10000);
+    dbenv->set_lg_max(1048576);
+    dbenv->set_lk_max_locks(40000);
+    dbenv->set_lk_max_objects(40000);
+    dbenv->set_errfile(fopen(pathErrorFile.string().c_str(), "a")); /// debug
+    dbenv->set_flags(DB_AUTO_COMMIT, 1);
+    dbenv->set_flags(DB_TXN_WRITE_NOSYNC, 1);
+    dbenv->log_set_config(DB_LOG_AUTO_REMOVE, 1);
+    int ret = dbenv->open(strPath.c_str(),
         DB_CREATE |
             DB_INIT_LOCK |
             DB_INIT_LOG |
@@ -117,14 +126,14 @@ void CDBEnv::MakeMock()
 
     LogPrint("db", "CDBEnv::MakeMock\n");
 
-    dbenv.set_cachesize(1, 0, 1);
-    dbenv.set_lg_bsize(10485760 * 4);
-    dbenv.set_lg_max(10485760);
-    dbenv.set_lk_max_locks(10000);
-    dbenv.set_lk_max_objects(10000);
-    dbenv.set_flags(DB_AUTO_COMMIT, 1);
-    dbenv.log_set_config(DB_LOG_IN_MEMORY, 1);
-    int ret = dbenv.open(NULL,
+    dbenv->set_cachesize(1, 0, 1);
+    dbenv->set_lg_bsize(10485760 * 4);
+    dbenv->set_lg_max(10485760);
+    dbenv->set_lk_max_locks(10000);
+    dbenv->set_lk_max_objects(10000);
+    dbenv->set_flags(DB_AUTO_COMMIT, 1);
+    dbenv->log_set_config(DB_LOG_IN_MEMORY, 1);
+    int ret = dbenv->open(NULL,
         DB_CREATE |
             DB_INIT_LOCK |
             DB_INIT_LOG |
@@ -145,7 +154,7 @@ CDBEnv::VerifyResult CDBEnv::Verify(std::string strFile, bool (*recoverFunc)(CDB
     LOCK(cs_db);
     assert(mapFileUseCount.count(strFile) == 0);
 
-    Db db(&dbenv, 0);
+    Db db(dbenv, 0);
     int result = db.verify(strFile.c_str(), NULL, NULL, 0);
     if (result == 0)
         return VERIFY_OK;
@@ -168,7 +177,7 @@ bool CDBEnv::Salvage(std::string strFile, bool fAggressive, std::vector<CDBEnv::
 
     stringstream strDump;
 
-    Db db(&dbenv, 0);
+    Db db(dbenv, 0);
     int result = db.verify(strFile.c_str(), NULL, &strDump, flags);
     if (result == DB_VERIFY_BAD) {
         LogPrintf("CDBEnv::Salvage : Database salvage found errors, all data may not be recoverable.\n");
@@ -209,10 +218,10 @@ bool CDBEnv::Salvage(std::string strFile, bool fAggressive, std::vector<CDBEnv::
 
 void CDBEnv::CheckpointLSN(const std::string& strFile)
 {
-    dbenv.txn_checkpoint(0, 0, 0);
+    dbenv->txn_checkpoint(0, 0, 0);
     if (fMockDb)
         return;
-    dbenv.lsn_reset(strFile.c_str(), 0);
+    dbenv->lsn_reset(strFile.c_str(), 0);
 }
 
 
@@ -237,7 +246,7 @@ CDB::CDB(const std::string& strFilename, const char* pszMode) : pdb(NULL), activ
         ++bitdb.mapFileUseCount[strFile];
         pdb = bitdb.mapDb[strFile];
         if (pdb == NULL) {
-            pdb = new Db(&bitdb.dbenv, 0);
+            pdb = new Db(bitdb.dbenv, 0);
 
             bool fMockDb = bitdb.IsMock();
             if (fMockDb) {
@@ -284,7 +293,7 @@ void CDB::Flush()
     if (fReadOnly)
         nMinutes = 1;
 
-    bitdb.dbenv.txn_checkpoint(nMinutes ? GetArg("-dblogsize", 100) * 1024 : 0, nMinutes, 0);
+    bitdb.dbenv->txn_checkpoint(nMinutes ? GetArg("-dblogsize", 100) * 1024 : 0, nMinutes, 0);
 }
 
 void CDB::Close()
@@ -323,7 +332,7 @@ bool CDBEnv::RemoveDb(const string& strFile)
     this->CloseDb(strFile);
 
     LOCK(cs_db);
-    int rc = dbenv.dbremove(NULL, strFile.c_str(), NULL, DB_AUTO_COMMIT);
+    int rc = dbenv->dbremove(NULL, strFile.c_str(), NULL, DB_AUTO_COMMIT);
     return (rc == 0);
 }
 
@@ -343,7 +352,7 @@ bool CDB::Rewrite(const string& strFile, const char* pszSkip)
                 string strFileRes = strFile + ".rewrite";
                 { // surround usage of db with extra {}
                     CDB db(strFile.c_str(), "r");
-                    Db* pdbCopy = new Db(&bitdb.dbenv, 0);
+                    Db* pdbCopy = new Db(bitdb.dbenv, 0);
 
                     int ret = pdbCopy->open(NULL, // Txn pointer
                         strFileRes.c_str(),       // Filename
@@ -393,10 +402,10 @@ bool CDB::Rewrite(const string& strFile, const char* pszSkip)
                     }
                 }
                 if (fSuccess) {
-                    Db dbA(&bitdb.dbenv, 0);
+                    Db dbA(bitdb.dbenv, 0);
                     if (dbA.remove(strFile.c_str(), NULL, 0))
                         fSuccess = false;
-                    Db dbB(&bitdb.dbenv, 0);
+                    Db dbB(bitdb.dbenv, 0);
                     if (dbB.rename(strFileRes.c_str(), NULL, strFile.c_str(), 0))
                         fSuccess = false;
                 }
@@ -428,12 +437,12 @@ void CDBEnv::Flush(bool fShutdown)
             if (nRefCount == 0) {
                 // Move log data to the dat file
                 CloseDb(strFile);
-                LogPrint("db", "CDBEnv::Flush : %s checkpoint\n", strFile);
-                dbenv.txn_checkpoint(0, 0, 0);
-                LogPrint("db", "CDBEnv::Flush : %s detach\n", strFile);
+                LogPrint("db", "CDBEnv::Flush: %s checkpoint\n", strFile);
+                dbenv->txn_checkpoint(0, 0, 0);
+                LogPrint("db", "CDBEnv::Flush: %s detach\n", strFile);
                 if (!fMockDb)
-                    dbenv.lsn_reset(strFile.c_str(), 0);
-                LogPrint("db", "CDBEnv::Flush : %s closed\n", strFile);
+                    dbenv->lsn_reset(strFile.c_str(), 0);
+                LogPrint("db", "CDBEnv::Flush: %s closed\n", strFile);
                 mapFileUseCount.erase(mi++);
             } else
                 mi++;
@@ -442,7 +451,7 @@ void CDBEnv::Flush(bool fShutdown)
         if (fShutdown) {
             char** listp;
             if (mapFileUseCount.empty()) {
-                dbenv.log_archive(&listp, DB_ARCH_REMOVE);
+                dbenv->log_archive(&listp, DB_ARCH_REMOVE);
                 Close();
                 if (!fMockDb)
                     boost::filesystem::remove_all(boost::filesystem::path(strPath) / "database");

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -43,12 +43,14 @@ private:
 
 public:
     mutable CCriticalSection cs_db;
-    DbEnv dbenv;
+    DbEnv *dbenv;
     std::map<std::string, int> mapFileUseCount;
     std::map<std::string, Db*> mapDb;
 
     CDBEnv();
     ~CDBEnv();
+    void Reset();
+
     void MakeMock();
     bool IsMock() { return fMockDb; }
 
@@ -83,7 +85,7 @@ public:
     DbTxn* TxnBegin(int flags = DB_TXN_WRITE_NOSYNC)
     {
         DbTxn* ptxn = NULL;
-        int ret = dbenv.txn_begin(NULL, &ptxn, flags);
+        int ret = dbenv->txn_begin(NULL, &ptxn, flags);
         if (!ptxn || ret != 0)
             return NULL;
         return ptxn;

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
+#include "test_pivx.h"
 
 // how many times to run all the tests to have a chance to catch errors that only show up with particular random shuffles
 #define RUN_TESTS 100
@@ -22,7 +23,7 @@ using namespace std;
 
 typedef set<pair<const CWalletTx*,unsigned int> > CoinSet;
 
-BOOST_AUTO_TEST_SUITE(wallet_tests)
+BOOST_FIXTURE_TEST_SUITE(wallet_tests, TestingSetup)
 
 static CWallet wallet;
 static vector<COutput> vCoins;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1113,8 +1113,8 @@ bool CWalletDB::Recover(CDBEnv& dbenv, std::string filename, bool fOnlyKeys)
     int64_t now = GetTime();
     std::string newFilename = strprintf("wallet.%d.bak", now);
 
-    int result = dbenv.dbenv.dbrename(NULL, filename.c_str(), NULL,
-        newFilename.c_str(), DB_AUTO_COMMIT);
+    int result = dbenv.dbenv->dbrename(NULL, filename.c_str(), NULL,
+                                       newFilename.c_str(), DB_AUTO_COMMIT);
     if (result == 0)
         LogPrintf("Renamed %s to %s\n", filename, newFilename);
     else {
@@ -1131,12 +1131,12 @@ bool CWalletDB::Recover(CDBEnv& dbenv, std::string filename, bool fOnlyKeys)
     LogPrintf("Salvage(aggressive) found %u records\n", salvagedData.size());
 
     bool fSuccess = allOK;
-    boost::scoped_ptr<Db> pdbCopy(new Db(&dbenv.dbenv, 0));
-    int ret = pdbCopy->open(NULL, // Txn pointer
-        filename.c_str(),         // Filename
-        "main",                   // Logical db name
-        DB_BTREE,                 // Database type
-        DB_CREATE,                // Flags
+    boost::scoped_ptr<Db> pdbCopy(new Db(dbenv.dbenv, 0));
+    int ret = pdbCopy->open(NULL,               // Txn pointer
+        filename.c_str(),   // Filename
+        "main",             // Logical db name
+        DB_BTREE,           // Database type
+        DB_CREATE,          // Flags
         0);
     if (ret > 0) {
         LogPrintf("Cannot create database file %s\n", filename);


### PR DESCRIPTION
This makes a new basic testing fixture initializing less stuff for most test cases. It also reinitializes the fixture between each test suite.
Backport of bitcoin#5852 and bitcoin#5883.