### PR TITLE
[Qt] Fixup duplicate label names

### DIFF
--- a/src/qt/forms/receivecoinsdialog.ui
+++ b/src/qt/forms/receivecoinsdialog.ui
@@ -181,7 +181,7 @@
               </widget>
              </item>
              <item row="6" column="0">
-              <widget class="QLabel" name="label">
+              <widget class="QLabel" name="label_8">
                <property name="toolTip">
                 <string>An optional amount to request. Leave this empty or zero to not request a specific amount.</string>
                </property>

--- a/src/qt/forms/zpivcontroldialog.ui
+++ b/src/qt/forms/zpivcontroldialog.ui
@@ -118,7 +118,7 @@
     </layout>
    </item>
    <item row="1" column="0">
-    <layout class="QVBoxLayout" name="verticalLayout">
+    <layout class="QVBoxLayout" name="verticalLayout_2">
      <item>
       <widget class="QTreeWidget" name="treeWidget">
       <property name="sizePolicy">


### PR DESCRIPTION
Resolves compiler warnings about a label's name having been already used.

```make
qt/forms/receivecoinsdialog.ui: Warning: The name 'label' (QLabel) is already in use, defaulting to 'label1'.
qt/forms/zpivcontroldialog.ui: Warning: The name 'verticalLayout' (QVBoxLayout) is already in use, defaulting to 'verticalLayout1'.
```