### PR TITLE
[Miner] Don't create new keys when generating PoS blocks

### DIFF
--- a/src/miner.h
+++ b/src/miner.h
@@ -29,7 +29,7 @@ void UpdateTime(CBlockHeader* block, const CBlockIndex* pindexPrev);
     /** Run the miner threads */
     void GenerateBitcoins(bool fGenerate, CWallet* pwallet, int nThreads);
     /** Generate a new block, without valid proof-of-work */
-    CBlockTemplate* CreateNewBlockWithKey(CReserveKey& reservekey, CWallet* pwallet, bool fProofOfStake);
+    CBlockTemplate* CreateNewBlockWithKey(CReserveKey& reservekey, CWallet* pwallet);
 
     void BitcoinMiner(CWallet* pwallet, bool fProofOfStake);
     void ThreadStakeMinter();

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -154,7 +154,9 @@ UniValue generate(const UniValue& params, bool fHelp)
     while (nHeight < nHeightEnd)
     {
 
-        std::unique_ptr<CBlockTemplate> pblocktemplate(CreateNewBlockWithKey(reservekey, pwalletMain, fPoS));
+        std::unique_ptr<CBlockTemplate> pblocktemplate(
+                fPoS ? CreateNewBlock(CScript(), pwalletMain, fPoS) : CreateNewBlockWithKey(reservekey, pwalletMain)
+                        );
         if (!pblocktemplate.get())
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");
         CBlock *pblock = &pblocktemplate->block;


### PR DESCRIPTION
This fixes the calls to `CreateNewBlockWithKey` with PoS blocks, which are not needed.
We simply call `CreateNewBlock` with an empy script for coinbase.

It should prevent the problem described in https://github.com/PIVX-Project/PIVX/pull/956#issuecomment-520166966