### PR TITLE
[Staking][Wallet] Add Multi-Split functionality to stake output splitting

### DIFF
--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -327,7 +327,20 @@ void CMasternodePayments::FillBlockPayee(CMutableTransaction& txNew, int64_t nFe
 
             //subtract mn payment from the stake reward
             if (!txNew.vout[1].IsZerocoinMint())
-                txNew.vout[i - 1].nValue -= masternodePayment;
+                if (i == 2) {
+                    // Majority of cases; do it quick and move on
+                    txNew.vout[i - 1].nValue -= masternodePayment;
+                } else if (i > 2) {
+                    // special case, stake is split between (i-1) outputs
+                    unsigned int outputs = i-1;
+                    CAmount mnPaymentSplit = masternodePayment / outputs;
+                    CAmount mnPaymentRemainder = masternodePayment - (mnPaymentSplit * outputs);
+                    for (unsigned int j=1; j<=outputs; j++) {
+                        txNew.vout[j].nValue -= mnPaymentSplit;
+                    }
+                    // in case it's not an even division, take the last bit of dust from the last one
+                    txNew.vout[outputs].nValue -= mnPaymentRemainder;
+                }
         } else {
             txNew.vout.resize(2);
             txNew.vout[1].scriptPubKey = payee;

--- a/src/stakeinput.cpp
+++ b/src/stakeinput.cpp
@@ -224,8 +224,17 @@ bool CPivStake::CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmoun
     vout.emplace_back(CTxOut(0, scriptPubKey));
 
     // Calculate if we need to split the output
-    if (nTotal / 2 > (CAmount)(pwallet->nStakeSplitThreshold * COIN))
-        vout.emplace_back(CTxOut(0, scriptPubKey));
+    int nSplit = nTotal / (static_cast<CAmount>(pwallet->nStakeSplitThreshold * COIN));
+    if (nSplit > 1) {
+        // if nTotal is twice or more of the threshold; create more outputs
+        int txSizeMax = MAX_STANDARD_TX_SIZE >> 11; // limit splits to <10% of the max TX size (/2048)
+        if (nSplit > txSizeMax)
+            nSplit = txSizeMax;
+        for (int i = nSplit; i > 1; i--) {
+            LogPrintf("%s: StakeSplit: nTotal = %d; adding output %d of %d\n", __func__, nTotal, (nSplit-i)+2, nSplit);
+            vout.emplace_back(CTxOut(0, scriptPubKey));
+        }
+    }
 
     return true;
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2425,11 +2425,19 @@ bool CWallet::CreateCoinStake(
             CAmount nMinFee = 0;
             if (!stakeInput->IsZPIV()) {
                 // Set output amount
-                if (txNew.vout.size() == 3) {
-                    txNew.vout[1].nValue = ((nCredit - nMinFee) / 2 / CENT) * CENT;
-                    txNew.vout[2].nValue = nCredit - nMinFee - txNew.vout[1].nValue;
-                } else
-                    txNew.vout[1].nValue = nCredit - nMinFee;
+                unsigned int outputs = txNew.vout.size() - 1;
+                CAmount nRemaining = nCredit - nMinFee;
+                if (outputs > 1) {
+                    // Split the stake across the outputs
+                    CAmount nShare = nRemaining / outputs;
+                    for (int i = 1; i < outputs; i++) {
+                        // loop through all but the last one.
+                        txNew.vout[i].nValue = nShare;
+                        nRemaining -= nShare;
+                    }
+                }
+                // put the remaining on the last output (which all into the first if only one output)
+                txNew.vout[outputs].nValue += nRemaining;
             }
 
             // Limit size


### PR DESCRIPTION
### **Release notes**
- [Staking] Staking inputs are now split into 2 or more outputs based on the stake split threshold

### **Note**
For ease of rebasing; and for cleaner testing; this PR is built on top of PR #952 and will need adjustments if PR #952 has changes.

### **Background**
The common function of `stakesplitthreshold` is to break a stake that has grown large into two outputs, splitting them in half.  It is assumed the size of the split is based on the users amount of coins they are staking, and they desire their staking UTXOs to be sized between their stake split threshold and 2 times that stake split threshold.

This design falters when a stake UTXO is a multiple of the stake split threshold; causing repetitive halving until all outputs reach below twice the stake split threshold.  

For example, with a stake split threshold of 2000; a UTXO will grow until it hits 4000 coins, at which point it will split to 2000 coins.  However if the UTXO was 10,000 coins; it would split to two 5000 coin UTXOs, which would then split on the next stake for each of them; to 2500 coins.  

This becomes more problematic when considering the impact to the coin owners staking odds.  After a split; the coins will not stake until they mature.  So when that 10k splits into two 5k blocks, they won't stake for another 101 transactions.   After 101 transactions, the 10k is now being staked, until the next split; at which point only 5k is staking for the next 101 transactions.

This issue comes up in a variety of scenarios;  A large transaction from an exchange or a payment received, Unlocking a masternode for staking, auto combine rewards (especially with PR #953) sweeping up a lot of dust bunnies into a big UTXO; just to name a few.

### **Multi-Split**
Multi-Split will now use the stake split threshold to determine how many multiples of the threshold is contained in the input transaction; and split accordingly.  In the theoretical example above; that first stake of 10k will now be split into 5 outputs of 2000.4.  When one of those outputs receives a stake, instead of only the other 5k being staked for the 101 transactions to maturity; now 8k will remain staked for the maturity period of the UTXO (post split) being unavailable for staking.

For a real example, with a stake split threshold of 1500, and a UTXO of 4708.1557; the current stake split algorithm would break that into two outputs of approximately 2355.07785.  With this new logic; it will be broken into 3 outputs instead of two; each sized 1570.0519 (4708.1557 input + 2 stake = 4710.1557 / 3 outputs = 1570.0519.  

_See this test transaction in [testnet block 1171496](https://testnet.pivx.link/block/1171496)_

In order to limit the potential size growth of the staking transaction; the number of splits is limited.  This limit is a calculation based on the MAX_STANDARD_TX_SIZE, and is meant to limit the staking transaction to less than 10% of that size.  With an assumed per vout size of 190, rounded up, and converted to a bit shift for speed; MAX_STANDARD_TX_SIZE is shifted right 11 bits.  In simpler math: 
 The limit is effectively MAX_STANDARD_TX_SIZE divided by 2048, creating a maximum limit of outputs for the stake split to 48 (with the current MAX_STANDARD_TX_SIZE of 100k).

An example of this test can be seen in [testblock 1171785](https://testnet.pivx.link/block/1171785), where a UTXO of 13114.83882369 coins was used for a stake; and the stake split threshold was set to 100.  The logic would have split this into 131 outputs of 131.116 and change, however the maximum threshold is reached, and thus it is split into 47 outputs of 273.26747549, with the 48th output having the .17 uPiv remainder added and resulting in that final output of 273.26747566.

As the stake splitting is contained within the wallet software itself; there is **no protocol change with this PR**; the consensus is already built to look at the last vout for the masternode payment, and look at the total value of a variable number of outputs to confirm that an overmint is not occurring.