### PR TITLE
[Consensus] Remove Old message format in CMasternodeBroadcast

### DIFF
--- a/src/masternode.h
+++ b/src/masternode.h
@@ -303,8 +303,7 @@ public:
     bool Sign(CKey& keyCollateralAddress);
     bool VerifySignature();
     void Relay();
-    std::string GetOldStrMessage();
-    std::string GetNewStrMessage();
+    std::string GetStrMessage();
 
     ADD_SERIALIZE_METHODS;
 


### PR DESCRIPTION
The new message format was introduced with protocol 70914 (v3.1.0) and the old message was retained in order to be able to still check against it during the update.
After 4 more protocol upgrades we can safely assume that no masternode has MNANNOUNCE message signed with the old format so we can remove it from the code.

The function `GetOldStrMessage()` is removed and `GetNewStrMessage()` is renamed to `GetStrMessage()`.