### PR TITLE
[Qt] Fix a windows only crash when r-clicking a proposal

### DIFF
--- a/src/qt/proposalframe.cpp
+++ b/src/qt/proposalframe.cpp
@@ -17,6 +17,7 @@
 #include <QClipboard>
 #include <QUrl>
 #include <QSpacerItem>
+#include <QMouseEvent>
 
 ProposalFrame::ProposalFrame(QWidget* parent) : QFrame(parent)
 {
@@ -214,6 +215,8 @@ void ProposalFrame::close()
 void ProposalFrame::mouseReleaseEvent(QMouseEvent* event)
 {
     if (!governancePage) //TODO implement an error
+        return;
+    if (event->button() == Qt::RightButton)
         return;
     extended = !extended;
     if (extended)


### PR DESCRIPTION
The problem seems to be related to a stack corruption issue occuring within Qt and only for windows builds. Further investigation is required but this is a suitable fix for now and there is no need to have the r-click doing the same job as the l-click in this situation.
Fix #823.
Thanks to @CryptoDev-Project for report and suggested fix.