### PR TITLE
[Staking] Align block value with masternode payment

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2651,7 +2651,7 @@ bool CWallet::CreateCoinStake(
 
         // Calculate reward
         CAmount nReward;
-        nReward = GetBlockValue(chainActive.Height() + 1);
+        nReward = GetBlockValue(chainActive.Height()); // align with FillBlockPayee value
         nCredit += nReward;
 
         // Create the output transaction(s)


### PR DESCRIPTION
_[Splitting from #952 ]_

### **Release Notes**
- The block reward value calculated during block creation now matches the block value used to determine masternode payment, and consensus validation.

### **Details**
There is a documented overmint error (PR #814 ), that requires a fair effort of rolling back through the chain and making sure that all overmints are accounted for when validating the full chain.  However, part of PR #582 made one [small change](https://github.com/PIVX-Project/PIVX/pull/582/commits/3b778f56fe2b5e5b363c8c6d794a848a84d630d1) in CreateCoinStake(); calling GetBlockValue() with the next height, instead of the current height:
```
            nReward = GetBlockValue(chainActive.Height() + 1);
```

This, of course, is the right block value to get.  However everywhere else (consensus and masternode payment) is using the previous block height for it's calculations.  So this correction actually threw the whole system out of whack on block 1153160.  If you look at that block; you will see where this was a minor issue.  The block creator calculated the block reward to be 5; but then when filling the masternode payee; it went through SeeSaw to calculate the masternode payment.  It's a historical issue; but should the block values change again, this could pose a much larger problem....   i.e.  if it had been in place on block 648000; The miner would have figured the reward was 4.5; but then calculated the masternode's share from a block value of 9; likely paying the masternode more than the total block reward (i.e. the staker ends up "paying" to stake the block).

Of course consensus didn't care, because it just cares that you didn't overmint (at least their perception of overmint), and cares that you didn't short change the masternode.  Since the writer of 1153160 actually short changed itself (as far as consensus was concerned); the block was accepted.

So while the issue still exists where the reward changes will happen 1 block after intended; all parties will at least be looking up the same block height (the previous block) when determining the reward split; and if any future subsidy changes are made; the staker doesn't rip themselves off.  This area of code can be corrected when the rest of the system is.