### PR TITLE
[Build] [macOS] Fix macOS dmg issue (10.12+)

### DIFF
--- a/contrib/macdeploy/custom_dsstore.py
+++ b/contrib/macdeploy/custom_dsstore.py
@@ -13,7 +13,7 @@ package_name_ns = sys.argv[2]
 ds = DSStore.open(output_file, 'w+')
 ds['.']['bwsp'] = {
     'ShowStatusBar': False,
-    'WindowBounds': b'{{300, 280}, {500, 343}}',
+    'WindowBounds': '{{300, 280}, {500, 343}}',
     'ContainerShowSidebar': False,
     'SidebarWidth': 0,
     'ShowTabView': False,


### PR DESCRIPTION
macOS versions 10.12 and above have a problem reading the WindowBounds object in the custom `.DS_Store` when it is a byte object. This fixes the issue by changing the WindowBounds object to a string.

Fixes #857 