### PR TITLE
Modify GetNextWorkRequired to set Target Limit correctly 

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -149,6 +149,8 @@ public:
 
         /** Height or Time Based Activations **/
         nLastPOWBlock = 259200;
+        nPivxBadBlockTime = 1471401614; // Skip nBit validation of Block 259201 per PR #915
+        nPivxBadBlocknBits = 0x1c056dac; // Skip nBit validation of Block 259201 per PR #915
         nModifierUpdateBlock = 615800;
         nZerocoinStartHeight = 863787;
         nZerocoinStartTime = 1508214600; // October 17, 2017 4:30:00 AM
@@ -279,6 +281,8 @@ public:
         nTargetTimespan = 1 * 60; // PIVX: 1 day
         nTargetSpacing = 1 * 60;  // PIVX: 1 minute
         nLastPOWBlock = 200;
+        nPivxBadBlockTime = 1489001494; // Skip nBit validation of Block 259201 per PR #915
+        nPivxBadBlocknBits = 0x1e0a20bd; // Skip nBit validation of Block 201 per PR #915
         nMaturity = 15;
         nMasternodeCountDrift = 4;
         nModifierUpdateBlock = 51197; //approx Mon, 17 Apr 2017 04:00:00 GMT

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -120,6 +120,8 @@ public:
     /** Height or Time Based Activations **/
     int ModifierUpgradeBlock() const { return nModifierUpdateBlock; }
     int LAST_POW_BLOCK() const { return nLastPOWBlock; }
+    int PivxBadBlockTime() const { return nPivxBadBlockTime; }
+    int PivxBadBlocknBits() const { return nPivxBadBlocknBits; }
     int Zerocoin_StartHeight() const { return nZerocoinStartHeight; }
     int Zerocoin_Block_EnforceSerialRange() const { return nBlockEnforceSerialRange; }
     int Zerocoin_Block_RecalculateAccumulators() const { return nBlockRecalculateAccumulators; }
@@ -155,6 +157,8 @@ protected:
     int64_t nTargetTimespan;
     int64_t nTargetSpacing;
     int nLastPOWBlock;
+    int64_t nPivxBadBlockTime;
+    unsigned int nPivxBadBlocknBits;
     int nMasternodeCountDrift;
     int nMaturity;
     int nModifierUpdateBlock;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4511,9 +4511,7 @@ bool CheckWork(const CBlock block, CBlockIndex* const pindexPrev)
 
     if (block.nBits != nBitsRequired) {
         // Pivx Specific reference to the block with the wrong threshold was used.
-        static const int64_t PivxBadBlockTime = 1471401614;
-        static const unsigned int PivxBadBlocknBits = 0x1c056dac;
-        if ((block.nTime == PivxBadBlockTime) && (block.nBits == PivxBadBlocknBits)) {
+        if ((block.nTime == Params().PivxBadBlockTime()) && (block.nBits == Params().PivxBadBlocknBits())) {
             // accept PIVX block minted with incorrect proof of work threshold
             return true;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4509,8 +4509,17 @@ bool CheckWork(const CBlock block, CBlockIndex* const pindexPrev)
         return true;
     }
 
-    if (block.nBits != nBitsRequired)
+    if (block.nBits != nBitsRequired) {
+        // Pivx Specific reference to the block with the wrong threshold was used.
+        static const int64_t PivxBadBlockTime = 1471401614;
+        static const unsigned int PivxBadBlocknBits = 0x1c056dac;
+        if ((block.nTime == PivxBadBlockTime) && (block.nBits == PivxBadBlocknBits)) {
+            // accept PIVX block minted with incorrect proof of work threshold
+            return true;
+        }
+
         return error("%s : incorrect proof of work at %d", __func__, pindexPrev->nHeight + 1);
+    }
 
     return true;
 }

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -37,7 +37,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
         return Params().ProofOfWorkLimit().GetCompact();
     }
 
-    if (pindexLast->nHeight > Params().LAST_POW_BLOCK()) {
+    if (pindexLast->nHeight >= Params().LAST_POW_BLOCK()) {
         uint256 bnTargetLimit = (~uint256(0) >> 24);
         int64_t nTargetSpacing = 60;
         int64_t nTargetTimespan = 60 * 40;


### PR DESCRIPTION
GetNextWorkRequired() was not setting the work required properly on the first Proof of Stake block.  The code section to cap the work at the bnTargetLimit wasn't called on that first block, but rather on the second Proof of Stake block.

The end result is that the first PoS block uses the difficulty from the PoW, rather than capping it at the target limit; with the second PoS block capping it at the target limit:

`uint256 bnTargetLimit = (~uint256(0) >> 24);`

Creating a difficulty problem should the final PoW difficulty be greater than bnTargetLimit.

---
This code has been tested on an altcoin; and I can provide debug output demonstrating the shift of the TargetLimit to 00000FFFF the block after the first PoS block should it be desired.