### PR TITLE
[Performance][Wallet][QT][Model] TransactionTableModel multi-thread initialization + tx filter sort speed improved.

### DIFF
--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -464,7 +464,7 @@ AC_DEFUN([_BITCOIN_QT_FIND_LIBS_WITHOUT_PKGCONFIG],[
   TEMP_LIBS="$LIBS"
   BITCOIN_QT_CHECK([
     if test "x$qt_include_path" != x; then
-      QT_INCLUDES="-I$qt_include_path -I$qt_include_path/QtCore -I$qt_include_path/QtGui -I$qt_include_path/QtWidgets -I$qt_include_path/QtNetwork -I$qt_include_path/QtTest -I$qt_include_path/QtDBus -I$qt_include_path/QtSvg -I$qt_include_path/QtCharts"
+      QT_INCLUDES="-I$qt_include_path -I$qt_include_path/QtCore -I$qt_include_path/QtGui -I$qt_include_path/QtWidgets -I$qt_include_path/QtNetwork -I$qt_include_path/QtTest -I$qt_include_path/QtDBus -I$qt_include_path/QtConcurrent -I$qt_include_path/QtSvg -I$qt_include_path/QtCharts"
       CPPFLAGS="$QT_INCLUDES $CPPFLAGS"
     fi
   ])

--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -432,7 +432,7 @@ dnl Outputs: have_qt_test and have_qt_dbus are set (if applicable) to yes|no.
 AC_DEFUN([_BITCOIN_QT_FIND_LIBS_WITH_PKGCONFIG],[
   m4_ifdef([PKG_CHECK_MODULES],[
     QT_LIB_PREFIX=Qt5
-    qt5_modules="Qt5Core Qt5Gui Qt5Network Qt5Widgets Qt5Svg"
+    qt5_modules="Qt5Core Qt5Gui Qt5Network Qt5Widgets Qt5Svg Qt5Concurrent"
     BITCOIN_QT_CHECK([
       PKG_CHECK_MODULES([QT5], [$qt5_modules], [QT_INCLUDES="$QT5_CFLAGS"; QT_LIBS="$QT5_LIBS" have_qt=yes],[have_qt=no])
 

--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -474,6 +474,7 @@ AC_DEFUN([_BITCOIN_QT_FIND_LIBS_WITHOUT_PKGCONFIG],[
   BITCOIN_QT_CHECK([AC_CHECK_HEADER([QLocalSocket],, BITCOIN_QT_FAIL(QtNetwork headers missing))])
   BITCOIN_QT_CHECK([AC_CHECK_HEADER([QtSvg],, BITCOIN_QT_FAIL(QtSvg headers missing))])
   BITCOIN_QT_CHECK([AC_CHECK_HEADER([QtCharts],, BITCOIN_QT_FAIL(QtCharts headers missing))])
+  BITCOIN_QT_CHECK([AC_CHECK_HEADER([QtConcurrent],, BITCOIN_QT_FAIL(QtConcurrent headers missing))])
 
   BITCOIN_QT_CHECK([
     if test "x$bitcoin_qt_want_version" = xauto; then
@@ -509,6 +510,7 @@ AC_DEFUN([_BITCOIN_QT_FIND_LIBS_WITHOUT_PKGCONFIG],[
   BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}Network],[main],,BITCOIN_QT_FAIL(lib${QT_LIB_PREFIX}Network not found)))
   BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}Widgets],[main],,BITCOIN_QT_FAIL(lib${QT_LIB_PREFIX}Widgets not found)))
   BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}Svg],[main],,BITCOIN_QT_FAIL(lib${QT_LIB_PREFIX}Svg not found)))
+  BITCOIN_QT_CHECK(AC_CHECK_LIB([${QT_LIB_PREFIX}Concurrent],[main],,BITCOIN_QT_FAIL(lib${QT_LIB_PREFIX}Concurrent not found)))
   QT_LIBS="$LIBS"
   LIBS="$TEMP_LIBS"
 

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -7,7 +7,7 @@ $(package)_sha256_hash=36dd9574f006eaa1e5af780e4b33d11fe39d09fd7c12f3b9d83294174
 $(package)_dependencies=openssl zlib
 $(package)_linux_dependencies=freetype fontconfig libxcb libX11 xproto libXext
 $(package)_build_subdir=qtbase
-$(package)_qt_libs=corelib network widgets gui plugins testlib
+$(package)_qt_libs=corelib network widgets gui plugins testlib concurrent
 $(package)_patches=fix_qt_pkgconfig.patch mac-qmake.conf fix_configure_mac.patch fix_no_printer.patch fix_rcc_determinism.patch fix_riscv64_arch.patch fix_s390x_powerpc_mips_mipsel_architectures.patch xkb-default.patch
 
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
@@ -84,6 +84,7 @@ $(package)_config_opts += -no-feature-lcdnumber
 $(package)_config_opts += -no-feature-pdf
 $(package)_config_opts += -no-feature-printer
 $(package)_config_opts += -no-feature-printdialog
+$(package)_config_opts += -feature-concurrent
 $(package)_config_opts += -no-feature-sql
 $(package)_config_opts += -no-feature-statemachine
 $(package)_config_opts += -no-feature-syntaxhighlighter

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -84,7 +84,6 @@ $(package)_config_opts += -no-feature-lcdnumber
 $(package)_config_opts += -no-feature-pdf
 $(package)_config_opts += -no-feature-printer
 $(package)_config_opts += -no-feature-printdialog
-$(package)_config_opts += -no-feature-concurrent
 $(package)_config_opts += -no-feature-sql
 $(package)_config_opts += -no-feature-statemachine
 $(package)_config_opts += -no-feature-syntaxhighlighter

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -358,7 +358,7 @@ void AskPassphraseDialog::run(int type){
         }
     }
 }
