### PR TITLE
[Consensus] Mainnet public spend enforcement height set.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -164,7 +164,7 @@ public:
         nRejectOldSporkKey = 1527811200; //!> Fully reject old spork key after (GMT): Friday, June 1, 2018 12:00:00 AM
 
         // Public coin spend enforcement
-        nPublicZCSpends = 2000000;
+        nPublicZCSpends = 1880000;
 
         // Fake Serial Attack
         nFakeSerialBlockheightEnd = 1686229;


### PR DESCRIPTION
The PR merely set the zerocoin public spend network enforcement block height. 

After block **1,880,000** (~ 28/06/19), users will be able to convert their v2 zPIV back to PIV freely. Using the functionality described and recently merged on #891.