### PR TITLE
[Build] Use in-tree intermediary endian header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,11 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     endif()
     list(APPEND CMAKE_PREFIX_PATH /usr/lib/x86_64-linux-gnu/cmake/Qt5)
     set(Qt5core_DIR "/usr/lib/x86_64-linux-gnu/cmake/Qt5/QtCore")
-    add_definitions("-D__BYTE_ORDER -D__LITTLE_ENDIAN -D__GLIBC__ -DHAVE_DECL_BSWAP_16=0 -DHAVE_DECL_BSWAP_32=0 -DHAVE_DECL_BSWAP_64=0")
+    find_path(ENDIAN_INCLUDES endian.h)
+    if(ENDIAN_INCLUDES)
+        message(STATUS "Found endian.h: ${ENDIAN_INCLUDES}")
+    endif()
+    #add_definitions("-D__BYTE_ORDER -D__LITTLE_ENDIAN -D__GLIBC__ -DHAVE_DECL_BSWAP_16=0 -DHAVE_DECL_BSWAP_32=0 -DHAVE_DECL_BSWAP_64=0")
 endif()
 
 # Find Dependencies
@@ -108,7 +112,6 @@ ExternalProject_Add (
         )
 
 set(libleveldb_a_headers
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/config/pivx-config.h
         ${CMAKE_CURRENT_SOURCE_DIR}/src/leveldb/port/atomic_pointer.h
         ${CMAKE_CURRENT_SOURCE_DIR}/src/leveldb/port/port_example.h
         ${CMAKE_CURRENT_SOURCE_DIR}/src/leveldb/port/port_posix.h
@@ -223,11 +226,10 @@ endif()
 
 add_library(leveldb STATIC ${libleveldb_a_headers} ${libleveldb_a_sources})
 target_compile_definitions(leveldb PUBLIC ${libleveldb_cpp_flags} -DLEVELDB_ATOMIC_PRESENT -D__STDC_LIMIT_MACROS)
-target_include_directories(leveldb PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src/leveldb
+target_include_directories(leveldb PUBLIC ${ENDIAN_INCLUDES}
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/leveldb
         ${CMAKE_CURRENT_SOURCE_DIR}/src/leveldb/include
         ${CMAKE_CURRENT_SOURCE_DIR}/src/leveldb/helpers/memenv
-        ${CMAKE_CURRENT_SOURCE_DIR}/src
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/compat
         )
 
 set(libmemenv_a_sources
@@ -368,6 +370,7 @@ set(BITCOIN_CRYPTO_SOURCES
         ./src/crypto/sha1.cpp
         ./src/crypto/sha256.cpp
         ./src/crypto/sha512.cpp
+        ./src/crypto/chacha20.cpp
         ./src/crypto/hmac_sha256.cpp
         ./src/crypto/rfc6979_hmac_sha256.cpp
         ./src/crypto/hmac_sha512.cpp
@@ -383,6 +386,7 @@ set(BITCOIN_CRYPTO_SOURCES
         ./src/crypto/common.h
         ./src/crypto/sha256.h
         ./src/crypto/sha512.h
+        ./src/crypto/chacha20.h
         ./src/crypto/hmac_sha256.h
         ./src/crypto/rfc6979_hmac_sha256.h
         ./src/crypto/hmac_sha512.h

--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -1,127 +1,93 @@
-// Copyright (c) 2014 The Bitcoin developers
+// Copyright (c) 2014-2018 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef BITCOIN_CRYPTO_COMMON_H
 #define BITCOIN_CRYPTO_COMMON_H
 
-#include <stdint.h>
-
-#if defined(HAVE_ENDIAN_H)
-#include <endian.h>
+#if defined(HAVE_CONFIG_H)
+#include <config/pivx-config.h>
 #endif
+
+#include <stdint.h>
+#include <string.h>
+
+#include <compat/endian.h>
+
+uint16_t static inline ReadLE16(const unsigned char* ptr)
+{
+    uint16_t x;
+    memcpy((char*)&x, ptr, 2);
+    return le16toh(x);
+}
 
 uint32_t static inline ReadLE32(const unsigned char* ptr)
 {
-#if HAVE_DECL_LE32TOH == 1
-    return le32toh(*((uint32_t*)ptr));
-#elif !defined(WORDS_BIGENDIAN)
-    return *((uint32_t*)ptr);
-#else
-    return ((uint32_t)ptr[3] << 24 | (uint32_t)ptr[2] << 16 | (uint32_t)ptr[1] << 8 | (uint32_t)ptr[0]);
-#endif
+    uint32_t x;
+    memcpy((char*)&x, ptr, 4);
+    return le32toh(x);
 }
 
 uint64_t static inline ReadLE64(const unsigned char* ptr)
 {
-#if HAVE_DECL_LE64TOH == 1
-    return le64toh(*((uint64_t*)ptr));
-#elif !defined(WORDS_BIGENDIAN)
-    return *((uint64_t*)ptr);
-#else
-    return ((uint64_t)ptr[7] << 56 | (uint64_t)ptr[6] << 48 | (uint64_t)ptr[5] << 40 | (uint64_t)ptr[4] << 32 |
-            (uint64_t)ptr[3] << 24 | (uint64_t)ptr[2] << 16 | (uint64_t)ptr[1] << 8 | (uint64_t)ptr[0]);
-#endif
+    uint64_t x;
+    memcpy((char*)&x, ptr, 8);
+    return le64toh(x);
+}
+
+void static inline WriteLE16(unsigned char* ptr, uint16_t x)
+{
+    uint16_t v = htole16(x);
+    memcpy(ptr, (char*)&v, 2);
 }
 
 void static inline WriteLE32(unsigned char* ptr, uint32_t x)
 {
-#if HAVE_DECL_HTOLE32 == 1
-    *((uint32_t*)ptr) = htole32(x);
-#elif !defined(WORDS_BIGENDIAN)
-    *((uint32_t*)ptr) = x;
-#else
-    ptr[3] = x >> 24;
-    ptr[2] = x >> 16;
-    ptr[1] = x >> 8;
-    ptr[0] = x;
-#endif
+    uint32_t v = htole32(x);
+    memcpy(ptr, (char*)&v, 4);
 }
 
 void static inline WriteLE64(unsigned char* ptr, uint64_t x)
 {
-#if HAVE_DECL_HTOLE64 == 1
-    *((uint64_t*)ptr) = htole64(x);
-#elif !defined(WORDS_BIGENDIAN)
-    *((uint64_t*)ptr) = x;
-#else
-    ptr[7] = x >> 56;
-    ptr[6] = x >> 48;
-    ptr[5] = x >> 40;
-    ptr[4] = x >> 32;
-    ptr[3] = x >> 24;
-    ptr[2] = x >> 16;
-    ptr[1] = x >> 8;
-    ptr[0] = x;
-#endif
+    uint64_t v = htole64(x);
+    memcpy(ptr, (char*)&v, 8);
 }
 
 uint32_t static inline ReadBE32(const unsigned char* ptr)
 {
-#if HAVE_DECL_BE32TOH == 1
-    return be32toh(*((uint32_t*)ptr));
-#else
-    return ((uint32_t)ptr[0] << 24 | (uint32_t)ptr[1] << 16 | (uint32_t)ptr[2] << 8 | (uint32_t)ptr[3]);
-#endif
+    uint32_t x;
+    memcpy((char*)&x, ptr, 4);
+    return be32toh(x);
 }
 
 uint64_t static inline ReadBE64(const unsigned char* ptr)
 {
-#if HAVE_DECL_BE64TOH == 1
-    return be64toh(*((uint64_t*)ptr));
-#else
-    return ((uint64_t)ptr[0] << 56 | (uint64_t)ptr[1] << 48 | (uint64_t)ptr[2] << 40 | (uint64_t)ptr[3] << 32 |
-            (uint64_t)ptr[4] << 24 | (uint64_t)ptr[5] << 16 | (uint64_t)ptr[6] << 8 | (uint64_t)ptr[7]);
-#endif
+    uint64_t x;
+    memcpy((char*)&x, ptr, 8);
+    return be64toh(x);
 }
 
 void static inline WriteBE32(unsigned char* ptr, uint32_t x)
 {
-#if HAVE_DECL_HTOBE32 == 1
-    *((uint32_t*)ptr) = htobe32(x);
-#else
-    ptr[0] = x >> 24;
-    ptr[1] = x >> 16;
-    ptr[2] = x >> 8;
-    ptr[3] = x;
-#endif
+    uint32_t v = htobe32(x);
+    memcpy(ptr, (char*)&v, 4);
 }
 
 void static inline WriteBE64(unsigned char* ptr, uint64_t x)
 {
-#if HAVE_DECL_HTOBE64 == 1
-    *((uint64_t*)ptr) = htobe64(x);
-#else
-    ptr[0] = x >> 56;
-    ptr[1] = x >> 48;
-    ptr[2] = x >> 40;
-    ptr[3] = x >> 32;
-    ptr[4] = x >> 24;
-    ptr[5] = x >> 16;
-    ptr[6] = x >> 8;
-    ptr[7] = x;
-#endif
+    uint64_t v = htobe64(x);
+    memcpy(ptr, (char*)&v, 8);
 }
 
 /** Return the smallest number n such that (x >> n) == 0 (or 64 if the highest bit in x is set. */
 uint64_t static inline CountBits(uint64_t x)
 {
-#ifdef HAVE_DECL___BUILTIN_CLZL
+#if HAVE_DECL___BUILTIN_CLZL
     if (sizeof(unsigned long) >= sizeof(uint64_t)) {
         return x ? 8 * sizeof(unsigned long) - __builtin_clzl(x) : 0;
     }
 #endif
-#ifdef HAVE_DECL___BUILTIN_CLZLL
+#if HAVE_DECL___BUILTIN_CLZLL
     if (sizeof(unsigned long long) >= sizeof(uint64_t)) {
         return x ? 8 * sizeof(unsigned long long) - __builtin_clzll(x) : 0;
     }

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -8,10 +8,6 @@ set(CMAKE_AUTOUIC ON)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-    execute_process(
-            COMMAND sed -i /HAVE_DECL_BSWAP/d pivx-config.h
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/config
-    )
 endif ()
 
 find_package(Qrcode)
@@ -220,6 +216,7 @@ QT5_ADD_RESOURCES(QRC_LOCALE_RESOURCE pivx_locale.qrc)
 
 add_executable(pivx-qt pivx.cpp ${QM} ${QRC_RESOURCE} ${QRC_LOCALE_RESOURCE})
 add_dependencies(pivx-qt translations_target libunivalue libsecp256k1 leveldb leveldb_sse42 memenv)
+target_include_directories(pivx-qt PUBLIC ${ENDIAN_INCLUDES})
 target_link_libraries(pivx-qt
         qt_stuff
         univalue


### PR DESCRIPTION
instead of using the ambiguous `endian.h` header include in `crypto/common.h`, specify our in-tree intermediary header. At the same time, make use of `config/pivx-config.h` and fixup the CMake builds on linux that previously used forced defines.