### PR TITLE
[Minting] Overmint error when rewards increase

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3066,9 +3066,9 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         nExpectedMint += nFees;
 
     //Check that the block does not overmint
-    if (!IsBlockValueValid(block, nExpectedMint, pindex->nMint)) {
+    if (!IsBlockValueValid(block, nExpectedMint, pindex->pprev->nMint)) {
         return state.DoS(100, error("ConnectBlock() : reward pays too much (actual=%s vs limit=%s)",
-                                    FormatMoney(pindex->nMint), FormatMoney(nExpectedMint)),
+                                    FormatMoney(pindex->pprev->nMint), FormatMoney(nExpectedMint)),
                          REJECT_INVALID, "bad-cb-amount");
     }
 


### PR DESCRIPTION
Checking expected vs actual mint for the block can stop the chain on a block where rewards increase. The expected value is less than the new value and the error "reward pays too much (actual=%s vs limit=%s)" is logged because it is comparing expected mint and actual mint of different blocks.