### PR TITLE
[ZPIV] Zerocoin public coin spend.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -185,6 +185,7 @@ BITCOIN_CORE_H = \
   zpiv/zerocoin.h \
   zpiv/zpivtracker.h \
   zpiv/zpivwallet.h \
+  zpiv/zpivmodule.h \
   genwit.h \
   concurrentqueue.h \
   lightzpivthread.h \
@@ -281,6 +282,7 @@ libbitcoin_wallet_a_SOURCES = \
   zpiv/zpivtracker.cpp \
   stakeinput.cpp \
   genwit.cpp \
+  zpiv/zpivmodule.cpp \
   lightzpivthread.cpp \
   $(BITCOIN_CORE_H)
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -163,6 +163,9 @@ public:
         nEnforceNewSporkKey = 1525158000; //!> Sporks signed after (GMT): Tuesday, May 1, 2018 7:00:00 AM GMT must use the new spork key
         nRejectOldSporkKey = 1527811200; //!> Fully reject old spork key after (GMT): Friday, June 1, 2018 12:00:00 AM
 
+        // Public coin spend enforcement
+        nPublicZCSpends = 2000000;
+
         // Fake Serial Attack
         nFakeSerialBlockheightEnd = 1686229;
         nSupplyBeforeFakeSerial = 4131563 * COIN;   // zerocoin supply at block nFakeSerialBlockheightEnd
@@ -293,6 +296,9 @@ public:
         nEnforceNewSporkKey = 1521604800; //!> Sporks signed after Wednesday, March 21, 2018 4:00:00 AM GMT must use the new spork key
         nRejectOldSporkKey = 1522454400; //!> Reject old spork key after Saturday, March 31, 2018 12:00:00 AM GMT
 
+        // Public coin spend enforcement
+        nPublicZCSpends = 1086574;
+
         // Fake Serial Attack
         nFakeSerialBlockheightEnd = -1;
         nSupplyBeforeFakeSerial = 0;
@@ -383,6 +389,9 @@ public:
         nBlockRecalculateAccumulators = 999999999; //Trigger a recalculation of accumulators
         nBlockFirstFraudulent = 999999999; //First block that bad serials emerged
         nBlockLastGoodCheckpoint = 999999999; //Last valid accumulator checkpoint
+
+        // Public coin spend enforcement
+        nPublicZCSpends = 350;
 
         // Fake Serial Attack
         nFakeSerialBlockheightEnd = -1;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -298,7 +298,7 @@ public:
         nRejectOldSporkKey = 1522454400; //!> Reject old spork key after Saturday, March 31, 2018 12:00:00 AM GMT
 
         // Public coin spend enforcement
-        nPublicZCSpends = 1086574;
+        nPublicZCSpends = 1818300;
 
         // Fake Serial Attack
         nFakeSerialBlockheightEnd = -1;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -239,6 +239,7 @@ public:
             "8441436038339044149526344321901146575444541784240209246165157233507787077498171257724679629263863563732899121548"
             "31438167899885040445364023527381951378636564391212010397122822120720357";
         nMaxZerocoinSpendsPerTransaction = 7; // Assume about 20kb each
+        nMaxZerocoinPublicSpendsPerTransaction = 637; // Assume about 220 bytes each input
         nMinZerocoinMintFee = 1 * CENT; //high fee required for zerocoin mints
         nMintRequiredConfirmations = 20; //the maximum amount of confirmations until accumulated in 19
         nRequiredAccumulation = 1;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -298,7 +298,7 @@ public:
         nRejectOldSporkKey = 1522454400; //!> Reject old spork key after Saturday, March 31, 2018 12:00:00 AM GMT
 
         // Public coin spend enforcement
-        nPublicZCSpends = 1818300;
+        nPublicZCSpends = 1106100;
 
         // Fake Serial Attack
         nFakeSerialBlockheightEnd = -1;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -109,6 +109,7 @@ public:
     std::string Zerocoin_Modulus() const { return zerocoinModulus; }
     libzerocoin::ZerocoinParams* Zerocoin_Params(bool useModulusV1) const;
     int Zerocoin_MaxSpendsPerTransaction() const { return nMaxZerocoinSpendsPerTransaction; }
+    int Zerocoin_MaxPublicSpendsPerTransaction() const { return nMaxZerocoinPublicSpendsPerTransaction; }
     CAmount Zerocoin_MintFee() const { return nMinZerocoinMintFee; }
     int Zerocoin_MintRequiredConfirmations() const { return nMintRequiredConfirmations; }
     int Zerocoin_RequiredAccumulation() const { return nRequiredAccumulation; }
@@ -183,6 +184,7 @@ protected:
     int64_t nStartMasternodePayments;
     std::string zerocoinModulus;
     int nMaxZerocoinSpendsPerTransaction;
+    int nMaxZerocoinPublicSpendsPerTransaction;
     CAmount nMinZerocoinMintFee;
     CAmount nInvalidAmountFiltered;
     int nMintRequiredConfirmations;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -135,6 +135,8 @@ public:
     int Zerocoin_Block_Double_Accumulated() const { return nBlockDoubleAccumulated; }
     CAmount InvalidAmountFiltered() const { return nInvalidAmountFiltered; };
 
+    int Zerocoin_Block_Public_Spend_Enabled() const { return nPublicZCSpends; }
+
 protected:
     CChainParams() {}
 
@@ -200,6 +202,7 @@ protected:
     int nBlockEnforceInvalidUTXO;
     int nBlockZerocoinV2;
     int nBlockDoubleAccumulated;
