### PR TITLE
[Build] Fix wrong argument when verifying MacOS signatures

### DIFF
--- a/contrib/gitian-build.py
+++ b/contrib/gitian-build.py
@@ -133,7 +133,7 @@ def verify():
         rc = 1
 
     print('\nVerifying v'+args.version+' MacOS\n')
-    if subprocess.call(['bin/gverify', '-v', '-d', '../gitian.sigs/', '-r', args.version+'-win-signed', '../pivx/contrib/gitian-descriptors/gitian-osx.yml']):
+    if subprocess.call(['bin/gverify', '-v', '-d', '../gitian.sigs/', '-r', args.version+'-osx-unsigned', '../pivx/contrib/gitian-descriptors/gitian-osx.yml']):
         print('Verifying v'+args.version+' MacOS FAILED\n')
         rc = 1
 


### PR DESCRIPTION
Verifying MacOS signatures failed because the verifying script used the wrong OS as path to the binaries.