### PR TITLE
[Multisend][Wallet] Don't send multiple multisend transactions for a stake that resulted …

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3492,6 +3492,9 @@ bool CWallet::MultiSend()
         bool sendMSonMNReward = fMultiSendMasternodeReward && outpoint.IsMasternodeReward(out.tx);
         bool sendMSOnStake = fMultiSendStake && out.tx->IsCoinStake() && !sendMSonMNReward; //output is either mnreward or stake reward, not both
 
+        if (sendMSOnStake && stakeSent)
+            continue;
+
         if (!(sendMSOnStake || sendMSonMNReward))
             continue;
 


### PR DESCRIPTION
…in a UTXO split

At the moment, where the UTXO that wins a staking reward is split, the subsequent multi-send transaction sends the value of the staking reward multiple times - once per split output.