### PR TITLE
[QT][Performance] Memory leak re creating the row object instead of re initialize it.

### DIFF
--- a/src/qt/pivx/addresseswidget.cpp
+++ b/src/qt/pivx/addresseswidget.cpp
@@ -28,7 +28,9 @@ public:
     explicit ContactsHolder(bool _isLightTheme) : FurListRow(), isLightTheme(_isLightTheme){}
 
     AddressLabelRow* createHolder(int pos) override{
-        return new AddressLabelRow(isLightTheme, false);
+        if (!cachedRow) cachedRow = new AddressLabelRow();
+        cachedRow->init(isLightTheme, false);
+        return cachedRow;
     }
 
     void init(QWidget* holder,const QModelIndex &index, bool isHovered, bool isSelected) const override{
@@ -50,6 +52,7 @@ public:
     ~ContactsHolder() override{}
 
     bool isLightTheme;
+    AddressLabelRow* cachedRow = nullptr;
 };
 
 #include "qt/pivx/moc_addresseswidget.cpp"

--- a/src/qt/pivx/addresslabelrow.cpp
+++ b/src/qt/pivx/addresslabelrow.cpp
@@ -4,17 +4,17 @@
 
 #include "qt/pivx/addresslabelrow.h"
 #include "qt/pivx/forms/ui_addresslabelrow.h"
-#include "QFile"
 
-AddressLabelRow::AddressLabelRow(bool isLightTheme, bool isHover , QWidget *parent) :
+AddressLabelRow::AddressLabelRow(QWidget *parent) :
     QWidget(parent),
     ui(new Ui::AddressLabelRow)
 {
     ui->setupUi(this);
-
     ui->lblAddress->setProperty("cssClass", "text-list-body1");
     ui->lblLabel->setProperty("cssClass", "text-list-title1");
+}
 
+void AddressLabelRow::init(bool isLightTheme, bool isHover) {
     updateState(isLightTheme, isHover, false);
 }
 

--- a/src/qt/pivx/addresslabelrow.h
+++ b/src/qt/pivx/addresslabelrow.h
@@ -16,8 +16,10 @@ class AddressLabelRow : public QWidget
     Q_OBJECT
 
 public:
-    explicit AddressLabelRow(bool isLightTheme, bool isHover , QWidget *parent = nullptr);
+    explicit AddressLabelRow(QWidget *parent = nullptr);
     ~AddressLabelRow();
+
+    void init(bool isLightTheme, bool isHover);
 
     void updateState(bool isLightTheme, bool isHovered, bool isSelected);
     void updateView(QString address, QString label);

--- a/src/qt/pivx/contactdropdownrow.cpp
+++ b/src/qt/pivx/contactdropdownrow.cpp
@@ -5,13 +5,16 @@
 #include "qt/pivx/contactdropdownrow.h"
 #include "qt/pivx/forms/ui_contactdropdownrow.h"
 
-ContactDropdownRow::ContactDropdownRow(bool isLightTheme, bool isHover, QWidget *parent) :
+ContactDropdownRow::ContactDropdownRow(QWidget *parent) :
     QWidget(parent),
     ui(new Ui::ContactDropdownRow)
 {
     ui->setupUi(this);
     ui->lblAddress->setProperty("cssClass", "text-list-contact-body1");
     ui->lblLabel->setProperty("cssClass", "text-list-contact-title1");
+}
+
+void ContactDropdownRow::init(bool isLightTheme, bool isHover) {
     update(isLightTheme, isHover, false);
 }
 

--- a/src/qt/pivx/contactdropdownrow.h
+++ b/src/qt/pivx/contactdropdownrow.h
@@ -16,9 +16,10 @@ class ContactDropdownRow : public QWidget
     Q_OBJECT
 
 public:
-    explicit ContactDropdownRow(bool isLightTheme, bool isHover, QWidget *parent = nullptr);
+    explicit ContactDropdownRow(QWidget *parent = nullptr);
     ~ContactDropdownRow();
 
