### PR TITLE
[Cleanup] Fix redundant redeclaration of boost's to_internal

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -88,19 +88,6 @@
 #include <openssl/crypto.h>
 #include <openssl/rand.h>
 
-// Work around clang compilation problem in Boost 1.46:
-// /usr/include/boost/program_options/detail/config_file.hpp:163:17: error: call to function 'to_internal' that is neither visible in the template definition nor found by argument-dependent lookup
-// See also: http://stackoverflow.com/questions/10020179/compilation-fail-in-boost-librairies-program-options
-//           http://clang.debian.net/status.php?version=3.0&key=CANNOT_FIND_FUNCTION
-namespace boost
-{
-namespace program_options
-{
-std::string to_internal(const std::string&);
-}
-
-} // namespace boost
-
 using namespace std;
 
 // PIVX only features


### PR DESCRIPTION
fixes warning during compilation:
```
util.cpp:100:13: warning: redundant redeclaration of ‘std::__cxx11::string boost::program_options::to_internal(const string&)’ in same scope [-Wredundant-decls]
 std::string to_internal(const std::string&);
             ^~~~~~~~~~~
In file included from /usr/include/boost/program_options/detail/config_file.hpp:20:0,
                 from util.cpp:85:
/usr/include/boost/program_options/detail/convert.hpp:70:48: note: previous declaration of ‘std::__cxx11::string boost::program_options::to_internal(const string&)’
         BOOST_PROGRAM_OPTIONS_DECL std::string to_internal(const std::string&);
                                                ^~~~~~~~~~~
```