### PR TITLE
Minor typo fixes

### DIFF
--- a/src/qt/forms/privacydialog.ui
+++ b/src/qt/forms/privacydialog.ui
@@ -670,7 +670,7 @@
                          </font>
                         </property>
                         <property name="toolTip">
-                         <string>Status and/or Mesages from the last Mint Action.</string>
+                         <string>Status and/or Messages from the last Mint Action.</string>
                         </property>
                         <property name="frameShape">
                          <enum>QFrame::Panel</enum>

--- a/src/qt/locale/pivx_bg.ts
+++ b/src/qt/locale/pivx_bg.ts
@@ -2422,7 +2422,7 @@ To enable AutoMint change 'enablezeromint=0' to 'enablezeromint=1' in pivx.conf<
         <translation>Сканирай</translation>
     </message>
     <message>
-        <source>Status and/or Mesages from the last Mint Action.</source>
+        <source>Status and/or Messages from the last Mint Action.</source>
         <translation>Състояния и/или Съобщения от последните действия по сечене на монети.</translation>
     </message>
     <message>

--- a/src/qt/locale/pivx_da.ts
+++ b/src/qt/locale/pivx_da.ts
@@ -2433,7 +2433,7 @@ For at aktivere AutoMint-ændring 'enablezeromint = 0' til 'enablezeromint = 1' 
         <translation>ReScan</translation>
     </message>
     <message>
-        <source>Status and/or Mesages from the last Mint Action.</source>
+        <source>Status and/or Messages from the last Mint Action.</source>
         <translation>Status og / eller Beskeder fra sidste minuts handling.</translation>
     </message>
     <message>

--- a/src/qt/locale/pivx_de.ts
+++ b/src/qt/locale/pivx_de.ts
@@ -2425,7 +2425,7 @@ Um das automatische Prägen zu aktivieren ändere 'enablezeromint=0' zu 'enablez
         <translation>Erneut Scannen</translation>
     </message>
     <message>
-        <source>Status and/or Mesages from the last Mint Action.</source>
+        <source>Status and/or Messages from the last Mint Action.</source>
         <translation>Status und/oder Mitteilungen aus der letzten Prägung</translation>
     </message>
     <message>

--- a/src/qt/locale/pivx_en.ts
+++ b/src/qt/locale/pivx_en.ts
@@ -3141,7 +3141,7 @@ To enable AutoMint change &apos;enablezeromint=0&apos; to &apos;enablezeromint=1
     </message>
     <message>
         <location line="+27"/>
-        <source>Status and/or Mesages from the last Mint Action.</source>
+        <source>Status and/or Messages from the last Mint Action.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qt/locale/pivx_es.ts
+++ b/src/qt/locale/pivx_es.ts
@@ -2434,7 +2434,7 @@ Para habilitar AutoMint cambie 'enablezeromint = 0' a 'enablezeromint = 1' en pi
         <translation>ReeScanear</translation>
     </message>
     <message>
-        <source>Status and/or Mesages from the last Mint Action.</source>
+        <source>Status and/or Messages from the last Mint Action.</source>
         <translation>Estado y/o Mensajes de la última acción mint.</translation>
     </message>
     <message>

--- a/src/qt/locale/pivx_fr_FR.ts
+++ b/src/qt/locale/pivx_fr_FR.ts
@@ -2368,7 +2368,7 @@ Pour activer Auto-monnayage, changez 'enablezeromint = 0' en 'enablezeromint = 1
         <translation>ReScan</translation>
     </message>
     <message>
-        <source>Status and/or Mesages from the last Mint Action.</source>
+        <source>Status and/or Messages from the last Mint Action.</source>
         <translation>Statut et / ou messages de dernière action Monnayage.</translation>
     </message>
     <message>

--- a/src/qt/locale/pivx_hr_HR.ts
+++ b/src/qt/locale/pivx_hr_HR.ts
@@ -2434,7 +2434,7 @@ Da biste omogućili, promjenite postavke AutoMint 'enablezeromint=0' na 'enablez
         <translation>Ponovno pretraži</translation>
     </message>
     <message>