-void AskPassphraseDialog::onError(int type, QString error){
+void AskPassphraseDialog::onError(QString error, int type){
     newpassCache = "";
 }
 

--- a/src/qt/askpassphrasedialog.h
+++ b/src/qt/askpassphrasedialog.h
@@ -67,7 +67,7 @@ private:
     SecureString newpassCache = "";
 
     void run(int type) override;
-    void onError(int type, QString error) override;
+    void onError(QString error, int type) override;
     QCheckBox *btnWatch;
 
     void initWatch(QWidget *parent);

--- a/src/qt/pivx.cpp
+++ b/src/qt/pivx.cpp
@@ -376,10 +376,8 @@ void BitcoinApplication::createSplashScreen(const NetworkStyle* networkStyle)
 bool BitcoinApplication::createTutorialScreen()
 {
     WelcomeContentWidget* widget = new WelcomeContentWidget();
-    //widget->setOptionsModel(optionsModel);
 
     connect(widget, &WelcomeContentWidget::onLanguageSelected, [this](){
-        std::cout << "updating translations.." << std::endl;
         updateTranslation();
     });
 

--- a/src/qt/pivx/dashboardwidget.cpp
+++ b/src/qt/pivx/dashboardwidget.cpp
@@ -220,9 +220,13 @@ void DashboardWidget::loadWalletModel(){
 #ifdef USE_QTCHARTS
         // chart filter
         stakesFilter = new TransactionFilterProxy();
+        stakesFilter->setDynamicSortFilter(true);
+        stakesFilter->setSortCaseSensitivity(Qt::CaseInsensitive);
+        stakesFilter->setFilterCaseSensitivity(Qt::CaseInsensitive);
+        stakesFilter->setSortRole(Qt::EditRole);
+        stakesFilter->setOnlyStakes(true);
         stakesFilter->setSourceModel(txModel);
         stakesFilter->sort(TransactionTableModel::Date, Qt::AscendingOrder);
-        stakesFilter->setOnlyStakes(true);
         loadChart();
 #endif
     }

--- a/src/qt/pivx/dashboardwidget.cpp
+++ b/src/qt/pivx/dashboardwidget.cpp
@@ -762,7 +762,7 @@ void DashboardWidget::run(int type) {
     }
 #endif
 }
-void DashboardWidget::onError(int type, QString error) {
+void DashboardWidget::onError(QString error, int type) {
     inform(tr("Error loading chart: %1").arg(error));
 }
 

--- a/src/qt/pivx/dashboardwidget.cpp
+++ b/src/qt/pivx/dashboardwidget.cpp
@@ -157,6 +157,7 @@ DashboardWidget::DashboardWidget(PIVXGUI* parent) :
 bool hasCharts = false;
 #ifdef USE_QTCHARTS
     hasCharts = true;
+    isLoading = false;
     setChartShow(YEAR);
     connect(ui->pushButtonYear, &QPushButton::clicked, [this](){setChartShow(YEAR);});
     connect(ui->pushButtonMonth, &QPushButton::clicked, [this](){setChartShow(MONTH);});
@@ -372,11 +373,18 @@ void DashboardWidget::loadChart(){
 
 void DashboardWidget::showHideEmptyChart(bool showEmpty, bool loading, bool forceView) {
     if (stakesFilter->rowCount() > SHOW_EMPTY_CHART_VIEW_THRESHOLD || forceView) {
-        if (!ui->layoutChart->isVisible()) {
+        if (ui->emptyContainerChart->isVisible() != showEmpty) {
             ui->layoutChart->setVisible(!showEmpty);
             ui->emptyContainerChart->setVisible(showEmpty);
         }
     }
+    // Enable/Disable sort buttons
+    bool invLoading = !loading;
+    ui->comboBoxMonths->setEnabled(invLoading);
+    ui->comboBoxYears->setEnabled(invLoading);
+    ui->pushButtonMonth->setEnabled(invLoading);
+    ui->pushButtonAll->setEnabled(invLoading);
+    ui->pushButtonYear->setEnabled(invLoading);
     ui->labelEmptyChart->setText(loading ? tr("Loading chart..") : tr("You have no staking rewards"));
 }
 
@@ -434,8 +442,7 @@ void DashboardWidget::changeChartColors(){
     if (set1) set1->setBorderColor(gridLineColorX);
 }
 
-// pair PIV, zPIV
-QMap<int, std::pair<qint64, qint64>> DashboardWidget::getAmountBy() {
+void DashboardWidget::updateStakeFilter() {
     if (chartShow != ALL) {
         bool filterByMonth = false;
         if (monthFilter != 0 && chartShow == MONTH) {
@@ -468,6 +475,11 @@ QMap<int, std::pair<qint64, qint64>> DashboardWidget::getAmountBy() {
     } else {
         stakesFilter->clearDateRange();
     }
+}
+
+// pair PIV, zPIV
+QMap<int, std::pair<qint64, qint64>> DashboardWidget::getAmountBy() {
+    updateStakeFilter();
     int size = stakesFilter->rowCount();
     QMap<int, std::pair<qint64, qint64>> amountBy;
     // Get all of the stakes
@@ -576,6 +588,8 @@ void DashboardWidget::onChartMonthChanged(const QString& monthStr) {
 }
 
 bool DashboardWidget::refreshChart(){
+    if (isLoading) return false;
+    isLoading = true;
     isChartMin = width() < 1300;
     isChartInitialized = false;
     showHideEmptyChart(true, true);
@@ -678,6 +692,7 @@ void DashboardWidget::onChartRefreshed() {
     // back to normal
     isChartInitialized = true;
     showHideEmptyChart(false, false, true);
+    isLoading = false;
 }
 
 std::pair<int, int> DashboardWidget::getChartRange(QMap<int, std::pair<qint64, qint64>> amountsBy) {

--- a/src/qt/pivx/dashboardwidget.h
+++ b/src/qt/pivx/dashboardwidget.h
@@ -12,6 +12,7 @@
 #include "qt/pivx/txviewholder.h"
 #include "transactionfilterproxy.h"
 
+#include <atomic>
 #include <cstdlib>
 #include <QWidget>
 #include <QLineEdit>
@@ -143,6 +144,7 @@ private:
 #ifdef USE_QTCHARTS
 
     int64_t lastRefreshTime = 0;
+    std::atomic<bool> isLoading;
 
     // Chart
     TransactionFilterProxy* stakesFilter = nullptr;
@@ -169,6 +171,7 @@ private:
     void showHideEmptyChart(bool show, bool loading, bool forceView = false);
     bool refreshChart();
     void tryChartRefresh();
+    void updateStakeFilter();
     QMap<int, std::pair<qint64, qint64>> getAmountBy();
     void loadChartData(bool withMonthNames);
     void updateAxisX(const QStringList *arg = nullptr);

--- a/src/qt/pivx/dashboardwidget.h
+++ b/src/qt/pivx/dashboardwidget.h
@@ -102,7 +102,7 @@ public:
     void loadChart();
 
     void run(int type) override;
-    void onError(int type, QString error) override;
+    void onError(QString error, int type) override;
 
 public slots:
     void walletSynced(bool isSync);

--- a/src/qt/pivx/loadingdialog.cpp
+++ b/src/qt/pivx/loadingdialog.cpp
@@ -10,11 +10,12 @@ void Worker::process(){
     try {
         if (runnable)
             runnable->run(type);
-        emit finished();
     } catch (std::exception& e) {
-        std::cout << e.what() << std::endl;
-        emit error(QString::fromStdString(e.what()));
+        QString errorStr = QString::fromStdString(e.what());
+        runnable->onError(errorStr, type);
+        emit error(errorStr, type);
     }
+    emit finished();
 };
 
 LoadingDialog::LoadingDialog(QWidget *parent) :
@@ -45,7 +46,6 @@ void LoadingDialog::execute(Runnable *runnable, int type){
     QThread* thread = new QThread;
     Worker* worker = new Worker(runnable, type);
     worker->moveToThread(thread);
-    connect(worker, SIGNAL (error(QString)), this, SLOT (errorString(QString)));
     connect(thread, SIGNAL (started()), worker, SLOT (process()));
     connect(worker, SIGNAL (finished()), thread, SLOT (quit()));
     connect(worker, SIGNAL (finished()), worker, SLOT (deleteLater()));

--- a/src/qt/pivx/loadingdialog.h
+++ b/src/qt/pivx/loadingdialog.h
@@ -24,7 +24,7 @@ public slots:
     void process();
 signals:
     void finished();
-    void error(QString err);
+    void error(QString err, int type);
 
 private:
     Runnable* runnable;

--- a/src/qt/pivx/privacywidget.cpp
+++ b/src/qt/pivx/privacywidget.cpp
@@ -165,9 +165,13 @@ void PrivacyWidget::loadWalletModel(){
         txModel = walletModel->getTransactionTableModel();
         // Set up transaction list
         filter = new TransactionFilterProxy();
+        filter->setDynamicSortFilter(true);
+        filter->setSortCaseSensitivity(Qt::CaseInsensitive);
+        filter->setFilterCaseSensitivity(Qt::CaseInsensitive);
+        filter->setSortRole(Qt::EditRole);
+        filter->setShowZcTxes(true);
         filter->setSourceModel(txModel);
         filter->sort(TransactionTableModel::Date, Qt::DescendingOrder);
-        filter->setShowZcTxes(true);
         txHolder->setDisplayUnit(walletModel->getOptionsModel()->getDisplayUnit());
         txHolder->setFilter(filter);
         ui->listView->setModel(filter);

--- a/src/qt/pivx/prunnable.h
+++ b/src/qt/pivx/prunnable.h
@@ -8,7 +8,7 @@
 class Runnable {
 public:
     virtual void run(int type) = 0;
-    virtual void onError(int type, QString error) = 0;
+    virtual void onError(QString error, int type) = 0;
 };
 
 #endif //PIVX_CORE_NEW_GUI_PRUNNABLE_H

--- a/src/qt/pivx/pwidget.cpp
+++ b/src/qt/pivx/pwidget.cpp
@@ -79,7 +79,7 @@ public:
 
 bool PWidget::execute(int type){
     Worker* worker = new Worker(this, type);
-    connect(worker, SIGNAL (error(QString&)), this, SLOT (errorString(QString)));
+    connect(worker, SIGNAL (error(QString, int)), this, SLOT (errorString(QString, int)));
     connect(worker, SIGNAL (finished()), worker, SLOT (deleteLater()));
 
     WorkerTask* task = new WorkerTask(worker);
@@ -94,6 +94,10 @@ bool PWidget::verifyWalletUnlocked(){
         return false;
     }
     return true;
+}
+
+void PWidget::errorString(QString error, int type) {
+    onError(error, type);
 }
 
 ////////////////////////////////////////////////////////////////
@@ -116,6 +120,6 @@ void PWidget::changeTheme(bool isLightTheme, QString& theme){
 void PWidget::run(int type) {
     // override
 }
-void PWidget::onError(int type, QString error) {
+void PWidget::onError(QString error, int type) {
     // override
 }

--- a/src/qt/pivx/pwidget.h
+++ b/src/qt/pivx/pwidget.h
@@ -31,7 +31,7 @@ public:
     PIVXGUI* getWindow() { return this->window; }
 
     void run(int type) override;
-    void onError(int type, QString error) override;
+    void onError(QString error, int type) override;
 
 signals:
     void message(const QString& title, const QString& body, unsigned int style, bool* ret = nullptr);
@@ -62,6 +62,9 @@ protected:
 
 private:
     void init();
+private slots:
+    void errorString(QString, int);
+
 };
 
 #endif // PWIDGET_H

--- a/src/qt/pivx/res/css/style_dark.css
+++ b/src/qt/pivx/res/css/style_dark.css
@@ -1740,6 +1740,16 @@ QComboBox[cssClass="btn-combo-chart-selected"]:on {
     background-color: #B35c4b7d;
 }
 
+QComboBox[cssClass="btn-combo-chart-selected"]:disabled {
+    background-color:#20192e;
+    padding:6px 12px 6px 6px;
+    font-size:16px;
+    border:1px solid #5c4b7d;
+    color: #FFFFFF;
+    text-align: right;
+    border-radius:2px;
+}
+
 QComboBox::drop-down {
     border-width: 0px;
 }
@@ -1778,6 +1788,15 @@ QPushButton[cssClass="btn-check-time"]:pressed {
     font-size:14px;
     padding:4px;
     color: #b088ff;
+}
+
+QPushButton[cssClass="btn-check-time"]:disabled {
+    background-color:#20192e;
+    border-radius:2px;
+    font-size:14px;
+    padding:4px;
+    color: #FFFFFF;
+    border:1px solid #5c4b7d;
 }
 
 /*HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH

--- a/src/qt/pivx/res/css/style_light.css
+++ b/src/qt/pivx/res/css/style_light.css
@@ -1737,6 +1737,16 @@ QComboBox[cssClass="btn-combo-chart-selected"]:on {
     background-color: #5c4b7d;
 }
 
+QComboBox[cssClass="btn-combo-chart-selected"]:disabled {
+    background-color:#20192e;
+    padding:6px 12px 6px 6px;
+    font-size:16px;
+    border:1px solid #5c4b7d;
+    color: #FFFFFF;
+    text-align: right;
+    border-radius: 2px;
+}
+
 QComboBox::drop-down {
     border-width: 0px;
 }
@@ -1775,6 +1785,15 @@ QPushButton[cssClass="btn-check-time"]:pressed {
     font-size:14px;
     padding:4px;
     color: #b088ff;
+}
+
+QPushButton[cssClass="btn-check-time"]:disabled {
+    background-color:#20192e;
+    font-size:14px;
+    color: #FFFFFF;
+    padding:4px;
+    border:1px solid #5c4b7d;
+    border-radius: 2px;
 }
 
 /*HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -88,6 +88,17 @@ const CWalletTx* CWallet::GetWalletTx(const uint256& hash) const
     return &(it->second);
 }
 
+std::vector<const CWalletTx> CWallet::getWalletTxs()
+{
+    LOCK(cs_wallet);
+    std::vector<const CWalletTx> result;
+    result.reserve(mapWallet.size());
+    for (const auto& entry : mapWallet) {
+        result.emplace_back(entry.second);
+    }
+    return result;
+}
+
 CPubKey CWallet::GenerateNewKey()
 {
     AssertLockHeld(cs_wallet);                                 // mapKeyMetadata

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -88,10 +88,10 @@ const CWalletTx* CWallet::GetWalletTx(const uint256& hash) const
     return &(it->second);
 }
 
-std::vector<const CWalletTx> CWallet::getWalletTxs()
+std::vector<CWalletTx> CWallet::getWalletTxs()
 {
     LOCK(cs_wallet);
-    std::vector<const CWalletTx> result;
+    std::vector<CWalletTx> result;
     result.reserve(mapWallet.size());
     for (const auto& entry : mapWallet) {
         result.emplace_back(entry.second);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -412,6 +412,8 @@ public:
 
     const CWalletTx* GetWalletTx(const uint256& hash) const;
 
+    std::vector<const CWalletTx> getWalletTxs();
+
     void PrecomputeSpends();
 
     //! check whether we are allowed to upgrade (or already support) to the named feature

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -412,7 +412,7 @@ public:
 
     const CWalletTx* GetWalletTx(const uint256& hash) const;
 
-    std::vector<const CWalletTx> getWalletTxs();
+    std::vector<CWalletTx> getWalletTxs();
 
     void PrecomputeSpends();
 


### PR DESCRIPTION
Rationale

When the splash screen finishes loading and the wallet is big enough (wallet.dat with lot of transactions), the UI gets frozen for a large period of time processing data in the main thread.

To solve it, two improvements were done:

1)  Parallelization of the transactionTableModel initial loop (for-each loop over every wallet transaction to generate the TransactionRecord list that is used in the UI).

2) stakeFilter in dashboard widget and txFilter in the privacyWidget sort speed drastically improved, done after the editRole and filter type flag set to not do it over all of the transactions and not do it twice in any of the filter flag set list invalidation.


Test environment:

- Wallet with:
    - 4,400,00 tPIV (4.4kk).
    - 40,150 ztPIV (40k)
    -  104,000 transactions (104k). 

- Computer macbook pro i7 16gb ram.

Test results:

	Current master:
		- Startup time: 17:15 minutes.
		- UI frozen for 13 minutes after backend finish loading.

	PR:
		- Startup time:  1:59 minutes.
		- UI frozen for 30 seconds after backend finish loading.