### PR TITLE
[GUI][Trivial] Remove hardcoded address.

### DIFF
--- a/src/qt/pivx/forms/addnewaddressdialog.ui
+++ b/src/qt/pivx/forms/addnewaddressdialog.ui
@@ -113,7 +113,7 @@
         <item>
          <widget class="QLabel" name="labelAddress">
           <property name="text">
-           <string>D7VFR83SQbiezrW72hjcWJtcfip5krte2Z </string>
+           <string>Address</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
The `addnewaddressdialog.ui` has a hardcoded address used to draft the UI forms, even when it's cleaned in the view object initialization, it's better to remove it.