### PR TITLE
[zPIV] Free memory from ToString()

### DIFF
--- a/src/libzerocoin/bignum_gmp.cpp
+++ b/src/libzerocoin/bignum_gmp.cpp
@@ -196,6 +196,11 @@ std::string CBigNum::ToString(int nBase) const
 {
     char* c_str = mpz_get_str(NULL, nBase, bn);
     std::string str(c_str);
+    // Free c_str with the right free function:
+    void (*freefunc)(void *, size_t);
+    mp_get_memory_functions (NULL, NULL, &freefunc);
+    freefunc(c_str, strlen(c_str) + 1);
+
     return str;
 }
 


### PR DESCRIPTION
Fix a memory leak.

Before: (https://gist.github.com/Warrows/755c33593a74addcfedbe3cd5a9b8eb4)
```
==10580== LEAK SUMMARY:
==10580==    definitely lost: 8,080,863 bytes in 133,017 blocks
==10580==    indirectly lost: 0 bytes in 0 blocks
==10580==      possibly lost: 288 bytes in 1 blocks
==10580==    still reachable: 2,224 bytes in 10 blocks
==10580== suppressed: 0 bytes in 0 blocks
```
After: (https://gist.github.com/Warrows/ab3b40e7b8e56bf0570923f77715f922)
```
==10478== LEAK SUMMARY:
==10478==    definitely lost: 160 bytes in 1 blocks
==10478==    indirectly lost: 0 bytes in 0 blocks
==10478==      possibly lost: 288 bytes in 1 blocks
==10478==    still reachable: 2,224 bytes in 10 blocks
==10478==         suppressed: 0 bytes in 0 blocks
```