+    void init(bool isLightTheme, bool isHover);
     void update(bool isLightTheme, bool isHover, bool isSelected);
     void setData(QString address, QString label);
 

--- a/src/qt/pivx/contactsdropdown.cpp
+++ b/src/qt/pivx/contactsdropdown.cpp
@@ -24,7 +24,9 @@ public:
     explicit ContViewHolder(bool _isLightTheme) : FurListRow(), isLightTheme(_isLightTheme){}
 
     ContactDropdownRow* createHolder(int pos) override{
-        return new ContactDropdownRow(true, false);
+        if (!row) row = new ContactDropdownRow();
+        row->init(true, false);
+        return row;
     }
 
     void init(QWidget* holder,const QModelIndex &index, bool isHovered, bool isSelected) const override{
@@ -43,6 +45,7 @@ public:
     ~ContViewHolder() override{}
 
     bool isLightTheme;
+    ContactDropdownRow* row = nullptr;
 };
 
 ContactsDropdown::ContactsDropdown(int minWidth, int minHeight, PWidget *parent) :

--- a/src/qt/pivx/dashboardwidget.h
+++ b/src/qt/pivx/dashboardwidget.h
@@ -163,14 +163,14 @@ private:
     int dayStart = 1;
     bool hasZpivStakes = false;
 
-    ChartData chartData;
+    ChartData* chartData = nullptr;
 
     void initChart();
     void showHideEmptyChart(bool show, bool loading, bool forceView = false);
     bool refreshChart();
     void tryChartRefresh();
     QMap<int, std::pair<qint64, qint64>> getAmountBy();
-    ChartData loadChartData(bool withMonthNames);
+    void loadChartData(bool withMonthNames);
     void updateAxisX(const QStringList *arg = nullptr);
     void setChartShow(ChartShowType type);
     std::pair<int, int> getChartRange(QMap<int, std::pair<qint64, qint64>> amountsBy);

--- a/src/qt/pivx/masternodeswidget.cpp
+++ b/src/qt/pivx/masternodeswidget.cpp
@@ -38,7 +38,8 @@ public:
     explicit MNHolder(bool _isLightTheme) : FurListRow(), isLightTheme(_isLightTheme){}
 
     MNRow* createHolder(int pos) override{
-        return new MNRow();
+        if(!cachedRow) cachedRow = new MNRow();
+        return cachedRow;
     }
 
     void init(QWidget* holder,const QModelIndex &index, bool isHovered, bool isSelected) const override{
@@ -57,6 +58,7 @@ public:
     ~MNHolder() override{}
 
     bool isLightTheme;
+    MNRow* cachedRow = nullptr;
 };
 
 #include "qt/pivx/moc_masternodeswidget.cpp"

--- a/src/qt/pivx/myaddressrow.cpp
+++ b/src/qt/pivx/myaddressrow.cpp
@@ -13,7 +13,6 @@ MyAddressRow::MyAddressRow(QWidget *parent) :
     ui->labelName->setProperty("cssClass", "text-list-title1");
     ui->labelAddress->setProperty("cssClass", "text-list-body2");
     ui->labelDate->setProperty("cssClass", "text-list-caption");
