### PR TITLE
[Wallet] Remove stale wallet transactions on initial load.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1982,7 +1982,7 @@ bool AppInit2()
 #ifdef ENABLE_WALLET
     if (pwalletMain) {
         // Add wallet transactions that aren't already in a block to mapTransactions
-        pwalletMain->ReacceptWalletTransactions();
+        pwalletMain->ReacceptWalletTransactions(/*fFirstLoad*/true);
 
         // Run a thread to flush wallet periodically
         threadGroup.create_thread(boost::bind(&ThreadFlushWalletDB, boost::ref(pwalletMain->strWalletFile)));

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -474,7 +474,7 @@ public:
     bool AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pblock, bool fUpdate);
     void EraseFromWallet(const uint256& hash);
     int ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false);
-    void ReacceptWalletTransactions();
+    void ReacceptWalletTransactions(bool fFirstLoad = false);
     void ResendWalletTransactions();
     CAmount GetBalance() const;
     CAmount GetZerocoinBalance(bool fMatureOnly) const;


### PR DESCRIPTION
On first load, remove stale transactions from wallet that fail to be added to mempool.

Recommend also cherry-picking https://github.com/bitcoin/bitcoin/commit/fd4bd5009eed5235c9afb6dc2e7e095a8bdd8c0b and replacing `EraseFromWallet` with abandoning of the wtx.