### PR TITLE
[Qt] Reintroduce networkstyle to title texts

### DIFF
--- a/src/qt/networkstyle.cpp
+++ b/src/qt/networkstyle.cpp
@@ -16,9 +16,9 @@ static const struct {
     const char* titleAddText;
     const char* splashImage;
 } network_styles[] = {
-    {"main", QAPP_APP_NAME_DEFAULT, ":/icons/bitcoin", "", ":/images/splash"},
-    {"test", QAPP_APP_NAME_TESTNET, ":/icons/bitcoin_testnet", QT_TRANSLATE_NOOP("SplashScreen", "[testnet]"), ":/images/splash_testnet"},
-    {"regtest", QAPP_APP_NAME_TESTNET, ":/icons/bitcoin_regtest", "[regtest]", ":/images/splash_regtest"}};
+    {"main", QAPP_APP_NAME_DEFAULT, ":/icons/bitcoin", "", ":/bg-splash-png"},
+    {"test", QAPP_APP_NAME_TESTNET, ":/icons/bitcoin_testnet", QT_TRANSLATE_NOOP("SplashScreen", "[testnet]"), ":/bg-splash-png"},
+    {"regtest", QAPP_APP_NAME_TESTNET, ":/icons/bitcoin_regtest", "[regtest]", ":/bg-splash-png"}};
 static const unsigned network_styles_count = sizeof(network_styles) / sizeof(*network_styles);
 
 // titleAddText needs to be const char* for tr()

--- a/src/qt/pivx.cpp
+++ b/src/qt/pivx.cpp
@@ -365,7 +365,7 @@ void BitcoinApplication::createWindow(const NetworkStyle* networkStyle)
 
 void BitcoinApplication::createSplashScreen(const NetworkStyle* networkStyle)
 {
-    Splash* splash = new Splash(0);
+    Splash* splash = new Splash(0, networkStyle);
     // We don't hold a direct pointer to the splash screen after creation, so use
     // Qt::WA_DeleteOnClose to make sure that the window will be deleted eventually.
     splash->setAttribute(Qt::WA_DeleteOnClose);

--- a/src/qt/pivx/forms/splash.ui
+++ b/src/qt/pivx/forms/splash.ui
@@ -119,34 +119,85 @@
         </property>
        </spacer>
       </item>
-      <item alignment="Qt::AlignHCenter">
-       <widget class="QLabel" name="lblMessage">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
+      <item>
+       <widget class="QWidget" name="horizontalWidget" native="true">
         <property name="minimumSize">
          <size>
           <width>0</width>
           <height>30</height>
          </size>
         </property>
-        <property name="font">
-         <font>
-          <pointsize>16</pointsize>
-         </font>
-        </property>
-        <property name="styleSheet">
-         <string notr="true">color:white;</string>
-        </property>
-        <property name="text">
-         <string>Loading…</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignHCenter|Qt::AlignTop</set>
-        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>10</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>10</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="lblMessage">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>30</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>16</pointsize>
+            </font>
+           </property>
+           <property name="styleSheet">
+            <string notr="true">color:white; padding-left:50px;</string>
+           </property>
+           <property name="text">
+            <string>Loading…</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignHCenter|Qt::AlignTop</set>
+           </property>
+          </widget>
+         </item>
+         <item alignment="Qt::AlignVCenter">
+          <widget class="QLabel" name="lblVersion">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>30</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>15</pointsize>
+            </font>
+           </property>
+           <property name="styleSheet">
+            <string notr="true">color:white; padding-top:1px;</string>
+           </property>
+           <property name="text">
+            <string notr="true">vX.X.X</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignHCenter|Qt::AlignTop</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
       <item>

--- a/src/qt/pivx/forms/splash.ui
+++ b/src/qt/pivx/forms/splash.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1200</width>
-    <height>700</height>
+    <width>768</width>
+    <height>533</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>0</width>
-    <height>700</height>
+    <width>768</width>
+    <height>533</height>
    </size>
   </property>
   <property name="maximumSize">
@@ -53,10 +53,10 @@
       <string notr="true"/>
      </property>
      <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
+      <enum>QFrame::NoFrame</enum>
      </property>
      <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
+      <enum>QFrame::Plain</enum>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
       <property name="spacing">

--- a/src/qt/pivx/pivxgui.cpp
+++ b/src/qt/pivx/pivxgui.cpp
@@ -53,6 +53,7 @@ PIVXGUI::PIVXGUI(const NetworkStyle* networkStyle, QWidget* parent) :
         windowTitle += tr("Node");
     }
 
