### PR TITLE
[RPC] [Wallet] AutoCombineRewards fixes and Improvements

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -128,6 +128,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
         {"setstakesplitthreshold", 0},
         {"autocombinerewards", 0},
         {"autocombinerewards", 1},
+        {"autocombinerewards", 2},
         {"getzerocoinbalance", 0},
         {"listmintedzerocoins", 0},
         {"listmintedzerocoins", 1},

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -418,6 +418,7 @@ static const CRPCCommand vRPCCommands[] =
         {"wallet", "getreceivedbyaddress", &getreceivedbyaddress, false, false, true},
         {"wallet", "getstakingstatus", &getstakingstatus, false, false, true},
         {"wallet", "getstakesplitthreshold", &getstakesplitthreshold, false, false, true},
+        {"wallet", "getautocombineinfo", &getautocombineinfo, false, false, true},
         {"wallet", "gettransaction", &gettransaction, false, false, true},
         {"wallet", "getunconfirmedbalance", &getunconfirmedbalance, false, false, true},
         {"wallet", "getwalletinfo", &getwalletinfo, false, false, true},

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -249,6 +249,7 @@ extern UniValue reservebalance(const UniValue& params, bool fHelp);
 extern UniValue setstakesplitthreshold(const UniValue& params, bool fHelp);
 extern UniValue getstakesplitthreshold(const UniValue& params, bool fHelp);
 extern UniValue multisend(const UniValue& params, bool fHelp);
