### PR TITLE
[Build] Fix app name casing in mac deploy related files

### DIFF
--- a/contrib/macdeploy/detached-sig-create.sh
+++ b/contrib/macdeploy/detached-sig-create.sh
@@ -7,7 +7,7 @@ export LC_ALL=C
 set -e
 
 ROOTDIR=dist
-BUNDLE=${ROOTDIR}/Pivx-Qt.app
+BUNDLE=${ROOTDIR}/PIVX-Qt.app
 CODESIGN=codesign
 TEMPDIR=sign.temp
 TEMPLIST=${TEMPDIR}/signatures.txt

--- a/contrib/macdeploy/fancy.plist
+++ b/contrib/macdeploy/fancy.plist
@@ -22,7 +22,7 @@
 			<integer>370</integer>
 			<integer>156</integer>
 		</array>
-		<key>Pivx-Qt.app</key>
+		<key>PIVX-Qt.app</key>
 		<array>
 			<integer>128</integer>
 			<integer>156</integer>


### PR DESCRIPTION
The app bundle's filename is `PIVX-Qt.app`, not `Pivx-Qt.app`.