### PR TITLE
[RPC] Add PoS support to transaction utilities

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2022,14 +2022,33 @@ void ListTransactions(const CWalletTx& wtx, const std::string& strAccount, int n
     if ((!listSent.empty() || nFee != 0) && (fAllAccounts || strAccount == strSentAccount)) {
         for (const COutputEntry& s : listSent) {
             UniValue entry(UniValue::VOBJ);
+            std::string sCat="send";
+            const bool isCoinStake = wtx.IsCoinStake();
+
             if (involvesWatchonly || (::IsMine(*pwalletMain, s.destination) & ISMINE_WATCH_ONLY))
                 entry.push_back(Pair("involvesWatchonly", true));
             entry.push_back(Pair("account", strSentAccount));
             MaybePushAddress(entry, s.destination);
-            entry.push_back(Pair("category", "send"));
+            std::map<std::string, std::string>::const_iterator it = wtx.mapValue.find("DS");
+            if (isCoinStake) {
+                static CTxDestination stakeAddr;
+                if (s.vout == 1) stakeAddr = s.destination;  // save the stake destination
+                if ((s.vout > 1) && (stakeAddr != static_cast<CTxDestination>(s.destination))) {
+                    // If the destination doesn't match the staking destination, don't show it.
+                    continue;
+                }
+                sCat="stake";
+            } else {
+                sCat = (it != wtx.mapValue.end() && it->second == "1") ? "darksent" : "send";
+            }
+            entry.push_back(Pair("category", sCat));
             entry.push_back(Pair("amount", ValueFromAmount(-s.amount)));
             entry.push_back(Pair("vout", s.vout));
-            entry.push_back(Pair("fee", ValueFromAmount(-nFee)));
+            if (isCoinStake) {
+                entry.push_back(Pair("fee", ValueFromAmount(0)));
+            } else {
+                entry.push_back(Pair("fee", ValueFromAmount(-nFee)));
+            }
             if (fLong)
                 WalletTxToJSON(wtx, entry);
             ret.push_back(entry);
@@ -2040,6 +2059,7 @@ void ListTransactions(const CWalletTx& wtx, const std::string& strAccount, int n
     int depth = wtx.GetDepthInMainChain();
     if (listReceived.size() > 0 && depth >= nMinDepth) {
         for (const COutputEntry& r : listReceived) {
+            const bool isCoinStake = wtx.IsCoinStake();
             std::string account;
             if (pwalletMain->mapAddressBook.count(r.destination))
                 account = pwalletMain->mapAddressBook[r.destination].name;
@@ -2055,12 +2075,14 @@ void ListTransactions(const CWalletTx& wtx, const std::string& strAccount, int n
                     else if (wtx.GetBlocksToMaturity() > 0)
                         entry.push_back(Pair("category", "immature"));
                     else
-                        entry.push_back(Pair("category", "generate"));
+                        entry.push_back(Pair("category", (isCoinStake) ? "stake" : "generate"));
                 } else {
                     entry.push_back(Pair("category", "receive"));
                 }
                 entry.push_back(Pair("amount", ValueFromAmount(r.amount)));
                 entry.push_back(Pair("vout", r.vout));
+                if (isCoinStake)
+                    entry.push_back(Pair("generated", ValueFromAmount(-nFee)));
                 if (fLong)
                     WalletTxToJSON(wtx, entry);
                 ret.push_back(entry);
@@ -2437,9 +2459,17 @@ UniValue gettransaction(const UniValue& params, bool fHelp)
     CAmount nNet = nCredit - nDebit;
     CAmount nFee = (wtx.IsFromMe(filter) ? wtx.GetValueOut() - nDebit : 0);
 
-    entry.push_back(Pair("amount", ValueFromAmount(nNet - nFee)));
-    if (wtx.IsFromMe(filter))
-        entry.push_back(Pair("fee", ValueFromAmount(nFee)));
+    if (wtx.IsCoinStake()) {
+        entry.push_back(Pair("amount", ValueFromAmount(nCredit)));
+        entry.push_back(Pair("fee", ValueFromAmount(0)));
+        entry.push_back(Pair("generated", ValueFromAmount(nFee)));
+    }
+    else {
+        entry.push_back(Pair("amount", ValueFromAmount(nNet - nFee)));
+
+        if (wtx.IsFromMe(filter))
+            entry.push_back(Pair("fee", ValueFromAmount(nFee)));
+    }
 
     WalletTxToJSON(wtx, entry);
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2017,75 +2017,112 @@ void ListTransactions(const CWalletTx& wtx, const std::string& strAccount, int n
 
     bool fAllAccounts = (strAccount == std::string("*"));
     bool involvesWatchonly = wtx.IsFromMe(ISMINE_WATCH_ONLY);
+    const bool isCoinStake = wtx.IsCoinStake();
+    int depth = wtx.GetDepthInMainChain();
 
-    // Sent
-    if ((!listSent.empty() || nFee != 0) && (fAllAccounts || strAccount == strSentAccount)) {
-        for (const COutputEntry& s : listSent) {
+    if (isCoinStake) {
+        // If we signed it, show the stake input
+        CAmount nStakedAmt = wtx.GetDebit(filter);
+        if (nStakedAmt > 0) {
             UniValue entry(UniValue::VOBJ);
-            std::string sCat="send";
-            const bool isCoinStake = wtx.IsCoinStake();
-
-            if (involvesWatchonly || (::IsMine(*pwalletMain, s.destination) & ISMINE_WATCH_ONLY))
-                entry.push_back(Pair("involvesWatchonly", true));
-            entry.push_back(Pair("account", strSentAccount));
-            MaybePushAddress(entry, s.destination);
-            std::map<std::string, std::string>::const_iterator it = wtx.mapValue.find("DS");
-            if (isCoinStake) {
-                static CTxDestination stakeAddr;
-                if (s.vout == 1) stakeAddr = s.destination;  // save the stake destination
-                if ((s.vout > 1) && (stakeAddr != static_cast<CTxDestination>(s.destination))) {
-                    // If the destination doesn't match the staking destination, don't show it.
-                    continue;
-                }
-                sCat="stake";
-            } else {
-                sCat = (it != wtx.mapValue.end() && it->second == "1") ? "darksent" : "send";
-            }
-            entry.push_back(Pair("category", sCat));
-            entry.push_back(Pair("amount", ValueFromAmount(-s.amount)));
-            entry.push_back(Pair("vout", s.vout));
-            if (isCoinStake) {
-                entry.push_back(Pair("fee", ValueFromAmount(0)));
-            } else {
-                entry.push_back(Pair("fee", ValueFromAmount(-nFee)));
-            }
-            if (fLong)
-                WalletTxToJSON(wtx, entry);
+            entry.push_back(Pair("category", "stake_input"));
+            entry.push_back(Pair("amount", ValueFromAmount(-nStakedAmt)));
+            entry.push_back(Pair("fee", ValueFromAmount(0)));
             ret.push_back(entry);
         }
-    }
 
-    // Received
-    int depth = wtx.GetDepthInMainChain();
-    if (listReceived.size() > 0 && depth >= nMinDepth) {
-        for (const COutputEntry& r : listReceived) {
-            const bool isCoinStake = wtx.IsCoinStake();
-            std::string account;
-            if (pwalletMain->mapAddressBook.count(r.destination))
-                account = pwalletMain->mapAddressBook[r.destination].name;
-            if (fAllAccounts || (account == strAccount)) {
+        // Stake outputs
+        unsigned int outputs = listReceived.size();
+        if (
+                (outputs > 0 && nStakedAmt == 0) ||
+                (outputs > 1 && listReceived.front().destination != listReceived.back().destination) ) {
+            UniValue entry(UniValue::VOBJ);
+            entry.push_back(Pair("category", "masternode_payout"));
+            entry.push_back(Pair("amount", ValueFromAmount(listReceived.back().amount)));
+            entry.push_back(Pair("generated", ValueFromAmount(listReceived.back().amount)));
+            ret.push_back(entry);
+            if (nStakedAmt == 0) return; // only MN output
+            listReceived.pop_back();
+            --outputs;
+        }
+
+        if (outputs > 0) {
+            CAmount generated_tot = 0;
+            for (const COutputEntry& r : listReceived)
+                generated_tot += r.amount;
+            generated_tot -= nStakedAmt;
+            CAmount generated =  generated_tot / outputs;
+            CAmount generated_last = generated_tot - (outputs - 1) * generated;
+            for (const COutputEntry& r : listReceived) {
                 UniValue entry(UniValue::VOBJ);
-                if (involvesWatchonly || (::IsMine(*pwalletMain, r.destination) & ISMINE_WATCH_ONLY))
-                    entry.push_back(Pair("involvesWatchonly", true));
-                entry.push_back(Pair("account", account));
                 MaybePushAddress(entry, r.destination);
-                if (wtx.IsCoinBase()) {
-                    if (depth < 1)
-                        entry.push_back(Pair("category", "orphan"));
-                    else if (wtx.GetBlocksToMaturity() > 0)
-                        entry.push_back(Pair("category", "immature"));
-                    else
-                        entry.push_back(Pair("category", (isCoinStake) ? "stake" : "generate"));
-                } else {
-                    entry.push_back(Pair("category", "receive"));
-                }
+                if (depth < 1)
+                    entry.push_back(Pair("category", "orphan"));
+                else if (wtx.GetBlocksToMaturity() > 0)
+                    entry.push_back(Pair("category", "immature"));
+                else
+                    entry.push_back(Pair("category", "stake"));
                 entry.push_back(Pair("amount", ValueFromAmount(r.amount)));
-                entry.push_back(Pair("vout", r.vout));
-                if (isCoinStake)
-                    entry.push_back(Pair("generated", ValueFromAmount(-nFee)));
+                if (r.vout == (int)outputs - 1)
+                    entry.push_back(Pair("generated", ValueFromAmount(generated_last)));
+                else
+                    entry.push_back(Pair("generated", ValueFromAmount(generated)));
+                ret.push_back(entry);
+            }
+        }
+
+    } else {
+
+        // Sent
+        if ((!listSent.empty() || nFee != 0) && (fAllAccounts || strAccount == strSentAccount)) {
+            for (const COutputEntry& s : listSent) {
+                UniValue entry(UniValue::VOBJ);
+                std::string sCat="send";
+
+                if (involvesWatchonly || (::IsMine(*pwalletMain, s.destination) & ISMINE_WATCH_ONLY))
+                    entry.push_back(Pair("involvesWatchonly", true));
+                entry.push_back(Pair("account", strSentAccount));
+                MaybePushAddress(entry, s.destination);
+                std::map<std::string, std::string>::const_iterator it = wtx.mapValue.find("DS");
+                sCat = (it != wtx.mapValue.end() && it->second == "1") ? "darksent" : "send";
+                entry.push_back(Pair("category", sCat));
+                entry.push_back(Pair("amount", ValueFromAmount(-s.amount)));
+                entry.push_back(Pair("vout", s.vout));
+                entry.push_back(Pair("fee", ValueFromAmount(-nFee)));
                 if (fLong)
                     WalletTxToJSON(wtx, entry);
                 ret.push_back(entry);
+            }
+        }
+
+        // Received
+        if (listReceived.size() > 0 && depth >= nMinDepth) {
+            for (const COutputEntry& r : listReceived) {
+                std::string account = "";
+                if (pwalletMain->mapAddressBook.count(r.destination))
+                    account = pwalletMain->mapAddressBook[r.destination].name;
+                if (fAllAccounts || (account == strAccount)) {
+                    UniValue entry(UniValue::VOBJ);
+                    if (involvesWatchonly || (::IsMine(*pwalletMain, r.destination) & ISMINE_WATCH_ONLY))
+                        entry.push_back(Pair("involvesWatchonly", true));
+                    entry.push_back(Pair("account", account));
+                    MaybePushAddress(entry, r.destination);
+                    if (wtx.IsCoinBase()) {
+                        if (depth < 1)
+                            entry.push_back(Pair("category", "orphan"));
+                        else if (wtx.GetBlocksToMaturity() > 0)
+                            entry.push_back(Pair("category", "immature"));
+                        else
+                            entry.push_back(Pair("category", "generate"));
+                    } else {
+                        entry.push_back(Pair("category", "receive"));
+                    }
+                    entry.push_back(Pair("amount", ValueFromAmount(r.amount)));
+                    entry.push_back(Pair("vout", r.vout));
+                    if (fLong)
+                        WalletTxToJSON(wtx, entry);
+                    ret.push_back(entry);
+                }
             }
         }
     }
@@ -2460,7 +2497,7 @@ UniValue gettransaction(const UniValue& params, bool fHelp)
     CAmount nFee = (wtx.IsFromMe(filter) ? wtx.GetValueOut() - nDebit : 0);
 
     if (wtx.IsCoinStake()) {
-        entry.push_back(Pair("amount", ValueFromAmount(nCredit)));
+        entry.push_back(Pair("amount", ValueFromAmount(wtx.GetValueOut())));
         entry.push_back(Pair("fee", ValueFromAmount(0)));
         entry.push_back(Pair("generated", ValueFromAmount(nFee)));
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1542,6 +1542,7 @@ void CWalletTx::GetAmounts(std::list<COutputEntry>& listReceived,
     listReceived.clear();
     listSent.clear();
     strSentAccount = strFromAccount;
+    const bool isCoinStake = IsCoinStake();
 
     // Compute fee:
     CAmount nDebit = GetDebit(filter);
@@ -1560,8 +1561,11 @@ void CWalletTx::GetAmounts(std::list<COutputEntry>& listReceived,
         //   1) they debit from us (sent)
         //   2) the output is to us (received)
         if (nDebit > 0) {
-            // Don't report 'change' txouts
-            if (pwallet->IsChange(txout))
+            // Don't report 'change' txouts (except when this is staking of change)
+            if (!isCoinStake && pwallet->IsChange(txout))
+                continue;
+            // Don't report the first output of a CoinStake
+            if (isCoinStake && (i == 0))
                 continue;
         } else if (!(fIsMine & filter) && !hasZerocoinSpends)
             continue;
@@ -1572,7 +1576,7 @@ void CWalletTx::GetAmounts(std::list<COutputEntry>& listReceived,
         if (txout.IsZerocoinMint()) {
             address = CNoDestination();
         } else if (!ExtractDestination(txout.scriptPubKey, address, fColdStake)) {
-            if (!IsCoinStake() && !IsCoinBase()) {
+            if (isCoinStake && !IsCoinBase()) {
                 LogPrintf("CWalletTx::GetAmounts: Unknown transaction type found, txid %s\n", this->GetHash().ToString());
             }
             address = CNoDestination();


### PR DESCRIPTION
After investigating issue #959 ; it is clear to me that there needs to be code added to the underlying transaction displaying (gettransaction, listtransactions, etc) to recognize CoinStake transactions.

`ListTransactions()` remains elusive (well, technically the challenge is buried down in `GetAmounts()`); as I can't seem to pull enough information to separate the minting between the stake output and the masternode payment; and to have the staking input show the input amount, rather than the output amount (as GetAmounts() runs through the outputs).

Figured I would put it up here, WIP, to request some advise.