### PR TITLE
[Refactor] Move ThreadStakeMinter out of net.cpp

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2008,6 +2008,11 @@ bool AppInit2()
             // Run a thread to precompute any zPIV spends
             threadGroup.create_thread(boost::bind(&ThreadPrecomputeSpends));
         }
+
+        if (GetBoolArg("-staking", true)) {
+            // ppcoin:mint proof-of-stake blocks in the background
+            threadGroup.create_thread(boost::bind(&ThreadStakeMinter));
+        }
     }
 #endif
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -855,4 +855,21 @@ void GenerateBitcoins(bool fGenerate, CWallet* pwallet, int nThreads)
         minerThreads->create_thread(boost::bind(&ThreadBitcoinMiner, pwallet));
 }
 
+// ppcoin: stake minter thread
+void ThreadStakeMinter()
+{
+    boost::this_thread::interruption_point();
+    LogPrintf("ThreadStakeMinter started\n");
+    CWallet* pwallet = pwalletMain;
+    try {
+        BitcoinMiner(pwallet, true);
+        boost::this_thread::interruption_point();
+    } catch (std::exception& e) {
+        LogPrintf("ThreadStakeMinter() exception \n");
+    } catch (...) {
+        LogPrintf("ThreadStakeMinter() error \n");
+    }
+    LogPrintf("ThreadStakeMinter exiting,\n");
+}
+
 #endif // ENABLE_WALLET

--- a/src/miner.h
+++ b/src/miner.h
@@ -29,6 +29,7 @@ void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& 
 void UpdateTime(CBlockHeader* block, const CBlockIndex* pindexPrev);
 
 void BitcoinMiner(CWallet* pwallet, bool fProofOfStake);
+void ThreadStakeMinter();
 
 extern double dHashesPerSec;
 extern int64_t nHPSTimerStart;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -19,9 +19,6 @@
 #include "primitives/transaction.h"
 #include "scheduler.h"
 #include "guiinterface.h"
-#ifdef ENABLE_WALLET
-#include "wallet/wallet.h"
-#endif // ENABLE_WALLET
 
 #ifdef WIN32
 #include <string.h>
@@ -1556,25 +1553,6 @@ void ThreadMessageHandler()
     }
 }
 
-#ifdef ENABLE_WALLET
-// ppcoin: stake minter thread
-void static ThreadStakeMinter()
-{
-    boost::this_thread::interruption_point();
-    LogPrintf("ThreadStakeMinter started\n");
-    CWallet* pwallet = pwalletMain;
-    try {
-        BitcoinMiner(pwallet, true);
-        boost::this_thread::interruption_point();
-    } catch (std::exception& e) {
-        LogPrintf("ThreadStakeMinter() exception \n");
-    } catch (...) {
-        LogPrintf("ThreadStakeMinter() error \n");
-    }
-    LogPrintf("ThreadStakeMinter exiting,\n");
-}
-#endif // ENABLE_WALLET
-
 bool BindListenPort(const CService& addrBind, std::string& strError, bool fWhitelisted)
 {
     strError = "";
@@ -1772,12 +1750,6 @@ void StartNode(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     // Dump network addresses
     scheduler.scheduleEvery(&DumpData, DUMP_ADDRESSES_INTERVAL);
-
-#ifdef ENABLE_WALLET
-    // ppcoin:mint proof-of-stake blocks in the background
-    if (GetBoolArg("-staking", true) && pwalletMain)
-        threadGroup.create_thread(boost::bind(&TraceThread<void (*)()>, "stakemint", &ThreadStakeMinter));
-#endif // ENABLE_WALLET
 }
 
 bool StopNode()


### PR DESCRIPTION
This moves the implementation function and thread creation to a more
appropriate file (`miner.cpp`).

Resolves #938