### PR TITLE
[Refactor] Rename ui_interface.h file

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -162,7 +162,7 @@ BITCOIN_CORE_H = \
   torcontrol.h \
   txdb.h \
   txmempool.h \
-  ui_interface.h \
+  guiinterface.h \
   uint256.h \
   undo.h \
   util.h \

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -11,7 +11,7 @@
 #include "net.h"
 #include "pubkey.h"
 #include "timedata.h"
-#include "ui_interface.h"
+#include "guiinterface.h"
 #include "util.h"
 
 #include <algorithm>

--- a/src/guiinterface.h
+++ b/src/guiinterface.h
@@ -4,8 +4,8 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_UI_INTERFACE_H
-#define BITCOIN_UI_INTERFACE_H
+#ifndef BITCOIN_GUIINTERFACE_H
+#define BITCOIN_GUIINTERFACE_H
 
 #include <stdint.h>
 #include <string>
@@ -122,4 +122,4 @@ inline std::string _(const char* psz)
     return rv ? (*rv) : psz;
 }
 
-#endif // BITCOIN_UI_INTERFACE_H
+#endif // BITCOIN_GUIINTERFACE_H

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -14,7 +14,7 @@
 #include "sync.h"
 #include "util.h"
 #include "utilstrencodings.h"
-#include "ui_interface.h"
+#include "guiinterface.h"
 
 #include <boost/algorithm/string.hpp> // boost::trim
 

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -11,7 +11,7 @@
 #include "netbase.h"
 #include "rpc/protocol.h" // For HTTP status codes
 #include "sync.h"
-#include "ui_interface.h"
+#include "guiinterface.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -35,7 +35,7 @@
 #include "sporkdb.h"
 #include "txdb.h"
 #include "torcontrol.h"
-#include "ui_interface.h"
+#include "guiinterface.h"
 #include "util.h"
 #include "utilmoneystr.h"
 #include "validationinterface.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,7 +29,7 @@
 #include "swifttx.h"
 #include "txdb.h"
 #include "txmempool.h"
-#include "ui_interface.h"
+#include "guiinterface.h"
 #include "util.h"
 #include "utilmoneystr.h"
 #include "validationinterface.h"

--- a/src/masternodeconfig.cpp
+++ b/src/masternodeconfig.cpp
@@ -6,7 +6,7 @@
 #include "netbase.h"
 #include "masternodeconfig.h"
 #include "util.h"
-#include "ui_interface.h"
+#include "guiinterface.h"
 #include <base58.h>
 
 CMasternodeConfig masternodeConfig;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -18,7 +18,7 @@
 #include "obfuscation.h"
 #include "primitives/transaction.h"
 #include "scheduler.h"
-#include "ui_interface.h"
+#include "guiinterface.h"
 #ifdef ENABLE_WALLET
 #include "wallet/wallet.h"
 #endif // ENABLE_WALLET

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -7,7 +7,7 @@
 
 #include "noui.h"
 
-#include "ui_interface.h"
+#include "guiinterface.h"
 #include "util.h"
 
 #include <cstdio>

--- a/src/obfuscation.cpp
+++ b/src/obfuscation.cpp
@@ -10,7 +10,7 @@
 #include "masternodeman.h"
 #include "script/sign.h"
 #include "swifttx.h"
-#include "ui_interface.h"
+#include "guiinterface.h"
 #include "util.h"
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/filesystem.hpp>

--- a/src/pivx-tx.cpp
+++ b/src/pivx-tx.cpp
@@ -12,7 +12,7 @@
 #include "primitives/transaction.h"
 #include "script/script.h"
 #include "script/sign.h"
-#include "ui_interface.h" // for _(...)
+#include "guiinterface.h" // for _(...)
 #include <univalue.h>
 #include "util.h"
 #include "utilmoneystr.h"

--- a/src/pivxd.cpp
+++ b/src/pivxd.cpp
@@ -11,7 +11,7 @@
 #include "masternodeconfig.h"
 #include "noui.h"
 #include "rpc/server.h"
-#include "ui_interface.h"
+#include "guiinterface.h"
 #include "util.h"
 #include "httpserver.h"
 #include "httprpc.h"

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -31,7 +31,7 @@
 
 #include "init.h"
 #include "masternodelist.h"
-#include "ui_interface.h"
+#include "guiinterface.h"
 #include "util.h"
 
 #include <iostream>

--- a/src/qt/blockexplorer.cpp
+++ b/src/qt/blockexplorer.cpp
@@ -12,7 +12,7 @@
 #include "net.h"
 #include "txdb.h"
 #include "ui_blockexplorer.h"
-#include "ui_interface.h"
+#include "guiinterface.h"
 #include "util.h"
 #include "utilstrencodings.h"
 #include <QDateTime>

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -19,7 +19,7 @@
 #include "masternodeman.h"
 #include "net.h"
 #include "netbase.h"
