### PR TITLE
[Wallet] Remove (explicitely) unused tx comparator

### DIFF
--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -325,17 +325,6 @@ struct CMutableTransaction
     uint256 GetHash() const;
 
     std::string ToString() const;
-
-    friend bool operator==(const CMutableTransaction& a, const CMutableTransaction& b)
-    {
-        return a.GetHash() == b.GetHash();
-    }
-
-    friend bool operator!=(const CMutableTransaction& a, const CMutableTransaction& b)
-    {
-        return !(a == b);
-    }
-
 };
 
 #endif // BITCOIN_PRIMITIVES_TRANSACTION_H


### PR DESCRIPTION
'==' and '!=' operators in CMutableTransaction are never used explicitly.
Them being used implicitly is probably what causes #510. There is no good reason to keep them and BTC removed them here: https://github.com/bitcoin/bitcoin/pull/13443
Should fix #510