-
 }
 
 void MyAddressRow::updateView(QString address, QString label, QString date){

--- a/src/qt/pivx/pwidget.cpp
+++ b/src/qt/pivx/pwidget.cpp
@@ -6,6 +6,8 @@
 #include "qt/pivx/qtutils.h"
 #include "qt/pivx/moc_pwidget.cpp"
 #include "qt/pivx/loadingdialog.h"
+#include <QRunnable>
+#include <QThreadPool>
 
 PWidget::PWidget(PIVXGUI* _window, QWidget *parent) : QWidget((parent) ? parent : _window), window(_window){init();}
 PWidget::PWidget(PWidget* parent) : QWidget(parent), window(parent->getWindow()){init();}
@@ -57,21 +59,32 @@ void PWidget::emitMessage(const QString& title, const QString& body, unsigned in
     emit message(title, body, style, ret);
 }
 
-bool PWidget::execute(int type){
-    // if the thread it's already running don't start a new task
-    if (!quitWorker(false))
-        return false;
+class WorkerTask : public QRunnable {
 
-    thread = new QThread;
+public:
+    WorkerTask(Worker* worker) {
+        this->worker = worker;
+    }
+
+    ~WorkerTask() {
+        delete this->worker;
+    }
+
+    void run() override {
+        if (worker) worker->process();
+    }
+
+    Worker* worker = nullptr;
+};
+
+bool PWidget::execute(int type){
     Worker* worker = new Worker(this, type);
-    worker->moveToThread(thread);
     connect(worker, SIGNAL (error(QString&)), this, SLOT (errorString(QString)));
-    connect(thread, SIGNAL (started()), worker, SLOT (process()));
-    connect(worker, SIGNAL (finished()), thread, SLOT (quit()));
     connect(worker, SIGNAL (finished()), worker, SLOT (deleteLater()));
-    connect(thread, SIGNAL (finished()), thread, SLOT (deleteLater()));
-    connect(thread, &QThread::destroyed, [this](){ this->thread = nullptr; });
-    thread->start();
+
+    WorkerTask* task = new WorkerTask(worker);
+    task->setAutoDelete(true);
+    QThreadPool::globalInstance()->start(task);
     return true;
 }
 
@@ -79,18 +92,6 @@ bool PWidget::verifyWalletUnlocked(){
     if (!walletModel->isWalletUnlocked()) {
         inform(tr("Wallet locked, you need to unlock it to perform this action"));
         return false;
-    }
-    return true;
-}
-
-bool PWidget::quitWorker(bool forceTermination) {
-    if (thread) {
-        // don't run it if it's already running
-        if (!thread->isFinished() && !forceTermination)
-            return false;
-        thread->quit();
-        delete thread;
-        thread = nullptr;
     }
     return true;
 }

--- a/src/qt/pivx/pwidget.h
+++ b/src/qt/pivx/pwidget.h
@@ -8,7 +8,6 @@
 #include <QObject>
 #include <QWidget>
 #include <QString>
-#include <QThread>
 #include "qt/pivx/prunnable.h"
 
 class PIVXGUI;
@@ -60,11 +59,8 @@ protected:
     void emitMessage(const QString& title, const QString& message, unsigned int style, bool* ret = nullptr);
 
     bool verifyWalletUnlocked();
-    bool quitWorker(bool forceTermination);
 
 private:
-    QThread* thread = nullptr;
-
     void init();
 };
 

--- a/src/qt/pivx/receivewidget.cpp
+++ b/src/qt/pivx/receivewidget.cpp
@@ -27,7 +27,8 @@ public:
     explicit AddressHolder(bool _isLightTheme) : FurListRow(), isLightTheme(_isLightTheme){}
 
     MyAddressRow* createHolder(int pos) override{
-        return new MyAddressRow();
+        if (!cachedRow) cachedRow = new MyAddressRow();
+        return cachedRow;
     }
 
     void init(QWidget* holder,const QModelIndex &index, bool isHovered, bool isSelected) const override{
@@ -46,6 +47,7 @@ public:
     ~AddressHolder() override{}
 
     bool isLightTheme;
+    MyAddressRow* cachedRow = nullptr;
 };
 
 #include "qt/pivx/moc_receivewidget.cpp"

--- a/src/qt/pivx/settings/settingsmultisendwidget.cpp
+++ b/src/qt/pivx/settings/settingsmultisendwidget.cpp
@@ -60,54 +60,56 @@ public:
     explicit MultiSendHolder(bool _isLightTheme) : FurListRow(), isLightTheme(_isLightTheme){}
 
     QWidget* createHolder(int pos) override{
-        QWidget *row = new QWidget();
-        QVBoxLayout *verticalLayout_2;
-        QFrame *frame_2;
-        QHBoxLayout *horizontalLayout;
-        QLabel *labelName;
-        QSpacerItem *horizontalSpacer;
-        QLabel *labelDate;
-        QLabel *lblDivisory;
+        if (!row) {
+            row = new QWidget();
+            QVBoxLayout *verticalLayout_2;
+            QFrame *frame_2;
+            QHBoxLayout *horizontalLayout;
+            QLabel *labelName;
+            QSpacerItem *horizontalSpacer;
+            QLabel *labelDate;
+            QLabel *lblDivisory;
 
-        if (row->objectName().isEmpty())
-            row->setObjectName(QStringLiteral("multiSendrow"));
-        row->resize(475, 65);
-        row->setStyleSheet(QStringLiteral(""));
-        setCssProperty(row, "container");
-        verticalLayout_2 = new QVBoxLayout(row);
-        verticalLayout_2->setSpacing(0);
-        verticalLayout_2->setObjectName(QStringLiteral("verticalLayout_2"));
-        verticalLayout_2->setContentsMargins(20, 0, 20, 0);
-        frame_2 = new QFrame(row);
-        frame_2->setObjectName(QStringLiteral("frame_2"));
-        frame_2->setStyleSheet(QStringLiteral("border:none;"));
-        frame_2->setFrameShape(QFrame::StyledPanel);
-        frame_2->setFrameShadow(QFrame::Raised);
-        horizontalLayout = new QHBoxLayout(frame_2);
-        horizontalLayout->setObjectName(QStringLiteral("horizontalLayout"));
-        horizontalLayout->setContentsMargins(0, -1, 0, -1);
-        labelName = new QLabel(frame_2);
-        labelName->setObjectName(QStringLiteral("labelAddress"));
-        setCssProperty(labelName, "text-list-title1");
-        horizontalLayout->addWidget(labelName);
+            if (row->objectName().isEmpty())
+                row->setObjectName(QStringLiteral("multiSendrow"));
+            row->resize(475, 65);
+            row->setStyleSheet(QStringLiteral(""));
+            setCssProperty(row, "container");
+            verticalLayout_2 = new QVBoxLayout(row);
+            verticalLayout_2->setSpacing(0);
+            verticalLayout_2->setObjectName(QStringLiteral("verticalLayout_2"));
+            verticalLayout_2->setContentsMargins(20, 0, 20, 0);
+            frame_2 = new QFrame(row);
+            frame_2->setObjectName(QStringLiteral("frame_2"));
+            frame_2->setStyleSheet(QStringLiteral("border:none;"));
+            frame_2->setFrameShape(QFrame::StyledPanel);
+            frame_2->setFrameShadow(QFrame::Raised);
+            horizontalLayout = new QHBoxLayout(frame_2);
+            horizontalLayout->setObjectName(QStringLiteral("horizontalLayout"));
+            horizontalLayout->setContentsMargins(0, -1, 0, -1);
+            labelName = new QLabel(frame_2);
+            labelName->setObjectName(QStringLiteral("labelAddress"));
+            setCssProperty(labelName, "text-list-title1");
+            horizontalLayout->addWidget(labelName);
 
-        horizontalSpacer = new QSpacerItem(40, 20, QSizePolicy::Expanding, QSizePolicy::Minimum);
-        horizontalLayout->addItem(horizontalSpacer);
+            horizontalSpacer = new QSpacerItem(40, 20, QSizePolicy::Expanding, QSizePolicy::Minimum);
+            horizontalLayout->addItem(horizontalSpacer);
 
-        labelDate = new QLabel(frame_2);
-        labelDate->setObjectName(QStringLiteral("labelPercentage"));
-        setCssProperty(labelDate, "text-list-caption-medium");
-        horizontalLayout->addWidget(labelDate);
+            labelDate = new QLabel(frame_2);
+            labelDate->setObjectName(QStringLiteral("labelPercentage"));
+            setCssProperty(labelDate, "text-list-caption-medium");
+            horizontalLayout->addWidget(labelDate);
 
-        verticalLayout_2->addWidget(frame_2);
+            verticalLayout_2->addWidget(frame_2);
 
-        lblDivisory = new QLabel(row);
-        lblDivisory->setObjectName(QStringLiteral("lblDivisory"));
-        lblDivisory->setMinimumSize(QSize(0, 1));
-        lblDivisory->setMaximumSize(QSize(16777215, 1));
-        lblDivisory->setStyleSheet(QStringLiteral("background-color:#bababa;"));
-        lblDivisory->setAlignment(Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft);
-        verticalLayout_2->addWidget(lblDivisory);
+            lblDivisory = new QLabel(row);
+            lblDivisory->setObjectName(QStringLiteral("lblDivisory"));
+            lblDivisory->setMinimumSize(QSize(0, 1));
+            lblDivisory->setMaximumSize(QSize(16777215, 1));
+            lblDivisory->setStyleSheet(QStringLiteral("background-color:#bababa;"));
+            lblDivisory->setAlignment(Qt::AlignBottom | Qt::AlignLeading | Qt::AlignLeft);
+            verticalLayout_2->addWidget(lblDivisory);
+        }
 
         return row;
     }
@@ -126,6 +128,7 @@ public:
     ~MultiSendHolder() override{}
 
     bool isLightTheme;
+    QWidget *row = nullptr;
 };
 
 

