### PR TITLE
[QT] Add label to show when zPIV is in maintenance

### DIFF
--- a/src/qt/forms/privacydialog.ui
+++ b/src/qt/forms/privacydialog.ui
@@ -73,7 +73,39 @@
              <string>PRIVACY</string>
             </property>
            </widget>
+    
           </item>
+          <item>
+      <widget class="QLabel" name="labelOverviewInMaintainence">
+            <property name="minimumSize">
+             <size>
+              <width>464</width>
+              <height>60</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>60</height>
+             </size>
+            </property>
+            <property name="font">
+             <font >
+              <pointsize>15</pointsize>
+              <weight>75</weight>
+              <bold>false</bold>
+        
+             </font>
+
+            </property>
+              <property name="styleSheet">
+                           <string notr="true">QLabel { color: #00a9ff; }</string>
+                          </property>
+            <property name="text">
+             <string>Info:zPIV is currently undergoing maintenance.</string>
+            </property>
+           </widget>
+           </item>
           <item>
            <spacer name="horizontalSpacer_1">
             <property name="orientation">

--- a/src/qt/forms/privacydialog.ui
+++ b/src/qt/forms/privacydialog.ui
@@ -73,7 +73,6 @@
              <string>PRIVACY</string>
             </property>
            </widget>
-    
           </item>
           <item>
       <widget class="QLabel" name="labelOverviewInMaintainence">

--- a/src/qt/privacydialog.cpp
+++ b/src/qt/privacydialog.cpp
@@ -59,6 +59,12 @@ PrivacyDialog::PrivacyDialog(QWidget* parent) : QDialog(parent, Qt::WindowSystem
     connect(clipboardAmountAction, SIGNAL(triggered()), this, SLOT(coinControlClipboardAmount()));
     ui->labelCoinControlQuantity->addAction(clipboardQuantityAction);
     ui->labelCoinControlAmount->addAction(clipboardAmountAction);
+    
+    //zPIV Maintainence Dialog
+    ui->labelOverviewInMaintainence->setVisible(false);
+    if(GetAdjustedTime() > GetSporkValue(SPORK_16_ZEROCOIN_MAINTENANCE_MODE)) {
+    ui->labelOverviewInMaintainence->setVisible(true);
+    }
 
     // Denomination labels
     ui->labelzDenom1Text->setText(tr("Denom. with value <b>1</b>:"));
@@ -141,6 +147,7 @@ void PrivacyDialog::setModel(WalletModel* walletModel)
         connect(walletModel->getOptionsModel(), SIGNAL(zeromintEnableChanged(bool)), this, SLOT(updateAutomintStatus()));
         connect(walletModel->getOptionsModel(), SIGNAL(zeromintPercentageChanged(int)), this, SLOT(updateAutomintStatus()));
         ui->securityLevel->setValue(nSecurityLevel);
+    
     }
 }
 


### PR DESCRIPTION
This PR adds a new widget to the titlebar,to show when zPIV is undergoing maintenance

This is the preview for the ui addition
<img width="956" alt="Screen Shot 2019-03-09 at 8 20 24 PM" src="https://user-images.githubusercontent.com/25401217/54074853-ce06c580-42a8-11e9-91a3-14c3adab7691.png">