-        <source>Status and/or Mesages from the last Mint Action.</source>
+        <source>Status and/or Messages from the last Mint Action.</source>
         <translation>Status i/ili poruke od zadnje Mint akcije</translation>
     </message>
     <message>

--- a/src/qt/locale/pivx_ko_KR.ts
+++ b/src/qt/locale/pivx_ko_KR.ts
@@ -2433,7 +2433,7 @@ To enable AutoMint change 'enablezeromint=0' to 'enablezeromint=1' in pivx.conf<
         <translation>다시 스캔</translation>
     </message>
     <message>
-        <source>Status and/or Mesages from the last Mint Action.</source>
+        <source>Status and/or Messages from the last Mint Action.</source>
         <translation>마지막 발행 이후 상태나 메세지</translation>
     </message>
     <message>

--- a/src/qt/locale/pivx_nl.ts
+++ b/src/qt/locale/pivx_nl.ts
@@ -2434,7 +2434,7 @@ Om AutoMint in te schakelend verander je 'enablezeromint=0' naar 'enablezeromint
         <translation>ReScan</translation>
     </message>
     <message>
-        <source>Status and/or Mesages from the last Mint Action.</source>
+        <source>Status and/or Messages from the last Mint Action.</source>
         <translation>Status en/of Berichten van de laatste mint actie.</translation>
     </message>
     <message>

--- a/src/qt/locale/pivx_ru.ts
+++ b/src/qt/locale/pivx_ru.ts
@@ -2433,7 +2433,7 @@ To enable AutoMint change 'enablezeromint=0' to 'enablezeromint=1' in pivx.conf<
         <translation>Пересканирование</translation>
     </message>
     <message>
-        <source>Status and/or Mesages from the last Mint Action.</source>
+        <source>Status and/or Messages from the last Mint Action.</source>
         <translation>статус и / или сообщения от последней чеканки.</translation>
     </message>
     <message>

--- a/src/qt/locale/pivx_sv.ts
+++ b/src/qt/locale/pivx_sv.ts
@@ -2409,7 +2409,7 @@ För att aktivera AutoMint ändra 'enablezeromint=0' till 'enablezeromint=1' i p
         <translation>Skanna om</translation>
     </message>
     <message>
-        <source>Status and/or Mesages from the last Mint Action.</source>
+        <source>Status and/or Messages from the last Mint Action.</source>
         <translation>Status och/eller Meddelande från den senaste präglingen.</translation>
     </message>
     <message>

--- a/src/qt/locale/pivx_tr.ts
+++ b/src/qt/locale/pivx_tr.ts
@@ -2365,7 +2365,7 @@ To enable AutoMint change 'enablezeromint=0' to 'enablezeromint=1' in pivx.conf<
         <translation>ReScan</translation>
     </message>
     <message>
-        <source>Status and/or Mesages from the last Mint Action.</source>
+        <source>Status and/or Messages from the last Mint Action.</source>
         <translation>Son mint Eyleminden Durum ve / veya Mesajlar</translation>
     </message>
     <message>

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin developers
 // Copyright (c) 2014-2015 The Dash developers
-// Copyright (c) 2015-2018 The PIVX developers
+// Copyright (c) 2015-2019 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -2106,9 +2106,9 @@ UniValue settxfee(const UniValue& params, bool fHelp)
 
     // Amount
     CAmount nAmount = 0;
-    if (params[0].get_real() != 0.0)
+    if (params[0].get_real() != 0.0) {
         nAmount = AmountFromValue(params[0]); // rejects 0.0 amounts
-
+    } else throw runtime_error("Invalid Parameter. The TX Fee must be a value larger than 0");
     payTxFee = CFeeRate(nAmount, 1000);
     return true;
 }

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -227,7 +227,7 @@ public:
     void InitAutoConvertAddresses();
 
 
-    /** Zerocin entry changed.
+    /** Zerocoin entry changed.
     * @note called with lock cs_wallet held.
     */
     boost::signals2::signal<void(CWallet* wallet, const std::string& pubCoin, const std::string& isUsed, ChangeType status)> NotifyZerocoinChanged;


### PR DESCRIPTION
"Mesages" --> "Messages" (Zerocoin console tooltip)
"Zerocin" --> "Zerocoin" (Code comment)