### PR TITLE
[RPC] Correct issues with budget commands

### DIFF
--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -51,9 +51,6 @@ void budgetToJSON(CBudgetProposal* pbudgetProposal, UniValue& bObj)
 void checkBudgetInputs(const UniValue& params, std::string &strProposalName, std::string &strURL,
                        int &nPaymentCount, int &nBlockStart, CBitcoinAddress &address, CAmount &nAmount)
 {
-    int nBlockMin = 0;
-    CBlockIndex* pindexPrev = chainActive.Tip();
-
     strProposalName = SanitizeString(params[0].get_str());
     if (strProposalName.size() > 20)
         throw std::runtime_error("Invalid proposal name, limit of 20 characters.");
@@ -66,22 +63,20 @@ void checkBudgetInputs(const UniValue& params, std::string &strProposalName, std
     if (nPaymentCount < 1)
         throw std::runtime_error("Invalid payment count, must be more than zero.");
 
-    // Start must be in the next budget cycle
-    if (pindexPrev != NULL) nBlockMin = pindexPrev->nHeight - pindexPrev->nHeight % Params().GetBudgetCycleBlocks() + Params().GetBudgetCycleBlocks();
+    CBlockIndex* pindexPrev = chainActive.Tip();
+    if (pindexPrev == NULL)
+        throw std::runtime_error("Try again after active chain is loaded");
+
+    // Start must be in the next budget cycle or later
+    const int budgetCycleBlocks = Params().GetBudgetCycleBlocks();
+    int pHeight = pindexPrev->nHeight;
+
+    int nBlockMin = pHeight - (pHeight % budgetCycleBlocks) + budgetCycleBlocks;
 
     nBlockStart = params[3].get_int();
-    if (nBlockStart % Params().GetBudgetCycleBlocks() != 0) {
-        int nNext = pindexPrev->nHeight - pindexPrev->nHeight % Params().GetBudgetCycleBlocks() + Params().GetBudgetCycleBlocks();
-        throw std::runtime_error(strprintf("Invalid block start - must be a budget cycle block. Next valid block: %d", nNext));
+    if ((nBlockStart < nBlockMin) || ((nBlockStart % budgetCycleBlocks) != 0)) {
+        throw std::runtime_error(strprintf("Invalid block start - must be a budget cycle block. Next valid block: %d", nBlockMin));
     }
-
-    int nBlockEnd = nBlockStart + (Params().GetBudgetCycleBlocks() * nPaymentCount); // End must be AFTER current cycle
-
-    if (nBlockStart < nBlockMin)
-        throw std::runtime_error("Invalid block start, must be more than current height.");
-
-    if (nBlockEnd < pindexPrev->nHeight)
-        throw std::runtime_error("Invalid ending block, starting block + (payment_cycle*payments) must be more than current height.");
 
     address = params[4].get_str();
     if (!address.IsValid())
@@ -111,6 +106,10 @@ UniValue preparebudget(const UniValue& params, bool fHelp)
             "\nExamples:\n" +
             HelpExampleCli("preparebudget", "\"test-proposal\" \"https://forum.pivx.org/t/test-proposal\" 2 820800 \"D9oc6C3dttUbv8zd7zGNq1qKBGf4ZQ1XEE\" 500") +
             HelpExampleRpc("preparebudget", "\"test-proposal\" \"https://forum.pivx.org/t/test-proposal\" 2 820800 \"D9oc6C3dttUbv8zd7zGNq1qKBGf4ZQ1XEE\" 500"));
+
+    if (!pwalletMain) {
+        throw std::runtime_error("Try again after wallet is fully started");
+    }
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
 

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -53,19 +53,19 @@ void checkBudgetInputs(const UniValue& params, std::string &strProposalName, std
 {
     strProposalName = SanitizeString(params[0].get_str());
     if (strProposalName.size() > 20)
-        throw std::runtime_error("Invalid proposal name, limit of 20 characters.");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid proposal name, limit of 20 characters.");
 
     strURL = SanitizeString(params[1].get_str());
     if (strURL.size() > 64)
-        throw std::runtime_error("Invalid url, limit of 64 characters.");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid url, limit of 64 characters.");
 
     nPaymentCount = params[2].get_int();
     if (nPaymentCount < 1)
-        throw std::runtime_error("Invalid payment count, must be more than zero.");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid payment count, must be more than zero.");
 
     CBlockIndex* pindexPrev = chainActive.Tip();
-    if (pindexPrev == NULL)
-        throw std::runtime_error("Try again after active chain is loaded");
+    if (!pindexPrev)
+        throw JSONRPCError(RPC_IN_WARMUP, "Try again after active chain is loaded");
 
     // Start must be in the next budget cycle or later
     const int budgetCycleBlocks = Params().GetBudgetCycleBlocks();
@@ -75,7 +75,7 @@ void checkBudgetInputs(const UniValue& params, std::string &strProposalName, std
 
     nBlockStart = params[3].get_int();
     if ((nBlockStart < nBlockMin) || ((nBlockStart % budgetCycleBlocks) != 0)) {
-        throw std::runtime_error(strprintf("Invalid block start - must be a budget cycle block. Next valid block: %d", nBlockMin));
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid block start - must be a budget cycle block. Next valid block: %d", nBlockMin));
     }
 
     address = params[4].get_str();
@@ -108,7 +108,7 @@ UniValue preparebudget(const UniValue& params, bool fHelp)
             HelpExampleRpc("preparebudget", "\"test-proposal\" \"https://forum.pivx.org/t/test-proposal\" 2 820800 \"D9oc6C3dttUbv8zd7zGNq1qKBGf4ZQ1XEE\" 500"));
 
     if (!pwalletMain) {
-        throw std::runtime_error("Try again after wallet is fully started");
+        throw JSONRPCError(RPC_IN_WARMUP, "Try again after active chain is loaded");
     }
 
     LOCK2(cs_main, pwalletMain->cs_wallet);


### PR DESCRIPTION
### **Release notes**
- [RPC] Fix potential wallet crashes in budget commands
- [RPC] Remove unnecessary conditionals in parameter checking of budget commands

### **Details**
**wallet segfault**
`preparebudget`, invoked before the wallet has fully started, caused a segfault and crashed.  This was due to the lack of checking for `pwalletMain` before referencing cs_wallet.  This is solved with a throw error to tell the user to try again after the wallet has started.

Furthermore; both `preparebudget` and `submitbudget` has a check for `pindexPrev` to conditionalize the assignment of nBlockMin (which references `pindexPrev->nHeight`); however later checks, `pindexPrev->nHeight` is referenced even if the pindexPrev check failed; which would have caused a crash if pindexPrev was NULL.  This would occur if `chainActive->Tip()` returns null.  Given the logic of `getnextsuperblock`, the check added to preparebudget and submitbudget will generate a throw error if there is no active chain tip.

**Remove unnecessary conditionals and code**
`pindexPrev` is loaded from `chainActive.Tip()` pindexPrev->nHeight is checked multiple times in the parameter checking.  For ease of reading, pindexPrev->nHeight is now saved in a variable as it is used multiple times in the execution of the RPC commands in question.  Likewise, two function calls are used to determine the constant length of a budget cycle `Params().GetBudgetCycleBlocks()`; and is used several times.  Storing this information in a constant is more efficient then several calls for the information.

nBlockMin is determined (the next superblock).  However later nNext was defined to be the exact same thing.  It's not necessary to build them both.

By nature of validating that the chosen budget cycle block is greater than the current block, and validating the number of cycles is greater than zero; the need to check the end of the budget cycle is unnecessary.

Having a separate throw message for choosing the wrong block (not a budget block), and specifying a block that has passed is unnecessary.  These have been combined so that the user, putting in the wrong block, is informed, in both cases, what the next budget block is.

### **Note**
This PR was originally part of #964, but split out to distinguish between these changes and the other's refactoring.
