### PR TITLE
[GUI] Refresh coin control upon reopening

### DIFF
--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -48,6 +48,7 @@ public:
 
     void setModel(WalletModel* model);
     void updateDialogLabels();
+    void updateView();
 
     // static because also called from sendcoinsdialog
     static void updateLabels(WalletModel*, QDialog*);
@@ -71,7 +72,6 @@ private:
     QAction* unlockAction;
 
     void sortView(int, Qt::SortOrder);
-    void updateView();
 
     enum {
         COLUMN_CHECKBOX,

--- a/src/qt/pivx/send.cpp
+++ b/src/qt/pivx/send.cpp
@@ -643,6 +643,8 @@ void SendWidget::onCoinControlClicked(){
             if (!coinControlDialog) {
                 coinControlDialog = new CoinControlDialog();
                 coinControlDialog->setModel(walletModel);
+            } else {
+                coinControlDialog->updateView();
             }
             coinControlDialog->exec();
             ui->btnCoinControl->setActive(CoinControlDialog::coinControl->HasSelected());


### PR DESCRIPTION
At the moment, after the coin control is opened for the first time, subsequent attempts to open coin control do not give an up-to-date view of available coins.

A toggle between 'List mode' and 'Tree mode' will result in the expected update but this should not be required. This pull request will resolve this issue by calling updateView upon every opening of coin control.

**Note:** #1011 is a closed pull request for the same issue, whereby I was having difficult squashing old commits from another, yet to be merged, pull request - I had used master branch for the changes for that PR.