### PR TITLE
[Trivial][Tests] Do not fail test when warnings are written to stderr

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -55,45 +55,50 @@ TEST_EXIT_SKIPPED = 77
 BASE_SCRIPTS= [
     # Scripts that are run by the travis build process.
     # Longest test should go first, to favor running tests in parallel
+    'wallet_basic.py',
     'wallet_backup.py',
+
+    # vv Tests less than 5m vv
+    'rpc_rawtransaction.py',
+    'wallet_zapwallettxes.py',
+    'wallet_keypool_topup.py',
+    'p2p_pos_doublespend.py',
+    'wallet_txn_doublespend.py --mineblock',
+    'wallet_txn_clone.py --mineblock',
+    'interface_rest.py',
+    'feature_proxy.py',
     'p2p_pos_fakestake.py',
     'p2p_pos_fakestake_accepted.py',
     #'p2p_zpos_fakestake.py',
     #'p2p_zpos_fakestake_accepted.py',
     #'zerocoin_wrapped_serials.py',
-    # vv Tests less than 5m vv
     #'feature_block.py',
     #'rpc_fundrawtransaction.py',
+
     # vv Tests less than 2m vv
-    'p2p_pos_doublespend.py',
-    'wallet_basic.py',
+    'feature_uacomment.py',
+    'wallet_listreceivedby.py',
     'wallet_accounts.py',
     'wallet_dump.py',
     'rpc_listtransactions.py',
+
     # vv Tests less than 60s vv
-    'wallet_zapwallettxes.py',
     #'wallet_importmulti.py',
     #'mempool_limit.py', # We currently don't limit our mempool
-    'wallet_listreceivedby.py',
     #'wallet_abandonconflict.py',
-    'rpc_rawtransaction.py',
     'feature_reindex.py',
     'rpc_bip38.py',
+
     # vv Tests less than 30s vv
-    'wallet_keypool_topup.py',
     #'interface_zmq.py',
     'interface_bitcoin_cli.py',
     'mempool_resurrect.py',
-    'wallet_txn_doublespend.py --mineblock',
-    'wallet_txn_clone.py --mineblock',
     #'rpc_getchaintips.py',
-    'interface_rest.py',
     'mempool_spend_coinbase.py',
     'mempool_reorg.py',
     #'mempool_persist.py', # Not yet implemented
     'interface_http.py',
     #'rpc_users.py',
-    'feature_proxy.py',
     'rpc_signrawtransaction.py',
     'p2p_disconnect_ban.py',
     'rpc_decodescript.py',
@@ -117,7 +122,6 @@ BASE_SCRIPTS= [
     #'wallet_resendwallettransactions.py',
     #'feature_minchainwork.py',
     #'p2p_fingerprint.py',
-    'feature_uacomment.py',
     #'p2p_unrequested_blocks.py',
     #'feature_config_args.py',
     'feature_help.py',
@@ -306,7 +310,11 @@ def run_tests(test_list, src_dir, build_dir, exeext, tmpdir, jobs=1, enable_cove
         test_results.append(test_result)
         done_str = "{}/{} - {}{}{}".format(i + 1, test_count, BOLD[1], test_result.name, BOLD[0])
         if test_result.status == "Passed":
-            logging.debug("%s passed, Duration: %s s" % (done_str, test_result.time))
+            if stderr == "":
+                logging.debug("%s passed, Duration: %s s" % (done_str, test_result.time))
+            else:
+                logging.debug("%s passed (with warnings), Duration: %s s" % (done_str, test_result.time))
+                print(BOLD[1] + 'stderr:\n' + BOLD[0] + stderr + '\n')
         elif test_result.status == "Skipped":
             logging.debug("%s skipped" % (done_str))
         else:
@@ -417,7 +425,7 @@ class TestHandler:
                     log_out.seek(0), log_err.seek(0)
                     [stdout, stderr] = [l.read().decode('utf-8') for l in (log_out, log_err)]
                     log_out.close(), log_err.close()
-                    if proc.returncode == TEST_EXIT_PASSED and stderr == "":
+                    if proc.returncode == TEST_EXIT_PASSED:
                         status = "Passed"
                     elif proc.returncode == TEST_EXIT_SKIPPED:
                         status = "Skipped"


### PR DESCRIPTION
Fixes https://github.com/PIVX-Project/PIVX/issues/960

Rationale: the test result should be set only through `assert`s in the test and not rely on what's printed on the console. Furthermore, as shown in the issue, stderr could contain simple warnings that don't affect the test's outcome.
If stderr is not empty though, print its content.

Also re-sort tests by duration.