### PR TITLE
[GMP] getuint256 crash fix.

### DIFF
--- a/src/libzerocoin/bignum.h
+++ b/src/libzerocoin/bignum.h
@@ -837,9 +837,20 @@ public:
 
     uint256 getuint256() const
     {
-        uint256 n = 0;
-        mpz_export((unsigned char*)&n, NULL, -1, 1, 0, 0, bn);
-        return n;
+        size_t size = (mpz_sizeinbase (bn, 2) + CHAR_BIT-1) / CHAR_BIT;
+        // This is just a fall back for invalid numbers, it will only take the last 256 bits as openssl implementation does.
+        if(size > 32){
+            std::vector<unsigned char> vch(size);
+            mpz_export(&vch[0], NULL, -1, 1, 0, 0, bn);
+            uint256 n = 0;
+            for (unsigned int i = 0, j = 0; i < sizeof(n); i++, j++)
+                ((unsigned char*)&n)[i] = vch[j];
+            return n;
+        }else{
+            uint256 n = 0;
+            mpz_export((unsigned char*)&n, NULL, -1, 1, 0, 0, bn);
+            return n;
+        }
     }
 
     void setvch(const std::vector<unsigned char>& vch)

--- a/src/libzerocoin/bignum.h
+++ b/src/libzerocoin/bignum.h
@@ -838,19 +838,19 @@ public:
     uint256 getuint256() const
     {
         size_t size = (mpz_sizeinbase (bn, 2) + CHAR_BIT-1) / CHAR_BIT;
+        uint256 n = uint256();
         // This is just a fall back for invalid numbers, it will only take the last 256 bits as openssl implementation does.
-        if(size > 32){
+        if(size > 32)
+        {
             std::vector<unsigned char> vch(size);
             mpz_export(&vch[0], NULL, -1, 1, 0, 0, bn);
-            uint256 n = 0;
             for (unsigned int i = 0, j = 0; i < sizeof(n); i++, j++)
                 ((unsigned char*)&n)[i] = vch[j];
-            return n;
-        }else{
-            uint256 n = 0;
+        } else
+        {
             mpz_export((unsigned char*)&n, NULL, -1, 1, 0, 0, bn);
-            return n;
         }
+        return n;
     }
 
     void setvch(const std::vector<unsigned char>& vch)


### PR DESCRIPTION
Contains part of the complete mitigation for the underling issue on #828.

Illegal allocation of long serials crashes the node using gmp, openssl implementation only takes last 256 bits of those. This PR equalize getuint256 method behavior for those specific scenarios. 

The chain will sync fine with gmp or openssl indifferently with this.