### PR TITLE
[Wallet][zPIV] zc public spend parse crash in wallet startup.

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -45,19 +45,8 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet* 
     bool fZSpendFromMe = false;
 
     if (wtx.HasZerocoinSpendInputs()) {
-        // a zerocoin spend that was created by this wallet
-        if (wtx.HasZerocoinPublicSpendInputs()) {
-            libzerocoin::ZerocoinParams* params = Params().Zerocoin_Params(false);
-            PublicCoinSpend publicSpend(params);
-            CValidationState state;
-            if (!ZPIVModule::ParseZerocoinPublicSpend(wtx.vin[0], wtx, state, publicSpend)){
-                throw std::runtime_error("Error parsing zc public spend");
-            }
-            fZSpendFromMe = wallet->IsMyZerocoinSpend(publicSpend.getCoinSerialNumber());
-        } else {
-            libzerocoin::CoinSpend zcspend = TxInToZerocoinSpend(wtx.vin[0]);
-            fZSpendFromMe = wallet->IsMyZerocoinSpend(zcspend.getCoinSerialNumber());
-        }
+        libzerocoin::CoinSpend zcspend = wtx.HasZerocoinPublicSpendInputs() ? ZPIVModule::parseCoinSpend(wtx.vin[0]) : TxInToZerocoinSpend(wtx.vin[0]);
+        fZSpendFromMe = wallet->IsMyZerocoinSpend(zcspend.getCoinSerialNumber());
     }
 
     if (wtx.IsCoinStake()) {

--- a/src/zpiv/zpivmodule.cpp
+++ b/src/zpiv/zpivmodule.cpp
@@ -21,11 +21,11 @@ bool PublicCoinSpend::validate() const {
             &params->coinCommitmentGroup, getCoinSerialNumber(), randomness);
 
     if (commitment.getCommitmentValue() != pubCoin.getValue()){
-        return error("%s: commitments values are not equal\n", __func__);
+        return error("%s: commitments values are not equal", __func__);
     }
     // Now check that the signature validates with the serial
     if (!HasValidSignature()) {
-        return error("%s: signature invalid\n", __func__);;
+        return error("%s: signature invalid", __func__);;
     }
     return true;
 }
@@ -44,12 +44,12 @@ namespace ZPIVModule {
         uint8_t nVersion = mint.GetVersion();
         if (nVersion < libzerocoin::PrivateCoin::PUBKEY_VERSION) {
             // No v1 serials accepted anymore.
-            return error("%s: failed to set zPIV privkey mint version=%d\n", __func__, nVersion);
+            return error("%s: failed to set zPIV privkey mint version=%d", __func__, nVersion);
         }
 
         CKey key;
         if (!mint.GetKeyPair(key))
-            return error("%s: failed to set zPIV privkey mint version=%d\n", __func__, nVersion);
+            return error("%s: failed to set zPIV privkey mint version=%d", __func__, nVersion);
 
         PublicCoinSpend spend(params, mint.GetSerialNumber(), mint.GetRandomness(), key.GetPubKey());
         spend.setTxOutHash(hashTxOut);
@@ -74,16 +74,19 @@ namespace ZPIVModule {
         return true;
     }
 
-    bool parseCoinSpend(const CTxIn &in, const CTransaction &tx, const CTxOut &prevOut, PublicCoinSpend &publicCoinSpend) {
-        if (!in.IsZerocoinPublicSpend() || !prevOut.IsZerocoinMint())
-            return error("%s: invalid argument/s\n", __func__);
-
+    PublicCoinSpend parseCoinSpend(const CTxIn &in) {
         std::vector<char, zero_after_free_allocator<char> > data;
         data.insert(data.end(), in.scriptSig.begin() + 4, in.scriptSig.end());
         CDataStream serializedCoinSpend(data, SER_NETWORK, PROTOCOL_VERSION);
         libzerocoin::ZerocoinParams *params = Params().Zerocoin_Params(false);
-        PublicCoinSpend spend(params, serializedCoinSpend);
+        return PublicCoinSpend(params, serializedCoinSpend);
+    }
 
+    bool parseCoinSpend(const CTxIn &in, const CTransaction &tx, const CTxOut &prevOut, PublicCoinSpend &publicCoinSpend) {
+        if (!in.IsZerocoinPublicSpend() || !prevOut.IsZerocoinMint())
+            return error("%s: invalid argument/s", __func__);
+
+        PublicCoinSpend spend = parseCoinSpend(in);
         spend.outputIndex = in.prevout.n;
         spend.txHash = in.prevout.hash;
         CMutableTransaction txNew(tx);
@@ -93,7 +96,7 @@ namespace ZPIVModule {
         // Check prev out now
         CValidationState state;
         if (!TxOutToPublicCoin(prevOut, spend.pubCoin, state))
-            return error("%s: cannot get mint from output\n", __func__);
+            return error("%s: cannot get mint from output", __func__);
 
         spend.setDenom(spend.pubCoin.getDenomination());
         publicCoinSpend = spend;
@@ -107,7 +110,7 @@ namespace ZPIVModule {
         }
         if (libzerocoin::ZerocoinDenominationToAmount(
                 libzerocoin::IntToZerocoinDenomination(in.nSequence)) != prevOut.nValue) {
-            return error("PublicCoinSpend validateInput :: input nSequence different to prevout value\n");
+            return error("PublicCoinSpend validateInput :: input nSequence different to prevout value");
         }
 
         return publicSpend.validate();
@@ -117,7 +120,7 @@ namespace ZPIVModule {
     {
         CTxOut prevOut;
         if(!GetOutput(txIn.prevout.hash, txIn.prevout.n ,state, prevOut)){
-            return state.DoS(100, error("%s: public zerocoin spend prev output not found, prevTx %s, index %d\n",
+            return state.DoS(100, error("%s: public zerocoin spend prev output not found, prevTx %s, index %d",
                                         __func__, txIn.prevout.hash.GetHex(), txIn.prevout.n));
         }
         if (!ZPIVModule::parseCoinSpend(txIn, tx, prevOut, publicSpend)) {

--- a/src/zpiv/zpivmodule.h
+++ b/src/zpiv/zpivmodule.h
@@ -74,6 +74,7 @@ class CValidationState;
 
 namespace ZPIVModule {
     bool createInput(CTxIn &in, CZerocoinMint& mint, uint256 hashTxOut);
+    PublicCoinSpend parseCoinSpend(const CTxIn &in);
     bool parseCoinSpend(const CTxIn &in, const CTransaction& tx, const CTxOut &prevOut, PublicCoinSpend& publicCoinSpend);
     bool validateInput(const CTxIn &in, const CTxOut &prevOut, const CTransaction& tx, PublicCoinSpend& ret);
 


### PR DESCRIPTION
### Crash Details
Essentially the crash happens when the wallet.dat file contains a zc public spend transaction (input) and the user have removed the chain data.

Specifically inside the `decomposeTransaction` in the `TransactionRecord` class the wallet tries to parse the `publicCoinSpend` looking for every output that is linked to the transaction, as there is no information about the output in disk, the wallet throws a runtime error on the startup blocking the initialization (only two ways to surpass this issue for current users: 

1) Download the snapshot. 
2) Start the wallet with another wallet.dat file and let it sync until the required output data is downloaded).

--------
### Fix
Use only the coin spend serial and not try to parse + validate the whole object, there is no need to do it there, if the transaction is in the internal wallet txes map then it means that it passed all of the validations.