### PR TITLE
[Scripts] Add optimize pngs python script

### DIFF
--- a/contrib/devtools/optimize-pngs.py
+++ b/contrib/devtools/optimize-pngs.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+'''
+Run this script every time you change one of the png files. Using pngcrush, it will optimize the png files, remove various color profiles, remove ancillary chunks (alla) and text chunks (text).
+#pngcrush -brute -ow -rem gAMA -rem cHRM -rem iCCP -rem sRGB -rem alla -rem text
+'''
+import os
+import sys
+import subprocess
+import hashlib
+from PIL import Image  # pip3 install Pillow
+
+def file_hash(filename):
+    '''Return hash of raw file contents'''
+    with open(filename, 'rb') as f:
+        return hashlib.sha256(f.read()).hexdigest()
+
+def content_hash(filename):
+    '''Return hash of RGBA contents of image'''
+    i = Image.open(filename)
+    i = i.convert('RGBA')
+    data = i.tobytes()
+    return hashlib.sha256(data).hexdigest()
+
+pngcrush = 'pngcrush'
+git = 'git'
+folders = ["src/qt/res/movies", "src/qt/res/icons", "share/pixmaps"]
+basePath = subprocess.check_output([git, 'rev-parse', '--show-toplevel'], universal_newlines=True, encoding='utf8').rstrip('\n')
+totalSaveBytes = 0
+noHashChange = True
+
+outputArray = []
+for folder in folders:
+    absFolder=os.path.join(basePath, folder)
+    for file in os.listdir(absFolder):
+        extension = os.path.splitext(file)[1]
+        if extension.lower() == '.png':
+            print("optimizing {}...".format(file), end =' ')
+            file_path = os.path.join(absFolder, file)
+            fileMetaMap = {'file' : file, 'osize': os.path.getsize(file_path), 'sha256Old' : file_hash(file_path)}
+            fileMetaMap['contentHashPre'] = content_hash(file_path)
+
+            try:
+                subprocess.call([pngcrush, "-brute", "-ow", "-rem", "gAMA", "-rem", "cHRM", "-rem", "iCCP", "-rem", "sRGB", "-rem", "alla", "-rem", "text", file_path],
+                                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            except:
+                print("pngcrush is not installed, aborting...")
+                sys.exit(0)
+
+            #verify
+            if "Not a PNG file" in subprocess.check_output([pngcrush, "-n", "-v", file_path], stderr=subprocess.STDOUT, universal_newlines=True, encoding='utf8'):
+                print("PNG file "+file+" is corrupted after crushing, check out pngcursh version")
+                sys.exit(1)
+
+            fileMetaMap['sha256New'] = file_hash(file_path)
+            fileMetaMap['contentHashPost'] = content_hash(file_path)
+
+            if fileMetaMap['contentHashPre'] != fileMetaMap['contentHashPost']:
+                print("Image contents of PNG file {} before and after crushing don't match".format(file))
+                sys.exit(1)
+
+            fileMetaMap['psize'] = os.path.getsize(file_path)
+            outputArray.append(fileMetaMap)
+            print("done")
+
+print("summary:\n+++++++++++++++++")
+for fileDict in outputArray:
+    oldHash = fileDict['sha256Old']
+    newHash = fileDict['sha256New']
+    totalSaveBytes += fileDict['osize'] - fileDict['psize']
+    noHashChange = noHashChange and (oldHash == newHash)
+    print(fileDict['file']+"\n  size diff from: "+str(fileDict['osize'])+" to: "+str(fileDict['psize'])+"\n  old sha256: "+oldHash+"\n  new sha256: "+newHash+"\n")
+
+print("completed. Checksum stable: "+str(noHashChange)+". Total reduction: "+str(totalSaveBytes)+" bytes")


### PR DESCRIPTION
Optimization script does optimize/clean all existing pngs in projects folder, before png is merged into master, it probably should be optimized.

How to use
-----------
Run script until you get: `Checksum stable: True`
```bash
contrib/devtools/optimize-pngs.py
```

Run on current pivx
-------------------
After adding the script, I did run and on first run it returned `Checksum stable: False` which means images were not optimized:

After running it, it did optimize `src/qt/res/icons/debugwindow.png`

Log
-----
- First run
  ```
  $ contrib/devtools/optimize-pngs.py
  optimizing spinner-025.png... done
  optimizing spinner-005.png... done
  optimizing spinner-020.png... done
  optimizing spinner-034.png... done
  optimizing spinner-018.png... done
  optimizing spinner-033.png... done
  optimizing spinner-000.png... done
  optimizing spinner-023.png... done
  optimizing spinner-014.png... done
  optimizing spinner-028.png... done
  optimizing spinner-002.png... done
  optimizing spinner-026.png... done
  optimizing spinner-031.png... done
  optimizing spinner-027.png... done
  optimizing spinner-008.png... done
  optimizing spinner-001.png... done
  optimizing spinner-022.png... done
  optimizing spinner-015.png... done
  optimizing spinner-012.png... done
  optimizing spinner-032.png... done
  optimizing spinner-017.png... done
  optimizing spinner-013.png... done
  optimizing spinner-007.png... done
  optimizing spinner-021.png... done
  optimizing spinner-019.png... done
  optimizing spinner-011.png... done
  optimizing spinner-030.png... done
  optimizing spinner-003.png... done
  optimizing spinner-016.png... done
  optimizing spinner-010.png... done
  optimizing spinner-029.png... done
  optimizing spinner-006.png... done
  optimizing spinner-004.png... done
  optimizing spinner-024.png... done
  optimizing spinner-009.png... done
  optimizing eye.png... done
  optimizing clock1.png... done
  optimizing bitcoin_testnet.png... done
  optimizing lock_open.png... done
  optimizing add.png... done
  optimizing overview.png... done
  optimizing transaction_conflicted.png... done
  optimizing import.png... done
  optimizing tx_output.png... done
  optimizing explorer.png... done
  optimizing unit_tpivx.png... done
  optimizing bitcoin.png... done
  optimizing clock5.png... done
  optimizing editpaste.png... done
  optimizing receive_dark.png... done
  optimizing unit_mpivx.png... done
  optimizing staking_inactive.png... done
  optimizing unit_tmpivx.png... done
  optimizing clock2.png... done
  optimizing lock_closed.png... done
  optimizing connect3_16.png... done
  optimizing masternodes.png... done
  optimizing browse.png... done
  optimizing eye_minus.png... done
  optimizing edit.png... done
  optimizing key.png... done
  optimizing trade.png... done
  optimizing tx_mined.png... done
  optimizing connect0_16.png... done
  optimizing tx_inout.png... done
  optimizing connect2_16.png... done
  optimizing clock4.png... done
  optimizing synced.png... done
  optimizing transaction0_dark.png... done
  optimizing filesave.png... done
  optimizing editcopy.png... done
  optimizing privacy.png... done
  optimizing eye_plus.png... done
  optimizing transaction0.png... done
  optimizing send_dark.png... done
  optimizing automint_inactive.png... done
  optimizing receive.png... done
  optimizing tx_input.png... done
  optimizing onion.png... done
  optimizing configure.png... done
  optimizing debugwindow.png... done
  optimizing unit_tupivx.png... done
  optimizing transaction2.png... done
  optimizing send.png... done
  optimizing connect4_16.png... done
  optimizing address-book.png... done
  optimizing quit.png... done
  optimizing staking_active.png... done
  optimizing bittrex.png... done
  optimizing remove.png... done
  optimizing automint_active.png... done
  optimizing clock3.png... done
  optimizing connect1_16.png... done
  optimizing export.png... done
  optimizing qrcode.png... done
  optimizing history.png... done
  optimizing notsynced.png... done
  optimizing unit_pivx.png... done
  optimizing unit_upivx.png... done
  optimizing bitcoin64.png... done
  optimizing bitcoin128.png... done
  optimizing bitcoin16.png... done
  optimizing bitcoin256.png... done
  optimizing bitcoin32.png... done
  summary:
  +++++++++++++++++
  spinner-025.png
  size diff from: 936 to: 936
  old sha256: ccf63ffb03a5d0b04defab040dece7a86d208b04c5b6343a65763bd5537b2808
  new sha256: ccf63ffb03a5d0b04defab040dece7a86d208b04c5b6343a65763bd5537b2808

  spinner-005.png
  size diff from: 896 to: 896
  old sha256: a977cc8a854e07888dde172ea46334ed105e02efa17c814f8c6243210d6a534d
  new sha256: a977cc8a854e07888dde172ea46334ed105e02efa17c814f8c6243210d6a534d

  spinner-020.png
  size diff from: 922 to: 922
  old sha256: 0f2a531c211dd9cd919439fb593472c072c3c98d6a6440bcc2c60c967e4b5c51
  new sha256: 0f2a531c211dd9cd919439fb593472c072c3c98d6a6440bcc2c60c967e4b5c51

  spinner-034.png
  size diff from: 945 to: 945
  old sha256: d6d6cfd6b62439c520fc1f4ec341eafbdd40569d44361c0eac422f987b2864ab
  new sha256: d6d6cfd6b62439c520fc1f4ec341eafbdd40569d44361c0eac422f987b2864ab

  spinner-018.png
  size diff from: 889 to: 889
  old sha256: 09ac672506ba35c64038d6ce13cca69f5e9d2082a766fa2e7519add3e293440f
  new sha256: 09ac672506ba35c64038d6ce13cca69f5e9d2082a766fa2e7519add3e293440f

  spinner-033.png
  size diff from: 940 to: 940
  old sha256: ea3bea2832dde6b06aad384ca5a6e2b0c6e97ef800a2213018a4e0bab4f32fba
  new sha256: ea3bea2832dde6b06aad384ca5a6e2b0c6e97ef800a2213018a4e0bab4f32fba

  spinner-000.png
  size diff from: 958 to: 958
  old sha256: f91376c5911c0682b9369132dccec1cc40873f82f25ca69516686edabc722ac9
  new sha256: f91376c5911c0682b9369132dccec1cc40873f82f25ca69516686edabc722ac9

  spinner-023.png
  size diff from: 894 to: 894
  old sha256: dd7935e00e8eedfda7dafc3fb7310888915e31d06df97a7e756b1dff3ea2d8d9
  new sha256: dd7935e00e8eedfda7dafc3fb7310888915e31d06df97a7e756b1dff3ea2d8d9

  spinner-014.png
  size diff from: 898 to: 898
  old sha256: e255a7942a601e24283991926d3fca83589f3a14b7f203091ea9bc8fc7da5d18
  new sha256: e255a7942a601e24283991926d3fca83589f3a14b7f203091ea9bc8fc7da5d18

  spinner-028.png
  size diff from: 964 to: 964
  old sha256: 3a973c052e77afd8edf6c5b9db255f431fda25267d25e00f562c0e6a162556b2
  new sha256: 3a973c052e77afd8edf6c5b9db255f431fda25267d25e00f562c0e6a162556b2

  spinner-002.png
  size diff from: 893 to: 893
  old sha256: b51f46e3b188aed1072b1b1742ed66c8a73c1f7ad259e925152367aee16cbfa5
  new sha256: b51f46e3b188aed1072b1b1742ed66c8a73c1f7ad259e925152367aee16cbfa5

  spinner-026.png
  size diff from: 948 to: 948
  old sha256: ce7e3ed736590ddf5f305f0fb965080daa37d9da976d805f0cf2c2f4e250fe48
  new sha256: ce7e3ed736590ddf5f305f0fb965080daa37d9da976d805f0cf2c2f4e250fe48

  spinner-031.png
  size diff from: 894 to: 894
  old sha256: 4f844f58cd3558b9e1bd71795881e224ed185dc838a36a5d6c6ffb0397081b56
  new sha256: 4f844f58cd3558b9e1bd71795881e224ed185dc838a36a5d6c6ffb0397081b56

  spinner-027.png
  size diff from: 941 to: 941
  old sha256: 40f37fc5e81aca46dc1cc456488bde303c70cefc9fe32dd62999eef04c224cb3
  new sha256: 40f37fc5e81aca46dc1cc456488bde303c70cefc9fe32dd62999eef04c224cb3

  spinner-008.png
  size diff from: 943 to: 943
  old sha256: d7a0ce3e0a2ab99a1aaf61a3b717086220719b127c72fbb7f8211f0672907e9e
  new sha256: d7a0ce3e0a2ab99a1aaf61a3b717086220719b127c72fbb7f8211f0672907e9e

  spinner-001.png
  size diff from: 887 to: 887
  old sha256: fe083942ad75e7450dff923c55894cac662a8ad698b1bf57263b9223341f7735
  new sha256: fe083942ad75e7450dff923c55894cac662a8ad698b1bf57263b9223341f7735

  spinner-022.png
  size diff from: 912 to: 912
  old sha256: 93d818c5f82e000c78bcaa3931679d1715af4dc2cbb133aa9061d73fa7c68d7d
  new sha256: 93d818c5f82e000c78bcaa3931679d1715af4dc2cbb133aa9061d73fa7c68d7d

  spinner-015.png
  size diff from: 878 to: 878
  old sha256: f801e38b796b5684c230ff0ae905513acafca20e805d4d194ef4e8c820b5aed9
  new sha256: f801e38b796b5684c230ff0ae905513acafca20e805d4d194ef4e8c820b5aed9

  spinner-012.png
  size diff from: 918 to: 918
  old sha256: bb073039eb2f04d70686a5b9e29e5b943ca5c500440d87ef6d89f21d90e5a4d6
  new sha256: bb073039eb2f04d70686a5b9e29e5b943ca5c500440d87ef6d89f21d90e5a4d6

  spinner-032.png
  size diff from: 896 to: 896
  old sha256: 7ee64fb3b1991c3e3da1425b780d42608bb7304e9bed2f8dcee6ac9ee3dc95f8
  new sha256: 7ee64fb3b1991c3e3da1425b780d42608bb7304e9bed2f8dcee6ac9ee3dc95f8

  spinner-017.png
  size diff from: 923 to: 923
  old sha256: 839b1e1b3ba046516ba0fc325d80978736a4a7f1bdd5f90fbcb2120bb7026a1f
  new sha256: 839b1e1b3ba046516ba0fc325d80978736a4a7f1bdd5f90fbcb2120bb7026a1f

  spinner-013.png
  size diff from: 923 to: 923
  old sha256: 7f79d41ec8cf099954adaf5e2aa87cfa87f4b298f9ab64add48f6941002f267a
  new sha256: 7f79d41ec8cf099954adaf5e2aa87cfa87f4b298f9ab64add48f6941002f267a

  spinner-007.png
  size diff from: 967 to: 967
  old sha256: 1f3fcb0a4e95d1088d805dd153a564d96b8c5e3a0985e36a06fceda00554a4b8
  new sha256: 1f3fcb0a4e95d1088d805dd153a564d96b8c5e3a0985e36a06fceda00554a4b8

  spinner-021.png
  size diff from: 910 to: 910
  old sha256: beb85dccece4ea986d00836863814cc932e218f16ff6ad8b8d1b205309be6893
  new sha256: beb85dccece4ea986d00836863814cc932e218f16ff6ad8b8d1b205309be6893

  spinner-019.png
  size diff from: 911 to: 911
  old sha256: b807ad24ab2cb929dbcc219c51f2e2fa9a2d8b85b4367a0a1a836f301ef8b929
  new sha256: b807ad24ab2cb929dbcc219c51f2e2fa9a2d8b85b4367a0a1a836f301ef8b929

  spinner-011.png
  size diff from: 931 to: 931
  old sha256: 75743d6f259da588eaed999b0135195dad7901f6468e021f0f772d83a44cd5dc
  new sha256: 75743d6f259da588eaed999b0135195dad7901f6468e021f0f772d83a44cd5dc

  spinner-030.png
  size diff from: 907 to: 907
  old sha256: d8a66bd3296e08befc671ff80bdb8eaeeeb56b81e002d4e5599b211d3f203074
  new sha256: d8a66bd3296e08befc671ff80bdb8eaeeeb56b81e002d4e5599b211d3f203074

  spinner-003.png
  size diff from: 914 to: 914
  old sha256: cbe63d4046168ec65c72a72403880a963444085b948d3b73a5ac92de32f48ead
  new sha256: cbe63d4046168ec65c72a72403880a963444085b948d3b73a5ac92de32f48ead

  spinner-016.png
  size diff from: 896 to: 896
  old sha256: e461ea5daf253ec469e3c2655cbf198a64d6a6e68bd54abb353da0b99e8365df
  new sha256: e461ea5daf253ec469e3c2655cbf198a64d6a6e68bd54abb353da0b99e8365df

  spinner-010.png
  size diff from: 913 to: 913
  old sha256: 2fce585c31dde63d7e40f49981d70ff0f79245d5e6fc5aa27c6fb8fa6a5b0be0
  new sha256: 2fce585c31dde63d7e40f49981d70ff0f79245d5e6fc5aa27c6fb8fa6a5b0be0

  spinner-029.png
  size diff from: 956 to: 956
  old sha256: 3ef33f73044a06b5fac11c203465e70c10ea640fce890afc0e0786c6eec320c1
  new sha256: 3ef33f73044a06b5fac11c203465e70c10ea640fce890afc0e0786c6eec320c1

  spinner-006.png
  size diff from: 915 to: 915
  old sha256: c49a9bed654ac27d71a96aa4cba1a7c6135d460ce14d366cb93a8c9f70b1d755
  new sha256: c49a9bed654ac27d71a96aa4cba1a7c6135d460ce14d366cb93a8c9f70b1d755

  spinner-004.png
  size diff from: 898 to: 898
  old sha256: 3d129bf55906f5e3abe9f5ccf08902f426cee798797211e09e4ace4a2a167342
  new sha256: 3d129bf55906f5e3abe9f5ccf08902f426cee798797211e09e4ace4a2a167342

  spinner-024.png
  size diff from: 953 to: 953
  old sha256: 41e0fbb960ab7ad45189f4210f95460ccf39d1f5ca4b04057164603de4402a2d
  new sha256: 41e0fbb960ab7ad45189f4210f95460ccf39d1f5ca4b04057164603de4402a2d

  spinner-009.png
  size diff from: 964 to: 964
  old sha256: 4f9cf63df66b654113a062bd03662c0f88d5dcead8dd8b8cff7c18a3e439386f
  new sha256: 4f9cf63df66b654113a062bd03662c0f88d5dcead8dd8b8cff7c18a3e439386f

  eye.png
  size diff from: 433 to: 433
  old sha256: f9018dd14c1ca8a9a1f6a49747169e77b03d6fbcabcb9195aa7d7a9b7fb447c6
  new sha256: f9018dd14c1ca8a9a1f6a49747169e77b03d6fbcabcb9195aa7d7a9b7fb447c6

  clock1.png
  size diff from: 911 to: 911
  old sha256: 34127e5e1fc7c632e67857144b98411f9a7d36319dbed83b323a9f874eb00436
  new sha256: 34127e5e1fc7c632e67857144b98411f9a7d36319dbed83b323a9f874eb00436

  bitcoin_testnet.png
  size diff from: 14590 to: 14590
  old sha256: ca4389357a4028d485a7ef7c2c30d68666be75a8bfad7b87f3fbf8fa7e93baf6
  new sha256: ca4389357a4028d485a7ef7c2c30d68666be75a8bfad7b87f3fbf8fa7e93baf6

  lock_open.png
  size diff from: 1017 to: 1017
  old sha256: 9a7edfcf06d9055bb5107322e3a14f5616ddfdc2b6f8f4f3fd839f84358a4974
  new sha256: 9a7edfcf06d9055bb5107322e3a14f5616ddfdc2b6f8f4f3fd839f84358a4974

  add.png
  size diff from: 134 to: 134
  old sha256: ed58207b979dc68ddb16cb26613a1b63f411f055697155b7fa7e61d62abfab63
  new sha256: ed58207b979dc68ddb16cb26613a1b63f411f055697155b7fa7e61d62abfab63

  overview.png
  size diff from: 6733 to: 6733
  old sha256: 68e0453745976bba873609c35d6d088285bd7524132e547476ba8d9e81c9243a
  new sha256: 68e0453745976bba873609c35d6d088285bd7524132e547476ba8d9e81c9243a

  transaction_conflicted.png
  size diff from: 142 to: 142
  old sha256: 8a3c097b9f5a31051613e29893c61f7c0047e0e37037600e399e35ec14042170
  new sha256: 8a3c097b9f5a31051613e29893c61f7c0047e0e37037600e399e35ec14042170

  import.png
  size diff from: 827 to: 827
  old sha256: de0f37b2ec4b75e1bef4e5cae03dbd835929d24358d14dc111c9945ad9f9446e
  new sha256: de0f37b2ec4b75e1bef4e5cae03dbd835929d24358d14dc111c9945ad9f9446e

  tx_output.png
  size diff from: 1117 to: 1117
  old sha256: 1b6f3157818c80c2b5f06d93203aa0ea218ecb6beed740c71608ec522139122e
  new sha256: 1b6f3157818c80c2b5f06d93203aa0ea218ecb6beed740c71608ec522139122e

  explorer.png
  size diff from: 2060 to: 2060
  old sha256: 2dd05d3952d8cf7e005685f47f78bd64a95babf7c3aff4fde4476d7ba90d2d1f
  new sha256: 2dd05d3952d8cf7e005685f47f78bd64a95babf7c3aff4fde4476d7ba90d2d1f

  unit_tpivx.png
  size diff from: 338 to: 338
  old sha256: aef848c514df1e260e52e1dd380f7e07d7748e75a5f3e0fa796cffdea06850e0
  new sha256: aef848c514df1e260e52e1dd380f7e07d7748e75a5f3e0fa796cffdea06850e0

  bitcoin.png
  size diff from: 14562 to: 14562
  old sha256: 1e6fc0d9c152cb0e6ada9de3c06ed07248208af14e6074920b38b0771079b467
  new sha256: 1e6fc0d9c152cb0e6ada9de3c06ed07248208af14e6074920b38b0771079b467

  clock5.png
  size diff from: 929 to: 929
  old sha256: 32269ee1bb58dec936d3f6d0569d28a76d28e2cddf681df77e262349f8958d1f
  new sha256: 32269ee1bb58dec936d3f6d0569d28a76d28e2cddf681df77e262349f8958d1f

  editpaste.png
  size diff from: 441 to: 441
  old sha256: ec7a88148dd051707cd40a2fbc1563daac7e633e4f88dc3d4d01be8d9b4777b8
  new sha256: ec7a88148dd051707cd40a2fbc1563daac7e633e4f88dc3d4d01be8d9b4777b8

  receive_dark.png
  size diff from: 1774 to: 1774
  old sha256: de981cf9051b4ed4de303b830bf0622db17080c2cec2e0a6451d8dae41ffddec
  new sha256: de981cf9051b4ed4de303b830bf0622db17080c2cec2e0a6451d8dae41ffddec

  unit_mpivx.png
  size diff from: 333 to: 333
  old sha256: 93abb9c386b0ef568f57d22604668b09d5f9b7e6bfe32fdfcc48a58e6787e98e
  new sha256: 93abb9c386b0ef568f57d22604668b09d5f9b7e6bfe32fdfcc48a58e6787e98e

  staking_inactive.png
  size diff from: 227 to: 227
  old sha256: 783efc4d839522f04d551429161d3b2f1c49f1ff30602a65e5daef0495ab298c
  new sha256: 783efc4d839522f04d551429161d3b2f1c49f1ff30602a65e5daef0495ab298c

  unit_tmpivx.png
  size diff from: 359 to: 359
  old sha256: f3ee1ff2c5f3efbd5671c2b0ccee687e7d5237075e48afddf9d228c6d38a165e
  new sha256: f3ee1ff2c5f3efbd5671c2b0ccee687e7d5237075e48afddf9d228c6d38a165e

  clock2.png
  size diff from: 911 to: 911
  old sha256: af408ee745c9b049e59b898afe090c4b883efe823ac0261109fa5fddf9b8dc89
  new sha256: af408ee745c9b049e59b898afe090c4b883efe823ac0261109fa5fddf9b8dc89

  lock_closed.png
  size diff from: 1423 to: 1423
  old sha256: afee9bf46a63bde058f6dcdbe8ff11936d5fe35550881994c73126fdb0f55bdd
  new sha256: afee9bf46a63bde058f6dcdbe8ff11936d5fe35550881994c73126fdb0f55bdd

  connect3_16.png
  size diff from: 713 to: 713
  old sha256: f0da3d04ddafd82f40ba3109ba32e806c22075b6998d18f21c41fbabf24ea654
  new sha256: f0da3d04ddafd82f40ba3109ba32e806c22075b6998d18f21c41fbabf24ea654

  masternodes.png
  size diff from: 3396 to: 3396
  old sha256: 3bd1b893bb9ee2b18dba08cd464ecb0734af89c610ab861b03aa19e35964a5ed
  new sha256: 3bd1b893bb9ee2b18dba08cd464ecb0734af89c610ab861b03aa19e35964a5ed

  browse.png
  size diff from: 1294 to: 1294
  old sha256: b2fd9f7b20b536c07a85f0fb7902e39aa42de2a0f9b6c0985ff388bc826adf3e
  new sha256: b2fd9f7b20b536c07a85f0fb7902e39aa42de2a0f9b6c0985ff388bc826adf3e

  eye_minus.png
  size diff from: 513 to: 513
  old sha256: 4cd807d710c96e0fbd1215220b2685384b077fb5c2fe214fd1bff33480732e97
  new sha256: 4cd807d710c96e0fbd1215220b2685384b077fb5c2fe214fd1bff33480732e97

  edit.png
  size diff from: 1223 to: 1223
  old sha256: 2554eef2497cc54cb43a37aaf1aaba904fbb3b4c8cdc9a39ea9b7b76a5d23479
  new sha256: 2554eef2497cc54cb43a37aaf1aaba904fbb3b4c8cdc9a39ea9b7b76a5d23479

  key.png
  size diff from: 267 to: 267
  old sha256: f0ca4ce57fa43d50ad305549dcd8e7f1e5087198d1048de2b66a21a30106c093
  new sha256: f0ca4ce57fa43d50ad305549dcd8e7f1e5087198d1048de2b66a21a30106c093

  trade.png
  size diff from: 517 to: 517
  old sha256: 7d2cecf98bc740155a47de26f9b9f0d2b720c7bea0030a31543226807e7ae83b
  new sha256: 7d2cecf98bc740155a47de26f9b9f0d2b720c7bea0030a31543226807e7ae83b

  tx_mined.png
  size diff from: 1231 to: 1231
  old sha256: 3a609752cb332a0c14a34c428f52a9d5c5c5ec40b1f029752f5f50ef4a00d10e
  new sha256: 3a609752cb332a0c14a34c428f52a9d5c5c5ec40b1f029752f5f50ef4a00d10e

  connect0_16.png
  size diff from: 662 to: 662
  old sha256: 38634d15b9a62cd77a6a37374c1af41308598482625788759826615ee42eafeb
  new sha256: 38634d15b9a62cd77a6a37374c1af41308598482625788759826615ee42eafeb

  tx_inout.png
  size diff from: 860 to: 860
  old sha256: e2734b8735a37ad36dbfbb7f43797a314df728df2423c8430961dbbfde2a6b7e
  new sha256: e2734b8735a37ad36dbfbb7f43797a314df728df2423c8430961dbbfde2a6b7e

  connect2_16.png
  size diff from: 450 to: 450
  old sha256: ddcf65ce1ff223d22ff54f05b9b990a8501760926356428d734d6123c22ff4b1
  new sha256: ddcf65ce1ff223d22ff54f05b9b990a8501760926356428d734d6123c22ff4b1

  clock4.png
  size diff from: 917 to: 917
  old sha256: 7064500b0527de2817549dc4b1c31b217e173b060c1c1509be652778f552393c
  new sha256: 7064500b0527de2817549dc4b1c31b217e173b060c1c1509be652778f552393c

  synced.png
  size diff from: 225 to: 225
  old sha256: 3ef55308a2ba4833378606b4a28a2718f8877ad216a14c8447698ec1c241b560
  new sha256: 3ef55308a2ba4833378606b4a28a2718f8877ad216a14c8447698ec1c241b560

  transaction0_dark.png
  size diff from: 193 to: 193
  old sha256: 90e88e625a2cfe3befdd2f72f30d29339706d6dfcfee663c36cec1ab228b956f
  new sha256: 90e88e625a2cfe3befdd2f72f30d29339706d6dfcfee663c36cec1ab228b956f

  filesave.png
  size diff from: 1294 to: 1294
  old sha256: b2fd9f7b20b536c07a85f0fb7902e39aa42de2a0f9b6c0985ff388bc826adf3e
  new sha256: b2fd9f7b20b536c07a85f0fb7902e39aa42de2a0f9b6c0985ff388bc826adf3e

  editcopy.png
  size diff from: 617 to: 617
  old sha256: d033ba7729f976dbd4feb5359b0b4caa0dc305e087485ace9a8f3d4bd9dec048
  new sha256: d033ba7729f976dbd4feb5359b0b4caa0dc305e087485ace9a8f3d4bd9dec048

  privacy.png
  size diff from: 19041 to: 19041
  old sha256: dcbefab6f87adacc90e95db50b7eebdc1f930b79fbd020e883cd4f2cf9fa6505
  new sha256: dcbefab6f87adacc90e95db50b7eebdc1f930b79fbd020e883cd4f2cf9fa6505

  eye_plus.png
  size diff from: 577 to: 577
  old sha256: ac81df7f76cf89c0c48e36344c238140ee242e545a0fe4943095a67700870efe
  new sha256: ac81df7f76cf89c0c48e36344c238140ee242e545a0fe4943095a67700870efe

  transaction0.png
  size diff from: 194 to: 194
  old sha256: 19340ede1ae82385b0aaf5c9c430aedf0484efbf3a93fb8c5bc5b565cdad4b32
  new sha256: 19340ede1ae82385b0aaf5c9c430aedf0484efbf3a93fb8c5bc5b565cdad4b32

  send_dark.png
  size diff from: 1808 to: 1808
  old sha256: ec9dbe34008dfea543ec3377c6201897932f0d36908e8228c3043c980cec6ba8
  new sha256: ec9dbe34008dfea543ec3377c6201897932f0d36908e8228c3043c980cec6ba8

  automint_inactive.png
  size diff from: 421 to: 421
  old sha256: 2c66146551984eace1775613257c86a8529feae8e90a2e0ce75649c9924a4ec5
  new sha256: 2c66146551984eace1775613257c86a8529feae8e90a2e0ce75649c9924a4ec5

  receive.png
  size diff from: 4731 to: 4731
  old sha256: 9811d572ecb528b9d15e1463647dbc559073c1a3b3355d36487e58a8898140a4
  new sha256: 9811d572ecb528b9d15e1463647dbc559073c1a3b3355d36487e58a8898140a4

  tx_input.png
  size diff from: 1132 to: 1132
  old sha256: c16f888d16549056280df8bb40923aac0e0f775678ca7961dbe349fffd7e3778
  new sha256: c16f888d16549056280df8bb40923aac0e0f775678ca7961dbe349fffd7e3778

  onion.png
  size diff from: 2526 to: 2526
  old sha256: 12b07a0961a6637927ba04783b6daee538255c1554e54fdffe203e3f96c164b0
  new sha256: 12b07a0961a6637927ba04783b6daee538255c1554e54fdffe203e3f96c164b0

  configure.png
  size diff from: 989 to: 989
  old sha256: fe810f2c745180b3f36ff945d843f55d5ab82578161d29939fc34fda6a3a6624
  new sha256: fe810f2c745180b3f36ff945d843f55d5ab82578161d29939fc34fda6a3a6624

  debugwindow.png
  size diff from: 4681 to: 4677
  old sha256: b109a3417b61dbce6d824f6515b90e2ebf6ebd82ef262fc360b6eccf793d9fc4
  new sha256: a8084b744e013e58cd5b3f9177d2134c8b446bdec097a184881db9c6abda7c19

  unit_tupivx.png
  size diff from: 364 to: 364
  old sha256: 132f1f33aa50b4f936e1459aa35beac0baba454de11e13ada1dedc1fc306df56
  new sha256: 132f1f33aa50b4f936e1459aa35beac0baba454de11e13ada1dedc1fc306df56

  transaction2.png
  size diff from: 274 to: 274
  old sha256: d11ca7a22d23713a1539ac21a5096b19d2f990cb04553ddb620bc8d86fc083b2
  new sha256: d11ca7a22d23713a1539ac21a5096b19d2f990cb04553ddb620bc8d86fc083b2

  send.png
  size diff from: 4743 to: 4743
  old sha256: 107f91d930a752fcafa7529dad122112d0889ffdc1dc615c9f4b0cb14791251a
  new sha256: 107f91d930a752fcafa7529dad122112d0889ffdc1dc615c9f4b0cb14791251a

  connect4_16.png
  size diff from: 990 to: 990
  old sha256: 4669d43b0617368b05fa191ad2e6d2ba22d2af9e5fbb9b2279f21e8c55ed2927
  new sha256: 4669d43b0617368b05fa191ad2e6d2ba22d2af9e5fbb9b2279f21e8c55ed2927

  address-book.png
  size diff from: 297 to: 297
  old sha256: 97345e7a9d735640860aba0f3af0fd9c25d1794db1953e9618fc34beaf8414c7
  new sha256: 97345e7a9d735640860aba0f3af0fd9c25d1794db1953e9618fc34beaf8414c7

  quit.png
  size diff from: 323 to: 323
  old sha256: 86501e9754a8f50ea7649e1feb756d2253c9bc5e6b0af2b1a4640e67d4ee710e
  new sha256: 86501e9754a8f50ea7649e1feb756d2253c9bc5e6b0af2b1a4640e67d4ee710e

  staking_active.png
  size diff from: 227 to: 227
  old sha256: 5fd4238ea519a6ab164873be8cc0effb5139c550d701b1e220c1b8d0f4c30f5a
  new sha256: 5fd4238ea519a6ab164873be8cc0effb5139c550d701b1e220c1b8d0f4c30f5a

  bittrex.png
  size diff from: 18057 to: 18057
  old sha256: ed5dc58b95a3c81ebd298f37fc842ecf6761a5a3c4f9f18005716b9bdc44b508
  new sha256: ed5dc58b95a3c81ebd298f37fc842ecf6761a5a3c4f9f18005716b9bdc44b508

  remove.png
  size diff from: 125 to: 125
  old sha256: 03dc2f0f12ffa9ecaec504b1ff8f29fac82ed615d432c01fb49b4a07079c3f2d
  new sha256: 03dc2f0f12ffa9ecaec504b1ff8f29fac82ed615d432c01fb49b4a07079c3f2d

  automint_active.png
  size diff from: 841 to: 841
  old sha256: 7bfc148dfc7404289e70e16dd0fa7a481da2aff19bf9c57c6c43d066f8c3c8d7
  new sha256: 7bfc148dfc7404289e70e16dd0fa7a481da2aff19bf9c57c6c43d066f8c3c8d7

  clock3.png
  size diff from: 921 to: 921
  old sha256: 4a30c7bc5be814ee8cd5511768fdee2c2572d0cb96245087fd3afaba1c712e61
  new sha256: 4a30c7bc5be814ee8cd5511768fdee2c2572d0cb96245087fd3afaba1c712e61

  connect1_16.png
  size diff from: 278 to: 278
  old sha256: 443dbb612cb838c62b62b2595d45efa6d17d3b7d3f87709b6cca8b2c1b46c332
  new sha256: 443dbb612cb838c62b62b2595d45efa6d17d3b7d3f87709b6cca8b2c1b46c332

  export.png
  size diff from: 2019 to: 2019
  old sha256: 5381d365bd47bf08bbb8467abb3619bcdbdc0ab1bc4b6d41b783b2f7d28cbe40
  new sha256: 5381d365bd47bf08bbb8467abb3619bcdbdc0ab1bc4b6d41b783b2f7d28cbe40

  qrcode.png
  size diff from: 183 to: 183
  old sha256: 792606de0bd0a7becbced04e150bd1e45bccd4409fa71dea4265b0161ebc43c5
  new sha256: 792606de0bd0a7becbced04e150bd1e45bccd4409fa71dea4265b0161ebc43c5

  history.png
  size diff from: 4733 to: 4733
  old sha256: d0dc99a5726c216e05a9f68881980437fbbaaf1eac416420f0808f34c3edcb66
  new sha256: d0dc99a5726c216e05a9f68881980437fbbaaf1eac416420f0808f34c3edcb66

  notsynced.png
  size diff from: 342 to: 342
  old sha256: 431b101d65063f2eddf5be51891afbf5a604ddfe17ac890e34b0b99888dac04f
  new sha256: 431b101d65063f2eddf5be51891afbf5a604ddfe17ac890e34b0b99888dac04f

  unit_pivx.png
  size diff from: 275 to: 275
  old sha256: 44bfb967f8049e8bcc1ad71173b77ca61c9dbca314717088a107477224812d03
  new sha256: 44bfb967f8049e8bcc1ad71173b77ca61c9dbca314717088a107477224812d03

  unit_upivx.png
  size diff from: 250 to: 250
  old sha256: 2f2d484e8539c69430fa343b7045fe5b19646d725869c25b00c2f804f7baca9b
  new sha256: 2f2d484e8539c69430fa343b7045fe5b19646d725869c25b00c2f804f7baca9b

  bitcoin64.png
  size diff from: 2538 to: 2538
  old sha256: 175ae7e2dbb04cb4d04e6c9a5a1f9d36ab89ba36bf065a1fdf344f858ac86293
  new sha256: 175ae7e2dbb04cb4d04e6c9a5a1f9d36ab89ba36bf065a1fdf344f858ac86293

  bitcoin128.png
  size diff from: 7704 to: 7704
  old sha256: a4d709bf774cd9eaa4e9280fb68e12d598d2b89108d09e10736b096a3b4a46c6
  new sha256: a4d709bf774cd9eaa4e9280fb68e12d598d2b89108d09e10736b096a3b4a46c6

  bitcoin16.png
  size diff from: 697 to: 697
  old sha256: 7dad72ea65b582a2fa54ed1b0f95e7e472ae213caf75cc3d5c9c382a75de8c15
  new sha256: 7dad72ea65b582a2fa54ed1b0f95e7e472ae213caf75cc3d5c9c382a75de8c15

  bitcoin256.png
  size diff from: 14562 to: 14562
  old sha256: 1e6fc0d9c152cb0e6ada9de3c06ed07248208af14e6074920b38b0771079b467
  new sha256: 1e6fc0d9c152cb0e6ada9de3c06ed07248208af14e6074920b38b0771079b467

  bitcoin32.png
  size diff from: 1572 to: 1572
  old sha256: 4046b969f3a028c317d20166757c37916eeb7255d7c8ba7d10228b491847125b
  new sha256: 4046b969f3a028c317d20166757c37916eeb7255d7c8ba7d10228b491847125b

  completed. Checksum stable: False. Total reduction: 4 bytes
  ```
- second run returns `Checksum stable: True`
```
$ contrib/devtools/optimize-pngs.py
optimizing spinner-025.png... done
optimizing spinner-005.png... done
optimizing spinner-020.png... done
optimizing spinner-034.png... done
optimizing spinner-018.png... done
optimizing spinner-033.png... done
optimizing spinner-000.png... done
optimizing spinner-023.png... done
optimizing spinner-014.png... done
optimizing spinner-028.png... done
optimizing spinner-002.png... done
optimizing spinner-026.png... done
optimizing spinner-031.png... done
optimizing spinner-027.png... done
optimizing spinner-008.png... done
optimizing spinner-001.png... done
optimizing spinner-022.png... done
optimizing spinner-015.png... done
optimizing spinner-012.png... done
optimizing spinner-032.png... done
optimizing spinner-017.png... done
optimizing spinner-013.png... done
optimizing spinner-007.png... done
optimizing spinner-021.png... done
optimizing spinner-019.png... done
optimizing spinner-011.png... done
optimizing spinner-030.png... done
optimizing spinner-003.png... done
optimizing spinner-016.png... done
optimizing spinner-010.png... done
optimizing spinner-029.png... done
optimizing spinner-006.png... done
optimizing spinner-004.png... done
optimizing spinner-024.png... done
optimizing spinner-009.png... done
optimizing eye.png... done
optimizing clock1.png... done
optimizing bitcoin_testnet.png... done
optimizing lock_open.png... done
optimizing add.png... done
optimizing overview.png... done
optimizing transaction_conflicted.png... done
optimizing import.png... done
optimizing tx_output.png... done
optimizing explorer.png... done
optimizing unit_tpivx.png... done
optimizing bitcoin.png... done
optimizing clock5.png... done
optimizing editpaste.png... done
optimizing receive_dark.png... done
optimizing unit_mpivx.png... done
optimizing staking_inactive.png... done
optimizing unit_tmpivx.png... done
optimizing clock2.png... done
optimizing lock_closed.png... done
optimizing connect3_16.png... done
optimizing masternodes.png... done
optimizing browse.png... done
optimizing eye_minus.png... done
optimizing edit.png... done
optimizing key.png... done
optimizing trade.png... done
optimizing tx_mined.png... done
optimizing connect0_16.png... done
optimizing tx_inout.png... done
optimizing connect2_16.png... done
optimizing clock4.png... done
optimizing synced.png... done
optimizing transaction0_dark.png... done
optimizing filesave.png... done
optimizing editcopy.png... done
optimizing privacy.png... done
optimizing eye_plus.png... done
optimizing transaction0.png... done
optimizing send_dark.png... done
optimizing automint_inactive.png... done
optimizing receive.png... done
optimizing tx_input.png... done
optimizing onion.png... done
optimizing configure.png... done
optimizing debugwindow.png... done
optimizing unit_tupivx.png... done
optimizing transaction2.png... done
optimizing send.png... done
optimizing connect4_16.png... done
optimizing address-book.png... done
optimizing quit.png... done
optimizing staking_active.png... done
optimizing bittrex.png... done
optimizing remove.png... done
optimizing automint_active.png... done
optimizing clock3.png... done
optimizing connect1_16.png... done
optimizing export.png... done
optimizing qrcode.png... done
optimizing history.png... done
optimizing notsynced.png... done
optimizing unit_pivx.png... done
optimizing unit_upivx.png... done
optimizing bitcoin64.png... done
optimizing bitcoin128.png... done
optimizing bitcoin16.png... done
optimizing bitcoin256.png... done
optimizing bitcoin32.png... done
summary:
+++++++++++++++++
spinner-025.png
  size diff from: 936 to: 936
  old sha256: ccf63ffb03a5d0b04defab040dece7a86d208b04c5b6343a65763bd5537b2808
  new sha256: ccf63ffb03a5d0b04defab040dece7a86d208b04c5b6343a65763bd5537b2808

spinner-005.png
  size diff from: 896 to: 896
  old sha256: a977cc8a854e07888dde172ea46334ed105e02efa17c814f8c6243210d6a534d
  new sha256: a977cc8a854e07888dde172ea46334ed105e02efa17c814f8c6243210d6a534d

spinner-020.png
  size diff from: 922 to: 922
  old sha256: 0f2a531c211dd9cd919439fb593472c072c3c98d6a6440bcc2c60c967e4b5c51
  new sha256: 0f2a531c211dd9cd919439fb593472c072c3c98d6a6440bcc2c60c967e4b5c51

spinner-034.png
  size diff from: 945 to: 945
  old sha256: d6d6cfd6b62439c520fc1f4ec341eafbdd40569d44361c0eac422f987b2864ab
  new sha256: d6d6cfd6b62439c520fc1f4ec341eafbdd40569d44361c0eac422f987b2864ab

spinner-018.png
  size diff from: 889 to: 889
  old sha256: 09ac672506ba35c64038d6ce13cca69f5e9d2082a766fa2e7519add3e293440f
  new sha256: 09ac672506ba35c64038d6ce13cca69f5e9d2082a766fa2e7519add3e293440f

spinner-033.png
  size diff from: 940 to: 940
  old sha256: ea3bea2832dde6b06aad384ca5a6e2b0c6e97ef800a2213018a4e0bab4f32fba
  new sha256: ea3bea2832dde6b06aad384ca5a6e2b0c6e97ef800a2213018a4e0bab4f32fba

spinner-000.png
  size diff from: 958 to: 958
  old sha256: f91376c5911c0682b9369132dccec1cc40873f82f25ca69516686edabc722ac9
  new sha256: f91376c5911c0682b9369132dccec1cc40873f82f25ca69516686edabc722ac9

spinner-023.png
  size diff from: 894 to: 894
  old sha256: dd7935e00e8eedfda7dafc3fb7310888915e31d06df97a7e756b1dff3ea2d8d9
  new sha256: dd7935e00e8eedfda7dafc3fb7310888915e31d06df97a7e756b1dff3ea2d8d9

spinner-014.png
  size diff from: 898 to: 898
  old sha256: e255a7942a601e24283991926d3fca83589f3a14b7f203091ea9bc8fc7da5d18
  new sha256: e255a7942a601e24283991926d3fca83589f3a14b7f203091ea9bc8fc7da5d18

spinner-028.png
  size diff from: 964 to: 964
  old sha256: 3a973c052e77afd8edf6c5b9db255f431fda25267d25e00f562c0e6a162556b2
  new sha256: 3a973c052e77afd8edf6c5b9db255f431fda25267d25e00f562c0e6a162556b2

spinner-002.png
  size diff from: 893 to: 893
  old sha256: b51f46e3b188aed1072b1b1742ed66c8a73c1f7ad259e925152367aee16cbfa5
  new sha256: b51f46e3b188aed1072b1b1742ed66c8a73c1f7ad259e925152367aee16cbfa5

spinner-026.png
  size diff from: 948 to: 948
  old sha256: ce7e3ed736590ddf5f305f0fb965080daa37d9da976d805f0cf2c2f4e250fe48
  new sha256: ce7e3ed736590ddf5f305f0fb965080daa37d9da976d805f0cf2c2f4e250fe48

spinner-031.png
  size diff from: 894 to: 894
  old sha256: 4f844f58cd3558b9e1bd71795881e224ed185dc838a36a5d6c6ffb0397081b56
  new sha256: 4f844f58cd3558b9e1bd71795881e224ed185dc838a36a5d6c6ffb0397081b56

spinner-027.png
  size diff from: 941 to: 941
  old sha256: 40f37fc5e81aca46dc1cc456488bde303c70cefc9fe32dd62999eef04c224cb3
  new sha256: 40f37fc5e81aca46dc1cc456488bde303c70cefc9fe32dd62999eef04c224cb3

spinner-008.png
  size diff from: 943 to: 943
  old sha256: d7a0ce3e0a2ab99a1aaf61a3b717086220719b127c72fbb7f8211f0672907e9e
  new sha256: d7a0ce3e0a2ab99a1aaf61a3b717086220719b127c72fbb7f8211f0672907e9e

spinner-001.png
  size diff from: 887 to: 887
  old sha256: fe083942ad75e7450dff923c55894cac662a8ad698b1bf57263b9223341f7735
  new sha256: fe083942ad75e7450dff923c55894cac662a8ad698b1bf57263b9223341f7735

spinner-022.png
  size diff from: 912 to: 912
  old sha256: 93d818c5f82e000c78bcaa3931679d1715af4dc2cbb133aa9061d73fa7c68d7d
  new sha256: 93d818c5f82e000c78bcaa3931679d1715af4dc2cbb133aa9061d73fa7c68d7d

spinner-015.png
  size diff from: 878 to: 878
  old sha256: f801e38b796b5684c230ff0ae905513acafca20e805d4d194ef4e8c820b5aed9
  new sha256: f801e38b796b5684c230ff0ae905513acafca20e805d4d194ef4e8c820b5aed9

spinner-012.png
  size diff from: 918 to: 918
  old sha256: bb073039eb2f04d70686a5b9e29e5b943ca5c500440d87ef6d89f21d90e5a4d6
  new sha256: bb073039eb2f04d70686a5b9e29e5b943ca5c500440d87ef6d89f21d90e5a4d6

spinner-032.png
  size diff from: 896 to: 896
  old sha256: 7ee64fb3b1991c3e3da1425b780d42608bb7304e9bed2f8dcee6ac9ee3dc95f8
  new sha256: 7ee64fb3b1991c3e3da1425b780d42608bb7304e9bed2f8dcee6ac9ee3dc95f8

spinner-017.png
  size diff from: 923 to: 923
  old sha256: 839b1e1b3ba046516ba0fc325d80978736a4a7f1bdd5f90fbcb2120bb7026a1f
  new sha256: 839b1e1b3ba046516ba0fc325d80978736a4a7f1bdd5f90fbcb2120bb7026a1f

spinner-013.png
  size diff from: 923 to: 923
  old sha256: 7f79d41ec8cf099954adaf5e2aa87cfa87f4b298f9ab64add48f6941002f267a
  new sha256: 7f79d41ec8cf099954adaf5e2aa87cfa87f4b298f9ab64add48f6941002f267a

spinner-007.png
  size diff from: 967 to: 967
  old sha256: 1f3fcb0a4e95d1088d805dd153a564d96b8c5e3a0985e36a06fceda00554a4b8
  new sha256: 1f3fcb0a4e95d1088d805dd153a564d96b8c5e3a0985e36a06fceda00554a4b8

spinner-021.png
  size diff from: 910 to: 910
  old sha256: beb85dccece4ea986d00836863814cc932e218f16ff6ad8b8d1b205309be6893
  new sha256: beb85dccece4ea986d00836863814cc932e218f16ff6ad8b8d1b205309be6893

spinner-019.png
  size diff from: 911 to: 911
  old sha256: b807ad24ab2cb929dbcc219c51f2e2fa9a2d8b85b4367a0a1a836f301ef8b929
  new sha256: b807ad24ab2cb929dbcc219c51f2e2fa9a2d8b85b4367a0a1a836f301ef8b929

spinner-011.png
  size diff from: 931 to: 931
  old sha256: 75743d6f259da588eaed999b0135195dad7901f6468e021f0f772d83a44cd5dc
  new sha256: 75743d6f259da588eaed999b0135195dad7901f6468e021f0f772d83a44cd5dc

spinner-030.png
  size diff from: 907 to: 907
  old sha256: d8a66bd3296e08befc671ff80bdb8eaeeeb56b81e002d4e5599b211d3f203074
  new sha256: d8a66bd3296e08befc671ff80bdb8eaeeeb56b81e002d4e5599b211d3f203074

spinner-003.png
  size diff from: 914 to: 914
  old sha256: cbe63d4046168ec65c72a72403880a963444085b948d3b73a5ac92de32f48ead
  new sha256: cbe63d4046168ec65c72a72403880a963444085b948d3b73a5ac92de32f48ead

spinner-016.png
  size diff from: 896 to: 896
  old sha256: e461ea5daf253ec469e3c2655cbf198a64d6a6e68bd54abb353da0b99e8365df
  new sha256: e461ea5daf253ec469e3c2655cbf198a64d6a6e68bd54abb353da0b99e8365df

spinner-010.png
  size diff from: 913 to: 913
  old sha256: 2fce585c31dde63d7e40f49981d70ff0f79245d5e6fc5aa27c6fb8fa6a5b0be0
  new sha256: 2fce585c31dde63d7e40f49981d70ff0f79245d5e6fc5aa27c6fb8fa6a5b0be0

spinner-029.png
  size diff from: 956 to: 956
  old sha256: 3ef33f73044a06b5fac11c203465e70c10ea640fce890afc0e0786c6eec320c1
  new sha256: 3ef33f73044a06b5fac11c203465e70c10ea640fce890afc0e0786c6eec320c1

spinner-006.png
  size diff from: 915 to: 915
  old sha256: c49a9bed654ac27d71a96aa4cba1a7c6135d460ce14d366cb93a8c9f70b1d755
  new sha256: c49a9bed654ac27d71a96aa4cba1a7c6135d460ce14d366cb93a8c9f70b1d755

spinner-004.png
  size diff from: 898 to: 898
  old sha256: 3d129bf55906f5e3abe9f5ccf08902f426cee798797211e09e4ace4a2a167342
  new sha256: 3d129bf55906f5e3abe9f5ccf08902f426cee798797211e09e4ace4a2a167342

spinner-024.png
  size diff from: 953 to: 953
  old sha256: 41e0fbb960ab7ad45189f4210f95460ccf39d1f5ca4b04057164603de4402a2d
  new sha256: 41e0fbb960ab7ad45189f4210f95460ccf39d1f5ca4b04057164603de4402a2d

spinner-009.png
  size diff from: 964 to: 964
  old sha256: 4f9cf63df66b654113a062bd03662c0f88d5dcead8dd8b8cff7c18a3e439386f
  new sha256: 4f9cf63df66b654113a062bd03662c0f88d5dcead8dd8b8cff7c18a3e439386f

eye.png
  size diff from: 433 to: 433
  old sha256: f9018dd14c1ca8a9a1f6a49747169e77b03d6fbcabcb9195aa7d7a9b7fb447c6
  new sha256: f9018dd14c1ca8a9a1f6a49747169e77b03d6fbcabcb9195aa7d7a9b7fb447c6

clock1.png
  size diff from: 911 to: 911
  old sha256: 34127e5e1fc7c632e67857144b98411f9a7d36319dbed83b323a9f874eb00436
  new sha256: 34127e5e1fc7c632e67857144b98411f9a7d36319dbed83b323a9f874eb00436

bitcoin_testnet.png
  size diff from: 14590 to: 14590
  old sha256: ca4389357a4028d485a7ef7c2c30d68666be75a8bfad7b87f3fbf8fa7e93baf6
  new sha256: ca4389357a4028d485a7ef7c2c30d68666be75a8bfad7b87f3fbf8fa7e93baf6

lock_open.png
  size diff from: 1017 to: 1017
  old sha256: 9a7edfcf06d9055bb5107322e3a14f5616ddfdc2b6f8f4f3fd839f84358a4974
  new sha256: 9a7edfcf06d9055bb5107322e3a14f5616ddfdc2b6f8f4f3fd839f84358a4974

add.png
  size diff from: 134 to: 134
  old sha256: ed58207b979dc68ddb16cb26613a1b63f411f055697155b7fa7e61d62abfab63
  new sha256: ed58207b979dc68ddb16cb26613a1b63f411f055697155b7fa7e61d62abfab63

overview.png
  size diff from: 6733 to: 6733
  old sha256: 68e0453745976bba873609c35d6d088285bd7524132e547476ba8d9e81c9243a
  new sha256: 68e0453745976bba873609c35d6d088285bd7524132e547476ba8d9e81c9243a

transaction_conflicted.png
  size diff from: 142 to: 142
  old sha256: 8a3c097b9f5a31051613e29893c61f7c0047e0e37037600e399e35ec14042170
  new sha256: 8a3c097b9f5a31051613e29893c61f7c0047e0e37037600e399e35ec14042170

import.png
  size diff from: 827 to: 827
  old sha256: de0f37b2ec4b75e1bef4e5cae03dbd835929d24358d14dc111c9945ad9f9446e
  new sha256: de0f37b2ec4b75e1bef4e5cae03dbd835929d24358d14dc111c9945ad9f9446e

tx_output.png
  size diff from: 1117 to: 1117
  old sha256: 1b6f3157818c80c2b5f06d93203aa0ea218ecb6beed740c71608ec522139122e
  new sha256: 1b6f3157818c80c2b5f06d93203aa0ea218ecb6beed740c71608ec522139122e

explorer.png
  size diff from: 2060 to: 2060
  old sha256: 2dd05d3952d8cf7e005685f47f78bd64a95babf7c3aff4fde4476d7ba90d2d1f
  new sha256: 2dd05d3952d8cf7e005685f47f78bd64a95babf7c3aff4fde4476d7ba90d2d1f

unit_tpivx.png
  size diff from: 338 to: 338
  old sha256: aef848c514df1e260e52e1dd380f7e07d7748e75a5f3e0fa796cffdea06850e0
  new sha256: aef848c514df1e260e52e1dd380f7e07d7748e75a5f3e0fa796cffdea06850e0

bitcoin.png
  size diff from: 14562 to: 14562
  old sha256: 1e6fc0d9c152cb0e6ada9de3c06ed07248208af14e6074920b38b0771079b467
  new sha256: 1e6fc0d9c152cb0e6ada9de3c06ed07248208af14e6074920b38b0771079b467

clock5.png
  size diff from: 929 to: 929
  old sha256: 32269ee1bb58dec936d3f6d0569d28a76d28e2cddf681df77e262349f8958d1f
  new sha256: 32269ee1bb58dec936d3f6d0569d28a76d28e2cddf681df77e262349f8958d1f

editpaste.png
  size diff from: 441 to: 441
  old sha256: ec7a88148dd051707cd40a2fbc1563daac7e633e4f88dc3d4d01be8d9b4777b8
  new sha256: ec7a88148dd051707cd40a2fbc1563daac7e633e4f88dc3d4d01be8d9b4777b8

receive_dark.png
  size diff from: 1774 to: 1774
  old sha256: de981cf9051b4ed4de303b830bf0622db17080c2cec2e0a6451d8dae41ffddec
  new sha256: de981cf9051b4ed4de303b830bf0622db17080c2cec2e0a6451d8dae41ffddec

unit_mpivx.png
  size diff from: 333 to: 333
  old sha256: 93abb9c386b0ef568f57d22604668b09d5f9b7e6bfe32fdfcc48a58e6787e98e
  new sha256: 93abb9c386b0ef568f57d22604668b09d5f9b7e6bfe32fdfcc48a58e6787e98e

staking_inactive.png
  size diff from: 227 to: 227
  old sha256: 783efc4d839522f04d551429161d3b2f1c49f1ff30602a65e5daef0495ab298c
  new sha256: 783efc4d839522f04d551429161d3b2f1c49f1ff30602a65e5daef0495ab298c

unit_tmpivx.png
  size diff from: 359 to: 359
  old sha256: f3ee1ff2c5f3efbd5671c2b0ccee687e7d5237075e48afddf9d228c6d38a165e
  new sha256: f3ee1ff2c5f3efbd5671c2b0ccee687e7d5237075e48afddf9d228c6d38a165e

clock2.png
  size diff from: 911 to: 911
  old sha256: af408ee745c9b049e59b898afe090c4b883efe823ac0261109fa5fddf9b8dc89
  new sha256: af408ee745c9b049e59b898afe090c4b883efe823ac0261109fa5fddf9b8dc89

lock_closed.png
  size diff from: 1423 to: 1423
  old sha256: afee9bf46a63bde058f6dcdbe8ff11936d5fe35550881994c73126fdb0f55bdd
  new sha256: afee9bf46a63bde058f6dcdbe8ff11936d5fe35550881994c73126fdb0f55bdd

connect3_16.png
  size diff from: 713 to: 713
  old sha256: f0da3d04ddafd82f40ba3109ba32e806c22075b6998d18f21c41fbabf24ea654
  new sha256: f0da3d04ddafd82f40ba3109ba32e806c22075b6998d18f21c41fbabf24ea654

masternodes.png
  size diff from: 3396 to: 3396
  old sha256: 3bd1b893bb9ee2b18dba08cd464ecb0734af89c610ab861b03aa19e35964a5ed
  new sha256: 3bd1b893bb9ee2b18dba08cd464ecb0734af89c610ab861b03aa19e35964a5ed

browse.png
  size diff from: 1294 to: 1294
  old sha256: b2fd9f7b20b536c07a85f0fb7902e39aa42de2a0f9b6c0985ff388bc826adf3e
  new sha256: b2fd9f7b20b536c07a85f0fb7902e39aa42de2a0f9b6c0985ff388bc826adf3e

eye_minus.png
  size diff from: 513 to: 513
  old sha256: 4cd807d710c96e0fbd1215220b2685384b077fb5c2fe214fd1bff33480732e97
  new sha256: 4cd807d710c96e0fbd1215220b2685384b077fb5c2fe214fd1bff33480732e97

edit.png
  size diff from: 1223 to: 1223
  old sha256: 2554eef2497cc54cb43a37aaf1aaba904fbb3b4c8cdc9a39ea9b7b76a5d23479
  new sha256: 2554eef2497cc54cb43a37aaf1aaba904fbb3b4c8cdc9a39ea9b7b76a5d23479

key.png
  size diff from: 267 to: 267
  old sha256: f0ca4ce57fa43d50ad305549dcd8e7f1e5087198d1048de2b66a21a30106c093
  new sha256: f0ca4ce57fa43d50ad305549dcd8e7f1e5087198d1048de2b66a21a30106c093

trade.png
  size diff from: 517 to: 517
  old sha256: 7d2cecf98bc740155a47de26f9b9f0d2b720c7bea0030a31543226807e7ae83b
  new sha256: 7d2cecf98bc740155a47de26f9b9f0d2b720c7bea0030a31543226807e7ae83b

tx_mined.png
  size diff from: 1231 to: 1231
  old sha256: 3a609752cb332a0c14a34c428f52a9d5c5c5ec40b1f029752f5f50ef4a00d10e
  new sha256: 3a609752cb332a0c14a34c428f52a9d5c5c5ec40b1f029752f5f50ef4a00d10e

connect0_16.png
  size diff from: 662 to: 662
  old sha256: 38634d15b9a62cd77a6a37374c1af41308598482625788759826615ee42eafeb
  new sha256: 38634d15b9a62cd77a6a37374c1af41308598482625788759826615ee42eafeb

tx_inout.png
  size diff from: 860 to: 860
  old sha256: e2734b8735a37ad36dbfbb7f43797a314df728df2423c8430961dbbfde2a6b7e
  new sha256: e2734b8735a37ad36dbfbb7f43797a314df728df2423c8430961dbbfde2a6b7e

connect2_16.png
  size diff from: 450 to: 450
  old sha256: ddcf65ce1ff223d22ff54f05b9b990a8501760926356428d734d6123c22ff4b1
  new sha256: ddcf65ce1ff223d22ff54f05b9b990a8501760926356428d734d6123c22ff4b1

clock4.png
  size diff from: 917 to: 917
  old sha256: 7064500b0527de2817549dc4b1c31b217e173b060c1c1509be652778f552393c
  new sha256: 7064500b0527de2817549dc4b1c31b217e173b060c1c1509be652778f552393c

synced.png
  size diff from: 225 to: 225
  old sha256: 3ef55308a2ba4833378606b4a28a2718f8877ad216a14c8447698ec1c241b560
  new sha256: 3ef55308a2ba4833378606b4a28a2718f8877ad216a14c8447698ec1c241b560

transaction0_dark.png
  size diff from: 193 to: 193
  old sha256: 90e88e625a2cfe3befdd2f72f30d29339706d6dfcfee663c36cec1ab228b956f
  new sha256: 90e88e625a2cfe3befdd2f72f30d29339706d6dfcfee663c36cec1ab228b956f

filesave.png
  size diff from: 1294 to: 1294
  old sha256: b2fd9f7b20b536c07a85f0fb7902e39aa42de2a0f9b6c0985ff388bc826adf3e
  new sha256: b2fd9f7b20b536c07a85f0fb7902e39aa42de2a0f9b6c0985ff388bc826adf3e

editcopy.png
  size diff from: 617 to: 617
  old sha256: d033ba7729f976dbd4feb5359b0b4caa0dc305e087485ace9a8f3d4bd9dec048
  new sha256: d033ba7729f976dbd4feb5359b0b4caa0dc305e087485ace9a8f3d4bd9dec048

privacy.png
  size diff from: 19041 to: 19041
  old sha256: dcbefab6f87adacc90e95db50b7eebdc1f930b79fbd020e883cd4f2cf9fa6505
  new sha256: dcbefab6f87adacc90e95db50b7eebdc1f930b79fbd020e883cd4f2cf9fa6505

eye_plus.png
  size diff from: 577 to: 577
  old sha256: ac81df7f76cf89c0c48e36344c238140ee242e545a0fe4943095a67700870efe
  new sha256: ac81df7f76cf89c0c48e36344c238140ee242e545a0fe4943095a67700870efe

transaction0.png
  size diff from: 194 to: 194
  old sha256: 19340ede1ae82385b0aaf5c9c430aedf0484efbf3a93fb8c5bc5b565cdad4b32
  new sha256: 19340ede1ae82385b0aaf5c9c430aedf0484efbf3a93fb8c5bc5b565cdad4b32

send_dark.png
  size diff from: 1808 to: 1808
  old sha256: ec9dbe34008dfea543ec3377c6201897932f0d36908e8228c3043c980cec6ba8
  new sha256: ec9dbe34008dfea543ec3377c6201897932f0d36908e8228c3043c980cec6ba8

automint_inactive.png
  size diff from: 421 to: 421
  old sha256: 2c66146551984eace1775613257c86a8529feae8e90a2e0ce75649c9924a4ec5
  new sha256: 2c66146551984eace1775613257c86a8529feae8e90a2e0ce75649c9924a4ec5

receive.png
  size diff from: 4731 to: 4731
  old sha256: 9811d572ecb528b9d15e1463647dbc559073c1a3b3355d36487e58a8898140a4
  new sha256: 9811d572ecb528b9d15e1463647dbc559073c1a3b3355d36487e58a8898140a4

tx_input.png
  size diff from: 1132 to: 1132
  old sha256: c16f888d16549056280df8bb40923aac0e0f775678ca7961dbe349fffd7e3778
  new sha256: c16f888d16549056280df8bb40923aac0e0f775678ca7961dbe349fffd7e3778

onion.png
  size diff from: 2526 to: 2526
  old sha256: 12b07a0961a6637927ba04783b6daee538255c1554e54fdffe203e3f96c164b0
  new sha256: 12b07a0961a6637927ba04783b6daee538255c1554e54fdffe203e3f96c164b0

configure.png
  size diff from: 989 to: 989
  old sha256: fe810f2c745180b3f36ff945d843f55d5ab82578161d29939fc34fda6a3a6624
  new sha256: fe810f2c745180b3f36ff945d843f55d5ab82578161d29939fc34fda6a3a6624

debugwindow.png
  size diff from: 4677 to: 4677
  old sha256: a8084b744e013e58cd5b3f9177d2134c8b446bdec097a184881db9c6abda7c19
  new sha256: a8084b744e013e58cd5b3f9177d2134c8b446bdec097a184881db9c6abda7c19

unit_tupivx.png
  size diff from: 364 to: 364
  old sha256: 132f1f33aa50b4f936e1459aa35beac0baba454de11e13ada1dedc1fc306df56
  new sha256: 132f1f33aa50b4f936e1459aa35beac0baba454de11e13ada1dedc1fc306df56

transaction2.png
  size diff from: 274 to: 274
  old sha256: d11ca7a22d23713a1539ac21a5096b19d2f990cb04553ddb620bc8d86fc083b2
  new sha256: d11ca7a22d23713a1539ac21a5096b19d2f990cb04553ddb620bc8d86fc083b2

send.png
  size diff from: 4743 to: 4743
  old sha256: 107f91d930a752fcafa7529dad122112d0889ffdc1dc615c9f4b0cb14791251a
  new sha256: 107f91d930a752fcafa7529dad122112d0889ffdc1dc615c9f4b0cb14791251a

connect4_16.png
  size diff from: 990 to: 990
  old sha256: 4669d43b0617368b05fa191ad2e6d2ba22d2af9e5fbb9b2279f21e8c55ed2927
  new sha256: 4669d43b0617368b05fa191ad2e6d2ba22d2af9e5fbb9b2279f21e8c55ed2927

address-book.png
  size diff from: 297 to: 297
  old sha256: 97345e7a9d735640860aba0f3af0fd9c25d1794db1953e9618fc34beaf8414c7
  new sha256: 97345e7a9d735640860aba0f3af0fd9c25d1794db1953e9618fc34beaf8414c7

quit.png
  size diff from: 323 to: 323
  old sha256: 86501e9754a8f50ea7649e1feb756d2253c9bc5e6b0af2b1a4640e67d4ee710e
  new sha256: 86501e9754a8f50ea7649e1feb756d2253c9bc5e6b0af2b1a4640e67d4ee710e

staking_active.png
  size diff from: 227 to: 227
  old sha256: 5fd4238ea519a6ab164873be8cc0effb5139c550d701b1e220c1b8d0f4c30f5a
  new sha256: 5fd4238ea519a6ab164873be8cc0effb5139c550d701b1e220c1b8d0f4c30f5a

bittrex.png
  size diff from: 18057 to: 18057
  old sha256: ed5dc58b95a3c81ebd298f37fc842ecf6761a5a3c4f9f18005716b9bdc44b508
  new sha256: ed5dc58b95a3c81ebd298f37fc842ecf6761a5a3c4f9f18005716b9bdc44b508

remove.png
  size diff from: 125 to: 125
  old sha256: 03dc2f0f12ffa9ecaec504b1ff8f29fac82ed615d432c01fb49b4a07079c3f2d
  new sha256: 03dc2f0f12ffa9ecaec504b1ff8f29fac82ed615d432c01fb49b4a07079c3f2d

automint_active.png
  size diff from: 841 to: 841
  old sha256: 7bfc148dfc7404289e70e16dd0fa7a481da2aff19bf9c57c6c43d066f8c3c8d7
  new sha256: 7bfc148dfc7404289e70e16dd0fa7a481da2aff19bf9c57c6c43d066f8c3c8d7

clock3.png
  size diff from: 921 to: 921
  old sha256: 4a30c7bc5be814ee8cd5511768fdee2c2572d0cb96245087fd3afaba1c712e61
  new sha256: 4a30c7bc5be814ee8cd5511768fdee2c2572d0cb96245087fd3afaba1c712e61

connect1_16.png
  size diff from: 278 to: 278
  old sha256: 443dbb612cb838c62b62b2595d45efa6d17d3b7d3f87709b6cca8b2c1b46c332
  new sha256: 443dbb612cb838c62b62b2595d45efa6d17d3b7d3f87709b6cca8b2c1b46c332

export.png
  size diff from: 2019 to: 2019
  old sha256: 5381d365bd47bf08bbb8467abb3619bcdbdc0ab1bc4b6d41b783b2f7d28cbe40
  new sha256: 5381d365bd47bf08bbb8467abb3619bcdbdc0ab1bc4b6d41b783b2f7d28cbe40

qrcode.png
  size diff from: 183 to: 183
  old sha256: 792606de0bd0a7becbced04e150bd1e45bccd4409fa71dea4265b0161ebc43c5
  new sha256: 792606de0bd0a7becbced04e150bd1e45bccd4409fa71dea4265b0161ebc43c5

history.png
  size diff from: 4733 to: 4733
  old sha256: d0dc99a5726c216e05a9f68881980437fbbaaf1eac416420f0808f34c3edcb66
  new sha256: d0dc99a5726c216e05a9f68881980437fbbaaf1eac416420f0808f34c3edcb66

notsynced.png
  size diff from: 342 to: 342
  old sha256: 431b101d65063f2eddf5be51891afbf5a604ddfe17ac890e34b0b99888dac04f
  new sha256: 431b101d65063f2eddf5be51891afbf5a604ddfe17ac890e34b0b99888dac04f

unit_pivx.png
  size diff from: 275 to: 275
  old sha256: 44bfb967f8049e8bcc1ad71173b77ca61c9dbca314717088a107477224812d03
  new sha256: 44bfb967f8049e8bcc1ad71173b77ca61c9dbca314717088a107477224812d03

unit_upivx.png
  size diff from: 250 to: 250
  old sha256: 2f2d484e8539c69430fa343b7045fe5b19646d725869c25b00c2f804f7baca9b
  new sha256: 2f2d484e8539c69430fa343b7045fe5b19646d725869c25b00c2f804f7baca9b

bitcoin64.png
  size diff from: 2538 to: 2538
  old sha256: 175ae7e2dbb04cb4d04e6c9a5a1f9d36ab89ba36bf065a1fdf344f858ac86293
  new sha256: 175ae7e2dbb04cb4d04e6c9a5a1f9d36ab89ba36bf065a1fdf344f858ac86293

bitcoin128.png
  size diff from: 7704 to: 7704
  old sha256: a4d709bf774cd9eaa4e9280fb68e12d598d2b89108d09e10736b096a3b4a46c6
  new sha256: a4d709bf774cd9eaa4e9280fb68e12d598d2b89108d09e10736b096a3b4a46c6

bitcoin16.png
  size diff from: 697 to: 697
  old sha256: 7dad72ea65b582a2fa54ed1b0f95e7e472ae213caf75cc3d5c9c382a75de8c15
  new sha256: 7dad72ea65b582a2fa54ed1b0f95e7e472ae213caf75cc3d5c9c382a75de8c15

bitcoin256.png
  size diff from: 14562 to: 14562
  old sha256: 1e6fc0d9c152cb0e6ada9de3c06ed07248208af14e6074920b38b0771079b467
  new sha256: 1e6fc0d9c152cb0e6ada9de3c06ed07248208af14e6074920b38b0771079b467

bitcoin32.png
  size diff from: 1572 to: 1572
  old sha256: 4046b969f3a028c317d20166757c37916eeb7255d7c8ba7d10228b491847125b
  new sha256: 4046b969f3a028c317d20166757c37916eeb7255d7c8ba7d10228b491847125b

completed. Checksum stable: True. Total reduction: 0 bytes
```