### PR TITLE
[Refactor] Combine parameter checking of budget commands

### DIFF
--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -48,14 +48,53 @@ void budgetToJSON(CBudgetProposal* pbudgetProposal, UniValue& bObj)
     bObj.push_back(Pair("fValid", pbudgetProposal->fValid));
 }
 
-UniValue preparebudget(const UniValue& params, bool fHelp)
+void checkBudgetInputs(const UniValue& params, std::string &strProposalName, std::string &strURL,
+                       int &nPaymentCount, int &nBlockStart, CBitcoinAddress &address, CAmount &nAmount)
 {
     int nBlockMin = 0;
     CBlockIndex* pindexPrev = chainActive.Tip();
 
+    strProposalName = SanitizeString(params[0].get_str());
+    if (strProposalName.size() > 20)
+        throw std::runtime_error("Invalid proposal name, limit of 20 characters.");
+
+    strURL = SanitizeString(params[1].get_str());
+    if (strURL.size() > 64)
+        throw std::runtime_error("Invalid url, limit of 64 characters.");
+
+    nPaymentCount = params[2].get_int();
+    if (nPaymentCount < 1)
+        throw std::runtime_error("Invalid payment count, must be more than zero.");
+
+    // Start must be in the next budget cycle
+    if (pindexPrev != NULL) nBlockMin = pindexPrev->nHeight - pindexPrev->nHeight % Params().GetBudgetCycleBlocks() + Params().GetBudgetCycleBlocks();
+
+    nBlockStart = params[3].get_int();
+    if (nBlockStart % Params().GetBudgetCycleBlocks() != 0) {
+        int nNext = pindexPrev->nHeight - pindexPrev->nHeight % Params().GetBudgetCycleBlocks() + Params().GetBudgetCycleBlocks();
+        throw std::runtime_error(strprintf("Invalid block start - must be a budget cycle block. Next valid block: %d", nNext));
+    }
+
+    int nBlockEnd = nBlockStart + (Params().GetBudgetCycleBlocks() * nPaymentCount); // End must be AFTER current cycle
+
+    if (nBlockStart < nBlockMin)
+        throw std::runtime_error("Invalid block start, must be more than current height.");
+
+    if (nBlockEnd < pindexPrev->nHeight)
+        throw std::runtime_error("Invalid ending block, starting block + (payment_cycle*payments) must be more than current height.");
+
+    address = params[4].get_str();
+    if (!address.IsValid())
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid PIVX address");
+
+    nAmount = AmountFromValue(params[5]);
+}
+
+UniValue preparebudget(const UniValue& params, bool fHelp)
+{
     if (fHelp || params.size() != 6)
         throw std::runtime_error(
-            "preparebudget \"proposal-name\" \"url\" payment-count block-start \"pivx-address\" monthly-payment\n"
+            "preparebudget \"proposal-name\" \"url\" payment-count block-start \"pivx-address\" monthy-payment\n"
             "\nPrepare proposal for network by signing and creating tx\n"
 
             "\nArguments:\n"
@@ -77,44 +116,17 @@ UniValue preparebudget(const UniValue& params, bool fHelp)
 
     EnsureWalletIsUnlocked();
 
-    std::string strProposalName = SanitizeString(params[0].get_str());
-    if (strProposalName.size() > 20)
-        throw std::runtime_error("Invalid proposal name, limit of 20 characters.");
+    std::string strProposalName;
+    std::string strURL;
+    int nPaymentCount;
+    int nBlockStart;
+    CBitcoinAddress address;
+    CAmount nAmount;
 
-    std::string strURL = SanitizeString(params[1].get_str());
-    if (strURL.size() > 64)
-        throw std::runtime_error("Invalid url, limit of 64 characters.");
-
-    int nPaymentCount = params[2].get_int();
-    if (nPaymentCount < 1)
-        throw std::runtime_error("Invalid payment count, must be more than zero.");
-
-    // Start must be in the next budget cycle
-    if (pindexPrev != NULL) nBlockMin = pindexPrev->nHeight - pindexPrev->nHeight % Params().GetBudgetCycleBlocks() + Params().GetBudgetCycleBlocks();
-
-    int nBlockStart = params[3].get_int();
-    if (nBlockStart % Params().GetBudgetCycleBlocks() != 0) {
-        int nNext = pindexPrev->nHeight - pindexPrev->nHeight % Params().GetBudgetCycleBlocks() + Params().GetBudgetCycleBlocks();
-        throw std::runtime_error(strprintf("Invalid block start - must be a budget cycle block. Next valid block: %d", nNext));
-    }
-
-    int nBlockEnd = nBlockStart + Params().GetBudgetCycleBlocks() * nPaymentCount; // End must be AFTER current cycle
-
-    if (nBlockStart < nBlockMin)
-        throw std::runtime_error("Invalid block start, must be more than current height.");
-
-    if (nBlockEnd < pindexPrev->nHeight)
-        throw std::runtime_error("Invalid ending block, starting block + (payment_cycle*payments) must be more than current height.");
-
-    CBitcoinAddress address(params[4].get_str());
-    if (!address.IsValid())
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid PIVX address");
+    checkBudgetInputs(params, strProposalName, strURL, nPaymentCount, nBlockStart, address, nAmount);
 
     // Parse PIVX address
     CScript scriptPubKey = GetScriptForDestination(address.Get());
-    CAmount nAmount = AmountFromValue(params[5]);
-
-    //*************************************************************************
 
     // create transaction 15 minutes into the future, to allow for confirmation time
     CBudgetProposalBroadcast budgetProposalBroadcast(strProposalName, strURL, nPaymentCount, scriptPubKey, nAmount, nBlockStart, 0);
@@ -145,9 +157,6 @@ UniValue preparebudget(const UniValue& params, bool fHelp)
 
 UniValue submitbudget(const UniValue& params, bool fHelp)
 {
-    int nBlockMin = 0;
-    CBlockIndex* pindexPrev = chainActive.Tip();
-
     if (fHelp || params.size() != 7)
         throw std::runtime_error(
             "submitbudget \"proposal-name\" \"url\" payment-count block-start \"pivx-address\" monthly-payment \"fee-tx\"\n"
@@ -169,45 +178,18 @@ UniValue submitbudget(const UniValue& params, bool fHelp)
             HelpExampleCli("submitbudget", "\"test-proposal\" \"https://forum.pivx.org/t/test-proposal\" 2 820800 \"D9oc6C3dttUbv8zd7zGNq1qKBGf4ZQ1XEE\" 500") +
             HelpExampleRpc("submitbudget", "\"test-proposal\" \"https://forum.pivx.org/t/test-proposal\" 2 820800 \"D9oc6C3dttUbv8zd7zGNq1qKBGf4ZQ1XEE\" 500"));
 
-    // Check these inputs the same way we check the vote commands:
-    // **********************************************************
+    std::string strProposalName;
+    std::string strURL;
+    int nPaymentCount;
+    int nBlockStart;
+    CBitcoinAddress address;
+    CAmount nAmount;
 
-    std::string strProposalName = SanitizeString(params[0].get_str());
-    if (strProposalName.size() > 20)
-        throw std::runtime_error("Invalid proposal name, limit of 20 characters.");
-
-    std::string strURL = SanitizeString(params[1].get_str());
-    if (strURL.size() > 64)
-        throw std::runtime_error("Invalid url, limit of 64 characters.");
-
-    int nPaymentCount = params[2].get_int();
-    if (nPaymentCount < 1)
-        throw std::runtime_error("Invalid payment count, must be more than zero.");
-
-    // Start must be in the next budget cycle
-    if (pindexPrev != NULL) nBlockMin = pindexPrev->nHeight - pindexPrev->nHeight % Params().GetBudgetCycleBlocks() + Params().GetBudgetCycleBlocks();
-
-    int nBlockStart = params[3].get_int();
-    if (nBlockStart % Params().GetBudgetCycleBlocks() != 0) {
-        int nNext = pindexPrev->nHeight - pindexPrev->nHeight % Params().GetBudgetCycleBlocks() + Params().GetBudgetCycleBlocks();
-        throw std::runtime_error(strprintf("Invalid block start - must be a budget cycle block. Next valid block: %d", nNext));
-    }
-
-    int nBlockEnd = nBlockStart + (Params().GetBudgetCycleBlocks() * nPaymentCount); // End must be AFTER current cycle
-
-    if (nBlockStart < nBlockMin)
-        throw std::runtime_error("Invalid block start, must be more than current height.");
-
-    if (nBlockEnd < pindexPrev->nHeight)
-        throw std::runtime_error("Invalid ending block, starting block + (payment_cycle*payments) must be more than current height.");
-
-    CBitcoinAddress address(params[4].get_str());
-    if (!address.IsValid())
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid PIVX address");
+    checkBudgetInputs(params, strProposalName, strURL, nPaymentCount, nBlockStart, address, nAmount);
 
     // Parse PIVX address
     CScript scriptPubKey = GetScriptForDestination(address.Get());
-    CAmount nAmount = AmountFromValue(params[5]);
+
     uint256 hash = ParseHashV(params[6], "parameter 1");
 
     //create the proposal incase we're the first to make it


### PR DESCRIPTION
### **Release notes**
- [Refactor] Move common budget parameter checking code into a function

### **Details**
The code in both `preparebudget` and `submitbudget` used the same parameter checking.  This pulls that parameter checking and loading into a common routine used by both; for ease of improvements and adjustments to the parameter checking... so the risk of not adjusting them consistently in both routines is removed.

### **Note**
The early discussion below is based on a combined PR that addressed this, plus #950 and a PR to be named later.  The decision was made to split and focus; so the discussions can be independent of each other and refactor as needed.