### PR TITLE
[Qt] Don't set placeholder on QPlainTextEdit

### DIFF
--- a/src/qt/pivx/settings/settingssignmessagewidgets.cpp
+++ b/src/qt/pivx/settings/settingssignmessagewidgets.cpp
@@ -61,7 +61,9 @@ SettingsSignMessageWidgets::SettingsSignMessageWidgets(PIVXGUI* _window, QWidget
     ui->labelSubtitleMessage->setText(tr("Message"));
     ui->labelSubtitleMessage->setProperty("cssClass", "text-title");
 
+#if QT_VERSION >= 0x050300
     ui->messageIn_SM->setPlaceholderText(tr("Write a message"));
+#endif
     ui->messageIn_SM->setProperty("cssClass","edit-primary");
     setShadow(ui->messageIn_SM);
     ui->messageIn_SM->setAttribute(Qt::WA_MacShowFocusRect, 0);


### PR DESCRIPTION
`setPlaceholderText()` for QPlainTextEdit wasn't introduced until Qt 5.3.
Guard with a simple pre-compiler conditional; needed to still support
Qt 5.2.1 (Ubuntu Trusty system package version).