### PR TITLE
[Build] Clean all coverage files during make clean

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -532,10 +532,16 @@ CLEANFILES = $(EXTRA_LIBRARIES)
 CLEANFILES += *.gcda *.gcno
 CLEANFILES += compat/*.gcda compat/*.gcno
 CLEANFILES += crypto/*.gcda crypto/*.gcno
+CLEANFILES += libzerocoin/*.gcda libzerocoin/*.gcno
 CLEANFILES += primitives/*.gcda primitives/*.gcno
+CLEANFILES += rpc/*.gcda rpc/*.gcno
 CLEANFILES += script/*.gcda script/*.gcno
+CLEANFILES += support/*.gcda support/*.gcno
 CLEANFILES += univalue/*.gcda univalue/*.gcno
+CLEANFILES += wallet/*.gcda wallet/*.gcno
+CLEANFILES += wallet/test/*.gcda wallet/test/*.gcno
 CLEANFILES += zmq/*.gcda zmq/*.gcno
+CLEANFILES += zpiv/*.gcda zpiv/*.gcno
 CLEANFILES += obj/build.h
 
 EXTRA_DIST =


### PR DESCRIPTION
This adds extra paths that were left out and ensures that `.gcda` and `.gcno` files are properly cleaned up.

Simple way to test this is to run the following chain of commands both without and with the changeset:

```
./configure --enable-lcov
make
make clean && make distclean
find . -name "*.gcno"
```
Without this, there are leftover (non-cleaned) `.gcno` files, which could cause errors due to stale or fragmented/incomplete information when attempting to generate the coverage report (`make cov`). With this change, the `find` command shows that no such `.gcno` files remain after cleaning.

This all requires that `lcov` is available on the system, as `configure` will properly error out when using the `--enable-lcov` option if it isn't found.