+    windowTitle += " " + networkStyle->getTitleAddText();
     setWindowTitle(windowTitle);
 
 #ifndef Q_OS_MAC

--- a/src/qt/pivx/res/css/style_dark.css
+++ b/src/qt/pivx/res/css/style_dark.css
@@ -1548,8 +1548,7 @@ HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH*/
 
 *[cssClass="container-splash"] {
     background-color:transparent;
-    border-image: url("://bg-splash-png") 0 0 0 0 stretch stretch;
-    border-radius: 4px;
+    background-image: url("://bg-splash-png");
 }
 
 *[cssClass="img-splash-logo"] {

--- a/src/qt/pivx/res/css/style_light.css
+++ b/src/qt/pivx/res/css/style_light.css
@@ -1545,8 +1545,7 @@ HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH*/
 
 *[cssClass="container-splash"] {
     background-color:transparent;
-    border-image: url("://bg-splash-png") 0 0 0 0 stretch stretch;
-    border-radius: 4px;
+    background-image: url("://bg-splash-png");
 }
 
 *[cssClass="img-splash-logo"] {

--- a/src/qt/pivx/splash.cpp
+++ b/src/qt/pivx/splash.cpp
@@ -41,6 +41,7 @@ Splash::Splash(Qt::WindowFlags f, const NetworkStyle* networkStyle) :
     ui->frame->setProperty("cssClass", "container-splash");
     ui->layoutProgress->setProperty("cssClass", "bg-progress");
     ui->imgLogo->setProperty("cssClass", "img-splash-logo");
+    ui->lblVersion->setText(QString("v") + QString::fromStdString(FormatVersionFriendly()));
 
     // Resize window and move to center of desktop, disallow resizing
     QRect r(QPoint(), size());

--- a/src/qt/pivx/splash.cpp
+++ b/src/qt/pivx/splash.cpp
@@ -22,12 +22,13 @@
 
 #include <iostream>
 
-Splash::Splash(QWidget *parent) :
-    QWidget(parent, Qt::FramelessWindowHint | Qt::WindowSystemMenuHint),
-    ui(new Ui::Splash)
+Splash::Splash(Qt::WindowFlags f, const NetworkStyle* networkStyle) :
+    QWidget(0, f), ui(new Ui::Splash)
 {
     ui->setupUi(this);
-    setWindowTitle("PIVX Wallet");
+    QString titleText = tr("PIVX Core");
+    QString titleAddText = networkStyle->getTitleAddText();
+    setWindowTitle(titleText + " " + titleAddText);
 
     this->setStyleSheet(GUIUtil::loadStyleSheet());
     this->setAttribute( Qt::WA_TranslucentBackground, true );

--- a/src/qt/pivx/splash.h
+++ b/src/qt/pivx/splash.h
@@ -7,6 +7,8 @@
 
 #include <QWidget>
 
+class NetworkStyle;
+
 namespace Ui {
 class Splash;
 }
@@ -16,7 +18,7 @@ class Splash : public QWidget
     Q_OBJECT
 
 public:
-    explicit Splash(QWidget *parent = nullptr);
+    explicit Splash(Qt::WindowFlags f, const NetworkStyle* networkStyle);
     ~Splash();
 
 public slots:


### PR DESCRIPTION
Allows for the window's title to contain `[testnet]` or `[regtest]` as
needed.

Also makes the splash screen a full window.

window with 96b4e09:
![Screen Shot 2019-09-15 at 12 23 57 AM](https://user-images.githubusercontent.com/7393257/64928842-6e96ee80-d7d2-11e9-9600-682a89390de6.png)

window with 4bfb2f6:
![Screen Shot 2019-09-15 at 1 41 12 AM](https://user-images.githubusercontent.com/7393257/64928849-7c4c7400-d7d2-11e9-811f-750b72ac42ae.png)
