### PR TITLE
[Cleanup] compiler warnings in coinSpend object.

### DIFF
--- a/src/libzerocoin/CoinSpend.cpp
+++ b/src/libzerocoin/CoinSpend.cpp
@@ -18,14 +18,15 @@
 namespace libzerocoin
 {
     CoinSpend::CoinSpend(const ZerocoinParams* paramsCoin, const ZerocoinParams* paramsAcc, const PrivateCoin& coin, Accumulator& a, const uint32_t& checksum,
-                     const AccumulatorWitness& witness, const uint256& ptxHash, const SpendType& spendType) : accChecksum(checksum),
-                                                                                  ptxHash(ptxHash),
+                     const AccumulatorWitness& witness, const uint256& ptxHash, const SpendType& spendType) :
                                                                                   coinSerialNumber((coin.getSerialNumber())),
+                                                                                  spendType(spendType),
+                                                                                  ptxHash(ptxHash),
+                                                                                  accChecksum(checksum),
                                                                                   accumulatorPoK(&paramsAcc->accumulatorParams),
                                                                                   serialNumberSoK(paramsCoin),
                                                                                   commitmentPoK(&paramsCoin->serialNumberSoKCommitmentGroup,
-                                                                                                &paramsAcc->accumulatorParams.accumulatorPoKCommitmentGroup),
-                                                                                  spendType(spendType)
+                                                                                                &paramsAcc->accumulatorParams.accumulatorPoKCommitmentGroup)
 {
     denomination = coin.getPublicCoin().getDenomination();
     version = coin.getVersion();

--- a/src/libzerocoin/CoinSpend.h
+++ b/src/libzerocoin/CoinSpend.h
@@ -89,6 +89,9 @@ public:
     CoinSpend(const ZerocoinParams* paramsCoin, const ZerocoinParams* paramsAcc, const PrivateCoin& coin, Accumulator& a, const uint32_t& checksum,
               const AccumulatorWitness& witness, const uint256& ptxHash, const SpendType& spendType);
 
+
+    virtual ~CoinSpend(){};
+
     /** Returns the serial number of the coin spend by this proof.
 	 *
 	 * @return the coin's serial number

--- a/src/zpiv/zpivmodule.h
+++ b/src/zpiv/zpivmodule.h
@@ -35,6 +35,8 @@ public:
         this->version = COIN_SPEND_PUBLIC_SPEND_VERSION;
     };
 
+    ~PublicCoinSpend(){};
+
     template <typename Stream>
     PublicCoinSpend(
             libzerocoin::ZerocoinParams* params,


### PR DESCRIPTION
Just a minor compiler warnings cleanup.