### PR TITLE
[Refactor] Replace deprecated auto_ptr with unique_ptr

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -154,7 +154,7 @@ UniValue generate(const UniValue& params, bool fHelp)
     while (nHeight < nHeightEnd)
     {
 
-        auto_ptr<CBlockTemplate> pblocktemplate(CreateNewBlockWithKey(reservekey, pwalletMain, fPoS));
+        unique_ptr<CBlockTemplate> pblocktemplate(CreateNewBlockWithKey(reservekey, pwalletMain, fPoS));
         if (!pblocktemplate.get())
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");
         CBlock *pblock = &pblocktemplate->block;


### PR DESCRIPTION
fixes warning during compilation:
`warning: ‘template<class> class std::auto_ptr’ is deprecated`