### PR TITLE
[DB] Db runtime error cleaning the variable that needs to be logged

### DIFF
--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -265,8 +265,9 @@ CDB::CDB(const std::string& strFilename, const char* pszMode) : pdb(NULL), activ
                 delete pdb;
                 pdb = NULL;
                 --bitdb.mapFileUseCount[strFile];
+                std::string tempCopy(strFile);
                 strFile = "";
-                throw std::runtime_error(strprintf("CDB : Error %d, can't open database %s", ret, strFile));
+                throw std::runtime_error(strprintf("CDB : Error %d, can't open database %s", ret, tempCopy));
             }
 
             if (fCreate && !Exists(std::string("version"))) {


### PR DESCRIPTION
Straightforward change, the variable is been cleaned before the logging. Temp variable copy to be able to print it.