### PR TITLE
Fix leveldb - comparison between signed and unsigned integer expressions

### DIFF
--- a/src/leveldb/util/logging.cc
+++ b/src/leveldb/util/logging.cc
@@ -52,7 +52,7 @@ bool ConsumeDecimalNumber(Slice* in, uint64_t* val) {
     unsigned char c = (*in)[0];
     if (c >= '0' && c <= '9') {
       ++digits;
-      const int delta = (c - '0');
+      const unsigned delta = (c - '0');
       static const uint64_t kMaxUint64 = ~static_cast<uint64_t>(0);
       if (v > kMaxUint64/10 ||
           (v == kMaxUint64/10 && delta > kMaxUint64%10)) {


### PR DESCRIPTION
fixes warning:
```
leveldb/util/logging.cc: In function ‘bool leveldb::ConsumeDecimalNumber(leveldb::Slice*, uint64_t*)’:
leveldb/util/logging.cc:58:40: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
           (v == kMaxUint64/10 && delta > kMaxUint64%10)) {
                                  ~~~~~~^~~~~~~~~~~~~~~
```

> The important difference between signed and unsigned ints is the interpretation of the last bit. The last bit in signed types represent the sign of the number, meaning: e.g:
> 
> 0001 is 1 signed and unsigned 1001 is -1 signed and 9 unsigned
> 
> It makes a difference to know if you compare with -1 or with +9.
> In many cases, programmers are just too lazy to declare counting ints
> as unsigned (bloating the for loop head f.i.) It is usually not an issue
> because with ints you have to count to 2^31 until your sign bit bites you.
> That's why it is only a warning. Because we are too lazy to write
> 'unsigned' instead of 'int'.

ref: https://stackoverflow.com/a/3661113

thanks to AndreasT