### PR TITLE
[Qt] Add new budget colors

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -242,6 +242,7 @@ public:
         nZerocoinRequiredStakeDepth = 200; //The required confirmations for a zpiv to be stakable
 
         nBudget_Fee_Confirmations = 6; // Number of confirmations for the finalization fee
+        nProposalEstablishmentTime = 60 * 60 * 24; // Proposals must be at least a day old to make it into a budget
     }
 
     const Checkpoints::CCheckpointData& Checkpoints() const
@@ -335,6 +336,8 @@ public:
         nStartMasternodePayments = 1420837558; //Fri, 09 Jan 2015 21:05:58 GMT
         nBudget_Fee_Confirmations = 3; // Number of confirmations for the finalization fee. We have to make this very short
                                        // here because we only have a 8 block finalization window on testnet
+
+        nProposalEstablishmentTime = 60 * 5; // Proposals must be at least 5 mns old to make it into a test budget
     }
     const Checkpoints::CCheckpointData& Checkpoints() const
     {

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -92,6 +92,7 @@ public:
     int PoolMaxTransactions() const { return nPoolMaxTransactions; }
     /** Return the number of blocks in a budget cycle */
     int GetBudgetCycleBlocks() const { return nBudgetCycleBlocks; }
+    int64_t GetProposalEstablishmentTime() const { return nProposalEstablishmentTime; }
 
     /** Spork key and Masternode Handling **/
     std::string SporkKey() const { return strSporkKey; }
@@ -190,6 +191,7 @@ protected:
     int nZerocoinStartHeight;
     int nZerocoinStartTime;
     int nZerocoinRequiredStakeDepth;
+    int64_t nProposalEstablishmentTime;
 
     int nBlockEnforceSerialRange;
     int nBlockRecalculateAccumulators;

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -788,7 +788,12 @@ std::vector<CBudgetProposal*> CBudgetManager::GetBudget()
     std::vector<CBudgetProposal*> vBudgetProposalsRet;
 
     CAmount nBudgetAllocated = 0;
-    CBlockIndex* pindexPrev = chainActive.Tip();
+
+    CBlockIndex* pindexPrev;
+    {
+        LOCK(cs_main);
+        pindexPrev = chainActive.Tip();
+    }
     if (pindexPrev == NULL) return vBudgetProposalsRet;
 
     int nBlockStart = pindexPrev->nHeight - pindexPrev->nHeight % Params().GetBudgetCycleBlocks() + Params().GetBudgetCycleBlocks();

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -1553,6 +1553,11 @@ bool CBudgetProposal::IsValid(std::string& strError, bool fCheckCollateral)
     return true;
 }
 
+bool CBudgetProposal::IsEstablished()
+{
+    return nTime < GetAdjustedTime() - Params().GetProposalEstablishmentTime();
+}
+
 bool CBudgetProposal::AddOrUpdateVote(CBudgetVote& vote, std::string& strError)
 {
     std::string strAction = "New vote inserted:";

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -493,6 +493,7 @@ public:
     bool IsValid(std::string& strError, bool fCheckCollateral = true);
 
     bool IsEstablished();
+    bool IsPassing(const CBlockIndex* pindexPrev, int nBlockStartBudget, int nBlockEndBudget, int mnCount);
 
     std::string GetName() { return strProposalName; }
     std::string GetURL() { return strURL; }

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -492,14 +492,7 @@ public:
 
     bool IsValid(std::string& strError, bool fCheckCollateral = true);
 
-    bool IsEstablished()
-    {
-        // Proposals must be at least a day old to make it into a budget
-        if (Params().NetworkID() == CBaseChainParams::MAIN) return (nTime < GetTime() - (60 * 60 * 24));
-
-        // For testing purposes - 5 minutes
-        return (nTime < GetTime() - (60 * 5));
-    }
+    bool IsEstablished();
 
     std::string GetName() { return strProposalName; }
     std::string GetURL() { return strURL; }

--- a/src/qt/governancepage.cpp
+++ b/src/qt/governancepage.cpp
@@ -84,7 +84,11 @@ void GovernancePage::updateProposalList()
     std::vector<CBudgetProposal*> proposalsList = budget.GetAllProposals();
     std::sort (proposalsList.begin(), proposalsList.end(), sortProposalsByVotes());
     int nRow = 0;
-    CBlockIndex* pindexPrev = chainActive.Tip();
+    CBlockIndex* pindexPrev;
+    {
+        LOCK(cs_main);
+        pindexPrev = chainActive.Tip();
+    }
     if (!pindexPrev) return;
     int nBlockStart = pindexPrev->nHeight - pindexPrev->nHeight % Params().GetBudgetCycleBlocks() + Params().GetBudgetCycleBlocks();
     int nBlocksLeft = nBlockStart - pindexPrev->nHeight;

--- a/src/qt/governancepage.cpp
+++ b/src/qt/governancepage.cpp
@@ -125,7 +125,7 @@ void GovernancePage::updateProposalList()
     ui->time_before_super_value->setText(QString::number(nBlocksLeft/60/24));
     ui->alloted_budget_value->setText(QString::number(nTotalAllotted/COIN));
     ui->unallocated_budget_value->setText(QString::number((budget.GetTotalBudget(pindexPrev->nHeight) - nTotalAllotted)/COIN));
-    ui->masternode_count_value->setText(QString::number(mnodeman.stable_size()));
+    ui->masternode_count_value->setText(QString::number(mnodeman.CountEnabled(ActiveProtocol())));
 }
 
 void GovernancePage::setExtendedProposal(CBudgetProposal* proposal)

