### PR TITLE
[zPIV] PublicCoinSpend v4 - Coin Randomness Schnorr Signature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -574,11 +574,11 @@ target_include_directories(pivxd PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src
 target_link_libraries(pivxd
         pthread
         SERVER_A
+        WALLET_A
         COMMON_A
         univalue
         ZEROCOIN_A
         UTIL_A
-        WALLET_A
         BITCOIN_CRYPTO_A
         ${CMAKE_BINARY_DIR}/libleveldb.a
         ${CMAKE_BINARY_DIR}/libleveldb_sse42.a

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -411,6 +411,7 @@ set(ZEROCOIN_SOURCES
         ./src/libzerocoin/bignum.h
         ./src/libzerocoin/bignum.cpp
         ./src/libzerocoin/Coin.h
+        ./src/libzerocoin/CoinRandomnessSchnorrSignature.h
         ./src/libzerocoin/CoinSpend.h
         ./src/libzerocoin/Commitment.h
         ./src/libzerocoin/Denominations.h
@@ -422,6 +423,7 @@ set(ZEROCOIN_SOURCES
         ./src/libzerocoin/Accumulator.cpp
         ./src/libzerocoin/AccumulatorProofOfKnowledge.cpp
         ./src/libzerocoin/Coin.cpp
+        ./src/libzerocoin/CoinRandomnessSchnorrSignature.cpp
         ./src/libzerocoin/Denominations.cpp
         ./src/libzerocoin/CoinSpend.cpp
         ./src/libzerocoin/Commitment.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -336,6 +336,7 @@ libzerocoin_libbitcoin_zerocoin_a_SOURCES = \
   libzerocoin/AccumulatorProofOfKnowledge.h \
   libzerocoin/bignum.h \
   libzerocoin/Coin.h \
+  libzerocoin/CoinRandomnessSchnorrSignature.h \
   libzerocoin/CoinSpend.h \
   libzerocoin/Commitment.h \
   libzerocoin/Denominations.h \
@@ -348,9 +349,10 @@ libzerocoin_libbitcoin_zerocoin_a_SOURCES = \
   libzerocoin/Accumulator.cpp \
   libzerocoin/AccumulatorProofOfKnowledge.cpp \
   libzerocoin/Coin.cpp \
-  libzerocoin/Denominations.cpp \
+  libzerocoin/CoinRandomnessSchnorrSignature.cpp \
   libzerocoin/CoinSpend.cpp \
   libzerocoin/Commitment.cpp \
+  libzerocoin/Denominations.cpp \
   libzerocoin/ParamGeneration.cpp \
   libzerocoin/Params.cpp \
   libzerocoin/SerialNumberSignatureOfKnowledge.cpp

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -129,6 +129,13 @@ bool CChainParams::HasStakeMinAgeOrDepth(const int contextHeight, const uint32_t
     return (contextHeight - utxoFromBlockHeight >= nStakeMinDepth);
 }
 
+int CChainParams::Zerocoin_PublicSpendVersion(const int nHeight) const
+{
+    if (nHeight < nPublicZCSpendsV4)
+        return 3;
+    return 4;
+}
+
 class CMainParams : public CChainParams
 {
 public:
@@ -182,6 +189,7 @@ public:
         nBlockStakeModifierlV2 = 1967000;
         // Public coin spend enforcement
         nPublicZCSpends = 1880000;
+        nPublicZCSpendsV4 = 2880000;
 
         // New P2P messages signatures
         nBlockEnforceNewMessageSignatures = 2967000;
@@ -320,6 +328,7 @@ public:
         nBlockStakeModifierlV2 = 1214000;
         // Public coin spend enforcement
         nPublicZCSpends = 1106100;
+        nPublicZCSpendsV4 = 2106100;
 
         // New P2P messages signatures
         nBlockEnforceNewMessageSignatures = 2214000;
@@ -416,6 +425,7 @@ public:
         nBlockStakeModifierlV2 = std::numeric_limits<int>::max(); // max integer value (never switch on regtest)
         // Public coin spend enforcement
         nPublicZCSpends = 350;
+        nPublicZCSpendsV4 = 450;
 
         // New P2P messages signatures
         nBlockEnforceNewMessageSignatures = 1;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -141,6 +141,7 @@ public:
     int Zerocoin_Block_V2_Start() const { return nBlockZerocoinV2; }
     bool IsStakeModifierV2(const int nHeight) const { return nHeight >= nBlockStakeModifierlV2; }
     int NewSigsActive(const int nHeight) const { return nHeight >= nBlockEnforceNewMessageSignatures; }
+    int Zerocoin_PublicSpendVersion(const int nHeight) const;
 
     // fake serial attack
     int Zerocoin_Block_EndFakeSerial() const { return nFakeSerialBlockheightEnd; }
@@ -223,6 +224,7 @@ protected:
     int nBlockZerocoinV2;
     int nBlockDoubleAccumulated;
     int nPublicZCSpends;
+    int nPublicZCSpendsV4;
     int nBlockStakeModifierlV2;
     int nBlockEnforceNewMessageSignatures;
 

--- a/src/libzerocoin/AccumulatorProofOfKnowledge.cpp
+++ b/src/libzerocoin/AccumulatorProofOfKnowledge.cpp
@@ -43,7 +43,7 @@ AccumulatorProofOfKnowledge::AccumulatorProofOfKnowledge(const AccumulatorAndPro
     this->C_r = g_n.pow_mod(r_2, params->accumulatorModulus) * h_n.pow_mod(r_3, params->accumulatorModulus);
 
     CBigNum r_alpha = CBigNum::randBignum(params->maxCoinValue * aR);
-    if(!(CBigNum::randBignum(CBigNum(3)) % 2)) {
+    if(!(CBigNum::randBignum(BN_THREE) % 2)) {
         r_alpha = 0-r_alpha;
     }
 
@@ -54,24 +54,24 @@ AccumulatorProofOfKnowledge::AccumulatorProofOfKnowledge(const AccumulatorAndPro
     CBigNum r_xi = CBigNum::randBignum(params->accumulatorPoKCommitmentGroup.modulus);
 
     CBigNum r_epsilon =  CBigNum::randBignum(aR_t_aM_4);
-    if(!(CBigNum::randBignum(CBigNum(3)) % 2)) {
+    if(!(CBigNum::randBignum(BN_THREE) % 2)) {
         r_epsilon = 0-r_epsilon;
     }
     CBigNum r_eta = CBigNum::randBignum(aR_t_aM_4);
-    if(!(CBigNum::randBignum(CBigNum(3)) % 2)) {
+    if(!(CBigNum::randBignum(BN_THREE) % 2)) {
         r_eta = 0-r_eta;
     }
     CBigNum r_zeta = CBigNum::randBignum(aR_t_aM_4);
-    if(!(CBigNum::randBignum(CBigNum(3)) % 2)) {
+    if(!(CBigNum::randBignum(BN_THREE) % 2)) {
         r_zeta = 0-r_zeta;
     }
 
     CBigNum r_beta = CBigNum::randBignum(aR_t_aM_4 * params->accumulatorPoKCommitmentGroup.modulus);
-    if(!(CBigNum::randBignum(CBigNum(3)) % 2)) {
+    if(!(CBigNum::randBignum(BN_THREE) % 2)) {
         r_beta = 0-r_beta;
     }
     CBigNum r_delta = CBigNum::randBignum(aR_t_aM_4 * params->accumulatorPoKCommitmentGroup.modulus);
-    if(!(CBigNum::randBignum(CBigNum(3)) % 2)) {
+    if(!(CBigNum::randBignum(BN_THREE) % 2)) {
         r_delta = 0-r_delta;
     }
 

--- a/src/libzerocoin/AccumulatorProofOfKnowledge.cpp
+++ b/src/libzerocoin/AccumulatorProofOfKnowledge.cpp
@@ -31,7 +31,7 @@ AccumulatorProofOfKnowledge::AccumulatorProofOfKnowledge(const AccumulatorAndPro
     CBigNum r = commitmentToCoin.getRandomness();
 
     CBigNum aM_4 = params->accumulatorModulus/CBigNum((long)4);
-    CBigNum aR = CBigNum(2).pow(params->k_prime + params->k_dprime);
+    CBigNum aR = BN_TWO.pow(params->k_prime + params->k_dprime);
     CBigNum aR_t_aM_4 = aM_4 * aR;
 
     CBigNum r_1 = CBigNum::randBignum(aM_4);
@@ -136,7 +136,7 @@ bool AccumulatorProofOfKnowledge:: Verify(const Accumulator& a, const CBigNum& v
     bool result_t3 = (t_3 == t_3_prime);
     bool result_t4 = (t_4 == t_4_prime);
 
-    bool result_range = ((s_alpha >= -(params->maxCoinValue * CBigNum(2).pow(params->k_prime + params->k_dprime + 1))) && (s_alpha <= (params->maxCoinValue * CBigNum(2).pow(params->k_prime + params->k_dprime + 1))));
+    bool result_range = ((s_alpha >= -(params->maxCoinValue * BN_TWO.pow(params->k_prime + params->k_dprime + 1))) && (s_alpha <= (params->maxCoinValue * BN_TWO.pow(params->k_prime + params->k_dprime + 1))));
 
     return result_st1 && result_st2 && result_st3 && result_t1 && result_t2 && result_t3 && result_t4 && result_range;
 }

--- a/src/libzerocoin/Coin.cpp
+++ b/src/libzerocoin/Coin.cpp
@@ -295,7 +295,7 @@ bool IsValidSerial(const ZerocoinParams* params, const CBigNum& bnSerial)
 
 bool IsValidCommitmentToCoinRange(const ZerocoinParams* params, const CBigNum& bnCommitment)
 {
-    return bnCommitment > CBigNum(0) && bnCommitment < params->serialNumberSoKCommitmentGroup.modulus;
+    return bnCommitment > BN_ZERO && bnCommitment < params->serialNumberSoKCommitmentGroup.modulus;
 }
 
 

--- a/src/libzerocoin/Coin.cpp
+++ b/src/libzerocoin/Coin.cpp
@@ -299,4 +299,12 @@ bool IsValidCommitmentToCoinRange(const ZerocoinParams* params, const CBigNum& b
 }
 
 
+CBigNum ExtractSerialFromPubKey(const CPubKey pubkey)
+{
+    uint256 hashedPubkey = Hash(pubkey.begin(), pubkey.end()) >> PrivateCoin::V2_BITSHIFT;
+    uint256 uintSerial = (uint256(0xF) << (256 - PrivateCoin::V2_BITSHIFT)) | hashedPubkey;
+    return CBigNum(uintSerial);
+}
+
+
 } /* namespace libzerocoin */

--- a/src/libzerocoin/Coin.h
+++ b/src/libzerocoin/Coin.h
@@ -33,6 +33,7 @@ namespace libzerocoin
     bool IsValidSerial(const ZerocoinParams* params, const CBigNum& bnSerial);
     bool IsValidCommitmentToCoinRange(const ZerocoinParams* params, const CBigNum& bnCommitment);
     CBigNum GetAdjustedSerial(const CBigNum& bnSerial);
+    CBigNum ExtractSerialFromPubKey(const CPubKey pubkey);
     bool GenerateKeyPair(const CBigNum& bnGroupOrder, const uint256& nPrivkey, CKey& key, CBigNum& bnSerial);
 
 /** A Public coin is the part of a coin that

--- a/src/libzerocoin/CoinRandomnessSchnorrSignature.cpp
+++ b/src/libzerocoin/CoinRandomnessSchnorrSignature.cpp
@@ -12,6 +12,7 @@ CoinRandomnessSchnorrSignature::CoinRandomnessSchnorrSignature(
     const CBigNum p = zcparams->coinCommitmentGroup.modulus;
     const CBigNum q = zcparams->coinCommitmentGroup.groupOrder;
     const CBigNum h = zcparams->coinCommitmentGroup.h;
+    const CBigNum pk = h.pow_mod(randomness, p);
 
     alpha = 0;
     beta = 0;
@@ -25,7 +26,7 @@ CoinRandomnessSchnorrSignature::CoinRandomnessSchnorrSignature(
 
         // challenge hash
         CHashWriter hasher(0,0);
-        hasher << *zcparams << r << msghash;
+        hasher << *zcparams << pk << r << msghash;
         alpha = CBigNum(hasher.GetHash()) % q;
         beta = (k - alpha.mul_mod(randomness, q)) % q;
     }
@@ -51,7 +52,7 @@ bool CoinRandomnessSchnorrSignature::Verify(
     // Signature verification.
     const CBigNum rv = (pk.pow_mod(alpha,p)).mul_mod(h.pow_mod(beta,p),p);
     CHashWriter hasher(0,0);
-    hasher << *zcparams << rv << msghash;
+    hasher << *zcparams << pk << rv << msghash;
 
     if (CBigNum(hasher.GetHash()) % q != alpha)
         return error("%s: Schnorr signature does not verify", __func__);

--- a/src/libzerocoin/CoinRandomnessSchnorrSignature.cpp
+++ b/src/libzerocoin/CoinRandomnessSchnorrSignature.cpp
@@ -1,0 +1,63 @@
+// Copyright (c) 2019 The PIVX developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "CoinRandomnessSchnorrSignature.h"
+
+namespace libzerocoin {
+
+CoinRandomnessSchnorrSignature::CoinRandomnessSchnorrSignature(
+        const ZerocoinParams* zcparams, const CBigNum randomness, const uint256 msghash)
+{
+    const CBigNum p = zcparams->coinCommitmentGroup.modulus;
+    const CBigNum q = zcparams->coinCommitmentGroup.groupOrder;
+    const CBigNum h = zcparams->coinCommitmentGroup.h;
+
+    alpha = 0;
+    beta = 0;
+
+    CBigNum k, r;
+
+    while (!alpha || !beta) {
+        // select random nonce k in Zq and let r = h^k mod p
+        k = CBigNum::randBignum(q);
+        r = h.pow_mod(k, p);
+
+        // challenge hash
+        CHashWriter hasher(0,0);
+        hasher << *zcparams << r << msghash;
+        alpha = CBigNum(hasher.GetHash()) % q;
+        beta = (k - alpha.mul_mod(randomness, q)) % q;
+    }
+
+}
+
+bool CoinRandomnessSchnorrSignature::Verify(
+        const ZerocoinParams* zcparams, const CBigNum& S, const CBigNum& C, const uint256 msghash) const
+{
+    const CBigNum p = zcparams->coinCommitmentGroup.modulus;
+    const CBigNum q = zcparams->coinCommitmentGroup.groupOrder;
+    const CBigNum h = zcparams->coinCommitmentGroup.h;
+    const CBigNum g = zcparams->coinCommitmentGroup.g;
+
+    // Params validation.
+    if (!IsValidSerial(zcparams, S)) return error("%s: Invalid serial range", __func__);
+    if (alpha < BN_ZERO || alpha >= q) return error("%s: alpha out of range", __func__);
+    if (beta < BN_ZERO || beta >= q) return error("%s: beta out of range", __func__);
+
+    // Schnorr public key computation.
+    const CBigNum pk = C.mul_mod(g.pow_mod(-S,p),p);
+
+    // Signature verification.
+    const CBigNum rv = (pk.pow_mod(alpha,p)).mul_mod(h.pow_mod(beta,p),p);
+    CHashWriter hasher(0,0);
+    hasher << *zcparams << rv << msghash;
+
+    if (CBigNum(hasher.GetHash()) % q != alpha)
+        return error("%s: Schnorr signature does not verify", __func__);
+
+    return true;
+
+}
+
+} /* namespace libzerocoin */

--- a/src/libzerocoin/CoinRandomnessSchnorrSignature.h
+++ b/src/libzerocoin/CoinRandomnessSchnorrSignature.h
@@ -1,0 +1,56 @@
+// Copyright (c) 2019 The PIVX developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef COINRANDOMNESSPROOF_H_
+#define COINRANDOMNESSPROOF_H_
+
+#include "Params.h"
+#include "Coin.h"
+#include "serialize.h"
+#include "hash.h"
+
+namespace libzerocoin {
+
+/**A Schnorr Signature on the hash of metadata attesting that the signer knows the randomness v
+ *  necessary to open a public coin C (which is a pedersen commitment g^S h^v mod p) with
+ * given serial number S.
+ */
+class CoinRandomnessSchnorrSignature {
+public:
+    CoinRandomnessSchnorrSignature() {};
+    template <typename Stream> CoinRandomnessSchnorrSignature(Stream& strm) {strm >> *this;}
+
+    /** Creates a Schnorr signature object using the randomness of a public coin as private key sk.
+     *
+     * @param zcparams zerocoin params (group modulus, order and generators)
+     * @param randomness the coin we are going to use for the signature (sk := randomness, pk := h^sk mod p).
+     * @param msghash hash of meta data to create a signature on.
+     */
+    CoinRandomnessSchnorrSignature(const ZerocoinParams* zcparams, const CBigNum randomness, const uint256 msghash);
+
+    /** Verifies the Schnorr signature on message msghash with public key pk = Cg^-S mod p
+     *
+     * @param zcparams zerocoin params (group modulus, order and generators)
+     * @param S serial number of the coin used for the signature
+     * @param C value of the public coin (commitment to serial S and randomness v) used for the signature.
+     * @param msghash hash of meta data to verify the signature on.
+     * @return
+     */
+    bool Verify(const ZerocoinParams* zcparams, const CBigNum& S, const CBigNum& C, const uint256 msghash) const;
+
+    ADD_SERIALIZE_METHODS;
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
+    {
+        READWRITE(alpha);
+        READWRITE(beta);
+    }
+
+private:
+    // signature components
+    CBigNum alpha, beta;
+};
+
+} /* namespace libzerocoin */
+#endif /* COINRANDOMNESSPROOF_H_ */

--- a/src/libzerocoin/CoinSpend.cpp
+++ b/src/libzerocoin/CoinSpend.cpp
@@ -169,4 +169,11 @@ std::vector<unsigned char> CoinSpend::ParseSerial(CDataStream& s) {
     return coinSerialNumber.getvch();
 }
 
+void CoinSpend::setPubKey(CPubKey pkey, bool fUpdateSerial) {
+    this->pubkey = pkey;
+    if (fUpdateSerial) {
+        this->coinSerialNumber = libzerocoin::ExtractSerialFromPubKey(this->pubkey);
+    }
+}
+
 } /* namespace libzerocoin */

--- a/src/libzerocoin/CoinSpend.cpp
+++ b/src/libzerocoin/CoinSpend.cpp
@@ -132,8 +132,9 @@ bool CoinSpend::HasValidSerial(ZerocoinParams* params) const
 //Additional verification layer that requires the spend be signed by the private key associated with the serial
 bool CoinSpend::HasValidSignature() const
 {
+    const int coinVersion = getCoinVersion();
     //No private key for V1
-    if (version < PrivateCoin::PUBKEY_VERSION)
+    if (coinVersion < PrivateCoin::PUBKEY_VERSION)
         return true;
 
     try {
@@ -154,7 +155,7 @@ bool CoinSpend::HasValidSignature() const
 CBigNum CoinSpend::CalculateValidSerial(ZerocoinParams* params)
 {
     CBigNum bnSerial = coinSerialNumber;
-    bnSerial = bnSerial.mul_mod(CBigNum(1),params->coinCommitmentGroup.groupOrder);
+    bnSerial = bnSerial % params->coinCommitmentGroup.groupOrder;
     return bnSerial;
 }
 

--- a/src/libzerocoin/CoinSpend.h
+++ b/src/libzerocoin/CoinSpend.h
@@ -54,8 +54,7 @@ public:
         strm >> *this;
 
         //Need to reset some parameters if v2
-        int serialVersion = ExtractVersionFromSerial(coinSerialNumber);
-        if (serialVersion >= PrivateCoin::PUBKEY_VERSION) {
+        if (getCoinVersion() >= PrivateCoin::PUBKEY_VERSION) {
             accumulatorPoK = AccumulatorProofOfKnowledge(&paramsV2->accumulatorParams);
             serialNumberSoK = SerialNumberSignatureOfKnowledge(paramsV2);
             commitmentPoK = CommitmentProofOfKnowledge(&paramsV2->serialNumberSoKCommitmentGroup, &paramsV2->accumulatorParams.accumulatorPoKCommitmentGroup);
@@ -118,6 +117,7 @@ public:
     CBigNum getAccCommitment() const { return accCommitmentToCoinValue; }
     CBigNum getSerialComm() const { return serialCommitmentToCoinValue; }
     uint8_t getVersion() const { return version; }
+    int getCoinVersion() const { return libzerocoin::ExtractVersionFromSerial(coinSerialNumber); }
     CPubKey getPubKey() const { return pubkey; }
     SpendType getSpendType() const { return spendType; }
     std::vector<unsigned char> getSignature() const { return vchSig; }

--- a/src/libzerocoin/CoinSpend.h
+++ b/src/libzerocoin/CoinSpend.h
@@ -130,6 +130,7 @@ public:
     bool HasValidSignature() const;
     void setTxOutHash(uint256 txOutHash) { this->ptxHash = txOutHash; };
     void setDenom(libzerocoin::CoinDenomination denom) { this->denomination = denom; }
+    void setPubKey(CPubKey pkey, bool fUpdateSerial = false);
 
     CBigNum CalculateValidSerial(ZerocoinParams* params);
     std::string ToString() const;

--- a/src/libzerocoin/Commitment.cpp
+++ b/src/libzerocoin/Commitment.cpp
@@ -66,7 +66,8 @@ CommitmentProofOfKnowledge::CommitmentProofOfKnowledge(const IntegerGroupParams*
     uint32_t randomSize = COMMITMENT_EQUALITY_CHALLENGE_SIZE + COMMITMENT_EQUALITY_SECMARGIN +
                           std::max(std::max(this->ap->modulus.bitSize(), this->bp->modulus.bitSize()),
                                    std::max(this->ap->groupOrder.bitSize(), this->bp->groupOrder.bitSize()));
-    CBigNum maxRange = (CBigNum(2).pow(randomSize) - CBigNum(1));
+
+    CBigNum maxRange = (BN_TWO.pow(randomSize) - BN_ONE);
 
     r1 = CBigNum::randBignum(maxRange);
     r2 = CBigNum::randBignum(maxRange);
@@ -114,11 +115,11 @@ bool CommitmentProofOfKnowledge::Verify(const CBigNum& A, const CBigNum& B) cons
     if ((uint32_t)this->S1.bitSize() > maxSize ||
             (uint32_t)this->S2.bitSize() > maxSize ||
             (uint32_t)this->S3.bitSize() > maxSize ||
-            this->S1 < CBigNum(0) ||
-            this->S2 < CBigNum(0) ||
-            this->S3 < CBigNum(0) ||
-            this->challenge < CBigNum(0) ||
-            this->challenge > (CBigNum(2).pow(COMMITMENT_EQUALITY_CHALLENGE_SIZE) - CBigNum(1))) {
+            this->S1 < BN_ZERO ||
+            this->S2 < BN_ZERO ||
+            this->S3 < BN_ZERO ||
+            this->challenge < BN_ZERO ||
+            this->challenge > (BN_TWO.pow(COMMITMENT_EQUALITY_CHALLENGE_SIZE) - BN_ONE)) {
         // Invalid inputs. Reject.
         return false;
     }

--- a/src/libzerocoin/ParamGeneration.cpp
+++ b/src/libzerocoin/ParamGeneration.cpp
@@ -87,25 +87,25 @@ CalculateParams(ZerocoinParams &params, CBigNum N, std::string aux, uint32_t sec
     uint32_t resultCtr;
     params.accumulatorParams.accumulatorQRNCommitmentGroup.g = generateIntegerFromSeed(NLen - 1,
             calculateSeed(N, aux, securityLevel, STRING_QRNCOMMIT_GROUPG),
-                                             &resultCtr).pow_mod(CBigNum(2),N);
+                                             &resultCtr).pow_mod(BN_TWO, N);
     params.accumulatorParams.accumulatorQRNCommitmentGroup.h = generateIntegerFromSeed(NLen - 1,
             calculateSeed(N, aux, securityLevel, STRING_QRNCOMMIT_GROUPH),
-                                             &resultCtr).pow_mod(CBigNum(2), N);
+                                             &resultCtr).pow_mod(BN_TWO, N);
 
     // Calculate the accumulator base, which we calculate as "u = C**2 mod N"
     // where C is an arbitrary value. In the unlikely case that "u = 1" we increment
     // "C" and repeat.
     CBigNum constant(ACCUMULATOR_BASE_CONSTANT);
-    params.accumulatorParams.accumulatorBase = CBigNum(1);
+    params.accumulatorParams.accumulatorBase = BN_ONE;
     for (uint32_t count = 0; count < MAX_ACCUMGEN_ATTEMPTS && params.accumulatorParams.accumulatorBase.isOne(); count++) {
-        params.accumulatorParams.accumulatorBase = constant.pow_mod(CBigNum(2), params.accumulatorParams.accumulatorModulus);
+        params.accumulatorParams.accumulatorBase = constant.pow_mod(BN_TWO, params.accumulatorParams.accumulatorModulus);
     }
 
     // Compute the accumulator range. The upper range is the largest possible coin commitment value.
     // The lower range is sqrt(upper range) + 1. Since OpenSSL doesn't have
     // a square root function we use a slightly higher approximation.
     params.accumulatorParams.maxCoinValue = params.coinCommitmentGroup.modulus;
-    params.accumulatorParams.minCoinValue = CBigNum(2).pow((params.coinCommitmentGroup.modulus.bitSize() / 2) + 3);
+    params.accumulatorParams.minCoinValue = BN_TWO.pow((params.coinCommitmentGroup.modulus.bitSize() / 2) + 3);
 
     // If all went well, mark params as successfully initialized.
     params.accumulatorParams.initialized = true;
@@ -300,7 +300,7 @@ deriveIntegerGroupFromOrder(CBigNum &groupOrder)
     // "p" is prime and i is a counter starting at 1.
     for (uint32_t i = 1; i < NUM_SCHNORRGEN_ATTEMPTS; i++) {
         // Set modulus equal to "groupOrder * 2 * i"
-        result.modulus = (result.groupOrder * CBigNum(i*2)) + CBigNum(1);
+        result.modulus = (result.groupOrder * CBigNum(i*2)) + BN_ONE;
 
         // Test the result for primality
         // TODO: This is a probabilistic routine and thus not the right choice
@@ -374,7 +374,7 @@ calculateGroupModulusAndOrder(uint256 seed, uint32_t pLen, uint32_t qLen,
     uint32_t    qgen_counter;
     *resultGroupOrder = generateRandomPrime(qLen, seed, &qseed, &qgen_counter);
 
-    // Using ⎡pLen / 2 + 1⎤ as the length and qseed as the input_seed, use the random prime
+    // Using pLen / 2 + 1 as the length and qseed as the input_seed, use the random prime
     // routine to obtain p0 , pseed, and pgen_counter. We pass exceptions upward.
     uint32_t    p0len = ceil((pLen / 2.0) + 1);
     uint256     pseed;
@@ -389,42 +389,42 @@ calculateGroupModulusAndOrder(uint256 seed, uint32_t pLen, uint32_t qLen,
     CBigNum x = generateIntegerFromSeed(pLen, pseed, &iterations);
     pseed += (iterations + 1);
 
-    // Set x = 2^{pLen−1} + (x mod 2^{pLen–1}).
-    CBigNum powerOfTwo = CBigNum(2).pow(pLen-1);
+    // Set x = 2^{pLen-1} + (x mod 2^{pLen-1}).
+    CBigNum powerOfTwo = BN_TWO.pow(pLen-1);
     x = powerOfTwo + (x % powerOfTwo);
 
-    // t = ⎡x / (2 * resultGroupOrder * p0)⎤.
+    // t = x / (2 * resultGroupOrder * p0).
     // TODO: we don't have a ceiling function
-    CBigNum t = x / (CBigNum(2) * (*resultGroupOrder) * p0);
+    CBigNum t = x / (BN_TWO * (*resultGroupOrder) * p0);
 
     // Now loop until we find a valid prime "p" or we fail due to
     // pgen_counter exceeding ((4*pLen) + old_counter).
     for ( ; pgen_counter <= ((4*pLen) + old_counter) ; pgen_counter++) {
         // If (2 * t * resultGroupOrder * p0 + 1) > 2^{pLen}, then
-        // t = ⎡2^{pLen−1} / (2 * resultGroupOrder * p0)⎤.
-        powerOfTwo = CBigNum(2).pow(pLen);
-        CBigNum prod = (CBigNum(2) * t * (*resultGroupOrder) * p0) + CBigNum(1);
+        // t = 2^{pLen-1} / (2 * resultGroupOrder * p0)
+        powerOfTwo = BN_TWO.pow(pLen);
+        CBigNum prod = (BN_TWO * t * (*resultGroupOrder) * p0) + BN_ONE;
         if (prod > powerOfTwo) {
             // TODO: implement a ceil function
-            t = CBigNum(2).pow(pLen-1) / (CBigNum(2) * (*resultGroupOrder) * p0);
+            t = BN_TWO.pow(pLen-1) / (BN_TWO * (*resultGroupOrder) * p0);
         }
 
         // Compute a candidate prime resultModulus = 2tqp0 + 1.
-        *resultModulus = (CBigNum(2) * t * (*resultGroupOrder) * p0) + CBigNum(1);
+        *resultModulus = (BN_TWO * t * (*resultGroupOrder) * p0) + BN_ONE;
 
         // Verify that resultModulus is prime. First generate a pseudorandom integer "a".
         CBigNum a = generateIntegerFromSeed(pLen, pseed, &iterations);
         pseed += iterations + 1;
 
-        // Set a = 2 + (a mod (resultModulus–3)).
-        a = CBigNum(2) + (a % ((*resultModulus) - CBigNum(3)));
+        // Set a = 2 + (a mod (resultModulusâ€“3)).
+        a = BN_TWO + (a % ((*resultModulus) - CBigNum(3)));
 
         // Set z = a^{2 * t * resultGroupOrder} mod resultModulus
-        CBigNum z = a.pow_mod(CBigNum(2) * t * (*resultGroupOrder), (*resultModulus));
+        CBigNum z = a.pow_mod(BN_TWO * t * (*resultGroupOrder), (*resultModulus));
 
-        // If GCD(z–1, resultModulus) == 1 AND (z^{p0} mod resultModulus == 1)
+        // If GCD(z-1, resultModulus) == 1 AND (z^{p0} mod resultModulus == 1)
         // then we have found our result. Return.
-        if ((resultModulus->gcd(z - CBigNum(1))).isOne() &&
+        if ((resultModulus->gcd(z - BN_ONE)).isOne() &&
                 (z.pow_mod(p0, (*resultModulus))).isOne()) {
             // Success! Return the seeds and primes.
             *resultPseed = pseed;
@@ -433,7 +433,7 @@ calculateGroupModulusAndOrder(uint256 seed, uint32_t pLen, uint32_t qLen,
         }
 
         // This prime did not work out. Increment "t" and try again.
-        t = t + CBigNum(1);
+        t = t + BN_ONE;
     } // loop continues until pgen_counter exceeds a limit
 
     // We reach this point only if we exceeded our maximum iteration count.
@@ -465,11 +465,11 @@ calculateGroupGenerator(uint256 seed, uint256 pSeed, uint256 qSeed, CBigNum modu
     }
 
     // Compute e = (modulus - 1) / groupOrder
-    CBigNum e = (modulus - CBigNum(1)) / groupOrder;
+    CBigNum e = (modulus - BN_ONE) / groupOrder;
 
     // Loop until we find a generator
     for (uint32_t count = 1; count < MAX_GENERATOR_ATTEMPTS; count++) {
-        // hash = Hash(seed || pSeed || qSeed || “ggen” || index || count
+        // hash = Hash(seed || pSeed || qSeed || "ggen" || index || count
         uint256 hash = calculateGeneratorSeed(seed, pSeed, qSeed, "ggen", index, count);
         CBigNum W(hash);
 
@@ -568,21 +568,21 @@ generateRandomPrime(uint32_t primeBitLen, uint256 in_seed, uint256 *out_seed,
         CBigNum x = generateIntegerFromSeed(primeBitLen, *out_seed, &numIterations);
         (*out_seed) += numIterations + 1;
 
-        // Compute "t" = ⎡x / (2 * c0⎤
+        // Compute "t" = x / (2 * c0)
         // TODO no Ceiling call
-        CBigNum t = x / (CBigNum(2) * c0);
+        CBigNum t = x / (BN_TWO * c0);
 
         // Repeat the following procedure until we find a prime (or time out)
         for (uint32_t testNum = 0; testNum < MAX_PRIMEGEN_ATTEMPTS; testNum++) {
 
             // If ((2 * t * c0) + 1 > 2^{primeBitLen}),
-            // then t = ⎡2^{primeBitLen} – 1 / (2 * c0)⎤.
-            if ((CBigNum(2) * t * c0) > (CBigNum(2).pow(CBigNum(primeBitLen)))) {
-                t = ((CBigNum(2).pow(CBigNum(primeBitLen))) - CBigNum(1)) / (CBigNum(2) * c0);
+            // then t = 2^{primeBitLen} � 1 / (2 * c0)
+            if ((BN_TWO * t * c0) > (BN_TWO.pow(CBigNum(primeBitLen)))) {
+                t = ((BN_TWO.pow(CBigNum(primeBitLen))) - BN_ONE) / (BN_TWO * c0);
             }
 
             // Set c = (2 * t * c0) + 1
-            CBigNum c = (CBigNum(2) * t * c0) + CBigNum(1);
+            CBigNum c = (BN_TWO * t * c0) + BN_ONE;
 
             // Increment prime_gen_counter
             (*prime_gen_counter)++;
@@ -590,23 +590,23 @@ generateRandomPrime(uint32_t primeBitLen, uint256 in_seed, uint256 *out_seed,
             // Test "c" for primality as follows:
             // 1. First pick an integer "a" in between 2 and (c - 2)
             CBigNum a = generateIntegerFromSeed(c.bitSize(), (*out_seed), &numIterations);
-            a = CBigNum(2) + (a % (c - CBigNum(3)));
+            a = BN_TWO + (a % (c - CBigNum(3)));
             (*out_seed) += (numIterations + 1);
 
             // 2. Compute "z" = a^{2*t} mod c
-            CBigNum z = a.pow_mod(CBigNum(2) * t, c);
+            CBigNum z = a.pow_mod(BN_TWO * t, c);
 
             // 3. Check if "c" is prime.
             //    Specifically, verify that gcd((z-1), c) == 1 AND (z^c0 mod c) == 1
             // If so we return "c" as our result.
-            if (c.gcd(z - CBigNum(1)).isOne() && z.pow_mod(c0, c).isOne()) {
+            if (c.gcd(z - BN_ONE).isOne() && z.pow_mod(c0, c).isOne()) {
                 // Return "c", out_seed and prime_gen_counter
                 // (the latter two of which were already updated)
                 return c;
             }
 
             // 4. If the test did not succeed, increment "t" and loop
-            t = t + CBigNum(1);
+            t = t + BN_ONE;
         } // end of test loop
     }
 
@@ -629,10 +629,10 @@ generateIntegerFromSeed(uint32_t numBits, uint256 seed, uint32_t *numIterations)
     // Loop "iterations" times filling up the value "result" with random bits
     for (uint32_t count = 0; count < iterations; count++) {
         // result += ( H(pseed + count) * 2^{count * p0len} )
-        result += CBigNum(calculateHash(seed + count)) * CBigNum(2).pow(count * HASH_OUTPUT_BITS);
+        result += CBigNum(calculateHash(seed + count)) * BN_TWO.pow(count * HASH_OUTPUT_BITS);
     }
 
-    result = CBigNum(2).pow(numBits - 1) + (result % (CBigNum(2).pow(numBits - 1)));
+    result = BN_TWO.pow(numBits - 1) + (result % (BN_TWO.pow(numBits - 1)));
 
     // Return the number of iterations and the result
     *numIterations = iterations;

--- a/src/libzerocoin/ParamGeneration.cpp
+++ b/src/libzerocoin/ParamGeneration.cpp
@@ -417,7 +417,7 @@ calculateGroupModulusAndOrder(uint256 seed, uint32_t pLen, uint32_t qLen,
         pseed += iterations + 1;
 
         // Set a = 2 + (a mod (resultModulus - 3)).
-        a = BN_TWO + (a % ((*resultModulus) - CBigNum(3)));
+        a = BN_TWO + (a % ((*resultModulus) - BN_THREE));
 
         // Set z = a^{2 * t * resultGroupOrder} mod resultModulus
         CBigNum z = a.pow_mod(BN_TWO * t * (*resultGroupOrder), (*resultModulus));
@@ -590,7 +590,7 @@ generateRandomPrime(uint32_t primeBitLen, uint256 in_seed, uint256 *out_seed,
             // Test "c" for primality as follows:
             // 1. First pick an integer "a" in between 2 and (c - 2)
             CBigNum a = generateIntegerFromSeed(c.bitSize(), (*out_seed), &numIterations);
-            a = BN_TWO + (a % (c - CBigNum(3)));
+            a = BN_TWO + (a % (c - BN_THREE));
             (*out_seed) += (numIterations + 1);
 
             // 2. Compute "z" = a^{2*t} mod c

--- a/src/libzerocoin/ParamGeneration.cpp
+++ b/src/libzerocoin/ParamGeneration.cpp
@@ -416,7 +416,7 @@ calculateGroupModulusAndOrder(uint256 seed, uint32_t pLen, uint32_t qLen,
         CBigNum a = generateIntegerFromSeed(pLen, pseed, &iterations);
         pseed += iterations + 1;
 
-        // Set a = 2 + (a mod (resultModulusâ€“3)).
+        // Set a = 2 + (a mod (resultModulus - 3)).
         a = BN_TWO + (a % ((*resultModulus) - CBigNum(3)));
 
         // Set z = a^{2 * t * resultGroupOrder} mod resultModulus
@@ -576,7 +576,7 @@ generateRandomPrime(uint32_t primeBitLen, uint256 in_seed, uint256 *out_seed,
         for (uint32_t testNum = 0; testNum < MAX_PRIMEGEN_ATTEMPTS; testNum++) {
 
             // If ((2 * t * c0) + 1 > 2^{primeBitLen}),
-            // then t = 2^{primeBitLen} � 1 / (2 * c0)
+            // then t = (2^{primeBitLen} - 1) / (2 * c0)
             if ((BN_TWO * t * c0) > (BN_TWO.pow(CBigNum(primeBitLen)))) {
                 t = ((BN_TWO.pow(CBigNum(primeBitLen))) - BN_ONE) / (BN_TWO * c0);
             }

--- a/src/libzerocoin/bignum.h
+++ b/src/libzerocoin/bignum.h
@@ -346,4 +346,10 @@ inline bool operator>(const CBigNum& a, const CBigNum& b)  { return (mpz_cmp(a.b
 inline std::ostream& operator<<(std::ostream &strm, const CBigNum &b) { return strm << b.ToString(10); }
 
 typedef CBigNum Bignum;
+
+/** constant bignum instances */
+const CBigNum BN_ZERO = CBigNum(0);
+const CBigNum BN_ONE = CBigNum(1);
+const CBigNum BN_TWO = CBigNum(2);
+
 #endif

--- a/src/libzerocoin/bignum.h
+++ b/src/libzerocoin/bignum.h
@@ -351,5 +351,6 @@ typedef CBigNum Bignum;
 const CBigNum BN_ZERO = CBigNum(0);
 const CBigNum BN_ONE = CBigNum(1);
 const CBigNum BN_TWO = CBigNum(2);
+const CBigNum BN_THREE = CBigNum(3);
 
 #endif

--- a/src/libzerocoin/bignum_gmp.cpp
+++ b/src/libzerocoin/bignum_gmp.cpp
@@ -86,7 +86,7 @@ CBigNum CBigNum::randKBitBignum(const uint32_t k)
     CBigNum ret(buf);
     if (ret < 0)
         mpz_neg(ret.bn, ret.bn);
-    return ret % (CBigNum(1) << k);
+    return ret % (BN_ONE << k);
 }
 
 /**Returns the size in bits of the underlying bignum.
@@ -116,7 +116,7 @@ unsigned int CBigNum::getuint() const
 int CBigNum::getint() const
 {
     unsigned long n = getulong();
-    if (mpz_cmp(bn, CBigNum(0).bn) >= 0) {
+    if (mpz_cmp(bn, BN_ZERO.bn) >= 0) {
         return (n > (unsigned long)std::numeric_limits<int>::max() ? std::numeric_limits<int>::max() : n);
     } else {
         return (n > (unsigned long)std::numeric_limits<int>::max() ? std::numeric_limits<int>::min() : -(int)n);
@@ -156,7 +156,7 @@ void CBigNum::setvch(const std::vector<unsigned char>& vch)
 
 std::vector<unsigned char> CBigNum::getvch() const
 {
-    if (mpz_cmp(bn, CBigNum(0).bn) == 0) {
+    if (mpz_cmp(bn, BN_ZERO.bn) == 0) {
         return std::vector<unsigned char>(0);
     }
     size_t size = (mpz_sizeinbase (bn, 2) + CHAR_BIT-1) / CHAR_BIT;
@@ -238,7 +238,7 @@ CBigNum CBigNum::mul_mod(const CBigNum& b, const CBigNum& m) const
 CBigNum CBigNum::pow_mod(const CBigNum& e, const CBigNum& m) const
 {
     CBigNum ret;
-    if (e > CBigNum(0) && mpz_odd_p(m.bn))
+    if (e > BN_ZERO && mpz_odd_p(m.bn))
         mpz_powm_sec (ret.bn, bn, e.bn, m.bn);
     else
         mpz_powm (ret.bn, bn, e.bn, m.bn);
@@ -298,12 +298,12 @@ bool CBigNum::isPrime(const int checks) const
 
 bool CBigNum::isOne() const
 {
-    return mpz_cmp(bn, CBigNum(1).bn) == 0;
+    return mpz_cmp(bn, BN_ONE.bn) == 0;
 }
 
 bool CBigNum::operator!() const
 {
-    return mpz_cmp(bn, CBigNum(0).bn) == 0;
+    return mpz_cmp(bn, BN_ZERO.bn) == 0;
 }
 
 CBigNum& CBigNum::operator+=(const CBigNum& b)
@@ -339,13 +339,13 @@ CBigNum& CBigNum::operator>>=(unsigned int shift)
 CBigNum& CBigNum::operator++()
 {
     // prefix operator
-    mpz_add(bn, bn, CBigNum(1).bn);
+    mpz_add(bn, bn, BN_ONE.bn);
     return *this;
 }
 
 CBigNum& CBigNum::operator--()
 {
     // prefix operator
-    mpz_sub(bn, bn, CBigNum(1).bn);
+    mpz_sub(bn, bn, BN_ONE.bn);
     return *this;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1009,6 +1009,10 @@ bool CheckPublicCoinSpendEnforced(int blockHeight, bool isPublicSpend) {
     return true;
 }
 
+bool CheckPublicCoinSpendVersion(int blockHeight, int version) {
+    return version >= Params().Zerocoin_PublicSpendVersion(blockHeight);
+}
+
 bool ContextualCheckZerocoinSpend(const CTransaction& tx, const libzerocoin::CoinSpend* spend, CBlockIndex* pindex, const uint256& hashBlock)
 {
     if(!ContextualCheckZerocoinSpendNoSerialCheck(tx, spend, pindex, hashBlock)){
@@ -1048,17 +1052,16 @@ bool ContextualCheckZerocoinSpendNoSerialCheck(const CTransaction& tx, const lib
         }
     }
 
-    bool v1Serial = spend->getVersion() < libzerocoin::PrivateCoin::PUBKEY_VERSION;
-    if (pindex->nHeight >= Params().Zerocoin_Block_Public_Spend_Enabled()) {
-        //Reject V1 old serials.
-        if (v1Serial) {
-            return error("%s : zPIV v1 serial spend not spendable, serial %s, tx %s\n", __func__,
-                         spend->getCoinSerialNumber().GetHex(), tx.GetHash().GetHex());
-        }
+    // Check spend version
+    if (pindex->nHeight >= Params().Zerocoin_Block_Public_Spend_Enabled() &&
+            !CheckPublicCoinSpendVersion(pindex->nHeight, (int)spend->getVersion())) {
+        return error("%s: Invalid public spend version for tx %s", __func__, tx.GetHash().GetHex());
     }
 
+    bool fUseV1Params = spend->getCoinVersion() < libzerocoin::PrivateCoin::PUBKEY_VERSION;
+
     //Reject serial's that are not in the acceptable value range
-    if (!spend->HasValidSerial(Params().Zerocoin_Params(v1Serial)))  {
+    if (!spend->HasValidSerial(Params().Zerocoin_Params(fUseV1Params)))  {
         // Up until this block our chain was not checking serials correctly..
         if (!isBlockBetweenFakeSerialAttackRange(pindex->nHeight))
             return error("%s : zPIV spend with serial %s from tx %s is not in valid range\n", __func__,

--- a/src/main.h
+++ b/src/main.h
@@ -375,6 +375,7 @@ bool isBlockBetweenFakeSerialAttackRange(int nHeight);
 
 // Public coin spend
 bool CheckPublicCoinSpendEnforced(int blockHeight, bool isPublicSpend);
+bool CheckPublicCoinSpendVersion(int blockHeight, int version);
 
 /**
  * Check if transaction will be final in the next block to be created.

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -391,7 +391,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, 
                             spend = &spendObj;
                         }
 
-                        bool fUseV1Params = libzerocoin::ExtractVersionFromSerial(spend->getCoinSerialNumber()) < libzerocoin::PrivateCoin::PUBKEY_VERSION;
+                        bool fUseV1Params = spend->getCoinVersion() < libzerocoin::PrivateCoin::PUBKEY_VERSION;
                         if (!spend->HasValidSerial(Params().Zerocoin_Params(fUseV1Params)))
                             fDoubleSerial = true;
                         if (std::count(vBlockSerials.begin(), vBlockSerials.end(), spend->getCoinSerialNumber()))

--- a/src/test/zerocoin_transactions_tests.cpp
+++ b/src/test/zerocoin_transactions_tests.cpp
@@ -4,6 +4,7 @@
 
 #include "libzerocoin/Denominations.h"
 #include "libzerocoin/Coin.h"
+#include "libzerocoin/CoinRandomnessSchnorrSignature.h"
 #include "amount.h"
 #include "chainparams.h"
 #include "coincontrol.h"
@@ -56,64 +57,234 @@ BOOST_AUTO_TEST_CASE(zerocoin_spend_test)
 
 }
 
+BOOST_AUTO_TEST_CASE(zerocoin_schnorr_signature_test)
+{
+    const int NUM_OF_TESTS = 50;
+    SelectParams(CBaseChainParams::MAIN);
+    libzerocoin::ZerocoinParams *ZCParams_v1 = Params().Zerocoin_Params(true);
+    (void)ZCParams_v1;
+    libzerocoin::ZerocoinParams *ZCParams_v2 = Params().Zerocoin_Params(false);
+    (void)ZCParams_v2;
+
+    for (int i=0; i<NUM_OF_TESTS; i++) {
+
+        // mint a v1 coin
+        CBigNum s = CBigNum::randBignum(ZCParams_v1->coinCommitmentGroup.groupOrder);
+        CBigNum r = CBigNum::randBignum(ZCParams_v1->coinCommitmentGroup.groupOrder);
+        CBigNum c = ZCParams_v1->coinCommitmentGroup.g.pow_mod(s, ZCParams_v1->coinCommitmentGroup.modulus).mul_mod(
+                ZCParams_v1->coinCommitmentGroup.h.pow_mod(r, ZCParams_v1->coinCommitmentGroup.modulus), ZCParams_v1->coinCommitmentGroup.modulus);
+        for (uint32_t attempt = 0; attempt < MAX_COINMINT_ATTEMPTS; attempt++) {
+            if (c.isPrime(ZEROCOIN_MINT_PRIME_PARAM)) break;
+            CBigNum r_delta = CBigNum::randBignum(ZCParams_v1->coinCommitmentGroup.groupOrder);
+            r = (r + r_delta) % ZCParams_v1->coinCommitmentGroup.groupOrder;
+            c = ZCParams_v1->coinCommitmentGroup.g.pow_mod(s, ZCParams_v1->coinCommitmentGroup.modulus).mul_mod(
+                    ZCParams_v1->coinCommitmentGroup.h.pow_mod(r, ZCParams_v1->coinCommitmentGroup.modulus), ZCParams_v1->coinCommitmentGroup.modulus);
+        }
+        BOOST_CHECK_MESSAGE(c.isPrime(ZEROCOIN_MINT_PRIME_PARAM), "Unable to mint v1 coin");
+        libzerocoin::PrivateCoin privCoin_v1(ZCParams_v1, libzerocoin::CoinDenomination::ZQ_ONE, s, r);
+        const CBigNum randomness_v1 = privCoin_v1.getRandomness();
+        const CBigNum pubCoinValue_v1 = privCoin_v1.getPublicCoin().getValue();
+        const CBigNum serialNumber_v1 = privCoin_v1.getSerialNumber();
+
+        // mint a v2 coin
+        libzerocoin::PrivateCoin privCoin_v2(ZCParams_v2, libzerocoin::CoinDenomination::ZQ_ONE, true);
+        const CBigNum randomness_v2 = privCoin_v2.getRandomness();
+        const CBigNum pubCoinValue_v2 = privCoin_v2.getPublicCoin().getValue();
+        const CBigNum serialNumber_v2 = privCoin_v2.getSerialNumber();
+
+        // get a random msghash
+        const uint256 msghash = CBigNum::randKBitBignum(256).getuint256();
+
+        // sign the msghash with the randomness of the v1 coin
+        libzerocoin::CoinRandomnessSchnorrSignature crss_v1(ZCParams_v1, randomness_v1, msghash);
+        CDataStream ser_crss_v1(SER_NETWORK, PROTOCOL_VERSION);
+        ser_crss_v1 << crss_v1;
+
+        // sign the msghash with the randomness of the v2 coin
+        libzerocoin::CoinRandomnessSchnorrSignature crss_v2(ZCParams_v2, randomness_v2, msghash);
+        CDataStream ser_crss_v2(SER_NETWORK, PROTOCOL_VERSION);
+        ser_crss_v2 << crss_v2;
+
+        // unserialize the v1 signature into a fresh object and verify it
+        libzerocoin::CoinRandomnessSchnorrSignature new_crss_v1(ser_crss_v1);
+        BOOST_CHECK_MESSAGE(
+                new_crss_v1.Verify(ZCParams_v1, serialNumber_v1, pubCoinValue_v1, msghash),
+                "Failed to verify schnorr signature with v1 coin"
+                );
+
+        // unserialize the v2 signature into a fresh object and verify it
+        libzerocoin::CoinRandomnessSchnorrSignature new_crss_v2(ser_crss_v2);
+        BOOST_CHECK_MESSAGE(
+                new_crss_v2.Verify(ZCParams_v2, serialNumber_v2, pubCoinValue_v2, msghash),
+                "Failed to verify schnorr signature with v2 coin"
+                );
+
+        // verify failure on different msghash
+        uint256 msghash2;
+        do {
+            msghash2 = CBigNum::randKBitBignum(256).getuint256();
+        } while (msghash2 == msghash);
+        BOOST_CHECK_MESSAGE(
+            !new_crss_v1.Verify(ZCParams_v1, serialNumber_v1, pubCoinValue_v1, msghash2),
+            "schnorr signature with v1 coin verifies on wrong msghash"
+            );
+        BOOST_CHECK_MESSAGE(
+            !new_crss_v2.Verify(ZCParams_v2, serialNumber_v2, pubCoinValue_v2, msghash2),
+            "schnorr signature with v2 coin verifies on wrong msghash"
+            );
+
+        // verify failure swapping serials
+        BOOST_CHECK_MESSAGE(
+            !new_crss_v1.Verify(ZCParams_v1, serialNumber_v2, pubCoinValue_v1, msghash),
+            "schnorr signature with v1 coin verifies on wrong serial"
+            );
+        BOOST_CHECK_MESSAGE(
+            !new_crss_v2.Verify(ZCParams_v2, serialNumber_v1, pubCoinValue_v2, msghash),
+            "schnorr signature with v2 coin verifies on wrong serial"
+            );
+
+        // verify failure swapping public coins
+        BOOST_CHECK_MESSAGE(
+            !new_crss_v1.Verify(ZCParams_v1, serialNumber_v1, pubCoinValue_v2, msghash),
+            "schnorr signature with v1 coin verifies on wrong public coin value"
+            );
+        BOOST_CHECK_MESSAGE(
+            !new_crss_v2.Verify(ZCParams_v2, serialNumber_v2, pubCoinValue_v1, msghash),
+            "schnorr signature with v2 coin verifies on wrong public coin value"
+            );
+
+    }
+
+}
+
 BOOST_AUTO_TEST_CASE(zerocoin_public_spend_test)
 {
     SelectParams(CBaseChainParams::MAIN);
-    libzerocoin::ZerocoinParams *ZCParams = Params().Zerocoin_Params(false);
-    (void)ZCParams;
+    libzerocoin::ZerocoinParams *ZCParams_v1 = Params().Zerocoin_Params(true);
+    libzerocoin::ZerocoinParams *ZCParams_v2 = Params().Zerocoin_Params(false);
+    (void)ZCParams_v1;
+    (void)ZCParams_v2;
 
-    libzerocoin::PrivateCoin privCoin(ZCParams, libzerocoin::CoinDenomination::ZQ_ONE, true);
-    const CPrivKey privKey = privCoin.getPrivKey();
+    // create v1 coin
+    CBigNum s = CBigNum::randBignum(ZCParams_v1->coinCommitmentGroup.groupOrder);
+    CBigNum r = CBigNum::randBignum(ZCParams_v1->coinCommitmentGroup.groupOrder);
+    CBigNum c = ZCParams_v1->coinCommitmentGroup.g.pow_mod(s, ZCParams_v1->coinCommitmentGroup.modulus).mul_mod(
+            ZCParams_v1->coinCommitmentGroup.h.pow_mod(r, ZCParams_v1->coinCommitmentGroup.modulus), ZCParams_v1->coinCommitmentGroup.modulus);
+    for (uint32_t attempt = 0; attempt < MAX_COINMINT_ATTEMPTS; attempt++) {
+        if (c.isPrime(ZEROCOIN_MINT_PRIME_PARAM)) break;
+        CBigNum r_delta = CBigNum::randBignum(ZCParams_v1->coinCommitmentGroup.groupOrder);
+        r = (r + r_delta) % ZCParams_v1->coinCommitmentGroup.groupOrder;
+        c = ZCParams_v1->coinCommitmentGroup.g.pow_mod(s, ZCParams_v1->coinCommitmentGroup.modulus).mul_mod(
+                ZCParams_v1->coinCommitmentGroup.h.pow_mod(r, ZCParams_v1->coinCommitmentGroup.modulus), ZCParams_v1->coinCommitmentGroup.modulus);
+    }
+    BOOST_CHECK_MESSAGE(c.isPrime(ZEROCOIN_MINT_PRIME_PARAM), "Unable to mint v1 coin");
+    libzerocoin::PrivateCoin privCoin_v1(ZCParams_v1, libzerocoin::CoinDenomination::ZQ_ONE, s, r);
 
-    CZerocoinMint mint = CZerocoinMint(
-            privCoin.getPublicCoin().getDenomination(),
-            privCoin.getPublicCoin().getValue(),
-            privCoin.getRandomness(),
-            privCoin.getSerialNumber(),
+    CZerocoinMint mint_v1 = CZerocoinMint(
+            privCoin_v1.getPublicCoin().getDenomination(),
+            privCoin_v1.getPublicCoin().getValue(),
+            privCoin_v1.getRandomness(),
+            privCoin_v1.getSerialNumber(),
             false,
-            privCoin.getVersion(),
+            1,
             nullptr);
-    mint.SetPrivKey(privKey);
 
+    // create v2 coin
+    libzerocoin::PrivateCoin privCoin_v2(ZCParams_v2, libzerocoin::CoinDenomination::ZQ_ONE, true);
+    CPrivKey privKey = privCoin_v2.getPrivKey();
 
-    // Mint tx
-    CTransaction prevTx;
+    CZerocoinMint mint_v2 = CZerocoinMint(
+            privCoin_v2.getPublicCoin().getDenomination(),
+            privCoin_v2.getPublicCoin().getValue(),
+            privCoin_v2.getRandomness(),
+            privCoin_v2.getSerialNumber(),
+            false,
+            privCoin_v2.getVersion(),
+            &privKey);
 
-    CScript scriptSerializedCoin = CScript()
-    << OP_ZEROCOINMINT << privCoin.getPublicCoin().getValue().getvch().size() << privCoin.getPublicCoin().getValue().getvch();
-    CTxOut out = CTxOut(libzerocoin::ZerocoinDenominationToAmount(privCoin.getPublicCoin().getDenomination()), scriptSerializedCoin);
-    prevTx.vout.push_back(out);
+    // Mint txs
+    CTransaction prevTx_v1;
+    CTransaction prevTx_v2;
 
-    mint.SetOutputIndex(0);
-    mint.SetTxHash(prevTx.GetHash());
+    CScript scriptSerializedCoin_v1 = CScript()
+    << OP_ZEROCOINMINT << privCoin_v1.getPublicCoin().getValue().getvch().size() << privCoin_v1.getPublicCoin().getValue().getvch();
+    CTxOut out_v1 = CTxOut(libzerocoin::ZerocoinDenominationToAmount(privCoin_v1.getPublicCoin().getDenomination()), scriptSerializedCoin_v1);
+    prevTx_v1.vout.push_back(out_v1);
 
-    // Spend tx
-    CMutableTransaction tx;
-    tx.vout.resize(1);
-    tx.vout[0].nValue = 1*CENT;
-    tx.vout[0].scriptPubKey = GetScriptForDestination(CBitcoinAddress("D9Ti4LEhF1n6dR2hGd2SyNADD51AVgva6q").Get());
+    CScript scriptSerializedCoin_v2 = CScript()
+    << OP_ZEROCOINMINT << privCoin_v2.getPublicCoin().getValue().getvch().size() << privCoin_v2.getPublicCoin().getValue().getvch();
+    CTxOut out_v2 = CTxOut(libzerocoin::ZerocoinDenominationToAmount(privCoin_v2.getPublicCoin().getDenomination()), scriptSerializedCoin_v2);
+    prevTx_v2.vout.push_back(out_v2);
 
-    CTxIn in;
-    if (!ZPIVModule::createInput(in, mint, tx.GetHash())){
-        BOOST_CHECK_MESSAGE(false, "Failed to create zc input");
-    }
+    mint_v1.SetOutputIndex(0);
+    mint_v1.SetTxHash(prevTx_v1.GetHash());
 
-    PublicCoinSpend publicSpend(ZCParams);
-    if (!ZPIVModule::validateInput(in, out, tx, publicSpend)){
-        BOOST_CHECK_MESSAGE(false, "Failed to validate zc input");
-    }
+    mint_v2.SetOutputIndex(0);
+    mint_v2.SetTxHash(prevTx_v2.GetHash());
 
-    PublicCoinSpend publicSpendTest(ZCParams);
-    BOOST_CHECK_MESSAGE(ZPIVModule::parseCoinSpend(in, tx, out, publicSpendTest), "Failed to parse public spend");
-    libzerocoin::CoinSpend *spend = &publicSpendTest;
+    // Spend txs
+    CMutableTransaction tx1, tx2, tx3;
+    tx1.vout.resize(1);
+    tx1.vout[0].nValue = 1*CENT;
+    tx1.vout[0].scriptPubKey = GetScriptForDestination(CBitcoinAddress("D9Ti4LEhF1n6dR2hGd2SyNADD51AVgva6q").Get());
+    tx2.vout.resize(1);
+    tx2.vout[0].nValue = 1*CENT;
+    tx2.vout[0].scriptPubKey = GetScriptForDestination(CBitcoinAddress("D9Ti4LEhF1n6dR2hGd2SyNADD51AVgva6q").Get());
+    tx3.vout.resize(1);
+    tx3.vout[0].nValue = 1*CENT;
+    tx3.vout[0].scriptPubKey = GetScriptForDestination(CBitcoinAddress("D9Ti4LEhF1n6dR2hGd2SyNADD51AVgva6q").Get());
 
-    BOOST_CHECK_MESSAGE(publicSpendTest.HasValidSignature(), "Failed to validate public spend signature");
-    BOOST_CHECK_MESSAGE(spend->HasValidSignature(), "Failed to validate spend signature");
+    CTxIn in1, in2, in3;
 
-    // Verify that fails with a different denomination
-    in.nSequence = 500;
-    PublicCoinSpend publicSpend2(ZCParams);
-    BOOST_CHECK_MESSAGE(!ZPIVModule::validateInput(in, out, tx, publicSpend2), "Different denomination");
+    // check spendVersion = 3 for v2 coins
+    // -----------------------------------
+    int spendVersion = 3;
+    BOOST_CHECK_MESSAGE(ZPIVModule::createInput(in1, mint_v2, tx1.GetHash(), spendVersion),
+            "Failed to create zc input for mint v2 and spendVersion 3");
+
+    std::cout << "Spend v3 size: " << ::GetSerializeSize(in1, SER_NETWORK, PROTOCOL_VERSION) << " bytes" << std::endl;
+
+    PublicCoinSpend publicSpend1(ZCParams_v2);
+    BOOST_CHECK_MESSAGE(ZPIVModule::validateInput(in1, out_v2, tx1, publicSpend1),
+            "Failed to validate zc input for mint v2 and spendVersion 3");
+
+    // Verify that it fails with a different denomination
+    in1.nSequence = 500;
+    PublicCoinSpend publicSpend1b(ZCParams_v2);
+    BOOST_CHECK_MESSAGE(!ZPIVModule::validateInput(in1, out_v2, tx1, publicSpend1b), "Different denomination for mint v2 and spendVersion 3");
+
+    // check spendVersion = 4 for v2 coins
+    // -----------------------------------
+    spendVersion = 4;
+    BOOST_CHECK_MESSAGE(ZPIVModule::createInput(in2, mint_v2, tx2.GetHash(), spendVersion),
+            "Failed to create zc input for mint v2 and spendVersion 4");
+
+    std::cout << "Spend v4 (coin v2) size: " << ::GetSerializeSize(in2, SER_NETWORK, PROTOCOL_VERSION) << " bytes" << std::endl;
+
+    PublicCoinSpend publicSpend2(ZCParams_v2);
+    BOOST_CHECK_MESSAGE(ZPIVModule::validateInput(in2, out_v2, tx2, publicSpend2),
+            "Failed to validate zc input for mint v2 and spendVersion 4");
+
+    // Verify that it fails with a different denomination
+    in2.nSequence = 500;
+    PublicCoinSpend publicSpend2b(ZCParams_v2);
+    BOOST_CHECK_MESSAGE(!ZPIVModule::validateInput(in2, out_v2, tx2, publicSpend2b), "Different denomination for mint v2 and spendVersion 4");
+
+    // check spendVersion = 4 for v1 coins
+    // -----------------------------------
+    BOOST_CHECK_MESSAGE(ZPIVModule::createInput(in3, mint_v1, tx3.GetHash(), spendVersion),
+            "Failed to create zc input for mint v1 and spendVersion 4");
+
+    std::cout << "Spend v4 (coin v1) size: " << ::GetSerializeSize(in3, SER_NETWORK, PROTOCOL_VERSION) << " bytes" << std::endl;
+
+    PublicCoinSpend publicSpend3(ZCParams_v1);
+    BOOST_CHECK_MESSAGE(ZPIVModule::validateInput(in3, out_v1, tx3, publicSpend3),
+            "Failed to validate zc input for mint v1 and spendVersion 4");
+
+    // Verify that it fails with a different denomination
+    in3.nSequence = 500;
+    PublicCoinSpend publicSpend3b(ZCParams_v1);
+    BOOST_CHECK_MESSAGE(!ZPIVModule::validateInput(in3, out_v1, tx3, publicSpend3b), "Different denomination for mint v1 and spendVersion 4");
 
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2001,6 +2001,9 @@ bool CWallet::SelectStakeCoins(std::list<std::unique_ptr<CStakeInput> >& listInp
             if (out.tx->vin[0].IsZerocoinSpend() && !out.tx->IsInMainChain())
                 continue;
 
+            if (!out.tx->hashBlock)
+                continue;
+
             CBlockIndex* utxoBlock = mapBlockIndex.at(out.tx->hashBlock);
             //check for maturity (min age/depth)
             if (!Params().HasStakeMinAgeOrDepth(blockHeight, GetAdjustedTime(), utxoBlock->nHeight, utxoBlock->GetBlockTime()))

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4214,6 +4214,17 @@ bool CWallet::MintsToInputVectorPublicSpend(std::map<CBigNum, CZerocoinMint>& ma
     // Default error status if not changed below
     receipt.SetStatus(_("Transaction Mint Started"), ZPIV_TXMINT_GENERAL);
 
+    // Get the chain tip to determine the active public spend version
+    int nHeight = 0;
+    {
+        LOCK(cs_main);
+        nHeight = chainActive.Height();
+    }
+    if (!nHeight)
+        return error("%s: Unable to get chain tip height", __func__);
+
+    int spendVersion = Params().Zerocoin_PublicSpendVersion(nHeight);
+
     int nLockAttempts = 0;
     while (nLockAttempts < 100) {
         TRY_LOCK(zpivTracker->cs_spendcache, lockSpendcache);
@@ -4263,7 +4274,7 @@ bool CWallet::MintsToInputVectorPublicSpend(std::map<CBigNum, CZerocoinMint>& ma
 
             mint.SetOutputIndex(outputIndex);
             CTxIn in;
-            if(!ZPIVModule::createInput(in, mint, hashTxOut)){
+            if(!ZPIVModule::createInput(in, mint, hashTxOut, spendVersion)) {
                 receipt.SetStatus(_("Cannot create public spend input"), ZPIV_TXMINT_GENERAL);
                 return false;
             }
@@ -4485,6 +4496,7 @@ bool CWallet::CreateZerocoinSpendTransaction(
             }
 
             //hash with only the output info in it to be used in Signature of Knowledge
+            // and in CoinRandomness Schnorr Signature
             uint256 hashTxOut = txNew.GetHash();
 
             CBlockIndex* pindexCheckpoint = nullptr;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1638,7 +1638,7 @@ std::list<CZerocoinSpend> CWalletDB::ListSpentCoins()
         // Read next record
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         if (fFlags == DB_SET_RANGE)
-            ssKey << make_pair(std::string("zcserial"), CBigNum(0));
+            ssKey << make_pair(std::string("zcserial"), BN_ZERO);
         CDataStream ssValue(SER_DISK, CLIENT_VERSION);
         int ret = ReadAtCursor(pcursor, ssKey, ssValue, fFlags);
         fFlags = DB_NEXT;
@@ -1693,7 +1693,7 @@ std::list<CZerocoinMint> CWalletDB::ListArchivedZerocoins()
         // Read next record
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         if (fFlags == DB_SET_RANGE)
-            ssKey << make_pair(std::string("zco"), CBigNum(0));
+            ssKey << make_pair(std::string("zco"), BN_ZERO);
         CDataStream ssValue(SER_DISK, CLIENT_VERSION);
         int ret = ReadAtCursor(pcursor, ssKey, ssValue, fFlags);
         fFlags = DB_NEXT;
@@ -1736,7 +1736,7 @@ std::list<CDeterministicMint> CWalletDB::ListArchivedDeterministicMints()
         // Read next record
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         if (fFlags == DB_SET_RANGE)
-            ssKey << make_pair(std::string("dzco"), CBigNum(0));
+            ssKey << make_pair(std::string("dzco"), BN_ZERO);
         CDataStream ssValue(SER_DISK, CLIENT_VERSION);
         int ret = ReadAtCursor(pcursor, ssKey, ssValue, fFlags);
         fFlags = DB_NEXT;

--- a/src/zpiv/accumulatormap.cpp
+++ b/src/zpiv/accumulatormap.cpp
@@ -80,7 +80,7 @@ libzerocoin::Accumulator AccumulatorMap::GetAccumulator(libzerocoin::CoinDenomin
 CBigNum AccumulatorMap::GetValue(libzerocoin::CoinDenomination denom)
 {
     if (denom == libzerocoin::CoinDenomination::ZQ_ERROR)
-        return CBigNum(0);
+        return BN_ZERO;
     return mapAccumulators.at(denom)->getValue();
 }
 

--- a/src/zpiv/witness.cpp
+++ b/src/zpiv/witness.cpp
@@ -79,9 +79,9 @@ void CoinWitnessCacheData::SetNull()
     nHeightCheckpoint = 0;
     nHeightAccStart = 0;
     nHeightAccEnd = 0;
-    coinAmount = CBigNum(0);
+    coinAmount = BN_ZERO;
     coinDenom = libzerocoin::CoinDenomination::ZQ_ERROR;
-    accumulatorAmount = CBigNum(0);
+    accumulatorAmount = BN_ZERO;
     accumulatorDenom = libzerocoin::CoinDenomination::ZQ_ERROR;
 
 }

--- a/src/zpiv/zpivmodule.h
+++ b/src/zpiv/zpivmodule.h
@@ -26,25 +26,25 @@ class PublicCoinSpend : public libzerocoin::CoinSpend {
 public:
 
     PublicCoinSpend(libzerocoin::ZerocoinParams* params): pubCoin(params) {};
-
     PublicCoinSpend(libzerocoin::ZerocoinParams* params, const uint8_t version, const CBigNum& serial, const CBigNum& randomness, const uint256& ptxHash, CPubKey* pubkey);
+    template <typename Stream> PublicCoinSpend(libzerocoin::ZerocoinParams* params, Stream& strm);
 
     ~PublicCoinSpend(){};
-
-    template <typename Stream>
-    PublicCoinSpend(
-            libzerocoin::ZerocoinParams* params,
-            Stream& strm): pubCoin(params) {
-        strm >> *this;
-        this->spendType = libzerocoin::SpendType::SPEND;
-    }
 
     const uint256 signatureHash() const override;
     void setVchSig(std::vector<unsigned char> vchSig) { this->vchSig = vchSig; };
     bool Verify(const libzerocoin::Accumulator& a, bool verifyParams = true) const override;
+    bool HasValidSignature() const;
     bool validate() const;
+    static bool isAllowed(const bool fUseV1Params, const int spendVersion) { return !fUseV1Params || spendVersion >= PUBSPEND_SCHNORR; }
+    bool isAllowed() const {
+        const bool fUseV1Params = getCoinVersion() < libzerocoin::PrivateCoin::PUBKEY_VERSION;
+        return isAllowed(fUseV1Params, version);
+    }
+    int getCoinVersion() const { return this->coinVersion; }
 
     // Members
+    int coinVersion;
     CBigNum randomness;
     libzerocoin::CoinRandomnessSchnorrSignature schnorrSig;
     // prev out values
@@ -57,14 +57,23 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(version);
-        READWRITE(coinSerialNumber);
-        if (version < PUBSPEND_SCHNORR)
+
+        if (version < PUBSPEND_SCHNORR) {
+            READWRITE(coinSerialNumber);
             READWRITE(randomness);
-        else
-            READWRITE(schnorrSig);
-        if (libzerocoin::ExtractVersionFromSerial(coinSerialNumber) >= libzerocoin::PrivateCoin::PUBKEY_VERSION) {
             READWRITE(pubkey);
             READWRITE(vchSig);
+
+        } else {
+            READWRITE(coinVersion);
+            if (coinVersion < libzerocoin::PrivateCoin::PUBKEY_VERSION) {
+                READWRITE(coinSerialNumber);
+            }
+            else {
+                READWRITE(pubkey);
+                READWRITE(vchSig);
+            }
+            READWRITE(schnorrSig);
         }
     }
 };

--- a/test/functional/zerocoin_valid_public_spend.py
+++ b/test/functional/zerocoin_valid_public_spend.py
@@ -4,26 +4,31 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 '''
-Covers the 'Wrapped Serials Attack' scenario
+Tests a valid publicCoinSpend spend
 '''
 
-import random
+
 from time import sleep
 
 from test_framework.authproxy import JSONRPCException
-from test_framework.util import assert_equal, assert_greater_than
 
 from fake_stake.base_test import PIVX_FakeStakeTest
 
 class zPIVValidCoinSpendTest(PIVX_FakeStakeTest):
 
+    def mintZerocoin(self, denom):
+        self.node.mintzerocoin(denom)
+        self.node.generate(5)
+        sleep(1)
+
     def run_test(self):
-        self.description = "Covers the 'valid publicCoinSpend spend' scenario."
+        self.description = "Tests a valid publicCoinSpend spend."
         self.init_test()
 
         INITAL_MINED_BLOCKS = 301   # Blocks mined before minting
-        MORE_MINED_BLOCKS = 52      # Blocks mined after minting (before spending)
+        MORE_MINED_BLOCKS = 26      # Blocks mined after minting (before spending)
         DENOM_TO_USE = 1         # zc denomination used for double spending attack
+        V4_ACTIVATION = 450
 
         # 1) Start mining blocks
         self.log.info("Mining %d first blocks..." % INITAL_MINED_BLOCKS)
@@ -32,70 +37,103 @@ class zPIVValidCoinSpendTest(PIVX_FakeStakeTest):
 
         # 2) Mint zerocoins
         self.log.info("Minting %d-denom zPIVs..." % DENOM_TO_USE)
-        self.node.mintzerocoin(DENOM_TO_USE)
-        self.node.generate(1)
-        sleep(2)
-        self.node.mintzerocoin(DENOM_TO_USE)
-        sleep(2)
+        for i in range(5):
+            self.mintZerocoin(DENOM_TO_USE)
+        sleep(1)
 
         # 3) Mine more blocks and collect the mint
         self.log.info("Mining %d more blocks..." % MORE_MINED_BLOCKS)
         self.node.generate(MORE_MINED_BLOCKS)
         sleep(2)
         list = self.node.listmintedzerocoins(True, True)
-        mint = list[0]
+        serial_ids = [mint["serial hash"] for mint in list]
+        assert(len(serial_ids) >= 3)
 
-        # 4) Get the raw zerocoin data
+        # 4) Get the raw zerocoin data - save a v3 spend for later
         exported_zerocoins = self.node.exportzerocoins(False)
-        zc = [x for x in exported_zerocoins if mint["serial hash"] == x["id"]]
-        if len(zc) == 0:
-            raise AssertionError("mint not found")
+        zc = [x for x in exported_zerocoins if x["id"] in serial_ids]
+        assert (len(zc) >= 3)
+        old_spend_v3 = self.node.createrawzerocoinpublicspend(zc[2]["id"])
 
-        # 5) Spend the minted coin (mine six more blocks)
+        # 5) Spend the minted coin (mine six more blocks) - spend v3
         self.log.info("Spending the minted coin with serial %s and mining six more blocks..." % zc[0]["s"])
-        txid = self.node.spendzerocoinmints([mint["serial hash"]])['txid']
+        txid = self.node.spendzerocoinmints([zc[0]["id"]])['txid']
         self.log.info("Spent on tx %s" % txid)
         self.node.generate(6)
         sleep(2)
-
         rawTx = self.node.getrawtransaction(txid, 1)
         if rawTx is None:
-            self.log.warning("rawTx is: %s" % rawTx)
+            self.log.warning("rawTx not found for: %s" % txid)
             raise AssertionError("TEST FAILED")
         else:
             assert (rawTx["confirmations"] == 6)
+        self.log.info("%s: VALID PUBLIC COIN SPEND (v3) PASSED" % self.__class__.__name__)
 
-        self.log.info("%s VALID PUBLIC COIN SPEND PASSED" % self.__class__.__name__)
-
-        self.log.info("%s Trying to spend the serial twice now" % self.__class__.__name__)
-
+        # 6) Check double spends - spend v3
+        self.log.info("%s: Trying to spend the serial twice now" % self.__class__.__name__)
         serial = zc[0]["s"]
         randomness = zc[0]["r"]
         privkey = zc[0]["k"]
-
         tx = None
         try:
             tx = self.node.spendrawzerocoin(serial, randomness, DENOM_TO_USE, privkey)
         except JSONRPCException as e:
-            self.log.info("GOOD: Transaction did not verify")
-
+            self.log.info("GOOD: Double-spending transaction did not verify (%s)" % str(e))
         if tx is not None:
             self.log.warning("Tx is: %s" % tx)
             raise AssertionError("TEST FAILED")
 
-        self.log.info("%s DOUBLE SPENT SERIAL NOT VERIFIED, TEST PASSED" % self.__class__.__name__)
-
-        self.log.info("%s Trying to spend using the old coin spend method.." % self.__class__.__name__)
-
-        tx = None
+        # 6) Check spend v2 disabled
+        self.log.info("%s: Trying to spend using the old coin spend method.." % self.__class__.__name__)
         try:
-            tx = self.node.spendzerocoin(DENOM_TO_USE, False, False, "", False)
+            self.node.spendzerocoin(DENOM_TO_USE, False, False, "", False)
             raise AssertionError("TEST FAILED, old coinSpend spent")
         except JSONRPCException as e:
             self.log.info("GOOD: spendzerocoin old spend did not verify")
+        self.log.info("%s: OLD COIN SPEND NON USABLE ANYMORE, TEST PASSED" % self.__class__.__name__)
 
+        # 7) Mine more blocks
+        more_blocks = V4_ACTIVATION - self.node.getblockcount() + 1
+        self.log.info("Mining %d more blocks to get to V4 Spends activation..." % more_blocks)
+        self.node.generate(more_blocks)
+        sleep(2)
 
-        self.log.info("%s OLD COIN SPEND NON USABLE ANYMORE, TEST PASSED" % self.__class__.__name__)
+        # 8) Spend the minted coin (mine six more blocks) - spend v4
+        self.log.info("Spending the minted coin with serial %s and mining six more blocks..." % zc[1]["s"])
+        txid = self.node.spendzerocoinmints([zc[1]["id"]])['txid']
+        self.log.info("Spent on tx %s" % txid)
+        self.node.generate(6)
+        sleep(2)
+        rawTx = self.node.getrawtransaction(txid, 1)
+        if rawTx is None:
+            self.log.warning("rawTx not found for: %s" % txid)
+            raise AssertionError("TEST FAILED")
+        else:
+            assert (rawTx["confirmations"] == 6)
+        self.log.info("%s: VALID PUBLIC COIN SPEND (v4) PASSED" % self.__class__.__name__)
+
+        # 9) Check double spends - spend v4
+        self.log.info("%s: Trying to spend the serial twice now" % self.__class__.__name__)
+        serial = zc[1]["s"]
+        randomness = zc[1]["r"]
+        privkey = zc[1]["k"]
+        tx = None
+        try:
+            tx = self.node.spendrawzerocoin(serial, randomness, DENOM_TO_USE, privkey)
+        except JSONRPCException as e:
+            self.log.info("GOOD: Double-spending transaction did not verify (%s)" % str(e))
+        if tx is not None:
+            self.log.warning("Tx is: %s" % tx)
+            raise AssertionError("TEST FAILED")
+
+        # 10) Try to relay old v3 spend now
+        self.log.info("%s: Trying to send old v3 spend now" % self.__class__.__name__)
+        try:
+            tx = self.node.sendrawtransaction(old_spend_v3)
+            print(str(tx))
+            assert(False)
+        except JSONRPCException as e:
+            self.log.info("GOOD: Old transaction not sent (%s)" % str(e))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR proposes (as hard fork) a new PublicCoinSpend protocol suitable to be used also with zerocoins version 1. Closes https://github.com/PIVX-Project/PIVX/issues/937

Motivation and overview in the following document:
https://github.com/random-zebra/PIVX-Wiki/blob/master/Developer-Documentation/Specs/zPIV/CoinRandomnessSchnorrSignature.mediawiki

Enforcement height uses placeholder values (one million blocks after the activation of spends v3 for main net and testnet, and 100 blocks for regnet).

Changes
- replaces many instances of `CBigNum(0)`, `CBigNum(1)`, `CBigNum(2)` throughout the code with fixed constants defined in bignum.h.

- defines the `CoinRandomnessSchnorrSignature` using the algorithm described in the [wiki](https://github.com/random-zebra/PIVX-Wiki/blob/master/Developer-Documentation/Specs/zPIV/CoinRandomnessSchnorrSignature.mediawiki).

- defines the temporary activation height and also defines an helper function `Zerocoin_PublicSpendVersion` which returns the version active at a given block height.

- defines a convenient method to retrieve the coin version from a `PublicCoinSpend` class (now that coin version and spend version are different).

- defines `PublicCoinSpend` behaviour for v4.

- enforces the PublicCoinSpend version in `ContextualCheckZerocoinSpendNoSerialCheck`.

- provides unit tests for the new v4 `PublicCoinSpend` class.