### PR TITLE
[Qt] Guard MN tab from possible missing TXs in masternode.conf

### DIFF
--- a/src/qt/pivx/mnmodel.cpp
+++ b/src/qt/pivx/mnmodel.cpp
@@ -37,7 +37,7 @@ void MNModel::updateMNList(){
             {
                 LOCK2(cs_main, pwalletMain->cs_wallet);
                 const CWalletTx *walletTx = pwalletMain->GetWalletTx(txHash);
-                if (walletTx->GetDepthInMainChain() > 0) {
+                if (walletTx && walletTx->GetDepthInMainChain() > 0) {
                     txAccepted = true;
                 }
             }
@@ -103,7 +103,7 @@ QVariant MNModel::data(const QModelIndex &index, int role) const
                     {
                         LOCK2(cs_main, pwalletMain->cs_wallet);
                         const CWalletTx *walletTx = pwalletMain->GetWalletTx(rec->vin.prevout.hash);
-                        txAccepted = walletTx->GetDepthInMainChain() > 0;
+                        txAccepted = walletTx && walletTx->GetDepthInMainChain() > 0;
                     }
                     return txAccepted;
                 }


### PR DESCRIPTION
In the event that masternode.conf contains invalid TXIDs, return early
instead of trying to further process, and thus avoiding a segfault.