### PR TITLE
[QT] Fix a display bug about zPIV mints

### DIFF
--- a/src/qt/zpivcontroldialog.cpp
+++ b/src/qt/zpivcontroldialog.cpp
@@ -140,6 +140,8 @@ void ZPivControlDialog::updateList()
             string strReason = "";
             if(nConfirmations < Params().Zerocoin_MintRequiredConfirmations())
                 strReason = strprintf("Needs %d more confirmations", Params().Zerocoin_MintRequiredConfirmations() - nConfirmations);
+            else if (model->getEncryptionStatus() == WalletModel::EncryptionStatus::Locked)
+                strReason = "Your wallet is locked. Impossible to precompute or spend zPIV.";
             else if (!mint.isSeedCorrect)
                 strReason = "The zPIV seed used to mint this zPIV is not the same as currently hold in the wallet";
             else


### PR DESCRIPTION
When opening the zPIV coin selection in privacy tab, if the wallet is
locked the message for all mints is that the seed is wrong. This commit
fixes it by replacing the message and stating that the locked wallet
prevents precomputation and spending.
Fix #851