### PR TITLE
Adds message when setting 0 txfee

### DIFF
--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -2106,9 +2106,9 @@ UniValue settxfee(const UniValue& params, bool fHelp)
 
     // Amount
     CAmount nAmount = 0;
-    if (params[0].get_real() != 0.0)
+    if (params[0].get_real() != 0.0) {
         nAmount = AmountFromValue(params[0]); // rejects 0.0 amounts
-
+    } else throw runtime_error("0 fees are sometimes possible but not guaranteed. You may pay a fee.");
     payTxFee = CFeeRate(nAmount, 1000);
     return true;
 }


### PR DESCRIPTION
Adds informative message when setting txfee to 0 in RPC console.

Ref Warrows comment in issue #796 

> So that's where there is space for improvement. But I think a simple message saying that "0 fees are not always possible and the wallet will do its best to achieve it" is the way to go here.
