### PR TITLE
[RPC] require valid URL scheme on budget commands

### DIFF
--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -56,8 +56,9 @@ void checkBudgetInputs(const UniValue& params, std::string &strProposalName, std
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid proposal name, limit of 20 characters.");
 
     strURL = SanitizeString(params[1].get_str());
-    if (strURL.size() > 64)
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid url, limit of 64 characters.");
+    std::string strErr;
+    if (!validateURL(strURL, strErr))
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strErr);
 
     nPaymentCount = params[2].get_int();
     if (nPaymentCount < 1)

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -39,6 +39,33 @@ std::string SanitizeString(const std::string& str, int rule)
     return strResult;
 }
 
+bool validateURL(std::string strURL, std::string& strErr, unsigned int maxSize) {
+
+    // Check URL size
+    if (strURL.size() > maxSize) {
+        strErr = strprintf("Invalid URL: %d exceeds limit of %d characters.", strURL.size(), maxSize);
+        return false;
+    }
+
+    std::vector<std::string> reqPre;
+
+    // Required initial strings; URL must contain one
+    reqPre.push_back("http://");
+    reqPre.push_back("https://");
+
+    // check fronts
+    bool found = false;
+    for (int i=0; i < reqPre.size() && !found; i++) {
+        if (strURL.find(reqPre[i]) == 0) found = true;
+    }
+    if ((!found) && (reqPre.size() > 0)) {
+        strErr = "Invalid URL, check scheme (e.g. https://)";
+        return false;
+    }
+
+    return true;
+}
+
 const signed char p_util_hexdigit[256] =
     {
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -40,6 +40,16 @@ enum SafeChars
 * @return           A new string without unsafe chars
 */
 std::string SanitizeString(const std::string& str, int rule = SAFE_CHARS_DEFAULT);
+
+/**
+* Check URL format for conformance for validity to a defined pattern
+* @param[in] strURL   The string to be processed for validity
+* @param[in] stdErr   A string that will be loaded with any validation error message
+* @param[in] maxSize  An unsigned int, defaulted to 64, to restrict the length
+* @return             A bool, true if valid, false if not (reason in stdErr)
+*/
+bool validateURL(std::string strURL, std::string& strErr, unsigned int maxSize = 64);
+
 std::vector<unsigned char> ParseHex(const char* psz);
 std::vector<unsigned char> ParseHex(const std::string& str);
 signed char HexDigit(char c);


### PR DESCRIPTION
### **Release Notes** 
[RPC] Require valid URL schemes (URLs starting with "http" or "https") on preparebudget and submitbudget.

### **Details** 
The budget proposal system did not have any checks on the URL aside of string length.  This allowed for the scheme to be left off the URL; which on some browsers, resulted in the link to fail when clicked:

![image](https://user-images.githubusercontent.com/36988814/61176879-69c97a80-a596-11e9-9307-cbeeb210e133.png)
```
gio: file:///home/CaveSpectre/forum.pivx.org/index.php%3Fthreads/bizdev-proposal-john-m.285: 
Error when getting information for file “/home/CaveSpectre/forum.pivx.org/index.php?
threads/bizdev-proposal-john-m.285”: No such file or directory
```

The included PR changes the `submitbudget` and `preparebudget` rpc commands to prevent inadvertent omissions of the URL scheme (http:// or https://).  

Qt changes to fixup the existing & historical budget URLs will be submitted as a separate PR after the merging of #954 .

![image](https://user-images.githubusercontent.com/36988814/61176955-017b9880-a598-11e9-8df0-f4afe1ccdf7d.png)

_(This PR originally included the Qt changes, and as a result some of the below discussion relates to that, before the decision was made to back out the Qt changes until a later date)_