### PR TITLE
[Staking] Prevent potential negative out values during stake splitting

### DIFF
--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -327,7 +327,20 @@ void CMasternodePayments::FillBlockPayee(CMutableTransaction& txNew, int64_t nFe
 
             //subtract mn payment from the stake reward
             if (!txNew.vout[1].IsZerocoinMint())
-                txNew.vout[i - 1].nValue -= masternodePayment;
+                if (i == 2) {
+                    // Majority of cases; do it quick and move on
+                    txNew.vout[i - 1].nValue -= masternodePayment;
+                } else if (i > 2) {
+                    // special case, stake is split between (i-1) outputs
+                    unsigned int outputs = i-1;
+                    CAmount mnPaymentSplit = masternodePayment / outputs;
+                    CAmount mnPaymentRemainder = masternodePayment - (mnPaymentSplit * outputs);
+                    for (unsigned int j=1; j<=outputs; j++) {
+                        txNew.vout[j].nValue -= mnPaymentSplit;
+                    }
+                    // in case it's not an even division, take the last bit of dust from the last one
+                    txNew.vout[outputs].nValue -= mnPaymentRemainder;
+                }
         } else {
             txNew.vout.resize(2);
             txNew.vout[1].scriptPubKey = payee;


### PR DESCRIPTION
On the rare occasion that a small UTXO wins a stake; and that user has (by lack of understanding, or by error) configured a very small StakeSplitThreshold; they can end up in a situation where their extremely lucky stake win fails at consensus because of the way the stake split is calculated.

The logic split the block reward between the two outputs; along with the input.  However if that input is significantly small, and the block reward is significantly weighted to the masternode; then the potential for a negative (and thus very very large) output would be created in the second side of the split.  This is due to the fact that the full masternode reward is taken out of the "previous" output (`vout[i - 1]`).

This is a rare, if not relatively impossible, scenario with PIVX at it's current state, but the potential grows much larger when coin parameters are re-arranged; e.g. small stakes with a heavy weight onto the masternode reward.  i.e. a stake split of 5, with a block reward of 10, and 90% to the masternode.   15 ends up split into vout[1] and vout[2], both receiving 7.5; yet FillBlockPayee will subtract 9 from vout[2]; resulting in a negative wrapped to a large positive.

This logic simply puts the reward that will be deducted from into the second vout.  So with the above numbers; vout[1] is split to 2.5, vout[2] is initially 12.5 and then after the unknown (at that time) masternode fee of 9, is reduced to 3.5; no longer going negative.

Of course this is an extreme example; but the potential still exists.

Alternatively, restrictions could be placed on setstakesplitthreshold to prevent the user from setting a threshold dangerously low; or a minstake could be setup to prevent a stake small enough to be a problem from being considered.  However, this seems like the best solution to the problem; by handling it without adding a lot of logic to collect the chain parameters and set limits that make sense to whatever chosen configuration is used.
