### PR TITLE
[Consensus] Define SPORK_17

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -203,9 +203,6 @@ public:
         nFakeSerialBlockheightEnd = 1686229;
         nSupplyBeforeFakeSerial = 4131563 * COIN;   // zerocoin supply at block nFakeSerialBlockheightEnd
 
-        // Cold Staking enforcement
-        nColdStakingStart = 2880000;
-
         /**
          * Build the genesis block. Note that the output of the genesis coinbase cannot
          * be spent as it did not originally exist in the database.
@@ -347,9 +344,6 @@ public:
         nFakeSerialBlockheightEnd = -1;
         nSupplyBeforeFakeSerial = 0;
 
-        // Cold Staking enforcement
-        nColdStakingStart = 2106100;
-
         //! Modify the testnet genesis block so the timestamp is valid for a later start.
         genesis.nTime = 1454124731;
         genesis.nNonce = 2402015;
@@ -447,9 +441,6 @@ public:
 
         // Fake Serial Attack
         nFakeSerialBlockheightEnd = -1;
-
-        // Cold Staking enforcement
-        nColdStakingStart = 251;
 
         //! Modify the regtest genesis block so the timestamp is valid for a later start.
         genesis.nTime = 1454124731;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -145,8 +145,6 @@ public:
     bool IsStakeModifierV2(const int nHeight) const { return nHeight >= nBlockStakeModifierlV2; }
     int NewSigsActive(const int nHeight) const { return nHeight >= nBlockEnforceNewMessageSignatures; }
     int Zerocoin_PublicSpendVersion(const int nHeight) const;
-    bool Cold_Staking_Enabled(const int height) const { return height >= nColdStakingStart; }
-    int Block_Enforce_Cold_Staking() const { return nColdStakingStart; }
 
     // fake serial attack
     int Zerocoin_Block_EndFakeSerial() const { return nFakeSerialBlockheightEnd; }
@@ -232,7 +230,7 @@ protected:
     int nPublicZCSpendsV4;
     int nBlockStakeModifierlV2;
     int nBlockEnforceNewMessageSignatures;
-    int nColdStakingStart;
+
     CAmount nMinColdStakingAmount;
 
     // fake serial attack

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1212,7 +1212,7 @@ bool CheckTransaction(const CTransaction& tx, bool fZerocoinActive, bool fReject
             if(!CheckZerocoinMint(tx.GetHash(), txout, state, true))
                 return state.DoS(100, error("CheckTransaction() : invalid zerocoin mint"));
         }
-        // check cold staking enforcement and value out
+        // check cold staking enforcement (for delegations) and value out
         if (txout.scriptPubKey.IsPayToColdStaking()) {
             if (!fColdStakingActive)
                 return state.DoS(100, error("%s: cold staking not active", __func__), REJECT_INVALID, "bad-txns-cold-stake");
@@ -1357,7 +1357,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
 
     // Cold staking and zerocoin enforcement
     int chainHeight = chainActive.Height();
-    bool fColdStakingActive = Params().Cold_Staking_Enabled(chainHeight);
+    bool fColdStakingActive = sporkManager.IsSporkActive(SPORK_17_COLDSTAKING_ENFORCEMENT);
     if (!CheckTransaction(tx, chainHeight >= Params().Zerocoin_StartHeight(), true, state, isBlockBetweenFakeSerialAttackRange(chainHeight), fColdStakingActive))
         return state.DoS(100, error("%s : CheckTransaction failed", __func__), REJECT_INVALID, "bad-tx");
 
@@ -4496,6 +4496,12 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
         LogPrintf("%s : skipping transaction locking checks\n", __func__);
     }
 
+    // Cold Staking enforcement (true during sync - reject P2CS outputs when false)
+    bool fColdStakingActive = true;
+
+    // Zerocoin activation
+    bool fZerocoinActive = block.GetBlockTime() > Params().Zerocoin_StartTime();
+
     // masternode payments / budgets
     CBlockIndex* pindexPrev = chainActive.Tip();
     int nHeight = 0;
@@ -4522,7 +4528,10 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
                         REJECT_INVALID, "bad-p2cs-outs");
             }
 
-            // Valid masternode/budget payment
+            // set Cold Staking Spork
+            fColdStakingActive = sporkManager.IsSporkActive(SPORK_17_COLDSTAKING_ENFORCEMENT);
+
+            // check masternode/budget payment
             if (!IsBlockPayeeValid(block, nHeight)) {
                 mapRejectedBlocks.insert(std::make_pair(block.GetHash(), GetTime()));
                 return state.DoS(0, error("%s : Couldn't find masternode/budget payment", __func__),
@@ -4535,8 +4544,6 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
     }
 
     // Check transactions
-    bool fZerocoinActive = block.GetBlockTime() > Params().Zerocoin_StartTime();
-    bool fColdStakingActive = Params().Cold_Staking_Enabled(nHeight);
     std::vector<CBigNum> vBlockSerials;
     // TODO: Check if this is ok... blockHeight is always the tip or should we look for the prevHash and get the height?
     int blockHeight = chainActive.Height() + 1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1215,7 +1215,7 @@ bool CheckTransaction(const CTransaction& tx, bool fZerocoinActive, bool fReject
         // check cold staking enforcement (for delegations) and value out
         if (txout.scriptPubKey.IsPayToColdStaking()) {
             if (!fColdStakingActive)
-                return state.DoS(100, error("%s: cold staking not active", __func__), REJECT_INVALID, "bad-txns-cold-stake");
+                return state.DoS(10, error("%s: cold staking not active", __func__), REJECT_INVALID, "bad-txns-cold-stake");
             if (txout.nValue < minColdStakingAmount)
                 return state.DoS(100, error("%s: dust amount (%d) not allowed for cold staking. Min amount: %d",
                         __func__, txout.nValue, minColdStakingAmount), REJECT_INVALID, "bad-txns-cold-stake");
@@ -1355,7 +1355,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
         return state.DoS(10, error("%s : Zerocoin transactions are temporarily disabled for maintenance",
                 __func__), REJECT_INVALID, "bad-tx");
 
-    // Cold staking and zerocoin enforcement
+    // Check transaction
     int chainHeight = chainActive.Height();
     bool fColdStakingActive = sporkManager.IsSporkActive(SPORK_17_COLDSTAKING_ENFORCEMENT);
     if (!CheckTransaction(tx, chainHeight >= Params().Zerocoin_StartHeight(), true, state, isBlockBetweenFakeSerialAttackRange(chainHeight), fColdStakingActive))

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -24,6 +24,7 @@ std::vector<CSporkDef> sporkDefs = {
     MAKE_SPORK_DEF(SPORK_14_NEW_PROTOCOL_ENFORCEMENT,       4070908800ULL), // OFF
     MAKE_SPORK_DEF(SPORK_15_NEW_PROTOCOL_ENFORCEMENT_2,     4070908800ULL), // OFF
     MAKE_SPORK_DEF(SPORK_16_ZEROCOIN_MAINTENANCE_MODE,      4070908800ULL), // OFF
+    MAKE_SPORK_DEF(SPORK_17_COLDSTAKING_ENFORCEMENT,        4070908800ULL), // OFF
 };
 
 CSporkManager sporkManager;
@@ -171,6 +172,7 @@ bool CSporkManager::UpdateSpork(SporkId nSporkID, int64_t nValue)
         LOCK(cs_main);
         fNewSigs = chainActive.NewSigsActive();
     }
+
 
     CSporkMessage spork = CSporkMessage(nSporkID, nValue, GetTime());
 

--- a/src/spork.h
+++ b/src/spork.h
@@ -18,6 +18,7 @@
 #include "obfuscation.h"
 #include "protocol.h"
 
+
 class CSporkMessage;
 class CSporkManager;
 

--- a/src/sporkid.h
+++ b/src/sporkid.h
@@ -22,6 +22,7 @@ enum SporkId : int32_t {
     SPORK_14_NEW_PROTOCOL_ENFORCEMENT           = 10013,
     SPORK_15_NEW_PROTOCOL_ENFORCEMENT_2         = 10014,
     SPORK_16_ZEROCOIN_MAINTENANCE_MODE          = 10015,
+    SPORK_17_COLDSTAKING_ENFORCEMENT            = 10017,
 
     SPORK_INVALID                               = -1
 };

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -560,11 +560,10 @@ UniValue CreateColdStakeDelegation(const UniValue& params, CWalletTx& wtxNew, CR
     if (params.size() > 5 && !params[5].isNull())
         fForceNotEnabled = params[5].get_bool();
 
-    int nBestHeight = chainActive.Height();
-    if (!Params().Cold_Staking_Enabled(nBestHeight) && !fForceNotEnabled) {
-        std::string errMsg = strprintf("Cold Staking not enforced yet at block %d.\n"
-                "If the wallet is syncing, you may force the stake delegation setting fForceNotEnabled to true.\n"
-                "WARNING: If the network hasn't reached the activation height, this tx will be rejected resulting in a ban.\n", nBestHeight);
+    if (!sporkManager.IsSporkActive(SPORK_17_COLDSTAKING_ENFORCEMENT) && !fForceNotEnabled) {
+        std::string errMsg = "Cold Staking disabled with SPORK 17.\n"
+                "You may force the stake delegation setting fForceNotEnabled to true.\n"
+                "WARNING: If relayed before activation, this tx will be rejected resulting in a ban.\n";
         throw JSONRPCError(RPC_WALLET_ERROR, errMsg);
     }
 
@@ -657,7 +656,7 @@ UniValue delegatestake(const UniValue& params, bool fHelp)
             "4. \"fExternalOwner\"      (boolean, optional, default = false) use the provided 'owneraddress' anyway, even if not present in this wallet.\n"
             "                               WARNING: The owner of the keys to 'owneraddress' will be the only one allowed to spend these coins.\n"
             "5. \"fUseDelegated\"       (boolean, optional, default = false) include already delegated inputs if needed."
-            "6. \"fForceNotEnabled\"    (boolean, optional, default = false) force the creation before the activation height (during sync)."
+            "6. \"fForceNotEnabled\"    (boolean, optional, default = false) force the creation even if SPORK 17 is disabled (for tests)."
 
             "\nResult:\n"
             "{\n"

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2103,7 +2103,7 @@ bool CWallet::SelectStakeCoins(std::list<std::unique_ptr<CStakeInput> >& listInp
     std::vector<COutput> vCoins;
 
     // include cold, exclude delegated
-    const bool fIncludeCold = Params().Cold_Staking_Enabled(blockHeight) && GetBoolArg("-coldstaking", true);
+    const bool fIncludeCold = sporkManager.IsSporkActive(SPORK_17_COLDSTAKING_ENFORCEMENT) && GetBoolArg("-coldstaking", true);
     AvailableCoins(vCoins, true, NULL, false, STAKABLE_COINS, false, 1, fIncludeCold, false);
 
     CAmount nAmountSelected = 0;
@@ -2184,7 +2184,7 @@ bool CWallet::MintableCoins()
 
         std::vector<COutput> vCoins;
         // include cold, exclude delegated
-        const bool fIncludeCold = Params().Cold_Staking_Enabled(chainHeight) && GetBoolArg("-coldstaking", true);
+        const bool fIncludeCold = sporkManager.IsSporkActive(SPORK_17_COLDSTAKING_ENFORCEMENT) && GetBoolArg("-coldstaking", true);
         AvailableCoins(vCoins, true, NULL, false, STAKABLE_COINS, false, 1, fIncludeCold, false);
 
         int64_t time = GetAdjustedTime();


### PR DESCRIPTION
This is based on top of https://github.com/PIVX-Project/PIVX/pull/955 (only the last commit, 5a6eab590505d409481ee3f385d65b09f40bb8fd , is relevant for this PR).

It sets Cold Staking activation via SPORK instead of having it height-based.

When `SPORK_17_COLDSTAKING_ENFORCEMENT` is **not** active (default), transactions with P2CS outputs are rejected on the network. This way only cold-staking and new delegations are disabled while coin-owners can still spend their coins.