+    int nPublicZCSpends;
 
     // fake serial attack
     int nFakeSerialBlockheightEnd = 0;

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -372,7 +372,8 @@ bool CheckProofOfStake(const CBlock block, uint256& hashProofOfStake, std::uniqu
         uint256 hashBlock;
         CTransaction txPrev;
         if (!GetTransaction(txin.prevout.hash, txPrev, hashBlock, true))
-            return error("CheckProofOfStake() : INFO: read txPrev failed");
+            return error("CheckProofOfStake() : INFO: read txPrev failed, tx id prev: %s, block id %s",
+                         txin.prevout.hash.GetHex(), block.GetHash().GetHex());
 
         //verify signature and script
         if (!VerifyScript(txin.scriptSig, txPrev.vout[txin.prevout.n].scriptPubKey, STANDARD_SCRIPT_VERIFY_FLAGS, TransactionSignatureChecker(&tx, 0)))

--- a/src/libzerocoin/AccumulatorProofOfKnowledge.h
+++ b/src/libzerocoin/AccumulatorProofOfKnowledge.h
@@ -24,6 +24,7 @@ namespace libzerocoin {
  */
 class AccumulatorProofOfKnowledge {
 public:
+    AccumulatorProofOfKnowledge(){};
 	AccumulatorProofOfKnowledge(const AccumulatorAndProofParams* p);
 
 	/** Generates a proof that a commitment to a coin c was accumulated

--- a/src/libzerocoin/CoinSpend.h
+++ b/src/libzerocoin/CoinSpend.h
@@ -122,9 +122,12 @@ public:
     static std::vector<unsigned char> ParseSerial(CDataStream& s);
 
     virtual const uint256 signatureHash() const;
-    bool Verify(const Accumulator& a, bool verifyParams = true) const;
-    virtual bool HasValidSerial(ZerocoinParams* params) const;
-    virtual bool HasValidSignature() const;
+    virtual bool Verify(const Accumulator& a, bool verifyParams = true) const;
+    bool HasValidSerial(ZerocoinParams* params) const;
+    bool HasValidSignature() const;
+    void setTxOutHash(uint256 txOutHash) { this->ptxHash = txOutHash; };
+    void setDenom(libzerocoin::CoinDenomination denom) { this->denomination = denom; }
+
     CBigNum CalculateValidSerial(ZerocoinParams* params);
     std::string ToString() const;
 
@@ -153,17 +156,17 @@ public:
     }
 
 protected:
-    CoinDenomination denomination;
+    CoinDenomination denomination = ZQ_ERROR;
     CBigNum coinSerialNumber;
     uint8_t version;
     //As of version 2
     CPubKey pubkey;
     std::vector<unsigned char> vchSig;
     SpendType spendType;
+    uint256 ptxHash;
 
 private:
     uint32_t accChecksum;
-    uint256 ptxHash;
     CBigNum accCommitmentToCoinValue;
     CBigNum serialCommitmentToCoinValue;
     AccumulatorProofOfKnowledge accumulatorPoK;

--- a/src/libzerocoin/CoinSpend.h
+++ b/src/libzerocoin/CoinSpend.h
@@ -38,6 +38,8 @@ class CoinSpend
 {
 public:
 
+    CoinSpend(){};
+
     //! \param paramsV1 - if this is a V1 zerocoin, then use params that existed with initial modulus, ignored otherwise
     //! \param paramsV2 - params that begin when V2 zerocoins begin on the PIVX network
     //! \param strm - a serialized CoinSpend
@@ -119,10 +121,10 @@ public:
 
     static std::vector<unsigned char> ParseSerial(CDataStream& s);
 
-    const uint256 signatureHash() const;
+    virtual const uint256 signatureHash() const;
     bool Verify(const Accumulator& a, bool verifyParams = true) const;
-    bool HasValidSerial(ZerocoinParams* params) const;
-    bool HasValidSignature() const;
+    virtual bool HasValidSerial(ZerocoinParams* params) const;
+    virtual bool HasValidSignature() const;
     CBigNum CalculateValidSerial(ZerocoinParams* params);
     std::string ToString() const;
 
@@ -150,22 +152,24 @@ public:
         }
     }
 
-private:
+protected:
     CoinDenomination denomination;
-    uint32_t accChecksum;
-    uint256 ptxHash;
-    CBigNum accCommitmentToCoinValue;
-    CBigNum serialCommitmentToCoinValue;
     CBigNum coinSerialNumber;
-    AccumulatorProofOfKnowledge accumulatorPoK;
-    SerialNumberSignatureOfKnowledge serialNumberSoK;
-    CommitmentProofOfKnowledge commitmentPoK;
     uint8_t version;
-
     //As of version 2
     CPubKey pubkey;
     std::vector<unsigned char> vchSig;
     SpendType spendType;
+
+private:
+    uint32_t accChecksum;
+    uint256 ptxHash;
+    CBigNum accCommitmentToCoinValue;
+    CBigNum serialCommitmentToCoinValue;
+    AccumulatorProofOfKnowledge accumulatorPoK;
+    SerialNumberSignatureOfKnowledge serialNumberSoK;
+    CommitmentProofOfKnowledge commitmentPoK;
+
 };
 
 } /* namespace libzerocoin */

--- a/src/libzerocoin/Commitment.h
+++ b/src/libzerocoin/Commitment.h
@@ -60,6 +60,7 @@ private:
  */
 class CommitmentProofOfKnowledge {
 public:
+    CommitmentProofOfKnowledge(){};
 	CommitmentProofOfKnowledge(const IntegerGroupParams* ap, const IntegerGroupParams* bp);
 	/** Generates a proof that two commitments, a and b, open to the same value.
 	 *

--- a/src/libzerocoin/SerialNumberSignatureOfKnowledge.h
+++ b/src/libzerocoin/SerialNumberSignatureOfKnowledge.h
@@ -34,6 +34,7 @@ namespace libzerocoin {
  */
 class SerialNumberSignatureOfKnowledge {
 public:
+    SerialNumberSignatureOfKnowledge(){};
 	SerialNumberSignatureOfKnowledge(const ZerocoinParams* p);
 	/** Creates a Signature of knowledge object that a commitment to a coin contains a coin with serial number x
 	 *

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1042,9 +1042,13 @@ bool ContextualCheckZerocoinSpendNoSerialCheck(const CTransaction& tx, const Coi
         }
     }
 
+    //Reject V1 old serials.
+    if (spend->getVersion() < libzerocoin::PrivateCoin::PUBKEY_VERSION) {
+        return error("%s : zPIV v1 serial spend not spendable\n", __func__,
+                     spend->getCoinSerialNumber().GetHex(), tx.GetHash().GetHex());
+    }
     //Reject serial's that are not in the acceptable value range
-    bool fUseV1Params = spend->getVersion() < libzerocoin::PrivateCoin::PUBKEY_VERSION;
-    if (!spend->HasValidSerial(Params().Zerocoin_Params(fUseV1Params))) {
+    if (!spend->HasValidSerial(Params().Zerocoin_Params(false))) {
         // Up until this block our chain was not checking serials correctly..
         if (!isBlockBetweenFakeSerialAttackRange(pindex->nHeight))
             return error("%s : zPIV spend with serial %s from tx %s is not in valid range\n", __func__,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7087,13 +7087,13 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
 //       it was the one which was commented out
 int ActiveProtocol()
 {
-    // SPORK_14 is used for 70913 (v3.1.0+)
-    if (IsSporkActive(SPORK_14_NEW_PROTOCOL_ENFORCEMENT))
-            return MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT;
-
-    // SPORK_15 was used for 70912 (v3.0.5+), commented out now.
-    //if (IsSporkActive(SPORK_15_NEW_PROTOCOL_ENFORCEMENT_2))
+    // SPORK_14 was used for 70913 (v3.1.0+), commented out now.
+    //if (IsSporkActive(SPORK_14_NEW_PROTOCOL_ENFORCEMENT))
     //        return MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT;
+
+    // SPORK_15 is used for 70916 (v3.3+)
+    if (IsSporkActive(SPORK_15_NEW_PROTOCOL_ENFORCEMENT_2))
+            return MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT;
 
     return MIN_PEER_PROTO_VERSION_BEFORE_ENFORCEMENT;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -988,10 +988,10 @@ bool isBlockBetweenFakeSerialAttackRange(int nHeight)
     return nHeight <= Params().Zerocoin_Block_EndFakeSerial();
 }
 
-bool CheckPublicCoinSpendEnforced(int blockHeight, bool isPrivZerocoinSpend, bool isPublicSpend) {
+bool CheckPublicCoinSpendEnforced(int blockHeight, bool isPublicSpend) {
     if (blockHeight >= Params().Zerocoin_Block_Public_Spend_Enabled()) {
         // reject old coin spend
-        if (isPrivZerocoinSpend) {
+        if (!isPublicSpend) {
             return error("%s: failed to add block with older zc spend version", __func__);
         }
 
@@ -1042,11 +1042,14 @@ bool ContextualCheckZerocoinSpendNoSerialCheck(const CTransaction& tx, const Coi
         }
     }
 
-    //Reject V1 old serials.
-    if (spend->getVersion() < libzerocoin::PrivateCoin::PUBKEY_VERSION) {
-        return error("%s : zPIV v1 serial spend not spendable\n", __func__,
-                     spend->getCoinSerialNumber().GetHex(), tx.GetHash().GetHex());
+    if (pindex->nHeight >= Params().Zerocoin_Block_Public_Spend_Enabled()) {
+        //Reject V1 old serials.
+        if (spend->getVersion() < libzerocoin::PrivateCoin::PUBKEY_VERSION) {
+            return error("%s : zPIV v1 serial spend not spendable, serial %s, tx %s\n", __func__,
+                         spend->getCoinSerialNumber().GetHex(), tx.GetHash().GetHex());
+        }
     }
+
     //Reject serial's that are not in the acceptable value range
     if (!spend->HasValidSerial(Params().Zerocoin_Params(false))) {
         // Up until this block our chain was not checking serials correctly..
@@ -1416,7 +1419,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
                 }
 
                 // Check enforcement
-                if (!CheckPublicCoinSpendEnforced(chainActive.Height(), isPrivZerocoinSpend, isPublicSpend)){
+                if (!CheckPublicCoinSpendEnforced(chainActive.Height(), isPublicSpend)){
                     return state.Invalid(error("%s: AcceptToMemoryPool failed for tx %s", __func__,
                                                tx.GetHash().GetHex()), REJECT_INVALID, "bad-txns-invalid-zpiv");
                 }
@@ -3250,7 +3253,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                     continue;
 
                 // Check enforcement
-                if (!CheckPublicCoinSpendEnforced(pindex->nHeight, isPrivZerocoinSpend, isPublicSpend)){
+                if (!CheckPublicCoinSpendEnforced(pindex->nHeight, isPublicSpend)){
                     return false;
                 }
 
@@ -4811,7 +4814,7 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
                     if (isPrivZerocoinSpend || isPublicSpend) {
 
                         // Check enforcement
-                        if (!CheckPublicCoinSpendEnforced(pindex->nHeight, isPrivZerocoinSpend, isPublicSpend)){
+                        if (!CheckPublicCoinSpendEnforced(pindex->nHeight, isPublicSpend)){
                             return false;
                         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1085,7 +1085,7 @@ bool CheckZerocoinSpend(const CTransaction& tx, bool fVerifySignature, CValidati
     for (const CTxIn& txin : tx.vin) {
 
         //only check txin that is a zcspend
-        bool isPublicSpend = txin.scriptSig.IsZerocoinPublicSpend();
+        bool isPublicSpend = txin.IsZerocoinPublicSpend();
         if (!txin.IsZerocoinSpend() && !isPublicSpend)
             continue;
 
@@ -1221,7 +1221,7 @@ bool CheckTransaction(const CTransaction& tx, bool fZerocoinActive, bool fReject
         //require that a zerocoinspend only has inputs that are zerocoins
         if (tx.HasZerocoinSpendInputs()) {
             for (const CTxIn& in : tx.vin) {
-                if (!in.IsZerocoinSpend() && !in.scriptSig.IsZerocoinPublicSpend())
+                if (!in.IsZerocoinSpend() && !in.IsZerocoinPublicSpend())
                     return state.DoS(100,
                                      error("CheckTransaction() : zerocoinspend contains inputs that are not zerocoins"));
             }
@@ -1394,7 +1394,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
             //Check for double spending of serial #'s
             for (const CTxIn& txIn : tx.vin) {
                 // Only allow for zc spends inputs
-                bool isPublicSpend = txIn.scriptSig.IsZerocoinPublicSpend();
+                bool isPublicSpend = txIn.IsZerocoinPublicSpend();
                 if (!txIn.IsZerocoinSpend() && !isPublicSpend) {
                     return state.Invalid(error("%s: ContextualCheckZerocoinSpend failed for tx %s, every input must be a zcspend or zcpublicspend", __func__,
                                         tx.GetHash().GetHex()), REJECT_INVALID, "bad-txns-invalid-zpiv");
@@ -2447,7 +2447,7 @@ void AddInvalidSpendsToMap(const CBlock& block)
 
         //Check all zerocoinspends for bad serials
         for (const CTxIn& in : tx.vin) {
-            bool isPublicSpend = in.scriptSig.IsZerocoinPublicSpend();
+            bool isPublicSpend = in.IsZerocoinPublicSpend();
             if (in.IsZerocoinSpend() || isPublicSpend) {
 
                 CoinSpend* spend;
@@ -2654,7 +2654,7 @@ bool DisconnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex
             if (tx.HasZerocoinSpendInputs()) {
                 //erase all zerocoinspends in this transaction
                 for (const CTxIn &txin : tx.vin) {
-                    bool isPublicSpend = txin.scriptSig.IsZerocoinPublicSpend();
+                    bool isPublicSpend = txin.IsZerocoinPublicSpend();
                     if (txin.scriptSig.IsZerocoinSpend() || isPublicSpend) {
                         CBigNum serial;
                         if (isPublicSpend) {
@@ -3223,7 +3223,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             //Check for double spending of serial #'s
             set<CBigNum> setSerials;
             for (const CTxIn& txIn : tx.vin) {
-                bool isPublicSpend = txIn.scriptSig.IsZerocoinPublicSpend();
+                bool isPublicSpend = txIn.IsZerocoinPublicSpend();
                 bool isPrivZerocoinSpend = txIn.IsZerocoinSpend();
                 if (!isPrivZerocoinSpend && !isPublicSpend)
                     continue;
@@ -4427,7 +4427,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
         // double check that there are no double spent zPIV spends in this block
         if (tx.HasZerocoinSpendInputs()) {
             for (const CTxIn& txIn : tx.vin) {
-                bool isPublicSpend = txIn.scriptSig.IsZerocoinPublicSpend();
+                bool isPublicSpend = txIn.IsZerocoinPublicSpend();
                 if (txIn.IsZerocoinSpend() || isPublicSpend) {
                     libzerocoin::CoinSpend spend;
                     if (isPublicSpend) {
@@ -4785,7 +4785,7 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
         for (const CTransaction& tx : block.vtx) {
             for (const CTxIn& in: tx.vin) {
                 if(nHeight >= Params().Zerocoin_StartHeight()) {
-                    bool isPublicSpend = in.scriptSig.IsZerocoinPublicSpend();
+                    bool isPublicSpend = in.IsZerocoinPublicSpend();
                     bool isPrivZerocoinSpend = in.IsZerocoinSpend();
                     if (isPrivZerocoinSpend || isPublicSpend) {
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -988,6 +988,21 @@ bool isBlockBetweenFakeSerialAttackRange(int nHeight)
     return nHeight <= Params().Zerocoin_Block_EndFakeSerial();
 }
 
+bool CheckPublicCoinSpendEnforced(int blockHeight, bool isPrivZerocoinSpend, bool isPublicSpend) {
+    if (blockHeight >= Params().Zerocoin_Block_Public_Spend_Enabled()) {
+        // reject old coin spend
+        if (isPrivZerocoinSpend) {
+            return error("%s: failed to add block with older zc spend version", __func__);
+        }
+
+    } else {
+        if (isPublicSpend) {
+            return error("%s: failed to add block, public spend enforcement not activated", __func__);
+        }
+    }
+    return true;
+}
+
 bool ContextualCheckZerocoinSpend(const CTransaction& tx, const CoinSpend* spend, CBlockIndex* pindex, const uint256& hashBlock)
 {
     if(!ContextualCheckZerocoinSpendNoSerialCheck(tx, spend, pindex, hashBlock)){
@@ -3209,9 +3224,14 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             set<CBigNum> setSerials;
             for (const CTxIn& txIn : tx.vin) {
                 bool isPublicSpend = txIn.scriptSig.IsZerocoinPublicSpend();
-                if (!txIn.IsZerocoinSpend() && !isPublicSpend)
+                bool isPrivZerocoinSpend = txIn.IsZerocoinSpend();
+                if (!isPrivZerocoinSpend && !isPublicSpend)
                     continue;
 
+                // Check enforcement
+                if (!CheckPublicCoinSpendEnforced(pindex->nHeight, isPrivZerocoinSpend, isPublicSpend)){
+                    return false;
+                }
 
                 if (isPublicSpend) {
                     libzerocoin::ZerocoinParams* params = Params().Zerocoin_Params(false);
@@ -4766,7 +4786,14 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
             for (const CTxIn& in: tx.vin) {
                 if(nHeight >= Params().Zerocoin_StartHeight()) {
                     bool isPublicSpend = in.scriptSig.IsZerocoinPublicSpend();
-                    if (in.IsZerocoinSpend() || isPublicSpend) {
+                    bool isPrivZerocoinSpend = in.IsZerocoinSpend();
+                    if (isPrivZerocoinSpend || isPublicSpend) {
+
+                        // Check enforcement
+                        if (!CheckPublicCoinSpendEnforced(pindex->nHeight, isPrivZerocoinSpend, isPublicSpend)){
+                            return false;
+                        }
+
                         libzerocoin::CoinSpend spend;
                         if (isPublicSpend) {
                             libzerocoin::ZerocoinParams* params = Params().Zerocoin_Params(false);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -988,7 +988,7 @@ bool isBlockBetweenFakeSerialAttackRange(int nHeight)
     return nHeight <= Params().Zerocoin_Block_EndFakeSerial();
 }
 
-bool ContextualCheckZerocoinSpend(const CTransaction& tx, const CoinSpend& spend, CBlockIndex* pindex, const uint256& hashBlock)
+bool ContextualCheckZerocoinSpend(const CTransaction& tx, const CoinSpend* spend, CBlockIndex* pindex, const uint256& hashBlock)
 {
     if(!ContextualCheckZerocoinSpendNoSerialCheck(tx, spend, pindex, hashBlock)){
         return false;
@@ -996,19 +996,19 @@ bool ContextualCheckZerocoinSpend(const CTransaction& tx, const CoinSpend& spend
 
     //Reject serial's that are already in the blockchain
     int nHeightTx = 0;
-    if (IsSerialInBlockchain(spend.getCoinSerialNumber(), nHeightTx))
+    if (IsSerialInBlockchain(spend->getCoinSerialNumber(), nHeightTx))
         return error("%s : zPIV spend with serial %s is already in block %d\n", __func__,
-                     spend.getCoinSerialNumber().GetHex(), nHeightTx);
+                     spend->getCoinSerialNumber().GetHex(), nHeightTx);
 
     return true;
 }
 
-bool ContextualCheckZerocoinSpendNoSerialCheck(const CTransaction& tx, const CoinSpend& spend, CBlockIndex* pindex, const uint256& hashBlock)
+bool ContextualCheckZerocoinSpendNoSerialCheck(const CTransaction& tx, const CoinSpend* spend, CBlockIndex* pindex, const uint256& hashBlock)
 {
     //Check to see if the zPIV is properly signed
     if (pindex->nHeight >= Params().Zerocoin_Block_V2_Start()) {
         try {
-            if (!spend.HasValidSignature())
+            if (!spend->HasValidSignature())
                 return error("%s: V2 zPIV spend does not have a valid signature\n", __func__);
         } catch (libzerocoin::InvalidSerialException &e) {
             // Check if we are in the range of the attack
@@ -1021,19 +1021,19 @@ bool ContextualCheckZerocoinSpendNoSerialCheck(const CTransaction& tx, const Coi
         libzerocoin::SpendType expectedType = libzerocoin::SpendType::SPEND;
         if (tx.IsCoinStake())
             expectedType = libzerocoin::SpendType::STAKE;
-        if (spend.getSpendType() != expectedType) {
+        if (spend->getSpendType() != expectedType) {
             return error("%s: trying to spend zPIV without the correct spend type. txid=%s\n", __func__,
                          tx.GetHash().GetHex());
         }
     }
 
     //Reject serial's that are not in the acceptable value range
-    bool fUseV1Params = spend.getVersion() < libzerocoin::PrivateCoin::PUBKEY_VERSION;
-    if (!spend.HasValidSerial(Params().Zerocoin_Params(fUseV1Params))) {
+    bool fUseV1Params = spend->getVersion() < libzerocoin::PrivateCoin::PUBKEY_VERSION;
+    if (!spend->HasValidSerial(Params().Zerocoin_Params(fUseV1Params))) {
         // Up until this block our chain was not checking serials correctly..
         if (!isBlockBetweenFakeSerialAttackRange(pindex->nHeight))
             return error("%s : zPIV spend with serial %s from tx %s is not in valid range\n", __func__,
-                     spend.getCoinSerialNumber().GetHex(), tx.GetHash().GetHex());
+                     spend->getCoinSerialNumber().GetHex(), tx.GetHash().GetHex());
         else
             LogPrintf("%s:: HasValidSerial :: Invalid serial detected within range in block %d\n", __func__, pindex->nHeight);
     }
@@ -1066,16 +1066,29 @@ bool CheckZerocoinSpend(const CTransaction& tx, bool fVerifySignature, CValidati
 
     bool fValidated = false;
     set<CBigNum> serials;
-    list<CoinSpend> vSpends;
     CAmount nTotalRedeemed = 0;
     for (const CTxIn& txin : tx.vin) {
 
         //only check txin that is a zcspend
-        if (!txin.IsZerocoinSpend())
+        bool isPublicSpend = txin.scriptSig.IsZerocoinPublicSpend();
+        if (!txin.IsZerocoinSpend() && !isPublicSpend)
             continue;
 
-        CoinSpend newSpend = TxInToZerocoinSpend(txin);
-        vSpends.push_back(newSpend);
+        CoinSpend newSpend;
+        CTxOut prevOut;
+        if (isPublicSpend) {
+            if(!GetOutput(txin.prevout.hash, txin.prevout.n, state, prevOut)){
+                return state.DoS(100, error("CheckZerocoinSpend(): public zerocoin spend prev output not found, prevTx %s, index %d", txin.prevout.hash.GetHex(), txin.prevout.n));
+            }
+            libzerocoin::ZerocoinParams* params = Params().Zerocoin_Params(false);
+            PublicCoinSpend publicSpend(params);
+            if (!ZPIVModule::parseCoinSpend(txin, tx, prevOut, publicSpend)){
+                return state.DoS(100, error("CheckZerocoinSpend(): public zerocoin spend parse failed"));
+            }
+            newSpend = publicSpend;
+        }else {
+            newSpend = TxInToZerocoinSpend(txin);
+        }
 
         //check that the denomination is valid
         if (newSpend.getDenomination() == ZQ_ERROR)
@@ -1089,22 +1102,29 @@ bool CheckZerocoinSpend(const CTransaction& tx, bool fVerifySignature, CValidati
         if (newSpend.getTxOutHash() != hashTxOut)
             return state.DoS(100, error("Zerocoinspend does not use the same txout that was used in the SoK"));
 
-        // Skip signature verification during initial block download
-        if (fVerifySignature) {
-            //see if we have record of the accumulator used in the spend tx
-            CBigNum bnAccumulatorValue = 0;
-            if (!zerocoinDB->ReadAccumulatorValue(newSpend.getAccumulatorChecksum(), bnAccumulatorValue)) {
-                uint32_t nChecksum = newSpend.getAccumulatorChecksum();
-                return state.DoS(100, error("%s: Zerocoinspend could not find accumulator associated with checksum %s", __func__, HexStr(BEGIN(nChecksum), END(nChecksum))));
+        if (isPublicSpend) {
+            libzerocoin::ZerocoinParams* params = Params().Zerocoin_Params(false);
+            PublicCoinSpend ret(params);
+            if (!ZPIVModule::validateInput(txin, prevOut, tx, ret)){
+                return state.DoS(100, error("CheckZerocoinSpend(): public zerocoin spend did not verify"));
             }
+        } else
+            // Skip signature verification during initial block download
+            if (fVerifySignature) {
+                //see if we have record of the accumulator used in the spend tx
+                CBigNum bnAccumulatorValue = 0;
+                if (!zerocoinDB->ReadAccumulatorValue(newSpend.getAccumulatorChecksum(), bnAccumulatorValue)) {
+                    uint32_t nChecksum = newSpend.getAccumulatorChecksum();
+                    return state.DoS(100, error("%s: Zerocoinspend could not find accumulator associated with checksum %s", __func__, HexStr(BEGIN(nChecksum), END(nChecksum))));
+                }
 
-            Accumulator accumulator(Params().Zerocoin_Params(chainActive.Height() < Params().Zerocoin_Block_V2_Start()),
-                                    newSpend.getDenomination(), bnAccumulatorValue);
+                Accumulator accumulator(Params().Zerocoin_Params(chainActive.Height() < Params().Zerocoin_Block_V2_Start()),
+                                        newSpend.getDenomination(), bnAccumulatorValue);
 
-            //Check that the coin has been accumulated
-            if(!newSpend.Verify(accumulator, !fFakeSerialAttack))
-                    return state.DoS(100, error("CheckZerocoinSpend(): zerocoin spend did not verify"));
-        }
+                //Check that the coin has been accumulated
+                if(!newSpend.Verify(accumulator, !fFakeSerialAttack))
+                        return state.DoS(100, error("CheckZerocoinSpend(): zerocoin spend did not verify"));
+            }
 
         if (serials.count(newSpend.getCoinSerialNumber()))
             return state.DoS(100, error("Zerocoinspend serial is used twice in the same tx"));
@@ -1186,8 +1206,9 @@ bool CheckTransaction(const CTransaction& tx, bool fZerocoinActive, bool fReject
         //require that a zerocoinspend only has inputs that are zerocoins
         if (tx.HasZerocoinSpendInputs()) {
             for (const CTxIn& in : tx.vin) {
-                if (!in.IsZerocoinSpend())
-                    return state.DoS(100, error("CheckTransaction() : zerocoinspend contains inputs that are not zerocoins"));
+                if (!in.IsZerocoinSpend() && !in.scriptSig.IsZerocoinPublicSpend())
+                    return state.DoS(100,
+                                     error("CheckTransaction() : zerocoinspend contains inputs that are not zerocoins"));
             }
 
             // Do not require signature verification if this is initial sync and a block over 24 hours old
@@ -1357,12 +1378,29 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
 
             //Check for double spending of serial #'s
             for (const CTxIn& txIn : tx.vin) {
-                if (!txIn.IsZerocoinSpend())
-                    continue;
-                CoinSpend spend = TxInToZerocoinSpend(txIn);
-                if (!ContextualCheckZerocoinSpend(tx, spend, chainActive.Tip(), 0))
-                    return state.Invalid(error("%s: ContextualCheckZerocoinSpend failed for tx %s", __func__,
-                                               tx.GetHash().GetHex()), REJECT_INVALID, "bad-txns-invalid-zpiv");
+                // Only allow for zc spends inputs
+                bool isPublicSpend = txIn.scriptSig.IsZerocoinPublicSpend();
+                if (!txIn.IsZerocoinSpend() && !isPublicSpend) {
+                    return state.Invalid(error("%s: ContextualCheckZerocoinSpend failed for tx %s, every input must be a zcspend or zcpublicspend", __func__,
+                                        tx.GetHash().GetHex()), REJECT_INVALID, "bad-txns-invalid-zpiv");
+                }
+
+                if (isPublicSpend) {
+                    libzerocoin::ZerocoinParams* params = Params().Zerocoin_Params(false);
+                    PublicCoinSpend publicSpend(params);
+                    if (!ZPIVModule::ParseZerocoinPublicSpend(txIn, tx, state, publicSpend)){
+                        return false;
+                    }
+                    if (!ContextualCheckZerocoinSpend(tx, &publicSpend, chainActive.Tip(), 0))
+                        return state.Invalid(error("%s: ContextualCheckZerocoinSpend failed for tx %s", __func__,
+                                                   tx.GetHash().GetHex()), REJECT_INVALID, "bad-txns-invalid-zpiv");
+                } else {
+                    CoinSpend spend = TxInToZerocoinSpend(txIn);
+                    if (!ContextualCheckZerocoinSpend(tx, &spend, chainActive.Tip(), 0))
+                        return state.Invalid(error("%s: ContextualCheckZerocoinSpend failed for tx %s", __func__,
+                                                   tx.GetHash().GetHex()), REJECT_INVALID, "bad-txns-invalid-zpiv");
+                }
+
             }
         } else {
             LOCK(pool.cs);
@@ -1406,7 +1444,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
             // are the actual inputs available?
             if (!view.HaveInputs(tx))
                 return state.Invalid(error("AcceptToMemoryPool : inputs already spent"),
-                    REJECT_DUPLICATE, "bad-txns-inputs-spent");
+                                     REJECT_DUPLICATE, "bad-txns-inputs-spent");
 
             // Bring the best block into scope
             view.GetBestBlock();
@@ -1735,6 +1773,22 @@ bool AcceptableInputs(CTxMemPool& pool, CValidationState& state, const CTransact
 
     // SyncWithWallets(tx, NULL);
 
+    return true;
+}
+
+bool GetOutput(const uint256& hash, unsigned int index, CValidationState& state, CTxOut& out)
+{
+    libzerocoin::ZerocoinParams* params = Params().Zerocoin_Params(false);
+    PublicCoinSpend ret(params);
+    CTransaction txPrev;
+    uint256 hashBlock;
+    if (!GetTransaction(hash, txPrev, hashBlock, true)) {
+        return state.DoS(100, error("Output not found"));
+    }
+    if (index > txPrev.vout.size()) {
+        return state.DoS(100, error("Output not found, invalid index %d", index));
+    }
+    out = txPrev.vout[index];
     return true;
 }
 
@@ -2378,19 +2432,33 @@ void AddInvalidSpendsToMap(const CBlock& block)
 
         //Check all zerocoinspends for bad serials
         for (const CTxIn& in : tx.vin) {
-            if (in.IsZerocoinSpend()) {
-                CoinSpend spend = TxInToZerocoinSpend(in);
+            bool isPublicSpend = in.scriptSig.IsZerocoinPublicSpend();
+            if (in.IsZerocoinSpend() || isPublicSpend) {
+
+                CoinSpend* spend;
+                if (isPublicSpend) {
+                    libzerocoin::ZerocoinParams* params = Params().Zerocoin_Params(false);
+                    PublicCoinSpend publicSpend(params);
+                    CValidationState state;
+                    if (!ZPIVModule::ParseZerocoinPublicSpend(in, tx, state, publicSpend)){
+                        throw runtime_error("Failed to parse public spend");
+                    }
+                    spend = &publicSpend;
+                } else {
+                    CoinSpend spendObj = TxInToZerocoinSpend(in);
+                    spend = &spendObj;
+                }
 
                 //If serial is not valid, mark all outputs as bad
-                if (!spend.HasValidSerial(Params().Zerocoin_Params(false))) {
-                    mapInvalidSerials[spend.getCoinSerialNumber()] = spend.getDenomination() * COIN;
+                if (!spend->HasValidSerial(Params().Zerocoin_Params(false))) {
+                    mapInvalidSerials[spend->getCoinSerialNumber()] = spend->getDenomination() * COIN;
 
                     // Derive the actual valid serial from the invalid serial if possible
-                    CBigNum bnActualSerial = spend.CalculateValidSerial(Params().Zerocoin_Params(false));
+                    CBigNum bnActualSerial = spend->CalculateValidSerial(Params().Zerocoin_Params(false));
                     uint256 txHash;
 
                     if (zerocoinDB->ReadCoinSpend(bnActualSerial, txHash)) {
-                        mapInvalidSerials[bnActualSerial] = spend.getDenomination() * COIN;
+                        mapInvalidSerials[bnActualSerial] = spend->getDenomination() * COIN;
 
                         CTransaction txPrev;
                         uint256 hashBlock;
@@ -2567,25 +2635,40 @@ bool DisconnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex
          * note we only undo zerocoin databasing in the following statement, value to and from PIVX
          * addresses should still be handled by the typical bitcoin based undo code
          * */
-        if (tx.HasZerocoinSpendInputs()) {
-            //erase all zerocoinspends in this transaction
-            for (const CTxIn& txin : tx.vin) {
-                if (txin.IsZerocoinSpend()) {
-                    CoinSpend spend = TxInToZerocoinSpend(txin);
-                    if (!zerocoinDB->EraseCoinSpend(spend.getCoinSerialNumber()))
-                        return error("failed to erase spent zerocoin in block");
+        if (tx.ContainsZerocoins()) {
+            if (tx.IsZerocoinSpend()) {
+                //erase all zerocoinspends in this transaction
+                for (const CTxIn& txin : tx.vin) {
+                    bool isPublicSpend = txin.scriptSig.IsZerocoinPublicSpend();
+                    if (txin.scriptSig.IsZerocoinSpend() || isPublicSpend) {
+                        CBigNum serial;
+                        if (isPublicSpend) {
+                            libzerocoin::ZerocoinParams* params = Params().Zerocoin_Params(false);
+                            PublicCoinSpend publicSpend(params);
+                            CValidationState state;
+                            if (!ZPIVModule::ParseZerocoinPublicSpend(txin, tx, state, publicSpend)){
+                                return error("Failed to parse public spend");
+                            }
+                            serial = publicSpend.getCoinSerialNumber();
+                        } else {
+                            CoinSpend spend = TxInToZerocoinSpend(txin);
+                            serial = spend.getCoinSerialNumber();
+                        }
 
-                    //if this was our spend, then mark it unspent now
-                    if (pwalletMain) {
-                        if (pwalletMain->IsMyZerocoinSpend(spend.getCoinSerialNumber())) {
-                            if (!pwalletMain->SetMintUnspent(spend.getCoinSerialNumber()))
-                                LogPrintf("%s: failed to automatically reset mint", __func__);
+                        if (!zerocoinDB->EraseCoinSpend(serial))
+                            return error("failed to erase spent zerocoin in block");
+
+                        //if this was our spend, then mark it unspent now
+                        if (pwalletMain) {
+                            if (pwalletMain->IsMyZerocoinSpend(spend.getCoinSerialNumber())) {
+                                if (!pwalletMain->SetMintUnspent(spend.getCoinSerialNumber()))
+                                    LogPrintf("%s: failed to automatically reset mint", __func__);
+                            }
                         }
                     }
-                }
 
+                }
             }
-        }
 
         if (tx.HasZerocoinMintOutputs()) {
             //erase all zerocoinmints in this transaction
@@ -3124,15 +3207,30 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             //Check for double spending of serial #'s
             set<CBigNum> setSerials;
             for (const CTxIn& txIn : tx.vin) {
-                if (!txIn.IsZerocoinSpend())
+                bool isPublicSpend = txIn.scriptSig.IsZerocoinPublicSpend();
+                if (!txIn.IsZerocoinSpend() && !isPublicSpend)
                     continue;
-                CoinSpend spend = TxInToZerocoinSpend(txIn);
-                nValueIn += spend.getDenomination() * COIN;
 
-                //queue for db write after the 'justcheck' section has concluded
-                vSpends.emplace_back(make_pair(spend, tx.GetHash()));
-                if (!ContextualCheckZerocoinSpend(tx, spend, pindex, hashBlock))
-                    return state.DoS(100, error("%s: failed to add block %s with invalid zerocoinspend", __func__, tx.GetHash().GetHex()), REJECT_INVALID);
+
+                if (isPublicSpend) {
+                    libzerocoin::ZerocoinParams* params = Params().Zerocoin_Params(false);
+                    PublicCoinSpend publicSpend(params);
+                    if (!ZPIVModule::ParseZerocoinPublicSpend(txIn, tx, state, publicSpend)){
+                        return false;
+                    }
+                    nValueIn += publicSpend.getDenomination() * COIN;
+                    //queue for db write after the 'justcheck' section has concluded
+                    vSpends.emplace_back(make_pair(publicSpend, tx.GetHash()));
+                    if (!ContextualCheckZerocoinSpend(tx, &publicSpend, pindex, hashBlock))
+                        return state.DoS(100, error("%s: failed to add block %s with invalid public zc spend", __func__, tx.GetHash().GetHex()), REJECT_INVALID);
+                } else {
+                    CoinSpend spend = TxInToZerocoinSpend(txIn);
+                    nValueIn += spend.getDenomination() * COIN;
+                    //queue for db write after the 'justcheck' section has concluded
+                    vSpends.emplace_back(make_pair(spend, tx.GetHash()));
+                    if (!ContextualCheckZerocoinSpend(tx, &spend, pindex, hashBlock))
+                        return state.DoS(100, error("%s: failed to add block %s with invalid zerocoinspend", __func__, tx.GetHash().GetHex()), REJECT_INVALID);
+                }
             }
 
             // Check that zPIV mints are not already known
@@ -4308,8 +4406,19 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
         // double check that there are no double spent zPIV spends in this block
         if (tx.HasZerocoinSpendInputs()) {
             for (const CTxIn& txIn : tx.vin) {
-                if (txIn.IsZerocoinSpend()) {
-                    libzerocoin::CoinSpend spend = TxInToZerocoinSpend(txIn);
+                bool isPublicSpend = txIn.scriptSig.IsZerocoinPublicSpend();
+                if (txIn.IsZerocoinSpend() || isPublicSpend) {
+                    libzerocoin::CoinSpend spend;
+                    if (isPublicSpend) {
+                        libzerocoin::ZerocoinParams* params = Params().Zerocoin_Params(false);
+                        PublicCoinSpend publicSpend(params);
+                        if (!ZPIVModule::ParseZerocoinPublicSpend(txIn, tx, state, publicSpend)){
+                            return false;
+                        }
+                        spend = publicSpend;
+                    } else {
+                        spend = TxInToZerocoinSpend(txIn);
+                    }
                     if (count(vBlockSerials.begin(), vBlockSerials.end(), spend.getCoinSerialNumber()))
                         return state.DoS(100, error("%s : Double spending of zPIV serial %s in block\n Block: %s",
                                                     __func__, spend.getCoinSerialNumber().GetHex(), block.ToString()));
@@ -4655,8 +4764,19 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
         for (const CTransaction& tx : block.vtx) {
             for (const CTxIn& in: tx.vin) {
                 if(nHeight >= Params().Zerocoin_StartHeight()) {
-                    if (in.IsZerocoinSpend()) {
-                        CoinSpend spend = TxInToZerocoinSpend(in);
+                    bool isPublicSpend = in.scriptSig.IsZerocoinPublicSpend();
+                    if (in.IsZerocoinSpend() || isPublicSpend) {
+                        libzerocoin::CoinSpend spend;
+                        if (isPublicSpend) {
+                            libzerocoin::ZerocoinParams* params = Params().Zerocoin_Params(false);
+                            PublicCoinSpend publicSpend(params);
+                            if (!ZPIVModule::ParseZerocoinPublicSpend(in, tx, state, publicSpend)){
+                                return false;
+                            }
+                            spend = publicSpend;
+                        } else {
+                            spend = TxInToZerocoinSpend(in);
+                        }
                         // Check for serials double spending in the same block
                         if (std::find(inBlockSerials.begin(), inBlockSerials.end(), spend.getCoinSerialNumber()) !=
                             inBlockSerials.end()) {
@@ -4757,7 +4877,7 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
                             return state.DoS(100, error("%s: serial double spent on main chain", __func__));
                     }
 
-                    if (!ContextualCheckZerocoinSpendNoSerialCheck(stakeTxIn, spend, pindex, 0))
+                    if (!ContextualCheckZerocoinSpendNoSerialCheck(stakeTxIn, &spend, pindex, 0))
                         return state.DoS(100,error("%s: forked chain ContextualCheckZerocoinSpend failed for tx %s", __func__,
                                                    stakeTxIn.GetHash().GetHex()), REJECT_INVALID, "bad-txns-invalid-zpiv");
 
@@ -4803,7 +4923,7 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
             if(!isBlockFromFork)
                 for (const CTxIn& zPivInput : zPIVInputs) {
                         CoinSpend spend = TxInToZerocoinSpend(zPivInput);
-                        if (!ContextualCheckZerocoinSpend(stakeTxIn, spend, pindex, 0))
+                        if (!ContextualCheckZerocoinSpend(stakeTxIn, &spend, pindex, 0))
                             return state.DoS(100,error("%s: main chain ContextualCheckZerocoinSpend failed for tx %s", __func__,
                                     stakeTxIn.GetHash().GetHex()), REJECT_INVALID, "bad-txns-invalid-zpiv");
                 }

--- a/src/main.h
+++ b/src/main.h
@@ -21,6 +21,7 @@
 #include "primitives/block.h"
 #include "primitives/transaction.h"
 #include "zpiv/zerocoin.h"
+#include "zpiv/zpivmodule.h"
 #include "script/script.h"
 #include "script/sigcache.h"
 #include "script/standard.h"
@@ -235,6 +236,8 @@ bool IsInitialBlockDownload();
 std::string GetWarnings(std::string strFor);
 /** Retrieve a transaction (from memory pool, or from disk, if possible) */
 bool GetTransaction(const uint256& hash, CTransaction& tx, uint256& hashBlock, bool fAllowSlow = false, CBlockIndex* blockIndex = nullptr);
+/** Retrieve an output (from memory pool, or from disk, if possible) */
+bool GetOutput(const uint256& hash, unsigned int index, CValidationState& state, CTxOut& out);
 /** Find the best known block, and make it the tip of the block chain */
 
 // ***TODO***
@@ -355,8 +358,8 @@ void UpdateCoins(const CTransaction& tx, CValidationState& state, CCoinsViewCach
 bool CheckTransaction(const CTransaction& tx, bool fZerocoinActive, bool fRejectBadUTXO, CValidationState& state, bool fFakeSerialAttack = false);
 bool CheckZerocoinMint(const uint256& txHash, const CTxOut& txout, CValidationState& state, bool fCheckOnly = false);
 bool CheckZerocoinSpend(const CTransaction& tx, bool fVerifySignature, CValidationState& state, bool fFakeSerialAttack = false);
-bool ContextualCheckZerocoinSpend(const CTransaction& tx, const libzerocoin::CoinSpend& spend, CBlockIndex* pindex, const uint256& hashBlock);
-bool ContextualCheckZerocoinSpendNoSerialCheck(const CTransaction& tx, const libzerocoin::CoinSpend& spend, CBlockIndex* pindex, const uint256& hashBlock);
+bool ContextualCheckZerocoinSpend(const CTransaction& tx, const libzerocoin::CoinSpend* spend, CBlockIndex* pindex, const uint256& hashBlock);
+bool ContextualCheckZerocoinSpendNoSerialCheck(const CTransaction& tx, const libzerocoin::CoinSpend* spend, CBlockIndex* pindex, const uint256& hashBlock);
 bool IsTransactionInChain(const uint256& txId, int& nHeightTx, CTransaction& tx);
 bool IsTransactionInChain(const uint256& txId, int& nHeightTx);
 bool IsBlockHashInChain(const uint256& hashBlock);
@@ -369,7 +372,6 @@ bool ReindexAccumulators(list<uint256>& listMissingCheckpoints, string& strError
 
 // Fake Serial attack Range
 bool isBlockBetweenFakeSerialAttackRange(int nHeight);
-
 
 /**
  * Check if transaction will be final in the next block to be created.

--- a/src/main.h
+++ b/src/main.h
@@ -373,6 +373,9 @@ bool ReindexAccumulators(list<uint256>& listMissingCheckpoints, string& strError
 // Fake Serial attack Range
 bool isBlockBetweenFakeSerialAttackRange(int nHeight);
 
+// Public coin spend
+bool CheckPublicCoinSpendEnforced(int blockHeight, bool isPrivZerocoinSpend, bool isPublicSpend);
+
 /**
  * Check if transaction will be final in the next block to be created.
  *

--- a/src/main.h
+++ b/src/main.h
@@ -374,7 +374,7 @@ bool ReindexAccumulators(list<uint256>& listMissingCheckpoints, string& strError
 bool isBlockBetweenFakeSerialAttackRange(int nHeight);
 
 // Public coin spend
-bool CheckPublicCoinSpendEnforced(int blockHeight, bool isPrivZerocoinSpend, bool isPublicSpend);
+bool CheckPublicCoinSpendEnforced(int blockHeight, bool isPublicSpend);
 
 /**
  * Check if transaction will be final in the next block to be created.

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -371,7 +371,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, 
 
                 bool fDoubleSerial = false;
                 for (const CTxIn& txIn : tx.vin) {
-                    bool isPublicSpend = txIn.scriptSig.IsZerocoinPublicSpend();
+                    bool isPublicSpend = txIn.IsZerocoinPublicSpend();
                     if (txIn.IsZerocoinSpend() || isPublicSpend) {
                         libzerocoin::CoinSpend* spend;
                         if (isPublicSpend) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -371,18 +371,32 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, 
 
                 bool fDoubleSerial = false;
                 for (const CTxIn& txIn : tx.vin) {
-                    if (txIn.IsZerocoinSpend()) {
-                        libzerocoin::CoinSpend spend = TxInToZerocoinSpend(txIn);
-                        bool fUseV1Params = libzerocoin::ExtractVersionFromSerial(spend.getCoinSerialNumber()) < libzerocoin::PrivateCoin::PUBKEY_VERSION;
-                        if (!spend.HasValidSerial(Params().Zerocoin_Params(fUseV1Params)))
+                    bool isPublicSpend = txIn.scriptSig.IsZerocoinPublicSpend();
+                    if (txIn.IsZerocoinSpend() || isPublicSpend) {
+                        libzerocoin::CoinSpend* spend;
+                        if (isPublicSpend) {
+                            libzerocoin::ZerocoinParams* params = Params().Zerocoin_Params(false);
+                            PublicCoinSpend publicSpend(params);
+                            CValidationState state;
+                            if (!ZPIVModule::ParseZerocoinPublicSpend(txIn, tx, state, publicSpend)){
+                                throw std::runtime_error("Invalid public spend parse");
+                            }
+                            spend = &publicSpend;
+                        } else {
+                            libzerocoin::CoinSpend spendObj = TxInToZerocoinSpend(txIn);
+                            spend = &spendObj;
+                        }
+
+                        bool fUseV1Params = libzerocoin::ExtractVersionFromSerial(spend->getCoinSerialNumber()) < libzerocoin::PrivateCoin::PUBKEY_VERSION;
+                        if (!spend->HasValidSerial(Params().Zerocoin_Params(fUseV1Params)))
                             fDoubleSerial = true;
-                        if (count(vBlockSerials.begin(), vBlockSerials.end(), spend.getCoinSerialNumber()))
+                        if (count(vBlockSerials.begin(), vBlockSerials.end(), spend->getCoinSerialNumber()))
                             fDoubleSerial = true;
-                        if (count(vTxSerials.begin(), vTxSerials.end(), spend.getCoinSerialNumber()))
+                        if (count(vTxSerials.begin(), vTxSerials.end(), spend->getCoinSerialNumber()))
                             fDoubleSerial = true;
                         if (fDoubleSerial)
                             break;
-                        vTxSerials.emplace_back(spend.getCoinSerialNumber());
+                        vTxSerials.emplace_back(spend->getCoinSerialNumber());
                     }
                 }
                 //This zPIV serial has already been included in the block, do not add this tx.

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -166,7 +166,7 @@ CTransaction& CTransaction::operator=(const CTransaction &tx) {
 bool CTransaction::HasZerocoinSpendInputs() const
 {
     for (const CTxIn& txin: vin) {
-        if (txin.IsZerocoinSpend())
+        if (txin.IsZerocoinSpend() || txin.scriptSig.IsZerocoinPublicSpend())
             return true;
     }
     return false;
@@ -242,9 +242,12 @@ std::list<COutPoint> CTransaction::GetOutPoints() const
 
 CAmount CTransaction::GetZerocoinSpent() const
 {
+    if(!IsZerocoinSpend() && !IsZerocoinPublicSpend())
+        return 0;
+
     CAmount nValueOut = 0;
     for (const CTxIn& txin : vin) {
-        if(!txin.IsZerocoinSpend())
+        if(!txin.IsZerocoinSpend() && !txin.scriptSig.IsZerocoinPublicSpend())
             continue;
 
         nValueOut += txin.nSequence * COIN;

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -64,6 +64,11 @@ bool CTxIn::IsZerocoinSpend() const
     return prevout.hash == 0 && scriptSig.IsZerocoinSpend();
 }
 
+bool CTxIn::IsZerocoinPublicSpend() const
+{
+    return scriptSig.IsZerocoinPublicSpend();
+}
+
 std::string CTxIn::ToString() const
 {
     std::string str;
@@ -166,7 +171,7 @@ CTransaction& CTransaction::operator=(const CTransaction &tx) {
 bool CTransaction::HasZerocoinSpendInputs() const
 {
     for (const CTxIn& txin: vin) {
-        if (txin.IsZerocoinSpend() || txin.scriptSig.IsZerocoinPublicSpend())
+        if (txin.IsZerocoinSpend() || txin.IsZerocoinPublicSpend())
             return true;
     }
     return false;
@@ -181,11 +186,11 @@ bool CTransaction::HasZerocoinMintOutputs() const
     return false;
 }
 
-bool CTransaction::IsZerocoinPublicSpend() const
+bool CTransaction::HasZerocoinPublicSpendInputs() const
 {
     // The wallet only allows publicSpend inputs in the same tx and not a combination between piv and zpiv
     for(const CTxIn& txin : vin) {
-        if (txin.scriptSig.IsZerocoinPublicSpend())
+        if (txin.IsZerocoinPublicSpend())
             return true;
     }
     return false;
@@ -254,7 +259,7 @@ CAmount CTransaction::GetZerocoinSpent() const
 {
     CAmount nValueOut = 0;
     for (const CTxIn& txin : vin) {
-        if(!txin.IsZerocoinSpend() && !txin.scriptSig.IsZerocoinPublicSpend())
+        if(!txin.IsZerocoinSpend())
             continue;
 
         nValueOut += txin.nSequence * COIN;

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -181,6 +181,16 @@ bool CTransaction::HasZerocoinMintOutputs() const
     return false;
 }
 
+bool CTransaction::IsZerocoinPublicSpend() const
+{
+    // The wallet only allows publicSpend inputs in the same tx and not a combination between piv and zpiv
+    for(const CTxIn& txin : vin) {
+        if (txin.scriptSig.IsZerocoinPublicSpend())
+            return true;
+    }
+    return false;
+}
+
 bool CTransaction::IsCoinStake() const
 {
     if (vin.empty())
@@ -242,9 +252,6 @@ std::list<COutPoint> CTransaction::GetOutPoints() const
 
 CAmount CTransaction::GetZerocoinSpent() const
 {
-    if(!IsZerocoinSpend() && !IsZerocoinPublicSpend())
-        return 0;
-
     CAmount nValueOut = 0;
     for (const CTxIn& txin : vin) {
         if(!txin.IsZerocoinSpend() && !txin.scriptSig.IsZerocoinPublicSpend())

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -96,6 +96,7 @@ public:
     }
 
     bool IsZerocoinSpend() const;
+    bool IsZerocoinPublicSpend() const;
 
     friend bool operator==(const CTxIn& a, const CTxIn& b)
     {
@@ -260,15 +261,14 @@ public:
     unsigned int CalculateModifiedSize(unsigned int nTxSize=0) const;
 
     bool HasZerocoinSpendInputs() const;
+    bool HasZerocoinPublicSpendInputs() const;
 
     bool HasZerocoinMintOutputs() const;
 
     bool ContainsZerocoins() const
     {
-        return HasZerocoinSpendInputs() || HasZerocoinMintOutputs();
+        return HasZerocoinSpendInputs() || HasZerocoinPublicSpendInputs() || HasZerocoinMintOutputs();
     }
-
-    bool IsZerocoinPublicSpend() const;
 
     CAmount GetZerocoinMinted() const;
     CAmount GetZerocoinSpent() const;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -268,6 +268,17 @@ public:
         return HasZerocoinSpendInputs() || HasZerocoinMintOutputs();
     }
 
+    // TODO: Move this to the cpp and add it to the HasZerocoinSpendinputs method
+    bool IsZerocoinPublicSpend() const
+    {
+        // The wallet only allows publicSpend inputs in the same tx and not a combination between piv and zpiv
+        for(const CTxIn& txin : vin) {
+            if (txin.scriptSig.IsZerocoinPublicSpend())
+                return true;
+        }
+        return false;
+    }
+
     CAmount GetZerocoinMinted() const;
     CAmount GetZerocoinSpent() const;
     int GetZerocoinMintCount() const;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -268,16 +268,7 @@ public:
         return HasZerocoinSpendInputs() || HasZerocoinMintOutputs();
     }
 
-    // TODO: Move this to the cpp and add it to the HasZerocoinSpendinputs method
-    bool IsZerocoinPublicSpend() const
-    {
-        // The wallet only allows publicSpend inputs in the same tx and not a combination between piv and zpiv
-        for(const CTxIn& txin : vin) {
-            if (txin.scriptSig.IsZerocoinPublicSpend())
-                return true;
-        }
-        return false;
-    }
+    bool IsZerocoinPublicSpend() const;
 
     CAmount GetZerocoinMinted() const;
     CAmount GetZerocoinSpent() const;

--- a/src/qt/privacydialog.cpp
+++ b/src/qt/privacydialog.cpp
@@ -440,17 +440,19 @@ void PrivacyDialog::sendzPIV()
 
     // Display errors during spend
     if (!fSuccess) {
+        /*
         int nNeededSpends = receipt.GetNeededSpends(); // Number of spends we would need for this transaction
-        /*const int nMaxSpends = Params().Zerocoin_MaxSpendsPerTransaction(); // Maximum possible spends for one zPIV transaction
+        const int nMaxSpends = Params().Zerocoin_MaxSpendsPerTransaction(); // Maximum possible spends for one zPIV transaction
         if (nNeededSpends > nMaxSpends) {
             QString strStatusMessage = tr("Too much inputs (") + QString::number(nNeededSpends, 10) + tr(") needed.\nMaximum allowed: ") + QString::number(nMaxSpends, 10);
             strStatusMessage += tr("\nEither mint higher denominations (so fewer inputs are needed) or reduce the amount to spend.");
             QMessageBox::warning(this, tr("Spend Zerocoin"), strStatusMessage.toStdString().c_str(), QMessageBox::Ok, QMessageBox::Ok);
             ui->TEMintStatus->setPlainText(tr("Spend Zerocoin failed with status = ") +QString::number(receipt.GetStatus(), 10) + "\n" + "Message: " + QString::fromStdString(strStatusMessage.toStdString()));
         }
-        else {*/
-            QMessageBox::warning(this, tr("Spend Zerocoin"), receipt.GetStatusMessage().c_str(), QMessageBox::Ok, QMessageBox::Ok);
-            ui->TEMintStatus->setPlainText(tr("Spend Zerocoin failed with status = ") +QString::number(receipt.GetStatus(), 10) + "\n" + "Message: " + QString::fromStdString(receipt.GetStatusMessage()));
+        else {
+         */
+        QMessageBox::warning(this, tr("Spend Zerocoin"), receipt.GetStatusMessage().c_str(), QMessageBox::Ok, QMessageBox::Ok);
+        ui->TEMintStatus->setPlainText(tr("Spend Zerocoin failed with status = ") +QString::number(receipt.GetStatus(), 10) + "\n" + "Message: " + QString::fromStdString(receipt.GetStatusMessage()));
         //}
         ui->zPIVpayAmount->setFocus();
         ui->TEMintStatus->repaint();

--- a/src/qt/privacydialog.cpp
+++ b/src/qt/privacydialog.cpp
@@ -109,6 +109,8 @@ PrivacyDialog::PrivacyDialog(QWidget* parent) : QDialog(parent, Qt::WindowSystem
     if(!settings.contains("fDenomsSectionMinimized"))
         settings.setValue("fDenomsSectionMinimized", true);
     minimizeDenomsSection(settings.value("fDenomsSectionMinimized").toBool());
+
+    ui->checkBoxMintChange->setVisible(false);
 }
 
 PrivacyDialog::~PrivacyDialog()
@@ -343,7 +345,7 @@ void PrivacyDialog::sendzPIV()
     }
 
     // Convert change to zPIV
-    bool fMintChange = ui->checkBoxMintChange->isChecked();
+    bool fMintChange = false;// ui->checkBoxMintChange->isChecked();
 
     // Persist minimize change setting
     fMinimizeChange = ui->checkBoxMinimizeChange->isChecked();

--- a/src/qt/privacydialog.cpp
+++ b/src/qt/privacydialog.cpp
@@ -439,17 +439,17 @@ void PrivacyDialog::sendzPIV()
     // Display errors during spend
     if (!fSuccess) {
         int nNeededSpends = receipt.GetNeededSpends(); // Number of spends we would need for this transaction
-        const int nMaxSpends = Params().Zerocoin_MaxSpendsPerTransaction(); // Maximum possible spends for one zPIV transaction
+        /*const int nMaxSpends = Params().Zerocoin_MaxSpendsPerTransaction(); // Maximum possible spends for one zPIV transaction
         if (nNeededSpends > nMaxSpends) {
             QString strStatusMessage = tr("Too much inputs (") + QString::number(nNeededSpends, 10) + tr(") needed.\nMaximum allowed: ") + QString::number(nMaxSpends, 10);
             strStatusMessage += tr("\nEither mint higher denominations (so fewer inputs are needed) or reduce the amount to spend.");
             QMessageBox::warning(this, tr("Spend Zerocoin"), strStatusMessage.toStdString().c_str(), QMessageBox::Ok, QMessageBox::Ok);
             ui->TEMintStatus->setPlainText(tr("Spend Zerocoin failed with status = ") +QString::number(receipt.GetStatus(), 10) + "\n" + "Message: " + QString::fromStdString(strStatusMessage.toStdString()));
         }
-        else {
+        else {*/
             QMessageBox::warning(this, tr("Spend Zerocoin"), receipt.GetStatusMessage().c_str(), QMessageBox::Ok, QMessageBox::Ok);
             ui->TEMintStatus->setPlainText(tr("Spend Zerocoin failed with status = ") +QString::number(receipt.GetStatus(), 10) + "\n" + "Message: " + QString::fromStdString(receipt.GetStatusMessage()));
-        }
+        //}
         ui->zPIVpayAmount->setFocus();
         ui->TEMintStatus->repaint();
         ui->TEMintStatus->verticalScrollBar()->setValue(ui->TEMintStatus->verticalScrollBar()->maximum()); // Automatically scroll to end of text

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -12,7 +12,9 @@
 #include "timedata.h"
 #include "wallet/wallet.h"
 #include "zpivchain.h"
+#include "main.h"
 
+#include <iostream>
 #include <stdint.h>
 
 /* Return positive answer if transaction should be shown in list.
@@ -44,8 +46,18 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet* 
 
     if (wtx.HasZerocoinSpendInputs()) {
         // a zerocoin spend that was created by this wallet
-        libzerocoin::CoinSpend zcspend = TxInToZerocoinSpend(wtx.vin[0]);
-        fZSpendFromMe = wallet->IsMyZerocoinSpend(zcspend.getCoinSerialNumber());
+        if (wtx.IsZerocoinPublicSpend()) {
+            libzerocoin::ZerocoinParams* params = Params().Zerocoin_Params(false);
+            PublicCoinSpend publicSpend(params);
+            CValidationState state;
+            if (!ZPIVModule::ParseZerocoinPublicSpend(wtx.vin[0], wtx, state, publicSpend)){
+                throw std::runtime_error("Error parsing zc public spend");
+            }
+            fZSpendFromMe = wallet->IsMyZerocoinSpend(publicSpend.getCoinSerialNumber());
+        } else {
+            libzerocoin::CoinSpend zcspend = TxInToZerocoinSpend(wtx.vin[0]);
+            fZSpendFromMe = wallet->IsMyZerocoinSpend(zcspend.getCoinSerialNumber());
+        }
     }
 
     if (wtx.IsCoinStake()) {

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -46,7 +46,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet* 
 
     if (wtx.HasZerocoinSpendInputs()) {
         // a zerocoin spend that was created by this wallet
-        if (wtx.IsZerocoinPublicSpend()) {
+        if (wtx.HasZerocoinPublicSpendInputs()) {
             libzerocoin::ZerocoinParams* params = Params().Zerocoin_Params(false);
             PublicCoinSpend publicSpend(params);
             CValidationState state;

--- a/src/qt/zpivcontroldialog.cpp
+++ b/src/qt/zpivcontroldialog.cpp
@@ -80,7 +80,7 @@ void ZPivControlDialog::updateList()
 
     //populate rows with mint info
     int nBestHeight = chainActive.Height();
-    map<CoinDenomination, int> mapMaturityHeight = GetMintMaturityHeight();
+    //map<CoinDenomination, int> mapMaturityHeight = GetMintMaturityHeight();
     for (const CMintMeta& mint : setMints) {
         // assign this mint to the correct denomination in the tree view
         libzerocoin::CoinDenomination denom = mint.denom;
@@ -123,9 +123,10 @@ void ZPivControlDialog::updateList()
         }
 
         // check for maturity
-        bool isMature = false;
-        if (mapMaturityHeight.count(mint.denom))
-            isMature = mint.nHeight < mapMaturityHeight.at(denom);
+        // Always mature, public spends doesn't require any new accumulation.
+        bool isMature = true;
+        //if (mapMaturityHeight.count(mint.denom))
+        //    isMature = mint.nHeight < mapMaturityHeight.at(denom);
 
         // disable selecting this mint if it is not spendable - also display a reason why
         bool fSpendable = isMature && nConfirmations >= Params().Zerocoin_MintRequiredConfirmations() && mint.isSeedCorrect;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1051,7 +1051,7 @@ UniValue getfeeinfo(const UniValue& params, bool fHelp)
                 continue;
 
             for (unsigned int j = 0; j < tx.vin.size(); j++) {
-                if (tx.vin[j].IsZerocoinSpend() || tx.vin[j].scriptSig.IsZerocoinPublicSpend()) {
+                if (tx.vin[j].IsZerocoinSpend() || tx.vin[j].IsZerocoinPublicSpend()) {
                     nValueIn += tx.vin[j].nSequence * COIN;
                     continue;
                 }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1051,7 +1051,7 @@ UniValue getfeeinfo(const UniValue& params, bool fHelp)
                 continue;
 
             for (unsigned int j = 0; j < tx.vin.size(); j++) {
-                if (tx.vin[j].IsZerocoinSpend()) {
+                if (tx.vin[j].IsZerocoinSpend() || tx.vin[j].scriptSig.IsZerocoinPublicSpend()) {
                     nValueIn += tx.vin[j].nSequence * COIN;
                     continue;
                 }
@@ -1446,6 +1446,7 @@ UniValue getserials(const UniValue& params, bool fHelp) {
             }
             // loop through each input
             for (const CTxIn& txin : tx.vin) {
+                // TODO: Add public coin spend parse here..
                 if (txin.IsZerocoinSpend()) {
                     libzerocoin::CoinSpend spend = TxInToZerocoinSpend(txin);
                     std::string serial_str = spend.getCoinSerialNumber().ToString(16);

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -446,6 +446,7 @@ static const CRPCCommand vRPCCommands[] =
         {"wallet", "walletpassphrase", &walletpassphrase, true, false, true},
 
         {"zerocoin", "createrawzerocoinstake", &createrawzerocoinstake, false, false, true},
+        {"zerocoin", "createrawzerocoinpublicspend", &createrawzerocoinpublicspend, false, false, true},
         {"zerocoin", "getzerocoinbalance", &getzerocoinbalance, false, false, true},
         {"zerocoin", "listmintedzerocoins", &listmintedzerocoins, false, false, true},
         {"zerocoin", "listspentzerocoins", &listspentzerocoins, false, false, true},

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -179,7 +179,7 @@ extern std::string HelpExampleCli(std::string methodname, std::string args);
 extern std::string HelpExampleRpc(std::string methodname, std::string args);
 
 extern void EnsureWalletIsUnlocked(bool fAllowAnonOnly = false);
-extern UniValue DoZpivSpend(const CAmount nAmount, bool fMintChange, bool fMinimizeChange, vector<CZerocoinMint>& vMintsSelected, std::string address_str);
+extern UniValue DoZpivSpend(const CAmount nAmount, bool fMintChange, bool fMinimizeChange, vector<CZerocoinMint>& vMintsSelected, std::string address_str, bool isPublicSpend = true);
 
 extern UniValue getconnectioncount(const UniValue& params, bool fHelp); // in rpc/net.cpp
 extern UniValue getpeerinfo(const UniValue& params, bool fHelp);

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -284,6 +284,7 @@ extern UniValue decodescript(const UniValue& params, bool fHelp);
 extern UniValue signrawtransaction(const UniValue& params, bool fHelp);
 extern UniValue sendrawtransaction(const UniValue& params, bool fHelp);
 extern UniValue createrawzerocoinstake(const UniValue& params, bool fHelp);
+extern UniValue createrawzerocoinpublicspend(const UniValue& params, bool fHelp);
 
 extern UniValue findserial(const UniValue& params, bool fHelp); // in rpc/blockchain.cpp
 extern UniValue getblockcount(const UniValue& params, bool fHelp);

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -154,6 +154,7 @@ const char* GetOpName(opcodetype opcode)
     // zerocoin
     case OP_ZEROCOINMINT           : return "OP_ZEROCOINMINT";
     case OP_ZEROCOINSPEND          : return "OP_ZEROCOINSPEND";
+    case OP_ZEROCOINPUBLICSPEND          : return "OP_ZEROCOINPUBLICSPEND";
 
     case OP_INVALIDOPCODE          : return "OP_INVALIDOPCODE";
 
@@ -261,6 +262,14 @@ bool CScript::IsZerocoinMint() const
 bool CScript::IsZerocoinSpend() const
 {
     return StartsWithOpcode(OP_ZEROCOINSPEND);
+}
+
+bool CScript::IsZerocoinPublicSpend() const
+{
+    if (this->empty())
+        return false;
+
+    return (this->at(0) == OP_ZEROCOINPUBLICSPEND);
 }
 
 bool CScript::IsPushOnly(const_iterator pc) const

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -266,10 +266,7 @@ bool CScript::IsZerocoinSpend() const
 
 bool CScript::IsZerocoinPublicSpend() const
 {
-    if (this->empty())
-        return false;
-
-    return (this->at(0) == OP_ZEROCOINPUBLICSPEND);
+    return StartsWithOpcode(OP_ZEROCOINPUBLICSPEND);
 }
 
 bool CScript::IsPushOnly(const_iterator pc) const

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -171,6 +171,7 @@ enum opcodetype
     // zerocoin
     OP_ZEROCOINMINT = 0xc1,
     OP_ZEROCOINSPEND = 0xc2,
+    OP_ZEROCOINPUBLICSPEND = 0xc3,
 
     // template matching params
     OP_SMALLINTEGER = 0xfa,
@@ -601,6 +602,7 @@ public:
     bool StartsWithOpcode(const opcodetype opcode) const;
     bool IsZerocoinMint() const;
     bool IsZerocoinSpend() const;
+    bool IsZerocoinPublicSpend() const;
 
     /** Called by IsStandardTx and P2SH/BIP62 VerifyScript (which makes it consensus-critical). */
     bool IsPushOnly(const_iterator pc) const;

--- a/src/test/zerocoin_transactions_tests.cpp
+++ b/src/test/zerocoin_transactions_tests.cpp
@@ -61,8 +61,6 @@ BOOST_AUTO_TEST_CASE(zerocoin_public_spend_test)
     ZerocoinParams *ZCParams = Params().Zerocoin_Params(false);
     (void)ZCParams;
 
-    ZPIVModule zpivModule;
-
     PrivateCoin privCoin(ZCParams, libzerocoin::CoinDenomination::ZQ_ONE, true);
     const CPrivKey privKey = privCoin.getPrivKey();
 
@@ -95,17 +93,17 @@ BOOST_AUTO_TEST_CASE(zerocoin_public_spend_test)
     tx.vout[0].scriptPubKey = GetScriptForDestination(CBitcoinAddress("D9Ti4LEhF1n6dR2hGd2SyNADD51AVgva6q").Get());
 
     CTxIn in;
-    if (!zpivModule.createInput(in, mint, tx.GetHash())){
+    if (!ZPIVModule::createInput(in, mint, tx.GetHash())){
         BOOST_CHECK_MESSAGE(false, "Failed to create zc input");
     }
 
     PublicCoinSpend publicSpend(ZCParams);
-    if (!zpivModule.validateInput(in, out, tx, publicSpend)){
+    if (!ZPIVModule::validateInput(in, out, tx, publicSpend)){
         BOOST_CHECK_MESSAGE(false, "Failed to validate zc input");
     }
 
     PublicCoinSpend publicSpendTest(ZCParams);
-    BOOST_CHECK_MESSAGE(zpivModule.parseCoinSpend(in, tx, out, publicSpendTest), "Failed to parse public spend");
+    BOOST_CHECK_MESSAGE(ZPIVModule::parseCoinSpend(in, tx, out, publicSpendTest), "Failed to parse public spend");
     libzerocoin::CoinSpend *spend = &publicSpendTest;
 
     BOOST_CHECK_MESSAGE(publicSpendTest.HasValidSignature(), "Failed to validate public spend signature");

--- a/src/test/zerocoin_transactions_tests.cpp
+++ b/src/test/zerocoin_transactions_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "libzerocoin/Denominations.h"
+#include "libzerocoin/Coin.h"
 #include "amount.h"
 #include "chainparams.h"
 #include "coincontrol.h"
@@ -10,6 +11,7 @@
 #include "wallet/wallet.h"
 #include "wallet/walletdb.h"
 #include "txdb.h"
+#include "zpiv/zpivmodule.h"
 #include <boost/test/unit_test.hpp>
 #include <iostream>
 
@@ -50,6 +52,64 @@ BOOST_AUTO_TEST_CASE(zerocoin_spend_test)
     /// BOOST_CHECK_MESSAGE(vString == "Error: Wallet locked, unable to create transaction!"," Locked Wallet Check Failed");
 
     BOOST_CHECK_MESSAGE(receipt2.GetStatus() == ZPIV_TRX_FUNDS_PROBLEMS, "Failed Invalid Amount Check");
+
+}
+
+BOOST_AUTO_TEST_CASE(zerocoin_public_spend_test)
+{
+    SelectParams(CBaseChainParams::MAIN);
+    ZerocoinParams *ZCParams = Params().Zerocoin_Params(false);
+    (void)ZCParams;
+
+    ZPIVModule zpivModule;
+
+    PrivateCoin privCoin(ZCParams, libzerocoin::CoinDenomination::ZQ_ONE, true);
+    const CPrivKey privKey = privCoin.getPrivKey();
+
+    CZerocoinMint mint = CZerocoinMint(
+            privCoin.getPublicCoin().getDenomination(),
+            privCoin.getPublicCoin().getValue(),
+            privCoin.getRandomness(),
+            privCoin.getSerialNumber(),
+            false,
+            privCoin.getVersion(),
+            nullptr);
+    mint.SetPrivKey(privKey);
+
+
+    // Mint tx
+    CTransaction prevTx;
+
+    CScript scriptSerializedCoin = CScript()
+    << OP_ZEROCOINMINT << privCoin.getPublicCoin().getValue().getvch().size() << privCoin.getPublicCoin().getValue().getvch();
+    CTxOut out = CTxOut(libzerocoin::ZerocoinDenominationToAmount(privCoin.getPublicCoin().getDenomination()), scriptSerializedCoin);
+    prevTx.vout.push_back(out);
+
+    mint.SetOutputIndex(0);
+    mint.SetTxHash(prevTx.GetHash());
+
+    // Spend tx
+    CMutableTransaction tx;
+    tx.vout.resize(1);
+    tx.vout[0].nValue = 1*CENT;
+    tx.vout[0].scriptPubKey = GetScriptForDestination(CBitcoinAddress("D9Ti4LEhF1n6dR2hGd2SyNADD51AVgva6q").Get());
+
+    CTxIn in;
+    if (!zpivModule.createInput(in, mint, tx.GetHash())){
+        BOOST_CHECK_MESSAGE(false, "Failed to create zc input");
+    }
+
+    PublicCoinSpend publicSpend(ZCParams);
+    if (!zpivModule.validateInput(in, out, tx, publicSpend)){
+        BOOST_CHECK_MESSAGE(false, "Failed to validate zc input");
+    }
+
+    PublicCoinSpend publicSpendTest(ZCParams);
+    BOOST_CHECK_MESSAGE(zpivModule.parseCoinSpend(in, tx, out, publicSpendTest), "Failed to parse public spend");
+    libzerocoin::CoinSpend *spend = &publicSpendTest;
+
+    BOOST_CHECK_MESSAGE(publicSpendTest.HasValidSignature(), "Failed to validate public spend signature");
+    BOOST_CHECK_MESSAGE(spend->HasValidSignature(), "Failed to validate spend signature");
 
 }
 

--- a/src/test/zerocoin_transactions_tests.cpp
+++ b/src/test/zerocoin_transactions_tests.cpp
@@ -109,6 +109,11 @@ BOOST_AUTO_TEST_CASE(zerocoin_public_spend_test)
     BOOST_CHECK_MESSAGE(publicSpendTest.HasValidSignature(), "Failed to validate public spend signature");
     BOOST_CHECK_MESSAGE(spend->HasValidSignature(), "Failed to validate spend signature");
 
+    // Verify that fails with a different denomination
+    in.nSequence = 500;
+    PublicCoinSpend publicSpend2(ZCParams);
+    BOOST_CHECK_MESSAGE(!ZPIVModule::validateInput(in, out, tx, publicSpend2), "Different denomination");
+
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/zerocoin_transactions_tests.cpp
+++ b/src/test/zerocoin_transactions_tests.cpp
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(zerocoin_spend_test)
     CZerocoinSpendReceipt receipt;
     cWallet.SpendZerocoin(nAmount, *wtx, receipt, vMints, fMintChange, fMinimizeChange);
 
-    BOOST_CHECK_MESSAGE(receipt.GetStatus() == ZPIV_TRX_FUNDS_PROBLEMS, "Failed Invalid Amount Check");
+    BOOST_CHECK_MESSAGE(receipt.GetStatus() == ZPIV_TRX_FUNDS_PROBLEMS, strprintf("Failed Invalid Amount Check: %s", receipt.GetStatusMessage()));
 
     nAmount = 1;
     CZerocoinSpendReceipt receipt2;
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(zerocoin_spend_test)
     // if using "wallet.dat", instead of "unlocked.dat" need this
     /// BOOST_CHECK_MESSAGE(vString == "Error: Wallet locked, unable to create transaction!"," Locked Wallet Check Failed");
 
-    BOOST_CHECK_MESSAGE(receipt2.GetStatus() == ZPIV_TRX_FUNDS_PROBLEMS, "Failed Invalid Amount Check");
+    BOOST_CHECK_MESSAGE(receipt2.GetStatus() == ZPIV_TRX_FUNDS_PROBLEMS, strprintf("Failed Invalid Amount Check: %s", receipt.GetStatusMessage()));
 
 }
 

--- a/src/test/zerocoin_transactions_tests.cpp
+++ b/src/test/zerocoin_transactions_tests.cpp
@@ -12,13 +12,14 @@
 #include "wallet/walletdb.h"
 #include "txdb.h"
 #include "zpiv/zpivmodule.h"
+#include "test/test_pivx.h"
 #include <boost/test/unit_test.hpp>
 #include <iostream>
 
 using namespace libzerocoin;
 
 
-BOOST_AUTO_TEST_SUITE(zerocoin_transactions_tests)
+BOOST_FIXTURE_TEST_SUITE(zerocoin_transactions_tests, TestingSetup)
 
 static CWallet cWallet("unlocked.dat");
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -565,11 +565,11 @@ void CTxMemPool::check(const CCoinsViewCache* pcoins) const
                 fDependsWait = true;
             } else {
                 const CCoins* coins = pcoins->AccessCoins(txin.prevout.hash);
-                if(!txin.IsZerocoinSpend())
+                if(!txin.IsZerocoinSpend() && !txin.scriptSig.IsZerocoinPublicSpend())
                     assert(coins && coins->IsAvailable(txin.prevout.n));
             }
             // Check whether its inputs are marked in mapNextTx.
-            if(!txin.IsZerocoinSpend()) {
+            if(!txin.IsZerocoinSpend()  && !txin.scriptSig.IsZerocoinPublicSpend()) {
                 std::map<COutPoint, CInPoint>::const_iterator it3 = mapNextTx.find(txin.prevout);
                 assert(it3 != mapNextTx.end());
                 assert(it3->second.ptx == &tx);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -565,11 +565,11 @@ void CTxMemPool::check(const CCoinsViewCache* pcoins) const
                 fDependsWait = true;
             } else {
                 const CCoins* coins = pcoins->AccessCoins(txin.prevout.hash);
-                if(!txin.IsZerocoinSpend() && !txin.scriptSig.IsZerocoinPublicSpend())
+                if(!txin.IsZerocoinSpend() && !txin.IsZerocoinPublicSpend())
                     assert(coins && coins->IsAvailable(txin.prevout.n));
             }
             // Check whether its inputs are marked in mapNextTx.
-            if(!txin.IsZerocoinSpend()  && !txin.scriptSig.IsZerocoinPublicSpend()) {
+            if(!txin.IsZerocoinSpend()  && !txin.IsZerocoinPublicSpend()) {
                 std::map<COutPoint, CInPoint>::const_iterator it3 = mapNextTx.find(txin.prevout);
                 assert(it3 != mapNextTx.end());
                 assert(it3->second.ptx == &tx);

--- a/src/version.h
+++ b/src/version.h
@@ -11,7 +11,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70915;
+static const int PROTOCOL_VERSION = 70916;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -20,8 +20,8 @@ static const int INIT_PROTO_VERSION = 209;
 static const int GETHEADERS_VERSION = 70077;
 
 //! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION_BEFORE_ENFORCEMENT = 70912;
-static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT = 70914;
+static const int MIN_PEER_PROTO_VERSION_BEFORE_ENFORCEMENT = 70914;
+static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT = 70916;
 
 //! masternodes older than this proto version use old strMessage format for mnannounce
 static const int MIN_PEER_MNANNOUNCE = 70913;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2853,6 +2853,7 @@ UniValue spendzerocoin(const UniValue& params, bool fHelp)
             "3. minimizechange  (boolean, required) Try to minimize the returning change  [false]\n"
             "4. \"address\"     (string, optional, default=change) Send to specified address or to a new change address.\n"
             "                       If there is change then an address is required\n"
+            "5. ispublicspend (boolean, optional, default=true) create a public zc spend instead of use the old code (only for regression tests)"
 
             "\nResult:\n"
             "{\n"
@@ -2892,10 +2893,15 @@ UniValue spendzerocoin(const UniValue& params, bool fHelp)
     bool fMintChange = params[1].get_bool();        // Mint change to zPIV
     bool fMinimizeChange = params[2].get_bool();    // Minimize change
     std::string address_str = params.size() > 3 ? params[3].get_str() : "";
+    bool ispublicspend = params.size() > 4 ? params[3].get_bool() : true;
 
     vector<CZerocoinMint> vMintsSelected;
 
-    return DoZpivSpend(nAmount, fMintChange, fMinimizeChange, vMintsSelected, address_str);
+    if (!ispublicspend && Params().NetworkID() != CBaseChainParams::REGTEST) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "zPIV old spend only available in regtest for tests purposes");
+    }
+
+    return DoZpivSpend(nAmount, fMintChange, fMinimizeChange, vMintsSelected, address_str, ispublicspend);
 }
 
 
@@ -2993,7 +2999,7 @@ UniValue spendzerocoinmints(const UniValue& params, bool fHelp)
 }
 
 
-extern UniValue DoZpivSpend(const CAmount nAmount, bool fMintChange, bool fMinimizeChange, vector<CZerocoinMint>& vMintsSelected, std::string address_str)
+extern UniValue DoZpivSpend(const CAmount nAmount, bool fMintChange, bool fMinimizeChange, vector<CZerocoinMint>& vMintsSelected, std::string address_str, bool ispublicspend)
 {
     int64_t nTimeStart = GetTimeMillis();
     CBitcoinAddress address = CBitcoinAddress(); // Optional sending address. Dummy initialization here.
@@ -3005,9 +3011,9 @@ extern UniValue DoZpivSpend(const CAmount nAmount, bool fMintChange, bool fMinim
         address = CBitcoinAddress(address_str);
         if(!address.IsValid())
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid PIVX address");
-        fSuccess = pwalletMain->SpendZerocoin(nAmount, wtx, receipt, vMintsSelected, fMintChange, fMinimizeChange, &address);
+        fSuccess = pwalletMain->SpendZerocoin(nAmount, wtx, receipt, vMintsSelected, fMintChange, fMinimizeChange, &address, ispublicspend);
     } else                   // Spend to newly generated local address
-        fSuccess = pwalletMain->SpendZerocoin(nAmount, wtx, receipt, vMintsSelected, fMintChange, fMinimizeChange);
+        fSuccess = pwalletMain->SpendZerocoin(nAmount, wtx, receipt, vMintsSelected, fMintChange, fMinimizeChange, nullptr, ispublicspend);
 
     if (!fSuccess)
         throw JSONRPCError(RPC_WALLET_ERROR, receipt.GetStatusMessage());

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1660,20 +1660,25 @@ CAmount CWallet::GetBalance() const
     return nTotal;
 }
 
-std::map<libzerocoin::CoinDenomination, int> mapMintMaturity;
-int nLastMaturityCheck = 0;
+//std::map<libzerocoin::CoinDenomination, int> mapMintMaturity;
+//int nLastMaturityCheck = 0;
+
 CAmount CWallet::GetZerocoinBalance(bool fMatureOnly) const
 {
     if (fMatureOnly) {
-        if (chainActive.Height() > nLastMaturityCheck)
-            mapMintMaturity = GetMintMaturityHeight();
-        nLastMaturityCheck = chainActive.Height();
+        // This code is not removed just for when we back to use zPIV in the future, for now it's useless,
+        // every public coin spend is now spendable without need to have new mints on top.
+
+        //if (chainActive.Height() > nLastMaturityCheck)
+        //    mapMintMaturity = GetMintMaturityHeight();
+        //nLastMaturityCheck = chainActive.Height();
 
         CAmount nBalance = 0;
         vector<CMintMeta> vMints = zpivTracker->GetMints(true);
         for (auto meta : vMints) {
-            if (meta.nHeight >= mapMintMaturity.at(meta.denom) || meta.nHeight >= chainActive.Height() || meta.nHeight == 0)
-                continue;
+            // Every public coin spend is now spendable, no need to mint new coins on top.
+            //if (meta.nHeight >= mapMintMaturity.at(meta.denom) || meta.nHeight >= chainActive.Height() || meta.nHeight == 0)
+            //    continue;
             nBalance += libzerocoin::ZerocoinDenominationToAmount(meta.denom);
         }
         return nBalance;
@@ -4922,7 +4927,8 @@ bool CWallet::CreateZerocoinSpendTransaction(CAmount nValue, CWalletTx& wtxNew, 
     const int nMaxSpends = Params().Zerocoin_MaxSpendsPerTransaction(); // Maximum possible spends for one zPIV transaction
     vector<CMintMeta> vMintsToFetch;
     if (vSelectedMints.empty()) {
-        setMints = zpivTracker->ListMints(true, true, true); // need to find mints to spend
+        //  All of the zPIV used in the public coin spend are mature by default (everything is public now.. no need to wait for any accumulation)
+        setMints = zpivTracker->ListMints(true, false, true); // need to find mints to spend
         if(setMints.empty()) {
             receipt.SetStatus(_("Failed to find Zerocoins in wallet.dat"), nStatus);
             return false;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4903,7 +4903,6 @@ bool CWallet::MintsToInputVectorPublicSpend(std::map<CBigNum, CZerocoinMint>& ma
 
 bool CWallet::CreateZerocoinSpendTransaction(CAmount nValue, CWalletTx& wtxNew, CReserveKey& reserveKey, CZerocoinSpendReceipt& receipt, vector<CZerocoinMint>& vSelectedMints, vector<CDeterministicMint>& vNewMints, bool fMintChange,  bool fMinimizeChange, CBitcoinAddress* address)
 {
-
     // Check available funds
     int nStatus = ZPIV_TRX_FUNDS_PROBLEMS;
     if (nValue > GetZerocoinBalance(true)) {
@@ -4929,7 +4928,7 @@ bool CWallet::CreateZerocoinSpendTransaction(CAmount nValue, CWalletTx& wtxNew, 
     vector<CMintMeta> vMintsToFetch;
     if (vSelectedMints.empty()) {
         //  All of the zPIV used in the public coin spend are mature by default (everything is public now.. no need to wait for any accumulation)
-        setMints = zpivTracker->ListMints(true, false, true); // need to find mints to spend
+        setMints = zpivTracker->ListMints(true, false, true, true); // need to find mints to spend
         if(setMints.empty()) {
             receipt.SetStatus(_("Failed to find Zerocoins in wallet.dat"), nStatus);
             return false;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4924,7 +4924,7 @@ bool CWallet::CreateZerocoinSpendTransaction(CAmount nValue, CWalletTx& wtxNew, 
     CAmount nValueSelected = 0;
     int nCoinsReturned = 0; // Number of coins returned in change from function below (for debug)
     int nNeededSpends = 0;  // Number of spends which would be needed if selection failed
-    const int nMaxSpends = Params().Zerocoin_MaxSpendsPerTransaction(); // Maximum possible spends for one zPIV transaction
+    const int nMaxSpends = Params().Zerocoin_MaxPublicSpendsPerTransaction(); // Maximum possible spends for one zPIV public spend transaction
     vector<CMintMeta> vMintsToFetch;
     if (vSelectedMints.empty()) {
         //  All of the zPIV used in the public coin spend are mature by default (everything is public now.. no need to wait for any accumulation)
@@ -5017,10 +5017,12 @@ bool CWallet::CreateZerocoinSpendTransaction(CAmount nValue, CWalletTx& wtxNew, 
         return false;
     }
 
-    if ((static_cast<int>(vSelectedMints.size()) > Params().Zerocoin_MaxSpendsPerTransaction())) {
+
+    if (static_cast<int>(vSelectedMints.size()) > nMaxSpends) {
         receipt.SetStatus(_("Failed to find coin set amongst held coins with less than maxNumber of Spends"), nStatus);
         return false;
     }
+
 
     // Create change if needed
     nStatus = ZPIV_TRX_CHANGE;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4903,6 +4903,13 @@ bool CWallet::MintsToInputVectorPublicSpend(std::map<CBigNum, CZerocoinMint>& ma
 
 bool CWallet::CreateZerocoinSpendTransaction(CAmount nValue, CWalletTx& wtxNew, CReserveKey& reserveKey, CZerocoinSpendReceipt& receipt, vector<CZerocoinMint>& vSelectedMints, vector<CDeterministicMint>& vNewMints, bool fMintChange,  bool fMinimizeChange, CBitcoinAddress* address)
 {
+
+    // Check enforcement
+    if (chainActive.Tip()->nHeight < Params().Zerocoin_Block_Public_Spend_Enabled()){
+        receipt.SetStatus(_("New protocol enforcement not activated"), ZPIV_SPEND_ERROR);
+        return false;
+    }
+
     // Check available funds
     int nStatus = ZPIV_TRX_FUNDS_PROBLEMS;
     if (nValue > GetZerocoinBalance(true)) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4904,12 +4904,6 @@ bool CWallet::MintsToInputVectorPublicSpend(std::map<CBigNum, CZerocoinMint>& ma
 bool CWallet::CreateZerocoinSpendTransaction(CAmount nValue, CWalletTx& wtxNew, CReserveKey& reserveKey, CZerocoinSpendReceipt& receipt, vector<CZerocoinMint>& vSelectedMints, vector<CDeterministicMint>& vNewMints, bool fMintChange,  bool fMinimizeChange, CBitcoinAddress* address)
 {
 
-    // Check enforcement
-    if (chainActive.Tip()->nHeight < Params().Zerocoin_Block_Public_Spend_Enabled()){
-        receipt.SetStatus(_("New protocol enforcement not activated"), ZPIV_SPEND_ERROR);
-        return false;
-    }
-
     // Check available funds
     int nStatus = ZPIV_TRX_FUNDS_PROBLEMS;
     if (nValue > GetZerocoinBalance(true)) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3114,7 +3114,7 @@ bool CWallet::CreateCoinStake(
 
     // Sign for PIV
     int nIn = 0;
-    if (!txNew.vin[0].IsZerocoinSpend()) {
+    if (!txNew.vin[0].scriptSig.IsZerocoinSpend()) {
         for (CTxIn txIn : txNew.vin) {
             const CWalletTx *wtx = GetWalletTx(txIn.prevout.hash);
             if (!SignSignature(*this, *wtx, txNew, nIn++))
@@ -4706,7 +4706,7 @@ bool CWallet::MintToTxIn(CZerocoinMint mint, const uint256& hashTxOut, CTxIn& ne
     std::map<CBigNum, CZerocoinMint> mapMints;
     mapMints.insert(std::make_pair(mint.GetValue(), mint));
     std::vector<CTxIn> vin;
-    if (MintsToInputVector(mapMints, hashTxOut, vin, receipt, spendType, pindexCheckpoint)) {
+    if (MintsToInputVectorPublicSpend(mapMints, hashTxOut, vin, receipt, spendType, pindexCheckpoint)) {
         newTxIn = vin[0];
         return true;
     }
@@ -4820,6 +4820,82 @@ bool CWallet::MintsToInputVector(std::map<CBigNum, CZerocoinMint>& mapMintsSelec
     return true;
 }
 
+bool CWallet::MintsToInputVectorPublicSpend(std::map<CBigNum, CZerocoinMint>& mapMintsSelected, const uint256& hashTxOut, std::vector<CTxIn>& vin,
+                                    CZerocoinSpendReceipt& receipt, libzerocoin::SpendType spendType, CBlockIndex* pindexCheckpoint)
+{
+    // Default error status if not changed below
+    receipt.SetStatus(_("Transaction Mint Started"), ZPIV_TXMINT_GENERAL);
+
+    int nLockAttempts = 0;
+    while (nLockAttempts < 100) {
+        TRY_LOCK(zpivTracker->cs_spendcache, lockSpendcache);
+        if (!lockSpendcache) {
+            fGlobalUnlockSpendCache = true;
+            MilliSleep(100);
+            ++nLockAttempts;
+            continue;
+        }
+
+        for (auto &it : mapMintsSelected) {
+            CZerocoinMint mint = it.second;
+
+            // Create the simple input and the scriptSig -> Serial + Randomness + Private key signature of both.
+            // As the mint doesn't have the output index search it..
+            CTransaction txMint;
+            uint256 hashBlock;
+            if (!GetTransaction(mint.GetTxHash(), txMint, hashBlock)) {
+                receipt.SetStatus(strprintf(_("Unable to find transaction containing mint %s"), mint.GetTxHash().GetHex()), ZPIV_TXMINT_GENERAL);
+                return false;
+            } else if (mapBlockIndex.count(hashBlock) < 1) {
+                // check that this mint made it into the blockchain
+                receipt.SetStatus(_("Mint did not make it into blockchain"), ZPIV_TXMINT_GENERAL);
+                return false;
+            }
+
+            int outputIndex = -1;
+            for (unsigned long i = 0; i < txMint.vout.size(); ++i) {
+                CTxOut out = txMint.vout[i];
+                if (out.scriptPubKey.IsZerocoinMint()){
+                    libzerocoin::PublicCoin pubcoin(Params().Zerocoin_Params(false));
+                    CValidationState state;
+                    if (!TxOutToPublicCoin(out, pubcoin, state))
+                        return error("%s: extracting pubcoin from txout failed", __func__);
+
+                    if (pubcoin.getValue() == mint.GetValue()){
+                        outputIndex = i;
+                        break;
+                    }
+                }
+            }
+
+            if (outputIndex == -1) {
+                receipt.SetStatus(_("Pubcoin not found in mint tx"), ZPIV_TXMINT_GENERAL);
+                return false;
+            }
+
+            mint.SetOutputIndex(outputIndex);
+            CTxIn in;
+            if(!ZPIVModule::createInput(in, mint, hashTxOut)){
+                receipt.SetStatus(_("Cannot create public spend input"), ZPIV_TXMINT_GENERAL);
+                return false;
+            }
+            vin.emplace_back(in);
+            receipt.AddSpend(CZerocoinSpend(mint.GetSerialNumber(), 0, mint.GetValue(), mint.GetDenomination(), 0));
+        }
+        break;
+    }
+
+    if (nLockAttempts == 100) {
+        LogPrintf("%s : could not get lock on cs_spendcache\n", __func__);
+        receipt.SetStatus(_("could not get lock on cs_spendcache"), ZPIV_TXMINT_GENERAL);
+        return false;
+    }
+
+    receipt.SetStatus(_("Spend Valid"), ZPIV_SPEND_OKAY); // Everything okay
+
+    return true;
+}
+
 bool CWallet::CreateZerocoinSpendTransaction(CAmount nValue, CWalletTx& wtxNew, CReserveKey& reserveKey, CZerocoinSpendReceipt& receipt, vector<CZerocoinMint>& vSelectedMints, vector<CDeterministicMint>& vNewMints, bool fMintChange,  bool fMinimizeChange, CBitcoinAddress* address)
 {
     // Check available funds
@@ -4907,7 +4983,7 @@ bool CWallet::CreateZerocoinSpendTransaction(CAmount nValue, CWalletTx& wtxNew, 
         uint256 hashBlock;
         bool fArchive = false;
         if (!GetTransaction(mint.GetTxHash(), txMint, hashBlock)) {
-            receipt.SetStatus(_("Unable to find transaction containing mint"), nStatus);
+            receipt.SetStatus(strprintf(_("Unable to find transaction containing mint, txHash: %s"), mint.GetTxHash().GetHex()), nStatus);
             fArchive = true;
         } else if (mapBlockIndex.count(hashBlock) < 1) {
             receipt.SetStatus(_("Mint did not make it into blockchain"), nStatus);
@@ -5011,7 +5087,7 @@ bool CWallet::CreateZerocoinSpendTransaction(CAmount nValue, CWalletTx& wtxNew, 
 
             //add all of the mints to the transaction as inputs
             std::vector<CTxIn> vin;
-            if (!MintsToInputVector(mapSelectedMints, hashTxOut, vin, receipt, libzerocoin::SpendType::SPEND, pindexCheckpoint))
+            if (!MintsToInputVectorPublicSpend(mapSelectedMints, hashTxOut, vin, receipt, libzerocoin::SpendType::SPEND, pindexCheckpoint))
                 return false;
             txNew.vin = vin;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -209,9 +209,9 @@ public:
 
     // Zerocoin additions
     bool CreateZerocoinMintTransaction(const CAmount nValue, CMutableTransaction& txNew, vector<CDeterministicMint>& vDMints, CReserveKey* reservekey, int64_t& nFeeRet, std::string& strFailReason, const CCoinControl* coinControl = NULL, const bool isZCSpendChange = false);
-    bool CreateZerocoinSpendTransaction(CAmount nValue, CWalletTx& wtxNew, CReserveKey& reserveKey, CZerocoinSpendReceipt& receipt, vector<CZerocoinMint>& vSelectedMints, vector<CDeterministicMint>& vNewMints, bool fMintChange,  bool fMinimizeChange, CBitcoinAddress* address = NULL);
+    bool CreateZerocoinSpendTransaction(CAmount nValue, CWalletTx& wtxNew, CReserveKey& reserveKey, CZerocoinSpendReceipt& receipt, vector<CZerocoinMint>& vSelectedMints, vector<CDeterministicMint>& vNewMints, bool fMintChange,  bool fMinimizeChange, CBitcoinAddress* address = NULL, bool isPublicSpend = true);
     bool CheckCoinSpend(libzerocoin::CoinSpend& spend, libzerocoin::Accumulator& accumulator, CZerocoinSpendReceipt& receipt);
-    bool MintToTxIn(CZerocoinMint mint, const uint256& hashTxOut, CTxIn& newTxIn, CZerocoinSpendReceipt& receipt, libzerocoin::SpendType spendType, CBlockIndex* pindexCheckpoint = nullptr);
+    bool MintToTxIn(CZerocoinMint mint, const uint256& hashTxOut, CTxIn& newTxIn, CZerocoinSpendReceipt& receipt, libzerocoin::SpendType spendType, CBlockIndex* pindexCheckpoint = nullptr, bool publicCoinSpend = true);
     bool MintsToInputVector(std::map<CBigNum, CZerocoinMint>& mapMintsSelected, const uint256& hashTxOut, std::vector<CTxIn>& vin,
                             CZerocoinSpendReceipt& receipt, libzerocoin::SpendType spendType, CBlockIndex* pindexCheckpoint = nullptr);
 
@@ -221,7 +221,7 @@ public:
 
     std::string MintZerocoinFromOutPoint(CAmount nValue, CWalletTx& wtxNew, std::vector<CDeterministicMint>& vDMints, const vector<COutPoint> vOutpts);
     std::string MintZerocoin(CAmount nValue, CWalletTx& wtxNew, vector<CDeterministicMint>& vDMints, const CCoinControl* coinControl = NULL);
-    bool SpendZerocoin(CAmount nValue, CWalletTx& wtxNew, CZerocoinSpendReceipt& receipt, vector<CZerocoinMint>& vMintsSelected, bool fMintChange, bool fMinimizeChange, CBitcoinAddress* addressTo = NULL);
+    bool SpendZerocoin(CAmount nValue, CWalletTx& wtxNew, CZerocoinSpendReceipt& receipt, vector<CZerocoinMint>& vMintsSelected, bool fMintChange, bool fMinimizeChange, CBitcoinAddress* addressTo = NULL, bool isPublicSpend = true);
     std::string ResetMintZerocoin();
     std::string ResetSpentZerocoin();
     void ReconsiderZerocoins(std::list<CZerocoinMint>& listMintsRestored, std::list<CDeterministicMint>& listDMintsRestored);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -23,6 +23,7 @@
 #include "validationinterface.h"
 #include "wallet/wallet_ismine.h"
 #include "wallet/walletdb.h"
+#include "zpiv/zpivmodule.h"
 #include "zpiv/zpivwallet.h"
 #include "zpiv/zpivtracker.h"
 
@@ -213,6 +214,11 @@ public:
     bool MintToTxIn(CZerocoinMint mint, const uint256& hashTxOut, CTxIn& newTxIn, CZerocoinSpendReceipt& receipt, libzerocoin::SpendType spendType, CBlockIndex* pindexCheckpoint = nullptr);
     bool MintsToInputVector(std::map<CBigNum, CZerocoinMint>& mapMintsSelected, const uint256& hashTxOut, std::vector<CTxIn>& vin,
                             CZerocoinSpendReceipt& receipt, libzerocoin::SpendType spendType, CBlockIndex* pindexCheckpoint = nullptr);
+
+    // Public coin spend input creation
+    bool MintsToInputVectorPublicSpend(std::map<CBigNum, CZerocoinMint>& mapMintsSelected, const uint256& hashTxOut, std::vector<CTxIn>& vin,
+    CZerocoinSpendReceipt& receipt, libzerocoin::SpendType spendType, CBlockIndex* pindexCheckpoint = nullptr);
+
     std::string MintZerocoinFromOutPoint(CAmount nValue, CWalletTx& wtxNew, std::vector<CDeterministicMint>& vDMints, const vector<COutPoint> vOutpts);
     std::string MintZerocoin(CAmount nValue, CWalletTx& wtxNew, vector<CDeterministicMint>& vDMints, const CCoinControl* coinControl = NULL);
     bool SpendZerocoin(CAmount nValue, CWalletTx& wtxNew, CZerocoinSpendReceipt& receipt, vector<CZerocoinMint>& vMintsSelected, bool fMintChange, bool fMinimizeChange, CBitcoinAddress* addressTo = NULL);

--- a/src/zpiv/zerocoin.h
+++ b/src/zpiv/zerocoin.h
@@ -43,6 +43,7 @@ private:
     CBigNum randomness;
     CBigNum serialNumber;
     uint256 txid;
+    int outputIndex;
     CPrivKey privkey;
     uint8_t version;
     bool isUsed;
@@ -103,6 +104,9 @@ public:
     CPrivKey GetPrivKey() const { return this->privkey; }
     void SetPrivKey(const CPrivKey& privkey) { this->privkey = privkey; }
     bool GetKeyPair(CKey& key) const;
+
+    unsigned int GetOutputIndex() { return this->outputIndex; }
+    void SetOutputIndex(unsigned int index) {this->outputIndex = index; }
 
     inline bool operator <(const CZerocoinMint& a) const { return GetHeight() < a.GetHeight(); }
 
@@ -186,6 +190,7 @@ private:
     libzerocoin::CoinDenomination denomination;
     unsigned int nAccumulatorChecksum;
     int nMintCount; //memory only - the amount of mints that belong to the accumulator this is spent from
+    bool publicSpend = false;
 
 public:
     CZerocoinSpend()
@@ -200,6 +205,16 @@ public:
         this->pubCoin = pubCoin;
         this->denomination = denomination;
         this->nAccumulatorChecksum = nAccumulatorChecksum;
+    }
+
+    CZerocoinSpend(CBigNum coinSerial, uint256 hashTx, CBigNum pubCoin, libzerocoin::CoinDenomination denomination, unsigned int nAccumulatorChecksum, bool isPublicSpend)
+    {
+        this->coinSerial = coinSerial;
+        this->hashTx = hashTx;
+        this->pubCoin = pubCoin;
+        this->denomination = denomination;
+        this->nAccumulatorChecksum = nAccumulatorChecksum;
+        this->publicSpend = isPublicSpend;
     }
 
     void SetNull()
@@ -219,6 +234,7 @@ public:
     uint256 GetHash() const;
     void SetMintCount(int nMintsAdded) { this->nMintCount = nMintsAdded; }
     int GetMintCount() const { return nMintCount; }
+    bool IsPublicSpend() const { return publicSpend; }
  
     ADD_SERIALIZE_METHODS;
 

--- a/src/zpiv/zerocoin.h
+++ b/src/zpiv/zerocoin.h
@@ -43,7 +43,7 @@ private:
     CBigNum randomness;
     CBigNum serialNumber;
     uint256 txid;
-    int outputIndex;
+    int outputIndex = -1;
     CPrivKey privkey;
     uint8_t version;
     bool isUsed;
@@ -105,8 +105,8 @@ public:
     void SetPrivKey(const CPrivKey& privkey) { this->privkey = privkey; }
     bool GetKeyPair(CKey& key) const;
 
-    unsigned int GetOutputIndex() { return this->outputIndex; }
-    void SetOutputIndex(unsigned int index) {this->outputIndex = index; }
+    int GetOutputIndex() { return this->outputIndex; }
+    void SetOutputIndex(int index) { this->outputIndex = index; }
 
     inline bool operator <(const CZerocoinMint& a) const { return GetHeight() < a.GetHeight(); }
 
@@ -190,7 +190,6 @@ private:
     libzerocoin::CoinDenomination denomination;
     unsigned int nAccumulatorChecksum;
     int nMintCount; //memory only - the amount of mints that belong to the accumulator this is spent from
-    bool publicSpend = false;
 
 public:
     CZerocoinSpend()
@@ -205,16 +204,6 @@ public:
         this->pubCoin = pubCoin;
         this->denomination = denomination;
         this->nAccumulatorChecksum = nAccumulatorChecksum;
-    }
-
-    CZerocoinSpend(CBigNum coinSerial, uint256 hashTx, CBigNum pubCoin, libzerocoin::CoinDenomination denomination, unsigned int nAccumulatorChecksum, bool isPublicSpend)
-    {
-        this->coinSerial = coinSerial;
-        this->hashTx = hashTx;
-        this->pubCoin = pubCoin;
-        this->denomination = denomination;
-        this->nAccumulatorChecksum = nAccumulatorChecksum;
-        this->publicSpend = isPublicSpend;
     }
 
     void SetNull()
@@ -234,7 +223,6 @@ public:
     uint256 GetHash() const;
     void SetMintCount(int nMintsAdded) { this->nMintCount = nMintsAdded; }
     int GetMintCount() const { return nMintCount; }
-    bool IsPublicSpend() const { return publicSpend; }
  
     ADD_SERIALIZE_METHODS;
 

--- a/src/zpiv/zpivmodule.cpp
+++ b/src/zpiv/zpivmodule.cpp
@@ -4,101 +4,108 @@
 
 #include "zpiv/zpivmodule.h"
 #include "zpivchain.h"
-#include "chainparams.h"
 #include "libzerocoin/Commitment.h"
 #include "libzerocoin/Coin.h"
 #include "hash.h"
+#include "main.h"
 #include "iostream"
 
-bool PublicCoinSpend::HasValidSerial(libzerocoin::ZerocoinParams* params) const {
-    return IsValidSerial(params, coinSerialNumber);
+bool PublicCoinSpend::Verify(const libzerocoin::Accumulator& a, bool verifyParams) const {
+    return validate();
 }
 
-bool PublicCoinSpend::HasValidSignature() const {
-    // Now check that the signature validates with the serial
-    try {
-        //V2 serial requires that the signature hash be signed by the public key associated with the serial
-        uint256 hashedPubkey = Hash(pubkey.begin(), pubkey.end()) >> libzerocoin::PrivateCoin::V2_BITSHIFT;
-        if (hashedPubkey != libzerocoin::GetAdjustedSerial(coinSerialNumber).getuint256()) {
-            return error("%s: adjusted serial invalid\n", __func__);
-        }
-    } catch(std::range_error &e) {
-        throw libzerocoin::InvalidSerialException("Serial longer than 256 bits");
-    }
-
-    if (!pubkey.Verify(hashTxOut, vchSig)){
-        std::cout << "pubkey not verified" << std::endl;
-        return error("%s: adjusted serial invalid\n", __func__);
-    }
-    return true;
-}
-
-bool ZPIVModule::createInput(CTxIn &in, CZerocoinMint mint, uint256 hashTxOut){
-    uint8_t nVersion = mint.GetVersion();
-    if (nVersion < libzerocoin::PrivateCoin::PUBKEY_VERSION) {
-        // No v1 serials accepted anymore.
-        return error("%s: failed to set zPIV privkey mint version=%d\n", __func__, nVersion);
-    }
-    CKey key;
-    if (!mint.GetKeyPair(key))
-        return error("%s: failed to set zPIV privkey mint version=%d\n", __func__, nVersion);
-
-    std::vector<unsigned char> vchSig;
-    if (!key.Sign(hashTxOut, vchSig))
-        throw std::runtime_error("ZPIVModule failed to sign hashTxOut\n");
-
-    CDataStream ser(SER_NETWORK, PROTOCOL_VERSION);
-    PublicCoinSpend spend(mint.GetSerialNumber(),  mint.GetRandomness(), key.GetPubKey(), vchSig);
-    ser << spend;
-
-    std::vector<unsigned char> data(ser.begin(), ser.end());
-    CScript scriptSigIn = CScript() << OP_ZEROCOINPUBLICSPEND << data.size();
-    scriptSigIn.insert(scriptSigIn.end(), data.begin(), data.end());
-    in = CTxIn(mint.GetTxHash(), mint.GetOutputIndex(), scriptSigIn, mint.GetDenomination());
-    return true;
-}
-
-PublicCoinSpend ZPIVModule::parseCoinSpend(const CTxIn &in, const CTransaction& tx){
-    if (!in.scriptSig.IsZerocoinPublicSpend()) throw runtime_error("parseCoinSpend() :: input is not a public coin spend");
-    std::vector<char, zero_after_free_allocator<char> > data;
-    data.insert(data.end(), in.scriptSig.begin() + 4, in.scriptSig.end());
-    CDataStream serializedCoinSpend(data, SER_NETWORK, PROTOCOL_VERSION);
-    PublicCoinSpend spend(serializedCoinSpend);
-    spend.outputIndex = in.prevout.n;
-    spend.txHash = in.prevout.hash;
-    CTransaction txNew;
-    txNew.vout = tx.vout;
-    spend.hashTxOut = txNew.GetHash();
-    return spend;
-}
-
-bool ZPIVModule::validateInput(const CTxIn &in, const CTxOut &prevOut, const CTransaction& tx, PublicCoinSpend& ret){
-    if (!in.scriptSig.IsZerocoinPublicSpend() || !prevOut.scriptPubKey.IsZerocoinMint())
-        return error("%s: not valid argument/s\n", __func__);
-
-    // Now prove that the commitment value opens to the input
-    PublicCoinSpend publicSpend = parseCoinSpend(in, tx);
+bool PublicCoinSpend::validate() const {
     libzerocoin::ZerocoinParams* params = Params().Zerocoin_Params(false);
-
-    // Check prev out now
-    CValidationState state;
-    libzerocoin::PublicCoin pubCoin(params);
-    if (!TxOutToPublicCoin(prevOut, pubCoin, state))
-        return error("%s: cannot get mint from output\n", __func__);
-    publicSpend.pubCoin = &pubCoin;
-
     // Check that it opens to the input values
     libzerocoin::Commitment commitment(
-            &params->coinCommitmentGroup, publicSpend.getCoinSerialNumber(), publicSpend.randomness);
+            &params->coinCommitmentGroup, getCoinSerialNumber(), randomness);
+
     if (commitment.getCommitmentValue() != pubCoin.getValue()){
+        std::cout << "invalid commitment" << std::endl;
         return error("%s: commitments values are not equal\n", __func__);
     }
-    ret = publicSpend;
-
     // Now check that the signature validates with the serial
-    if (!publicSpend.HasValidSignature()) {
+    if (!HasValidSignature()) {
         return error("%s: signature invalid\n", __func__);;
     }
-
     return true;
+}
+
+namespace ZPIVModule {
+
+    bool createInput(CTxIn &in, CZerocoinMint &mint, uint256 hashTxOut) {
+        libzerocoin::ZerocoinParams *params = Params().Zerocoin_Params(false);
+        uint8_t nVersion = mint.GetVersion();
+        if (nVersion < libzerocoin::PrivateCoin::PUBKEY_VERSION) {
+            // No v1 serials accepted anymore.
+            return error("%s: failed to set zPIV privkey mint version=%d\n", __func__, nVersion);
+        }
+        CKey key;
+        if (!mint.GetKeyPair(key))
+            return error("%s: failed to set zPIV privkey mint version=%d\n", __func__, nVersion);
+
+        std::vector<unsigned char> vchSig;
+        if (!key.Sign(hashTxOut, vchSig))
+            throw std::runtime_error("ZPIVModule failed to sign hashTxOut\n");
+
+        CDataStream ser(SER_NETWORK, PROTOCOL_VERSION);
+        PublicCoinSpend spend(params, mint.GetSerialNumber(), mint.GetRandomness(), key.GetPubKey(), vchSig);
+        ser << spend;
+
+        std::vector<unsigned char> data(ser.begin(), ser.end());
+        CScript scriptSigIn = CScript() << OP_ZEROCOINPUBLICSPEND << data.size();
+        scriptSigIn.insert(scriptSigIn.end(), data.begin(), data.end());
+        in = CTxIn(mint.GetTxHash(), mint.GetOutputIndex(), scriptSigIn, mint.GetDenomination());
+        in.nSequence = mint.GetDenomination();
+        return true;
+    }
+
+    bool parseCoinSpend(const CTxIn &in, const CTransaction &tx, const CTxOut &prevOut, PublicCoinSpend &publicCoinSpend) {
+        if (!in.scriptSig.IsZerocoinPublicSpend() || !prevOut.scriptPubKey.IsZerocoinMint())
+            return error("%s: invalid argument/s\n", __func__);
+
+        std::vector<char, zero_after_free_allocator<char> > data;
+        data.insert(data.end(), in.scriptSig.begin() + 4, in.scriptSig.end());
+        CDataStream serializedCoinSpend(data, SER_NETWORK, PROTOCOL_VERSION);
+        libzerocoin::ZerocoinParams *params = Params().Zerocoin_Params(false);
+        PublicCoinSpend spend(params, serializedCoinSpend);
+
+        spend.outputIndex = in.prevout.n;
+        spend.txHash = in.prevout.hash;
+        CMutableTransaction txNew(tx);
+        txNew.vin.clear();
+        spend.setTxOutHash(txNew.GetHash());
+
+        // Check prev out now
+        CValidationState state;
+        if (!TxOutToPublicCoin(prevOut, spend.pubCoin, state))
+            return error("%s: cannot get mint from output\n", __func__);
+
+        spend.setDenom(spend.pubCoin.getDenomination());
+        publicCoinSpend = spend;
+        return true;
+    }
+
+    bool validateInput(const CTxIn &in, const CTxOut &prevOut, const CTransaction &tx, PublicCoinSpend &publicSpend) {
+        // Now prove that the commitment value opens to the input
+        if (!parseCoinSpend(in, tx, prevOut, publicSpend)) {
+            return false;
+        }
+        // TODO: Validate that the prev out has the same spend denom?
+        return publicSpend.validate();
+    }
+
+    bool ParseZerocoinPublicSpend(const CTxIn &txIn, const CTransaction& tx, CValidationState& state, PublicCoinSpend& publicSpend)
+    {
+        CTxOut prevOut;
+        if(!GetOutput(txIn.prevout.hash, txIn.prevout.n ,state, prevOut)){
+            return state.DoS(100, error("%s: public zerocoin spend prev output not found, prevTx %s, index %d",
+                                        __func__, txIn.prevout.hash.GetHex(), txIn.prevout.n));
+        }
+        if (!ZPIVModule::parseCoinSpend(txIn, tx, prevOut, publicSpend)) {
+            return state.Invalid(error("%s: invalid public coin spend parse %s", __func__,
+                                       tx.GetHash().GetHex()), REJECT_INVALID, "bad-txns-invalid-zpiv");
+        }
+        return true;
+    }
 }

--- a/src/zpiv/zpivmodule.cpp
+++ b/src/zpiv/zpivmodule.cpp
@@ -75,7 +75,7 @@ namespace ZPIVModule {
     }
 
     bool parseCoinSpend(const CTxIn &in, const CTransaction &tx, const CTxOut &prevOut, PublicCoinSpend &publicCoinSpend) {
-        if (!in.scriptSig.IsZerocoinPublicSpend() || !prevOut.scriptPubKey.IsZerocoinMint())
+        if (!in.IsZerocoinPublicSpend() || !prevOut.IsZerocoinMint())
             return error("%s: invalid argument/s\n", __func__);
 
         std::vector<char, zero_after_free_allocator<char> > data;

--- a/src/zpiv/zpivmodule.cpp
+++ b/src/zpiv/zpivmodule.cpp
@@ -103,10 +103,13 @@ namespace ZPIVModule {
     bool validateInput(const CTxIn &in, const CTxOut &prevOut, const CTransaction &tx, PublicCoinSpend &publicSpend) {
         // Now prove that the commitment value opens to the input
         if (!parseCoinSpend(in, tx, prevOut, publicSpend)) {
-            std::cout << "parse failed" << std::endl;
             return false;
         }
-        // TODO: Validate that the prev out has the same spend denom?
+        if (libzerocoin::ZerocoinDenominationToAmount(
+                libzerocoin::IntToZerocoinDenomination(in.nSequence)) != prevOut.nValue) {
+            return error("PublicCoinSpend validateInput :: input nSequence different to prevout value\n");
+        }
+
         return publicSpend.validate();
     }
 

--- a/src/zpiv/zpivmodule.cpp
+++ b/src/zpiv/zpivmodule.cpp
@@ -1,0 +1,104 @@
+// Copyright (c) 2019 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "zpiv/zpivmodule.h"
+#include "zpivchain.h"
+#include "chainparams.h"
+#include "libzerocoin/Commitment.h"
+#include "libzerocoin/Coin.h"
+#include "hash.h"
+#include "iostream"
+
+bool PublicCoinSpend::HasValidSerial(libzerocoin::ZerocoinParams* params) const {
+    return IsValidSerial(params, coinSerialNumber);
+}
+
+bool PublicCoinSpend::HasValidSignature() const {
+    // Now check that the signature validates with the serial
+    try {
+        //V2 serial requires that the signature hash be signed by the public key associated with the serial
+        uint256 hashedPubkey = Hash(pubkey.begin(), pubkey.end()) >> libzerocoin::PrivateCoin::V2_BITSHIFT;
+        if (hashedPubkey != libzerocoin::GetAdjustedSerial(coinSerialNumber).getuint256()) {
+            return error("%s: adjusted serial invalid\n", __func__);
+        }
+    } catch(std::range_error &e) {
+        throw libzerocoin::InvalidSerialException("Serial longer than 256 bits");
+    }
+
+    if (!pubkey.Verify(hashTxOut, vchSig)){
+        std::cout << "pubkey not verified" << std::endl;
+        return error("%s: adjusted serial invalid\n", __func__);
+    }
+    return true;
+}
+
+bool ZPIVModule::createInput(CTxIn &in, CZerocoinMint mint, uint256 hashTxOut){
+    uint8_t nVersion = mint.GetVersion();
+    if (nVersion < libzerocoin::PrivateCoin::PUBKEY_VERSION) {
+        // No v1 serials accepted anymore.
+        return error("%s: failed to set zPIV privkey mint version=%d\n", __func__, nVersion);
+    }
+    CKey key;
+    if (!mint.GetKeyPair(key))
+        return error("%s: failed to set zPIV privkey mint version=%d\n", __func__, nVersion);
+
+    std::vector<unsigned char> vchSig;
+    if (!key.Sign(hashTxOut, vchSig))
+        throw std::runtime_error("ZPIVModule failed to sign hashTxOut\n");
+
+    CDataStream ser(SER_NETWORK, PROTOCOL_VERSION);
+    PublicCoinSpend spend(mint.GetSerialNumber(),  mint.GetRandomness(), key.GetPubKey(), vchSig);
+    ser << spend;
+
+    std::vector<unsigned char> data(ser.begin(), ser.end());
+    CScript scriptSigIn = CScript() << OP_ZEROCOINPUBLICSPEND << data.size();
+    scriptSigIn.insert(scriptSigIn.end(), data.begin(), data.end());
+    in = CTxIn(mint.GetTxHash(), mint.GetOutputIndex(), scriptSigIn, mint.GetDenomination());
+    return true;
+}
+
+PublicCoinSpend ZPIVModule::parseCoinSpend(const CTxIn &in, const CTransaction& tx){
+    if (!in.scriptSig.IsZerocoinPublicSpend()) throw runtime_error("parseCoinSpend() :: input is not a public coin spend");
+    std::vector<char, zero_after_free_allocator<char> > data;
+    data.insert(data.end(), in.scriptSig.begin() + 4, in.scriptSig.end());
+    CDataStream serializedCoinSpend(data, SER_NETWORK, PROTOCOL_VERSION);
+    PublicCoinSpend spend(serializedCoinSpend);
+    spend.outputIndex = in.prevout.n;
+    spend.txHash = in.prevout.hash;
+    CTransaction txNew;
+    txNew.vout = tx.vout;
+    spend.hashTxOut = txNew.GetHash();
+    return spend;
+}
+
+bool ZPIVModule::validateInput(const CTxIn &in, const CTxOut &prevOut, const CTransaction& tx, PublicCoinSpend& ret){
+    if (!in.scriptSig.IsZerocoinPublicSpend() || !prevOut.scriptPubKey.IsZerocoinMint())
+        return error("%s: not valid argument/s\n", __func__);
+
+    // Now prove that the commitment value opens to the input
+    PublicCoinSpend publicSpend = parseCoinSpend(in, tx);
+    libzerocoin::ZerocoinParams* params = Params().Zerocoin_Params(false);
+
+    // Check prev out now
+    CValidationState state;
+    libzerocoin::PublicCoin pubCoin(params);
+    if (!TxOutToPublicCoin(prevOut, pubCoin, state))
+        return error("%s: cannot get mint from output\n", __func__);
+    publicSpend.pubCoin = &pubCoin;
+
+    // Check that it opens to the input values
+    libzerocoin::Commitment commitment(
+            &params->coinCommitmentGroup, publicSpend.getCoinSerialNumber(), publicSpend.randomness);
+    if (commitment.getCommitmentValue() != pubCoin.getValue()){
+        return error("%s: commitments values are not equal\n", __func__);
+    }
+    ret = publicSpend;
+
+    // Now check that the signature validates with the serial
+    if (!publicSpend.HasValidSignature()) {
+        return error("%s: signature invalid\n", __func__);;
+    }
+
+    return true;
+}

--- a/src/zpiv/zpivmodule.h
+++ b/src/zpiv/zpivmodule.h
@@ -29,6 +29,7 @@ public:
         this->coinSerialNumber = serial;
         this->randomness = randomness;
         this->pubkey = pubkey;
+        this->spendType = libzerocoin::SpendType::SPEND;
     };
 
     template <typename Stream>
@@ -36,13 +37,13 @@ public:
             libzerocoin::ZerocoinParams* params,
             Stream& strm):pubCoin(params){
         strm >> *this;
+        this->spendType = libzerocoin::SpendType::SPEND;
     }
 
     uint8_t getVersion() const { return libzerocoin::PrivateCoin::PUBKEY_VERSION; }
 
     const uint256 signatureHash() const override;
     void setVchSig(std::vector<unsigned char> vchSig) { this->vchSig = vchSig; };
-    libzerocoin::SpendType getSpendType() const { return libzerocoin::SpendType::SPEND; }
     bool Verify(const libzerocoin::Accumulator& a, bool verifyParams = true) const override;
     bool validate() const;
 

--- a/src/zpiv/zpivmodule.h
+++ b/src/zpiv/zpivmodule.h
@@ -19,6 +19,8 @@
 #include "zpiv/zerocoin.h"
 #include "chainparams.h"
 
+static int const COIN_SPEND_PUBLIC_SPEND_VERSION = 3;
+
 class PublicCoinSpend : public libzerocoin::CoinSpend{
 public:
 
@@ -30,6 +32,7 @@ public:
         this->randomness = randomness;
         this->pubkey = pubkey;
         this->spendType = libzerocoin::SpendType::SPEND;
+        this->version = COIN_SPEND_PUBLIC_SPEND_VERSION;
     };
 
     template <typename Stream>
@@ -39,8 +42,6 @@ public:
         strm >> *this;
         this->spendType = libzerocoin::SpendType::SPEND;
     }
-
-    uint8_t getVersion() const { return libzerocoin::PrivateCoin::PUBKEY_VERSION; }
 
     const uint256 signatureHash() const override;
     void setVchSig(std::vector<unsigned char> vchSig) { this->vchSig = vchSig; };
@@ -58,6 +59,7 @@ public:
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(version);
         READWRITE(coinSerialNumber);
         READWRITE(randomness);
         READWRITE(pubkey);

--- a/src/zpiv/zpivmodule.h
+++ b/src/zpiv/zpivmodule.h
@@ -25,10 +25,9 @@ public:
     PublicCoinSpend(libzerocoin::ZerocoinParams* params):pubCoin(params){};
 
     PublicCoinSpend(libzerocoin::ZerocoinParams* params,
-            CBigNum serial, CBigNum randomness, CPubKey pubkey, std::vector<unsigned char> vchSig):pubCoin(params){
+            CBigNum serial, CBigNum randomness, CPubKey pubkey):pubCoin(params){
         this->coinSerialNumber = serial;
         this->randomness = randomness;
-        this->vchSig = vchSig;
         this->pubkey = pubkey;
     };
 
@@ -41,7 +40,8 @@ public:
 
     uint8_t getVersion() const { return libzerocoin::PrivateCoin::PUBKEY_VERSION; }
 
-    const uint256 signatureHash() const override { return ptxHash; }
+    const uint256 signatureHash() const override;
+    void setVchSig(std::vector<unsigned char> vchSig) { this->vchSig = vchSig; };
     libzerocoin::SpendType getSpendType() const { return libzerocoin::SpendType::SPEND; }
     bool Verify(const libzerocoin::Accumulator& a, bool verifyParams = true) const override;
     bool validate() const;

--- a/src/zpiv/zpivmodule.h
+++ b/src/zpiv/zpivmodule.h
@@ -1,0 +1,77 @@
+// Copyright (c) 2019 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+//
+#ifndef PIVX_ZPIVMODULE_H
+#define PIVX_ZPIVMODULE_H
+
+#include "libzerocoin/bignum.h"
+#include "libzerocoin/Denominations.h"
+#include "libzerocoin/CoinSpend.h"
+#include "libzerocoin/Coin.h"
+#include "libzerocoin/SpendType.h"
+#include "primitives/transaction.h"
+#include "script/script.h"
+#include "main.h"
+#include "serialize.h"
+#include "uint256.h"
+#include <streams.h>
+#include <utilstrencodings.h>
+#include "zpiv/zerocoin.h"
+
+class PublicCoinSpend : public libzerocoin::CoinSpend{
+public:
+
+    PublicCoinSpend(){};
+
+    PublicCoinSpend(CBigNum serial, CBigNum randomness, CPubKey pubkey, std::vector<unsigned char> vchSig){
+        this->coinSerialNumber = serial;
+        this->randomness = randomness;
+        this->vchSig = vchSig;
+        this->pubkey = pubkey;
+    };
+
+    template <typename Stream>
+    PublicCoinSpend(Stream& strm){
+        strm >> *this;
+    }
+
+    uint8_t getVersion() const { return libzerocoin::PrivateCoin::PUBKEY_VERSION; }
+
+    bool HasValidSerial(libzerocoin::ZerocoinParams* params) const override;
+    bool HasValidSignature() const override ;
+    const uint256 signatureHash() const override { return hashTxOut; }
+    libzerocoin::SpendType getSpendType() const { return libzerocoin::SpendType::SPEND; }
+
+    CBigNum randomness;
+    // prev out values
+    uint256 txHash = 0;
+    // hash of the outputs of the txes that spend this coins
+    uint256 hashTxOut = 0;
+    unsigned int outputIndex = -1;
+    libzerocoin::PublicCoin *pubCoin = nullptr;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(coinSerialNumber);
+        READWRITE(randomness);
+        READWRITE(pubkey);
+        READWRITE(vchSig);
+    }
+};
+
+
+class ZPIVModule {
+
+public:
+    ZPIVModule(){}
+
+    bool createInput(CTxIn &in, CZerocoinMint mint, uint256 hashTxOut);
+    PublicCoinSpend parseCoinSpend(const CTxIn &in, const CTransaction& tx);
+    bool validateInput(const CTxIn &in, const CTxOut &prevOut, const CTransaction& tx, PublicCoinSpend& ret);
+};
+
+
+#endif //PIVX_ZPIVMODULE_H

--- a/src/zpiv/zpivtracker.cpp
+++ b/src/zpiv/zpivtracker.cpp
@@ -460,7 +460,7 @@ bool CzPIVTracker::UpdateStatusInternal(const std::set<uint256>& setMempool, CMi
     return false;
 }
 
-std::set<CMintMeta> CzPIVTracker::ListMints(bool fUnusedOnly, bool fMatureOnly, bool fUpdateStatus, bool fWrongSeed)
+std::set<CMintMeta> CzPIVTracker::ListMints(bool fUnusedOnly, bool fMatureOnly, bool fUpdateStatus, bool fWrongSeed, bool fExcludeV1)
 {
     CWalletDB walletdb(strWalletFile);
     if (fUpdateStatus) {
@@ -473,6 +473,8 @@ std::set<CMintMeta> CzPIVTracker::ListMints(bool fUnusedOnly, bool fMatureOnly, 
 
         CzPIVWallet* zPIVWallet = new CzPIVWallet(strWalletFile);
         for (auto& dMint : listDeterministicDB) {
+            if (fExcludeV1 && dMint.GetVersion() < 2)
+                continue;
             Add(dMint, false, false, zPIVWallet);
         }
         delete zPIVWallet;

--- a/src/zpiv/zpivtracker.h
+++ b/src/zpiv/zpivtracker.h
@@ -45,7 +45,7 @@ public:
     bool ClearSpendCache() EXCLUSIVE_LOCKS_REQUIRED(cs_spendcache);
     std::vector<CMintMeta> GetMints(bool fConfirmedOnly) const;
     CAmount GetUnconfirmedBalance() const;
-    std::set<CMintMeta> ListMints(bool fUnusedOnly, bool fMatureOnly, bool fUpdateStatus, bool fWrongSeed = false);
+    std::set<CMintMeta> ListMints(bool fUnusedOnly, bool fMatureOnly, bool fUpdateStatus, bool fWrongSeed = false, bool fExcludeV1 = false);
     void RemovePending(const uint256& txid);
     void SetPubcoinUsed(const uint256& hashPubcoin, const uint256& txid);
     void SetPubcoinNotUsed(const uint256& hashPubcoin);

--- a/src/zpivchain.cpp
+++ b/src/zpivchain.cpp
@@ -286,7 +286,7 @@ std::string ReindexZerocoinDB()
                     //Record Serials
                     if (tx.HasZerocoinSpendInputs()) {
                         for (auto& in : tx.vin) {
-                            bool isPublicSpend = in.scriptSig.IsZerocoinPublicSpend();
+                            bool isPublicSpend = in.IsZerocoinPublicSpend();
                             if (!in.IsZerocoinSpend() && !isPublicSpend)
                                 continue;
                             if (isPublicSpend) {
@@ -387,7 +387,7 @@ std::list<libzerocoin::CoinDenomination> ZerocoinSpendListFromBlock(const CBlock
             continue;
 
         for (const CTxIn& txin : tx.vin) {
-            bool isPublicSpend = txin.scriptSig.IsZerocoinPublicSpend();
+            bool isPublicSpend = txin.IsZerocoinPublicSpend();
             if (!txin.IsZerocoinSpend() && !isPublicSpend)
                 continue;
 

--- a/src/zpivchain.cpp
+++ b/src/zpivchain.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "zpivchain.h"
+#include "zpiv/zpivmodule.h"
 #include "invalid.h"
 #include "main.h"
 #include "txdb.h"
@@ -285,11 +286,21 @@ std::string ReindexZerocoinDB()
                     //Record Serials
                     if (tx.HasZerocoinSpendInputs()) {
                         for (auto& in : tx.vin) {
-                            if (!in.IsZerocoinSpend())
+                            bool isPublicSpend = in.scriptSig.IsZerocoinPublicSpend();
+                            if (!in.IsZerocoinSpend() && !isPublicSpend)
                                 continue;
-
-                            libzerocoin::CoinSpend spend = TxInToZerocoinSpend(in);
-                            vSpendInfo.push_back(make_pair(spend, txid));
+                            if (isPublicSpend) {
+                                libzerocoin::ZerocoinParams* params = Params().Zerocoin_Params(false);
+                                PublicCoinSpend publicSpend(params);
+                                CValidationState state;
+                                if (!ZPIVModule::ParseZerocoinPublicSpend(in, tx, state, publicSpend)){
+                                    return _("Failed to parse public spend");
+                                }
+                                vSpendInfo.push_back(make_pair(publicSpend, txid));
+                            } else {
+                                libzerocoin::CoinSpend spend = TxInToZerocoinSpend(in);
+                                vSpendInfo.push_back(make_pair(spend, txid));
+                            }
                         }
                     }
 
@@ -376,10 +387,11 @@ std::list<libzerocoin::CoinDenomination> ZerocoinSpendListFromBlock(const CBlock
             continue;
 
         for (const CTxIn& txin : tx.vin) {
-            if (!txin.IsZerocoinSpend())
+            bool isPublicSpend = txin.scriptSig.IsZerocoinPublicSpend();
+            if (!txin.IsZerocoinSpend() && !isPublicSpend)
                 continue;
 
-            if (fFilterInvalid) {
+            if (fFilterInvalid && !isPublicSpend) {
                 libzerocoin::CoinSpend spend = TxInToZerocoinSpend(txin);
                 if (invalid_out::ContainsSerial(spend.getCoinSerialNumber()))
                     continue;

--- a/test/functional/fake_stake/base_test.py
+++ b/test/functional/fake_stake/base_test.py
@@ -48,7 +48,9 @@ class PIVX_FakeStakeTest(BitcoinTestFramework):
         :param:
         :return:
         '''
-        self.log.info("\n\n*** Starting %s ***\n------------------------\n%s\n", self.__class__.__name__, self.description)
+        title = "*** Starting %s ***" % self.__class__.__name__
+        underline = "-" * len(title)
+        self.log.info("\n\n%s\n%s\n%s\n", title, underline, self.description)
         # Global Test parameters (override in run_test)
         self.DEFAULT_FEE = 0.1
         # Spam blocks to send in current test
@@ -92,8 +94,6 @@ class PIVX_FakeStakeTest(BitcoinTestFramework):
         :return  block:              (CBlock) generated block
         '''
 
-        self.log.info("Creating Spam Block")
-
         # If not given inputs to create spam txes, use a copy of the staking inputs
         if len(spendingPrevOuts) == 0:
             spendingPrevOuts = dict(stakingPrevOuts)
@@ -117,8 +117,6 @@ class PIVX_FakeStakeTest(BitcoinTestFramework):
         if not block.solve_stake(stakingPrevOuts):
             raise Exception("Not able to solve for any prev_outpoint")
 
-        self.log.info("Stake found. Signing block...")
-
         # Sign coinstake TX and add it to the block
         signed_stake_tx = self.sign_stake_tx(block, stakingPrevOuts[block.prevoutStake][0], fZPoS)
         block.vtx.append(signed_stake_tx)
@@ -130,10 +128,10 @@ class PIVX_FakeStakeTest(BitcoinTestFramework):
 
         # remove a random prevout from the list
         # (to randomize block creation if the same height is picked two times)
-        del spendingPrevOuts[choice(list(spendingPrevOuts))]
+        if len(spendingPrevOuts) > 0:
+            del spendingPrevOuts[choice(list(spendingPrevOuts))]
 
         # Create spam for the block. Sign the spendingPrevouts
-        self.log.info("Creating spam TXes...")
         for outPoint in spendingPrevOuts:
             value_out = int(spendingPrevOuts[outPoint][0] - self.DEFAULT_FEE * COIN)
             tx = create_transaction(outPoint, b"", value_out, nTime, scriptPubKey=CScript([self.block_sig_key.get_pubkey(), OP_CHECKSIG]))

--- a/test/functional/zerocoin_publicSpend_reorg.py
+++ b/test/functional/zerocoin_publicSpend_reorg.py
@@ -1,0 +1,208 @@
+# !/usr/bin/env python3
+# Copyright (c) 2019 The PIVX Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+'''
+Covers the scenario of two valid PoS blocks with same height
+and same coinstake input.
+'''
+
+from copy import deepcopy
+from io import BytesIO
+import time
+from test_framework.messages import CTransaction, CBlock
+from test_framework.util import bytes_to_hex_str, hex_str_to_bytes, assert_equal
+from fake_stake.base_test import PIVX_FakeStakeTest
+
+
+class ZerocoinPublicSpendReorg(PIVX_FakeStakeTest):
+
+    def run_test(self):
+        self.description = "Covers the reorg with a zc public spend in vtx"
+        self.init_test()
+        DENOM_TO_USE = 10           # zc denomination
+        INITAL_MINED_BLOCKS = 321   # First mined blocks (rewards collected to mint)
+        MORE_MINED_BLOCKS = 105     # More blocks mined before spending zerocoins
+
+        # 1) Starting mining blocks
+        self.log.info("Mining %d blocks.." % INITAL_MINED_BLOCKS)
+        self.node.generate(INITAL_MINED_BLOCKS)
+
+        # 2) Mint 2 zerocoins
+        self.node.mintzerocoin(DENOM_TO_USE)
+        self.node.generate(1)
+        self.node.mintzerocoin(DENOM_TO_USE)
+        self.node.generate(1)
+
+        # 3) Mine additional blocks and collect the mints
+        self.log.info("Mining %d blocks.." % MORE_MINED_BLOCKS)
+        self.node.generate(MORE_MINED_BLOCKS)
+        self.log.info("Collecting mints...")
+        mints = self.node.listmintedzerocoins(True, False)
+        assert len(mints) == 2, "mints list has len %d (!= 2)" % len(mints)
+
+        # 4) Get unspent coins and chain tip
+        self.unspent = self.node.listunspent()
+        block_count = self.node.getblockcount()
+        pastBlockHash = self.node.getblockhash(block_count)
+        self.log.info("Block count: %d - Current best: %s..." % (self.node.getblockcount(), self.node.getbestblockhash()[:5]))
+        pastBlock = CBlock()
+        pastBlock.deserialize(BytesIO(hex_str_to_bytes(self.node.getblock(pastBlockHash, False))))
+        checkpoint = pastBlock.nAccumulatorCheckpoint
+
+        # 5) get the raw zerocoin spend txes
+        self.log.info("Getting the raw zerocoin public spends...")
+        public_spend_A = self.node.createrawzerocoinpublicspend(mints[0].get("serial hash"))
+        tx_A = CTransaction()
+        tx_A.deserialize(BytesIO(hex_str_to_bytes(public_spend_A)))
+        tx_A.rehash()
+        public_spend_B = self.node.createrawzerocoinpublicspend(mints[1].get("serial hash"))
+        tx_B = CTransaction()
+        tx_B.deserialize(BytesIO(hex_str_to_bytes(public_spend_B)))
+        tx_B.rehash()
+        # Spending same coins to different recipients to get different txids
+        my_addy = "yAVWM5urwaTyhiuFQHP2aP47rdZsLUG5PH"
+        public_spend_A2 = self.node.createrawzerocoinpublicspend(mints[0].get("serial hash"), my_addy)
+        tx_A2 = CTransaction()
+        tx_A2.deserialize(BytesIO(hex_str_to_bytes(public_spend_A2)))
+        tx_A2.rehash()
+        public_spend_B2 = self.node.createrawzerocoinpublicspend(mints[1].get("serial hash"), my_addy)
+        tx_B2 = CTransaction()
+        tx_B2.deserialize(BytesIO(hex_str_to_bytes(public_spend_B2)))
+        tx_B2.rehash()
+        self.log.info("tx_A id: %s" % str(tx_A.hash))
+        self.log.info("tx_B id: %s" % str(tx_B.hash))
+        self.log.info("tx_A2 id: %s" % str(tx_A2.hash))
+        self.log.info("tx_B2 id: %s" % str(tx_B2.hash))
+
+
+        self.test_nodes[0].handle_connect()
+
+        # 6) create block_A --> main chain
+        self.log.info("")
+        self.log.info("*** block_A ***")
+        self.log.info("Creating block_A [%d] with public spend tx_A in it." % (block_count + 1))
+        block_A = self.new_block(block_count, pastBlock, checkpoint, tx_A)
+        self.log.info("Hash of block_A: %s..." % block_A.hash[:5])
+        self.log.info("sending block_A...")
+        var = self.node.submitblock(bytes_to_hex_str(block_A.serialize()))
+        if var is not None:
+            self.log.info("result: %s" % str(var))
+            raise Exception("block_A not accepted")
+        time.sleep(2)
+        assert_equal(self.node.getblockcount(), block_count+1)
+        assert_equal(self.node.getbestblockhash(), block_A.hash)
+        self.log.info("  >>  block_A connected  <<")
+        self.log.info("Current chain: ... --> block_0 [%d] --> block_A [%d]\n" % (block_count, block_count+1))
+
+        # 7) create block_B --> forked chain
+        self.log.info("*** block_B ***")
+        self.log.info("Creating block_B [%d] with public spend tx_B in it." % (block_count + 1))
+        block_B = self.new_block(block_count, pastBlock, checkpoint, tx_B)
+        self.log.info("Hash of block_B: %s..." % block_B.hash[:5])
+        self.log.info("sending block_B...")
+        var = self.node.submitblock(bytes_to_hex_str(block_B.serialize()))
+        self.log.info("result of block_B submission: %s" % str(var))
+        time.sleep(2)
+        assert_equal(self.node.getblockcount(), block_count+1)
+        assert_equal(self.node.getbestblockhash(), block_A.hash)
+        # block_B is not added. Chain remains the same
+        self.log.info("  >>  block_B not connected  <<")
+        self.log.info("Current chain: ... --> block_0 [%d] --> block_A [%d]\n" % (block_count, block_count+1))
+
+        # 8) Create new block block_C on the forked chain (block_B)
+        block_count += 1
+        self.log.info("*** block_C ***")
+        self.log.info("Creating block_C [%d] on top of block_B triggering the reorg" % (block_count + 1))
+        block_C = self.new_block(block_count, block_B, checkpoint)
+        self.log.info("Hash of block_C: %s..." % block_C.hash[:5])
+        self.log.info("sending block_C...")
+        var = self.node.submitblock(bytes_to_hex_str(block_C.serialize()))
+        if var is not None:
+            self.log.info("result: %s" % str(var))
+            raise Exception("block_C not accepted")
+        time.sleep(2)
+        assert_equal(self.node.getblockcount(), block_count+1)
+        assert_equal(self.node.getbestblockhash(), block_C.hash)
+        self.log.info("  >>  block_A disconnected / block_B and block_C connected  <<")
+        self.log.info("Current chain: ... --> block_0 [%d] --> block_B [%d] --> block_C [%d]\n" % (
+                block_count - 1, block_count, block_count+1
+        ))
+
+        # 7) Now create block_D which tries to spend same coin of tx_B again on the (new) main chain
+        # (this block will be rejected)
+        block_count += 1
+        self.log.info("*** block_D ***")
+        self.log.info("Creating block_D [%d] trying to double spend the coin of tx_B" % (block_count + 1))
+        block_D = self.new_block(block_count, block_C, checkpoint, tx_B2)
+        self.log.info("Hash of block_D: %s..." % block_D.hash[:5])
+        self.log.info("sending block_D...")
+        var = self.node.submitblock(bytes_to_hex_str(block_D.serialize()))
+        self.log.info("result of block_D submission: %s" % str(var))
+        time.sleep(2)
+        assert_equal(self.node.getblockcount(), block_count)
+        assert_equal(self.node.getbestblockhash(), block_C.hash)
+        # block_D is not added. Chain remains the same
+        self.log.info("  >>  block_D rejected  <<")
+        self.log.info("Current chain: ... --> block_0 [%d] --> block_B [%d] --> block_C [%d]\n" % (
+                block_count - 2, block_count - 1, block_count
+        ))
+
+        # 8) Now create block_E which spends tx_A again on main chain
+        # (this block will be accepted and connected since tx_A was spent on block_A now disconnected)
+        self.log.info("*** block_E ***")
+        self.log.info("Creating block_E [%d] trying spend tx_A on main chain" % (block_count + 1))
+        block_E = self.new_block(block_count, block_C, checkpoint, tx_A)
+        self.log.info("Hash of block_E: %s..." % block_E.hash[:5])
+        self.log.info("sending block_E...")
+        var = self.node.submitblock(bytes_to_hex_str(block_E.serialize()))
+        if var is not None:
+            self.log.info("result: %s" % str(var))
+            raise Exception("block_E not accepted")
+        time.sleep(2)
+        assert_equal(self.node.getblockcount(), block_count+1)
+        assert_equal(self.node.getbestblockhash(), block_E.hash)
+        self.log.info("  >>  block_E connected <<")
+        self.log.info("Current chain: ... --> block_0 [%d] --> block_B [%d] --> block_C [%d] --> block_E [%d]\n" % (
+                block_count - 2, block_count - 1, block_count, block_count+1
+        ))
+
+        # 9) Now create block_F which tries to double spend the coin in tx_A
+        # # (this block will be rejected)
+        block_count += 1
+        self.log.info("*** block_F ***")
+        self.log.info("Creating block_F [%d] trying to double spend the coin in tx_A" % (block_count + 1))
+        block_F = self.new_block(block_count, block_E, checkpoint, tx_A2)
+        self.log.info("Hash of block_F: %s..." % block_F.hash[:5])
+        self.log.info("sending block_F...")
+        var = self.node.submitblock(bytes_to_hex_str(block_F.serialize()))
+        self.log.info("result of block_F submission: %s" % str(var))
+        time.sleep(2)
+        assert_equal(self.node.getblockcount(), block_count)
+        assert_equal(self.node.getbestblockhash(), block_E.hash)
+        self.log.info("  >>  block_F rejected <<")
+        self.log.info("Current chain: ... --> block_0 [%d] --> block_B [%d] --> block_C [%d] --> block_E [%d]\n" % (
+                block_count - 3, block_count - 2, block_count - 1, block_count
+        ))
+        self.log.info("All good.")
+
+
+
+    def new_block(self, block_count, prev_block, checkpoint, zcspend = None):
+        if prev_block.hash is None:
+            prev_block.rehash()
+        staking_utxo_list = [self.unspent.pop()]
+        pastBlockHash = prev_block.hash
+        stakingPrevOuts = self.get_prevouts(staking_utxo_list, block_count)
+        block = self.create_spam_block(pastBlockHash, stakingPrevOuts, block_count + 1)
+        if zcspend is not None:
+            block.vtx.append(zcspend)
+            block.hashMerkleRoot = block.calc_merkle_root()
+        block.nAccumulatorCheckpoint = checkpoint
+        block.rehash()
+        block.sign_block(self.block_sig_key)
+        return block
+
+if __name__ == '__main__':
+    ZerocoinPublicSpendReorg().main()

--- a/test/functional/zerocoin_valid_public_spend.py
+++ b/test/functional/zerocoin_valid_public_spend.py
@@ -65,9 +65,25 @@ class zPIVValidCoinSpendTest(PIVX_FakeStakeTest):
         else:
             assert (rawTx["confirmations"] == 6)
 
-        self.log.info("%s PASSED" % self.__class__.__name__)
+        self.log.info("%s VALID PUBLIC COIN SPEND PASSED" % self.__class__.__name__)
 
+        self.log.info("%s Trying to spend the serial twice now" % self.__class__.__name__)
 
+        serial = zc[0]["s"]
+        randomness = zc[0]["r"]
+        privkey = zc[0]["k"]
+
+        tx = None
+        try:
+            tx = self.node.spendrawzerocoin(serial, randomness, DENOM_TO_USE, privkey)
+        except JSONRPCException as e:
+            self.log.info("GOOD: Transaction did not verify")
+
+        if tx is not None:
+            self.log.warning("Tx is: %s" % tx)
+            raise AssertionError("TEST FAILED")
+
+        self.log.info("%s DOUBLE SPENT SERIAL NOT VERIFIED, TEST PASSED" % self.__class__.__name__)
 
 if __name__ == '__main__':
     zPIVValidCoinSpendTest().main()

--- a/test/functional/zerocoin_valid_public_spend.py
+++ b/test/functional/zerocoin_valid_public_spend.py
@@ -85,5 +85,18 @@ class zPIVValidCoinSpendTest(PIVX_FakeStakeTest):
 
         self.log.info("%s DOUBLE SPENT SERIAL NOT VERIFIED, TEST PASSED" % self.__class__.__name__)
 
+        self.log.info("%s Trying to spend using the old coin spend method.." % self.__class__.__name__)
+
+        tx = None
+        try:
+            tx = self.node.spendzerocoin(DENOM_TO_USE, False, False, "", False)
+            raise AssertionError("TEST FAILED, old coinSpend spent")
+        except JSONRPCException as e:
+            self.log.info("GOOD: spendzerocoin old spend did not verify")
+
+
+        self.log.info("%s OLD COIN SPEND NON USABLE ANYMORE, TEST PASSED" % self.__class__.__name__)
+
+
 if __name__ == '__main__':
     zPIVValidCoinSpendTest().main()

--- a/test/functional/zerocoin_valid_public_spend.py
+++ b/test/functional/zerocoin_valid_public_spend.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The PIVX Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+'''
+Covers the 'Wrapped Serials Attack' scenario
+'''
+
+import random
+from time import sleep
+
+from test_framework.authproxy import JSONRPCException
+from test_framework.util import assert_equal, assert_greater_than
+
+from fake_stake.base_test import PIVX_FakeStakeTest
+
+class zPIVValidCoinSpendTest(PIVX_FakeStakeTest):
+
+    def run_test(self):
+        self.description = "Covers the 'valid publicCoinSpend spend' scenario."
+        self.init_test()
+
+        INITAL_MINED_BLOCKS = 301   # Blocks mined before minting
+        MORE_MINED_BLOCKS = 52      # Blocks mined after minting (before spending)
+        DENOM_TO_USE = 1         # zc denomination used for double spending attack
+
+        # 1) Start mining blocks
+        self.log.info("Mining %d first blocks..." % INITAL_MINED_BLOCKS)
+        self.node.generate(INITAL_MINED_BLOCKS)
+        sleep(2)
+
+        # 2) Mint zerocoins
+        self.log.info("Minting %d-denom zPIVs..." % DENOM_TO_USE)
+        self.node.mintzerocoin(DENOM_TO_USE)
+        self.node.generate(1)
+        sleep(2)
+        self.node.mintzerocoin(DENOM_TO_USE)
+        sleep(2)
+
+        # 3) Mine more blocks and collect the mint
+        self.log.info("Mining %d more blocks..." % MORE_MINED_BLOCKS)
+        self.node.generate(MORE_MINED_BLOCKS)
+        sleep(2)
+        list = self.node.listmintedzerocoins(True, True)
+        mint = list[0]
+
+        # 4) Get the raw zerocoin data
+        exported_zerocoins = self.node.exportzerocoins(False)
+        zc = [x for x in exported_zerocoins if mint["serial hash"] == x["id"]]
+        if len(zc) == 0:
+            raise AssertionError("mint not found")
+
+        # 5) Spend the minted coin (mine six more blocks)
+        self.log.info("Spending the minted coin with serial %s and mining six more blocks..." % zc[0]["s"])
+        txid = self.node.spendzerocoinmints([mint["serial hash"]])['txid']
+        self.log.info("Spent on tx %s" % txid)
+        self.node.generate(6)
+        sleep(2)
+
+        rawTx = self.node.getrawtransaction(txid, 1)
+        if rawTx is None:
+            self.log.warning("rawTx is: %s" % rawTx)
+            raise AssertionError("TEST FAILED")
+        else:
+            assert (rawTx["confirmations"] == 6)
+
+        self.log.info("%s PASSED" % self.__class__.__name__)
+
+
+
+if __name__ == '__main__':
+    zPIVValidCoinSpendTest().main()


### PR DESCRIPTION
Recent exploits over the Zerocoin protocol (Wrapped serials and broken P1 proof) required us to enable the zerocoin spork and deactivate the zPIV functionality in order to secure the supply until the pertinent review process is completed.

This PR aims to move forward from this undesired situation by enabling a secure and chain storage friendly solution for the zerocoin public spend (aka zPIV to PIV conversion).

The explanation of how this works can be defined as follows: 

- Every zPIV is a cryptographic commitment, specifically a pedersen commitment, in which its value is stored in the PIVX blockchain on the zc_mint transaction, the user burn coins in exchange of the accumulation of such value into an specific RSA accumulator.

The commitment is defined as: `Comm(S, v)`, where `S` is a formatted public key hash and `v` a random big number part of a group order.

- Instead of perform several zero knowledge proofs, like zerocoin does, to redeem the coins, the public spend links the spend input to the mint output and includes data to verify, S and v on the script, that the commitment opens to such value, plus the signature of the private key associated to S. Thus requiring the minimum amount of data storage and processing power.

This is the first required step that we need to take in order to allow everyone to move their zPIV safely and securely back into PIV while we continue to work for a better privacy solution.

The public coin spend validation flow follow the previous coin spend flow and not modifies any major area of it, could easily end up with major architectural modifications that want to avoid in this undesired situation.

When #888 is completed, this will be rebased on top. 

** This surely will need some more modifications and cleanup, making it public now to start testing and playing with it as soon as possible **