### PR TITLE
[UI] Send screen, total amounts refresh after custom options cleaned.

### DIFF
--- a/src/coincontrol.h
+++ b/src/coincontrol.h
@@ -46,7 +46,7 @@ public:
 
     bool HasSelected() const
     {
-        return (setSelected.size() > 0);
+        return (!setSelected.empty());
     }
 
     bool IsSelected(const uint256& hash, unsigned int n) const

--- a/src/qt/pivx/send.cpp
+++ b/src/qt/pivx/send.cpp
@@ -97,7 +97,7 @@ SendWidget::SendWidget(PIVXGUI* parent) :
     connect(ui->btnCoinControl, SIGNAL(clicked()), this, SLOT(onCoinControlClicked()));
     connect(ui->btnChangeAddress, SIGNAL(clicked()), this, SLOT(onChangeAddressClicked()));
     connect(ui->btnUri, SIGNAL(clicked()), this, SLOT(onOpenUriClicked()));
-    connect(ui->pushButtonReset, SIGNAL(clicked()), this, SLOT(onResetCustomOptions()));
+    connect(ui->pushButtonReset, &QPushButton::clicked, [this](){ onResetCustomOptions(true); });
 
     setCssProperty(ui->coinWidget, "container-coin-type");
     setCssProperty(ui->labelLine, "container-divider");
@@ -221,7 +221,7 @@ void SendWidget::loadWalletModel() {
 }
 
 void SendWidget::clearAll(){
-    onResetCustomOptions();
+    onResetCustomOptions(false);
     if(customFeeDialog) customFeeDialog->clear();
     ui->pushButtonFee->setText(tr("Customize Fee"));
     if(walletModel) walletModel->setWalletDefaultFee();
@@ -229,10 +229,13 @@ void SendWidget::clearAll(){
     refreshAmounts();
 }
 
-void SendWidget::onResetCustomOptions(){
+void SendWidget::onResetCustomOptions(bool fRefreshAmounts){
     CoinControlDialog::coinControl->SetNull();
     ui->btnChangeAddress->setActive(false);
     ui->btnCoinControl->setActive(false);
+    if (fRefreshAmounts) {
+        refreshAmounts();
+    }
 }
 
 void SendWidget::clearEntries(){
@@ -365,7 +368,6 @@ bool SendWidget::send(QList<SendCoinsRecipient> recipients){
         processSendCoinsReturn(sendStatus);
 
         if (sendStatus.status == WalletModel::OK) {
-            CoinControlDialog::coinControl->UnSelectAll();
             clearAll();
             inform(tr("Transaction sent"));
             return true;

--- a/src/qt/pivx/send.h
+++ b/src/qt/pivx/send.h
@@ -69,7 +69,7 @@ private slots:
     void refreshView();
     void onContactMultiClicked();
     void onDeleteClicked();
-    void onResetCustomOptions();
+    void onResetCustomOptions(bool fRefreshAmounts);
 private:
     Ui::send *ui;
     QPushButton *coinIcon;


### PR DESCRIPTION
As the title says, the screen needed refresh the bottom amounts when the coinControl gets cleaned. Before only happened on the clearAll option and not when the resetCustom button was touched. Now it happen on both.