### PR TITLE
[Consensus] Block version 7: remove accumulators checkpoint

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -238,7 +238,7 @@ public:
         nTime = block.nTime;
         nBits = block.nBits;
         nNonce = block.nNonce;
-        if(block.nVersion > 3)
+        if(block.nVersion > 3 && block.nVersion < 7)
             nAccumulatorCheckpoint = block.nAccumulatorCheckpoint;
 
         if (block.IsProofOfStake()) {

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -218,6 +218,8 @@ public:
         // New P2P messages signatures
         nBlockEnforceNewMessageSignatures = nBlockTimeProtocolV2;
 
+        nBlockV7StartHeight = 2967000;
+
         // Fake Serial Attack
         nFakeSerialBlockheightEnd = 1686229;
         nSupplyBeforeFakeSerial = 4131563 * COIN;   // zerocoin supply at block nFakeSerialBlockheightEnd
@@ -359,6 +361,8 @@ public:
         // New P2P messages signatures
         nBlockEnforceNewMessageSignatures = nBlockTimeProtocolV2;
 
+        nBlockV7StartHeight = 2214000;
+
         // Fake Serial Attack
         nFakeSerialBlockheightEnd = -1;
         nSupplyBeforeFakeSerial = 0;
@@ -455,6 +459,7 @@ public:
 
         // Public coin spend enforcement
         nPublicZCSpends = 350;
+        nBlockV7StartHeight = nPublicZCSpends + 1;
 
         // New P2P messages signatures
         nBlockEnforceNewMessageSignatures = 1;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -218,6 +218,8 @@ public:
         // New P2P messages signatures
         nBlockEnforceNewMessageSignatures = nBlockTimeProtocolV2;
 
+        // Blocks v7
+        nBlockLastAccumulatorCheckpoint = 1686240;
         nBlockV7StartHeight = 2967000;
 
         // Fake Serial Attack
@@ -361,6 +363,8 @@ public:
         // New P2P messages signatures
         nBlockEnforceNewMessageSignatures = nBlockTimeProtocolV2;
 
+        // Blocks v7
+        nBlockLastAccumulatorCheckpoint = nPublicZCSpends - 10;
         nBlockV7StartHeight = 2214000;
 
         // Fake Serial Attack
@@ -459,7 +463,10 @@ public:
 
         // Public coin spend enforcement
         nPublicZCSpends = 350;
+
+        // Blocks v7
         nBlockV7StartHeight = nPublicZCSpends + 1;
+        nBlockLastAccumulatorCheckpoint = nPublicZCSpends - 10;
 
         // New P2P messages signatures
         nBlockEnforceNewMessageSignatures = 1;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -161,6 +161,7 @@ public:
     CAmount InvalidAmountFiltered() const { return nInvalidAmountFiltered; };
 
     int Zerocoin_Block_Public_Spend_Enabled() const { return nPublicZCSpends; }
+    int Zerocoin_Block_Last_Checkpoint() const { return nBlockLastAccumulatorCheckpoint; }
 
 protected:
     CChainParams() {}
@@ -245,6 +246,7 @@ protected:
     int nBlockTimeProtocolV2;
     int nBlockEnforceNewMessageSignatures;
     int nBlockV7StartHeight;
+    int nBlockLastAccumulatorCheckpoint;
 
     CAmount nMinColdStakingAmount;
 

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -151,6 +151,7 @@ public:
     bool IsStakeModifierV2(const int nHeight) const { return nHeight >= nBlockStakeModifierlV2; }
     int NewSigsActive(const int nHeight) const { return nHeight >= nBlockEnforceNewMessageSignatures; }
     int BIP65ActivationHeight() const { return nBIP65ActivationHeight; }
+    int Block_V7_StartHeight() const { return nBlockV7StartHeight; }
 
     // fake serial attack
     int Zerocoin_Block_EndFakeSerial() const { return nFakeSerialBlockheightEnd; }
@@ -243,6 +244,7 @@ protected:
     int nBlockStakeModifierlV2;
     int nBlockTimeProtocolV2;
     int nBlockEnforceNewMessageSignatures;
+    int nBlockV7StartHeight;
 
     CAmount nMinColdStakingAmount;
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1567,7 +1567,7 @@ bool AppInit2()
                 if (GetBoolArg("-reindexaccumulators", false)) {
                     if (chainHeight > Params().Zerocoin_Block_V2_Start()) {
                         CBlockIndex *pindex = chainActive[Params().Zerocoin_Block_V2_Start()];
-                        while (pindex->nHeight < std::min(chainActive.Height(), Params().Zerocoin_Block_Last_Checkpoint()+1)) {
+                        while (pindex && pindex->nHeight < std::min(chainActive.Height(), Params().Zerocoin_Block_Last_Checkpoint()+1)) {
                             if (!count(listAccCheckpointsNoDB.begin(), listAccCheckpointsNoDB.end(),
                                        pindex->nAccumulatorCheckpoint))
                                 listAccCheckpointsNoDB.emplace_back(pindex->nAccumulatorCheckpoint);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1567,7 +1567,7 @@ bool AppInit2()
                 if (GetBoolArg("-reindexaccumulators", false)) {
                     if (chainHeight > Params().Zerocoin_Block_V2_Start()) {
                         CBlockIndex *pindex = chainActive[Params().Zerocoin_Block_V2_Start()];
-                        while (pindex->nHeight < chainActive.Height()) {
+                        while (pindex->nHeight < std::min(chainActive.Height(), Params().Zerocoin_Block_Last_Checkpoint()+1)) {
                             if (!count(listAccCheckpointsNoDB.begin(), listAccCheckpointsNoDB.end(),
                                        pindex->nAccumulatorCheckpoint))
                                 listAccCheckpointsNoDB.emplace_back(pindex->nAccumulatorCheckpoint);

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -440,8 +440,9 @@ bool ContextualCheckZerocoinStake(int nPreviousBlockHeight, CStakeInput* stake)
         if (depth < Params().Zerocoin_RequiredStakeDepth())
             return error("%s : zPIV stake does not have required confirmation depth. Current height %d,  stakeInput height %d.", __func__, nPreviousBlockHeight, pindexFrom->nHeight);
 
-        //The checksum needs to be the exact checksum from 200 blocks ago
-        uint256 nCheckpoint200 = chainActive[nPreviousBlockHeight - Params().Zerocoin_RequiredStakeDepth()]->nAccumulatorCheckpoint;
+        //The checksum needs to be the exact checksum from 200 blocks ago or latest checksum
+        const int checkpointHeight = std::min(Params().Zerocoin_Block_Last_Checkpoint(), (nPreviousBlockHeight - Params().Zerocoin_RequiredStakeDepth()));
+        uint256 nCheckpoint200 = chainActive[checkpointHeight]->nAccumulatorCheckpoint;
         uint32_t nChecksum200 = ParseChecksum(nCheckpoint200, libzerocoin::AmountToZerocoinDenomination(zPIV->GetValue()));
         if (nChecksum200 != zPIV->GetChecksum())
             return error("%s : accumulator checksum is different than the block 200 blocks previous. stake=%d block200=%d", __func__, zPIV->GetChecksum(), nChecksum200);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2793,7 +2793,7 @@ bool DisconnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex
     // move best block pointer to prevout block
     view.SetBestBlock(pindex->pprev->GetBlockHash());
 
-    if (!fVerifyingBlocks) {
+    if (!fVerifyingBlocks && pindex->nHeight <= Params().Zerocoin_Block_Last_Checkpoint()) {
         //if block is an accumulator checkpoint block, remove checkpoint and checksums from db
         uint256 nCheckpoint = pindex->nAccumulatorCheckpoint;
         if(nCheckpoint != pindex->pprev->nAccumulatorCheckpoint) {
@@ -3038,7 +3038,7 @@ bool ReindexAccumulators(std::list<uint256>& listMissingCheckpoints, std::string
 
         // find each checkpoint that is missing
         CBlockIndex* pindex = chainActive[nZerocoinStart];
-        while (pindex) {
+        while (pindex->nHeight <= Params().Zerocoin_Block_Last_Checkpoint()) {
             uiInterface.ShowProgress(_("Calculating missing accumulators..."), std::max(1, std::min(99, (int)((double)(pindex->nHeight - nZerocoinStart) / (double)(chainActive.Height() - nZerocoinStart) * 100))));
 
             if (ShutdownRequested())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3038,7 +3038,7 @@ bool ReindexAccumulators(std::list<uint256>& listMissingCheckpoints, std::string
 
         // find each checkpoint that is missing
         CBlockIndex* pindex = chainActive[nZerocoinStart];
-        while (pindex->nHeight <= Params().Zerocoin_Block_Last_Checkpoint()) {
+        while (pindex && pindex->nHeight <= Params().Zerocoin_Block_Last_Checkpoint()) {
             uiInterface.ShowProgress(_("Calculating missing accumulators..."), std::max(1, std::min(99, (int)((double)(pindex->nHeight - nZerocoinStart) / (double)(chainActive.Height() - nZerocoinStart) * 100))));
 
             if (ShutdownRequested())

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -129,8 +129,8 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, 
 
     const int nHeight = pindexPrev->nHeight + 1;
 
-    // Make sure to create the correct block version after zerocoin is enabled
-    if(nHeight >= Params().Block_V7_StartHeight()) {
+    // Make sure to create the correct block version
+    if (nHeight >= Params().Block_V7_StartHeight()) {
         pblock->nVersion = 7;       //!> Removes accumulator checkpoints
     } else {
         pblock->nVersion = 6;       //!> Supports V2 Stake Modifiers.

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -130,15 +130,15 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, 
     const int nHeight = pindexPrev->nHeight + 1;
 
     // Make sure to create the correct block version after zerocoin is enabled
-    bool fZerocoinActive = nHeight >= Params().Zerocoin_StartHeight();
-    if(Params().IsStakeModifierV2(nHeight)) {
-        pblock->nVersion = 6;       //!> Supports V2 Stake Modifiers.
+    if(nHeight >= Params().Block_V7_StartHeight()) {
+        pblock->nVersion = 7;       //!> Removes accumulator checkpoints
     } else {
-        pblock->nVersion = 5;       //!> Supports CLTV activation
+        pblock->nVersion = 6;       //!> Supports V2 Stake Modifiers.
     }
 
     // -regtest only: allow overriding block.nVersion with
     // -blockversion=N to test forking scenarios
+    bool fZerocoinActive = nHeight >= Params().Zerocoin_StartHeight();
     if (Params().MineBlocksOnDemand()) {
         if (fZerocoinActive)
             pblock->nVersion = 5;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -501,29 +501,31 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, 
         pblock->nNonce = 0;
 
         //Calculate the accumulator checkpoint only if the previous cached checkpoint need to be updated
-        if (fZerocoinActive) {
-            uint256 nCheckpoint;
-            uint256 hashBlockLastAccumulated = chainActive[nHeight - (nHeight % 10) - 10]->GetBlockHash();
-            if (nHeight >= pCheckpointCache.first || pCheckpointCache.second.first != hashBlockLastAccumulated) {
-                //For the period before v2 activation, zPIV will be disabled and previous block's checkpoint is all that will be needed
-                pCheckpointCache.second.second = pindexPrev->nAccumulatorCheckpoint;
-                if (pindexPrev->nHeight + 1 >= Params().Zerocoin_Block_V2_Start()) {
-                    AccumulatorMap mapAccumulators(Params().Zerocoin_Params(false));
-                    if (fZerocoinActive && !CalculateAccumulatorCheckpoint(nHeight, nCheckpoint, mapAccumulators)) {
-                        LogPrintf("%s: failed to get accumulator checkpoint\n", __func__);
-                    } else {
-                        // the next time the accumulator checkpoint should be recalculated ( the next height that is multiple of 10)
-                        pCheckpointCache.first = nHeight + (10 - (nHeight % 10));
+        if (pblock->nVersion < 7) {
+            if (fZerocoinActive) {
+                uint256 nCheckpoint;
+                uint256 hashBlockLastAccumulated = chainActive[nHeight - (nHeight % 10) - 10]->GetBlockHash();
+                if (nHeight >= pCheckpointCache.first || pCheckpointCache.second.first != hashBlockLastAccumulated) {
+                    //For the period before v2 activation, zPIV will be disabled and previous block's checkpoint is all that will be needed
+                    pCheckpointCache.second.second = pindexPrev->nAccumulatorCheckpoint;
+                    if (pindexPrev->nHeight + 1 >= Params().Zerocoin_Block_V2_Start()) {
+                        AccumulatorMap mapAccumulators(Params().Zerocoin_Params(false));
+                        if (fZerocoinActive && !CalculateAccumulatorCheckpoint(nHeight, nCheckpoint, mapAccumulators)) {
+                            LogPrintf("%s: failed to get accumulator checkpoint\n", __func__);
+                        } else {
+                            // the next time the accumulator checkpoint should be recalculated ( the next height that is multiple of 10)
+                            pCheckpointCache.first = nHeight + (10 - (nHeight % 10));
 
-                        // the block hash of the last block used in the accumulator checkpoint calc. This will handle reorg situations.
-                        pCheckpointCache.second.first = hashBlockLastAccumulated;
-                        pCheckpointCache.second.second = nCheckpoint;
+                            // the block hash of the last block used in the accumulator checkpoint calc. This will handle reorg situations.
+                            pCheckpointCache.second.first = hashBlockLastAccumulated;
+                            pCheckpointCache.second.second = nCheckpoint;
+                        }
                     }
                 }
             }
-        }
 
-        pblock->nAccumulatorCheckpoint = pCheckpointCache.second.second;
+            pblock->nAccumulatorCheckpoint = pCheckpointCache.second.second;
+        }
         pblocktemplate->vTxSigOps[0] = GetLegacySigOpCount(pblock->vtx[0]);
 
         if (fProofOfStake) {

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -15,10 +15,13 @@
 
 uint256 CBlockHeader::GetHash() const
 {
-    if(nVersion < 4)
+    if (nVersion < 4)
         return HashQuark(BEGIN(nVersion), END(nNonce));
 
-    return Hash(BEGIN(nVersion), END(nAccumulatorCheckpoint));
+    if (nVersion < 7)
+        return Hash(BEGIN(nVersion), END(nAccumulatorCheckpoint));
+
+    return Hash(BEGIN(nVersion), END(nNonce));
 }
 
 std::string CBlock::ToString() const

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -27,14 +27,14 @@ class CBlockHeader
 {
 public:
     // header
-    static const int32_t CURRENT_VERSION=6;     //!> Version 6 supports V2 Stake Modifiers
+    static const int32_t CURRENT_VERSION=7;     //!> Version 7 removes nAccumulatorCheckpoint from serialization
     int32_t nVersion;
     uint256 hashPrevBlock;
     uint256 hashMerkleRoot;
     uint32_t nTime;
     uint32_t nBits;
     uint32_t nNonce;
-    uint256 nAccumulatorCheckpoint;
+    uint256 nAccumulatorCheckpoint;             // only for version 4, 5 and 6.
 
     CBlockHeader()
     {
@@ -54,7 +54,7 @@ public:
         READWRITE(nNonce);
 
         //zerocoin active, header changes to include accumulator checksum
-        if(nVersion > 3)
+        if(nVersion > 3 && nVersion < 7)
             READWRITE(nAccumulatorCheckpoint);
     }
 

--- a/src/stakeinput.cpp
+++ b/src/stakeinput.cpp
@@ -87,7 +87,7 @@ bool CZPivStake::GetModifier(uint64_t& nStakeModifier)
     int64_t nTimeBlockFrom = pindex->GetBlockTime();
     // zPIV staking is disabled long before block v7 (and checkpoint is not included in blocks since v7)
     // just return false for now. !TODO: refactor/remove this method
-    while (pindex->nHeight + 1 <= std::min(chainActive.Height(), Params().Zerocoin_Block_Last_Checkpoint()-1)) {
+    while (pindex && pindex->nHeight + 1 <= std::min(chainActive.Height(), Params().Zerocoin_Block_Last_Checkpoint()-1)) {
         if (pindex->GetBlockTime() - nTimeBlockFrom > 60 * 60) {
             nStakeModifier = pindex->nAccumulatorCheckpoint.Get64();
             return true;

--- a/src/stakeinput.cpp
+++ b/src/stakeinput.cpp
@@ -21,6 +21,7 @@ CZPivStake::CZPivStake(const libzerocoin::CoinSpend& spend)
 int CZPivStake::GetChecksumHeightFromMint()
 {
     int nHeightChecksum = chainActive.Height() - Params().Zerocoin_RequiredStakeDepth();
+    nHeightChecksum = std::min(nHeightChecksum, Params().Zerocoin_Block_Last_Checkpoint());
 
     //Need to return the first occurance of this checksum in order for the validation process to identify a specific
     //block height
@@ -84,17 +85,18 @@ bool CZPivStake::GetModifier(uint64_t& nStakeModifier)
     }
 
     int64_t nTimeBlockFrom = pindex->GetBlockTime();
-    while (true) {
+    // zPIV staking is disabled long before block v7 (and checkpoint is not included in blocks since v7)
+    // just return false for now. !TODO: refactor/remove this method
+    while (pindex->nHeight + 1 <= std::min(chainActive.Height(), Params().Zerocoin_Block_Last_Checkpoint()-1)) {
         if (pindex->GetBlockTime() - nTimeBlockFrom > 60 * 60) {
             nStakeModifier = pindex->nAccumulatorCheckpoint.Get64();
             return true;
         }
 
-        if (pindex->nHeight + 1 <= chainActive.Height())
-            pindex = chainActive.Next(pindex);
-        else
-            return false;
+        pindex = chainActive.Next(pindex);
     }
+
+    return false;
 }
 
 CDataStream CZPivStake::GetUniqueness()

--- a/src/zpiv/accumulators.cpp
+++ b/src/zpiv/accumulators.cpp
@@ -45,7 +45,7 @@ int GetChecksumHeight(uint32_t nChecksum, libzerocoin::CoinDenomination denomina
         return 0;
 
     //Search through blocks to find the checksum
-    while (pindex->nHeight <= Params().Zerocoin_Block_Last_Checkpoint()) {
+    while (pindex && pindex->nHeight <= Params().Zerocoin_Block_Last_Checkpoint()) {
         if (ParseChecksum(pindex->nAccumulatorCheckpoint, denomination) == nChecksum)
             return pindex->nHeight;
 
@@ -276,7 +276,7 @@ bool CalculateAccumulatorCheckpoint(int nHeight, uint256& nCheckpoint, Accumulat
     int nTotalMintsFound = 0;
     CBlockIndex *pindex = chainActive[nHeightCheckpoint - 20];
 
-    while (pindex->nHeight < nHeight - 10) {
+    while (pindex && pindex->nHeight < nHeight - 10) {
         // checking whether we should stop this process due to a shutdown request
         if (ShutdownRequested())
             return false;
@@ -362,7 +362,7 @@ int ComputeAccumulatedCoins(int nHeightEnd, libzerocoin::CoinDenomination denom)
 {
     CBlockIndex* pindex = chainActive[GetZerocoinStartHeight()];
     int n = 0;
-    while (pindex->nHeight < nHeightEnd) {
+    while (pindex && pindex->nHeight < nHeightEnd) {
         n += count(pindex->vMintDenominationsInBlock.begin(), pindex->vMintDenominationsInBlock.end(), denom);
         pindex = chainActive.Next(pindex);
     }

--- a/src/zpiv/accumulators.cpp
+++ b/src/zpiv/accumulators.cpp
@@ -45,7 +45,7 @@ int GetChecksumHeight(uint32_t nChecksum, libzerocoin::CoinDenomination denomina
         return 0;
 
     //Search through blocks to find the checksum
-    while (pindex) {
+    while (pindex->nHeight <= Params().Zerocoin_Block_Last_Checkpoint()) {
         if (ParseChecksum(pindex->nAccumulatorCheckpoint, denomination) == nChecksum)
             return pindex->nHeight;
 
@@ -158,10 +158,11 @@ bool LoadAccumulatorValuesFromDB(const uint256 nCheckpoint)
 //Erase accumulator checkpoints for a certain block range
 bool EraseCheckpoints(int nStartHeight, int nEndHeight)
 {
-    if (chainActive.Height() < nStartHeight)
+    const int maxHeight = std::min(Params().Zerocoin_Block_Last_Checkpoint(), chainActive.Height());
+    if (maxHeight < nStartHeight)
         return false;
 
-    nEndHeight = std::min(chainActive.Height(), nEndHeight);
+    nEndHeight = std::min(maxHeight, nEndHeight);
 
     CBlockIndex* pindex = chainActive[nStartHeight];
     uint256 nCheckpointPrev = pindex->pprev->nAccumulatorCheckpoint;
@@ -196,6 +197,9 @@ bool InitializeAccumulators(const int nHeight, int& nHeightCheckpoint, Accumulat
 {
     if (nHeight < Params().Zerocoin_StartHeight())
         return error("%s: height is below zerocoin activated", __func__);
+
+    if (nHeight > Params().Zerocoin_Block_Last_Checkpoint())
+        return error("%s: height is above last accumulator checkpoint", __func__);
 
     //On a specific block, a recalculation of the accumulators will be forced
     if (nHeight == Params().Zerocoin_Block_RecalculateAccumulators() && Params().NetworkID() != CBaseChainParams::REGTEST) {
@@ -245,6 +249,11 @@ bool CalculateAccumulatorCheckpoint(int nHeight, uint256& nCheckpoint, Accumulat
 {
     if (nHeight < Params().Zerocoin_Block_V2_Start()) {
         nCheckpoint = 0;
+        return true;
+    }
+
+    if (nHeight > Params().Zerocoin_Block_Last_Checkpoint()) {
+        nCheckpoint = chainActive[Params().Zerocoin_Block_Last_Checkpoint()]->nAccumulatorCheckpoint;
         return true;
     }
 
@@ -319,6 +328,10 @@ bool ValidateAccumulatorCheckpoint(const CBlock& block, CBlockIndex* pindex, Acc
     //It is VERY IMPORTANT that when this is being run and height < v2_start, then zPIV need to be disabled at the same time!!
     if (pindex->nHeight < Params().Zerocoin_Block_V2_Start() || fVerifyingBlocks)
         return true;
+
+    if (pindex->nHeight > Params().Zerocoin_Block_Last_Checkpoint()) {
+        return true;
+    }
 
     if (pindex->nHeight % 10 == 0) {
         uint256 nCheckpointCalculated = 0;
@@ -437,6 +450,11 @@ bool GetAccumulatorValue(int& nHeight, const libzerocoin::CoinDenomination denom
     if (nHeight > chainActive.Height())
         return error("%s: height %d is more than active chain height", __func__, nHeight);
 
+    if (nHeight > Params().Zerocoin_Block_Last_Checkpoint()) {
+        nHeight = Params().Zerocoin_Block_Last_Checkpoint();
+        return GetAccumulatorValue(nHeight, denom, bnAccValue);
+    }
+
     //Every situation except for about 20 blocks should use this method
     uint256 nCheckpointBeforeMint = chainActive[nHeight]->nAccumulatorCheckpoint;
     if (nHeight > Params().Zerocoin_Block_V2_Start() + 20) {
@@ -529,6 +547,9 @@ void AccumulateRange(CoinWitnessData* coinWitness, int nHeightEnd)
 
 bool GenerateAccumulatorWitness(CoinWitnessData* coinWitness, AccumulatorMap& mapAccumulators, CBlockIndex* pindexCheckpoint)
 {
+    int nChainHeight = chainActive.Height();
+    if (nChainHeight > Params().Zerocoin_Block_Last_Checkpoint())
+        return error("%s : trying to generate accumulator witness after block v7 start", __func__);
     try {
         // Lock
         LogPrint("zero", "%s: generating\n", __func__);
@@ -555,7 +576,6 @@ bool GenerateAccumulatorWitness(CoinWitnessData* coinWitness, AccumulatorMap& ma
         }
 
         //add the pubcoins from the blockchain up to the next checksum starting from the block
-        int nChainHeight = chainActive.Height();
         int nHeightMax = nChainHeight % 10;
         nHeightMax = nChainHeight - nHeightMax - 20; // at least two checkpoints deep
 
@@ -612,6 +632,7 @@ bool calculateAccumulatedBlocksFor(
         std::list<CBigNum>& ret,
         std::string& strError
 ){
+    nHeightStop = std::min(nHeightStop, Params().Zerocoin_Block_Last_Checkpoint() - 10);
     bool fDoubleCounted = false;
     int nMintsAdded = 0;
     while (pindex) {
@@ -668,6 +689,7 @@ bool calculateAccumulatedBlocksFor(
         std::string& strError
 ){
 
+    nHeightStop = std::min(nHeightStop, Params().Zerocoin_Block_Last_Checkpoint() - 10);
     int amountOfScannedBlocks = 0;
     bool fDoubleCounted = false;
     int nMintsAdded = 0;


### PR DESCRIPTION
Since the disabling of zerocoin mints, the accumulator values never change anymore.
Last updated checkpoint was at mainnet block 1686240.
Removing the accumulator checkpoints from block headers saves 256 bits per block (both on chain and on the in-memory indexes).

This PR removes the need for CBlockIndex::nAccumulatorCheckpoint (past 1686240) and enforces block version 7 via hard-fork (after `nBlockV7StartHeight` currently set at a placeholder value).

Further changes to CBlockIndex (in order to don't store empty uint256) will be addressed in a subsequent PR.