-#include "ui_interface.h"
+#include "guiinterface.h"
 #include "util.h"
 
 #include <stdint.h>

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -12,7 +12,7 @@
 
 #include "base58.h"
 #include "chainparams.h"
-#include "ui_interface.h"
+#include "guiinterface.h"
 #include "util.h"
 #include "wallet/wallet.h"
 

--- a/src/qt/pivx.cpp
+++ b/src/qt/pivx.cpp
@@ -30,7 +30,7 @@
 #include "init.h"
 #include "main.h"
 #include "rpc/server.h"
-#include "ui_interface.h"
+#include "guiinterface.h"
 #include "util.h"
 
 #ifdef ENABLE_WALLET

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -19,7 +19,7 @@
 
 #include "base58.h"
 #include "coincontrol.h"
-#include "ui_interface.h"
+#include "guiinterface.h"
 #include "utilmoneystr.h"
 #include "wallet/wallet.h"
 

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -9,7 +9,7 @@
 #include "clientversion.h"
 #include "init.h"
 #include "networkstyle.h"
-#include "ui_interface.h"
+#include "guiinterface.h"
 #include "util.h"
 #include "version.h"
 

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -16,7 +16,7 @@
 #include "main.h"
 #include "script/script.h"
 #include "timedata.h"
-#include "ui_interface.h"
+#include "guiinterface.h"
 #include "util.h"
 #include "wallet/wallet.h"
 

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -17,7 +17,7 @@
 #include "transactiontablemodel.h"
 #include "walletmodel.h"
 
-#include "ui_interface.h"
+#include "guiinterface.h"
 
 #include <QComboBox>
 #include <QDateTimeEdit>

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -17,7 +17,7 @@
 #include "main.h"
 #include "spork.h"
 #include "sync.h"
-#include "ui_interface.h"
+#include "guiinterface.h"
 #include "wallet/wallet.h"
 #include "wallet/walletdb.h" // for BackupWallet
 #include <stdint.h>

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -25,7 +25,7 @@
 #include "transactionview.h"
 #include "walletmodel.h"
 
-#include "ui_interface.h"
+#include "guiinterface.h"
 
 #include <QAction>
 #include <QActionGroup>

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -11,7 +11,7 @@
 #include "masternodelist.h"
 
 #include <QStackedWidget>
-#include <ui_interface.h>
+#include <guiinterface.h>
 
 class BitcoinGUI;
 class ClientModel;

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -8,7 +8,7 @@
 #include "rpc/client.h"
 
 #include "rpc/protocol.h"
-#include "ui_interface.h"
+#include "guiinterface.h"
 #include "util.h"
 
 #include <set>

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -13,7 +13,7 @@
 #include "protocol.h"
 #include "sync.h"
 #include "timedata.h"
-#include "ui_interface.h"
+#include "guiinterface.h"
 #include "util.h"
 #include "version.h"
 

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -12,7 +12,7 @@
 #include "main.h"
 #include "random.h"
 #include "sync.h"
-#include "ui_interface.h"
+#include "guiinterface.h"
 #include "util.h"
 #include "utilstrencodings.h"
 

--- a/src/test/test_pivx.cpp
+++ b/src/test/test_pivx.cpp
@@ -8,7 +8,7 @@
 #include "main.h"
 #include "random.h"
 #include "txdb.h"
-#include "ui_interface.h"
+#include "guiinterface.h"
 #include "util.h"
 #ifdef ENABLE_WALLET
 #include "wallet/db.h"

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -7,7 +7,7 @@
 
 #include "netbase.h"
 #include "sync.h"
-#include "ui_interface.h"
+#include "guiinterface.h"
 #include "util.h"
 #include "utilstrencodings.h"
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -18,7 +18,7 @@
 #include "primitives/block.h"
 #include "primitives/transaction.h"
 #include "zpiv/zerocoin.h"
-#include "ui_interface.h"
+#include "guiinterface.h"
 #include "util.h"
 #include "validationinterface.h"
 #include "wallet/wallet_ismine.h"

--- a/src/zpivchain.cpp
+++ b/src/zpivchain.cpp
@@ -6,7 +6,7 @@
 #include "invalid.h"
 #include "main.h"
 #include "txdb.h"
-#include "ui_interface.h"
+#include "guiinterface.h"
 
 // 6 comes from OPCODE (1) + vch.size() (1) + BIGNUM size (4)
 #define SCRIPT_OFFSET 6


### PR DESCRIPTION
This file's naming convention is not in line with what is used
everywhere else. Additionally, the `ui_` prefix is typically reserved
for QMake's UIC pre-processor to generate compiler-compatible code from
Qt's `.ui` files.

Renaming this file opens the door to adding CMake build support
**without** needing to hackishly work around this one file's name, and
it becomes more in-line with the naming conventions used for every other
 source file.