### PR TITLE
[Tests] Add Spork functional test and update RegTest spork key

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -412,6 +412,13 @@ public:
         fMineBlocksOnDemand = true;
         fSkipProofOfWorkCheck = true;
         fTestnetToBeDeprecatedFieldRPC = false;
+
+        /* Spork Key for RegTest:
+        WIF private key: 932HEevBSujW2ud7RfB1YF91AFygbBRQj3de3LyaCRqNzKKgWXi
+        private key hex: bd4960dcbd9e7f2223f24e7164ecb6f1fe96fc3a416f5d3a830ba5720c84b8ca
+        Address: yCvUVd72w7xpimf981m114FSFbmAmne7j9
+        */
+        strSporkKey = "043969b1b0e6f327de37f297a015d37e2235eaaeeb3933deecd8162c075cee0207b13537618bde640879606001a8136091c62ec272dd0133424a178704e6e75bb7";
     }
     const Checkpoints::CCheckpointData& Checkpoints() const
     {

--- a/test/functional/rpc_spork.py
+++ b/test/functional/rpc_spork.py
@@ -4,13 +4,54 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 # -*- coding: utf-8 -*-
 
+from time import sleep
+
+from test_framework.mininode import network_thread_start
 from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import connect_nodes_bi, p2p_port
+from fake_stake.util import TestNode
+
 
 class PIVX_RPCSporkTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
-        self.num_nodes = 1
-        self.extra_args = [['-staking=1', '-sporkkey=932HEevBSujW2ud7RfB1YF91AFygbBRQj3de3LyaCRqNzKKgWXi']]
+        self.num_nodes = 2
+        self.extra_args = [['-staking=1']] * self.num_nodes
+        self.extra_args[0].append('-sporkkey=932HEevBSujW2ud7RfB1YF91AFygbBRQj3de3LyaCRqNzKKgWXi')
+
+
+    def setup_network(self):
+        ''' Can't rely on syncing all the nodes when staking=1
+        :param:
+        :return:
+        '''
+        self.setup_nodes()
+        for i in range(self.num_nodes - 1):
+            for j in range(i+1, self.num_nodes):
+                connect_nodes_bi(self.nodes, i, j)
+
+    def init_test(self):
+        ''' Initializes test parameters
+        :param:
+        :return:
+        '''
+        title = "*** Starting %s ***" % self.__class__.__name__
+        underline = "-" * len(title)
+        self.log.info("\n\n%s\n%s\n%s\n", title, underline, self.description)
+
+        # Setup the p2p connections and start up the network thread.
+        self.test_nodes = []
+        for i in range(self.num_nodes):
+            self.test_nodes.append(TestNode())
+            self.test_nodes[i].peer_connect('127.0.0.1', p2p_port(i))
+
+        network_thread_start()  # Start up network handling in another thread
+        self.node = self.nodes[0]
+
+        # Let the test nodes get in sync
+        for i in range(self.num_nodes):
+            self.test_nodes[i].wait_for_verack()
+
 
     def printDict(self, d):
         self.log.info("{")
@@ -22,15 +63,17 @@ class PIVX_RPCSporkTest(BitcoinTestFramework):
     def run_test(self):
         self.description = "Performs tests on the Spork RPC"
         # check spork values:
-        sporks = self.nodes[0].spork("show")
+        sporks = self.nodes[1].spork("show")
         self.printDict(sporks)
-        active = self.nodes[0].spork("active")
+        active = self.nodes[1].spork("active")
         assert(not active["SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT"])
         # activate SPORK 8
         new_value = 1563253447
         res = self.nodes[0].spork("SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT", new_value)
         assert(res == "success")
-        sporks = self.nodes[0].spork("show")
+        sleep(1)
+        self.sync_all()
+        sporks = self.nodes[1].spork("show")
         self.printDict(sporks)
         assert(sporks["SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT"] == new_value)
         active = self.nodes[0].spork("active")

--- a/test/functional/rpc_spork.py
+++ b/test/functional/rpc_spork.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The PIVX developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# -*- coding: utf-8 -*-
+
+from test_framework.test_framework import BitcoinTestFramework
+
+class PIVX_RPCSporkTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [['-staking=1', '-sporkkey=932HEevBSujW2ud7RfB1YF91AFygbBRQj3de3LyaCRqNzKKgWXi']]
+
+    def printDict(self, d):
+        self.log.info("{")
+        for k in d:
+            self.log.info("  %s = %d" % (k, d[k]))
+        self.log.info("}")
+
+
+    def run_test(self):
+        self.description = "Performs tests on the Spork RPC"
+        # check spork values:
+        sporks = self.nodes[0].spork("show")
+        self.printDict(sporks)
+        active = self.nodes[0].spork("active")
+        assert(not active["SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT"])
+        # activate SPORK 8
+        new_value = 1563253447
+        res = self.nodes[0].spork("SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT", new_value)
+        assert(res == "success")
+        sporks = self.nodes[0].spork("show")
+        self.printDict(sporks)
+        assert(sporks["SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT"] == new_value)
+        active = self.nodes[0].spork("active")
+        assert (active["SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT"])
+
+
+
+if __name__ == '__main__':
+    PIVX_RPCSporkTest().main()
+

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -211,9 +211,27 @@ class CAddress():
 
 class CInv():
     typemap = {
-        0: "Error",
-        1: "TX",
-        2: "Block",
+        0: "MSG_ERROR",
+        1: "MSG_TX",
+        2: "MSG_BLOCK",
+        3: "MSG_FILTERED_BLOCK",
+        4: "MSG_TXLOCK_REQUEST",
+        5: "MSG_TXLOCK_VOTE",
+        6: "MSG_SPORK",
+        7: "MSG_MASTERNODE_WINNER",
+        8: "MSG_MASTERNODE_SCANNING_ERROR",
+        9: "MSG_BUDGET_VOTE",
+        10: "MSG_BUDGET_PROPOSAL",
+        11: "MSG_BUDGET_FINALIZED",
+        12: "MSG_BUDGET_FINALIZED_VOTE",
+        13: "MSG_MASTERNODE_QUORUM",
+        14: "MSG_MASTERNODE_QUORUM",
+        15: "MSG_MASTERNODE_ANNOUNCE",
+        16: "MSG_MASTERNODE_PING",
+        17: "MSG_DSTX",
+        18: "MSG_PUBCOINS",
+        19: "MSG_GENWIT",
+        20: "MSG_ACC_VALUE"
     }
 
     def __init__(self, t=0, h=0):
@@ -1311,3 +1329,4 @@ class msg_witness_blocktxn(msg_blocktxn):
         r = b""
         r += self.block_transactions.serialize(with_witness=True)
         return r
+

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -295,7 +295,6 @@ def initialize_datadir(dirname, n):
         f.write("port=" + str(p2p_port(n)) + "\n")
         f.write("rpcport=" + str(rpc_port(n)) + "\n")
         f.write("listenonion=0\n")
-        f.write("litemode=1\n")
         f.write("enablezeromint=0\n")
         f.write("precompute=0\n")
         f.write("staking=0\n")

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -90,6 +90,7 @@ BASE_SCRIPTS= [
     'rpc_bip38.py',
 
     # vv Tests less than 30s vv
+    'rpc_spork.py',
     #'interface_zmq.py',
     'interface_bitcoin_cli.py',
     'mempool_resurrect.py',


### PR DESCRIPTION
This adds a first basic functional test for the spork RPC.
The spork key for RegTestNet is updated, and the relative private key is provided in the comment so anyone is able to test (prior to this, there was no public key set for RegNet so it inherited the TestNet value).