### PR TITLE
Fix to display missing clock5.png tx image

### DIFF
--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -493,7 +493,7 @@ QVariant TransactionTableModel::txStatusDecoration(const TransactionRecord* wtx)
         return QIcon(":/icons/transaction_conflicted");
     case TransactionStatus::Immature: {
         int total = wtx->status.depth + wtx->status.matures_in;
-        int part = (wtx->status.depth * 4 / total) + 1;
+        int part = (wtx->status.depth * 5 / total) + 1;
         return QIcon(QString(":/icons/transaction_%1").arg(part));
     }
     case TransactionStatus::MaturesWarning:


### PR DESCRIPTION
Feel free to ignore this PR if clock5.png is purposely not displayed in the transactions tab for some reason. Looking back through the code changes over time I see that clock5 has never been displayed properly, but yet it is still included in the newest source. My suggestion is to either use this fix to display the proper clock image for immature txs or else simply remove clock5.png from the source to prevent further confusion