+extern UniValue getautocombineinfo(const UniValue& params, bool fHelp);
 extern UniValue autocombinerewards(const UniValue& params, bool fHelp);
 extern UniValue getzerocoinbalance(const UniValue& params, bool fHelp);
 extern UniValue listmintedzerocoins(const UniValue& params, bool fHelp);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2279,7 +2279,7 @@ UniValue getautocombineinfo(const UniValue& params, bool fHelp)
     if (pwalletMain->fCombineDust) {
         obj.push_back(Pair("threshold",
                            int(pwalletMain->nAutoCombineThreshold)));
-        if (0 == pwalletMain->nAutoCombineBlockFrequency) {
+        if (pwalletMain->nAutoCombineBlockFrequency == 0) {
             obj.push_back(Pair("frequency", "nextblock"));
         } else {
             obj.push_back(Pair("frequency",
@@ -2287,7 +2287,7 @@ UniValue getautocombineinfo(const UniValue& params, bool fHelp)
         }
     }
     else {
-        if (0 == pwalletMain->nAutoCombineBlockFrequency) {
+        if (pwalletMain->nAutoCombineBlockFrequency == 0) {
             obj.push_back(Pair("threshold", int(pwalletMain->nAutoCombineThreshold)));
             obj.push_back(Pair("frequency", "startup"));
         }
@@ -2310,7 +2310,9 @@ UniValue autocombinerewards(const UniValue& params, bool fHelp)
             "autocombinerewards enable ( threshold ) ( frequency )\n"
             "\nWallet will automatically monitor for UTXOs with values below the threshold amount, "
             "and combine them into transactions sized to the threshold amount, if they reside with "
-            "the same UCC address.\n"
+            "the same PIVX address.\n"
+            "\nA threshold value of \"0\" will combine all the UTXOs, up to the maximum possible "
+            "within the maximum transaction size of a block.\n"
             "\nA frequency value of \"0\" will run the combine once, on the next available block, "
             "and once again on each wallet startup.\n"
             "\nWhen autocombinerewards runs it will create a transaction, and therefore will be subject "
@@ -2354,7 +2356,7 @@ UniValue autocombinerewards(const UniValue& params, bool fHelp)
     obj.push_back(Pair("enabled", pwalletMain->fCombineDust ? "on" : "off"));
     if (pwalletMain->fCombineDust) {
         obj.push_back(Pair("threshold", int(pwalletMain->nAutoCombineThreshold)));
-        if (0 == pwalletMain->nAutoCombineBlockFrequency) {
+        if (pwalletMain->nAutoCombineBlockFrequency == 0) {
             obj.push_back(Pair("frequency", "nextblock"));
         } else {
             obj.push_back(Pair("frequency", int(pwalletMain->nAutoCombineBlockFrequency)));

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2262,38 +2262,106 @@ UniValue getstakesplitthreshold(const UniValue& params, bool fHelp)
     return int(pwalletMain->nStakeSplitThreshold);
 }
 
+UniValue getautocombineinfo(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() != 0)
+        throw runtime_error(
+            "getautocombineinfo\n"
+            "Returns the autocombinerewards settings\n"
+            "\nResult:\n"
+            "1. enabled   (string) The feature turned \"on\" or \"off\".\n"
+            "2. threshold (numeric) If enabled on, returns autocombine threshold.\n"
+            "3. frequency (variable) If enabled, returns frequency in blocks, or \"nextblock\" if one time. "
+                                    "If one time already run, \"startup\" is returned\n");
+
+    UniValue obj(UniValue::VOBJ);
+    obj.push_back(Pair("enabled", pwalletMain->fCombineDust ? "on" : "off"));
+    if (pwalletMain->fCombineDust) {
+        obj.push_back(Pair("threshold",
+                           int(pwalletMain->nAutoCombineThreshold)));
+        if (0 == pwalletMain->nAutoCombineBlockFrequency) {
+            obj.push_back(Pair("frequency", "nextblock"));
+        } else {
+            obj.push_back(Pair("frequency",
+                           int(pwalletMain->nAutoCombineBlockFrequency)));
+        }
+    }
+    else {
+        if (0 == pwalletMain->nAutoCombineBlockFrequency) {
+            obj.push_back(Pair("threshold", int(pwalletMain->nAutoCombineThreshold)));
+            obj.push_back(Pair("frequency", "startup"));
+        }
+    }
+
+    return obj;
+}
+
 UniValue autocombinerewards(const UniValue& params, bool fHelp)
 {
-    bool fEnable;
-    if (params.size() >= 1)
-        fEnable = params[0].get_bool();
+    string strCommand;
+    bool fEnable = false;
 
-    if (fHelp || params.size() < 1 || (fEnable && params.size() != 2) || params.size() > 2)
+    if (params.size() >= 1) {
+        fEnable = params[0].get_bool();
+    }
+
+    if (fHelp || params.size() < 1 || (fEnable && params.size() < 2) || params.size() > 3)
         throw runtime_error(
-            "autocombinerewards enable ( threshold )\n"
-            "\nWallet will automatically monitor for any coins with value below the threshold amount, and combine them if they reside with the same PIVX address\n"
-            "When autocombinerewards runs it will create a transaction, and therefore will be subject to transaction fees.\n"
+            "autocombinerewards enable ( threshold ) ( frequency )\n"
+            "\nWallet will automatically monitor for UTXOs with values below the threshold amount, "
+            "and combine them into transactions sized to the threshold amount, if they reside with "
+            "the same UCC address.\n"
+            "\nA frequency value of \"0\" will run the combine once, on the next available block, "
+            "and once again on each wallet startup.\n"
+            "\nWhen autocombinerewards runs it will create a transaction, and therefore will be subject "
+            "to transaction fees.  Transactions will be limited to a full combine of the threshold "
+            "amount unless the transaction fees are zero.\n"
 
             "\nArguments:\n"
-            "1. enable          (boolean, required) Enable auto combine (true) or disable (false)\n"
-            "2. threshold       (numeric, optional) Threshold amount (default: 0)\n"
+            "1. enable    (boolean, required) Enable auto combine (true) or disable (false).\n"
+            "2. threshold (numeric, optional) (required for enable) target total PIV to combine into one UTXO.\n"
+            "3. frequency (numeric, optional) Frequency (in blocks) for autocombine to run (default: 15)\n"
+
+            "\nResult:\n"
+            "1. enabled   (string) The feature turned \"on\" or \"off\".\n"
+            "2. threshold (numeric) If enabled on, returns autocombine threshold.\n"
+            "3. frequency (variable) If enabled, returns frequency in blocks, or \"nextblock\" if one time.\n"
 
             "\nExamples:\n" +
-            HelpExampleCli("autocombinerewards", "true 500") + HelpExampleRpc("autocombinerewards", "true 500"));
+            HelpExampleCli("autocombinerewards", "true 500 15") + HelpExampleRpc("autocombinerewards", "true 500 15"));
 
     CWalletDB walletdb(pwalletMain->strWalletFile);
     CAmount nThreshold = 0;
+    int nBlockFrequency = 15;
 
-    if (fEnable)
+    if (fEnable) {
         nThreshold = params[1].get_int();
+        if (params.size() > 2) {
+            nBlockFrequency = params[2].get_int();
+            if (nBlockFrequency < 0)
+                nBlockFrequency = 1;
+        }
+    }
 
     pwalletMain->fCombineDust = fEnable;
     pwalletMain->nAutoCombineThreshold = nThreshold;
+    pwalletMain->nAutoCombineBlockFrequency = nBlockFrequency;
 
-    if (!walletdb.WriteAutoCombineSettings(fEnable, nThreshold))
+    if (!walletdb.WriteAutoCombineSettings(fEnable, nThreshold, nBlockFrequency))
         throw runtime_error("Changed settings in wallet but failed to save to database\n");
 
-    return NullUniValue;
+    UniValue obj(UniValue::VOBJ);
+    obj.push_back(Pair("enabled", pwalletMain->fCombineDust ? "on" : "off"));
+    if (pwalletMain->fCombineDust) {
+        obj.push_back(Pair("threshold", int(pwalletMain->nAutoCombineThreshold)));
+        if (0 == pwalletMain->nAutoCombineBlockFrequency) {
+            obj.push_back(Pair("frequency", "nextblock"));
+        } else {
+            obj.push_back(Pair("frequency", int(pwalletMain->nAutoCombineBlockFrequency)));
+        }
+    }
+
+    return obj;
 }
 
 UniValue printMultiSend()

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2298,7 +2298,6 @@ UniValue getautocombineinfo(const UniValue& params, bool fHelp)
 
 UniValue autocombinerewards(const UniValue& params, bool fHelp)
 {
-    string strCommand;
     bool fEnable = false;
 
     if (params.size() >= 1) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4190,7 +4190,7 @@ void CWallet::AutoCombineDust()
         return;
     }
 
-    if (0 != nAutoCombineBlockFrequency) {
+    if (nAutoCombineBlockFrequency != 0) {
         // If the block height hasn't exceeded our frequency; or is not a multiple of our frequency.
         if ((nAutoCombineBlockFrequency > chainActive.Tip()->nHeight) ||
             (chainActive.Tip()->nHeight % nAutoCombineBlockFrequency)) {
@@ -4229,7 +4229,9 @@ void CWallet::AutoCombineDust()
             vRewardCoins.push_back(out);
             nTotalRewardsValue += out.Value();
             // Combine until our total is enough above the threshold to remain above after adjustments
-            if ((nTotalRewardsValue - nTotalRewardsValue / 10) > nAutoCombineThreshold * COIN)
+            // Unless no threshold is set; in which case we want to keep going until we hit MAX_STANDARD_TX_SIZE
+            if (nAutoCombineThreshold && 
+                ((nTotalRewardsValue - nTotalRewardsValue / 10) > nAutoCombineThreshold * COIN))
                 break;
 
             // Around 180 bytes per input. We use 190 to be certain

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -279,6 +279,7 @@ public:
     //Auto Combine Inputs
     bool fCombineDust;
     CAmount nAutoCombineThreshold;
+    int nAutoCombineBlockFrequency;
 
     CWallet()
     {
@@ -330,6 +331,7 @@ public:
         //Auto Combine Dust
         fCombineDust = false;
         nAutoCombineThreshold = 0;
+        nAutoCombineBlockFrequency = 15;
     }
 
     int getZeromintPercentage()

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -278,12 +278,11 @@ bool CWalletDB::EraseMSDisabledAddresses(std::vector<std::string> vDisabledAddre
     }
     return ret;
 }
-bool CWalletDB::WriteAutoCombineSettings(bool fEnable, CAmount nCombineThreshold)
+bool CWalletDB::WriteAutoCombineSettings(bool fEnable, CAmount nCombineThreshold, int nBlockFrequency)
 {
     nWalletDBUpdated++;
-    std::pair<bool, CAmount> pSettings;
-    pSettings.first = fEnable;
-    pSettings.second = nCombineThreshold;
+    std::pair<bool, CAmount> enabledMS1(fEnable, nCombineThreshold);
+    std::pair<std::pair<bool, CAmount>,int> pSettings(enabledMS1, nBlockFrequency);
     return Write(std::string("autocombinesettings"), pSettings, true);
 }
 
@@ -700,10 +699,11 @@ bool ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue, CW
             ssValue >> strDisabledAddress;
             pwallet->vDisabledAddresses.push_back(strDisabledAddress);
         } else if (strType == "autocombinesettings") {
-            std::pair<bool, CAmount> pSettings;
+            std::pair<std::pair<bool, CAmount>,int> pSettings;
             ssValue >> pSettings;
-            pwallet->fCombineDust = pSettings.first;
-            pwallet->nAutoCombineThreshold = pSettings.second;
+            pwallet->fCombineDust = pSettings.first.first;
+            pwallet->nAutoCombineThreshold = pSettings.first.second;
+            pwallet->nAutoCombineBlockFrequency = pSettings.second;
         } else if (strType == "destdata") {
             std::string strAddress, strKey, strValue;
             ssKey >> strAddress;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -281,9 +281,19 @@ bool CWalletDB::EraseMSDisabledAddresses(std::vector<std::string> vDisabledAddre
 bool CWalletDB::WriteAutoCombineSettings(bool fEnable, CAmount nCombineThreshold, int nBlockFrequency)
 {
     nWalletDBUpdated++;
-    std::pair<bool, CAmount> enabledMS1(fEnable, nCombineThreshold);
-    std::pair<std::pair<bool, CAmount>,int> pSettings(enabledMS1, nBlockFrequency);
-    return Write(std::string("autocombinesettings"), pSettings, true);
+    // Overwrite the old format with a special flag
+    std::pair<bool, CAmount> pSettingsOld;
+    pSettingsOld.first = fEnable;
+    pSettingsOld.second = -1; // Negatives doesn't make sense, so we can use them as flags
+    if (Write(std::string("autocombinesettings"), pSettingsOld, true)) {
+        // Now add the new format as v2
+        std::pair<bool, CAmount> enabledMS1(fEnable, nCombineThreshold);
+        std::pair<std::pair<bool, CAmount>,int> pSettings(enabledMS1, nBlockFrequency);
+        return Write(std::string("autocombinesettingsV2"), pSettings, true);
+    } else {
+        // report the old format write failed
+        return false;
+    }
 }
 
 bool CWalletDB::WriteDefaultKey(const CPubKey& vchPubKey)
@@ -699,6 +709,18 @@ bool ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue, CW
             ssValue >> strDisabledAddress;
             pwallet->vDisabledAddresses.push_back(strDisabledAddress);
         } else if (strType == "autocombinesettings") {
+            // Old Format
+            std::pair<bool, CAmount> pSettings;
+            ssValue >> pSettings;
+            if (pSettings.second >= 0) {
+                // Convert the old format
+                pwallet->fCombineDust = pSettings.first;
+                pwallet->nAutoCombineThreshold = pSettings.second;
+                pwallet->nAutoCombineBlockFrequency = 15; // Default
+                LogPrintf("autocombinerewards settings are stale, refresh your settings for the new format\n");
+            }
+        } else if (strType == "autocombinesettingsV2") {
+            // New Format
             std::pair<std::pair<bool, CAmount>,int> pSettings;
             ssValue >> pSettings;
             pwallet->fCombineDust = pSettings.first.first;

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -125,7 +125,7 @@ public:
     bool WriteMSettings(bool fMultiSendStake, bool fMultiSendMasternode, int nLastMultiSendHeight);
     bool WriteMSDisabledAddresses(std::vector<std::string> vDisabledAddresses);
     bool EraseMSDisabledAddresses(std::vector<std::string> vDisabledAddresses);
-    bool WriteAutoCombineSettings(bool fEnable, CAmount nCombineThreshold);
+    bool WriteAutoCombineSettings(bool fEnable, CAmount nCombineThreshold, int nBlockFrequency);
 
     bool WriteDefaultKey(const CPubKey& vchPubKey);
 


### PR DESCRIPTION
Try 3, after battling through rebase and squash unsuccessfully.  See more in #867 .

Initially, this fix is a rebase of PR #849 ; which is contained within wallet.cpp.  More description is written in that PR, however the nutshell version is that there were certain situations were you would continually try to combine the previous combination (below the threshold) and the change (taking you above the threshold).  

Even with this fix, AutoCombineRewards was still hardly usable, as wallet scans on wallets with many active addresses was consuming significant resources when running AutoCombineDust() on every block.  I found an old change in many PIVX based coins that implemented a concept of "AutoCombineRewardsThresholdTime", which allowed you to configure the number of minutes between dust collection. 

That old algorithm was commented out and replaced with a 5 second wait. This concept also was flawed, in that it was going to be doing a sleep within the ProcessNewBlock() code. The first attempt was abandoned because it likely was blocking ProcessNewBlock for 15 minutes at a time, and no way to not block, if using the feature, for under a minute. The workaround (5 seconds) still wasn't desirable, as it would still lock up ProcessNewBlock for the 5 second block.

This new method changes that design from ThresholdTime, to Block Frequency, and defaults to 15 blocks. Time can be adjusted per implementation, to get a desired minute time based on the block frequency of the coin parameters. If AutoCombineDust is enabled, it will only check and attempt to combine dust if the block height is a multiple of the Block Frequency. e.g. if set to 10, then every 10th block it will be executed. 100; then every 100th block.

This can now be tailored by the user, based on their desired dust cleanup threshold, and their expectation of frequency that they will need to clean.

After some testing, I added one other addition; the concept of a "one shot" dust cleanup, allowing you to specify a block frequency of "zero", which will run the autocombine on the processing of the next block. This functionality assumes that someone would be running their wallet infrequently, and therefore is likely to want the one shot to run when they start the wallet again. As such, the "on" and "frequency 0" is saved in the database, but after it runs, it will be shut off for the duration of the wallet run.

If they do not want it running on startup; they would simply "autocombinerewards false" after it's done it's one shot.

The feature, in it's entirety:

- Defaults to false
- When "true", requires a threshold (in coin count)
- Block frequency defaults to every 15 blocks. This can changed to every block (resource intensive) or however many blocks one expects their threshold to hit.
- Block frequency of "0" will run the sweep on the next block, and then turn it off until they run it again, or restart their wallet.
- To prevent the one shot to run on startup, they simply need to turn it off after the sweep is complete (when getautocombineinfo returns "on startup" rather than "on next block")

For example.
**Configuring One Shot**
```
autocombinerewards true 5 0
```
```
{
  "enabled": "on",
  "threshold": 5,
  "frequency": "nextblock"
}
```
**Before the run**
```
getautocombineinfo
```
```
{
  "enabled": "on",
  "threshold": 5,
  "frequency": "nextblock"
}
```
**After the run**
```
getautocombineinfo
```
```
{
  "enabled": "off",
  "threshold": 5,
  "frequency": "startup"
}
```
**Configuring for frequency use***
```
autocombinerewards true 5 250
```
```
{
  "enabled": "on",
  "threshold": 5,
  "frequency": 250
}
```
The latter will run every time the block count is a multiple of 250.

Please Note:  This code has been tested on two Pivx based coins I have implemented it in.  I, however, am not a PIVX holder so I was unable to test this code in PIVX itself; but I felt the changes makes autocombinerewards a useful feature, and porting back to PIVX is the right thing to do.  Conceptually it should work fine, however there may have been a mistake made when porting, so please test on my behalf.