### PR TITLE
[Refactor] Fix a few compile time warnings

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -100,7 +100,6 @@ static const Checkpoints::CCheckpointData dataRegtest = {
 
 libzerocoin::ZerocoinParams* CChainParams::Zerocoin_Params(bool useModulusV1) const
 {
-    assert(this);
     static CBigNum bnHexModulus = 0;
     if (!bnHexModulus)
         bnHexModulus.SetHex(zerocoinModulus);

--- a/src/qt/privacydialog.cpp
+++ b/src/qt/privacydialog.cpp
@@ -706,10 +706,6 @@ void PrivacyDialog::setBalance(const CAmount& balance, const CAmount& unconfirme
         }
     }
     CAmount matureZerocoinBalance = zerocoinBalance - unconfirmedZerocoinBalance - immatureZerocoinBalance;
-    CAmount nLockedBalance = 0;
-    if (walletModel) {
-        nLockedBalance = walletModel->getLockedBalance();
-    }
 
     ui->labelzAvailableAmount->setText(QString::number(zerocoinBalance/COIN) + QString(" zPIV "));
     ui->labelzAvailableAmount_2->setText(QString::number(matureZerocoinBalance/COIN) + QString(" zPIV "));

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -27,9 +27,6 @@
 
 #include <univalue.h>
 
-
-void EnsureWalletIsUnlocked(bool fAllowAnonOnly);
-
 std::string static EncodeDumpTime(int64_t nTime)
 {
     return DateTimeStrFormat("%Y-%m-%dT%H:%M:%SZ", nTime);


### PR DESCRIPTION
Fixes the three following warnings when compiling:
```
wallet/rpcdump.cpp:31:6: warning: redundant redeclaration of ‘void EnsureWalletIsUnlocked(bool)’ in same scope [-Wredundant-decls]
 void EnsureWalletIsUnlocked(bool fAllowAnonOnly);
      ^~~~~~~~~~~~~~~~~~~~~~
In file included from wallet/rpcdump.cpp:10:
./rpc/server.h:181:13: note: previous declaration of ‘void EnsureWalletIsUnlocked(bool)’
 extern void EnsureWalletIsUnlocked(bool fAllowAnonOnly = false);
             ^~~~~~~~~~~~~~~~~~~~~~
```
```
qt/privacydialog.cpp: In member function ‘void PrivacyDialog::setBalance(const CAmount&, const CAmount&, const CAmount&, const CAmount&, const CAmount&, const CAmount&, const CAmount&, const CAmount&, const CAmount&)’:
qt/privacydialog.cpp:709:13: warning: variable ‘nLockedBalance’ set but not used [-Wunused-but-set-variable]
     CAmount nLockedBalance = 0;
             ^~~~~~~~~~~~~~
```
```
warning: nonnull argument 'this' compared to NULL [-Wnonnull-compare]
```