### PR TITLE
[zPIV] Disable zPIV staking

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2150,6 +2150,7 @@ bool CWallet::SelectStakeCoins(std::list<std::unique_ptr<CStakeInput> >& listInp
         }
     }
 
+    /* Disable zPIV Staking
     //zPIV
     if ((GetBoolArg("-zpivstake", true) || fPrecompute) && chainActive.Height() > Params().Zerocoin_Block_V2_Start() && !IsSporkActive(SPORK_16_ZEROCOIN_MAINTENANCE_MODE)) {
         //Only update zPIV set once per update interval
@@ -2179,7 +2180,7 @@ bool CWallet::SelectStakeCoins(std::list<std::unique_ptr<CStakeInput> >& listInp
             }
         }
     }
-
+    */
     return true;
 }
 


### PR DESCRIPTION
https://github.com/PIVX-Project/PIVX/pull/897 disables mints outputs at consensus level.
This prevents zerocoins from being included in `SelectStakeCoins` thus disabling zPIV staking in the wallet.