--- a/src/qt/governancepage.cpp
+++ b/src/qt/governancepage.cpp
@@ -84,6 +84,13 @@ void GovernancePage::updateProposalList()
     std::vector<CBudgetProposal*> proposalsList = budget.GetAllProposals();
     std::sort (proposalsList.begin(), proposalsList.end(), sortProposalsByVotes());
     int nRow = 0;
+    CBlockIndex* pindexPrev = chainActive.Tip();
+    if (!pindexPrev) return;
+    int nBlockStart = pindexPrev->nHeight - pindexPrev->nHeight % Params().GetBudgetCycleBlocks() + Params().GetBudgetCycleBlocks();
+    int nBlocksLeft = nBlockStart - pindexPrev->nHeight;
+    int nBlockEnd = nBlockStart + Params().GetBudgetCycleBlocks() - 1;
+    int mnCount = mnodeman.CountEnabled(ActiveProtocol());
+
     for (CBudgetProposal* pbudgetProposal : proposalsList) {
         if (!pbudgetProposal->fValid) continue;
         if (pbudgetProposal->GetRemainingPaymentCount() < 1) continue;
@@ -96,8 +103,13 @@ void GovernancePage::updateProposalList()
         if (std::find(allotedProposals.begin(), allotedProposals.end(), pbudgetProposal) != allotedProposals.end()) {
             nTotalAllotted += pbudgetProposal->GetAllotted();
             proposalFrame->setObjectName(QStringLiteral("proposalFramePassing"));
-        } else
+        } else if (!pbudgetProposal->IsEstablished()) {
+            proposalFrame->setObjectName(QStringLiteral("proposalFrameNotEstablished"));
+        } else if (pbudgetProposal->IsPassing(pindexPrev, nBlockStart, nBlockEnd, mnCount)) {
+            proposalFrame->setObjectName(QStringLiteral("proposalFramePassingUnfunded"));
+        } else {
             proposalFrame->setObjectName(QStringLiteral("proposalFrame"));
+        }
         proposalFrame->setFrameShape(QFrame::StyledPanel);
 
         if (extendedProposal == pbudgetProposal)
@@ -108,20 +120,9 @@ void GovernancePage::updateProposalList()
         ++nRow;
     }
 
-    CBlockIndex* pindexPrev = chainActive.Tip();
-    int nNext, nLeft;
-    if (!pindexPrev) {
-        nNext = 0;
-        nLeft = 0;
-    }
-    else {
-        nNext = pindexPrev->nHeight - pindexPrev->nHeight % Params().GetBudgetCycleBlocks() + Params().GetBudgetCycleBlocks();
-        nLeft = nNext - pindexPrev->nHeight;
-    }
-
-    ui->next_superblock_value->setText(QString::number(nNext));
-    ui->blocks_before_super_value->setText(QString::number(nLeft));
-    ui->time_before_super_value->setText(QString::number(nLeft/60/24));
+    ui->next_superblock_value->setText(QString::number(nBlockStart));
+    ui->blocks_before_super_value->setText(QString::number(nBlocksLeft));
+    ui->time_before_super_value->setText(QString::number(nBlocksLeft/60/24));
     ui->alloted_budget_value->setText(QString::number(nTotalAllotted/COIN));
     ui->unallocated_budget_value->setText(QString::number((budget.GetTotalBudget(pindexPrev->nHeight) - nTotalAllotted)/COIN));
     ui->masternode_count_value->setText(QString::number(mnodeman.stable_size()));

--- a/src/qt/res/css/default.css
+++ b/src/qt/res/css/default.css
@@ -1722,6 +1722,16 @@ QWidget#GovernancePage .ProposalFrame#proposalFramePassing {
     border:1px solid #00ef00;
 }
 
+QWidget#GovernancePage .ProposalFrame#proposalFrameNotEstablished {
+    background-color:qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #0080ff, stop: 1 #00a3ff);
+    border:1px solid #00a3ff;
+}
+
+QWidget#GovernancePage .ProposalFrame#proposalFramePassingUnfunded {
+    background-color:qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0, stop: 0 #cccc00, stop: 1 #efef00);
+    border:1px solid #efef00;
+}
+
 QWidget#GovernancePage .ProposalFrame > QLabel#strProposalName, QLabel#strMonthlyPayout, QLabel#strRemainingPaymentCount {
     font-size:18pt;
 }


### PR DESCRIPTION
This introduces two new colors for proposals items in the governance page. Yellow for proposals accepted by the voting system but unfunded by lack of funds and blue for unestablished (less than 24 hours old) proposals.
It also factors out a function to check if a proposal is passing, independently of it being funded or not. This is used for the colors and might be reused in the future.
![Capture d'écran de 2019-04-23 11-34-35](https://user-images.githubusercontent.com/835098/56572920-478c1600-65c0-11e9-843f-a18802f5a89f.png)