--- a/src/qt/pivx/txrow.cpp
+++ b/src/qt/pivx/txrow.cpp
@@ -8,11 +8,14 @@
 #include "guiutil.h"
 #include "qt/pivx/qtutils.h"
 
-TxRow::TxRow(bool isLightTheme, QWidget *parent) :
+TxRow::TxRow(QWidget *parent) :
     QWidget(parent),
     ui(new Ui::TxRow)
 {
     ui->setupUi(this);
+}
+
+void TxRow::init(bool isLightTheme) {
     setConfirmStatus(true);
     updateStatus(isLightTheme, false, false);
 }

--- a/src/qt/pivx/txrow.h
+++ b/src/qt/pivx/txrow.h
@@ -18,9 +18,10 @@ class TxRow : public QWidget
     Q_OBJECT
 
 public:
-    explicit TxRow(bool isLightTheme, QWidget *parent = nullptr);
+    explicit TxRow(QWidget *parent = nullptr);
     ~TxRow();
 
+    void init(bool isLightTheme);
     void updateStatus(bool isLightTheme, bool isHover, bool isSelected);
 
     void setDate(QDateTime);

--- a/src/qt/pivx/txviewholder.cpp
+++ b/src/qt/pivx/txviewholder.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "qt/pivx/txviewholder.h"
-#include "qt/pivx/txrow.h"
 #include "qt/pivx/qtutils.h"
 #include "transactiontablemodel.h"
 #include <QModelIndex>
@@ -11,7 +10,9 @@
 #define ADDRESS_SIZE 12
 
 QWidget* TxViewHolder::createHolder(int pos){
-    return new TxRow(isLightTheme);
+    if (!txRow) txRow = new TxRow();
+    txRow->init(isLightTheme);
+    return txRow;
 }
 
 void TxViewHolder::init(QWidget* holder,const QModelIndex &index, bool isHovered, bool isSelected) const{

--- a/src/qt/pivx/txviewholder.h
+++ b/src/qt/pivx/txviewholder.h
@@ -6,6 +6,7 @@
 #define TXVIEWHOLDER_H
 
 #include "qt/pivx/furlistrow.h"
+#include "qt/pivx/txrow.h"
 #include "bitcoinunits.h"
 #include <transactionfilterproxy.h>
 
@@ -41,6 +42,7 @@ public:
 private:
     int nDisplayUnit;
     TransactionFilterProxy *filter = nullptr;
+    TxRow* txRow = nullptr;
 };
 
 #endif // TXVIEWHOLDER_H


### PR DESCRIPTION
Memory leak issue solved and performance improvement over the chart load thread handler.
The memory was increasing on every list screen movement because of the row object being re created on every refresh.