### PR TITLE
[Consensus] New signatures for network messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,6 +341,7 @@ set(WALLET_SOURCES
         ./src/masternode-sync.cpp
         ./src/masternodeconfig.cpp
         ./src/masternodeman.cpp
+        ./src/messagesigner.cpp
         ./src/zpiv/mintpool.cpp
         ./src/wallet/rpcdump.cpp
         ./src/zpiv/deterministicmint.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -129,6 +129,7 @@ BITCOIN_CORE_H = \
   masternodeman.h \
   masternodeconfig.h \
   merkleblock.h \
+  messagesigner.h \
   miner.h \
   mruset.h \
   netbase.h \
@@ -269,6 +270,7 @@ libbitcoin_wallet_a_SOURCES = \
   masternode-sync.cpp \
   masternodeconfig.cpp \
   masternodeman.cpp \
+  messagesigner.cpp \
   wallet/rpcdump.cpp \
   wallet/rpcwallet.cpp \
   kernel.cpp \

--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -169,7 +169,7 @@ bool CActiveMasternode::SendMasternodePing(std::string& errorMessage)
 
     LogPrintf("CActiveMasternode::SendMasternodePing() - Relay Masternode Ping vin = %s\n", vin.ToString());
 
-    bool fNewSigs = true;
+    bool fNewSigs = false;
     {
         LOCK(cs_main);
         fNewSigs = chainActive.NewSigsActive();
@@ -284,7 +284,7 @@ bool CActiveMasternode::CreateBroadcast(CTxIn vin, CService service, CKey keyCol
     // wait for reindex and/or import to finish
     if (fImporting || fReindex) return false;
 
-    bool fNewSigs = true;
+    bool fNewSigs = false;
     {
         LOCK(cs_main);
         fNewSigs = chainActive.NewSigsActive();

--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -8,6 +8,7 @@
 #include "masternode.h"
 #include "masternodeconfig.h"
 #include "masternodeman.h"
+#include "messagesigner.h"
 #include "protocol.h"
 #include "spork.h"
 
@@ -100,9 +101,8 @@ void CActiveMasternode::ManageStatus()
             CPubKey pubKeyMasternode;
             CKey keyMasternode;
 
-            if (!obfuScationSigner.SetKey(strMasterNodePrivKey, errorMessage, keyMasternode, pubKeyMasternode)) {
-                notCapableReason = "Error upon calling SetKey: " + errorMessage;
-                LogPrintf("Register::ManageStatus() - %s\n", notCapableReason);
+            if (!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, keyMasternode, pubKeyMasternode)) {
+                LogPrintf("%s : Invalid masternode key", __func__);
                 return;
             }
 
@@ -162,8 +162,8 @@ bool CActiveMasternode::SendMasternodePing(std::string& errorMessage)
     CPubKey pubKeyMasternode;
     CKey keyMasternode;
 
-    if (!obfuScationSigner.SetKey(strMasterNodePrivKey, errorMessage, keyMasternode, pubKeyMasternode)) {
-        errorMessage = strprintf("Error upon calling SetKey: %s\n", errorMessage);
+    if (!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, keyMasternode, pubKeyMasternode)) {
+        errorMessage = "Error upon calling SetKey.\n";
         return false;
     }
 
@@ -206,12 +206,12 @@ bool CActiveMasternode::SendMasternodePing(std::string& errorMessage)
 
         std::string strMessage = service.ToString() + std::to_string(masterNodeSignatureTime) + std::to_string(false);
 
-        if (!obfuScationSigner.SignMessage(strMessage, retErrorMessage, vchMasterNodeSignature, keyMasternode)) {
-            errorMessage = "dseep sign message failed: " + retErrorMessage;
+        if (!CMessageSigner::SignMessage(strMessage, vchMasterNodeSignature, keyMasternode)) {
+            errorMessage = "dseep sign message failed.";
             return false;
         }
 
-        if (!obfuScationSigner.VerifyMessage(pubKeyMasternode, vchMasterNodeSignature, strMessage, retErrorMessage)) {
+        if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchMasterNodeSignature, strMessage, retErrorMessage)) {
             errorMessage = "dseep verify message failed: " + retErrorMessage;
             return false;
         }
@@ -250,8 +250,8 @@ bool CActiveMasternode::CreateBroadcast(std::string strService, std::string strK
         return false;
     }
 
-    if (!obfuScationSigner.SetKey(strKeyMasternode, errorMessage, keyMasternode, pubKeyMasternode)) {
-        errorMessage = strprintf("Can't find keys for masternode %s - %s", strService, errorMessage);
+    if (!CMessageSigner::GetKeysFromSecret(strKeyMasternode, keyMasternode, pubKeyMasternode)) {
+        errorMessage = strprintf("Can't find keys for masternode %s", strService);
         LogPrintf("CActiveMasternode::CreateBroadcast() - %s\n", errorMessage);
         return false;
     }
@@ -313,13 +313,13 @@ bool CActiveMasternode::CreateBroadcast(CTxIn vin, CService service, CKey keyCol
 
     std::string strMessage = service.ToString() + std::to_string(masterNodeSignatureTime) + vchPubKey + vchPubKey2 + std::to_string(PROTOCOL_VERSION) + donationAddress + std::to_string(donationPercantage);
 
-    if (!obfuScationSigner.SignMessage(strMessage, retErrorMessage, vchMasterNodeSignature, keyCollateralAddress)) {
-        errorMessage = "dsee sign message failed: " + retErrorMessage;
+    if (!CMessageSigner::SignMessage(strMessage, vchMasterNodeSignature, keyCollateralAddress)) {
+        errorMessage = "dsee sign message failed.";
         LogPrintf("CActiveMasternode::Register() - Error: %s\n", errorMessage.c_str());
         return false;
     }
 
-    if (!obfuScationSigner.VerifyMessage(pubKeyCollateralAddress, vchMasterNodeSignature, strMessage, retErrorMessage)) {
+    if (!CMessageSigner::VerifyMessage(pubKeyCollateralAddress, vchMasterNodeSignature, strMessage, retErrorMessage)) {
         errorMessage = "dsee verify message failed: " + retErrorMessage;
         LogPrintf("CActiveMasternode::Register() - Error: %s\n", errorMessage.c_str());
         return false;

--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -169,8 +169,14 @@ bool CActiveMasternode::SendMasternodePing(std::string& errorMessage)
 
     LogPrintf("CActiveMasternode::SendMasternodePing() - Relay Masternode Ping vin = %s\n", vin.ToString());
 
+    bool fNewSigs = true;
+    {
+        LOCK(cs_main);
+        fNewSigs = chainActive.NewSigsActive();
+    }
+
     CMasternodePing mnp(vin);
-    if (!mnp.Sign(keyMasternode, pubKeyMasternode)) {
+    if (!mnp.Sign(keyMasternode, pubKeyMasternode, fNewSigs)) {
         errorMessage = "Couldn't sign Masternode Ping";
         return false;
     }
@@ -278,8 +284,14 @@ bool CActiveMasternode::CreateBroadcast(CTxIn vin, CService service, CKey keyCol
     // wait for reindex and/or import to finish
     if (fImporting || fReindex) return false;
 
+    bool fNewSigs = true;
+    {
+        LOCK(cs_main);
+        fNewSigs = chainActive.NewSigsActive();
+    }
+
     CMasternodePing mnp(vin);
-    if (!mnp.Sign(keyMasternode, pubKeyMasternode)) {
+    if (!mnp.Sign(keyMasternode, pubKeyMasternode, fNewSigs)) {
         errorMessage = strprintf("Failed to sign ping, vin: %s", vin.ToString());
         LogPrintf("CActiveMasternode::CreateBroadcast() -  %s\n", errorMessage);
         mnb = CMasternodeBroadcast();
@@ -288,7 +300,7 @@ bool CActiveMasternode::CreateBroadcast(CTxIn vin, CService service, CKey keyCol
 
     mnb = CMasternodeBroadcast(service, vin, pubKeyCollateralAddress, pubKeyMasternode, PROTOCOL_VERSION);
     mnb.lastPing = mnp;
-    if (!mnb.Sign(keyCollateralAddress)) {
+    if (!mnb.Sign(keyCollateralAddress, pubKeyCollateralAddress, fNewSigs)) {
         errorMessage = strprintf("Failed to sign broadcast, vin: %s", vin.ToString());
         LogPrintf("CActiveMasternode::CreateBroadcast() - %s\n", errorMessage);
         mnb = CMasternodeBroadcast();

--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -163,7 +163,7 @@ bool CActiveMasternode::SendMasternodePing(std::string& errorMessage)
     CKey keyMasternode;
 
     if (!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, keyMasternode, pubKeyMasternode)) {
-        errorMessage = "Error upon calling SetKey.\n";
+        errorMessage = "Error upon calling GetKeysFromSecret.\n";
         return false;
     }
 

--- a/src/chain.h
+++ b/src/chain.h
@@ -599,6 +599,9 @@ public:
 
     /** Find the last common block between this chain and a block index entry. */
     const CBlockIndex* FindFork(const CBlockIndex* pindex) const;
+
+    /** Check if new message signatures are active **/
+    bool NewSigsActive() { return Params().NewSigsActive(Height()); }
 };
 
 #endif // BITCOIN_CHAIN_H

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -183,6 +183,9 @@ public:
         // Public coin spend enforcement
         nPublicZCSpends = 1880000;
 
+        // New P2P messages signatures
+        nBlockEnforceNewMessageSignatures = 2967000;
+
         // Fake Serial Attack
         nFakeSerialBlockheightEnd = 1686229;
         nSupplyBeforeFakeSerial = 4131563 * COIN;   // zerocoin supply at block nFakeSerialBlockheightEnd
@@ -318,6 +321,9 @@ public:
         // Public coin spend enforcement
         nPublicZCSpends = 1106100;
 
+        // New P2P messages signatures
+        nBlockEnforceNewMessageSignatures = 2214000;
+
         // Fake Serial Attack
         nFakeSerialBlockheightEnd = -1;
         nSupplyBeforeFakeSerial = 0;
@@ -410,6 +416,9 @@ public:
         nBlockStakeModifierlV2 = std::numeric_limits<int>::max(); // max integer value (never switch on regtest)
         // Public coin spend enforcement
         nPublicZCSpends = 350;
+
+        // New P2P messages signatures
+        nBlockEnforceNewMessageSignatures = 1;
 
         // Fake Serial Attack
         nFakeSerialBlockheightEnd = -1;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -140,6 +140,7 @@ public:
     int Block_Enforce_Invalid() const { return nBlockEnforceInvalidUTXO; }
     int Zerocoin_Block_V2_Start() const { return nBlockZerocoinV2; }
     bool IsStakeModifierV2(const int nHeight) const { return nHeight >= nBlockStakeModifierlV2; }
+    int NewSigsActive(const int nHeight) const { return nHeight >= nBlockEnforceNewMessageSignatures; }
 
     // fake serial attack
     int Zerocoin_Block_EndFakeSerial() const { return nFakeSerialBlockheightEnd; }
@@ -223,6 +224,7 @@ protected:
     int nBlockDoubleAccumulated;
     int nPublicZCSpends;
     int nBlockStakeModifierlV2;
+    int nBlockEnforceNewMessageSignatures;
 
     // fake serial attack
     int nFakeSerialBlockheightEnd = 0;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -26,6 +26,7 @@
 #include "masternode-payments.h"
 #include "masternodeconfig.h"
 #include "masternodeman.h"
+#include "messagesigner.h"
 #include "miner.h"
 #include "net.h"
 #include "rpc/server.h"
@@ -1897,7 +1898,7 @@ bool AppInit2()
             CKey key;
             CPubKey pubkey;
 
-            if (!obfuScationSigner.SetKey(strMasterNodePrivKey, errorMessage, key, pubkey)) {
+            if (!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, key, pubkey)) {
                 return InitError(_("Invalid masternodeprivkey. Please see documenation."));
             }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@
 #include "masternode-payments.h"
 #include "masternodeman.h"
 #include "merkleblock.h"
+#include "messagesigner.h"
 #include "net.h"
 #include "obfuscation.h"
 #include "pow.h"
@@ -6577,10 +6578,8 @@ bool static ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vR
                 std::string strMessage = tx.GetHash().ToString() + std::to_string(sigTime);
 
                 std::string errorMessage = "";
-                if (!obfuScationSigner.VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, errorMessage)) {
-                    LogPrintf("dstx: Got bad masternode address signature %s \n", vin.ToString());
-                    //pfrom->Misbehaving(20);
-                    return false;
+                if (!CMessageSigner::VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, errorMessage)) {
+                    return error("dstx: Got bad masternode address signature %s, error: %s", vin.ToString(), errorMessage);
                 }
 
                 LogPrintf("dstx: Got Masternode transaction %s\n", tx.GetHash().ToString());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1341,21 +1341,23 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
 
     //Temporarily disable zerocoin for maintenance
     if (sporkManager.IsSporkActive(SPORK_16_ZEROCOIN_MAINTENANCE_MODE) && tx.ContainsZerocoins())
-        return state.DoS(10, error("AcceptToMemoryPool : Zerocoin transactions are temporarily disabled for maintenance"), REJECT_INVALID, "bad-tx");
+        return state.DoS(10, error("%s : Zerocoin transactions are temporarily disabled for maintenance",
+                __func__), REJECT_INVALID, "bad-tx");
 
     int chainHeight = chainActive.Height();
     if (!CheckTransaction(tx, chainHeight >= Params().Zerocoin_StartHeight(), true, state, isBlockBetweenFakeSerialAttackRange(chainHeight)))
-        return state.DoS(100, error("AcceptToMemoryPool: : CheckTransaction failed"), REJECT_INVALID, "bad-tx");
+        return state.DoS(100, error("%s : CheckTransaction failed",
+                __func__), REJECT_INVALID, "bad-tx");
 
     // Coinbase is only valid in a block, not as a loose transaction
     if (tx.IsCoinBase())
-        return state.DoS(100, error("AcceptToMemoryPool: : coinbase as individual tx"),
-            REJECT_INVALID, "coinbase");
+        return state.DoS(100, error("%s : coinbase as individual tx",
+                __func__), REJECT_INVALID, "coinbase");
 
     //Coinstake is also only valid in a block, not as a loose transaction
     if (tx.IsCoinStake())
-        return state.DoS(100, error("AcceptToMemoryPool: coinstake as individual tx. txid=%s", tx.GetHash().GetHex()),
-            REJECT_INVALID, "coinstake");
+        return state.DoS(100, error("%s : coinstake as individual tx (id=%s): %s",
+                __func__, tx.GetHash().GetHex(), tx.ToString()), REJECT_INVALID, "coinstake");
 
     // Only accept nLockTime-using transactions that can be mined in the next
     // block; we don't want our mempool filled up with transactions that can't
@@ -1366,9 +1368,8 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
     // Rather not work on nonstandard transactions (unless -testnet/-regtest)
     std::string reason;
     if (Params().RequireStandard() && !IsStandardTx(tx, reason))
-        return state.DoS(0,
-            error("AcceptToMemoryPool : nonstandard transaction: %s", reason),
-            REJECT_NONSTANDARD, reason);
+        return state.DoS(0, error("%s : nonstandard transaction: %s",
+                    __func__, reason), REJECT_NONSTANDARD, reason);
     // is it already in the memory pool?
     uint256 hash = tx.GetHash();
     if (pool.exists(hash)) {
@@ -1382,8 +1383,8 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
         if (mapLockedInputs.count(in.prevout)) {
             if (mapLockedInputs[in.prevout] != tx.GetHash()) {
                 return state.DoS(0,
-                    error("AcceptToMemoryPool : conflicts with existing transaction lock: %s", reason),
-                    REJECT_INVALID, "tx-lock-conflict");
+                    error("%s : conflicts with existing transaction lock: %s",
+                            __func__, reason), REJECT_INVALID, "tx-lock-conflict");
             }
         }
     }
@@ -1412,8 +1413,8 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
             //Check that txid is not already in the chain
             int nHeightTx = 0;
             if (IsTransactionInChain(tx.GetHash(), nHeightTx))
-                return state.Invalid(error("AcceptToMemoryPool : zPIV spend tx %s already in block %d",
-                                           tx.GetHash().GetHex(), nHeightTx), REJECT_DUPLICATE, "bad-txns-inputs-spent");
+                return state.Invalid(error("%s : zPIV spend tx %s already in block %d",
+                        __func__, tx.GetHash().GetHex(), nHeightTx), REJECT_DUPLICATE, "bad-txns-inputs-spent");
 
             //Check for double spending of serial #'s
             for (const CTxIn& txIn : tx.vin) {
@@ -1421,14 +1422,14 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
                 bool isPublicSpend = txIn.IsZerocoinPublicSpend();
                 bool isPrivZerocoinSpend = txIn.IsZerocoinSpend();
                 if (!isPrivZerocoinSpend && !isPublicSpend) {
-                    return state.Invalid(error("%s: AcceptToMemoryPool failed for tx %s, every input must be a zcspend or zcpublicspend", __func__,
-                                        tx.GetHash().GetHex()), REJECT_INVALID, "bad-txns-invalid-zpiv");
+                    return state.Invalid(error("%s: failed for tx %s, every input must be a zcspend or zcpublicspend",
+                            __func__, tx.GetHash().GetHex()), REJECT_INVALID, "bad-txns-invalid-zpiv");
                 }
 
                 // Check enforcement
                 if (!CheckPublicCoinSpendEnforced(chainActive.Height(), isPublicSpend)){
-                    return state.Invalid(error("%s: AcceptToMemoryPool failed for tx %s", __func__,
-                                               tx.GetHash().GetHex()), REJECT_INVALID, "bad-txns-invalid-zpiv");
+                    return state.Invalid(error("%s: CheckPublicCoinSpendEnforced failed for tx %s",
+                            __func__, tx.GetHash().GetHex()), REJECT_INVALID, "bad-txns-invalid-zpiv");
                 }
 
                 if (isPublicSpend) {
@@ -1438,13 +1439,13 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
                         return false;
                     }
                     if (!ContextualCheckZerocoinSpend(tx, &publicSpend, chainActive.Tip(), 0))
-                        return state.Invalid(error("%s: ContextualCheckZerocoinSpend failed for tx %s", __func__,
-                                                   tx.GetHash().GetHex()), REJECT_INVALID, "bad-txns-invalid-zpiv");
+                        return state.Invalid(error("%s: ContextualCheckZerocoinSpend failed for tx %s",
+                                __func__, tx.GetHash().GetHex()), REJECT_INVALID, "bad-txns-invalid-zpiv");
                 } else {
                     libzerocoin::CoinSpend spend = TxInToZerocoinSpend(txIn);
                     if (!ContextualCheckZerocoinSpend(tx, &spend, chainActive.Tip(), 0))
-                        return state.Invalid(error("%s: ContextualCheckZerocoinSpend failed for tx %s", __func__,
-                                                   tx.GetHash().GetHex()), REJECT_INVALID, "bad-txns-invalid-zpiv");
+                        return state.Invalid(error("%s: ContextualCheckZerocoinSpend failed for tx %s",
+                                __func__, tx.GetHash().GetHex()), REJECT_INVALID, "bad-txns-invalid-zpiv");
                 }
 
             }
@@ -1469,8 +1470,8 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
 
                 //Check for invalid/fraudulent inputs
                 if (!ValidOutPoint(txin.prevout, chainActive.Height())) {
-                    return state.Invalid(error("%s : tried to spend invalid input %s in tx %s", __func__, txin.prevout.ToString(),
-                                                tx.GetHash().GetHex()), REJECT_INVALID, "bad-txns-invalid-inputs");
+                    return state.Invalid(error("%s : tried to spend invalid input %s in tx %s",
+                            __func__, txin.prevout.ToString(), tx.GetHash().GetHex()), REJECT_INVALID, "bad-txns-invalid-inputs");
                 }
             }
 
@@ -1481,7 +1482,8 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
 
                 libzerocoin::PublicCoin coin(Params().Zerocoin_Params(false));
                 if (!TxOutToPublicCoin(out, coin, state))
-                    return state.Invalid(error("%s: failed final check of zerocoinmint for tx %s", __func__, tx.GetHash().GetHex()));
+                    return state.Invalid(error("%s: failed final check of zerocoinmint for tx %s",
+                            __func__, tx.GetHash().GetHex()));
 
                 if (!ContextualCheckZerocoinMint(tx, coin, chainActive.Tip()))
                     return state.Invalid(error("%s: zerocoin mint failed contextual check", __func__));
@@ -1489,8 +1491,8 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
 
             // are the actual inputs available?
             if (!view.HaveInputs(tx))
-                return state.Invalid(error("AcceptToMemoryPool : inputs already spent"),
-                                     REJECT_DUPLICATE, "bad-txns-inputs-spent");
+                return state.Invalid(error("%s : inputs already spent",
+                        __func__), REJECT_DUPLICATE, "bad-txns-inputs-spent");
 
             // Bring the best block into scope
             view.GetBestBlock();
@@ -1503,7 +1505,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
 
         // Check for non-standard pay-to-script-hash in inputs
         if (Params().RequireStandard() && !AreInputsStandard(tx, view))
-            return error("AcceptToMemoryPool: : nonstandard transaction input");
+            return error("%s : nonstandard transaction input", __func__);
 
         // Check that the transaction doesn't have an excessive number of
         // sigops, making it impossible to mine. Since the coinbase transaction
@@ -1515,10 +1517,8 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
             unsigned int nMaxSigOps = MAX_TX_SIGOPS_CURRENT;
             nSigOps += GetP2SHSigOpCount(tx, view);
             if(nSigOps > nMaxSigOps)
-                return state.DoS(0,
-                                 error("AcceptToMemoryPool : too many sigops %s, %d > %d",
-                                       hash.ToString(), nSigOps, nMaxSigOps),
-                                 REJECT_NONSTANDARD, "bad-txns-too-many-sigops");
+                return state.DoS(0, error("%s : too many sigops %s, %d > %d",
+                        __func__, hash.ToString(), nSigOps, nMaxSigOps), REJECT_NONSTANDARD, "bad-txns-too-many-sigops");
         }
 
         CAmount nValueOut = tx.GetValueOut();
@@ -1537,9 +1537,8 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
         } else if (!ignoreFees) {
             CAmount txMinFee = GetMinRelayFee(tx, nSize, true);
             if (fLimitFree && nFees < txMinFee && !tx.HasZerocoinSpendInputs())
-                return state.DoS(0, error("AcceptToMemoryPool : not enough fees %s, %d < %d",
-                                        hash.ToString(), nFees, txMinFee),
-                    REJECT_INSUFFICIENTFEE, "insufficient fee");
+                return state.DoS(0, error("%s : not enough fees %s, %d < %d",
+                        __func__, hash.ToString(), nFees, txMinFee), REJECT_INSUFFICIENTFEE, "insufficient fee");
 
             // Require that free transactions have sufficient priority to be mined in the next block.
             if (tx.HasZerocoinMintOutputs()) {
@@ -1566,27 +1565,24 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
                 // -limitfreerelay unit is thousand-bytes-per-minute
                 // At default rate it would take over a month to fill 1GB
                 if (dFreeCount >= GetArg("-limitfreerelay", 30) * 10 * 1000)
-                    return state.DoS(0, error("AcceptToMemoryPool : free transaction rejected by rate limiter"),
-                        REJECT_INSUFFICIENTFEE, "rate limited free transaction");
+                    return state.DoS(0, error("%s : free transaction rejected by rate limiter",
+                            __func__), REJECT_INSUFFICIENTFEE, "rate limited free transaction");
                 LogPrint("mempool", "Rate limit dFreeCount: %g => %g\n", dFreeCount, dFreeCount + nSize);
                 dFreeCount += nSize;
             }
         }
 
         if (fRejectInsaneFee && nFees > ::minRelayTxFee.GetFee(nSize) * 10000)
-            return error("AcceptToMemoryPool: : insane fees %s, %d > %d",
-                hash.ToString(),
-                nFees, ::minRelayTxFee.GetFee(nSize) * 10000);
+            return error("%s : insane fees %s, %d > %d",
+                    __func__, hash.ToString(), nFees, ::minRelayTxFee.GetFee(nSize) * 10000);
 
         // As zero fee transactions are not going to be accepted in the near future (4.0) and the code will be fully refactored soon.
         // This is just a quick inline towards that goal, the mempool by default will not accept them. Blocking
         // any subsequent network relay.
         if ((Params().NetworkID() != CBaseChainParams::REGTEST) &&
             nFees == 0 && !tx.HasZerocoinSpendInputs()) {
-            return error("%s: zero fees not accepted %s, %d > %d",
-                         __func__,
-                         hash.ToString(),
-                         nFees, ::minRelayTxFee.GetFee(nSize) * 10000);
+            return error("%s : zero fees not accepted %s, %d > %d",
+                    __func__, hash.ToString(), nFees, ::minRelayTxFee.GetFee(nSize) * 10000);
         }
 
         bool fCLTVHasMajority = CBlockIndex::IsSuperMajority(5, chainActive.Tip(), Params().EnforceBlockUpgradeMajority());
@@ -1597,7 +1593,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
         if (fCLTVHasMajority)
             flags |= SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
         if (!CheckInputs(tx, state, view, true, flags, true)) {
-            return error("AcceptToMemoryPool: : ConnectInputs failed %s", hash.ToString());
+            return error("%s : ConnectInputs failed %s", __func__, hash.ToString());
         }
 
         // Check again against just the consensus-critical mandatory script
@@ -1613,7 +1609,8 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
         if (fCLTVHasMajority)
             flags |= SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
         if (!CheckInputs(tx, state, view, true, flags, true)) {
-            return error("AcceptToMemoryPool: : BUG! PLEASE REPORT THIS! ConnectInputs failed against MANDATORY but not STANDARD flags %s", hash.ToString());
+            return error("%s : BUG! PLEASE REPORT THIS! ConnectInputs failed against MANDATORY but not STANDARD flags %s",
+                    __func__, hash.ToString());
         }
 
         // Store transaction in memory

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -1797,16 +1797,6 @@ std::string CBudgetVote::GetStrMessage() const
             std::to_string(nVote) + std::to_string(nTime);
 }
 
-const CPubKey* CBudgetVote::GetPublicKey(std::string& strErrorRet) const
-{
-    CMasternode* pmn = mnodeman.Find(vin);
-    if(pmn) {
-        return &(pmn->pubKeyMasternode);
-    }
-    strErrorRet = strprintf("Unable to find masternode vin %s", vin.prevout.hash.GetHex());
-    return nullptr;
-}
-
 CFinalizedBudget::CFinalizedBudget() :
         fAutoChecked(false),
         fValid(true),
@@ -2295,16 +2285,6 @@ uint256 CFinalizedBudgetVote::GetHash() const
 std::string CFinalizedBudgetVote::GetStrMessage() const
 {
     return vin.prevout.ToStringShort() + nBudgetHash.ToString() + std::to_string(nTime);
-}
-
-const CPubKey* CFinalizedBudgetVote::GetPublicKey(std::string& strErrorRet) const
-{
-    CMasternode* pmn = mnodeman.Find(vin);
-    if(pmn) {
-        return &(pmn->pubKeyMasternode);
-    }
-    strErrorRet = strprintf("Unable to find masternode vin %s", vin.prevout.hash.GetHex());
-    return nullptr;
 }
 
 std::string CBudgetManager::ToString() const

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -1756,22 +1756,22 @@ void CBudgetProposalBroadcast::Relay()
 }
 
 CBudgetVote::CBudgetVote() :
+        vchSig(),
         fValid(true),
         fSynced(false),
         vin(),
         nProposalHash(0),
         nVote(VOTE_ABSTAIN),
-        nTime(0),
-        vchSig()
+        nTime(0)
 { }
 
 CBudgetVote::CBudgetVote(CTxIn vinIn, uint256 nProposalHashIn, int nVoteIn) :
+        vchSig(),
         fValid(true),
         fSynced(false),
         vin(vinIn),
         nProposalHash(nProposalHashIn),
-        nVote(nVoteIn),
-        vchSig()
+        nVote(nVoteIn)
 {
     nTime = GetAdjustedTime();
 }
@@ -2282,17 +2282,18 @@ void CFinalizedBudget::SubmitVote()
     }
 }
 
-CFinalizedBudgetBroadcast::CFinalizedBudgetBroadcast()
+CFinalizedBudgetBroadcast::CFinalizedBudgetBroadcast() :
+        vchSig()
 {
     strBudgetName = "";
     nBlockStart = 0;
     vecBudgetPayments.clear();
     mapVotes.clear();
-    vchSig.clear();
     nFeeTXHash = 0;
 }
 
-CFinalizedBudgetBroadcast::CFinalizedBudgetBroadcast(const CFinalizedBudget& other)
+CFinalizedBudgetBroadcast::CFinalizedBudgetBroadcast(const CFinalizedBudget& other) :
+        vchSig()
 {
     strBudgetName = other.strBudgetName;
     nBlockStart = other.nBlockStart;
@@ -2319,20 +2320,20 @@ void CFinalizedBudgetBroadcast::Relay()
 }
 
 CFinalizedBudgetVote::CFinalizedBudgetVote() :
+        vchSig(),
         fValid(true),
         fSynced(false),
         vin(),
         nBudgetHash(0),
-        nTime(0),
-        vchSig()
+        nTime(0)
 { }
 
 CFinalizedBudgetVote::CFinalizedBudgetVote(CTxIn vinIn, uint256 nBudgetHashIn) :
+        vchSig(),
         fValid(true),
         fSynced(false),
         vin(vinIn),
-        nBudgetHash(nBudgetHashIn),
-        vchSig()
+        nBudgetHash(nBudgetHashIn)
 {
     nTime = GetAdjustedTime();
 }

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -1823,11 +1823,11 @@ bool CBudgetVote::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
         std::string strMessage = GetStrMessage();
 
         if (!CMessageSigner::SignMessage(strMessage, vchSig, keyMasternode)) {
-            return error("%s - SignMessage() failed", __func__);
+            return error("%s : SignMessage() failed", __func__);
         }
 
         if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
-            return error("%s - VerifyMessage() failed, error: %s\n", __func__, strError);
+            return error("%s : VerifyMessage() failed, error: %s\n", __func__, strError);
         }
     }
 
@@ -1854,7 +1854,7 @@ bool CBudgetVote::CheckSignature(bool fSignatureCheck) const
     std::string strMessage = GetStrMessage();
 
     if (!CMessageSigner::VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, strError)) {
-        return error("%s - Got bad masternode signature for %s: %s\n", __func__,
+        return error("%s : Got bad masternode signature for %s: %s\n", __func__,
                 vin.prevout.hash.ToString(), strError);
     }
 
@@ -2382,11 +2382,11 @@ bool CFinalizedBudgetVote::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
         std::string strMessage = GetStrMessage();
 
         if (!CMessageSigner::SignMessage(strMessage, vchSig, keyMasternode)) {
-            return error("%s - SignMessage() failed", __func__);
+            return error("%s : SignMessage() failed", __func__);
         }
 
         if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
-            return error("%s - VerifyMessage() failed, error: %s\n", __func__, strError);
+            return error("%s : VerifyMessage() failed, error: %s\n", __func__, strError);
         }
     }
 
@@ -2413,7 +2413,7 @@ bool CFinalizedBudgetVote::CheckSignature(bool fSignatureCheck) const
     std::string strMessage = GetStrMessage();
 
     if (!CMessageSigner::VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, strError)) {
-        return error("%s - Got bad masternode signature for %s: %s\n", __func__,
+        return error("%s : Got bad masternode signature for %s: %s\n", __func__,
                 vin.prevout.hash.ToString(), strError);
     }
 

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -1781,22 +1781,53 @@ void CBudgetVote::Relay()
     RelayInv(inv);
 }
 
+uint256 CBudgetVote::GetHash() const
+{
+    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+    ss << vin;
+    ss << nProposalHash;
+    ss << nVote;
+    ss << nTime;
+    return ss.GetHash();
+}
+
+std::string CBudgetVote::GetStrMessage() const
+{
+    return vin.prevout.ToStringShort() + nProposalHash.ToString() +
+            std::to_string(nVote) + std::to_string(nTime);
+}
+
 bool CBudgetVote::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
 {
-    std::string strError = "";
-    std::string strMessage = vin.prevout.ToStringShort() + nProposalHash.ToString() + std::to_string(nVote) + std::to_string(nTime);
-    
-    CPubKey pubKeyCollateralAddress;
-    CKey keyCollateralAddress;
-
-    if (!CMessageSigner::SignMessage(strMessage, vchSig, keyMasternode)) {
-        LogPrint("mnbudget","CBudgetVote::Sign - Error upon calling SignMessage");
-        return false;
+    int nHeight;
+    {
+        LOCK(cs_main);
+        nHeight = chainActive.Height();
     }
 
-    if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
-        LogPrint("mnbudget","CBudgetVote::Sign - Error upon calling VerifyMessage: %s", strError);
-        return false;
+    std::string strError = "";
+
+    if (Params().NewSigsActive(nHeight)) {
+        uint256 hash = GetSignatureHash();
+
+        if(!CHashSigner::SignHash(hash, keyMasternode, vchSig)) {
+            return error("%s : SignHash() failed", __func__);
+        }
+
+        if (!CHashSigner::VerifyHash(hash, pubKeyMasternode, vchSig, strError)) {
+            return error("%s : VerifyHash() failed, error: %s", __func__, strError);
+        }
+    } else {
+        // use old signature format
+        std::string strMessage = GetStrMessage();
+
+        if (!CMessageSigner::SignMessage(strMessage, vchSig, keyMasternode)) {
+            return error("%s - SignMessage() failed", __func__);
+        }
+
+        if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
+            return error("%s - VerifyMessage() failed, error: %s\n", __func__, strError);
+        }
     }
 
     return true;
@@ -1804,23 +1835,26 @@ bool CBudgetVote::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
 
 bool CBudgetVote::SignatureValid(bool fSignatureCheck)
 {
-    std::string strError = "";
-    std::string strMessage = vin.prevout.ToStringShort() + nProposalHash.ToString() + std::to_string(nVote) + std::to_string(nTime);
-
     CMasternode* pmn = mnodeman.Find(vin);
-
-    if (pmn == NULL) {
-        if (fDebug){
-            LogPrint("mnbudget","CBudgetVote::SignatureValid() - Unknown Masternode - %s\n", vin.prevout.hash.ToString());
-        }
-        return false;
+    if (pmn == nullptr) {
+        return error("%s : vinMasternode not found", __func__);
     }
 
     if (!fSignatureCheck) return true;
 
+    std::string strError = "";
+
+    uint256 hash = GetSignatureHash();
+
+    if (CHashSigner::VerifyHash(hash, pmn->pubKeyMasternode, vchSig, strError))
+        return true;
+
+    // if new signature fails, try old format
+    std::string strMessage = GetStrMessage();
+
     if (!CMessageSigner::VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, strError)) {
-        LogPrint("mnbudget","CBudgetVote::SignatureValid() - Verify message failed, error: %s\n", strError);
-        return false;
+        return error("%s - Got bad masternode signature for %s: %s\n", __func__,
+                vin.prevout.hash.ToString(), strError);
     }
 
     return true;

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -2343,22 +2343,51 @@ void CFinalizedBudgetVote::Relay()
     RelayInv(inv);
 }
 
+uint256 CFinalizedBudgetVote::GetHash() const
+{
+    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+    ss << vin;
+    ss << nBudgetHash;
+    ss << nTime;
+    return ss.GetHash();
+}
+
+std::string CFinalizedBudgetVote::GetStrMessage() const
+{
+    return vin.prevout.ToStringShort() + nBudgetHash.ToString() + std::to_string(nTime);
+}
+
 bool CFinalizedBudgetVote::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
 {
-    std::string strError = "";
-    std::string strMessage = vin.prevout.ToStringShort() + nBudgetHash.ToString() + std::to_string(nTime);
-    
-    CPubKey pubKeyCollateralAddress;
-    CKey keyCollateralAddress;
-
-    if (!CMessageSigner::SignMessage(strMessage, vchSig, keyMasternode)) {
-        LogPrint("mnbudget","CFinalizedBudgetVote::Sign - Error upon calling SignMessage");
-        return false;
+    int nHeight;
+    {
+        LOCK(cs_main);
+        nHeight = chainActive.Height();
     }
 
-    if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
-        LogPrint("mnbudget","CFinalizedBudgetVote::Sign - Error upon calling VerifyMessage: %s", strError);
-        return false;
+    std::string strError = "";
+
+    if (Params().NewSigsActive(nHeight)) {
+        uint256 hash = GetSignatureHash();
+
+        if(!CHashSigner::SignHash(hash, keyMasternode, vchSig)) {
+            return error("%s : SignHash() failed", __func__);
+        }
+
+        if (!CHashSigner::VerifyHash(hash, pubKeyMasternode, vchSig, strError)) {
+            return error("%s : VerifyHash() failed, error: %s", __func__, strError);
+        }
+    } else {
+        // use old signature format
+        std::string strMessage = GetStrMessage();
+
+        if (!CMessageSigner::SignMessage(strMessage, vchSig, keyMasternode)) {
+            return error("%s - SignMessage() failed", __func__);
+        }
+
+        if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
+            return error("%s - VerifyMessage() failed, error: %s\n", __func__, strError);
+        }
     }
 
     return true;
@@ -2366,21 +2395,26 @@ bool CFinalizedBudgetVote::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
 
 bool CFinalizedBudgetVote::SignatureValid(bool fSignatureCheck)
 {
-    std::string strError;
-    std::string strMessage = vin.prevout.ToStringShort() + nBudgetHash.ToString() + std::to_string(nTime);
-
     CMasternode* pmn = mnodeman.Find(vin);
-
-    if (pmn == NULL) {
-        LogPrint("mnbudget","CFinalizedBudgetVote::SignatureValid() - Unknown Masternode %s\n", strMessage);
-        return false;
+    if (pmn == nullptr) {
+        return error("%s : vinMasternode not found", __func__);
     }
 
     if (!fSignatureCheck) return true;
 
+    std::string strError = "";
+
+    uint256 hash = GetSignatureHash();
+
+    if (CHashSigner::VerifyHash(hash, pmn->pubKeyMasternode, vchSig, strError))
+        return true;
+
+    // if new signature fails, try old format
+    std::string strMessage = GetStrMessage();
+
     if (!CMessageSigner::VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, strError)) {
-        LogPrint("mnbudget","CFinalizedBudgetVote::SignatureValid() - Verify message failed %s: %s\n", strMessage, strError);
-        return false;
+        return error("%s - Got bad masternode signature for %s: %s\n", __func__,
+                vin.prevout.hash.ToString(), strError);
     }
 
     return true;

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -1755,24 +1755,25 @@ void CBudgetProposalBroadcast::Relay()
     RelayInv(inv);
 }
 
-CBudgetVote::CBudgetVote()
-{
-    vin = CTxIn();
-    nProposalHash = 0;
-    nVote = VOTE_ABSTAIN;
-    nTime = 0;
-    fValid = true;
-    fSynced = false;
-}
+CBudgetVote::CBudgetVote() :
+        fValid(true),
+        fSynced(false),
+        vin(),
+        nProposalHash(0),
+        nVote(VOTE_ABSTAIN),
+        nTime(0),
+        vchSig()
+{ }
 
-CBudgetVote::CBudgetVote(CTxIn vinIn, uint256 nProposalHashIn, int nVoteIn)
+CBudgetVote::CBudgetVote(CTxIn vinIn, uint256 nProposalHashIn, int nVoteIn) :
+        fValid(true),
+        fSynced(false),
+        vin(vinIn),
+        nProposalHash(nProposalHashIn),
+        nVote(nVoteIn),
+        vchSig()
 {
-    vin = vinIn;
-    nProposalHash = nProposalHashIn;
-    nVote = nVoteIn;
     nTime = GetAdjustedTime();
-    fValid = true;
-    fSynced = false;
 }
 
 void CBudgetVote::Relay()
@@ -2317,24 +2318,23 @@ void CFinalizedBudgetBroadcast::Relay()
     RelayInv(inv);
 }
 
-CFinalizedBudgetVote::CFinalizedBudgetVote()
-{
-    vin = CTxIn();
-    nBudgetHash = 0;
-    nTime = 0;
-    vchSig.clear();
-    fValid = true;
-    fSynced = false;
-}
+CFinalizedBudgetVote::CFinalizedBudgetVote() :
+        fValid(true),
+        fSynced(false),
+        vin(),
+        nBudgetHash(0),
+        nTime(0),
+        vchSig()
+{ }
 
-CFinalizedBudgetVote::CFinalizedBudgetVote(CTxIn vinIn, uint256 nBudgetHashIn)
+CFinalizedBudgetVote::CFinalizedBudgetVote(CTxIn vinIn, uint256 nBudgetHashIn) :
+        fValid(true),
+        fSynced(false),
+        vin(vinIn),
+        nBudgetHash(nBudgetHashIn),
+        vchSig()
 {
-    vin = vinIn;
-    nBudgetHash = nBudgetHashIn;
     nTime = GetAdjustedTime();
-    vchSig.clear();
-    fValid = true;
-    fSynced = false;
 }
 
 void CFinalizedBudgetVote::Relay()

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -1142,7 +1142,7 @@ void CBudgetManager::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
 
 
         mapSeenMasternodeBudgetVotes.insert(std::make_pair(vote.GetHash(), vote));
-        if (!vote.SignatureValid(true)) {
+        if (!vote.CheckSignature(true)) {
             if (masternodeSync.IsSynced()) {
                 LogPrintf("CBudgetManager::ProcessMessage() : mvote - signature invalid\n");
                 Misbehaving(pfrom->GetId(), 20);
@@ -1622,7 +1622,7 @@ void CBudgetProposal::CleanAndRemove(bool fSignatureCheck)
     std::map<uint256, CBudgetVote>::iterator it = mapVotes.begin();
 
     while (it != mapVotes.end()) {
-        (*it).second.fValid = (*it).second.SignatureValid(fSignatureCheck);
+        (*it).second.fValid = (*it).second.CheckSignature(fSignatureCheck);
         ++it;
     }
 }
@@ -1833,7 +1833,7 @@ bool CBudgetVote::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
     return true;
 }
 
-bool CBudgetVote::SignatureValid(bool fSignatureCheck)
+bool CBudgetVote::CheckSignature(bool fSignatureCheck)
 {
     CMasternode* pmn = mnodeman.Find(vin);
     if (pmn == nullptr) {

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -1861,29 +1861,27 @@ bool CBudgetVote::CheckSignature(bool fSignatureCheck) const
     return true;
 }
 
-CFinalizedBudget::CFinalizedBudget()
-{
-    strBudgetName = "";
-    nBlockStart = 0;
-    vecBudgetPayments.clear();
-    mapVotes.clear();
-    nFeeTXHash = 0;
-    nTime = 0;
-    fValid = true;
-    fAutoChecked = false;
-}
+CFinalizedBudget::CFinalizedBudget() :
+        fAutoChecked(false),
+        fValid(true),
+        strBudgetName(""),
+        nBlockStart(0),
+        vecBudgetPayments(),
+        mapVotes(),
+        nFeeTXHash(0),
+        nTime(0)
+{ }
 
-CFinalizedBudget::CFinalizedBudget(const CFinalizedBudget& other)
-{
-    strBudgetName = other.strBudgetName;
-    nBlockStart = other.nBlockStart;
-    vecBudgetPayments = other.vecBudgetPayments;
-    mapVotes = other.mapVotes;
-    nFeeTXHash = other.nFeeTXHash;
-    nTime = other.nTime;
-    fValid = true;
-    fAutoChecked = false;
-}
+CFinalizedBudget::CFinalizedBudget(const CFinalizedBudget& other) :
+        fAutoChecked(false),
+        fValid(true),
+        strBudgetName(other.strBudgetName),
+        nBlockStart(other.nBlockStart),
+        vecBudgetPayments(other.vecBudgetPayments),
+        mapVotes(other.mapVotes),
+        nFeeTXHash(other.nFeeTXHash),
+        nTime(other.nTime)
+{ }
 
 bool CFinalizedBudget::AddOrUpdateVote(CFinalizedBudgetVote& vote, std::string& strError)
 {
@@ -2283,33 +2281,22 @@ void CFinalizedBudget::SubmitVote()
 }
 
 CFinalizedBudgetBroadcast::CFinalizedBudgetBroadcast() :
-        vchSig()
-{
-    strBudgetName = "";
-    nBlockStart = 0;
-    vecBudgetPayments.clear();
-    mapVotes.clear();
-    nFeeTXHash = 0;
-}
+        CFinalizedBudget()
+{ }
 
 CFinalizedBudgetBroadcast::CFinalizedBudgetBroadcast(const CFinalizedBudget& other) :
-        vchSig()
-{
-    strBudgetName = other.strBudgetName;
-    nBlockStart = other.nBlockStart;
-    for (CTxBudgetPayment out : other.vecBudgetPayments)
-        vecBudgetPayments.push_back(out);
-    mapVotes = other.mapVotes;
-    nFeeTXHash = other.nFeeTXHash;
-}
+        CFinalizedBudget(other)
+{ }
 
-CFinalizedBudgetBroadcast::CFinalizedBudgetBroadcast(std::string strBudgetNameIn, int nBlockStartIn, std::vector<CTxBudgetPayment> vecBudgetPaymentsIn, uint256 nFeeTXHashIn)
+CFinalizedBudgetBroadcast::CFinalizedBudgetBroadcast(std::string strBudgetNameIn,
+                                                     int nBlockStartIn,
+                                                     std::vector<CTxBudgetPayment> vecBudgetPaymentsIn,
+                                                     uint256 nFeeTXHashIn)
 {
     strBudgetName = strBudgetNameIn;
     nBlockStart = nBlockStartIn;
     for (CTxBudgetPayment out : vecBudgetPaymentsIn)
         vecBudgetPayments.push_back(out);
-    mapVotes.clear();
     nFeeTXHash = nFeeTXHashIn;
 }
 

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -1755,8 +1755,7 @@ void CBudgetProposalBroadcast::Relay()
 }
 
 CBudgetVote::CBudgetVote() :
-        vchSig(),
-        nMessVersion(MessageVersion::MESS_VER_HASH),
+        CSignedMessage(),
         fValid(true),
         fSynced(false),
         vin(),
@@ -1766,8 +1765,7 @@ CBudgetVote::CBudgetVote() :
 { }
 
 CBudgetVote::CBudgetVote(CTxIn vinIn, uint256 nProposalHashIn, int nVoteIn) :
-        vchSig(),
-        nMessVersion(MessageVersion::MESS_VER_HASH),
+        CSignedMessage(),
         fValid(true),
         fSynced(false),
         vin(vinIn),
@@ -1799,70 +1797,14 @@ std::string CBudgetVote::GetStrMessage() const
             std::to_string(nVote) + std::to_string(nTime);
 }
 
-bool CBudgetVote::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
-{
-    int nHeight;
-    {
-        LOCK(cs_main);
-        nHeight = chainActive.Height();
-    }
-
-    std::string strError = "";
-
-    if (Params().NewSigsActive(nHeight)) {
-        nMessVersion = MessageVersion::MESS_VER_HASH;
-        uint256 hash = GetSignatureHash();
-
-        if(!CHashSigner::SignHash(hash, keyMasternode, vchSig)) {
-            return error("%s : SignHash() failed", __func__);
-        }
-
-        if (!CHashSigner::VerifyHash(hash, pubKeyMasternode, vchSig, strError)) {
-            return error("%s : VerifyHash() failed, error: %s", __func__, strError);
-        }
-
-    } else {
-        // use old signature format
-        nMessVersion = MessageVersion::MESS_VER_STRMESS;
-        std::string strMessage = GetStrMessage();
-
-        if (!CMessageSigner::SignMessage(strMessage, vchSig, keyMasternode)) {
-            return error("%s : SignMessage() failed", __func__);
-        }
-
-        if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
-            return error("%s : VerifyMessage() failed, error: %s\n", __func__, strError);
-        }
-    }
-
-    return true;
-}
-
-bool CBudgetVote::CheckSignature(bool fSignatureCheck) const
+const CPubKey* CBudgetVote::GetPublicKey(std::string& strErrorRet) const
 {
     CMasternode* pmn = mnodeman.Find(vin);
-    if (pmn == nullptr) {
-        return error("%s : vinMasternode not found", __func__);
+    if(pmn) {
+        return &(pmn->pubKeyMasternode);
     }
-
-    if (!fSignatureCheck) return true;
-
-    std::string strError = "";
-
-    if (nMessVersion == MessageVersion::MESS_VER_HASH) {
-        uint256 hash = GetSignatureHash();
-        if(!CHashSigner::VerifyHash(hash, pmn->pubKeyMasternode, vchSig, strError))
-            return error("%s : VerifyHash failed for %s: %s", __func__,
-                    vin.prevout.hash.ToString(), strError);
-
-    } else {
-        std::string strMessage = GetStrMessage();
-        if(!CMessageSigner::VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, strError))
-            return error("%s : VerifyMessage failed for %s: %s", __func__,
-                    vin.prevout.hash.ToString(), strError);
-    }
-
-    return true;
+    strErrorRet = strprintf("Unable to find masternode vin %s", vin.prevout.hash.GetHex());
+    return nullptr;
 }
 
 CFinalizedBudget::CFinalizedBudget() :
@@ -2263,13 +2205,19 @@ void CFinalizedBudget::SubmitVote()
     CPubKey pubKeyMasternode;
     CKey keyMasternode;
 
+    bool fNewSigs = false;
+    {
+        LOCK(cs_main);
+        fNewSigs = chainActive.NewSigsActive();
+    }
+
     if (!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, keyMasternode, pubKeyMasternode)) {
         LogPrint("mnbudget","CFinalizedBudget::SubmitVote - Error upon calling SetKey\n");
         return;
     }
 
     CFinalizedBudgetVote vote(activeMasternode.vin, GetHash());
-    if (!vote.Sign(keyMasternode, pubKeyMasternode)) {
+    if (!vote.Sign(keyMasternode, pubKeyMasternode, fNewSigs)) {
         LogPrint("mnbudget","CFinalizedBudget::SubmitVote - Failure to sign.");
         return;
     }
@@ -2311,8 +2259,7 @@ void CFinalizedBudgetBroadcast::Relay()
 }
 
 CFinalizedBudgetVote::CFinalizedBudgetVote() :
-        vchSig(),
-        nMessVersion(MessageVersion::MESS_VER_HASH),
+        CSignedMessage(),
         fValid(true),
         fSynced(false),
         vin(),
@@ -2321,8 +2268,7 @@ CFinalizedBudgetVote::CFinalizedBudgetVote() :
 { }
 
 CFinalizedBudgetVote::CFinalizedBudgetVote(CTxIn vinIn, uint256 nBudgetHashIn) :
-        vchSig(),
-        nMessVersion(MessageVersion::MESS_VER_HASH),
+        CSignedMessage(),
         fValid(true),
         fSynced(false),
         vin(vinIn),
@@ -2351,70 +2297,14 @@ std::string CFinalizedBudgetVote::GetStrMessage() const
     return vin.prevout.ToStringShort() + nBudgetHash.ToString() + std::to_string(nTime);
 }
 
-bool CFinalizedBudgetVote::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
-{
-    int nHeight;
-    {
-        LOCK(cs_main);
-        nHeight = chainActive.Height();
-    }
-
-    std::string strError = "";
-
-    if (Params().NewSigsActive(nHeight)) {
-        nMessVersion = MessageVersion::MESS_VER_HASH;
-        uint256 hash = GetSignatureHash();
-
-        if(!CHashSigner::SignHash(hash, keyMasternode, vchSig)) {
-            return error("%s : SignHash() failed", __func__);
-        }
-
-        if (!CHashSigner::VerifyHash(hash, pubKeyMasternode, vchSig, strError)) {
-            return error("%s : VerifyHash() failed, error: %s", __func__, strError);
-        }
-
-    } else {
-        // use old signature format
-        nMessVersion = MessageVersion::MESS_VER_STRMESS;
-        std::string strMessage = GetStrMessage();
-
-        if (!CMessageSigner::SignMessage(strMessage, vchSig, keyMasternode)) {
-            return error("%s : SignMessage() failed", __func__);
-        }
-
-        if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
-            return error("%s : VerifyMessage() failed, error: %s\n", __func__, strError);
-        }
-    }
-
-    return true;
-}
-
-bool CFinalizedBudgetVote::CheckSignature(bool fSignatureCheck) const
+const CPubKey* CFinalizedBudgetVote::GetPublicKey(std::string& strErrorRet) const
 {
     CMasternode* pmn = mnodeman.Find(vin);
-    if (pmn == nullptr) {
-        return error("%s : vinMasternode not found", __func__);
+    if(pmn) {
+        return &(pmn->pubKeyMasternode);
     }
-
-    if (!fSignatureCheck) return true;
-
-    std::string strError = "";
-
-    if (nMessVersion == MessageVersion::MESS_VER_HASH) {
-        uint256 hash = GetSignatureHash();
-        if(!CHashSigner::VerifyHash(hash, pmn->pubKeyMasternode, vchSig, strError))
-            return error("%s : VerifyHash failed for %s: %s", __func__,
-                    vin.prevout.hash.ToString(), strError);
-
-    } else {
-        std::string strMessage = GetStrMessage();
-        if(!CMessageSigner::VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, strError))
-            return error("%s : VerifyMessage failed for %s: %s", __func__,
-                    vin.prevout.hash.ToString(), strError);
-    }
-
-    return true;
+    strErrorRet = strprintf("Unable to find masternode vin %s", vin.prevout.hash.GetHex());
+    return nullptr;
 }
 
 std::string CBudgetManager::ToString() const

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -1216,7 +1216,7 @@ void CBudgetManager::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         }
 
         mapSeenFinalizedBudgetVotes.insert(std::make_pair(vote.GetHash(), vote));
-        if (!vote.SignatureValid(true)) {
+        if (!vote.CheckSignature(true)) {
             if (masternodeSync.IsSynced()) {
                 LogPrintf("CBudgetManager::ProcessMessage() : fbvote - signature from masternode %s invalid\n", HexStr(pmn->pubKeyMasternode));
                 Misbehaving(pfrom->GetId(), 20);
@@ -1833,7 +1833,7 @@ bool CBudgetVote::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
     return true;
 }
 
-bool CBudgetVote::CheckSignature(bool fSignatureCheck)
+bool CBudgetVote::CheckSignature(bool fSignatureCheck) const
 {
     CMasternode* pmn = mnodeman.Find(vin);
     if (pmn == nullptr) {
@@ -2029,7 +2029,7 @@ void CFinalizedBudget::CleanAndRemove(bool fSignatureCheck)
     std::map<uint256, CFinalizedBudgetVote>::iterator it = mapVotes.begin();
 
     while (it != mapVotes.end()) {
-        (*it).second.fValid = (*it).second.SignatureValid(fSignatureCheck);
+        (*it).second.fValid = (*it).second.CheckSignature(fSignatureCheck);
         ++it;
     }
 }
@@ -2393,7 +2393,7 @@ bool CFinalizedBudgetVote::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
     return true;
 }
 
-bool CFinalizedBudgetVote::SignatureValid(bool fSignatureCheck)
+bool CFinalizedBudgetVote::CheckSignature(bool fSignatureCheck) const
 {
     CMasternode* pmn = mnodeman.Find(vin);
     if (pmn == nullptr) {

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -2202,7 +2202,7 @@ void CFinalizedBudget::SubmitVote()
     }
 
     if (!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, keyMasternode, pubKeyMasternode)) {
-        LogPrint("mnbudget","CFinalizedBudget::SubmitVote - Error upon calling SetKey\n");
+        LogPrint("mnbudget","CFinalizedBudget::SubmitVote - Error upon calling GetKeysFromSecret\n");
         return;
     }
 

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -70,7 +70,7 @@ public:
     CBudgetVote(CTxIn vin, uint256 nProposalHash, int nVoteIn);
 
     bool Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode);
-    bool SignatureValid(bool fSignatureCheck);
+    bool CheckSignature(bool fSignatureCheck);
     void Relay();
 
     std::string GetVoteString()

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -120,14 +120,9 @@ public:
     bool SignatureValid(bool fSignatureCheck);
     void Relay();
 
-    uint256 GetHash()
-    {
-        CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
-        ss << vin;
-        ss << nBudgetHash;
-        ss << nTime;
-        return ss.GetHash();
-    }
+    uint256 GetHash() const;
+    uint256 GetSignatureHash() const { return GetHash(); }
+    std::string GetStrMessage() const;
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -70,7 +70,7 @@ public:
     CBudgetVote(CTxIn vin, uint256 nProposalHash, int nVoteIn);
 
     bool Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode);
-    bool CheckSignature(bool fSignatureCheck);
+    bool CheckSignature(bool fSignatureCheck) const;
     void Relay();
 
     std::string GetVoteString()
@@ -117,7 +117,7 @@ public:
     CFinalizedBudgetVote(CTxIn vinIn, uint256 nBudgetHashIn);
 
     bool Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode);
-    bool SignatureValid(bool fSignatureCheck);
+    bool CheckSignature(bool fSignatureCheck) const;
     void Relay();
 
     uint256 GetHash() const;

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -81,15 +81,10 @@ public:
         return ret;
     }
 
-    uint256 GetHash()
-    {
-        CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
-        ss << vin;
-        ss << nProposalHash;
-        ss << nVote;
-        ss << nTime;
-        return ss.GetHash();
-    }
+    uint256 GetHash() const;
+    uint256 GetSignatureHash() const { return GetHash(); }
+    std::string GetStrMessage() const;
+
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -55,13 +55,9 @@ bool IsBudgetCollateralValid(uint256 nTxCollateralHash, uint256 nExpectedHash, s
 // CBudgetVote - Allow a masternode node to vote and broadcast throughout the network
 //
 
-class CBudgetVote
+class CBudgetVote : public CSignedMessage
 {
-private:
-    std::vector<unsigned char> vchSig;
-
 public:
-    int nMessVersion;
     bool fValid;  //if the vote is currently valid / counted
     bool fSynced; //if we've sent this to our peers
     CTxIn vin;
@@ -72,9 +68,6 @@ public:
     CBudgetVote();
     CBudgetVote(CTxIn vin, uint256 nProposalHash, int nVoteIn);
 
-    bool Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode);
-    bool CheckSignature(bool fSignatureCheck) const;
-    void SetVchSig(const std::vector<unsigned char>& vchSigIn) { vchSig = vchSigIn; }
     void Relay();
 
     std::string GetVoteString()
@@ -86,9 +79,11 @@ public:
     }
 
     uint256 GetHash() const;
-    uint256 GetSignatureHash() const { return GetHash(); }
-    std::string GetStrMessage() const;
 
+    // override CSignedMessage functions
+    uint256 GetSignatureHash() const override { return GetHash(); }
+    std::string GetStrMessage() const override;
+    const CPubKey* GetPublicKey(std::string& strErrorRet) const override;
 
     ADD_SERIALIZE_METHODS;
 
@@ -118,13 +113,9 @@ public:
 // CFinalizedBudgetVote - Allow a masternode node to vote and broadcast throughout the network
 //
 
-class CFinalizedBudgetVote
+class CFinalizedBudgetVote : public CSignedMessage
 {
-private:
-    std::vector<unsigned char> vchSig;
-
 public:
-    int nMessVersion;
     bool fValid;  //if the vote is currently valid / counted
     bool fSynced; //if we've sent this to our peers
     CTxIn vin;
@@ -134,13 +125,13 @@ public:
     CFinalizedBudgetVote();
     CFinalizedBudgetVote(CTxIn vinIn, uint256 nBudgetHashIn);
 
-    bool Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode);
-    bool CheckSignature(bool fSignatureCheck) const;
     void Relay();
-
     uint256 GetHash() const;
-    uint256 GetSignatureHash() const { return GetHash(); }
-    std::string GetStrMessage() const;
+
+    // override CSignedMessage functions
+    uint256 GetSignatureHash() const override { return GetHash(); }
+    std::string GetStrMessage() const override;
+    const CPubKey* GetPublicKey(std::string& strErrorRet) const override;
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -61,6 +61,7 @@ private:
     std::vector<unsigned char> vchSig;
 
 public:
+    int nMessVersion;
     bool fValid;  //if the vote is currently valid / counted
     bool fSynced; //if we've sent this to our peers
     CTxIn vin;
@@ -94,11 +95,22 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
     {
-        READWRITE(vin);
-        READWRITE(nProposalHash);
-        READWRITE(nVote);
-        READWRITE(nTime);
-        READWRITE(vchSig);
+        try
+        {
+            READWRITE(nMessVersion);
+            READWRITE(vin);
+            READWRITE(nProposalHash);
+            READWRITE(nVote);
+            READWRITE(nTime);
+            READWRITE(vchSig);
+        } catch(...) {
+            nMessVersion = MessageVersion::MESS_VER_STRMESS;
+            READWRITE(vin);
+            READWRITE(nProposalHash);
+            READWRITE(nVote);
+            READWRITE(nTime);
+            READWRITE(vchSig);
+        }
     }
 };
 
@@ -112,6 +124,7 @@ private:
     std::vector<unsigned char> vchSig;
 
 public:
+    int nMessVersion;
     bool fValid;  //if the vote is currently valid / counted
     bool fSynced; //if we've sent this to our peers
     CTxIn vin;
@@ -134,10 +147,20 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
     {
-        READWRITE(vin);
-        READWRITE(nBudgetHash);
-        READWRITE(nTime);
-        READWRITE(vchSig);
+        try
+        {
+            READWRITE(nMessVersion);
+            READWRITE(vin);
+            READWRITE(nBudgetHash);
+            READWRITE(nTime);
+            READWRITE(vchSig);
+        } catch (...) {
+            nMessVersion = MessageVersion::MESS_VER_STRMESS;
+            READWRITE(vin);
+            READWRITE(nBudgetHash);
+            READWRITE(nTime);
+            READWRITE(vchSig);
+        }
     }
 };
 

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -57,6 +57,9 @@ bool IsBudgetCollateralValid(uint256 nTxCollateralHash, uint256 nExpectedHash, s
 
 class CBudgetVote
 {
+private:
+    std::vector<unsigned char> vchSig;
+
 public:
     bool fValid;  //if the vote is currently valid / counted
     bool fSynced; //if we've sent this to our peers
@@ -64,13 +67,13 @@ public:
     uint256 nProposalHash;
     int nVote;
     int64_t nTime;
-    std::vector<unsigned char> vchSig;
 
     CBudgetVote();
     CBudgetVote(CTxIn vin, uint256 nProposalHash, int nVoteIn);
 
     bool Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode);
     bool CheckSignature(bool fSignatureCheck) const;
+    void SetVchSig(const std::vector<unsigned char>& vchSigIn) { vchSig = vchSigIn; }
     void Relay();
 
     std::string GetVoteString()
@@ -105,13 +108,15 @@ public:
 
 class CFinalizedBudgetVote
 {
+private:
+    std::vector<unsigned char> vchSig;
+
 public:
     bool fValid;  //if the vote is currently valid / counted
     bool fSynced; //if we've sent this to our peers
     CTxIn vin;
     uint256 nBudgetHash;
     int64_t nTime;
-    std::vector<unsigned char> vchSig;
 
     CFinalizedBudgetVote();
     CFinalizedBudgetVote(CTxIn vinIn, uint256 nBudgetHashIn);

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -83,7 +83,7 @@ public:
     // override CSignedMessage functions
     uint256 GetSignatureHash() const override { return GetHash(); }
     std::string GetStrMessage() const override;
-    const CPubKey* GetPublicKey(std::string& strErrorRet) const override;
+    const CTxIn GetVin() const override { return vin; };
 
     ADD_SERIALIZE_METHODS;
 
@@ -131,7 +131,7 @@ public:
     // override CSignedMessage functions
     uint256 GetSignatureHash() const override { return GetHash(); }
     std::string GetStrMessage() const override;
-    const CPubKey* GetPublicKey(std::string& strErrorRet) const override;
+    const CTxIn GetVin() const override { return vin; };
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -399,9 +399,6 @@ public:
 // FinalizedBudget are cast then sent to peers with this object, which leaves the votes out
 class CFinalizedBudgetBroadcast : public CFinalizedBudget
 {
-private:
-    std::vector<unsigned char> vchSig;
-
 public:
     CFinalizedBudgetBroadcast();
     CFinalizedBudgetBroadcast(const CFinalizedBudget& other);

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -90,21 +90,16 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
     {
+        READWRITE(vin);
+        READWRITE(nProposalHash);
+        READWRITE(nVote);
+        READWRITE(nTime);
+        READWRITE(vchSig);
         try
         {
             READWRITE(nMessVersion);
-            READWRITE(vin);
-            READWRITE(nProposalHash);
-            READWRITE(nVote);
-            READWRITE(nTime);
-            READWRITE(vchSig);
-        } catch(...) {
+        } catch (...) {
             nMessVersion = MessageVersion::MESS_VER_STRMESS;
-            READWRITE(vin);
-            READWRITE(nProposalHash);
-            READWRITE(nVote);
-            READWRITE(nTime);
-            READWRITE(vchSig);
         }
     }
 };
@@ -138,19 +133,15 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
     {
+        READWRITE(vin);
+        READWRITE(nBudgetHash);
+        READWRITE(nTime);
+        READWRITE(vchSig);
         try
         {
             READWRITE(nMessVersion);
-            READWRITE(vin);
-            READWRITE(nBudgetHash);
-            READWRITE(nTime);
-            READWRITE(vchSig);
         } catch (...) {
             nMessVersion = MessageVersion::MESS_VER_STRMESS;
-            READWRITE(vin);
-            READWRITE(nBudgetHash);
-            READWRITE(nTime);
-            READWRITE(vchSig);
         }
     }
 };

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -160,16 +160,6 @@ std::string CMasternodePaymentWinner::GetStrMessage() const
     return vinMasternode.prevout.ToStringShort() + std::to_string(nBlockHeight) + payee.ToString();
 }
 
-const CPubKey* CMasternodePaymentWinner::GetPublicKey(std::string& strErrorRet) const
-{
-    CMasternode* pmn = mnodeman.Find(vinMasternode);
-    if(pmn) {
-        return &(pmn->pubKeyMasternode);
-    }
-    strErrorRet = strprintf("Unable to find masternode vin %s", vinMasternode.prevout.hash.GetHex());
-    return nullptr;
-}
-
 bool CMasternodePaymentWinner::IsValid(CNode* pnode, std::string& strError)
 {
     CMasternode* pmn = mnodeman.Find(vinMasternode);

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -450,21 +450,51 @@ void CMasternodePayments::ProcessMessageMasternodePayments(CNode* pfrom, std::st
     }
 }
 
+uint256 CMasternodePaymentWinner::GetHash() const
+{
+    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+    ss << payee;
+    ss << nBlockHeight;
+    ss << vinMasternode.prevout;
+    return ss.GetHash();
+}
+
+std::string CMasternodePaymentWinner::GetStrMessage() const
+{
+    return vinMasternode.prevout.ToStringShort() + std::to_string(nBlockHeight) + payee.ToString();
+}
+
 bool CMasternodePaymentWinner::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
 {
-    std::string strError = "";
-    std::string strMasterNodeSignMessage;
-
-    std::string strMessage = vinMasternode.prevout.ToStringShort() + std::to_string(nBlockHeight) + payee.ToString();
-
-    if (!CMessageSigner::SignMessage(strMessage, vchSig, keyMasternode)) {
-        LogPrint("masternode","%s - SignMessage Error.%s\n", __func__);
-        return false;
+    int nHeight;
+    {
+        LOCK(cs_main);
+        nHeight = chainActive.Height();
     }
 
-    if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
-        LogPrint("masternode","%s - VerifyMessage Error: %s\n", __func__, strError);
-        return false;
+    std::string strError = "";
+
+    if (Params().NewSigsActive(nHeight)) {
+        uint256 hash = GetSignatureHash();
+
+        if(!CHashSigner::SignHash(hash, keyMasternode, vchSig)) {
+            return error("%s : SignHash() failed", __func__);
+        }
+
+        if (!CHashSigner::VerifyHash(hash, pubKeyMasternode, vchSig, strError)) {
+            return error("%s : VerifyHash() failed, error: %s", __func__, strError);
+        }
+    } else {
+        // use old signature format
+        std::string strMessage = GetStrMessage();
+
+        if (!CMessageSigner::SignMessage(strMessage, vchSig, keyMasternode)) {
+            return error("%s : SignMessage() failed", __func__);
+        }
+
+        if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
+            return error("%s : VerifyMessage() failed, error: %s\n", __func__, strError);
+        }
     }
 
     return true;
@@ -782,22 +812,29 @@ void CMasternodePaymentWinner::Relay()
     RelayInv(inv);
 }
 
-bool CMasternodePaymentWinner::SignatureValid()
+bool CMasternodePaymentWinner::SignatureValid() const
 {
     CMasternode* pmn = mnodeman.Find(vinMasternode);
-
-    if (pmn != NULL) {
-        std::string strMessage = vinMasternode.prevout.ToStringShort() + std::to_string(nBlockHeight) + payee.ToString();
-
-        std::string strError = "";
-        if (!CMessageSigner::VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, strError)) {
-            return error("CMasternodePaymentWinner::SignatureValid() - Got bad Masternode address signature for %s: %s\n", vinMasternode.prevout.hash.ToString(), strError);
-        }
-
-        return true;
+    if (pmn == nullptr) {
+        return error("%s : vinMasternode not found", __func__);
     }
 
-    return false;
+    std::string strError = "";
+
+    uint256 hash = GetSignatureHash();
+
+    if (CHashSigner::VerifyHash(hash, pmn->pubKeyMasternode, vchSig, strError))
+        return true;
+
+    // if new signature fails, try old format
+    std::string strMessage = GetStrMessage();
+
+    if (!CMessageSigner::VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, strError)) {
+        return error("%s - Got bad masternode signature for %s: %s\n", __func__,
+                vinMasternode.prevout.hash.ToString(), strError);
+    }
+
+    return true;
 }
 
 void CMasternodePayments::Sync(CNode* node, int nCountNeeded)

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -427,7 +427,7 @@ void CMasternodePayments::ProcessMessageMasternodePayments(CNode* pfrom, std::st
             return;
         }
 
-        if (!winner.SignatureValid()) {
+        if (!winner.CheckSignature()) {
             if (masternodeSync.IsSynced()) {
                 LogPrintf("CMasternodePayments::ProcessMessageMasternodePayments() : mnw - invalid signature\n");
                 Misbehaving(pfrom->GetId(), 20);
@@ -495,6 +495,31 @@ bool CMasternodePaymentWinner::Sign(CKey& keyMasternode, CPubKey& pubKeyMasterno
         if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
             return error("%s : VerifyMessage() failed, error: %s\n", __func__, strError);
         }
+    }
+
+    return true;
+}
+
+bool CMasternodePaymentWinner::CheckSignature() const
+{
+    CMasternode* pmn = mnodeman.Find(vinMasternode);
+    if (pmn == nullptr) {
+        return error("%s : vinMasternode not found", __func__);
+    }
+
+    std::string strError = "";
+
+    uint256 hash = GetSignatureHash();
+
+    if (CHashSigner::VerifyHash(hash, pmn->pubKeyMasternode, vchSig, strError))
+        return true;
+
+    // if new signature fails, try old format
+    std::string strMessage = GetStrMessage();
+
+    if (!CMessageSigner::VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, strError)) {
+        return error("%s - Got bad masternode signature for %s: %s\n", __func__,
+                vinMasternode.prevout.hash.ToString(), strError);
     }
 
     return true;
@@ -810,31 +835,6 @@ void CMasternodePaymentWinner::Relay()
 {
     CInv inv(MSG_MASTERNODE_WINNER, GetHash());
     RelayInv(inv);
-}
-
-bool CMasternodePaymentWinner::SignatureValid() const
-{
-    CMasternode* pmn = mnodeman.Find(vinMasternode);
-    if (pmn == nullptr) {
-        return error("%s : vinMasternode not found", __func__);
-    }
-
-    std::string strError = "";
-
-    uint256 hash = GetSignatureHash();
-
-    if (CHashSigner::VerifyHash(hash, pmn->pubKeyMasternode, vchSig, strError))
-        return true;
-
-    // if new signature fails, try old format
-    std::string strMessage = GetStrMessage();
-
-    if (!CMessageSigner::VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, strError)) {
-        return error("%s - Got bad masternode signature for %s: %s\n", __func__,
-                vinMasternode.prevout.hash.ToString(), strError);
-    }
-
-    return true;
 }
 
 void CMasternodePayments::Sync(CNode* node, int nCountNeeded)

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -518,7 +518,7 @@ bool CMasternodePaymentWinner::CheckSignature() const
     std::string strMessage = GetStrMessage();
 
     if (!CMessageSigner::VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, strError)) {
-        return error("%s - Got bad masternode signature for %s: %s\n", __func__,
+        return error("%s : Got bad masternode signature for %s: %s\n", __func__,
                 vinMasternode.prevout.hash.ToString(), strError);
     }
 

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -415,6 +415,12 @@ void CMasternodePayments::ProcessMessageMasternodePayments(CNode* pfrom, std::st
             return;
         }
 
+        // reject old signatures 6000 blocks after hard-fork
+        if (winner.nMessVersion != MessageVersion::MESS_VER_HASH && Params().NewSigsActive(winner.nBlockHeight - 6000)) {
+            LogPrintf("%s : nMessVersion=%d not accepted anymore at block %d", __func__, winner.nMessVersion, nHeight);
+            return;
+        }
+
         std::string strError = "";
         if (!winner.IsValid(pfrom, strError)) {
             // if(strError != "") LogPrint("masternode","mnw - invalid message - %s\n", strError);
@@ -465,15 +471,9 @@ std::string CMasternodePaymentWinner::GetStrMessage() const
 
 bool CMasternodePaymentWinner::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
 {
-    int nHeight;
-    {
-        LOCK(cs_main);
-        nHeight = chainActive.Height();
-    }
-
     std::string strError = "";
 
-    if (Params().NewSigsActive(nHeight)) {
+    if (Params().NewSigsActive(nBlockHeight - 20)) {
         nMessVersion = MessageVersion::MESS_VER_HASH;
         uint256 hash = GetSignatureHash();
 

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -9,7 +9,6 @@
 #include "masternode-budget.h"
 #include "masternode-sync.h"
 #include "masternodeman.h"
-#include "messagesigner.h"
 #include "obfuscation.h"
 #include "spork.h"
 #include "sync.h"
@@ -475,6 +474,7 @@ bool CMasternodePaymentWinner::Sign(CKey& keyMasternode, CPubKey& pubKeyMasterno
     std::string strError = "";
 
     if (Params().NewSigsActive(nHeight)) {
+        nMessVersion = MessageVersion::MESS_VER_HASH;
         uint256 hash = GetSignatureHash();
 
         if(!CHashSigner::SignHash(hash, keyMasternode, vchSig)) {
@@ -484,8 +484,10 @@ bool CMasternodePaymentWinner::Sign(CKey& keyMasternode, CPubKey& pubKeyMasterno
         if (!CHashSigner::VerifyHash(hash, pubKeyMasternode, vchSig, strError)) {
             return error("%s : VerifyHash() failed, error: %s", __func__, strError);
         }
+
     } else {
         // use old signature format
+        nMessVersion = MessageVersion::MESS_VER_STRMESS;
         std::string strMessage = GetStrMessage();
 
         if (!CMessageSigner::SignMessage(strMessage, vchSig, keyMasternode)) {
@@ -509,17 +511,17 @@ bool CMasternodePaymentWinner::CheckSignature() const
 
     std::string strError = "";
 
-    uint256 hash = GetSignatureHash();
+    if (nMessVersion == MessageVersion::MESS_VER_HASH) {
+        uint256 hash = GetSignatureHash();
+        if(!CHashSigner::VerifyHash(hash, pmn->pubKeyMasternode, vchSig, strError))
+            return error("%s : VerifyHash failed for %s: %s", __func__,
+                    vinMasternode.prevout.hash.ToString(), strError);
 
-    if (CHashSigner::VerifyHash(hash, pmn->pubKeyMasternode, vchSig, strError))
-        return true;
-
-    // if new signature fails, try old format
-    std::string strMessage = GetStrMessage();
-
-    if (!CMessageSigner::VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, strError)) {
-        return error("%s : Got bad masternode signature for %s: %s\n", __func__,
-                vinMasternode.prevout.hash.ToString(), strError);
+    } else {
+        std::string strMessage = GetStrMessage();
+        if(!CMessageSigner::VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, strError))
+            return error("%s : VerifyMessage failed for %s: %s", __func__,
+                    vinMasternode.prevout.hash.ToString(), strError);
     }
 
     return true;

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -9,6 +9,7 @@
 #include "masternode-budget.h"
 #include "masternode-sync.h"
 #include "masternodeman.h"
+#include "messagesigner.h"
 #include "obfuscation.h"
 #include "spork.h"
 #include "sync.h"
@@ -451,18 +452,18 @@ void CMasternodePayments::ProcessMessageMasternodePayments(CNode* pfrom, std::st
 
 bool CMasternodePaymentWinner::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
 {
-    std::string errorMessage;
+    std::string strError = "";
     std::string strMasterNodeSignMessage;
 
     std::string strMessage = vinMasternode.prevout.ToStringShort() + std::to_string(nBlockHeight) + payee.ToString();
 
-    if (!obfuScationSigner.SignMessage(strMessage, errorMessage, vchSig, keyMasternode)) {
-        LogPrint("masternode","CMasternodePing::Sign() - Error: %s\n", errorMessage.c_str());
+    if (!CMessageSigner::SignMessage(strMessage, vchSig, keyMasternode)) {
+        LogPrint("masternode","%s - SignMessage Error.%s\n", __func__);
         return false;
     }
 
-    if (!obfuScationSigner.VerifyMessage(pubKeyMasternode, vchSig, strMessage, errorMessage)) {
-        LogPrint("masternode","CMasternodePing::Sign() - Error: %s\n", errorMessage.c_str());
+    if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
+        LogPrint("masternode","%s - VerifyMessage Error: %s\n", __func__, strError);
         return false;
     }
 
@@ -756,8 +757,8 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight)
     CPubKey pubKeyMasternode;
     CKey keyMasternode;
 
-    if (!obfuScationSigner.SetKey(strMasterNodePrivKey, errorMessage, keyMasternode, pubKeyMasternode)) {
-        LogPrint("masternode","CMasternodePayments::ProcessBlock() - Error upon calling SetKey: %s\n", errorMessage.c_str());
+    if (!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, keyMasternode, pubKeyMasternode)) {
+        LogPrint("masternode","CMasternodePayments::ProcessBlock() - Error upon calling SetKey.\n");
         return false;
     }
 
@@ -788,9 +789,9 @@ bool CMasternodePaymentWinner::SignatureValid()
     if (pmn != NULL) {
         std::string strMessage = vinMasternode.prevout.ToStringShort() + std::to_string(nBlockHeight) + payee.ToString();
 
-        std::string errorMessage = "";
-        if (!obfuScationSigner.VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, errorMessage)) {
-            return error("CMasternodePaymentWinner::SignatureValid() - Got bad Masternode address signature %s\n", vinMasternode.prevout.hash.ToString());
+        std::string strError = "";
+        if (!CMessageSigner::VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, strError)) {
+            return error("CMasternodePaymentWinner::SignatureValid() - Got bad Masternode address signature for %s: %s\n", vinMasternode.prevout.hash.ToString(), strError);
         }
 
         return true;

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -470,7 +470,7 @@ void CMasternodePayments::ProcessMessageMasternodePayments(CNode* pfrom, std::st
 
         // reject old signatures 6000 blocks after hard-fork
         if (winner.nMessVersion != MessageVersion::MESS_VER_HASH && Params().NewSigsActive(winner.nBlockHeight - 6000)) {
-            LogPrintf("%s : nMessVersion=%d not accepted anymore at block %d", __func__, winner.nMessVersion, nHeight);
+            LogPrintf("%s : nMessVersion=%d not accepted anymore at block %d\n", __func__, winner.nMessVersion, nHeight);
             return;
         }
 
@@ -763,7 +763,7 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight)
     CKey keyMasternode;
 
     if (!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, keyMasternode, pubKeyMasternode)) {
-        LogPrint("masternode","CMasternodePayments::ProcessBlock() - Error upon calling SetKey.\n");
+        LogPrint("masternode","CMasternodePayments::ProcessBlock() - Error upon calling GetKeysFromSecret.\n");
         return false;
     }
 

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -146,6 +146,69 @@ CMasternodePaymentDB::ReadResult CMasternodePaymentDB::Read(CMasternodePayments&
     return Ok;
 }
 
+uint256 CMasternodePaymentWinner::GetHash() const
+{
+    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+    ss << payee;
+    ss << nBlockHeight;
+    ss << vinMasternode.prevout;
+    return ss.GetHash();
+}
+
+std::string CMasternodePaymentWinner::GetStrMessage() const
+{
+    return vinMasternode.prevout.ToStringShort() + std::to_string(nBlockHeight) + payee.ToString();
+}
+
+const CPubKey* CMasternodePaymentWinner::GetPublicKey(std::string& strErrorRet) const
+{
+    CMasternode* pmn = mnodeman.Find(vinMasternode);
+    if(pmn) {
+        return &(pmn->pubKeyMasternode);
+    }
+    strErrorRet = strprintf("Unable to find masternode vin %s", vinMasternode.prevout.hash.GetHex());
+    return nullptr;
+}
+
+bool CMasternodePaymentWinner::IsValid(CNode* pnode, std::string& strError)
+{
+    CMasternode* pmn = mnodeman.Find(vinMasternode);
+
+    if (!pmn) {
+        strError = strprintf("Unknown Masternode %s", vinMasternode.prevout.hash.ToString());
+        LogPrint("masternode","CMasternodePaymentWinner::IsValid - %s\n", strError);
+        mnodeman.AskForMN(pnode, vinMasternode);
+        return false;
+    }
+
+    if (pmn->protocolVersion < ActiveProtocol()) {
+        strError = strprintf("Masternode protocol too old %d - req %d", pmn->protocolVersion, ActiveProtocol());
+        LogPrint("masternode","CMasternodePaymentWinner::IsValid - %s\n", strError);
+        return false;
+    }
+
+    int n = mnodeman.GetMasternodeRank(vinMasternode, nBlockHeight - 100, ActiveProtocol());
+
+    if (n > MNPAYMENTS_SIGNATURES_TOTAL) {
+        //It's common to have masternodes mistakenly think they are in the top 10
+        // We don't want to print all of these messages, or punish them unless they're way off
+        if (n > MNPAYMENTS_SIGNATURES_TOTAL * 2) {
+            strError = strprintf("Masternode not in the top %d (%d)", MNPAYMENTS_SIGNATURES_TOTAL * 2, n);
+            LogPrint("masternode","CMasternodePaymentWinner::IsValid - %s\n", strError);
+            //if (masternodeSync.IsSynced()) Misbehaving(pnode->GetId(), 20);
+        }
+        return false;
+    }
+
+    return true;
+}
+
+void CMasternodePaymentWinner::Relay()
+{
+    CInv inv(MSG_MASTERNODE_WINNER, GetHash());
+    RelayInv(inv);
+}
+
 void DumpMasternodePayments()
 {
     int64_t nStart = GetTimeMillis();
@@ -455,78 +518,6 @@ void CMasternodePayments::ProcessMessageMasternodePayments(CNode* pfrom, std::st
     }
 }
 
-uint256 CMasternodePaymentWinner::GetHash() const
-{
-    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
-    ss << payee;
-    ss << nBlockHeight;
-    ss << vinMasternode.prevout;
-    return ss.GetHash();
-}
-
-std::string CMasternodePaymentWinner::GetStrMessage() const
-{
-    return vinMasternode.prevout.ToStringShort() + std::to_string(nBlockHeight) + payee.ToString();
-}
-
-bool CMasternodePaymentWinner::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
-{
-    std::string strError = "";
-
-    if (Params().NewSigsActive(nBlockHeight - 20)) {
-        nMessVersion = MessageVersion::MESS_VER_HASH;
-        uint256 hash = GetSignatureHash();
-
-        if(!CHashSigner::SignHash(hash, keyMasternode, vchSig)) {
-            return error("%s : SignHash() failed", __func__);
-        }
-
-        if (!CHashSigner::VerifyHash(hash, pubKeyMasternode, vchSig, strError)) {
-            return error("%s : VerifyHash() failed, error: %s", __func__, strError);
-        }
-
-    } else {
-        // use old signature format
-        nMessVersion = MessageVersion::MESS_VER_STRMESS;
-        std::string strMessage = GetStrMessage();
-
-        if (!CMessageSigner::SignMessage(strMessage, vchSig, keyMasternode)) {
-            return error("%s : SignMessage() failed", __func__);
-        }
-
-        if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
-            return error("%s : VerifyMessage() failed, error: %s\n", __func__, strError);
-        }
-    }
-
-    return true;
-}
-
-bool CMasternodePaymentWinner::CheckSignature() const
-{
-    CMasternode* pmn = mnodeman.Find(vinMasternode);
-    if (pmn == nullptr) {
-        return error("%s : vinMasternode not found", __func__);
-    }
-
-    std::string strError = "";
-
-    if (nMessVersion == MessageVersion::MESS_VER_HASH) {
-        uint256 hash = GetSignatureHash();
-        if(!CHashSigner::VerifyHash(hash, pmn->pubKeyMasternode, vchSig, strError))
-            return error("%s : VerifyHash failed for %s: %s", __func__,
-                    vinMasternode.prevout.hash.ToString(), strError);
-
-    } else {
-        std::string strMessage = GetStrMessage();
-        if(!CMessageSigner::VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, strError))
-            return error("%s : VerifyMessage failed for %s: %s", __func__,
-                    vinMasternode.prevout.hash.ToString(), strError);
-    }
-
-    return true;
-}
-
 bool CMasternodePayments::GetBlockPayee(int nBlockHeight, CScript& payee)
 {
     if (mapMasternodeBlocks.count(nBlockHeight)) {
@@ -728,39 +719,6 @@ void CMasternodePayments::CleanPaymentList()
     }
 }
 
-bool CMasternodePaymentWinner::IsValid(CNode* pnode, std::string& strError)
-{
-    CMasternode* pmn = mnodeman.Find(vinMasternode);
-
-    if (!pmn) {
-        strError = strprintf("Unknown Masternode %s", vinMasternode.prevout.hash.ToString());
-        LogPrint("masternode","CMasternodePaymentWinner::IsValid - %s\n", strError);
-        mnodeman.AskForMN(pnode, vinMasternode);
-        return false;
-    }
-
-    if (pmn->protocolVersion < ActiveProtocol()) {
-        strError = strprintf("Masternode protocol too old %d - req %d", pmn->protocolVersion, ActiveProtocol());
-        LogPrint("masternode","CMasternodePaymentWinner::IsValid - %s\n", strError);
-        return false;
-    }
-
-    int n = mnodeman.GetMasternodeRank(vinMasternode, nBlockHeight - 100, ActiveProtocol());
-
-    if (n > MNPAYMENTS_SIGNATURES_TOTAL) {
-        //It's common to have masternodes mistakenly think they are in the top 10
-        // We don't want to print all of these messages, or punish them unless they're way off
-        if (n > MNPAYMENTS_SIGNATURES_TOTAL * 2) {
-            strError = strprintf("Masternode not in the top %d (%d)", MNPAYMENTS_SIGNATURES_TOTAL * 2, n);
-            LogPrint("masternode","CMasternodePaymentWinner::IsValid - %s\n", strError);
-            //if (masternodeSync.IsSynced()) Misbehaving(pnode->GetId(), 20);
-        }
-        return false;
-    }
-
-    return true;
-}
-
 bool CMasternodePayments::ProcessBlock(int nBlockHeight)
 {
     if (!fMasterNode) return false;
@@ -819,8 +777,10 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight)
         return false;
     }
 
+    const bool fNewSigs = Params().NewSigsActive(nBlockHeight - 20);
+
     LogPrint("masternode","CMasternodePayments::ProcessBlock() - Signing Winner\n");
-    if (newWinner.Sign(keyMasternode, pubKeyMasternode)) {
+    if (newWinner.Sign(keyMasternode, pubKeyMasternode, fNewSigs)) {
         LogPrint("masternode","CMasternodePayments::ProcessBlock() - AddWinningMasternode\n");
 
         if (AddWinningMasternode(newWinner)) {
@@ -831,12 +791,6 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight)
     }
 
     return false;
-}
-
-void CMasternodePaymentWinner::Relay()
-{
-    CInv inv(MSG_MASTERNODE_WINNER, GetHash());
-    RelayInv(inv);
 }
 
 void CMasternodePayments::Sync(CNode* node, int nCountNeeded)

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -183,7 +183,7 @@ public:
     // override CSignedMessage functions
     uint256 GetSignatureHash() const override { return GetHash(); }
     std::string GetStrMessage() const override;
-    const CPubKey* GetPublicKey(std::string& strErrorRet) const override;
+    const CTxIn GetVin() const override { return vinMasternode; };
 
     bool IsValid(CNode* pnode, std::string& strError);
     void Relay();

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -161,38 +161,31 @@ class CMasternodePaymentWinner
 {
 public:
     CTxIn vinMasternode;
-
     int nBlockHeight;
     CScript payee;
     std::vector<unsigned char> vchSig;
 
-    CMasternodePaymentWinner()
-    {
-        nBlockHeight = 0;
-        vinMasternode = CTxIn();
-        payee = CScript();
-    }
+    CMasternodePaymentWinner() :
+        vinMasternode(),
+        nBlockHeight(0),
+        payee(),
+        vchSig()
+    {}
 
-    CMasternodePaymentWinner(CTxIn vinIn)
-    {
-        nBlockHeight = 0;
-        vinMasternode = vinIn;
-        payee = CScript();
-    }
+    CMasternodePaymentWinner(CTxIn vinIn) :
+        vinMasternode(vinIn),
+        nBlockHeight(0),
+        payee(),
+        vchSig()
+    {}
 
-    uint256 GetHash()
-    {
-        CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
-        ss << payee;
-        ss << nBlockHeight;
-        ss << vinMasternode.prevout;
+    uint256 GetHash() const;
+    uint256 GetSignatureHash() const { return GetHash(); }
+    std::string GetStrMessage() const;
 
-        return ss.GetHash();
-    }
-
-    bool Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode);
+    bool Sign(CKey& keyMasternode, CPubKey& pubKeyMasternod);
     bool IsValid(CNode* pnode, std::string& strError);
-    bool SignatureValid();
+    bool SignatureValid() const;
     void Relay();
 
     void AddPayee(CScript payeeIn)

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -159,24 +159,26 @@ public:
 // for storing the winning payments
 class CMasternodePaymentWinner
 {
+private:
+    std::vector<unsigned char> vchSig;
+
 public:
     CTxIn vinMasternode;
     int nBlockHeight;
     CScript payee;
-    std::vector<unsigned char> vchSig;
 
     CMasternodePaymentWinner() :
+        vchSig(),
         vinMasternode(),
         nBlockHeight(0),
-        payee(),
-        vchSig()
+        payee()
     {}
 
     CMasternodePaymentWinner(CTxIn vinIn) :
+        vchSig(),
         vinMasternode(vinIn),
         nBlockHeight(0),
-        payee(),
-        vchSig()
+        payee()
     {}
 
     uint256 GetHash() const;

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -163,12 +163,14 @@ private:
     std::vector<unsigned char> vchSig;
 
 public:
+    int nMessVersion;
     CTxIn vinMasternode;
     int nBlockHeight;
     CScript payee;
 
     CMasternodePaymentWinner() :
         vchSig(),
+        nMessVersion(MessageVersion::MESS_VER_HASH),
         vinMasternode(),
         nBlockHeight(0),
         payee()
@@ -176,6 +178,7 @@ public:
 
     CMasternodePaymentWinner(CTxIn vinIn) :
         vchSig(),
+        nMessVersion(MessageVersion::MESS_VER_HASH),
         vinMasternode(vinIn),
         nBlockHeight(0),
         payee()
@@ -201,10 +204,20 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
     {
-        READWRITE(vinMasternode);
-        READWRITE(nBlockHeight);
-        READWRITE(payee);
-        READWRITE(vchSig);
+        try
+        {
+            READWRITE(nMessVersion);
+            READWRITE(vinMasternode);
+            READWRITE(nBlockHeight);
+            READWRITE(payee);
+            READWRITE(vchSig);
+        } catch (...) {
+            nMessVersion = MessageVersion::MESS_VER_STRMESS;
+            READWRITE(vinMasternode);
+            READWRITE(nBlockHeight);
+            READWRITE(payee);
+            READWRITE(vchSig);
+        }
     }
 
     std::string ToString()

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -157,39 +157,34 @@ public:
 };
 
 // for storing the winning payments
-class CMasternodePaymentWinner
+class CMasternodePaymentWinner : public CSignedMessage
 {
-private:
-    std::vector<unsigned char> vchSig;
-
 public:
-    int nMessVersion;
     CTxIn vinMasternode;
     int nBlockHeight;
     CScript payee;
 
     CMasternodePaymentWinner() :
-        vchSig(),
-        nMessVersion(MessageVersion::MESS_VER_HASH),
+        CSignedMessage(),
         vinMasternode(),
         nBlockHeight(0),
         payee()
     {}
 
     CMasternodePaymentWinner(CTxIn vinIn) :
-        vchSig(),
-        nMessVersion(MessageVersion::MESS_VER_HASH),
+        CSignedMessage(),
         vinMasternode(vinIn),
         nBlockHeight(0),
         payee()
     {}
 
     uint256 GetHash() const;
-    uint256 GetSignatureHash() const { return GetHash(); }
-    std::string GetStrMessage() const;
 
-    bool Sign(CKey& keyMasternode, CPubKey& pubKeyMasternod);
-    bool CheckSignature() const;
+    // override CSignedMessage functions
+    uint256 GetSignatureHash() const override { return GetHash(); }
+    std::string GetStrMessage() const override;
+    const CPubKey* GetPublicKey(std::string& strErrorRet) const override;
+
     bool IsValid(CNode* pnode, std::string& strError);
     void Relay();
 
@@ -197,7 +192,6 @@ public:
     {
         payee = payeeIn;
     }
-
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -184,8 +184,8 @@ public:
     std::string GetStrMessage() const;
 
     bool Sign(CKey& keyMasternode, CPubKey& pubKeyMasternod);
+    bool CheckSignature() const;
     bool IsValid(CNode* pnode, std::string& strError);
-    bool SignatureValid() const;
     void Relay();
 
     void AddPayee(CScript payeeIn)

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -198,19 +198,15 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
     {
+        READWRITE(vinMasternode);
+        READWRITE(nBlockHeight);
+        READWRITE(payee);
+        READWRITE(vchSig);
         try
         {
             READWRITE(nMessVersion);
-            READWRITE(vinMasternode);
-            READWRITE(nBlockHeight);
-            READWRITE(payee);
-            READWRITE(vchSig);
         } catch (...) {
             nMessVersion = MessageVersion::MESS_VER_STRMESS;
-            READWRITE(vinMasternode);
-            READWRITE(nBlockHeight);
-            READWRITE(payee);
-            READWRITE(vchSig);
         }
     }
 

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -714,7 +714,14 @@ CMasternodePing::CMasternodePing() :
         blockHash(0),
         sigTime(0),
         vchSig()
-{ }
+{
+    int nHeight;
+    {
+        LOCK(cs_main);
+        nHeight = chainActive.Height();
+    }
+    fNewSigs = Params().NewSigsActive(nHeight);
+}
 
 CMasternodePing::CMasternodePing(CTxIn& newVin) :
         vin(),
@@ -728,12 +735,14 @@ CMasternodePing::CMasternodePing(CTxIn& newVin) :
         if (nHeight > 12)
             blockHash = chainActive[nHeight - 12]->GetBlockHash();
     }
+    fNewSigs = Params().NewSigsActive(nHeight);
 }
 
 uint256 CMasternodePing::GetHash() const
 {
     CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
     ss << vin;
+    if (fNewSigs) ss << blockHash;
     ss << sigTime;
     return ss.GetHash();
 }
@@ -745,16 +754,10 @@ std::string CMasternodePing::GetStrMessage() const
 
 bool CMasternodePing::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
 {
-    int nHeight;
-    {
-        LOCK(cs_main);
-        nHeight = chainActive.Height();
-    }
-
     std::string strError = "";
     sigTime = GetAdjustedTime();
 
-    if (Params().NewSigsActive(nHeight)) {
+    if (fNewSigs) {
         uint256 hash = GetSignatureHash();
 
         if(!CHashSigner::SignHash(hash, keyMasternode, vchSig)) {
@@ -782,15 +785,9 @@ bool CMasternodePing::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
 
 bool CMasternodePing::CheckSignature(CPubKey& pubKeyMasternode, int &nDos) const
 {
-    int nHeight;
-    {
-        LOCK(cs_main);
-        nHeight = chainActive.Height();
-    }
-
     std::string strError = "";
 
-    if (Params().NewSigsActive(nHeight)) {
+    if (fNewSigs) {
         uint256 hash = GetSignatureHash();
 
         if (!CHashSigner::VerifyHash(hash, pubKeyMasternode, vchSig, strError)) {

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -64,7 +64,7 @@ CMasternode::CMasternode()
     addr = CService();
     pubKeyCollateralAddress = CPubKey();
     pubKeyMasternode = CPubKey();
-    sig = std::vector<unsigned char>();
+    vchSig = std::vector<unsigned char>();
     activeState = MASTERNODE_ENABLED;
     sigTime = GetAdjustedTime();
     lastPing = CMasternodePing();
@@ -89,7 +89,7 @@ CMasternode::CMasternode(const CMasternode& other)
     addr = other.addr;
     pubKeyCollateralAddress = other.pubKeyCollateralAddress;
     pubKeyMasternode = other.pubKeyMasternode;
-    sig = other.sig;
+    vchSig = other.vchSig;
     activeState = other.activeState;
     sigTime = other.sigTime;
     lastPing = other.lastPing;
@@ -114,7 +114,7 @@ CMasternode::CMasternode(const CMasternodeBroadcast& mnb)
     addr = mnb.addr;
     pubKeyCollateralAddress = mnb.pubKeyCollateralAddress;
     pubKeyMasternode = mnb.pubKeyMasternode;
-    sig = mnb.sig;
+    vchSig = mnb.vchSig;
     activeState = MASTERNODE_ENABLED;
     sigTime = mnb.sigTime;
     lastPing = mnb.lastPing;
@@ -141,7 +141,7 @@ bool CMasternode::UpdateFromNewBroadcast(CMasternodeBroadcast& mnb)
         pubKeyMasternode = mnb.pubKeyMasternode;
         pubKeyCollateralAddress = mnb.pubKeyCollateralAddress;
         sigTime = mnb.sigTime;
-        sig = mnb.sig;
+        vchSig = mnb.vchSig;
         protocolVersion = mnb.protocolVersion;
         addr = mnb.addr;
         lastTimeChecked = 0;
@@ -354,7 +354,7 @@ CMasternodeBroadcast::CMasternodeBroadcast()
     addr = CService();
     pubKeyCollateralAddress = CPubKey();
     pubKeyMasternode1 = CPubKey();
-    sig = std::vector<unsigned char>();
+    vchSig = std::vector<unsigned char>();
     activeState = MASTERNODE_ENABLED;
     sigTime = GetAdjustedTime();
     lastPing = CMasternodePing();
@@ -374,7 +374,7 @@ CMasternodeBroadcast::CMasternodeBroadcast(CService newAddr, CTxIn newVin, CPubK
     addr = newAddr;
     pubKeyCollateralAddress = pubKeyCollateralAddressNew;
     pubKeyMasternode = pubKeyMasternodeNew;
-    sig = std::vector<unsigned char>();
+    vchSig = std::vector<unsigned char>();
     activeState = MASTERNODE_ENABLED;
     sigTime = GetAdjustedTime();
     lastPing = CMasternodePing();
@@ -394,7 +394,7 @@ CMasternodeBroadcast::CMasternodeBroadcast(const CMasternode& mn)
     addr = mn.addr;
     pubKeyCollateralAddress = mn.pubKeyCollateralAddress;
     pubKeyMasternode = mn.pubKeyMasternode;
-    sig = mn.sig;
+    vchSig = mn.vchSig;
     activeState = mn.activeState;
     sigTime = mn.sigTime;
     lastPing = mn.lastPing;
@@ -536,7 +536,7 @@ bool CMasternodeBroadcast::CheckAndUpdate(int& nDos)
     }
 
     std::string strError = "";
-    if (!CMessageSigner::VerifyMessage(pubKeyCollateralAddress, sig, GetStrMessage(), strError))
+    if (!CMessageSigner::VerifyMessage(pubKeyCollateralAddress, vchSig, GetStrMessage(), strError))
     {
         // don't ban for old masternodes, their sigs could be broken because of the bug
         nDos = protocolVersion < MIN_PEER_MNANNOUNCE ? 0 : 100;
@@ -715,22 +715,23 @@ bool CMasternodeBroadcast::Sign(CKey& keyCollateralAddress)
     if (Params().NewSigsActive(nHeight)) {
         uint256 hash = GetSignatureHash();
 
-        if(!CHashSigner::SignHash(hash, keyCollateralAddress, sig)) {
+        if(!CHashSigner::SignHash(hash, keyCollateralAddress, vchSig)) {
             return error("%s : SignHash() failed", __func__);
         }
 
-        if (!CHashSigner::VerifyHash(hash, pubKeyCollateralAddress, sig, strError)) {
+        if (!CHashSigner::VerifyHash(hash, pubKeyCollateralAddress, vchSig, strError)) {
             return error("%s : VerifyHash() failed, error: %s", __func__, strError);
         }
+
     } else {
         // use old signature format
         std::string strMessage = GetStrMessage();
 
-        if (!CMessageSigner::SignMessage(strMessage, sig, keyCollateralAddress)) {
+        if (!CMessageSigner::SignMessage(strMessage, vchSig, keyCollateralAddress)) {
             return error("%s : SignMessage() failed", __func__);
         }
 
-        if (!CMessageSigner::VerifyMessage(pubKeyCollateralAddress, sig, strMessage, strError)) {
+        if (!CMessageSigner::VerifyMessage(pubKeyCollateralAddress, vchSig, strMessage, strError)) {
             return error("%s : VerifyMessage() failed, error: %s\n", __func__, strError);
         }
     }
@@ -739,18 +740,18 @@ bool CMasternodeBroadcast::Sign(CKey& keyCollateralAddress)
 }
 
 
-bool CMasternodeBroadcast::VerifySignature() const
+bool CMasternodeBroadcast::CheckSignature() const
 {
     std::string strError = "";
     uint256 hash = GetSignatureHash();
 
-    if (CHashSigner::VerifyHash(hash, pubKeyCollateralAddress, sig, strError))
+    if (CHashSigner::VerifyHash(hash, pubKeyCollateralAddress, vchSig, strError))
         return true;
 
     // if new signature fails, try old format
     std::string strMessage = GetStrMessage();
 
-    if (!CMessageSigner::VerifyMessage(pubKeyCollateralAddress, sig, strMessage, strError)) {
+    if (!CMessageSigner::VerifyMessage(pubKeyCollateralAddress, vchSig, strMessage, strError)) {
         return error("%s : Got bad masternode signature for %s: %s\n", __func__,
                 vin.prevout.hash.ToString(), strError);
     }

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -56,14 +56,14 @@ bool GetBlockHash(uint256& hash, int nBlockHeight)
     return false;
 }
 
-CMasternode::CMasternode()
+CMasternode::CMasternode() :
+        CSignedMessage()
 {
     LOCK(cs);
     vin = CTxIn();
     addr = CService();
     pubKeyCollateralAddress = CPubKey();
     pubKeyMasternode = CPubKey();
-    vchSig = std::vector<unsigned char>();
     activeState = MASTERNODE_ENABLED;
     sigTime = GetAdjustedTime();
     lastPing = CMasternodePing();
@@ -81,14 +81,14 @@ CMasternode::CMasternode()
     nLastDseep = 0; // temporary, do not save. Remove after migration to v12
 }
 
-CMasternode::CMasternode(const CMasternode& other)
+CMasternode::CMasternode(const CMasternode& other) :
+        CSignedMessage(other)
 {
     LOCK(cs);
     vin = other.vin;
     addr = other.addr;
     pubKeyCollateralAddress = other.pubKeyCollateralAddress;
     pubKeyMasternode = other.pubKeyMasternode;
-    vchSig = other.vchSig;
     activeState = other.activeState;
     sigTime = other.sigTime;
     lastPing = other.lastPing;
@@ -106,29 +106,45 @@ CMasternode::CMasternode(const CMasternode& other)
     nLastDseep = other.nLastDseep; // temporary, do not save. Remove after migration to v12
 }
 
-CMasternode::CMasternode(const CMasternodeBroadcast& mnb)
+CMasternode::CMasternode(const CMasternodeBroadcast& mnb) :
+        CMasternode((CMasternode) mnb)
 {
     LOCK(cs);
-    vin = mnb.vin;
-    addr = mnb.addr;
-    pubKeyCollateralAddress = mnb.pubKeyCollateralAddress;
-    pubKeyMasternode = mnb.pubKeyMasternode;
-    vchSig = mnb.vchSig;
     activeState = MASTERNODE_ENABLED;
-    sigTime = mnb.sigTime;
-    lastPing = mnb.lastPing;
     cacheInputAge = 0;
     cacheInputAgeBlock = 0;
     unitTest = false;
     allowFreeTx = true;
     nActiveState = MASTERNODE_ENABLED,
-    protocolVersion = mnb.protocolVersion;
-    nLastDsq = mnb.nLastDsq;
     nScanningErrorCount = 0;
     nLastScanningErrorBlockHeight = 0;
-    lastTimeChecked = 0;
-    nLastDsee = 0;  // temporary, do not save. Remove after migration to v12
-    nLastDseep = 0; // temporary, do not save. Remove after migration to v12
+}
+
+uint256 CMasternode::GetSignatureHash() const
+{
+    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+    ss << nMessVersion;
+    ss << addr;
+    ss << sigTime;
+    ss << pubKeyCollateralAddress;
+    ss << pubKeyMasternode;
+    ss << protocolVersion;
+    return ss.GetHash();
+}
+
+std::string CMasternode::GetStrMessage() const
+{
+    return (addr.ToString() +
+            std::to_string(sigTime) +
+            pubKeyCollateralAddress.GetID().ToString() +
+            pubKeyMasternode.GetID().ToString() +
+            std::to_string(protocolVersion)
+    );
+}
+
+const CPubKey* CMasternode::GetPublicKey(std::string& strErrorRet) const
+{
+    return &(pubKeyMasternode);
 }
 
 //
@@ -347,68 +363,23 @@ bool CMasternode::IsInputAssociatedWithPubkey() const
     return false;
 }
 
-CMasternodeBroadcast::CMasternodeBroadcast()
-{
-    nMessVersion = MessageVersion::MESS_VER_HASH;
-    vin = CTxIn();
-    addr = CService();
-    pubKeyCollateralAddress = CPubKey();
-    pubKeyMasternode1 = CPubKey();
-    vchSig = std::vector<unsigned char>();
-    activeState = MASTERNODE_ENABLED;
-    sigTime = GetAdjustedTime();
-    lastPing = CMasternodePing();
-    cacheInputAge = 0;
-    cacheInputAgeBlock = 0;
-    unitTest = false;
-    allowFreeTx = true;
-    protocolVersion = PROTOCOL_VERSION;
-    nLastDsq = 0;
-    nScanningErrorCount = 0;
-    nLastScanningErrorBlockHeight = 0;
-}
+CMasternodeBroadcast::CMasternodeBroadcast() :
+        CMasternode()
+{ }
 
-CMasternodeBroadcast::CMasternodeBroadcast(CService newAddr, CTxIn newVin, CPubKey pubKeyCollateralAddressNew, CPubKey pubKeyMasternodeNew, int protocolVersionIn)
+CMasternodeBroadcast::CMasternodeBroadcast(CService newAddr, CTxIn newVin, CPubKey pubKeyCollateralAddressNew, CPubKey pubKeyMasternodeNew, int protocolVersionIn) :
+        CMasternode()
 {
-    nMessVersion = MessageVersion::MESS_VER_HASH;
     vin = newVin;
     addr = newAddr;
     pubKeyCollateralAddress = pubKeyCollateralAddressNew;
     pubKeyMasternode = pubKeyMasternodeNew;
-    vchSig = std::vector<unsigned char>();
-    activeState = MASTERNODE_ENABLED;
-    sigTime = GetAdjustedTime();
-    lastPing = CMasternodePing();
-    cacheInputAge = 0;
-    cacheInputAgeBlock = 0;
-    unitTest = false;
-    allowFreeTx = true;
     protocolVersion = protocolVersionIn;
-    nLastDsq = 0;
-    nScanningErrorCount = 0;
-    nLastScanningErrorBlockHeight = 0;
 }
 
-CMasternodeBroadcast::CMasternodeBroadcast(const CMasternode& mn)
-{
-    nMessVersion = MessageVersion::MESS_VER_HASH;
-    vin = mn.vin;
-    addr = mn.addr;
-    pubKeyCollateralAddress = mn.pubKeyCollateralAddress;
-    pubKeyMasternode = mn.pubKeyMasternode;
-    vchSig = mn.GetVchSig();
-    activeState = mn.activeState;
-    sigTime = mn.sigTime;
-    lastPing = mn.lastPing;
-    cacheInputAge = mn.cacheInputAge;
-    cacheInputAgeBlock = mn.cacheInputAgeBlock;
-    unitTest = mn.unitTest;
-    allowFreeTx = mn.allowFreeTx;
-    protocolVersion = mn.protocolVersion;
-    nLastDsq = mn.nLastDsq;
-    nScanningErrorCount = mn.nScanningErrorCount;
-    nLastScanningErrorBlockHeight = mn.nLastScanningErrorBlockHeight;
-}
+CMasternodeBroadcast::CMasternodeBroadcast(const CMasternode& mn) :
+        CMasternode(mn)
+{ }
 
 bool CMasternodeBroadcast::Create(std::string strService, std::string strKeyMasternode, std::string strTxHash, std::string strOutputIndex, std::string& strErrorRet, CMasternodeBroadcast& mnbRet, bool fOffline)
 {
@@ -449,12 +420,18 @@ bool CMasternodeBroadcast::Create(CTxIn txin, CService service, CKey keyCollater
     // wait for reindex and/or import to finish
     if (fImporting || fReindex) return false;
 
+    bool fNewSigs = true;
+    {
+        LOCK(cs_main);
+        fNewSigs = chainActive.NewSigsActive();
+    }
+
     LogPrint("masternode", "CMasternodeBroadcast::Create -- pubKeyCollateralAddressNew = %s, pubKeyMasternodeNew.GetID() = %s\n",
         CBitcoinAddress(pubKeyCollateralAddressNew.GetID()).ToString(),
         pubKeyMasternodeNew.GetID().ToString());
 
     CMasternodePing mnp(txin);
-    if (!mnp.Sign(keyMasternodeNew, pubKeyMasternodeNew)) {
+    if (!mnp.Sign(keyMasternodeNew, pubKeyMasternodeNew, fNewSigs)) {
         strErrorRet = strprintf("Failed to sign ping, masternode=%s", txin.prevout.hash.ToString());
         LogPrint("masternode","CMasternodeBroadcast::Create -- %s\n", strErrorRet);
         mnbRet = CMasternodeBroadcast();
@@ -471,7 +448,7 @@ bool CMasternodeBroadcast::Create(CTxIn txin, CService service, CKey keyCollater
     }
 
     mnbRet.lastPing = mnp;
-    if (!mnbRet.Sign(keyCollateralAddressNew)) {
+    if (!mnbRet.Sign(keyCollateralAddressNew, pubKeyCollateralAddressNew, fNewSigs)) {
         strErrorRet = strprintf("Failed to sign broadcast, masternode=%s", txin.prevout.hash.ToString());
         LogPrint("masternode","CMasternodeBroadcast::Create -- %s\n", strErrorRet);
         mnbRet = CMasternodeBroadcast();
@@ -682,102 +659,15 @@ uint256 CMasternodeBroadcast::GetHash() const
     return ss.GetHash();
 }
 
-uint256 CMasternodeBroadcast::GetSignatureHash() const
-{
-    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
-    ss << nMessVersion;
-    ss << addr;
-    ss << sigTime;
-    ss << pubKeyCollateralAddress;
-    ss << pubKeyMasternode;
-    ss << protocolVersion;
-    return ss.GetHash();
-}
-
-std::string CMasternodeBroadcast::GetStrMessage() const
-{
-    return (addr.ToString() +
-            std::to_string(sigTime) +
-            pubKeyCollateralAddress.GetID().ToString() +
-            pubKeyMasternode.GetID().ToString() +
-            std::to_string(protocolVersion)
-    );
-}
-
-bool CMasternodeBroadcast::Sign(CKey& keyCollateralAddress)
-{
-    int nHeight;
-    {
-        LOCK(cs_main);
-        nHeight = chainActive.Height();
-    }
-
-    std::string strError = "";
-    sigTime = GetAdjustedTime();
-
-    if (Params().NewSigsActive(nHeight)) {
-        nMessVersion = MessageVersion::MESS_VER_HASH;
-        uint256 hash = GetSignatureHash();
-
-        if(!CHashSigner::SignHash(hash, keyCollateralAddress, vchSig)) {
-            return error("%s : SignHash() failed", __func__);
-        }
-
-        if (!CHashSigner::VerifyHash(hash, pubKeyCollateralAddress, vchSig, strError)) {
-            return error("%s : VerifyHash() failed, error: %s", __func__, strError);
-        }
-
-    } else {
-        // use old signature format
-        nMessVersion = MessageVersion::MESS_VER_STRMESS;
-        std::string strMessage = GetStrMessage();
-
-        if (!CMessageSigner::SignMessage(strMessage, vchSig, keyCollateralAddress)) {
-            return error("%s : SignMessage() failed", __func__);
-        }
-
-        if (!CMessageSigner::VerifyMessage(pubKeyCollateralAddress, vchSig, strMessage, strError)) {
-            return error("%s : VerifyMessage() failed, error: %s\n", __func__, strError);
-        }
-    }
-
-    return true;
-}
-
-
-bool CMasternodeBroadcast::CheckSignature() const
-{
-    std::string strError = "";
-
-    if (nMessVersion == MessageVersion::MESS_VER_HASH) {
-        uint256 hash = GetSignatureHash();
-        if (!CHashSigner::VerifyHash(hash, pubKeyMasternode, vchSig, strError)) {
-            return error("%s : VerifyHash failed for %s: %s", __func__,
-                    vin.prevout.hash.ToString(), strError);
-        }
-
-    } else {
-        std::string strMessage = GetStrMessage();
-        if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
-            return error("%s : VerifyMessage failed for %s: %s", __func__,
-                    vin.prevout.hash.ToString(), strError);
-        }
-    }
-
-    return true;
-}
-
 CMasternodePing::CMasternodePing() :
-        vchSig(),
-        nMessVersion(MessageVersion::MESS_VER_HASH),
+        CSignedMessage(),
         vin(),
         blockHash(0),
         sigTime(0)
 { }
 
 CMasternodePing::CMasternodePing(CTxIn& newVin) :
-        vchSig(),
-        nMessVersion(MessageVersion::MESS_VER_HASH),
+        CSignedMessage(),
         vin(),
         sigTime(0)
 {
@@ -804,67 +694,14 @@ std::string CMasternodePing::GetStrMessage() const
     return vin.ToString() + blockHash.ToString() + std::to_string(sigTime);
 }
 
-bool CMasternodePing::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
+const CPubKey* CMasternodePing::GetPublicKey(std::string& strErrorRet) const
 {
-    int nHeight;
-    {
-        LOCK(cs_main);
-        nHeight = chainActive.Height();
+    CMasternode* pmn = mnodeman.Find(vin);
+    if(pmn) {
+        return &(pmn->pubKeyMasternode);
     }
-
-    std::string strError = "";
-    sigTime = GetAdjustedTime();
-
-    if (Params().NewSigsActive(nHeight)) {
-        nMessVersion = MessageVersion::MESS_VER_HASH;
-        uint256 hash = GetSignatureHash();
-
-        if(!CHashSigner::SignHash(hash, keyMasternode, vchSig)) {
-            return error("%s : SignHash() failed", __func__);
-        }
-
-        if (!CHashSigner::VerifyHash(hash, pubKeyMasternode, vchSig, strError)) {
-            return error("%s : VerifyHash() failed, error: %s", __func__, strError);
-        }
-    } else {
-        // use old signature format
-        nMessVersion = MessageVersion::MESS_VER_STRMESS;
-        std::string strMessage = GetStrMessage();
-
-        if (!CMessageSigner::SignMessage(strMessage, vchSig, keyMasternode)) {
-            return error("%s - SignMessage() failed", __func__);
-        }
-
-        if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
-            return error("%s - VerifyMessage() failed, error: %s\n", __func__, strError);
-        }
-    }
-
-    return true;
-}
-
-bool CMasternodePing::CheckSignature(CPubKey& pubKeyMasternode, int &nDos) const
-{
-    std::string strError = "";
-
-    if (nMessVersion == MessageVersion::MESS_VER_HASH) {
-        uint256 hash = GetSignatureHash();
-        if (!CHashSigner::VerifyHash(hash, pubKeyMasternode, vchSig, strError)) {
-            nDos = 33;
-            return error("%s : VerifyHash failed for %s: %s", __func__,
-                    vin.prevout.hash.ToString(), strError);
-        }
-
-    } else {
-        std::string strMessage = GetStrMessage();
-        if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
-            nDos = 33;
-            return error("%s : VerifyMessage failed for %s: %s", __func__,
-                    vin.prevout.hash.ToString(), strError);
-        }
-    }
-
-    return true;
+    strErrorRet = strprintf("Unable to find masternode vin %s", vin.prevout.hash.GetHex());
+    return nullptr;
 }
 
 bool CMasternodePing::CheckAndUpdate(int& nDos, bool fRequireEnabled, bool fCheckSigTimeOnly)
@@ -881,25 +718,32 @@ bool CMasternodePing::CheckAndUpdate(int& nDos, bool fRequireEnabled, bool fChec
         return false;
     }
 
+    // see if we have this Masternode
+    CMasternode* pmn = mnodeman.Find(vin);
+    const bool isMasternodeFound = (pmn != nullptr);
+    const bool isSignatureValid = (isMasternodeFound && CheckSignature(pmn->pubKeyMasternode));
+
     if(fCheckSigTimeOnly) {
-        CMasternode* pmn = mnodeman.Find(vin);
-        if(pmn) return CheckSignature(pmn->pubKeyMasternode, nDos);
+        if (isMasternodeFound && !isSignatureValid) {
+            nDos = 33;
+            return false;
+        }
         return true;
     }
 
     LogPrint("masternode", "CMasternodePing::CheckAndUpdate - New Ping - %s - %s - %lli\n", GetHash().ToString(), blockHash.ToString(), sigTime);
 
-    // see if we have this Masternode
-    CMasternode* pmn = mnodeman.Find(vin);
-    if (pmn != NULL && pmn->protocolVersion >= masternodePayments.GetMinMasternodePaymentsProto()) {
+    if (isMasternodeFound && pmn->protocolVersion >= masternodePayments.GetMinMasternodePaymentsProto()) {
         if (fRequireEnabled && !pmn->IsEnabled()) return false;
 
         // LogPrint("masternode","mnping - Found corresponding mn for vin: %s\n", vin.ToString());
         // update only if there is no known ping for this masternode or
         // last ping was more then MASTERNODE_MIN_MNP_SECONDS-60 ago comparing to this one
         if (!pmn->IsPingedWithin(MASTERNODE_MIN_MNP_SECONDS - 60, sigTime)) {
-            if (!CheckSignature(pmn->pubKeyMasternode, nDos))
+            if (!isSignatureValid) {
+                nDos = 33;
                 return false;
+            }
 
             BlockMap::iterator mi = mapBlockIndex.find(blockHash);
             if (mi != mapBlockIndex.end() && (*mi).second) {

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -685,6 +685,7 @@ uint256 CMasternodeBroadcast::GetHash() const
 uint256 CMasternodeBroadcast::GetSignatureHash() const
 {
     CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+    ss << nMessVersion;
     ss << addr;
     ss << sigTime;
     ss << pubKeyCollateralAddress;

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -394,7 +394,7 @@ CMasternodeBroadcast::CMasternodeBroadcast(const CMasternode& mn)
     addr = mn.addr;
     pubKeyCollateralAddress = mn.pubKeyCollateralAddress;
     pubKeyMasternode = mn.pubKeyMasternode;
-    vchSig = mn.vchSig;
+    vchSig = mn.GetVchSig();
     activeState = mn.activeState;
     sigTime = mn.sigTime;
     lastPing = mn.lastPing;
@@ -760,10 +760,10 @@ bool CMasternodeBroadcast::CheckSignature() const
 }
 
 CMasternodePing::CMasternodePing() :
+        vchSig(),
         vin(),
         blockHash(0),
-        sigTime(0),
-        vchSig()
+        sigTime(0)
 {
     int nHeight;
     {
@@ -774,9 +774,9 @@ CMasternodePing::CMasternodePing() :
 }
 
 CMasternodePing::CMasternodePing(CTxIn& newVin) :
+        vchSig(),
         vin(),
-        sigTime(0),
-        vchSig()
+        sigTime(0)
 {
     int nHeight;
     {

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -6,6 +6,7 @@
 #include "masternode.h"
 #include "addrman.h"
 #include "masternodeman.h"
+#include "messagesigner.h"
 #include "obfuscation.h"
 #include "sync.h"
 #include "util.h"
@@ -331,6 +332,22 @@ bool CMasternode::IsValidNetAddr()
            (IsReachable(addr) && addr.IsRoutable());
 }
 
+bool CMasternode::IsInputAssociatedWithPubkey() const
+{
+    CScript payee;
+    payee = GetScriptForDestination(pubKeyCollateralAddress.GetID());
+
+    CTransaction txVin;
+    uint256 hash;
+    if(GetTransaction(vin.prevout.hash, txVin, hash, true)) {
+        for (CTxOut out : txVin.vout) {
+            if (out.nValue == 10000 * COIN && out.scriptPubKey == payee) return true;
+        }
+    }
+
+    return false;
+}
+
 CMasternodeBroadcast::CMasternodeBroadcast()
 {
     vin = CTxIn();
@@ -406,7 +423,7 @@ bool CMasternodeBroadcast::Create(std::string strService, std::string strKeyMast
         return false;
     }
 
-    if (!obfuScationSigner.GetKeysFromSecret(strKeyMasternode, keyMasternodeNew, pubKeyMasternodeNew)) {
+    if (!CMessageSigner::GetKeysFromSecret(strKeyMasternode, keyMasternodeNew, pubKeyMasternodeNew)) {
         strErrorRet = strprintf("Invalid masternode key %s", strKeyMasternode);
         LogPrint("masternode","CMasternodeBroadcast::Create -- %s\n", strErrorRet);
         return false;
@@ -518,12 +535,12 @@ bool CMasternodeBroadcast::CheckAndUpdate(int& nDos)
         return false;
     }
 
-    std::string errorMessage = "";
-    if (!obfuScationSigner.VerifyMessage(pubKeyCollateralAddress, sig, GetStrMessage(), errorMessage))
+    std::string strError = "";
+    if (!CMessageSigner::VerifyMessage(pubKeyCollateralAddress, sig, GetStrMessage(), strError))
     {
         // don't ban for old masternodes, their sigs could be broken because of the bug
         nDos = protocolVersion < MIN_PEER_MNANNOUNCE ? 0 : 100;
-        return error("CMasternodeBroadcast::CheckAndUpdate - Got bad Masternode address signature : %s", errorMessage);
+        return error("CMasternodeBroadcast::CheckAndUpdate - Got bad Masternode address signature : %s", strError);
     }
 
     if (Params().NetworkID() == CBaseChainParams::MAIN) {
@@ -657,16 +674,16 @@ void CMasternodeBroadcast::Relay()
 
 bool CMasternodeBroadcast::Sign(CKey& keyCollateralAddress)
 {
-    std::string errorMessage;
+    std::string strError = "";
     sigTime = GetAdjustedTime();
 
     std::string strMessage = GetStrMessage();
 
-    if (!obfuScationSigner.SignMessage(strMessage, errorMessage, sig, keyCollateralAddress))
-        return error("CMasternodeBroadcast::Sign() - Error: %s", errorMessage);
+    if (!CMessageSigner::SignMessage(strMessage, sig, keyCollateralAddress))
+        return error("CMasternodeBroadcast::Sign() - Error.");
 
-    if (!obfuScationSigner.VerifyMessage(pubKeyCollateralAddress, sig, strMessage, errorMessage))
-        return error("CMasternodeBroadcast::Sign() - Error: %s", errorMessage);
+    if (!CMessageSigner::VerifyMessage(pubKeyCollateralAddress, sig, strMessage, strError))
+        return error("CMasternodeBroadcast::Sign() - Error: %s", strError);
 
     return true;
 }
@@ -674,10 +691,10 @@ bool CMasternodeBroadcast::Sign(CKey& keyCollateralAddress)
 
 bool CMasternodeBroadcast::VerifySignature()
 {
-    std::string errorMessage;
+    std::string strError;
 
-    if(!obfuScationSigner.VerifyMessage(pubKeyCollateralAddress, sig, GetStrMessage(), errorMessage))
-        return error("CMasternodeBroadcast::VerifySignature() - Error: %s", errorMessage);
+    if(!CMessageSigner::VerifyMessage(pubKeyCollateralAddress, sig, GetStrMessage(), strError))
+        return error("CMasternodeBroadcast::VerifySignature() - Error: %s", strError);
 
     return true;
 }
@@ -711,19 +728,19 @@ CMasternodePing::CMasternodePing(CTxIn& newVin)
 
 bool CMasternodePing::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
 {
-    std::string errorMessage;
+    std::string strError = "";
     std::string strMasterNodeSignMessage;
 
     sigTime = GetAdjustedTime();
     std::string strMessage = vin.ToString() + blockHash.ToString() + std::to_string(sigTime);
 
-    if (!obfuScationSigner.SignMessage(strMessage, errorMessage, vchSig, keyMasternode)) {
-        LogPrint("masternode","CMasternodePing::Sign() - Error: %s\n", errorMessage);
+    if (!CMessageSigner::SignMessage(strMessage, vchSig, keyMasternode)) {
+        LogPrint("masternode","%s : SignMessage() - Error.", __func__);
         return false;
     }
 
-    if (!obfuScationSigner.VerifyMessage(pubKeyMasternode, vchSig, strMessage, errorMessage)) {
-        LogPrint("masternode","CMasternodePing::Sign() - Error: %s\n", errorMessage);
+    if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
+        LogPrint("masternode","%s : VerifyMessage() - Error: %s\n", __func__, strError);
         return false;
     }
 
@@ -732,12 +749,12 @@ bool CMasternodePing::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
 
 bool CMasternodePing::VerifySignature(CPubKey& pubKeyMasternode, int &nDos)
 {
+    std::string strError = "";
     std::string strMessage = vin.ToString() + blockHash.ToString() + std::to_string(sigTime);
-    std::string errorMessage = "";
 
-    if(!obfuScationSigner.VerifyMessage(pubKeyMasternode, vchSig, strMessage, errorMessage)){
+    if(!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)){
         nDos = 33;
-        return error("CMasternodePing::VerifySignature - Got bad Masternode ping signature %s Error: %s", vin.ToString(), errorMessage);
+        return error("CMasternodePing::VerifySignature - Got bad Masternode ping signature %s Error: %s", vin.ToString(), strError);
     }
     return true;
 }

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -415,7 +415,7 @@ bool CMasternodeBroadcast::Create(CTxIn txin, CService service, CKey keyCollater
     // wait for reindex and/or import to finish
     if (fImporting || fReindex) return false;
 
-    bool fNewSigs = true;
+    bool fNewSigs = false;
     {
         LOCK(cs_main);
         fNewSigs = chainActive.NewSigsActive();

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -6,7 +6,6 @@
 #include "masternode.h"
 #include "addrman.h"
 #include "masternodeman.h"
-#include "messagesigner.h"
 #include "obfuscation.h"
 #include "sync.h"
 #include "util.h"
@@ -350,6 +349,7 @@ bool CMasternode::IsInputAssociatedWithPubkey() const
 
 CMasternodeBroadcast::CMasternodeBroadcast()
 {
+    nMessVersion = MessageVersion::MESS_VER_HASH;
     vin = CTxIn();
     addr = CService();
     pubKeyCollateralAddress = CPubKey();
@@ -370,6 +370,7 @@ CMasternodeBroadcast::CMasternodeBroadcast()
 
 CMasternodeBroadcast::CMasternodeBroadcast(CService newAddr, CTxIn newVin, CPubKey pubKeyCollateralAddressNew, CPubKey pubKeyMasternodeNew, int protocolVersionIn)
 {
+    nMessVersion = MessageVersion::MESS_VER_HASH;
     vin = newVin;
     addr = newAddr;
     pubKeyCollateralAddress = pubKeyCollateralAddressNew;
@@ -390,6 +391,7 @@ CMasternodeBroadcast::CMasternodeBroadcast(CService newAddr, CTxIn newVin, CPubK
 
 CMasternodeBroadcast::CMasternodeBroadcast(const CMasternode& mn)
 {
+    nMessVersion = MessageVersion::MESS_VER_HASH;
     vin = mn.vin;
     addr = mn.addr;
     pubKeyCollateralAddress = mn.pubKeyCollateralAddress;
@@ -713,6 +715,7 @@ bool CMasternodeBroadcast::Sign(CKey& keyCollateralAddress)
     sigTime = GetAdjustedTime();
 
     if (Params().NewSigsActive(nHeight)) {
+        nMessVersion = MessageVersion::MESS_VER_HASH;
         uint256 hash = GetSignatureHash();
 
         if(!CHashSigner::SignHash(hash, keyCollateralAddress, vchSig)) {
@@ -725,6 +728,7 @@ bool CMasternodeBroadcast::Sign(CKey& keyCollateralAddress)
 
     } else {
         // use old signature format
+        nMessVersion = MessageVersion::MESS_VER_STRMESS;
         std::string strMessage = GetStrMessage();
 
         if (!CMessageSigner::SignMessage(strMessage, vchSig, keyCollateralAddress)) {
@@ -743,17 +747,20 @@ bool CMasternodeBroadcast::Sign(CKey& keyCollateralAddress)
 bool CMasternodeBroadcast::CheckSignature() const
 {
     std::string strError = "";
-    uint256 hash = GetSignatureHash();
 
-    if (CHashSigner::VerifyHash(hash, pubKeyCollateralAddress, vchSig, strError))
-        return true;
+    if (nMessVersion == MessageVersion::MESS_VER_HASH) {
+        uint256 hash = GetSignatureHash();
+        if (!CHashSigner::VerifyHash(hash, pubKeyMasternode, vchSig, strError)) {
+            return error("%s : VerifyHash failed for %s: %s", __func__,
+                    vin.prevout.hash.ToString(), strError);
+        }
 
-    // if new signature fails, try old format
-    std::string strMessage = GetStrMessage();
-
-    if (!CMessageSigner::VerifyMessage(pubKeyCollateralAddress, vchSig, strMessage, strError)) {
-        return error("%s : Got bad masternode signature for %s: %s\n", __func__,
-                vin.prevout.hash.ToString(), strError);
+    } else {
+        std::string strMessage = GetStrMessage();
+        if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
+            return error("%s : VerifyMessage failed for %s: %s", __func__,
+                    vin.prevout.hash.ToString(), strError);
+        }
     }
 
     return true;
@@ -761,20 +768,15 @@ bool CMasternodeBroadcast::CheckSignature() const
 
 CMasternodePing::CMasternodePing() :
         vchSig(),
+        nMessVersion(MessageVersion::MESS_VER_HASH),
         vin(),
         blockHash(0),
         sigTime(0)
-{
-    int nHeight;
-    {
-        LOCK(cs_main);
-        nHeight = chainActive.Height();
-    }
-    fNewSigs = Params().NewSigsActive(nHeight);
-}
+{ }
 
 CMasternodePing::CMasternodePing(CTxIn& newVin) :
         vchSig(),
+        nMessVersion(MessageVersion::MESS_VER_HASH),
         vin(),
         sigTime(0)
 {
@@ -785,14 +787,13 @@ CMasternodePing::CMasternodePing(CTxIn& newVin) :
         if (nHeight > 12)
             blockHash = chainActive[nHeight - 12]->GetBlockHash();
     }
-    fNewSigs = Params().NewSigsActive(nHeight);
 }
 
 uint256 CMasternodePing::GetHash() const
 {
     CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
     ss << vin;
-    if (fNewSigs) ss << blockHash;
+    if (nMessVersion == MessageVersion::MESS_VER_HASH) ss << blockHash;
     ss << sigTime;
     return ss.GetHash();
 }
@@ -804,10 +805,17 @@ std::string CMasternodePing::GetStrMessage() const
 
 bool CMasternodePing::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
 {
+    int nHeight;
+    {
+        LOCK(cs_main);
+        nHeight = chainActive.Height();
+    }
+
     std::string strError = "";
     sigTime = GetAdjustedTime();
 
-    if (fNewSigs) {
+    if (Params().NewSigsActive(nHeight)) {
+        nMessVersion = MessageVersion::MESS_VER_HASH;
         uint256 hash = GetSignatureHash();
 
         if(!CHashSigner::SignHash(hash, keyMasternode, vchSig)) {
@@ -819,6 +827,7 @@ bool CMasternodePing::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
         }
     } else {
         // use old signature format
+        nMessVersion = MessageVersion::MESS_VER_STRMESS;
         std::string strMessage = GetStrMessage();
 
         if (!CMessageSigner::SignMessage(strMessage, vchSig, keyMasternode)) {
@@ -837,20 +846,20 @@ bool CMasternodePing::CheckSignature(CPubKey& pubKeyMasternode, int &nDos) const
 {
     std::string strError = "";
 
-    if (fNewSigs) {
+    if (nMessVersion == MessageVersion::MESS_VER_HASH) {
         uint256 hash = GetSignatureHash();
-
         if (!CHashSigner::VerifyHash(hash, pubKeyMasternode, vchSig, strError)) {
             nDos = 33;
-            return error("%s : Got bad masternode ping hash signature, error: %s\n", __func__, strError);
+            return error("%s : VerifyHash failed for %s: %s", __func__,
+                    vin.prevout.hash.ToString(), strError);
         }
 
     } else {
         std::string strMessage = GetStrMessage();
-
         if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
             nDos = 33;
-            return error("%s : Got bad masternode ping message signature, error: %s\n", __func__, strError);
+            return error("%s : VerifyMessage failed for %s: %s", __func__,
+                    vin.prevout.hash.ToString(), strError);
         }
     }
 

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -142,11 +142,6 @@ std::string CMasternode::GetStrMessage() const
     );
 }
 
-const CPubKey* CMasternode::GetPublicKey(std::string& strErrorRet) const
-{
-    return &(pubKeyMasternode);
-}
-
 //
 // When a new masternode broadcast is sent, update our information
 //
@@ -692,16 +687,6 @@ uint256 CMasternodePing::GetHash() const
 std::string CMasternodePing::GetStrMessage() const
 {
     return vin.ToString() + blockHash.ToString() + std::to_string(sigTime);
-}
-
-const CPubKey* CMasternodePing::GetPublicKey(std::string& strErrorRet) const
-{
-    CMasternode* pmn = mnodeman.Find(vin);
-    if(pmn) {
-        return &(pmn->pubKeyMasternode);
-    }
-    strErrorRet = strprintf("Unable to find masternode vin %s", vin.prevout.hash.GetHex());
-    return nullptr;
 }
 
 bool CMasternodePing::CheckAndUpdate(int& nDos, bool fRequireEnabled, bool fCheckSigTimeOnly)

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -709,53 +709,104 @@ std::string CMasternodeBroadcast::GetStrMessage()
     );
 }
 
-CMasternodePing::CMasternodePing()
+CMasternodePing::CMasternodePing() :
+        vin(),
+        blockHash(0),
+        sigTime(0),
+        vchSig()
+{ }
+
+CMasternodePing::CMasternodePing(CTxIn& newVin) :
+        vin(),
+        sigTime(0),
+        vchSig()
 {
-    vin = CTxIn();
-    blockHash = uint256(0);
-    sigTime = 0;
-    vchSig = std::vector<unsigned char>();
+    int nHeight;
+    {
+        LOCK(cs_main);
+        nHeight = chainActive.Height();
+        if (nHeight > 12)
+            blockHash = chainActive[nHeight - 12]->GetBlockHash();
+    }
 }
 
-CMasternodePing::CMasternodePing(CTxIn& newVin)
+uint256 CMasternodePing::GetHash() const
 {
-    vin = newVin;
-    blockHash = chainActive[chainActive.Height() - 12]->GetBlockHash();
-    sigTime = GetAdjustedTime();
-    vchSig = std::vector<unsigned char>();
+    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+    ss << vin;
+    ss << sigTime;
+    return ss.GetHash();
 }
 
+std::string CMasternodePing::GetStrMessage() const
+{
+    return vin.ToString() + blockHash.ToString() + std::to_string(sigTime);
+}
 
 bool CMasternodePing::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
 {
-    std::string strError = "";
-    std::string strMasterNodeSignMessage;
-
-    sigTime = GetAdjustedTime();
-    std::string strMessage = vin.ToString() + blockHash.ToString() + std::to_string(sigTime);
-
-    if (!CMessageSigner::SignMessage(strMessage, vchSig, keyMasternode)) {
-        LogPrint("masternode","%s : SignMessage() - Error.", __func__);
-        return false;
+    int nHeight;
+    {
+        LOCK(cs_main);
+        nHeight = chainActive.Height();
     }
 
-    if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
-        LogPrint("masternode","%s : VerifyMessage() - Error: %s\n", __func__, strError);
-        return false;
+    std::string strError = "";
+    sigTime = GetAdjustedTime();
+
+    if (Params().NewSigsActive(nHeight)) {
+        uint256 hash = GetSignatureHash();
+
+        if(!CHashSigner::SignHash(hash, keyMasternode, vchSig)) {
+            return error("%s : SignHash() failed", __func__);
+        }
+
+        if (!CHashSigner::VerifyHash(hash, pubKeyMasternode, vchSig, strError)) {
+            return error("%s : VerifyHash() failed, error: %s", __func__, strError);
+        }
+    } else {
+        // use old signature format
+        std::string strMessage = GetStrMessage();
+
+        if (!CMessageSigner::SignMessage(strMessage, vchSig, keyMasternode)) {
+            return error("%s - SignMessage() failed", __func__);
+        }
+
+        if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
+            return error("%s - VerifyMessage() failed, error: %s\n", __func__, strError);
+        }
     }
 
     return true;
 }
 
-bool CMasternodePing::VerifySignature(CPubKey& pubKeyMasternode, int &nDos)
+bool CMasternodePing::CheckSignature(CPubKey& pubKeyMasternode, int &nDos) const
 {
-    std::string strError = "";
-    std::string strMessage = vin.ToString() + blockHash.ToString() + std::to_string(sigTime);
-
-    if(!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)){
-        nDos = 33;
-        return error("CMasternodePing::VerifySignature - Got bad Masternode ping signature %s Error: %s", vin.ToString(), strError);
+    int nHeight;
+    {
+        LOCK(cs_main);
+        nHeight = chainActive.Height();
     }
+
+    std::string strError = "";
+
+    if (Params().NewSigsActive(nHeight)) {
+        uint256 hash = GetSignatureHash();
+
+        if (!CHashSigner::VerifyHash(hash, pubKeyMasternode, vchSig, strError)) {
+            nDos = 33;
+            return error("%s : Got bad masternode ping hash signature, error: %s\n", __func__, strError);
+        }
+
+    } else {
+        std::string strMessage = GetStrMessage();
+
+        if (!CMessageSigner::VerifyMessage(pubKeyMasternode, vchSig, strMessage, strError)) {
+            nDos = 33;
+            return error("%s : Got bad masternode ping message signature, error: %s\n", __func__, strError);
+        }
+    }
+
     return true;
 }
 
@@ -775,7 +826,7 @@ bool CMasternodePing::CheckAndUpdate(int& nDos, bool fRequireEnabled, bool fChec
 
     if(fCheckSigTimeOnly) {
         CMasternode* pmn = mnodeman.Find(vin);
-        if(pmn) return VerifySignature(pmn->pubKeyMasternode, nDos);
+        if(pmn) return CheckSignature(pmn->pubKeyMasternode, nDos);
         return true;
     }
 
@@ -790,7 +841,7 @@ bool CMasternodePing::CheckAndUpdate(int& nDos, bool fRequireEnabled, bool fChec
         // update only if there is no known ping for this masternode or
         // last ping was more then MASTERNODE_MIN_MNP_SECONDS-60 ago comparing to this one
         if (!pmn->IsPingedWithin(MASTERNODE_MIN_MNP_SECONDS - 60, sigTime)) {
-            if (!VerifySignature(pmn->pubKeyMasternode, nDos))
+            if (!CheckSignature(pmn->pubKeyMasternode, nDos))
                 return false;
 
             BlockMap::iterator mi = mapBlockIndex.find(blockHash);

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -672,34 +672,26 @@ void CMasternodeBroadcast::Relay()
     RelayInv(inv);
 }
 
-bool CMasternodeBroadcast::Sign(CKey& keyCollateralAddress)
+uint256 CMasternodeBroadcast::GetHash() const
 {
-    std::string strError = "";
-    sigTime = GetAdjustedTime();
-
-    std::string strMessage = GetStrMessage();
-
-    if (!CMessageSigner::SignMessage(strMessage, sig, keyCollateralAddress))
-        return error("CMasternodeBroadcast::Sign() - Error.");
-
-    if (!CMessageSigner::VerifyMessage(pubKeyCollateralAddress, sig, strMessage, strError))
-        return error("CMasternodeBroadcast::Sign() - Error: %s", strError);
-
-    return true;
+    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+    ss << sigTime;
+    ss << pubKeyCollateralAddress;
+    return ss.GetHash();
 }
 
-
-bool CMasternodeBroadcast::VerifySignature()
+uint256 CMasternodeBroadcast::GetSignatureHash() const
 {
-    std::string strError;
-
-    if(!CMessageSigner::VerifyMessage(pubKeyCollateralAddress, sig, GetStrMessage(), strError))
-        return error("CMasternodeBroadcast::VerifySignature() - Error: %s", strError);
-
-    return true;
+    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+    ss << addr;
+    ss << sigTime;
+    ss << pubKeyCollateralAddress;
+    ss << pubKeyMasternode;
+    ss << protocolVersion;
+    return ss.GetHash();
 }
 
-std::string CMasternodeBroadcast::GetStrMessage()
+std::string CMasternodeBroadcast::GetStrMessage() const
 {
     return (addr.ToString() +
             std::to_string(sigTime) +
@@ -707,6 +699,63 @@ std::string CMasternodeBroadcast::GetStrMessage()
             pubKeyMasternode.GetID().ToString() +
             std::to_string(protocolVersion)
     );
+}
+
+bool CMasternodeBroadcast::Sign(CKey& keyCollateralAddress)
+{
+    int nHeight;
+    {
+        LOCK(cs_main);
+        nHeight = chainActive.Height();
+    }
+
+    std::string strError = "";
+    sigTime = GetAdjustedTime();
+
+    if (Params().NewSigsActive(nHeight)) {
+        uint256 hash = GetSignatureHash();
+
+        if(!CHashSigner::SignHash(hash, keyCollateralAddress, sig)) {
+            return error("%s : SignHash() failed", __func__);
+        }
+
+        if (!CHashSigner::VerifyHash(hash, pubKeyCollateralAddress, sig, strError)) {
+            return error("%s : VerifyHash() failed, error: %s", __func__, strError);
+        }
+    } else {
+        // use old signature format
+        std::string strMessage = GetStrMessage();
+
+        if (!CMessageSigner::SignMessage(strMessage, sig, keyCollateralAddress)) {
+            return error("%s : SignMessage() failed", __func__);
+        }
+
+        if (!CMessageSigner::VerifyMessage(pubKeyCollateralAddress, sig, strMessage, strError)) {
+            return error("%s : VerifyMessage() failed, error: %s\n", __func__, strError);
+        }
+    }
+
+    return true;
+}
+
+
+bool CMasternodeBroadcast::VerifySignature() const
+{
+    std::string strError = "";
+    uint256 hash = GetSignatureHash();
+
+    if (CHashSigner::VerifyHash(hash, pubKeyCollateralAddress, sig, strError))
+        return true;
+
+    // if new signature fails, try old format
+    std::string strMessage = GetStrMessage();
+
+    if (!CMessageSigner::VerifyMessage(pubKeyCollateralAddress, sig, strMessage, strError)) {
+        return error("%s : Got bad masternode signature for %s: %s\n", __func__,
+                vin.prevout.hash.ToString(), strError);
+    }
+
+    return true;
 }
 
 CMasternodePing::CMasternodePing() :

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -106,20 +106,6 @@ CMasternode::CMasternode(const CMasternode& other) :
     nLastDseep = other.nLastDseep; // temporary, do not save. Remove after migration to v12
 }
 
-CMasternode::CMasternode(const CMasternodeBroadcast& mnb) :
-        CMasternode((CMasternode) mnb)
-{
-    LOCK(cs);
-    activeState = MASTERNODE_ENABLED;
-    cacheInputAge = 0;
-    cacheInputAgeBlock = 0;
-    unitTest = false;
-    allowFreeTx = true;
-    nActiveState = MASTERNODE_ENABLED,
-    nScanningErrorCount = 0;
-    nLastScanningErrorBlockHeight = 0;
-}
-
 uint256 CMasternode::GetSignatureHash() const
 {
     CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -496,11 +496,11 @@ bool CMasternodeBroadcast::CheckAndUpdate(int& nDos)
     }
 
     std::string strError = "";
-    if (!CMessageSigner::VerifyMessage(pubKeyCollateralAddress, vchSig, GetStrMessage(), strError))
+    if (!CheckSignature())
     {
         // don't ban for old masternodes, their sigs could be broken because of the bug
         nDos = protocolVersion < MIN_PEER_MNANNOUNCE ? 0 : 100;
-        return error("CMasternodeBroadcast::CheckAndUpdate - Got bad Masternode address signature : %s", strError);
+        return error("%s : Got bad Masternode address signature", __func__);
     }
 
     if (Params().NetworkID() == CBaseChainParams::MAIN) {
@@ -518,8 +518,8 @@ bool CMasternodeBroadcast::CheckAndUpdate(int& nDos)
     // unless someone is doing something fishy
     // (mapSeenMasternodeBroadcast in CMasternodeMan::ProcessMessage should filter legit duplicates)
     if(pmn->sigTime >= sigTime) {
-        return error("CMasternodeBroadcast::CheckAndUpdate - Bad sigTime %d for Masternode %20s %105s (existing broadcast is at %d)",
-                      sigTime, addr.ToString(), vin.ToString(), pmn->sigTime);
+        return error("%s : Bad sigTime %d for Masternode %20s %105s (existing broadcast is at %d)",
+                      __func__, sigTime, addr.ToString(), vin.ToString(), pmn->sigTime);
     }
 
     // masternode is not enabled yet/already, nothing to update
@@ -644,13 +644,13 @@ CMasternodePing::CMasternodePing() :
         CSignedMessage(),
         vin(),
         blockHash(0),
-        sigTime(0)
+        sigTime(GetAdjustedTime())
 { }
 
 CMasternodePing::CMasternodePing(CTxIn& newVin) :
         CSignedMessage(),
-        vin(),
-        sigTime(0)
+        vin(newVin),
+        sigTime(GetAdjustedTime())
 {
     int nHeight;
     {

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -439,6 +439,58 @@ bool CMasternodeBroadcast::Create(CTxIn txin, CService service, CKey keyCollater
     return true;
 }
 
+bool CMasternodeBroadcast::Sign(const CKey& key, const CPubKey& pubKey, const bool fNewSigs)
+{
+    std::string strError = "";
+    std::string strMessage;
+
+    if (fNewSigs) {
+        nMessVersion = MessageVersion::MESS_VER_HASH;
+        strMessage = GetSignatureHash().GetHex();
+    } else {
+        nMessVersion = MessageVersion::MESS_VER_STRMESS;
+        strMessage = GetStrMessage();
+    }
+
+    if (!CMessageSigner::SignMessage(strMessage, vchSig, key)) {
+        return error("%s : SignMessage() (nMessVersion=%d) failed", __func__, nMessVersion);
+    }
+
+    if (!CMessageSigner::VerifyMessage(pubKey, vchSig, strMessage, strError)) {
+        return error("%s : VerifyMessage() (nMessVersion=%d) failed, error: %s\n",
+                __func__, nMessVersion, strError);
+    }
+
+    return true;
+}
+
+bool CMasternodeBroadcast::Sign(const std::string strSignKey, const bool fNewSigs)
+{
+    CKey key;
+    CPubKey pubkey;
+
+    if (!CMessageSigner::GetKeysFromSecret(strSignKey, key, pubkey)) {
+        return error("%s : Invalid strSignKey", __func__);
+    }
+
+    return Sign(key, pubkey, fNewSigs);
+}
+
+bool CMasternodeBroadcast::CheckSignature() const
+{
+    std::string strError = "";
+    std::string strMessage = (
+                            nMessVersion == MessageVersion::MESS_VER_HASH ?
+                            GetSignatureHash().GetHex() :
+                            GetStrMessage()
+                            );
+
+    if(!CMessageSigner::VerifyMessage(pubKeyCollateralAddress, vchSig, strMessage, strError))
+        return error("%s : VerifyMessage (nMessVersion=%d) failed: %s", __func__, nMessVersion, strError);
+
+    return true;
+}
+
 bool CMasternodeBroadcast::CheckDefaultPort(std::string strService, std::string& strErrorRet, std::string strContext)
 {
     CService service = CService(strService);

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -128,7 +128,7 @@ public:
     CPubKey pubKeyMasternode;
     CPubKey pubKeyCollateralAddress1;
     CPubKey pubKeyMasternode1;
-    std::vector<unsigned char> sig;
+    std::vector<unsigned char> vchSig;
     int activeState;
     int64_t sigTime; //mnb message time
     int cacheInputAge;
@@ -161,7 +161,7 @@ public:
         swap(first.addr, second.addr);
         swap(first.pubKeyCollateralAddress, second.pubKeyCollateralAddress);
         swap(first.pubKeyMasternode, second.pubKeyMasternode);
-        swap(first.sig, second.sig);
+        swap(first.vchSig, second.vchSig);
         swap(first.activeState, second.activeState);
         swap(first.sigTime, second.sigTime);
         swap(first.lastPing, second.lastPing);
@@ -202,7 +202,7 @@ public:
         READWRITE(addr);
         READWRITE(pubKeyCollateralAddress);
         READWRITE(pubKeyMasternode);
-        READWRITE(sig);
+        READWRITE(vchSig);
         READWRITE(sigTime);
         READWRITE(protocolVersion);
         READWRITE(activeState);
@@ -307,7 +307,7 @@ public:
     std::string GetStrMessage() const;
 
     bool Sign(CKey& keyCollateralAddress);
-    bool VerifySignature() const;
+    bool CheckSignature() const;
     void Relay();
 
     ADD_SERIALIZE_METHODS;
@@ -319,7 +319,7 @@ public:
         READWRITE(addr);
         READWRITE(pubKeyCollateralAddress);
         READWRITE(pubKeyMasternode);
-        READWRITE(sig);
+        READWRITE(vchSig);
         READWRITE(sigTime);
         READWRITE(protocolVersion);
         READWRITE(lastPing);

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -58,18 +58,14 @@ public:
         READWRITE(vchSig);
     }
 
+    uint256 GetHash() const;
+    uint256 GetSignatureHash() const { return GetHash(); }
+    std::string GetStrMessage() const;
+
     bool CheckAndUpdate(int& nDos, bool fRequireEnabled = true, bool fCheckSigTimeOnly = false);
     bool Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode);
-    bool VerifySignature(CPubKey& pubKeyMasternode, int &nDos);
+    bool CheckSignature(CPubKey& pubKeyMasternode, int &nDos) const;
     void Relay();
-
-    uint256 GetHash()
-    {
-        CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
-        ss << vin;
-        ss << sigTime;
-        return ss.GetHash();
-    }
 
     void swap(CMasternodePing& first, CMasternodePing& second) // nothrow
     {

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -38,13 +38,13 @@ bool GetBlockHash(uint256& hash, int nBlockHeight);
 class CMasternodePing
 {
 private:
+    std::vector<unsigned char> vchSig;
     bool fNewSigs;  // not serialized
 
 public:
     CTxIn vin;
     uint256 blockHash;
     int64_t sigTime; //mnb message times
-    std::vector<unsigned char> vchSig;
 
     CMasternodePing();
     CMasternodePing(CTxIn& newVin);
@@ -63,6 +63,7 @@ public:
     uint256 GetHash() const;
     uint256 GetSignatureHash() const { return GetHash(); }
     std::string GetStrMessage() const;
+    std::string GetSignatureBase64() const { return EncodeBase64(&vchSig[0], vchSig.size()); }
 
     bool CheckAndUpdate(int& nDos, bool fRequireEnabled = true, bool fCheckSigTimeOnly = false);
     bool Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode);
@@ -103,6 +104,9 @@ public:
 //
 class CMasternode
 {
+protected:
+    std::vector<unsigned char> vchSig;
+
 private:
     // critical section to protect the inner data structures
     mutable CCriticalSection cs;
@@ -128,7 +132,6 @@ public:
     CPubKey pubKeyMasternode;
     CPubKey pubKeyCollateralAddress1;
     CPubKey pubKeyMasternode1;
-    std::vector<unsigned char> vchSig;
     int activeState;
     int64_t sigTime; //mnb message time
     int cacheInputAge;
@@ -149,6 +152,10 @@ public:
     CMasternode(const CMasternode& other);
     CMasternode(const CMasternodeBroadcast& mnb);
 
+    std::string GetSignatureBase64() const { return EncodeBase64(&vchSig[0], vchSig.size()); }
+    std::vector<unsigned char> GetVchSig() const { return vchSig; }
+    void SetVchSig(const std::vector<unsigned char>& vchSigIn) { vchSig = vchSigIn; }
+
 
     void swap(CMasternode& first, CMasternode& second) // nothrow
     {
@@ -161,7 +168,6 @@ public:
         swap(first.addr, second.addr);
         swap(first.pubKeyCollateralAddress, second.pubKeyCollateralAddress);
         swap(first.pubKeyMasternode, second.pubKeyMasternode);
-        swap(first.vchSig, second.vchSig);
         swap(first.activeState, second.activeState);
         swap(first.sigTime, second.sigTime);
         swap(first.lastPing, second.lastPing);
@@ -173,6 +179,10 @@ public:
         swap(first.nLastDsq, second.nLastDsq);
         swap(first.nScanningErrorCount, second.nScanningErrorCount);
         swap(first.nLastScanningErrorBlockHeight, second.nLastScanningErrorBlockHeight);
+        // swap signatures
+        std::vector<unsigned char> secondSig = second.GetVchSig();
+        second.SetVchSig(first.GetVchSig());
+        first.SetVchSig(secondSig);
     }
 
     CMasternode& operator=(CMasternode from)

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -72,7 +72,7 @@ public:
     // override CSignedMessage functions
     uint256 GetSignatureHash() const override { return GetHash(); }
     std::string GetStrMessage() const override;
-    const CPubKey* GetPublicKey(std::string& strErrorRet) const override;
+    const CTxIn GetVin() const override  { return vin; };
 
     bool CheckAndUpdate(int& nDos, bool fRequireEnabled = true, bool fCheckSigTimeOnly = false);
     void Relay();
@@ -160,7 +160,8 @@ public:
     // override CSignedMessage functions
     uint256 GetSignatureHash() const override;
     std::string GetStrMessage() const override;
-    const CPubKey* GetPublicKey(std::string& strErrorRet) const override;
+    const CTxIn GetVin() const override { return vin; };
+    const CPubKey GetPublicKey(std::string& strErrorRet) const override { return pubKeyMasternode; }
 
     void swap(CMasternode& first, CMasternode& second) // nothrow
     {

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -187,10 +187,6 @@ public:
         swap(first.nLastDsq, second.nLastDsq);
         swap(first.nScanningErrorCount, second.nScanningErrorCount);
         swap(first.nLastScanningErrorBlockHeight, second.nLastScanningErrorBlockHeight);
-        // swap signatures
-        std::vector<unsigned char> secondSig = second.GetVchSig();
-        second.SetVchSig(first.GetVchSig());
-        first.SetVchSig(secondSig);
     }
 
     CMasternode& operator=(CMasternode from)

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -301,10 +301,14 @@ public:
 
     bool CheckAndUpdate(int& nDoS);
     bool CheckInputsAndAdd(int& nDos);
+
+    uint256 GetHash() const;
+    uint256 GetSignatureHash() const;
+    std::string GetStrMessage() const;
+
     bool Sign(CKey& keyCollateralAddress);
-    bool VerifySignature();
+    bool VerifySignature() const;
     void Relay();
-    std::string GetStrMessage();
 
     ADD_SERIALIZE_METHODS;
 
@@ -320,14 +324,6 @@ public:
         READWRITE(protocolVersion);
         READWRITE(lastPing);
         READWRITE(nLastDsq);
-    }
-
-    uint256 GetHash()
-    {
-        CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
-        ss << sigTime;
-        ss << pubKeyCollateralAddress;
-        return ss.GetHash();
     }
 
     /// Create Masternode broadcast, needs to be relayed manually after that

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -284,6 +284,9 @@ public:
 
     int64_t GetLastPaid();
     bool IsValidNetAddr();
+
+    /// Is the input associated with collateral public key? (and there is 10000 PIV - checking if valid masternode)
+    bool IsInputAssociatedWithPubkey() const;
 };
 
 

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -9,6 +9,7 @@
 #include "base58.h"
 #include "key.h"
 #include "main.h"
+#include "messagesigner.h"
 #include "net.h"
 #include "sync.h"
 #include "timedata.h"
@@ -39,9 +40,9 @@ class CMasternodePing
 {
 private:
     std::vector<unsigned char> vchSig;
-    bool fNewSigs;  // not serialized
 
 public:
+    int nMessVersion;
     CTxIn vin;
     uint256 blockHash;
     int64_t sigTime; //mnb message times
@@ -54,10 +55,20 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
     {
-        READWRITE(vin);
-        READWRITE(blockHash);
-        READWRITE(sigTime);
-        READWRITE(vchSig);
+        try
+        {
+            READWRITE(nMessVersion);
+            READWRITE(vin);
+            READWRITE(blockHash);
+            READWRITE(sigTime);
+            READWRITE(vchSig);
+        } catch (...) {
+            nMessVersion = MessageVersion::MESS_VER_STRMESS;
+            READWRITE(vin);
+            READWRITE(blockHash);
+            READWRITE(sigTime);
+            READWRITE(vchSig);
+        }
     }
 
     uint256 GetHash() const;
@@ -305,6 +316,7 @@ public:
 class CMasternodeBroadcast : public CMasternode
 {
 public:
+    int nMessVersion;
     CMasternodeBroadcast();
     CMasternodeBroadcast(CService newAddr, CTxIn newVin, CPubKey newPubkey, CPubKey newPubkey2, int protocolVersionIn);
     CMasternodeBroadcast(const CMasternode& mn);
@@ -325,15 +337,29 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
     {
-        READWRITE(vin);
-        READWRITE(addr);
-        READWRITE(pubKeyCollateralAddress);
-        READWRITE(pubKeyMasternode);
-        READWRITE(vchSig);
-        READWRITE(sigTime);
-        READWRITE(protocolVersion);
-        READWRITE(lastPing);
-        READWRITE(nLastDsq);
+        try {
+            READWRITE(nMessVersion);
+            READWRITE(vin);
+            READWRITE(addr);
+            READWRITE(pubKeyCollateralAddress);
+            READWRITE(pubKeyMasternode);
+            READWRITE(vchSig);
+            READWRITE(sigTime);
+            READWRITE(protocolVersion);
+            READWRITE(lastPing);
+            READWRITE(nLastDsq);
+        } catch(...) {
+            nMessVersion = MessageVersion::MESS_VER_STRMESS;
+            READWRITE(vin);
+            READWRITE(addr);
+            READWRITE(pubKeyCollateralAddress);
+            READWRITE(pubKeyMasternode);
+            READWRITE(vchSig);
+            READWRITE(sigTime);
+            READWRITE(protocolVersion);
+            READWRITE(lastPing);
+            READWRITE(nLastDsq);
+        }
     }
 
     /// Create Masternode broadcast, needs to be relayed manually after that

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -36,13 +36,9 @@ bool GetBlockHash(uint256& hash, int nBlockHeight);
 // The Masternode Ping Class : Contains a different serialize method for sending pings from masternodes throughout the network
 //
 
-class CMasternodePing
+class CMasternodePing : public CSignedMessage
 {
-private:
-    std::vector<unsigned char> vchSig;
-
 public:
-    int nMessVersion;
     CTxIn vin;
     uint256 blockHash;
     int64_t sigTime; //mnb message times
@@ -72,17 +68,19 @@ public:
     }
 
     uint256 GetHash() const;
-    uint256 GetSignatureHash() const { return GetHash(); }
-    std::string GetStrMessage() const;
-    std::string GetSignatureBase64() const { return EncodeBase64(&vchSig[0], vchSig.size()); }
+
+    // override CSignedMessage functions
+    uint256 GetSignatureHash() const override { return GetHash(); }
+    std::string GetStrMessage() const override;
+    const CPubKey* GetPublicKey(std::string& strErrorRet) const override;
 
     bool CheckAndUpdate(int& nDos, bool fRequireEnabled = true, bool fCheckSigTimeOnly = false);
-    bool Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode);
-    bool CheckSignature(CPubKey& pubKeyMasternode, int &nDos) const;
     void Relay();
 
     void swap(CMasternodePing& first, CMasternodePing& second) // nothrow
     {
+        CSignedMessage::swap(first, second);
+
         // enable ADL (not necessary in our case, but good practice)
         using std::swap;
 
@@ -91,7 +89,6 @@ public:
         swap(first.vin, second.vin);
         swap(first.blockHash, second.blockHash);
         swap(first.sigTime, second.sigTime);
-        swap(first.vchSig, second.vchSig);
     }
 
     CMasternodePing& operator=(CMasternodePing from)
@@ -113,11 +110,8 @@ public:
 // The Masternode Class. For managing the Obfuscation process. It contains the input of the 10000 PIV, signature to prove
 // it's the one who own that ip address and code for calculating the payment election.
 //
-class CMasternode
+class CMasternode : public CSignedMessage
 {
-protected:
-    std::vector<unsigned char> vchSig;
-
 private:
     // critical section to protect the inner data structures
     mutable CCriticalSection cs;
@@ -163,13 +157,15 @@ public:
     CMasternode(const CMasternode& other);
     CMasternode(const CMasternodeBroadcast& mnb);
 
-    std::string GetSignatureBase64() const { return EncodeBase64(&vchSig[0], vchSig.size()); }
-    std::vector<unsigned char> GetVchSig() const { return vchSig; }
-    void SetVchSig(const std::vector<unsigned char>& vchSigIn) { vchSig = vchSigIn; }
-
+    // override CSignedMessage functions
+    uint256 GetSignatureHash() const override;
+    std::string GetStrMessage() const override;
+    const CPubKey* GetPublicKey(std::string& strErrorRet) const override;
 
     void swap(CMasternode& first, CMasternode& second) // nothrow
     {
+        CSignedMessage::swap(first, second);
+
         // enable ADL (not necessary in our case, but good practice)
         using std::swap;
 
@@ -316,7 +312,6 @@ public:
 class CMasternodeBroadcast : public CMasternode
 {
 public:
-    int nMessVersion;
     CMasternodeBroadcast();
     CMasternodeBroadcast(CService newAddr, CTxIn newVin, CPubKey newPubkey, CPubKey newPubkey2, int protocolVersionIn);
     CMasternodeBroadcast(const CMasternode& mn);
@@ -325,11 +320,7 @@ public:
     bool CheckInputsAndAdd(int& nDos);
 
     uint256 GetHash() const;
-    uint256 GetSignatureHash() const;
-    std::string GetStrMessage() const;
 
-    bool Sign(CKey& keyCollateralAddress);
-    bool CheckSignature() const;
     void Relay();
 
     ADD_SERIALIZE_METHODS;

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -37,12 +37,14 @@ bool GetBlockHash(uint256& hash, int nBlockHeight);
 
 class CMasternodePing
 {
+private:
+    bool fNewSigs;  // not serialized
+
 public:
     CTxIn vin;
     uint256 blockHash;
     int64_t sigTime; //mnb message times
     std::vector<unsigned char> vchSig;
-    //removed stop
 
     CMasternodePing();
     CMasternodePing(CTxIn& newVin);

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -155,7 +155,6 @@ public:
 
     CMasternode();
     CMasternode(const CMasternode& other);
-    CMasternode(const CMasternodeBroadcast& mnb);
 
     // override CSignedMessage functions
     uint256 GetSignatureHash() const override;

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -319,6 +319,11 @@ public:
 
     void Relay();
 
+    // special sign/verify
+    bool Sign(const CKey& key, const CPubKey& pubKey, const bool fNewSigs);
+    bool Sign(const std::string strSignKey, const bool fNewSigs);
+    bool CheckSignature() const;
+
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -51,19 +51,15 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
     {
+        READWRITE(vin);
+        READWRITE(blockHash);
+        READWRITE(sigTime);
+        READWRITE(vchSig);
         try
         {
             READWRITE(nMessVersion);
-            READWRITE(vin);
-            READWRITE(blockHash);
-            READWRITE(sigTime);
-            READWRITE(vchSig);
         } catch (...) {
             nMessVersion = MessageVersion::MESS_VER_STRMESS;
-            READWRITE(vin);
-            READWRITE(blockHash);
-            READWRITE(sigTime);
-            READWRITE(vchSig);
         }
     }
 
@@ -329,29 +325,17 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
     {
-        try {
-            READWRITE(nMessVersion);
-            READWRITE(vin);
-            READWRITE(addr);
-            READWRITE(pubKeyCollateralAddress);
-            READWRITE(pubKeyMasternode);
-            READWRITE(vchSig);
-            READWRITE(sigTime);
-            READWRITE(protocolVersion);
-            READWRITE(lastPing);
-            READWRITE(nLastDsq);
-        } catch(...) {
-            nMessVersion = MessageVersion::MESS_VER_STRMESS;
-            READWRITE(vin);
-            READWRITE(addr);
-            READWRITE(pubKeyCollateralAddress);
-            READWRITE(pubKeyMasternode);
-            READWRITE(vchSig);
-            READWRITE(sigTime);
-            READWRITE(protocolVersion);
-            READWRITE(lastPing);
-            READWRITE(nLastDsq);
-        }
+        READWRITE(vin);
+        READWRITE(addr);
+        READWRITE(pubKeyCollateralAddress);
+        READWRITE(pubKeyMasternode);
+        READWRITE(vchSig);
+        READWRITE(sigTime);
+        READWRITE(protocolVersion);
+        READWRITE(lastPing);
+        READWRITE(nMessVersion);    // abuse nLastDsq (which will be removed) for old serialization
+        if (ser_action.ForRead())
+            nLastDsq = 0;
     }
 
     /// Create Masternode broadcast, needs to be relayed manually after that

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -160,7 +160,7 @@ public:
     uint256 GetSignatureHash() const override;
     std::string GetStrMessage() const override;
     const CTxIn GetVin() const override { return vin; };
-    const CPubKey GetPublicKey(std::string& strErrorRet) const override { return pubKeyMasternode; }
+    const CPubKey GetPublicKey(std::string& strErrorRet) const override { return pubKeyCollateralAddress; }
 
     void swap(CMasternode& first, CMasternode& second) // nothrow
     {

--- a/src/masternodeconfig.cpp
+++ b/src/masternodeconfig.cpp
@@ -106,7 +106,7 @@ bool CMasternodeConfig::read(std::string& strErr)
     return true;
 }
 
-bool CMasternodeConfig::CMasternodeEntry::castOutputIndex(int &n)
+bool CMasternodeConfig::CMasternodeEntry::castOutputIndex(int &n) const
 {
     try {
         n = std::stoi(outputIndex);

--- a/src/masternodeconfig.h
+++ b/src/masternodeconfig.h
@@ -52,7 +52,7 @@ public:
             return outputIndex;
         }
 
-        bool castOutputIndex(int& n);
+        bool castOutputIndex(int& n) const;
 
         void setOutputIndex(const std::string& outputIndex)
         {

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -943,7 +943,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
                     if (pmn->protocolVersion < GETHEADERS_VERSION) {
                         pmn->pubKeyMasternode = pubkey2;
                         pmn->sigTime = sigTime;
-                        pmn->sig = vchSig;
+                        pmn->vchSig = vchSig;
                         pmn->protocolVersion = protocolVersion;
                         pmn->addr = addr;
                         //fake ping
@@ -1028,7 +1028,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
             mn.addr = addr;
             mn.vin = vin;
             mn.pubKeyCollateralAddress = pubkey;
-            mn.sig = vchSig;
+            mn.vchSig = vchSig;
             mn.sigTime = sigTime;
             mn.pubKeyMasternode = pubkey2;
             mn.protocolVersion = protocolVersion;

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -943,7 +943,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
                     if (pmn->protocolVersion < GETHEADERS_VERSION) {
                         pmn->pubKeyMasternode = pubkey2;
                         pmn->sigTime = sigTime;
-                        pmn->vchSig = vchSig;
+                        pmn->SetVchSig(vchSig);
                         pmn->protocolVersion = protocolVersion;
                         pmn->addr = addr;
                         //fake ping
@@ -1028,7 +1028,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
             mn.addr = addr;
             mn.vin = vin;
             mn.pubKeyCollateralAddress = pubkey;
-            mn.vchSig = vchSig;
+            mn.SetVchSig(vchSig);
             mn.sigTime = sigTime;
             mn.pubKeyMasternode = pubkey2;
             mn.protocolVersion = protocolVersion;

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -7,6 +7,7 @@
 #include "activemasternode.h"
 #include "addrman.h"
 #include "masternode.h"
+#include "messagesigner.h"
 #include "obfuscation.h"
 #include "spork.h"
 #include "util.h"
@@ -749,7 +750,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
 
         // make sure the vout that was signed is related to the transaction that spawned the Masternode
         //  - this is expensive, so it's only done once per Masternode
-        if (!obfuScationSigner.IsVinAssociatedWithPubkey(mnb.vin, mnb.pubKeyCollateralAddress)) {
+        if (!mnb.IsInputAssociatedWithPubkey()) {
             LogPrintf("CMasternodeMan::ProcessMessage() : mnb - Got mismatched pubkey and vin\n");
             Misbehaving(pfrom->GetId(), 33);
             return;
@@ -916,9 +917,9 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
             return;
         }
 
-        std::string errorMessage = "";
-        if (!obfuScationSigner.VerifyMessage(pubkey, vchSig, strMessage, errorMessage)) {
-            LogPrintf("CMasternodeMan::ProcessMessage() : dsee - Got bad Masternode address signature\n");
+        std::string strError = "";
+        if (!CMessageSigner::VerifyMessage(pubkey, vchSig, strMessage, strError)) {
+            LogPrintf("CMasternodeMan::ProcessMessage() : dsee - Got bad Masternode address signature: %s\n", strError);
             Misbehaving(pfrom->GetId(), 100);
             return;
         }
@@ -971,7 +972,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         mapSeenDsee.insert(std::make_pair(vin.prevout, pubkey));
         // make sure the vout that was signed is related to the transaction that spawned the Masternode
         //  - this is expensive, so it's only done once per Masternode
-        if (!obfuScationSigner.IsVinAssociatedWithPubkey(vin, pubkey)) {
+        if (!pmn->IsInputAssociatedWithPubkey()) {
             LogPrintf("CMasternodeMan::ProcessMessage() : dsee - Got mismatched pubkey and vin\n");
             Misbehaving(pfrom->GetId(), 100);
             return;
@@ -1097,9 +1098,9 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
             if (sigTime - pmn->nLastDseep > MASTERNODE_MIN_MNP_SECONDS) {
                 std::string strMessage = pmn->addr.ToString() + std::to_string(sigTime) + std::to_string(stop);
 
-                std::string errorMessage = "";
-                if (!obfuScationSigner.VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, errorMessage)) {
-                    LogPrint("masternode","dseep - Got bad Masternode address signature %s \n", vin.prevout.hash.ToString());
+                std::string strError = "";
+                if (!CMessageSigner::VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, strError)) {
+                    LogPrint("masternode","dseep - Got bad Masternode address signature %s, error: %s\n", vin.prevout.hash.ToString(), strError);
                     //Misbehaving(pfrom->GetId(), 100);
                     return;
                 }

--- a/src/messagesigner.cpp
+++ b/src/messagesigner.cpp
@@ -66,8 +66,8 @@ bool CHashSigner::VerifyHash(const uint256& hash, const CKeyID& keyID, const std
 
     if(pubkeyFromSig.GetID() != keyID) {
         strErrorRet = strprintf("Keys don't match: pubkey=%s, pubkeyFromSig=%s, hash=%s, vchSig=%s",
-                    keyID.ToString(), pubkeyFromSig.GetID().ToString(), hash.ToString(),
-                    EncodeBase64(&vchSig[0], vchSig.size()));
+                CBitcoinAddress(keyID).ToString(), CBitcoinAddress(pubkeyFromSig.GetID()).ToString(),
+                hash.ToString(), EncodeBase64(&vchSig[0], vchSig.size()));
         return false;
     }
 

--- a/src/messagesigner.cpp
+++ b/src/messagesigner.cpp
@@ -1,0 +1,74 @@
+// Copyright (c) 2014-2018 The Dash Core developers
+// Copyright (c) 2018-2019 The PIVX developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "base58.h"
+#include "hash.h"
+#include "main.h" // For strMessageMagic
+#include "messagesigner.h"
+#include "tinyformat.h"
+#include "utilstrencodings.h"
+
+bool CMessageSigner::GetKeysFromSecret(const std::string& strSecret, CKey& keyRet, CPubKey& pubkeyRet)
+{
+    CBitcoinSecret vchSecret;
+
+    if(!vchSecret.SetString(strSecret)) return false;
+
+    keyRet = vchSecret.GetKey();
+    pubkeyRet = keyRet.GetPubKey();
+
+    return true;
+}
+
+bool CMessageSigner::SignMessage(const std::string& strMessage, std::vector<unsigned char>& vchSigRet, const CKey& key)
+{
+    CHashWriter ss(SER_GETHASH, 0);
+    ss << strMessageMagic;
+    ss << strMessage;
+
+    return CHashSigner::SignHash(ss.GetHash(), key, vchSigRet);
+}
+
+bool CMessageSigner::VerifyMessage(const CPubKey& pubkey, const std::vector<unsigned char>& vchSig, const std::string& strMessage, std::string& strErrorRet)
+{
+    return VerifyMessage(pubkey.GetID(), vchSig, strMessage, strErrorRet);
+}
+
+bool CMessageSigner::VerifyMessage(const CKeyID& keyID, const std::vector<unsigned char>& vchSig, const std::string& strMessage, std::string& strErrorRet)
+{
+    CHashWriter ss(SER_GETHASH, 0);
+    ss << strMessageMagic;
+    ss << strMessage;
+
+    return CHashSigner::VerifyHash(ss.GetHash(), keyID, vchSig, strErrorRet);
+}
+
+bool CHashSigner::SignHash(const uint256& hash, const CKey& key, std::vector<unsigned char>& vchSigRet)
+{
+    return key.SignCompact(hash, vchSigRet);
+}
+
+bool CHashSigner::VerifyHash(const uint256& hash, const CPubKey& pubkey, const std::vector<unsigned char>& vchSig, std::string& strErrorRet)
+{
+    return VerifyHash(hash, pubkey.GetID(), vchSig, strErrorRet);
+}
+
+bool CHashSigner::VerifyHash(const uint256& hash, const CKeyID& keyID, const std::vector<unsigned char>& vchSig, std::string& strErrorRet)
+{
+    CPubKey pubkeyFromSig;
+    if(!pubkeyFromSig.RecoverCompact(hash, vchSig)) {
+        strErrorRet = "Error recovering public key.";
+        return false;
+    }
+
+    if(pubkeyFromSig.GetID() != keyID) {
+        strErrorRet = strprintf("Keys don't match: pubkey=%s, pubkeyFromSig=%s, hash=%s, vchSig=%s",
+                    keyID.ToString(), pubkeyFromSig.GetID().ToString(), hash.ToString(),
+                    EncodeBase64(&vchSig[0], vchSig.size()));
+        return false;
+    }
+
+    return true;
+}

--- a/src/messagesigner.h
+++ b/src/messagesigner.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2014-2018 The Dash Core developers
+// Copyright (c) 2018-2019 The PIVX developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef MESSAGESIGNER_H
+#define MESSAGESIGNER_H
+
+#include "key.h"
+
+/** Helper class for signing messages and checking their signatures
+ */
+class CMessageSigner
+{
+public:
+    /// Set the private/public key values, returns true if successful
+    static bool GetKeysFromSecret(const std::string& strSecret, CKey& keyRet, CPubKey& pubkeyRet);
+    /// Sign the message, returns true if successful
+    static bool SignMessage(const std::string& strMessage, std::vector<unsigned char>& vchSigRet, const CKey& key);
+    /// Verify the message signature, returns true if succcessful
+    static bool VerifyMessage(const CPubKey& pubkey, const std::vector<unsigned char>& vchSig, const std::string& strMessage, std::string& strErrorRet);
+    /// Verify the message signature, returns true if succcessful
+    static bool VerifyMessage(const CKeyID& keyID, const std::vector<unsigned char>& vchSig, const std::string& strMessage, std::string& strErrorRet);
+};
+
+/** Helper class for signing hashes and checking their signatures
+ */
+class CHashSigner
+{
+public:
+    /// Sign the hash, returns true if successful
+    static bool SignHash(const uint256& hash, const CKey& key, std::vector<unsigned char>& vchSigRet);
+    /// Verify the hash signature, returns true if succcessful
+    static bool VerifyHash(const uint256& hash, const CPubKey& pubkey, const std::vector<unsigned char>& vchSig, std::string& strErrorRet);
+    /// Verify the hash signature, returns true if succcessful
+    static bool VerifyHash(const uint256& hash, const CKeyID& keyID, const std::vector<unsigned char>& vchSig, std::string& strErrorRet);
+};
+
+#endif

--- a/src/messagesigner.h
+++ b/src/messagesigner.h
@@ -7,6 +7,7 @@
 #define MESSAGESIGNER_H
 
 #include "key.h"
+#include "primitives/transaction.h" // for CTxIn
 
 enum MessageVersion {
         MESS_VER_STRMESS    = 0,
@@ -75,7 +76,11 @@ public:
     // Must be implemented in child classes
     virtual uint256 GetSignatureHash() const = 0;
     virtual std::string GetStrMessage() const = 0;
-    virtual const CPubKey* GetPublicKey(std::string& strErrorRet) const = 0;
+    virtual const CTxIn GetVin() const = 0;
+
+    // GetPublicKey defaults to public key of masternode with vin from GetVin.
+    // Child classes can override if public key is directly accessible.
+    virtual const CPubKey GetPublicKey(std::string& strErrorRet) const;
 
     // Setters and getters
     void SetVchSig(const std::vector<unsigned char>& vchSigIn) { vchSig = vchSigIn; }

--- a/src/messagesigner.h
+++ b/src/messagesigner.h
@@ -20,11 +20,13 @@ class CMessageSigner
 public:
     /// Set the private/public key values, returns true if successful
     static bool GetKeysFromSecret(const std::string& strSecret, CKey& keyRet, CPubKey& pubkeyRet);
+    /// Get the hash based on the input message
+    static uint256 GetMessageHash(const std::string& strMessage);
     /// Sign the message, returns true if successful
     static bool SignMessage(const std::string& strMessage, std::vector<unsigned char>& vchSigRet, const CKey& key);
-    /// Verify the message signature, returns true if succcessful
+    /// Verify the message signature, returns true if successful
     static bool VerifyMessage(const CPubKey& pubkey, const std::vector<unsigned char>& vchSig, const std::string& strMessage, std::string& strErrorRet);
-    /// Verify the message signature, returns true if succcessful
+    /// Verify the message signature, returns true if successful
     static bool VerifyMessage(const CKeyID& keyID, const std::vector<unsigned char>& vchSig, const std::string& strMessage, std::string& strErrorRet);
 };
 
@@ -35,10 +37,50 @@ class CHashSigner
 public:
     /// Sign the hash, returns true if successful
     static bool SignHash(const uint256& hash, const CKey& key, std::vector<unsigned char>& vchSigRet);
-    /// Verify the hash signature, returns true if succcessful
+    /// Verify the hash signature, returns true if successful
     static bool VerifyHash(const uint256& hash, const CPubKey& pubkey, const std::vector<unsigned char>& vchSig, std::string& strErrorRet);
-    /// Verify the hash signature, returns true if succcessful
+    /// Verify the hash signature, returns true if successful
     static bool VerifyHash(const uint256& hash, const CKeyID& keyID, const std::vector<unsigned char>& vchSig, std::string& strErrorRet);
+};
+
+/** Base Class for all signed messages on the network
+ */
+class CSignedMessage
+{
+protected:
+    std::vector<unsigned char> vchSig;
+    void swap(CSignedMessage& first, CSignedMessage& second); // Swap two messages
+
+public:
+    int nMessVersion;
+
+    CSignedMessage() :
+        vchSig(),
+        nMessVersion(MessageVersion::MESS_VER_HASH)
+    {}
+    CSignedMessage(const CSignedMessage& other)
+    {
+        vchSig = other.GetVchSig();
+        nMessVersion = other.nMessVersion;
+    }
+    virtual ~CSignedMessage() {};
+
+    // Sign-Verify message
+    bool Sign(const CKey& key, const CPubKey& pubKey, const bool fNewSigs);
+    bool Sign(const std::string strSignKey, const bool fNewSigs);
+    bool CheckSignature(const CPubKey& pubKey) const;
+    bool CheckSignature(const bool fSignatureCheck = true) const;
+
+    // Pure virtual functions (used in Sign-Verify functions)
+    // Must be implemented in child classes
+    virtual uint256 GetSignatureHash() const = 0;
+    virtual std::string GetStrMessage() const = 0;
+    virtual const CPubKey* GetPublicKey(std::string& strErrorRet) const = 0;
+
+    // Setters and getters
+    void SetVchSig(const std::vector<unsigned char>& vchSigIn) { vchSig = vchSigIn; }
+    std::vector<unsigned char> GetVchSig() const { return vchSig; }
+    std::string GetSignatureBase64() const;
 };
 
 #endif

--- a/src/messagesigner.h
+++ b/src/messagesigner.h
@@ -8,6 +8,11 @@
 
 #include "key.h"
 
+enum MessageVersion {
+        MESS_VER_STRMESS    = 0,
+        MESS_VER_HASH       = 1,
+};
+
 /** Helper class for signing messages and checking their signatures
  */
 class CMessageSigner

--- a/src/obfuscation-relay.cpp
+++ b/src/obfuscation-relay.cpp
@@ -43,7 +43,7 @@ std::string CObfuScationRelay::ToString()
 uint256 CObfuScationRelay::GetSignatureHash() const
 {
     CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
-    ss << in << out;
+    ss << nMessVersion << in << out;
     return ss.GetHash();
 }
 

--- a/src/obfuscation-relay.cpp
+++ b/src/obfuscation-relay.cpp
@@ -6,24 +6,30 @@
 #include "messagesigner.h"
 #include "obfuscation-relay.h"
 
-CObfuScationRelay::CObfuScationRelay()
-{
-    vinMasternode = CTxIn();
-    nBlockHeight = 0;
-    nRelayType = 0;
-    in = CTxIn();
-    out = CTxOut();
-}
+CObfuScationRelay::CObfuScationRelay() :
+        vchSig(),
+        vchSig2(),
+        vinMasternode(),
+        nBlockHeight(0),
+        nRelayType(0),
+        in(),
+        out()
+{ }
 
-CObfuScationRelay::CObfuScationRelay(CTxIn& vinMasternodeIn, std::vector<unsigned char>& vchSigIn, int nBlockHeightIn, int nRelayTypeIn, CTxIn& in2, CTxOut& out2)
-{
-    vinMasternode = vinMasternodeIn;
-    vchSig = vchSigIn;
-    nBlockHeight = nBlockHeightIn;
-    nRelayType = nRelayTypeIn;
-    in = in2;
-    out = out2;
-}
+CObfuScationRelay::CObfuScationRelay(CTxIn& vinMasternodeIn,
+                                     std::vector<unsigned char>& vchSigIn,
+                                     int nBlockHeightIn,
+                                     int nRelayTypeIn,
+                                     CTxIn& in2,
+                                     CTxOut& out2):
+        vchSig(vchSigIn),
+        vchSig2(),
+        vinMasternode(vinMasternodeIn),
+        nBlockHeight(nBlockHeightIn),
+        nRelayType(nRelayTypeIn),
+        in(in2),
+        out(out2)
+{ }
 
 std::string CObfuScationRelay::ToString()
 {

--- a/src/obfuscation-relay.cpp
+++ b/src/obfuscation-relay.cpp
@@ -3,6 +3,7 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "messagesigner.h"
 #include "obfuscation-relay.h"
 
 CObfuScationRelay::CObfuScationRelay()
@@ -35,25 +36,22 @@ std::string CObfuScationRelay::ToString()
 
 bool CObfuScationRelay::Sign(std::string strSharedKey)
 {
+    std::string strError = "";
     std::string strMessage = in.ToString() + out.ToString();
 
     CKey key2;
     CPubKey pubkey2;
-    std::string errorMessage = "";
 
-    if (!obfuScationSigner.SetKey(strSharedKey, errorMessage, key2, pubkey2)) {
-        LogPrintf("CObfuScationRelay():Sign - ERROR: Invalid shared key: '%s'\n", errorMessage.c_str());
-        return false;
+    if (!CMessageSigner::GetKeysFromSecret(strSharedKey, key2, pubkey2)) {
+        return error("%s : Invalid shared key %s", __func__, strSharedKey);
     }
 
-    if (!obfuScationSigner.SignMessage(strMessage, errorMessage, vchSig2, key2)) {
-        LogPrintf("CObfuScationRelay():Sign - Sign message failed\n");
-        return false;
+    if (!CMessageSigner::SignMessage(strMessage, vchSig2, key2)) {
+        return error("%s : Sign message failed", __func__);
     }
 
-    if (!obfuScationSigner.VerifyMessage(pubkey2, vchSig2, strMessage, errorMessage)) {
-        LogPrintf("CObfuScationRelay():Sign - Verify message failed\n");
-        return false;
+    if (!CMessageSigner::VerifyMessage(pubkey2, vchSig2, strMessage, strError)) {
+        return error("%s : Verify message failed, error: %s", __func__, strError);
     }
 
     return true;
@@ -61,20 +59,18 @@ bool CObfuScationRelay::Sign(std::string strSharedKey)
 
 bool CObfuScationRelay::VerifyMessage(std::string strSharedKey)
 {
+    std::string strError = "";
     std::string strMessage = in.ToString() + out.ToString();
 
     CKey key2;
     CPubKey pubkey2;
-    std::string errorMessage = "";
 
-    if (!obfuScationSigner.SetKey(strSharedKey, errorMessage, key2, pubkey2)) {
-        LogPrintf("CObfuScationRelay()::VerifyMessage - ERROR: Invalid shared key: '%s'\n", errorMessage.c_str());
-        return false;
+    if (!CMessageSigner::GetKeysFromSecret(strSharedKey, key2, pubkey2)) {
+        return error("%s : Invalid shared key %s", __func__, strSharedKey);
     }
 
-    if (!obfuScationSigner.VerifyMessage(pubkey2, vchSig2, strMessage, errorMessage)) {
-        LogPrintf("CObfuScationRelay()::VerifyMessage - Verify message failed\n");
-        return false;
+    if (!CMessageSigner::VerifyMessage(pubkey2, vchSig2, strMessage, strError)) {
+        return error("%s : Verify message failed, error: %s", __func__, strError);
     }
 
     return true;

--- a/src/obfuscation-relay.cpp
+++ b/src/obfuscation-relay.cpp
@@ -69,6 +69,7 @@ bool CObfuScationRelay::Sign(std::string strSharedKey)
     }
 
     if (Params().NewSigsActive(nHeight)) {
+        nMessVersion = MessageVersion::MESS_VER_HASH;
         uint256 hash = GetSignatureHash();
 
         if(!CHashSigner::SignHash(hash, key2, vchSig2)) {
@@ -81,6 +82,7 @@ bool CObfuScationRelay::Sign(std::string strSharedKey)
 
     } else {
         // use old signature format
+        nMessVersion = MessageVersion::MESS_VER_STRMESS;
         std::string strMessage = GetStrMessage();
 
         if (!CMessageSigner::SignMessage(strMessage, vchSig2, key2)) {
@@ -105,16 +107,15 @@ bool CObfuScationRelay::CheckSignature(std::string strSharedKey) const
         return error("%s : Invalid shared key %s", __func__, strSharedKey);
     }
 
-    uint256 hash = GetSignatureHash();
+    if (nMessVersion == MessageVersion::MESS_VER_HASH) {
+        uint256 hash = GetSignatureHash();
+        if(!CHashSigner::VerifyHash(hash, pubkey2, vchSig, strError))
+            return error("%s : VerifyHash failed, error: %s", __func__, strError);
 
-    if (CHashSigner::VerifyHash(hash, pubkey2, vchSig2, strError))
-        return true;
-
-    // if new signature fails, try old format
-    std::string strMessage = GetStrMessage();
-
-    if (!CMessageSigner::VerifyMessage(pubkey2, vchSig2, strMessage, strError)) {
-        return error("%s : Got bad masternode signature: %s\n", __func__, strError);
+    } else {
+        std::string strMessage = GetStrMessage();
+        if(!CMessageSigner::VerifyMessage(pubkey2, vchSig, strMessage, strError))
+            return error("%s : VerifyMessage failed, error: %s", __func__, strError);
     }
 
     return true;

--- a/src/obfuscation-relay.cpp
+++ b/src/obfuscation-relay.cpp
@@ -7,7 +7,7 @@
 #include "obfuscation-relay.h"
 
 CObfuScationRelay::CObfuScationRelay() :
-        vchSig(),
+        CSignedMessage(),
         vchSig2(),
         vinMasternode(),
         nBlockHeight(0),
@@ -22,14 +22,16 @@ CObfuScationRelay::CObfuScationRelay(CTxIn& vinMasternodeIn,
                                      int nRelayTypeIn,
                                      CTxIn& in2,
                                      CTxOut& out2):
-        vchSig(vchSigIn),
+        CSignedMessage(),
         vchSig2(),
         vinMasternode(vinMasternodeIn),
         nBlockHeight(nBlockHeightIn),
         nRelayType(nRelayTypeIn),
         in(in2),
         out(out2)
-{ }
+{
+    SetVchSig(vchSigIn);
+}
 
 std::string CObfuScationRelay::ToString()
 {
@@ -92,30 +94,6 @@ bool CObfuScationRelay::Sign(std::string strSharedKey)
         if (!CMessageSigner::VerifyMessage(pubkey2, vchSig2, strMessage, strError)) {
             return error("%s : VerifyMessage() failed, error: %s\n", __func__, strError);
         }
-    }
-
-    return true;
-}
-
-bool CObfuScationRelay::CheckSignature(std::string strSharedKey) const
-{
-    std::string strError = "";
-    CKey key2;
-    CPubKey pubkey2;
-
-    if (!CMessageSigner::GetKeysFromSecret(strSharedKey, key2, pubkey2)) {
-        return error("%s : Invalid shared key %s", __func__, strSharedKey);
-    }
-
-    if (nMessVersion == MessageVersion::MESS_VER_HASH) {
-        uint256 hash = GetSignatureHash();
-        if(!CHashSigner::VerifyHash(hash, pubkey2, vchSig, strError))
-            return error("%s : VerifyHash failed, error: %s", __func__, strError);
-
-    } else {
-        std::string strMessage = GetStrMessage();
-        if(!CMessageSigner::VerifyMessage(pubkey2, vchSig, strMessage, strError))
-            return error("%s : VerifyMessage failed, error: %s", __func__, strError);
     }
 
     return true;

--- a/src/obfuscation-relay.cpp
+++ b/src/obfuscation-relay.cpp
@@ -34,11 +34,27 @@ std::string CObfuScationRelay::ToString()
     return info.str();
 }
 
+uint256 CObfuScationRelay::GetSignatureHash() const
+{
+    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+    ss << in << out;
+    return ss.GetHash();
+}
+
+std::string CObfuScationRelay::GetStrMessage() const
+{
+    return in.ToString() + out.ToString();
+}
+
 bool CObfuScationRelay::Sign(std::string strSharedKey)
 {
-    std::string strError = "";
-    std::string strMessage = in.ToString() + out.ToString();
+    int nHeight;
+    {
+        LOCK(cs_main);
+        nHeight = chainActive.Height();
+    }
 
+    std::string strError = "";
     CKey key2;
     CPubKey pubkey2;
 
@@ -46,22 +62,36 @@ bool CObfuScationRelay::Sign(std::string strSharedKey)
         return error("%s : Invalid shared key %s", __func__, strSharedKey);
     }
 
-    if (!CMessageSigner::SignMessage(strMessage, vchSig2, key2)) {
-        return error("%s : Sign message failed", __func__);
-    }
+    if (Params().NewSigsActive(nHeight)) {
+        uint256 hash = GetSignatureHash();
 
-    if (!CMessageSigner::VerifyMessage(pubkey2, vchSig2, strMessage, strError)) {
-        return error("%s : Verify message failed, error: %s", __func__, strError);
+        if(!CHashSigner::SignHash(hash, key2, vchSig2)) {
+            return error("%s : SignHash() failed", __func__);
+        }
+
+        if (!CHashSigner::VerifyHash(hash, pubkey2, vchSig2, strError)) {
+            return error("%s : VerifyHash() failed, error: %s", __func__, strError);
+        }
+
+    } else {
+        // use old signature format
+        std::string strMessage = GetStrMessage();
+
+        if (!CMessageSigner::SignMessage(strMessage, vchSig2, key2)) {
+            return error("%s : SignMessage() failed", __func__);
+        }
+
+        if (!CMessageSigner::VerifyMessage(pubkey2, vchSig2, strMessage, strError)) {
+            return error("%s : VerifyMessage() failed, error: %s\n", __func__, strError);
+        }
     }
 
     return true;
 }
 
-bool CObfuScationRelay::VerifyMessage(std::string strSharedKey)
+bool CObfuScationRelay::CheckSignature(std::string strSharedKey) const
 {
     std::string strError = "";
-    std::string strMessage = in.ToString() + out.ToString();
-
     CKey key2;
     CPubKey pubkey2;
 
@@ -69,8 +99,16 @@ bool CObfuScationRelay::VerifyMessage(std::string strSharedKey)
         return error("%s : Invalid shared key %s", __func__, strSharedKey);
     }
 
+    uint256 hash = GetSignatureHash();
+
+    if (CHashSigner::VerifyHash(hash, pubkey2, vchSig2, strError))
+        return true;
+
+    // if new signature fails, try old format
+    std::string strMessage = GetStrMessage();
+
     if (!CMessageSigner::VerifyMessage(pubkey2, vchSig2, strMessage, strError)) {
-        return error("%s : Verify message failed, error: %s", __func__, strError);
+        return error("%s : Got bad masternode signature: %s\n", __func__, strError);
     }
 
     return true;

--- a/src/obfuscation-relay.cpp
+++ b/src/obfuscation-relay.cpp
@@ -54,51 +54,6 @@ std::string CObfuScationRelay::GetStrMessage() const
     return in.ToString() + out.ToString();
 }
 
-bool CObfuScationRelay::Sign(std::string strSharedKey)
-{
-    int nHeight;
-    {
-        LOCK(cs_main);
-        nHeight = chainActive.Height();
-    }
-
-    std::string strError = "";
-    CKey key2;
-    CPubKey pubkey2;
-
-    if (!CMessageSigner::GetKeysFromSecret(strSharedKey, key2, pubkey2)) {
-        return error("%s : Invalid shared key %s", __func__, strSharedKey);
-    }
-
-    if (Params().NewSigsActive(nHeight)) {
-        nMessVersion = MessageVersion::MESS_VER_HASH;
-        uint256 hash = GetSignatureHash();
-
-        if(!CHashSigner::SignHash(hash, key2, vchSig2)) {
-            return error("%s : SignHash() failed", __func__);
-        }
-
-        if (!CHashSigner::VerifyHash(hash, pubkey2, vchSig2, strError)) {
-            return error("%s : VerifyHash() failed, error: %s", __func__, strError);
-        }
-
-    } else {
-        // use old signature format
-        nMessVersion = MessageVersion::MESS_VER_STRMESS;
-        std::string strMessage = GetStrMessage();
-
-        if (!CMessageSigner::SignMessage(strMessage, vchSig2, key2)) {
-            return error("%s : SignMessage() failed", __func__);
-        }
-
-        if (!CMessageSigner::VerifyMessage(pubkey2, vchSig2, strMessage, strError)) {
-            return error("%s : VerifyMessage() failed, error: %s\n", __func__, strError);
-        }
-    }
-
-    return true;
-}
-
 void CObfuScationRelay::Relay()
 {
     int nCount = std::min(mnodeman.CountEnabled(ActiveProtocol()), 20);

--- a/src/obfuscation-relay.h
+++ b/src/obfuscation-relay.h
@@ -18,6 +18,7 @@ private:
     std::vector<unsigned char> vchSig2;
 
 public:
+    int nMessVersion;
     CTxIn vinMasternode;
     int nBlockHeight;
     int nRelayType;
@@ -32,13 +33,26 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
     {
-        READWRITE(vinMasternode);
-        READWRITE(vchSig);
-        READWRITE(vchSig2);
-        READWRITE(nBlockHeight);
-        READWRITE(nRelayType);
-        READWRITE(in);
-        READWRITE(out);
+        try
+        {
+            READWRITE(nMessVersion);
+            READWRITE(vinMasternode);
+            READWRITE(vchSig);
+            READWRITE(vchSig2);
+            READWRITE(nBlockHeight);
+            READWRITE(nRelayType);
+            READWRITE(in);
+            READWRITE(out);
+        } catch (...) {
+            nMessVersion = MessageVersion::MESS_VER_STRMESS;
+            READWRITE(vinMasternode);
+            READWRITE(vchSig);
+            READWRITE(vchSig2);
+            READWRITE(nBlockHeight);
+            READWRITE(nRelayType);
+            READWRITE(in);
+            READWRITE(out);
+        }
     }
 
     std::string ToString();

--- a/src/obfuscation-relay.h
+++ b/src/obfuscation-relay.h
@@ -11,14 +11,12 @@
 #include "masternodeman.h"
 
 
-class CObfuScationRelay
+class CObfuScationRelay : public CSignedMessage
 {
 private:
-    std::vector<unsigned char> vchSig;
     std::vector<unsigned char> vchSig2;
 
 public:
-    int nMessVersion;
     CTxIn vinMasternode;
     int nBlockHeight;
     int nRelayType;
@@ -57,11 +55,12 @@ public:
 
     std::string ToString();
 
-    uint256 GetSignatureHash() const;
-    std::string GetStrMessage() const;
+    // override CSignedMessage functions
+    uint256 GetSignatureHash() const override;
+    std::string GetStrMessage() const override;
+    const CTxIn GetVin() const override { return vinMasternode; };
+    bool Sign(std::string strSharedKey);   // use vchSig2
 
-    bool Sign(std::string strSharedKey);
-    bool CheckSignature(std::string strSharedKey) const;
     void Relay();
     void RelayThroughNode(int nRank);
 };

--- a/src/obfuscation-relay.h
+++ b/src/obfuscation-relay.h
@@ -13,10 +13,12 @@
 
 class CObfuScationRelay
 {
-public:
-    CTxIn vinMasternode;
+private:
     std::vector<unsigned char> vchSig;
     std::vector<unsigned char> vchSig2;
+
+public:
+    CTxIn vinMasternode;
     int nBlockHeight;
     int nRelayType;
     CTxIn in;

--- a/src/obfuscation-relay.h
+++ b/src/obfuscation-relay.h
@@ -41,8 +41,11 @@ public:
 
     std::string ToString();
 
+    uint256 GetSignatureHash() const;
+    std::string GetStrMessage() const;
+
     bool Sign(std::string strSharedKey);
-    bool VerifyMessage(std::string strSharedKey);
+    bool CheckSignature(std::string strSharedKey) const;
     void Relay();
     void RelayThroughNode(int nRank);
 };

--- a/src/obfuscation-relay.h
+++ b/src/obfuscation-relay.h
@@ -31,25 +31,18 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
     {
+        READWRITE(vinMasternode);
+        READWRITE(vchSig);
+        READWRITE(vchSig2);
+        READWRITE(nBlockHeight);
+        READWRITE(nRelayType);
+        READWRITE(in);
+        READWRITE(out);
         try
         {
             READWRITE(nMessVersion);
-            READWRITE(vinMasternode);
-            READWRITE(vchSig);
-            READWRITE(vchSig2);
-            READWRITE(nBlockHeight);
-            READWRITE(nRelayType);
-            READWRITE(in);
-            READWRITE(out);
         } catch (...) {
             nMessVersion = MessageVersion::MESS_VER_STRMESS;
-            READWRITE(vinMasternode);
-            READWRITE(vchSig);
-            READWRITE(vchSig2);
-            READWRITE(nBlockHeight);
-            READWRITE(nRelayType);
-            READWRITE(in);
-            READWRITE(out);
         }
     }
 

--- a/src/obfuscation.cpp
+++ b/src/obfuscation.cpp
@@ -8,6 +8,7 @@
 #include "init.h"
 #include "main.h"
 #include "masternodeman.h"
+#include "messagesigner.h"
 #include "script/sign.h"
 #include "swifttx.h"
 #include "guiinterface.h"
@@ -24,8 +25,6 @@
 
 // The main object for accessing Obfuscation
 CObfuscationPool obfuScationPool;
-// A helper object for signing messages from Masternodes
-CObfuScationSigner obfuScationSigner;
 // The current Obfuscations in progress on the network
 std::vector<CObfuscationQueue> vecObfuscationQueue;
 // Keep track of the used Masternodes
@@ -202,18 +201,18 @@ void CObfuscationPool::CheckFinalTransaction()
         CKey key2;
         CPubKey pubkey2;
 
-        if (!obfuScationSigner.SetKey(strMasterNodePrivKey, strError, key2, pubkey2)) {
-            LogPrintf("CObfuscationPool::Check() - ERROR: Invalid Masternodeprivkey: '%s'\n", strError);
+        if (!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, key2, pubkey2)) {
+            LogPrintf("%s : Invalid masternode key %s", __func__, strMasterNodePrivKey);
             return;
         }
 
-        if (!obfuScationSigner.SignMessage(strMessage, strError, vchSig, key2)) {
-            LogPrintf("CObfuscationPool::Check() - Sign message failed\n");
+        if (!CMessageSigner::SignMessage(strMessage, vchSig, key2)) {
+            LogPrintf("%s : Sign message failed", __func__);
             return;
         }
 
-        if (!obfuScationSigner.VerifyMessage(pubkey2, vchSig, strMessage, strError)) {
-            LogPrintf("CObfuscationPool::Check() - Verify message failed\n");
+        if (!CMessageSigner::VerifyMessage(pubkey2, vchSig, strMessage, strError)) {
+            LogPrintf("%s : Verify message failed, error: %s", __func__, strError);
             return;
         }
 
@@ -524,107 +523,26 @@ void CObfuscationPool::NewBlock()
     obfuScationPool.CheckTimeout();
 }
 
-bool CObfuScationSigner::IsVinAssociatedWithPubkey(CTxIn& vin, CPubKey& pubkey)
-{
-    CScript payee2;
-    payee2 = GetScriptForDestination(pubkey.GetID());
-
-    CTransaction txVin;
-    uint256 hash;
-    if (GetTransaction(vin.prevout.hash, txVin, hash, true)) {
-        for (CTxOut out : txVin.vout) {
-            if (out.nValue == 10000 * COIN) {
-                if (out.scriptPubKey == payee2) return true;
-            }
-        }
-    }
-
-    return false;
-}
-
-bool CObfuScationSigner::SetKey(std::string strSecret, std::string& errorMessage, CKey& key, CPubKey& pubkey)
-{
-    CBitcoinSecret vchSecret;
-    bool fGood = vchSecret.SetString(strSecret);
-
-    if (!fGood) {
-        errorMessage = _("Invalid private key.");
-        return false;
-    }
-
-    key = vchSecret.GetKey();
-    pubkey = key.GetPubKey();
-
-    return true;
-}
-
-bool CObfuScationSigner::GetKeysFromSecret(std::string strSecret, CKey& keyRet, CPubKey& pubkeyRet)
-{
-    CBitcoinSecret vchSecret;
-
-    if (!vchSecret.SetString(strSecret)) return false;
-
-    keyRet = vchSecret.GetKey();
-    pubkeyRet = keyRet.GetPubKey();
-
-    return true;
-}
-
-bool CObfuScationSigner::SignMessage(std::string strMessage, std::string& errorMessage, std::vector<unsigned char>& vchSig, CKey key)
-{
-    CHashWriter ss(SER_GETHASH, 0);
-    ss << strMessageMagic;
-    ss << strMessage;
-
-    if (!key.SignCompact(ss.GetHash(), vchSig)) {
-        errorMessage = _("Signing failed.");
-        return false;
-    }
-
-    return true;
-}
-
-bool CObfuScationSigner::VerifyMessage(CPubKey pubkey, std::vector<unsigned char>& vchSig, std::string strMessage, std::string& errorMessage)
-{
-    CHashWriter ss(SER_GETHASH, 0);
-    ss << strMessageMagic;
-    ss << strMessage;
-
-    CPubKey pubkey2;
-    if (!pubkey2.RecoverCompact(ss.GetHash(), vchSig)) {
-        errorMessage = _("Error recovering public key.");
-        return false;
-    }
-
-    if (fDebug && pubkey2.GetID() != pubkey.GetID())
-        LogPrintf("CObfuScationSigner::VerifyMessage -- keys don't match: %s %s\n", pubkey2.GetID().ToString(), pubkey.GetID().ToString());
-
-    return (pubkey2.GetID() == pubkey.GetID());
-}
-
 bool CObfuscationQueue::Sign()
 {
     if (!fMasterNode) return false;
 
+    std::string strError = "";
     std::string strMessage = vin.ToString() + std::to_string(nDenom) + std::to_string(time) + std::to_string(ready);
 
     CKey key2;
     CPubKey pubkey2;
-    std::string errorMessage = "";
 
-    if (!obfuScationSigner.SetKey(strMasterNodePrivKey, errorMessage, key2, pubkey2)) {
-        LogPrintf("CObfuscationQueue():Relay - ERROR: Invalid Masternodeprivkey: '%s'\n", errorMessage);
-        return false;
+    if (!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, key2, pubkey2)) {
+        return error("%s : Invalid masternode key", __func__);
     }
 
-    if (!obfuScationSigner.SignMessage(strMessage, errorMessage, vchSig, key2)) {
-        LogPrintf("CObfuscationQueue():Relay - Sign message failed");
-        return false;
+    if (!CMessageSigner::SignMessage(strMessage, vchSig, key2)) {
+        return error("%s : Sign message failed", __func__);
     }
 
-    if (!obfuScationSigner.VerifyMessage(pubkey2, vchSig, strMessage, errorMessage)) {
-        LogPrintf("CObfuscationQueue():Relay - Verify message failed");
-        return false;
+    if (!CMessageSigner::VerifyMessage(pubkey2, vchSig, strMessage, strError)) {
+        return error("%s : Verify message failed, error: %s", __func__, strError);
     }
 
     return true;

--- a/src/obfuscation.h
+++ b/src/obfuscation.h
@@ -15,7 +15,6 @@
 
 class CTxIn;
 class CObfuscationPool;
-class CObfuScationSigner;
 class CMasterNodeVote;
 class CBitcoinAddress;
 class CObfuscationQueue;
@@ -50,7 +49,6 @@ static const CAmount OBFUSCATION_COLLATERAL = (10 * COIN);
 static const CAmount OBFUSCATION_POOL_MAX = (99999.99 * COIN);
 
 extern CObfuscationPool obfuScationPool;
-extern CObfuScationSigner obfuScationSigner;
 extern std::vector<CObfuscationQueue> vecObfuscationQueue;
 extern std::string strMasterNodePrivKey;
 extern std::map<uint256, CObfuscationBroadcastTx> mapObfuscationBroadcastTxes;
@@ -196,23 +194,6 @@ public:
     CTxIn vin;
     std::vector<unsigned char> vchSig;
     int64_t sigTime;
-};
-
-/** Helper object for signing and checking signatures
- */
-class CObfuScationSigner
-{
-public:
-    /// Is the inputs associated with this public key? (and there is 10000 PIV - checking if valid masternode)
-    bool IsVinAssociatedWithPubkey(CTxIn& vin, CPubKey& pubkey);
-    /// Set the private/public key values, returns true if successful
-    bool GetKeysFromSecret(std::string strSecret, CKey& keyRet, CPubKey& pubkeyRet);
-    /// Set the private/public key values, returns true if successful
-    bool SetKey(std::string strSecret, std::string& errorMessage, CKey& key, CPubKey& pubkey);
-    /// Sign the message, returns true if successful
-    bool SignMessage(std::string strMessage, std::string& errorMessage, std::vector<unsigned char>& vchSig, CKey key);
-    /// Verify the message, returns true if succcessful
-    bool VerifyMessage(CPubKey pubkey, std::vector<unsigned char>& vchSig, std::string strMessage, std::string& errorMessage);
 };
 
 /** Used to keep track of current status of Obfuscation pool

--- a/src/qt/proposalframe.cpp
+++ b/src/qt/proposalframe.cpp
@@ -6,6 +6,7 @@
 
 #include "masternode-budget.h"
 #include "masternodeconfig.h"
+#include "messagesigner.h"
 #include "utilmoneystr.h"
 
 #include <QLayout>
@@ -276,8 +277,8 @@ void ProposalFrame::SendVote(std::string strHash, int nVote)
         CPubKey pubKeyMasternode;
         CKey keyMasternode;
 
-        if (!obfuScationSigner.SetKey(mne.getPrivKey(), errorMessage, keyMasternode, pubKeyMasternode)) {
-            mnresult += mne.getAlias() + ": " + "Masternode signing error, could not set key correctly: " + errorMessage + "<br />";
+        if (!CMessageSigner::GetKeysFromSecret(mne.getPrivKey(), keyMasternode, pubKeyMasternode)) {
+            mnresult += mne.getAlias() + ": " + "Masternode signing error, could not set key correctly.<br />";
             failed++;
             continue;
         }

--- a/src/qt/proposalframe.cpp
+++ b/src/qt/proposalframe.cpp
@@ -6,6 +6,7 @@
 
 #include "masternode-budget.h"
 #include "masternodeconfig.h"
+#include "main.h"
 #include "messagesigner.h"
 #include "utilmoneystr.h"
 
@@ -290,8 +291,13 @@ void ProposalFrame::SendVote(std::string strHash, int nVote)
             continue;
         }
 
+        bool fNewSigs = false;
+        {
+            LOCK(cs_main);
+            fNewSigs = chainActive.NewSigsActive();
+        }
         CBudgetVote vote(pmn->vin, hash, nVote);
-        if (!vote.Sign(keyMasternode, pubKeyMasternode)) {
+        if (!vote.Sign(keyMasternode, pubKeyMasternode, fNewSigs)) {
             mnresult += mne.getAlias() + ": " + "Failure to sign" + "<br />";
             failed++;
             continue;

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -726,7 +726,7 @@ UniValue mnbudgetrawvote(const UniValue& params, bool fHelp)
     vote.nTime = nTime;
     vote.vchSig = vchSig;
 
-    if (!vote.SignatureValid(true)) {
+    if (!vote.CheckSignature(true)) {
         return "Failure to verify signature.";
     }
 

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -724,7 +724,7 @@ UniValue mnbudgetrawvote(const UniValue& params, bool fHelp)
 
     CBudgetVote vote(vin, hashProposal, nVote);
     vote.nTime = nTime;
-    vote.vchSig = vchSig;
+    vote.SetVchSig(vchSig);
 
     if (!vote.CheckSignature(true)) {
         return "Failure to verify signature.";

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -274,6 +274,12 @@ UniValue mnbudgetvote(const UniValue& params, bool fHelp)
     int success = 0;
     int failed = 0;
 
+    bool fNewSigs = false;
+    {
+        LOCK(cs_main);
+        fNewSigs = chainActive.NewSigsActive();
+    }
+
     UniValue resultsObj(UniValue::VARR);
 
     if (strCommand == "local") {
@@ -303,7 +309,7 @@ UniValue mnbudgetvote(const UniValue& params, bool fHelp)
             }
 
             CBudgetVote vote(activeMasternode.vin, hash, nVote);
-            if (!vote.Sign(keyMasternode, pubKeyMasternode)) {
+            if (!vote.Sign(keyMasternode, pubKeyMasternode, fNewSigs)) {
                 failed++;
                 statusObj.push_back(Pair("node", "local"));
                 statusObj.push_back(Pair("result", "failed"));
@@ -369,7 +375,7 @@ UniValue mnbudgetvote(const UniValue& params, bool fHelp)
             }
 
             CBudgetVote vote(pmn->vin, hash, nVote);
-            if (!vote.Sign(keyMasternode, pubKeyMasternode)) {
+            if (!vote.Sign(keyMasternode, pubKeyMasternode, fNewSigs)) {
                 failed++;
                 statusObj.push_back(Pair("node", mne.getAlias()));
                 statusObj.push_back(Pair("result", "failed"));
@@ -443,7 +449,7 @@ UniValue mnbudgetvote(const UniValue& params, bool fHelp)
             }
 
             CBudgetVote vote(pmn->vin, hash, nVote);
-            if(!vote.Sign(keyMasternode, pubKeyMasternode)){
+            if(!vote.Sign(keyMasternode, pubKeyMasternode, fNewSigs)){
                 failed++;
                 statusObj.push_back(Pair("node", mne.getAlias()));
                 statusObj.push_back(Pair("result", "failed"));
@@ -758,6 +764,12 @@ UniValue mnfinalbudget(const UniValue& params, bool fHelp)
             "  show        - Show existing finalized budgets\n"
             "  getvotes     - Get vote information for each finalized budget\n");
 
+    bool fNewSigs = false;
+    {
+        LOCK(cs_main);
+        fNewSigs = chainActive.NewSigsActive();
+    }
+
     if (strCommand == "vote-many") {
         if (params.size() != 2)
             throw std::runtime_error("Correct usage is 'mnfinalbudget vote-many BUDGET_HASH'");
@@ -800,7 +812,7 @@ UniValue mnfinalbudget(const UniValue& params, bool fHelp)
 
 
             CFinalizedBudgetVote vote(pmn->vin, hash);
-            if (!vote.Sign(keyMasternode, pubKeyMasternode)) {
+            if (!vote.Sign(keyMasternode, pubKeyMasternode, fNewSigs)) {
                 failed++;
                 statusObj.push_back(Pair("result", "failed"));
                 statusObj.push_back(Pair("errorMessage", "Failure to sign."));
@@ -848,7 +860,7 @@ UniValue mnfinalbudget(const UniValue& params, bool fHelp)
         }
 
         CFinalizedBudgetVote vote(activeMasternode.vin, hash);
-        if (!vote.Sign(keyMasternode, pubKeyMasternode)) {
+        if (!vote.Sign(keyMasternode, pubKeyMasternode, fNewSigs)) {
             return "Failure to sign.";
         }
 

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -12,6 +12,7 @@
 #include "masternode-payments.h"
 #include "masternodeconfig.h"
 #include "masternodeman.h"
+#include "messagesigner.h"
 #include "rpc/server.h"
 #include "utilmoneystr.h"
 
@@ -278,16 +279,15 @@ UniValue mnbudgetvote(const UniValue& params, bool fHelp)
     if (strCommand == "local") {
         CPubKey pubKeyMasternode;
         CKey keyMasternode;
-        std::string errorMessage;
 
         UniValue statusObj(UniValue::VOBJ);
 
         while (true) {
-            if (!obfuScationSigner.SetKey(strMasterNodePrivKey, errorMessage, keyMasternode, pubKeyMasternode)) {
+            if (!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, keyMasternode, pubKeyMasternode)) {
                 failed++;
                 statusObj.push_back(Pair("node", "local"));
                 statusObj.push_back(Pair("result", "failed"));
-                statusObj.push_back(Pair("error", "Masternode signing error, could not set key correctly: " + errorMessage));
+                statusObj.push_back(Pair("error", "Masternode signing error, could not set key correctly."));
                 resultsObj.push_back(statusObj);
                 break;
             }
@@ -339,7 +339,6 @@ UniValue mnbudgetvote(const UniValue& params, bool fHelp)
 
     if (strCommand == "many") {
         for (CMasternodeConfig::CMasternodeEntry mne : masternodeConfig.getEntries()) {
-            std::string errorMessage;
             std::vector<unsigned char> vchMasterNodeSignature;
             std::string strMasterNodeSignMessage;
 
@@ -350,11 +349,11 @@ UniValue mnbudgetvote(const UniValue& params, bool fHelp)
 
             UniValue statusObj(UniValue::VOBJ);
 
-            if (!obfuScationSigner.SetKey(mne.getPrivKey(), errorMessage, keyMasternode, pubKeyMasternode)) {
+            if (!CMessageSigner::GetKeysFromSecret(mne.getPrivKey(), keyMasternode, pubKeyMasternode)) {
                 failed++;
                 statusObj.push_back(Pair("node", mne.getAlias()));
                 statusObj.push_back(Pair("result", "failed"));
-                statusObj.push_back(Pair("error", "Masternode signing error, could not set key correctly: " + errorMessage));
+                statusObj.push_back(Pair("error", "Masternode signing error, could not set key correctly."));
                 resultsObj.push_back(statusObj);
                 continue;
             }
@@ -413,7 +412,6 @@ UniValue mnbudgetvote(const UniValue& params, bool fHelp)
 
             if( strAlias != mne.getAlias()) continue;
 
-            std::string errorMessage;
             std::vector<unsigned char> vchMasterNodeSignature;
             std::string strMasterNodeSignMessage;
 
@@ -424,11 +422,11 @@ UniValue mnbudgetvote(const UniValue& params, bool fHelp)
 
             UniValue statusObj(UniValue::VOBJ);
 
-            if(!obfuScationSigner.SetKey(mne.getPrivKey(), errorMessage, keyMasternode, pubKeyMasternode)){
+            if(!CMessageSigner::GetKeysFromSecret(mne.getPrivKey(), keyMasternode, pubKeyMasternode)){
                 failed++;
                 statusObj.push_back(Pair("node", mne.getAlias()));
                 statusObj.push_back(Pair("result", "failed"));
-                statusObj.push_back(Pair("error", "Masternode signing error, could not set key correctly: " + errorMessage));
+                statusObj.push_back(Pair("error", "Masternode signing error, could not set key correctly."));
                 resultsObj.push_back(statusObj);
                 continue;
             }
@@ -773,7 +771,6 @@ UniValue mnfinalbudget(const UniValue& params, bool fHelp)
         UniValue resultsObj(UniValue::VOBJ);
 
         for (CMasternodeConfig::CMasternodeEntry mne : masternodeConfig.getEntries()) {
-            std::string errorMessage;
             std::vector<unsigned char> vchMasterNodeSignature;
             std::string strMasterNodeSignMessage;
 
@@ -784,10 +781,10 @@ UniValue mnfinalbudget(const UniValue& params, bool fHelp)
 
             UniValue statusObj(UniValue::VOBJ);
 
-            if (!obfuScationSigner.SetKey(mne.getPrivKey(), errorMessage, keyMasternode, pubKeyMasternode)) {
+            if (!CMessageSigner::GetKeysFromSecret(mne.getPrivKey(), keyMasternode, pubKeyMasternode)) {
                 failed++;
                 statusObj.push_back(Pair("result", "failed"));
-                statusObj.push_back(Pair("errorMessage", "Masternode signing error, could not set key correctly: " + errorMessage));
+                statusObj.push_back(Pair("errorMessage", "Masternode signing error, could not set key correctly."));
                 resultsObj.push_back(Pair(mne.getAlias(), statusObj));
                 continue;
             }
@@ -841,9 +838,8 @@ UniValue mnfinalbudget(const UniValue& params, bool fHelp)
 
         CPubKey pubKeyMasternode;
         CKey keyMasternode;
-        std::string errorMessage;
 
-        if (!obfuScationSigner.SetKey(strMasterNodePrivKey, errorMessage, keyMasternode, pubKeyMasternode))
+        if (!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, keyMasternode, pubKeyMasternode))
             return "Error upon calling SetKey";
 
         CMasternode* pmn = mnodeman.Find(activeMasternode.vin);

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -293,7 +293,7 @@ UniValue mnbudgetvote(const UniValue& params, bool fHelp)
                 failed++;
                 statusObj.push_back(Pair("node", "local"));
                 statusObj.push_back(Pair("result", "failed"));
-                statusObj.push_back(Pair("error", "Masternode signing error, could not set key correctly."));
+                statusObj.push_back(Pair("error", "Masternode signing error, GetKeysFromSecret failed."));
                 resultsObj.push_back(statusObj);
                 break;
             }
@@ -852,7 +852,7 @@ UniValue mnfinalbudget(const UniValue& params, bool fHelp)
         CKey keyMasternode;
 
         if (!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, keyMasternode, pubKeyMasternode))
-            return "Error upon calling SetKey";
+            return "Error upon calling GetKeysFromSecret";
 
         CMasternode* pmn = mnodeman.Find(activeMasternode.vin);
         if (pmn == NULL) {

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -907,7 +907,7 @@ UniValue decodemasternodebroadcast(const UniValue& params, bool fHelp)
     if (!DecodeHexMnb(mnb, params[0].get_str()))
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Masternode broadcast message decode failed");
 
-    if(!mnb.VerifySignature())
+    if(!mnb.CheckSignature())
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Masternode broadcast signature verification failed");
 
     UniValue resultObj(UniValue::VOBJ);
@@ -916,7 +916,7 @@ UniValue decodemasternodebroadcast(const UniValue& params, bool fHelp)
     resultObj.push_back(Pair("addr", mnb.addr.ToString()));
     resultObj.push_back(Pair("pubkeycollateral", CBitcoinAddress(mnb.pubKeyCollateralAddress.GetID()).ToString()));
     resultObj.push_back(Pair("pubkeymasternode", CBitcoinAddress(mnb.pubKeyMasternode.GetID()).ToString()));
-    resultObj.push_back(Pair("vchsig", EncodeBase64(&mnb.sig[0], mnb.sig.size())));
+    resultObj.push_back(Pair("vchsig", EncodeBase64(&mnb.vchSig[0], mnb.vchSig.size())));
     resultObj.push_back(Pair("sigtime", mnb.sigTime));
     resultObj.push_back(Pair("protocolversion", mnb.protocolVersion));
     resultObj.push_back(Pair("nlastdsq", mnb.nLastDsq));
@@ -951,7 +951,7 @@ UniValue relaymasternodebroadcast(const UniValue& params, bool fHelp)
     if (!DecodeHexMnb(mnb, params[0].get_str()))
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Masternode broadcast message decode failed");
 
-    if(!mnb.VerifySignature())
+    if(!mnb.CheckSignature())
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Masternode broadcast signature verification failed");
 
     mnodeman.UpdateMasternodeList(mnb);

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -916,7 +916,7 @@ UniValue decodemasternodebroadcast(const UniValue& params, bool fHelp)
     resultObj.push_back(Pair("addr", mnb.addr.ToString()));
     resultObj.push_back(Pair("pubkeycollateral", CBitcoinAddress(mnb.pubKeyCollateralAddress.GetID()).ToString()));
     resultObj.push_back(Pair("pubkeymasternode", CBitcoinAddress(mnb.pubKeyMasternode.GetID()).ToString()));
-    resultObj.push_back(Pair("vchsig", EncodeBase64(&mnb.vchSig[0], mnb.vchSig.size())));
+    resultObj.push_back(Pair("vchsig", mnb.GetSignatureBase64()));
     resultObj.push_back(Pair("sigtime", mnb.sigTime));
     resultObj.push_back(Pair("protocolversion", mnb.protocolVersion));
     resultObj.push_back(Pair("nlastdsq", mnb.nLastDsq));
@@ -925,7 +925,7 @@ UniValue decodemasternodebroadcast(const UniValue& params, bool fHelp)
     lastPingObj.push_back(Pair("vin", mnb.lastPing.vin.prevout.ToString()));
     lastPingObj.push_back(Pair("blockhash", mnb.lastPing.blockHash.ToString()));
     lastPingObj.push_back(Pair("sigtime", mnb.lastPing.sigTime));
-    lastPingObj.push_back(Pair("vchsig", EncodeBase64(&mnb.lastPing.vchSig[0], mnb.lastPing.vchSig.size())));
+    lastPingObj.push_back(Pair("vchsig", mnb.lastPing.GetSignatureBase64()));
 
     resultObj.push_back(Pair("lastping", lastPingObj));
 

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -252,6 +252,64 @@ UniValue masternodedebug (const UniValue& params, bool fHelp)
         return activeMasternode.GetStatus();
 }
 
+bool StartMasternodeEntry(UniValue& statusObjRet, CMasternodeBroadcast& mnbRet, bool& fSuccessRet, const CMasternodeConfig::CMasternodeEntry& mne, std::string& errorMessage, std::string strCommand = "")
+{
+    int nIndex;
+    if(!mne.castOutputIndex(nIndex)) {
+        return false;
+    }
+
+    CTxIn vin = CTxIn(uint256(mne.getTxHash()), uint32_t(nIndex));
+    CMasternode* pmn = mnodeman.Find(vin);
+    if (pmn != NULL) {
+        if (strCommand == "missing") return false;
+        if (strCommand == "disabled" && pmn->IsEnabled()) return false;
+    }
+
+    fSuccessRet = activeMasternode.CreateBroadcast(mne.getIp(), mne.getPrivKey(), mne.getTxHash(), mne.getOutputIndex(), errorMessage, mnbRet);
+
+    statusObjRet.push_back(Pair("alias", mne.getAlias()));
+    statusObjRet.push_back(Pair("result", fSuccessRet ? "success" : "failed"));
+    statusObjRet.push_back(Pair("error", fSuccessRet ? "" : errorMessage));
+
+    return true;
+}
+
+void RelayMNB(CMasternodeBroadcast& mnb, const bool fSuccess, int& successful, int& failed)
+{
+    if (fSuccess) {
+        successful++;
+        mnodeman.UpdateMasternodeList(mnb);
+        mnb.Relay();
+    } else {
+        failed++;
+    }
+}
+
+void RelayMNB(CMasternodeBroadcast& mnb, const bool fSucces)
+{
+    int successful = 0, failed = 0;
+    return RelayMNB(mnb, fSucces, successful, failed);
+}
+
+void SerializeMNB(UniValue& statusObjRet, const CMasternodeBroadcast& mnb, const bool fSuccess, int& successful, int& failed)
+{
+    if(fSuccess) {
+        successful++;
+        CDataStream ssMnb(SER_NETWORK, PROTOCOL_VERSION);
+        ssMnb << mnb;
+        statusObjRet.push_back(Pair("hex", HexStr(ssMnb.begin(), ssMnb.end())));
+    } else {
+        failed++;
+    }
+}
+
+void SerializeMNB(UniValue& statusObjRet, const CMasternodeBroadcast& mnb, const bool fSuccess)
+{
+    int successful = 0, failed = 0;
+    return SerializeMNB(statusObjRet, mnb, fSuccess, successful, failed);
+}
+
 UniValue startmasternode (const UniValue& params, bool fHelp)
 {
     std::string strCommand;
@@ -331,36 +389,14 @@ UniValue startmasternode (const UniValue& params, bool fHelp)
         UniValue resultsObj(UniValue::VARR);
 
         for (CMasternodeConfig::CMasternodeEntry mne : masternodeConfig.getEntries()) {
-            std::string errorMessage;
-            int nIndex;
-            if(!mne.castOutputIndex(nIndex))
-                continue;
-            CTxIn vin = CTxIn(uint256(mne.getTxHash()), uint32_t(nIndex));
-            CMasternode* pmn = mnodeman.Find(vin);
-            CMasternodeBroadcast mnb;
-
-            if (pmn != NULL) {
-                if (strCommand == "missing") continue;
-                if (strCommand == "disabled" && pmn->IsEnabled()) continue;
-            }
-
-            bool result = activeMasternode.CreateBroadcast(mne.getIp(), mne.getPrivKey(), mne.getTxHash(), mne.getOutputIndex(), errorMessage, mnb);
-
             UniValue statusObj(UniValue::VOBJ);
-            statusObj.push_back(Pair("alias", mne.getAlias()));
-            statusObj.push_back(Pair("result", result ? "success" : "failed"));
-
-            if (result) {
-                successful++;
-                mnodeman.UpdateMasternodeList(mnb);
-                mnb.Relay();
-                statusObj.push_back(Pair("error", ""));
-            } else {
-                failed++;
-                statusObj.push_back(Pair("error", errorMessage));
-            }
-
+            CMasternodeBroadcast mnb;
+            std::string errorMessage;
+            bool fSuccess = false;
+            if (!StartMasternodeEntry(statusObj, mnb, fSuccess, mne, errorMessage, strCommand))
+                continue;
             resultsObj.push_back(statusObj);
+            RelayMNB(mnb, fSuccess, successful, failed);
         }
         if (fLock)
             pwalletMain->Lock();
@@ -376,51 +412,32 @@ UniValue startmasternode (const UniValue& params, bool fHelp)
         std::string alias = params[2].get_str();
 
         bool found = false;
-        int successful = 0;
-        int failed = 0;
 
         UniValue resultsObj(UniValue::VARR);
         UniValue statusObj(UniValue::VOBJ);
-        statusObj.push_back(Pair("alias", alias));
 
         for (CMasternodeConfig::CMasternodeEntry mne : masternodeConfig.getEntries()) {
             if (mne.getAlias() == alias) {
+                CMasternodeBroadcast mnb;
                 found = true;
                 std::string errorMessage;
-                CMasternodeBroadcast mnb;
-
-                bool result = activeMasternode.CreateBroadcast(mne.getIp(), mne.getPrivKey(), mne.getTxHash(), mne.getOutputIndex(), errorMessage, mnb);
-
-                statusObj.push_back(Pair("result", result ? "successful" : "failed"));
-
-                if (result) {
-                    successful++;
-                    mnodeman.UpdateMasternodeList(mnb);
-                    mnb.Relay();
-                } else {
-                    failed++;
-                    statusObj.push_back(Pair("errorMessage", errorMessage));
-                }
+                bool fSuccess = false;
+                if (!StartMasternodeEntry(statusObj, mnb, fSuccess, mne, errorMessage, strCommand))
+                        continue;
+                RelayMNB(mnb, fSuccess);
                 break;
             }
         }
 
-        if (!found) {
-            failed++;
-            statusObj.push_back(Pair("result", "failed"));
-            statusObj.push_back(Pair("error", "could not find alias in config. Verify with list-conf."));
-        }
-
-        resultsObj.push_back(statusObj);
-
         if (fLock)
             pwalletMain->Lock();
 
-        UniValue returnObj(UniValue::VOBJ);
-        returnObj.push_back(Pair("overall", strprintf("Successfully started %d masternodes, failed to start %d, total %d", successful, failed, successful + failed)));
-        returnObj.push_back(Pair("detail", resultsObj));
+        if(!found) {
+            statusObj.push_back(Pair("success", false));
+            statusObj.push_back(Pair("error_message", "Could not find alias in config. Verify with list-conf."));
+        }
 
-        return returnObj;
+        return statusObj;
     }
     return NullUniValue;
 }
@@ -799,20 +816,13 @@ UniValue createmasternodebroadcast(const UniValue& params, bool fHelp)
 
         for (CMasternodeConfig::CMasternodeEntry mne : masternodeConfig.getEntries()) {
             if(mne.getAlias() == alias) {
+                CMasternodeBroadcast mnb;
                 found = true;
                 std::string errorMessage;
-                CMasternodeBroadcast mnb;
-
-                bool success = activeMasternode.CreateBroadcast(mne.getIp(), mne.getPrivKey(), mne.getTxHash(), mne.getOutputIndex(), errorMessage, mnb, true);
-
-                statusObj.push_back(Pair("success", success));
-                if(success) {
-                    CDataStream ssMnb(SER_NETWORK, PROTOCOL_VERSION);
-                    ssMnb << mnb;
-                    statusObj.push_back(Pair("hex", HexStr(ssMnb.begin(), ssMnb.end())));
-                } else {
-                    statusObj.push_back(Pair("error_message", errorMessage));
-                }
+                bool fSuccess = false;
+                if (!StartMasternodeEntry(statusObj, mnb, fSuccess, mne, errorMessage, strCommand))
+                        continue;
+                SerializeMNB(statusObj, mnb, fSuccess);
                 break;
             }
         }
@@ -823,7 +833,6 @@ UniValue createmasternodebroadcast(const UniValue& params, bool fHelp)
         }
 
         return statusObj;
-
     }
 
     if (strCommand == "all")
@@ -841,27 +850,13 @@ UniValue createmasternodebroadcast(const UniValue& params, bool fHelp)
         UniValue resultsObj(UniValue::VARR);
 
         for (CMasternodeConfig::CMasternodeEntry mne : masternodeConfig.getEntries()) {
-            std::string errorMessage;
-
-            CTxIn vin = CTxIn(uint256S(mne.getTxHash()), uint32_t(atoi(mne.getOutputIndex().c_str())));
-            CMasternodeBroadcast mnb;
-
-            bool success = activeMasternode.CreateBroadcast(mne.getIp(), mne.getPrivKey(), mne.getTxHash(), mne.getOutputIndex(), errorMessage, mnb, true);
-
             UniValue statusObj(UniValue::VOBJ);
-            statusObj.push_back(Pair("alias", mne.getAlias()));
-            statusObj.push_back(Pair("success", success));
-
-            if(success) {
-                successful++;
-                CDataStream ssMnb(SER_NETWORK, PROTOCOL_VERSION);
-                ssMnb << mnb;
-                statusObj.push_back(Pair("hex", HexStr(ssMnb.begin(), ssMnb.end())));
-            } else {
-                failed++;
-                statusObj.push_back(Pair("error_message", errorMessage));
-            }
-
+            CMasternodeBroadcast mnb;
+            std::string errorMessage;
+            bool fSuccess = false;
+            if (!StartMasternodeEntry(statusObj, mnb, fSuccess, mne, errorMessage, strCommand))
+                    continue;
+            SerializeMNB(statusObj, mnb, fSuccess, successful, failed);
             resultsObj.push_back(statusObj);
         }
 
@@ -892,13 +887,16 @@ UniValue decodemasternodebroadcast(const UniValue& params, bool fHelp)
             "  \"pubkeymasternode\": \"xxxx\"   (string) Masternode's public key\n"
             "  \"vchsig\": \"xxxx\"             (string) Base64-encoded signature of this message (verifiable via pubkeycollateral)\n"
             "  \"sigtime\": \"nnn\"             (numeric) Signature timestamp\n"
+            "  \"sigvalid\": \"xxx\"            (string) \"true\"/\"false\" whether or not the mnb signature checks out.\n"
             "  \"protocolversion\": \"nnn\"     (numeric) Masternode's protocol version\n"
             "  \"nlastdsq\": \"nnn\"            (numeric) The last time the masternode sent a DSQ message (for mixing) (DEPRECATED)\n"
             "  \"lastping\" : {                 (object) JSON object with information about the masternode's last ping\n"
             "      \"vin\": \"xxxx\"            (string) The unspent output of the masternode which is signing the message\n"
             "      \"blockhash\": \"xxxx\"      (string) Current chaintip blockhash minus 12\n"
             "      \"sigtime\": \"nnn\"         (numeric) Signature time for this ping\n"
+            "      \"sigvalid\": \"xxx\"        (string) \"true\"/\"false\" whether or not the mnp signature checks out.\n"
             "      \"vchsig\": \"xxxx\"         (string) Base64-encoded signature of this ping (verifiable via pubkeymasternode)\n"
+            "  }\n"
             "}\n"
 
             "\nExamples:\n" +
@@ -909,9 +907,6 @@ UniValue decodemasternodebroadcast(const UniValue& params, bool fHelp)
     if (!DecodeHexMnb(mnb, params[0].get_str()))
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Masternode broadcast message decode failed");
 
-    if(!mnb.CheckSignature())
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Masternode broadcast signature verification failed");
-
     UniValue resultObj(UniValue::VOBJ);
 
     resultObj.push_back(Pair("vin", mnb.vin.prevout.ToString()));
@@ -920,6 +915,7 @@ UniValue decodemasternodebroadcast(const UniValue& params, bool fHelp)
     resultObj.push_back(Pair("pubkeymasternode", CBitcoinAddress(mnb.pubKeyMasternode.GetID()).ToString()));
     resultObj.push_back(Pair("vchsig", mnb.GetSignatureBase64()));
     resultObj.push_back(Pair("sigtime", mnb.sigTime));
+    resultObj.push_back(Pair("sigvalid", mnb.CheckSignature() ? "true" : "false"));
     resultObj.push_back(Pair("protocolversion", mnb.protocolVersion));
     resultObj.push_back(Pair("nlastdsq", mnb.nLastDsq));
 
@@ -927,6 +923,7 @@ UniValue decodemasternodebroadcast(const UniValue& params, bool fHelp)
     lastPingObj.push_back(Pair("vin", mnb.lastPing.vin.prevout.ToString()));
     lastPingObj.push_back(Pair("blockhash", mnb.lastPing.blockHash.ToString()));
     lastPingObj.push_back(Pair("sigtime", mnb.lastPing.sigTime));
+    lastPingObj.push_back(Pair("sigvalid", mnb.lastPing.CheckSignature(mnb.pubKeyMasternode) ? "true" : "false"));
     lastPingObj.push_back(Pair("vchsig", mnb.lastPing.GetSignatureBase64()));
 
     resultObj.push_back(Pair("lastping", lastPingObj));
@@ -961,4 +958,3 @@ UniValue relaymasternodebroadcast(const UniValue& params, bool fHelp)
 
     return strprintf("Masternode broadcast sent (service %s, vin %s)", mnb.addr.ToString(), mnb.vin.ToString());
 }
-

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -890,12 +890,14 @@ UniValue decodemasternodebroadcast(const UniValue& params, bool fHelp)
             "  \"sigvalid\": \"xxx\"            (string) \"true\"/\"false\" whether or not the mnb signature checks out.\n"
             "  \"protocolversion\": \"nnn\"     (numeric) Masternode's protocol version\n"
             "  \"nlastdsq\": \"nnn\"            (numeric) The last time the masternode sent a DSQ message (for mixing) (DEPRECATED)\n"
+            "  \"nMessVersion\": \"nnn\"        (numeric) MNB Message version number\n"
             "  \"lastping\" : {                 (object) JSON object with information about the masternode's last ping\n"
             "      \"vin\": \"xxxx\"            (string) The unspent output of the masternode which is signing the message\n"
             "      \"blockhash\": \"xxxx\"      (string) Current chaintip blockhash minus 12\n"
             "      \"sigtime\": \"nnn\"         (numeric) Signature time for this ping\n"
             "      \"sigvalid\": \"xxx\"        (string) \"true\"/\"false\" whether or not the mnp signature checks out.\n"
             "      \"vchsig\": \"xxxx\"         (string) Base64-encoded signature of this ping (verifiable via pubkeymasternode)\n"
+            "      \"nMessVersion\": \"nnn\"    (numeric) MNP Message version number\n"
             "  }\n"
             "}\n"
 
@@ -918,6 +920,7 @@ UniValue decodemasternodebroadcast(const UniValue& params, bool fHelp)
     resultObj.push_back(Pair("sigvalid", mnb.CheckSignature() ? "true" : "false"));
     resultObj.push_back(Pair("protocolversion", mnb.protocolVersion));
     resultObj.push_back(Pair("nlastdsq", mnb.nLastDsq));
+    resultObj.push_back(Pair("nMessVersion", mnb.nMessVersion));
 
     UniValue lastPingObj(UniValue::VOBJ);
     lastPingObj.push_back(Pair("vin", mnb.lastPing.vin.prevout.ToString()));
@@ -925,6 +928,7 @@ UniValue decodemasternodebroadcast(const UniValue& params, bool fHelp)
     lastPingObj.push_back(Pair("sigtime", mnb.lastPing.sigTime));
     lastPingObj.push_back(Pair("sigvalid", mnb.lastPing.CheckSignature(mnb.pubKeyMasternode) ? "true" : "false"));
     lastPingObj.push_back(Pair("vchsig", mnb.lastPing.GetSignatureBase64()));
+    lastPingObj.push_back(Pair("nMessVersion", mnb.lastPing.nMessVersion));
 
     resultObj.push_back(Pair("lastping", lastPingObj));
 

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -352,6 +352,8 @@ UniValue startmasternode (const UniValue& params, bool fHelp)
 
             if (result) {
                 successful++;
+                mnodeman.UpdateMasternodeList(mnb);
+                mnb.Relay();
                 statusObj.push_back(Pair("error", ""));
             } else {
                 failed++;

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -231,6 +231,7 @@ std::string CSporkManager::ToString() const
 uint256 CSporkMessage::GetSignatureHash() const
 {
     CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+    ss << nMessVersion;
     ss << nSporkID;
     ss << nValue;
     ss << nTimeSigned;

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -91,6 +91,20 @@ void CSporkManager::ProcessSpork(CNode* pfrom, std::string& strCommand, CDataStr
             return;
         }
 
+        // reject old signatures 600 blocks after hard-fork
+        if (spork.nMessVersion != MessageVersion::MESS_VER_HASH) {
+            int nHeight;
+            {
+                LOCK(cs_main);
+                nHeight = chainActive.Height();
+            }
+            if (Params().NewSigsActive(nHeight - 600)) {
+                LogPrintf("%s : nMessVersion=%d not accepted anymore at block %d", __func__, spork.nMessVersion, nHeight);
+                return;
+            }
+        }
+
+
         uint256 hash = spork.GetHash();
         {
             LOCK(cs);

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -5,6 +5,7 @@
 
 #include "main.h"
 #include "masternode-budget.h"
+#include "messagesigner.h"
 #include "net.h"
 #include "spork.h"
 #include "sporkdb.h"
@@ -228,22 +229,22 @@ std::string CSporkManager::ToString() const
 
 bool CSporkMessage::Sign(std::string strSignKey)
 {
+    std::string strError = "";
     std::string strMessage = std::to_string(nSporkID) + std::to_string(nValue) + std::to_string(nTimeSigned);
 
     CKey key;
     CPubKey pubkey;
-    std::string errorMessage = "";
 
-    if (!obfuScationSigner.SetKey(strSignKey, errorMessage, key, pubkey)) {
-        return error("%s : SetKey error: '%s'\n", __func__, errorMessage);
+    if (!CMessageSigner::GetKeysFromSecret(strSignKey, key, pubkey)) {
+        return error("%s : SetKey error.", __func__);
     }
 
-    if (!obfuScationSigner.SignMessage(strMessage, errorMessage, vchSig, key)) {
+    if (!CMessageSigner::SignMessage(strMessage, vchSig, key)) {
         return error("%s : Sign message failed", __func__);
     }
 
-    if (!obfuScationSigner.VerifyMessage(pubkey, vchSig, strMessage, errorMessage)) {
-        return error("%s : Verify message failed", __func__);
+    if (!CMessageSigner::VerifyMessage(pubkey, vchSig, strMessage, strError)) {
+        return error("%s : Verify message failed, error: %s", __func__, strError);
     }
 
     return true;
@@ -251,12 +252,11 @@ bool CSporkMessage::Sign(std::string strSignKey)
 
 bool CSporkMessage::CheckSignature(bool fRequireNew)
 {
-    //note: need to investigate why this is failing
+    std::string strError = "";
     std::string strMessage = std::to_string(nSporkID) + std::to_string(nValue) + std::to_string(nTimeSigned);
     CPubKey pubkeynew(ParseHex(Params().SporkPubKey()));
-    std::string errorMessage = "";
 
-    bool fValidWithNewKey = obfuScationSigner.VerifyMessage(pubkeynew, vchSig, strMessage, errorMessage);
+    bool fValidWithNewKey = CMessageSigner::VerifyMessage(pubkeynew, vchSig, strMessage, strError);
 
     if (fRequireNew && !fValidWithNewKey)
         return false;
@@ -264,7 +264,7 @@ bool CSporkMessage::CheckSignature(bool fRequireNew)
     // See if window is open that allows for old spork key to sign messages
     if (!fValidWithNewKey && GetAdjustedTime() < Params().RejectOldSporkKey()) {
         CPubKey pubkeyold(ParseHex(Params().SporkPubKeyOld()));
-        return obfuScationSigner.VerifyMessage(pubkeyold, vchSig, strMessage, errorMessage);
+        return CMessageSigner::VerifyMessage(pubkeyold, vchSig, strMessage, strError);
     }
 
     return fValidWithNewKey;

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -227,36 +227,77 @@ std::string CSporkManager::ToString() const
     return strprintf("Sporks: %llu", mapSporksActive.size());
 }
 
+uint256 CSporkMessage::GetSignatureHash() const
+{
+    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+    ss << nSporkID;
+    ss << nValue;
+    ss << nTimeSigned;
+    return ss.GetHash();
+}
+
+std::string CSporkMessage::GetStrMessage() const
+{
+    return std::to_string(nSporkID) +
+            std::to_string(nValue) +
+            std::to_string(nTimeSigned);
+}
+
 bool CSporkMessage::Sign(std::string strSignKey)
 {
-    std::string strError = "";
-    std::string strMessage = std::to_string(nSporkID) + std::to_string(nValue) + std::to_string(nTimeSigned);
+    int nHeight;
+    {
+        LOCK(cs_main);
+        nHeight = chainActive.Height();
+    }
 
+    std::string strError = "";
     CKey key;
     CPubKey pubkey;
 
     if (!CMessageSigner::GetKeysFromSecret(strSignKey, key, pubkey)) {
-        return error("%s : SetKey error.", __func__);
+        return error("%s : Invalid strSignKey", __func__);
     }
 
-    if (!CMessageSigner::SignMessage(strMessage, vchSig, key)) {
-        return error("%s : Sign message failed", __func__);
-    }
+    if (Params().NewSigsActive(nHeight)) {
+        uint256 hash = GetSignatureHash();
 
-    if (!CMessageSigner::VerifyMessage(pubkey, vchSig, strMessage, strError)) {
-        return error("%s : Verify message failed, error: %s", __func__, strError);
+        if(!CHashSigner::SignHash(hash, key, vchSig)) {
+            return error("%s : SignHash() failed", __func__);
+        }
+
+        if (!CHashSigner::VerifyHash(hash, pubkey, vchSig, strError)) {
+            return error("%s : VerifyHash() failed, error: %s", __func__, strError);
+        }
+
+    } else {
+        // use old signature format
+        std::string strMessage = GetStrMessage();
+
+        if (!CMessageSigner::SignMessage(strMessage, vchSig, key)) {
+            return error("%s : SignMessage() failed", __func__);
+        }
+
+        if (!CMessageSigner::VerifyMessage(pubkey, vchSig, strMessage, strError)) {
+            return error("%s : VerifyMessage() failed, error: %s\n", __func__, strError);
+        }
     }
 
     return true;
 }
 
-bool CSporkMessage::CheckSignature(bool fRequireNew)
+bool CSporkMessage::CheckSignature(bool fRequireNew) const
 {
     std::string strError = "";
-    std::string strMessage = std::to_string(nSporkID) + std::to_string(nValue) + std::to_string(nTimeSigned);
     CPubKey pubkeynew(ParseHex(Params().SporkPubKey()));
+    uint256 hash = GetSignatureHash();
+    std::string strMessage = GetStrMessage();
 
-    bool fValidWithNewKey = CMessageSigner::VerifyMessage(pubkeynew, vchSig, strMessage, strError);
+    bool fValidWithNewKey = CHashSigner::VerifyHash(hash, pubkeynew, vchSig, strError);
+    if (!fValidWithNewKey) {
+        // if new signature fails, try old format
+        fValidWithNewKey = CMessageSigner::VerifyMessage(pubkeynew, vchSig, strMessage, strError);
+    }
 
     if (fRequireNew && !fValidWithNewKey)
         return false;
@@ -264,7 +305,12 @@ bool CSporkMessage::CheckSignature(bool fRequireNew)
     // See if window is open that allows for old spork key to sign messages
     if (!fValidWithNewKey && GetAdjustedTime() < Params().RejectOldSporkKey()) {
         CPubKey pubkeyold(ParseHex(Params().SporkPubKeyOld()));
-        return CMessageSigner::VerifyMessage(pubkeyold, vchSig, strMessage, strError);
+        bool fValidWithOldKey = CHashSigner::VerifyHash(hash, pubkeyold, vchSig, strError);
+        if (!fValidWithOldKey) {
+            // if new signature fails, try old format
+            fValidWithOldKey = CMessageSigner::VerifyMessage(pubkeyold, vchSig, strMessage, strError);
+        }
+        return fValidWithOldKey;
     }
 
     return fValidWithNewKey;

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -126,8 +126,17 @@ void CSporkManager::ProcessSpork(CNode* pfrom, std::string& strCommand, CDataStr
 
         LogPrintf("%s : new %s ID %d Time %d bestHeight %d\n", __func__, hash.ToString(), spork.nSporkID, spork.nValue, chainActive.Tip()->nHeight);
 
-        bool fRequireNew = spork.nTimeSigned >= Params().NewSporkStart();
-        if (!spork.CheckSignature(fRequireNew)) {
+        const bool fRequireNew = spork.nTimeSigned >= Params().NewSporkStart();
+        bool fValidSig = spork.CheckSignature();
+        if (!fValidSig && !fRequireNew) {
+            // See if window is open that allows for old spork key to sign messages
+            if (GetAdjustedTime() < Params().RejectOldSporkKey()) {
+                CPubKey pubkeyold = spork.GetPublicKeyOld();
+                fValidSig = spork.CheckSignature(pubkeyold);
+            }
+        }
+
+        if (!fValidSig) {
             LOCK(cs_main);
             LogPrintf("%s : Invalid Signature\n", __func__);
             Misbehaving(pfrom->GetId(), 100);
@@ -157,11 +166,15 @@ void CSporkManager::ProcessSpork(CNode* pfrom, std::string& strCommand, CDataStr
 
 bool CSporkManager::UpdateSpork(SporkId nSporkID, int64_t nValue)
 {
+    bool fNewSigs = false;
+    {
+        LOCK(cs_main);
+        fNewSigs = chainActive.NewSigsActive();
+    }
 
-    CSporkMessage spork = CSporkMessage(MessageVersion::MESS_VER_HASH,
-            nSporkID, nValue, GetTime());
+    CSporkMessage spork = CSporkMessage(nSporkID, nValue, GetTime());
 
-    if(spork.Sign(strMasterPrivKey)){
+    if(spork.Sign(strMasterPrivKey, fNewSigs)){
         spork.Relay();
         LOCK(cs);
         mapSporks[spork.GetHash()] = spork;
@@ -222,10 +235,18 @@ bool CSporkManager::SetPrivKey(std::string strPrivKey)
 {
     CSporkMessage spork;
 
-    spork.Sign(strPrivKey);
+    spork.Sign(strPrivKey, true);
 
     const bool fRequireNew = GetTime() >= Params().NewSporkStart();
-    if (spork.CheckSignature(fRequireNew)) {
+    bool fValidSig = spork.CheckSignature();
+    if (!fValidSig && !fRequireNew) {
+        // See if window is open that allows for old spork key to sign messages
+        if (GetAdjustedTime() < Params().RejectOldSporkKey()) {
+            CPubKey pubkeyold = spork.GetPublicKeyOld();
+            fValidSig = spork.CheckSignature(pubkeyold);
+        }
+    }
+    if (fValidSig) {
         LOCK(cs);
         // Test signing successful, proceed
         LogPrintf("%s : Successfully initialized as spork signer\n", __func__);
@@ -259,81 +280,14 @@ std::string CSporkMessage::GetStrMessage() const
             std::to_string(nTimeSigned);
 }
 
-bool CSporkMessage::Sign(std::string strSignKey)
+const CPubKey CSporkMessage::GetPublicKey(std::string& strErrorRet) const
 {
-    int nHeight;
-    {
-        LOCK(cs_main);
-        nHeight = chainActive.Height();
-    }
-
-    std::string strError = "";
-    CKey key;
-    CPubKey pubkey;
-
-    if (!CMessageSigner::GetKeysFromSecret(strSignKey, key, pubkey)) {
-        return error("%s : Invalid strSignKey", __func__);
-    }
-
-    if (Params().NewSigsActive(nHeight)) {
-        nMessVersion = MessageVersion::MESS_VER_HASH;
-        uint256 hash = GetSignatureHash();
-
-        if(!CHashSigner::SignHash(hash, key, vchSig)) {
-            return error("%s : SignHash() failed", __func__);
-        }
-
-        if (!CHashSigner::VerifyHash(hash, pubkey, vchSig, strError)) {
-            return error("%s : VerifyHash() failed, error: %s", __func__, strError);
-        }
-
-    } else {
-        // use old signature format
-        nMessVersion = MessageVersion::MESS_VER_STRMESS;
-        std::string strMessage = GetStrMessage();
-
-        if (!CMessageSigner::SignMessage(strMessage, vchSig, key)) {
-            return error("%s : SignMessage() failed", __func__);
-        }
-
-        if (!CMessageSigner::VerifyMessage(pubkey, vchSig, strMessage, strError)) {
-            return error("%s : VerifyMessage() failed, error: %s\n", __func__, strError);
-        }
-    }
-
-    return true;
+    return CPubKey(ParseHex(Params().SporkPubKey()));
 }
 
-bool CSporkMessage::CheckSignature(bool fRequireNew) const
+const CPubKey CSporkMessage::GetPublicKeyOld() const
 {
-    std::string strError = "";
-    CPubKey pubkeynew(ParseHex(Params().SporkPubKey()));
-    uint256 hash = GetSignatureHash();
-    std::string strMessage = GetStrMessage();
-
-    const bool fNewSigs = (nMessVersion == MessageVersion::MESS_VER_HASH);
-
-    bool fValidWithNewKey =
-            fNewSigs ?
-                    CHashSigner::VerifyHash(hash, pubkeynew, vchSig, strError) :
-                    CMessageSigner::VerifyMessage(pubkeynew, vchSig, strMessage, strError);
-
-    if (fRequireNew && !fValidWithNewKey)
-        return false;
-
-    // See if window is open that allows for old spork key to sign messages
-    if (!fValidWithNewKey && GetAdjustedTime() < Params().RejectOldSporkKey()) {
-        CPubKey pubkeyold(ParseHex(Params().SporkPubKeyOld()));
-
-        bool fValidWithOldKey =
-                fNewSigs ?
-                        CHashSigner::VerifyHash(hash, pubkeyold, vchSig, strError) :
-                        CMessageSigner::VerifyMessage(pubkeyold, vchSig, strMessage, strError);
-
-        return fValidWithOldKey;
-    }
-
-    return fValidWithNewKey;
+    return CPubKey(ParseHex(Params().SporkPubKeyOld()));
 }
 
 void CSporkMessage::Relay()

--- a/src/spork.h
+++ b/src/spork.h
@@ -36,12 +36,26 @@ private:
     std::vector<unsigned char> vchSig;
 
 public:
+    int nMessVersion;
     SporkId nSporkID;
     int64_t nValue;
     int64_t nTimeSigned;
 
-    CSporkMessage(SporkId nSporkID, int64_t nValue, int64_t nTimeSigned) : nSporkID(nSporkID), nValue(nValue), nTimeSigned(nTimeSigned) {}
-    CSporkMessage() : nSporkID((SporkId)0), nValue(0), nTimeSigned(0) {}
+    CSporkMessage() :
+        vchSig(),
+        nMessVersion(MessageVersion::MESS_VER_HASH),
+        nSporkID((SporkId)0),
+        nValue(0),
+        nTimeSigned(0)
+    {}
+
+    CSporkMessage(int nMessVersion, SporkId nSporkID, int64_t nValue, int64_t nTimeSigned) :
+        vchSig(),
+        nMessVersion(nMessVersion),
+        nSporkID(nSporkID),
+        nValue(nValue),
+        nTimeSigned(nTimeSigned)
+    { }
 
     uint256 GetHash() const { return HashQuark(BEGIN(nSporkID), END(nTimeSigned)); }
     uint256 GetSignatureHash() const;
@@ -56,10 +70,20 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
     {
-        READWRITE(nSporkID);
-        READWRITE(nValue);
-        READWRITE(nTimeSigned);
-        READWRITE(vchSig);
+        try
+        {
+            READWRITE(nMessVersion);
+            READWRITE(nSporkID);
+            READWRITE(nValue);
+            READWRITE(nTimeSigned);
+            READWRITE(vchSig);
+        } catch (...) {
+            nMessVersion = MessageVersion::MESS_VER_STRMESS;
+            READWRITE(nSporkID);
+            READWRITE(nValue);
+            READWRITE(nTimeSigned);
+            READWRITE(vchSig);
+        }
     }
 };
 

--- a/src/spork.h
+++ b/src/spork.h
@@ -43,9 +43,12 @@ public:
     CSporkMessage(SporkId nSporkID, int64_t nValue, int64_t nTimeSigned) : nSporkID(nSporkID), nValue(nValue), nTimeSigned(nTimeSigned) {}
     CSporkMessage() : nSporkID((SporkId)0), nValue(0), nTimeSigned(0) {}
 
-    uint256 GetHash() { return HashQuark(BEGIN(nSporkID), END(nTimeSigned)); }
+    uint256 GetHash() const { return HashQuark(BEGIN(nSporkID), END(nTimeSigned)); }
+    uint256 GetSignatureHash() const;
+    std::string GetStrMessage() const;
+
     bool Sign(std::string strSignKey);
-    bool CheckSignature(bool fRequireNew = false);
+    bool CheckSignature(bool fRequireNew = false) const;
     void Relay();
 
     ADD_SERIALIZE_METHODS;

--- a/src/spork.h
+++ b/src/spork.h
@@ -30,39 +30,38 @@ extern CSporkManager sporkManager;
 // Keep track of all of the network spork settings
 //
 
-class CSporkMessage
+class CSporkMessage : public CSignedMessage
 {
-private:
-    std::vector<unsigned char> vchSig;
-
 public:
-    int nMessVersion;
     SporkId nSporkID;
     int64_t nValue;
     int64_t nTimeSigned;
 
     CSporkMessage() :
-        vchSig(),
-        nMessVersion(MessageVersion::MESS_VER_HASH),
+        CSignedMessage(),
         nSporkID((SporkId)0),
         nValue(0),
         nTimeSigned(0)
     {}
 
-    CSporkMessage(int nMessVersion, SporkId nSporkID, int64_t nValue, int64_t nTimeSigned) :
-        vchSig(),
-        nMessVersion(nMessVersion),
+    CSporkMessage(SporkId nSporkID, int64_t nValue, int64_t nTimeSigned) :
+        CSignedMessage(),
         nSporkID(nSporkID),
         nValue(nValue),
         nTimeSigned(nTimeSigned)
     { }
 
     uint256 GetHash() const { return HashQuark(BEGIN(nSporkID), END(nTimeSigned)); }
-    uint256 GetSignatureHash() const;
-    std::string GetStrMessage() const;
 
-    bool Sign(std::string strSignKey);
-    bool CheckSignature(bool fRequireNew = false) const;
+    // override CSignedMessage functions
+    uint256 GetSignatureHash() const override;
+    std::string GetStrMessage() const override;
+    const CTxIn GetVin() const override { return CTxIn(); };
+
+    // override GetPublicKey - gets Params().SporkPubkey()
+    const CPubKey GetPublicKey(std::string& strErrorRet) const override;
+    const CPubKey GetPublicKeyOld() const;
+
     void Relay();
 
     ADD_SERIALIZE_METHODS;

--- a/src/spork.h
+++ b/src/spork.h
@@ -69,19 +69,15 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
     {
+        READWRITE(nSporkID);
+        READWRITE(nValue);
+        READWRITE(nTimeSigned);
+        READWRITE(vchSig);
         try
         {
             READWRITE(nMessVersion);
-            READWRITE(nSporkID);
-            READWRITE(nValue);
-            READWRITE(nTimeSigned);
-            READWRITE(vchSig);
         } catch (...) {
             nMessVersion = MessageVersion::MESS_VER_STRMESS;
-            READWRITE(nSporkID);
-            READWRITE(nValue);
-            READWRITE(nTimeSigned);
-            READWRITE(vchSig);
         }
     }
 };

--- a/src/swifttx.cpp
+++ b/src/swifttx.cpp
@@ -288,7 +288,7 @@ void DoConsensusVote(CTransaction& tx, int64_t nBlockHeight)
         LogPrintf("SwiftX::DoConsensusVote - Failed to sign consensus vote\n");
         return;
     }
-    if (!ctx.SignatureValid()) {
+    if (!ctx.CheckSignature()) {
         LogPrintf("SwiftX::DoConsensusVote - Signature invalid\n");
         return;
     }
@@ -320,7 +320,7 @@ bool ProcessConsensusVote(CNode* pnode, CConsensusVote& ctx)
         return false;
     }
 
-    if (!ctx.SignatureValid()) {
+    if (!ctx.CheckSignature()) {
         LogPrintf("SwiftX::ProcessConsensusVote - Signature invalid\n");
         // don't ban, it could just be a non-synced masternode
         mnodeman.AskForMN(pnode, ctx.vinMasternode);
@@ -531,7 +531,7 @@ bool CConsensusVote::Sign()
     return true;
 }
 
-bool CConsensusVote::SignatureValid() const
+bool CConsensusVote::CheckSignature() const
 {
     CMasternode* pmn = mnodeman.Find(vinMasternode);
     if (pmn == nullptr) {
@@ -572,7 +572,7 @@ bool CTransactionLock::SignaturesValid()
             return false;
         }
 
-        if (!vote.SignatureValid()) {
+        if (!vote.CheckSignature()) {
             LogPrintf("CTransactionLock::SignaturesValid() - Signature not valid\n");
             return false;
         }

--- a/src/swifttx.cpp
+++ b/src/swifttx.cpp
@@ -475,48 +475,82 @@ uint256 CConsensusVote::GetHash() const
     return vinMasternode.prevout.hash + vinMasternode.prevout.n + txHash;
 }
 
-
-bool CConsensusVote::SignatureValid()
+uint256 CConsensusVote::GetSignatureHash() const
 {
-    std::string strError = "";
-    std::string strMessage = txHash.ToString().c_str() + std::to_string(nBlockHeight);
-    //LogPrintf("verify strMessage %s \n", strMessage.c_str());
+    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+    ss << vinMasternode;
+    ss << txHash;
+    ss << nBlockHeight;
+    return ss.GetHash();
+}
 
-    CMasternode* pmn = mnodeman.Find(vinMasternode);
-
-    if (pmn == NULL) {
-        LogPrintf("SwiftX::CConsensusVote::SignatureValid() - Unknown Masternode\n");
-        return false;
-    }
-
-    if (!CMessageSigner::VerifyMessage(pmn->pubKeyMasternode, vchMasterNodeSignature, strMessage, strError)) {
-        LogPrintf("SwiftX::CConsensusVote::SignatureValid() - Verify message failed, error: %s\n", strError);
-        return false;
-    }
-
-    return true;
+std::string CConsensusVote::GetStrMessage() const
+{
+    return txHash.ToString().c_str() + std::to_string(nBlockHeight);
 }
 
 bool CConsensusVote::Sign()
 {
-    std::string strError = "";
+    int nHeight;
+    {
+        LOCK(cs_main);
+        nHeight = chainActive.Height();
+    }
 
+    std::string strError = "";
     CKey key2;
     CPubKey pubkey2;
-    std::string strMessage = txHash.ToString().c_str() + std::to_string(nBlockHeight);
-    //LogPrintf("signing strMessage %s \n", strMessage.c_str());
-    //LogPrintf("signing privkey %s \n", strMasterNodePrivKey.c_str());
 
     if (!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, key2, pubkey2)) {
         return error("%s : Invalid masternodeprivkey", __func__);
     }
 
-    if (!CMessageSigner::SignMessage(strMessage, vchMasterNodeSignature, key2)) {
-        return error("%s : Sign message failed", __func__);
+    if (Params().NewSigsActive(nHeight)) {
+        uint256 hash = GetSignatureHash();
+
+        if(!CHashSigner::SignHash(hash, key2, vchSig)) {
+            return error("%s : SignHash() failed", __func__);
+        }
+
+        if (!CHashSigner::VerifyHash(hash, pubkey2, vchSig, strError)) {
+            return error("%s : VerifyHash() failed, error: %s", __func__, strError);
+        }
+    } else {
+        // use old signature format
+        std::string strMessage = GetStrMessage();
+
+        if (!CMessageSigner::SignMessage(strMessage, vchSig, key2)) {
+            return error("%s - SignMessage() failed", __func__);
+        }
+
+        if (!CMessageSigner::VerifyMessage(pubkey2, vchSig, strMessage, strError)) {
+            return error("%s - VerifyMessage() failed, error: %s\n", __func__, strError);
+        }
     }
 
-    if (!CMessageSigner::VerifyMessage(pubkey2, vchMasterNodeSignature, strMessage, strError)) {
-        return error("%s : Verify message failed, error: %s", __func__, strError);
+    return true;
+}
+
+bool CConsensusVote::SignatureValid() const
+{
+    CMasternode* pmn = mnodeman.Find(vinMasternode);
+    if (pmn == nullptr) {
+        return error("%s : vinMasternode not found", __func__);
+    }
+
+    std::string strError = "";
+
+    uint256 hash = GetSignatureHash();
+
+    if (CHashSigner::VerifyHash(hash, pmn->pubKeyMasternode, vchSig, strError))
+        return true;
+
+    // if new signature fails, try old format
+    std::string strMessage = GetStrMessage();
+
+    if (!CMessageSigner::VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, strError)) {
+        return error("%s - Got bad masternode signature for %s: %s\n", __func__,
+                vinMasternode.prevout.hash.ToString(), strError);
     }
 
     return true;

--- a/src/swifttx.cpp
+++ b/src/swifttx.cpp
@@ -285,7 +285,12 @@ void DoConsensusVote(CTransaction& tx, int64_t nBlockHeight)
     ctx.vinMasternode = activeMasternode.vin;
     ctx.txHash = tx.GetHash();
     ctx.nBlockHeight = nBlockHeight;
-    if (!ctx.Sign()) {
+    bool fNewSigs = false;
+    {
+        LOCK(cs_main);
+        fNewSigs = chainActive.NewSigsActive();
+    }
+    if (!ctx.Sign(strMasterNodePrivKey, fNewSigs)) {
         LogPrintf("%s : Failed to sign consensus vote\n", __func__);
         return;
     }
@@ -491,77 +496,6 @@ std::string CConsensusVote::GetStrMessage() const
 {
     return txHash.ToString().c_str() + std::to_string(nBlockHeight);
 }
-
-bool CConsensusVote::Sign()
-{
-    int nHeight;
-    {
-        LOCK(cs_main);
-        nHeight = chainActive.Height();
-    }
-
-    std::string strError = "";
-    CKey key2;
-    CPubKey pubkey2;
-
-    if (!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, key2, pubkey2)) {
-        return error("%s : Invalid masternodeprivkey", __func__);
-    }
-
-    if (Params().NewSigsActive(nHeight)) {
-        nMessVersion = MessageVersion::MESS_VER_HASH;
-        uint256 hash = GetSignatureHash();
-
-        if(!CHashSigner::SignHash(hash, key2, vchSig)) {
-            return error("%s : SignHash() failed", __func__);
-        }
-
-        if (!CHashSigner::VerifyHash(hash, pubkey2, vchSig, strError)) {
-            return error("%s : VerifyHash() failed, error: %s", __func__, strError);
-        }
-
-    } else {
-        // use old signature format
-        nMessVersion = MessageVersion::MESS_VER_STRMESS;
-        std::string strMessage = GetStrMessage();
-
-        if (!CMessageSigner::SignMessage(strMessage, vchSig, key2)) {
-            return error("%s : SignMessage() failed", __func__);
-        }
-
-        if (!CMessageSigner::VerifyMessage(pubkey2, vchSig, strMessage, strError)) {
-            return error("%s : VerifyMessage() failed, error: %s\n", __func__, strError);
-        }
-    }
-
-    return true;
-}
-
-bool CConsensusVote::CheckSignature() const
-{
-    CMasternode* pmn = mnodeman.Find(vinMasternode);
-    if (pmn == nullptr) {
-        return error("%s : vinMasternode not found", __func__);
-    }
-
-    std::string strError = "";
-
-    if (nMessVersion == MessageVersion::MESS_VER_HASH) {
-        uint256 hash = GetSignatureHash();
-        if(!CHashSigner::VerifyHash(hash, pmn->pubKeyMasternode, vchSig, strError))
-            return error("%s : VerifyHash failed for %s: %s", __func__,
-                    vinMasternode.prevout.hash.ToString(), strError);
-
-    } else {
-        std::string strMessage = GetStrMessage();
-        if(!CMessageSigner::VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, strError))
-            return error("%s : VerifyMessage failed for %s: %s", __func__,
-                    vinMasternode.prevout.hash.ToString(), strError);
-    }
-
-    return true;
-}
-
 
 bool CTransactionLock::SignaturesValid()
 {

--- a/src/swifttx.cpp
+++ b/src/swifttx.cpp
@@ -480,6 +480,7 @@ uint256 CConsensusVote::GetHash() const
 uint256 CConsensusVote::GetSignatureHash() const
 {
     CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+    ss << nMessVersion;
     ss << vinMasternode;
     ss << txHash;
     ss << nBlockHeight;

--- a/src/swifttx.cpp
+++ b/src/swifttx.cpp
@@ -9,6 +9,7 @@
 #include "base58.h"
 #include "key.h"
 #include "masternodeman.h"
+#include "messagesigner.h"
 #include "net.h"
 #include "obfuscation.h"
 #include "protocol.h"
@@ -477,7 +478,7 @@ uint256 CConsensusVote::GetHash() const
 
 bool CConsensusVote::SignatureValid()
 {
-    std::string errorMessage;
+    std::string strError = "";
     std::string strMessage = txHash.ToString().c_str() + std::to_string(nBlockHeight);
     //LogPrintf("verify strMessage %s \n", strMessage.c_str());
 
@@ -488,8 +489,8 @@ bool CConsensusVote::SignatureValid()
         return false;
     }
 
-    if (!obfuScationSigner.VerifyMessage(pmn->pubKeyMasternode, vchMasterNodeSignature, strMessage, errorMessage)) {
-        LogPrintf("SwiftX::CConsensusVote::SignatureValid() - Verify message failed\n");
+    if (!CMessageSigner::VerifyMessage(pmn->pubKeyMasternode, vchMasterNodeSignature, strMessage, strError)) {
+        LogPrintf("SwiftX::CConsensusVote::SignatureValid() - Verify message failed, error: %s\n", strError);
         return false;
     }
 
@@ -498,7 +499,7 @@ bool CConsensusVote::SignatureValid()
 
 bool CConsensusVote::Sign()
 {
-    std::string errorMessage;
+    std::string strError = "";
 
     CKey key2;
     CPubKey pubkey2;
@@ -506,19 +507,16 @@ bool CConsensusVote::Sign()
     //LogPrintf("signing strMessage %s \n", strMessage.c_str());
     //LogPrintf("signing privkey %s \n", strMasterNodePrivKey.c_str());
 
-    if (!obfuScationSigner.SetKey(strMasterNodePrivKey, errorMessage, key2, pubkey2)) {
-        LogPrintf("CConsensusVote::Sign() - ERROR: Invalid masternodeprivkey: '%s'\n", errorMessage.c_str());
-        return false;
+    if (!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, key2, pubkey2)) {
+        return error("%s : Invalid masternodeprivkey", __func__);
     }
 
-    if (!obfuScationSigner.SignMessage(strMessage, errorMessage, vchMasterNodeSignature, key2)) {
-        LogPrintf("CConsensusVote::Sign() - Sign message failed");
-        return false;
+    if (!CMessageSigner::SignMessage(strMessage, vchMasterNodeSignature, key2)) {
+        return error("%s : Sign message failed", __func__);
     }
 
-    if (!obfuScationSigner.VerifyMessage(pubkey2, vchMasterNodeSignature, strMessage, errorMessage)) {
-        LogPrintf("CConsensusVote::Sign() - Verify message failed");
-        return false;
+    if (!CMessageSigner::VerifyMessage(pubkey2, vchMasterNodeSignature, strMessage, strError)) {
+        return error("%s : Verify message failed, error: %s", __func__, strError);
     }
 
     return true;

--- a/src/swifttx.cpp
+++ b/src/swifttx.cpp
@@ -508,6 +508,7 @@ bool CConsensusVote::Sign()
     }
 
     if (Params().NewSigsActive(nHeight)) {
+        nMessVersion = MessageVersion::MESS_VER_HASH;
         uint256 hash = GetSignatureHash();
 
         if(!CHashSigner::SignHash(hash, key2, vchSig)) {
@@ -517,8 +518,10 @@ bool CConsensusVote::Sign()
         if (!CHashSigner::VerifyHash(hash, pubkey2, vchSig, strError)) {
             return error("%s : VerifyHash() failed, error: %s", __func__, strError);
         }
+
     } else {
         // use old signature format
+        nMessVersion = MessageVersion::MESS_VER_STRMESS;
         std::string strMessage = GetStrMessage();
 
         if (!CMessageSigner::SignMessage(strMessage, vchSig, key2)) {
@@ -542,17 +545,17 @@ bool CConsensusVote::CheckSignature() const
 
     std::string strError = "";
 
-    uint256 hash = GetSignatureHash();
+    if (nMessVersion == MessageVersion::MESS_VER_HASH) {
+        uint256 hash = GetSignatureHash();
+        if(!CHashSigner::VerifyHash(hash, pmn->pubKeyMasternode, vchSig, strError))
+            return error("%s : VerifyHash failed for %s: %s", __func__,
+                    vinMasternode.prevout.hash.ToString(), strError);
 
-    if (CHashSigner::VerifyHash(hash, pmn->pubKeyMasternode, vchSig, strError))
-        return true;
-
-    // if new signature fails, try old format
-    std::string strMessage = GetStrMessage();
-
-    if (!CMessageSigner::VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, strError)) {
-        return error("%s : Got bad masternode signature for %s: %s\n", __func__,
-                vinMasternode.prevout.hash.ToString(), strError);
+    } else {
+        std::string strMessage = GetStrMessage();
+        if(!CMessageSigner::VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, strError))
+            return error("%s : VerifyMessage failed for %s: %s", __func__,
+                    vinMasternode.prevout.hash.ToString(), strError);
     }
 
     return true;

--- a/src/swifttx.cpp
+++ b/src/swifttx.cpp
@@ -63,7 +63,7 @@ void ProcessMessageSwiftTX(CNode* pfrom, std::string& strCommand, CDataStream& v
             // IX supports normal scripts and unspendable scripts (used in DS collateral and Budget collateral).
             // TODO: Look into other script types that are normal and can be included
             if (!o.scriptPubKey.IsNormalPaymentScript() && !o.scriptPubKey.IsUnspendable()) {
-                LogPrintf("ProcessMessageSwiftTX::ix - Invalid Script %s\n", tx.ToString().c_str());
+                LogPrintf("%s : Invalid Script %s\n", __func__, tx.ToString().c_str());
                 return;
             }
         }
@@ -85,9 +85,9 @@ void ProcessMessageSwiftTX(CNode* pfrom, std::string& strCommand, CDataStream& v
 
             mapTxLockReq.insert(std::make_pair(tx.GetHash(), tx));
 
-            LogPrintf("ProcessMessageSwiftTX::ix - Transaction Lock Request: %s %s : accepted %s\n",
-                pfrom->addr.ToString().c_str(), pfrom->cleanSubVer.c_str(),
-                tx.GetHash().ToString().c_str());
+            LogPrintf("%s : Transaction Lock Request: %s %s : accepted %s\n", __func__,
+                    pfrom->addr.ToString().c_str(), pfrom->cleanSubVer.c_str(),
+                    tx.GetHash().ToString().c_str());
 
             if (GetTransactionLockSignatures(tx.GetHash()) == SWIFTTX_SIGNATURES_REQUIRED) {
                 GetMainSignals().NotifyTransactionLock(tx);
@@ -100,7 +100,7 @@ void ProcessMessageSwiftTX(CNode* pfrom, std::string& strCommand, CDataStream& v
 
             // can we get the conflicting transaction as proof?
 
-            LogPrintf("ProcessMessageSwiftTX::ix - Transaction Lock Request: %s %s : rejected %s\n",
+            LogPrintf("%s : Transaction Lock Request: %s %s : rejected %s\n", __func__,
                 pfrom->addr.ToString().c_str(), pfrom->cleanSubVer.c_str(),
                 tx.GetHash().ToString().c_str());
 
@@ -116,7 +116,7 @@ void ProcessMessageSwiftTX(CNode* pfrom, std::string& strCommand, CDataStream& v
                 //we only care if we have a complete tx lock
                 if ((*i).second.CountSignatures() >= SWIFTTX_SIGNATURES_REQUIRED) {
                     if (!CheckForConflictingLocks(tx)) {
-                        LogPrintf("ProcessMessageSwiftTX::ix - Found Existing Complete IX Lock\n");
+                        LogPrintf("%s : Found Existing Complete IX Lock\n", __func__);
 
                         //reprocess the last 15 blocks
                         ReprocessBlocks(15);
@@ -155,7 +155,7 @@ void ProcessMessageSwiftTX(CNode* pfrom, std::string& strCommand, CDataStream& v
 
                 if (mapUnknownVotes[ctx.vinMasternode.prevout.hash] > GetTime() &&
                     mapUnknownVotes[ctx.vinMasternode.prevout.hash] - GetAverageVoteTime() > 60 * 10) {
-                    LogPrintf("ProcessMessageSwiftTX::ix - masternode is spamming transaction votes: %s %s\n",
+                    LogPrintf("%s : masternode is spamming transaction votes: %s %s\n", __func__,
                         ctx.vinMasternode.ToString().c_str(),
                         ctx.txHash.ToString().c_str());
                     return;
@@ -199,12 +199,12 @@ bool IsIXTXValid(const CTransaction& txCollateral)
     }
 
     if (nValueOut > sporkManager.GetSporkValue(SPORK_5_MAX_VALUE) * COIN) {
-        LogPrint("swiftx", "IsIXTXValid - Transaction value too high - %s\n", txCollateral.ToString().c_str());
+        LogPrint("swiftx", "%s : Transaction value too high - %s\n", __func__, txCollateral.ToString().c_str());
         return false;
     }
 
     if (missingTx) {
-        LogPrint("swiftx", "IsIXTXValid - Unknown inputs in IX transaction - %s\n", txCollateral.ToString().c_str());
+        LogPrint("swiftx", "%s : Unknown inputs in IX transaction - %s\n", __func__, txCollateral.ToString().c_str());
         /*
             This happens sometimes for an unknown reason, so we'll return that it's a valid transaction.
             If someone submits an invalid transaction it will be rejected by the network anyway and this isn't
@@ -214,7 +214,7 @@ bool IsIXTXValid(const CTransaction& txCollateral)
     }
 
     if (nValueIn - nValueOut < COIN * 0.01) {
-        LogPrint("swiftx", "IsIXTXValid - did not include enough fees in transaction %d\n%s\n", nValueOut - nValueIn, txCollateral.ToString().c_str());
+        LogPrint("swiftx", "%s : did not include enough fees in transaction %d\n%s\n", __func__, nValueOut - nValueIn, txCollateral.ToString().c_str());
         return false;
     }
 
@@ -228,7 +228,8 @@ int64_t CreateNewLock(CTransaction tx)
         nTxAge = GetInputAge(i);
         if (nTxAge < 5) //1 less than the "send IX" gui requires, incase of a block propagating the network at the time
         {
-            LogPrintf("CreateNewLock - Transaction not found / too new: %d / %s\n", nTxAge, tx.GetHash().ToString().c_str());
+            LogPrintf("%s : Transaction not found / too new: %d / %s\n", __func__, nTxAge,
+                    tx.GetHash().ToString().c_str());
             return 0;
         }
     }
@@ -241,7 +242,7 @@ int64_t CreateNewLock(CTransaction tx)
     int nBlockHeight = (chainActive.Tip()->nHeight - nTxAge) + 4;
 
     if (!mapTxLocks.count(tx.GetHash())) {
-        LogPrintf("CreateNewLock - New Transaction Lock %s !\n", tx.GetHash().ToString().c_str());
+        LogPrintf("%s : New Transaction Lock %s !\n", __func__, tx.GetHash().ToString().c_str());
 
         CTransactionLock newLock;
         newLock.nBlockHeight = nBlockHeight;
@@ -251,7 +252,7 @@ int64_t CreateNewLock(CTransaction tx)
         mapTxLocks.insert(std::make_pair(tx.GetHash(), newLock));
     } else {
         mapTxLocks[tx.GetHash()].nBlockHeight = nBlockHeight;
-        LogPrint("swiftx", "CreateNewLock - Transaction Lock Exists %s !\n", tx.GetHash().ToString().c_str());
+        LogPrint("swiftx", "%s : Transaction Lock Exists %s !\n", __func__, tx.GetHash().ToString().c_str());
     }
 
 
@@ -266,30 +267,30 @@ void DoConsensusVote(CTransaction& tx, int64_t nBlockHeight)
     int n = mnodeman.GetMasternodeRank(activeMasternode.vin, nBlockHeight, MIN_SWIFTTX_PROTO_VERSION);
 
     if (n == -1) {
-        LogPrint("swiftx", "SwiftX::DoConsensusVote - Unknown Masternode\n");
+        LogPrint("swiftx", "%s : Unknown Masternode\n", __func__);
         return;
     }
 
     if (n > SWIFTTX_SIGNATURES_TOTAL) {
-        LogPrint("swiftx", "SwiftX::DoConsensusVote - Masternode not in the top %d (%d)\n", SWIFTTX_SIGNATURES_TOTAL, n);
+        LogPrint("swiftx", "%s : Masternode not in the top %d (%d)\n", __func__, SWIFTTX_SIGNATURES_TOTAL, n);
         return;
     }
     /*
         nBlockHeight calculated from the transaction is the authoritive source
     */
 
-    LogPrint("swiftx", "SwiftX::DoConsensusVote - In the top %d (%d)\n", SWIFTTX_SIGNATURES_TOTAL, n);
+    LogPrint("swiftx", "%s : In the top %d (%d)\n", __func__, SWIFTTX_SIGNATURES_TOTAL, n);
 
     CConsensusVote ctx;
     ctx.vinMasternode = activeMasternode.vin;
     ctx.txHash = tx.GetHash();
     ctx.nBlockHeight = nBlockHeight;
     if (!ctx.Sign()) {
-        LogPrintf("SwiftX::DoConsensusVote - Failed to sign consensus vote\n");
+        LogPrintf("%s : Failed to sign consensus vote\n", __func__);
         return;
     }
     if (!ctx.CheckSignature()) {
-        LogPrintf("SwiftX::DoConsensusVote - Signature invalid\n");
+        LogPrintf("%s : Signature invalid\n", __func__);
         return;
     }
 
@@ -306,29 +307,29 @@ bool ProcessConsensusVote(CNode* pnode, CConsensusVote& ctx)
 
     CMasternode* pmn = mnodeman.Find(ctx.vinMasternode);
     if (pmn != NULL)
-        LogPrint("swiftx", "SwiftX::ProcessConsensusVote - Masternode ADDR %s %d\n", pmn->addr.ToString().c_str(), n);
+        LogPrint("swiftx", "%s : Masternode ADDR %s %d\n", __func__, pmn->addr.ToString().c_str(), n);
 
     if (n == -1) {
         //can be caused by past versions trying to vote with an invalid protocol
-        LogPrint("swiftx", "SwiftX::ProcessConsensusVote - Unknown Masternode\n");
+        LogPrint("swiftx", "%s : Unknown Masternode\n", __func__);
         mnodeman.AskForMN(pnode, ctx.vinMasternode);
         return false;
     }
 
     if (n > SWIFTTX_SIGNATURES_TOTAL) {
-        LogPrint("swiftx", "SwiftX::ProcessConsensusVote - Masternode not in the top %d (%d) - %s\n", SWIFTTX_SIGNATURES_TOTAL, n, ctx.GetHash().ToString().c_str());
+        LogPrint("swiftx", "%s : Masternode not in the top %d (%d) - %s\n", __func__,
+                SWIFTTX_SIGNATURES_TOTAL, n, ctx.GetHash().ToString().c_str());
         return false;
     }
 
     if (!ctx.CheckSignature()) {
-        LogPrintf("SwiftX::ProcessConsensusVote - Signature invalid\n");
         // don't ban, it could just be a non-synced masternode
         mnodeman.AskForMN(pnode, ctx.vinMasternode);
-        return false;
+        return error("%s : Signature invalid\n", __func__);
     }
 
     if (!mapTxLocks.count(ctx.txHash)) {
-        LogPrintf("SwiftX::ProcessConsensusVote - New Transaction Lock %s !\n", ctx.txHash.ToString().c_str());
+        LogPrintf("%s : New Transaction Lock %s !\n", __func__, ctx.txHash.ToString().c_str());
 
         CTransactionLock newLock;
         newLock.nBlockHeight = 0;
@@ -337,7 +338,7 @@ bool ProcessConsensusVote(CNode* pnode, CConsensusVote& ctx)
         newLock.txHash = ctx.txHash;
         mapTxLocks.insert(std::make_pair(ctx.txHash, newLock));
     } else
-        LogPrint("swiftx", "SwiftX::ProcessConsensusVote - Transaction Lock Exists %s !\n", ctx.txHash.ToString().c_str());
+        LogPrint("swiftx", "%s : Transaction Lock Exists %s !\n", __func__, ctx.txHash.ToString().c_str());
 
     //compile consessus vote
     std::map<uint256, CTransactionLock>::iterator i = mapTxLocks.find(ctx.txHash);
@@ -352,10 +353,10 @@ bool ProcessConsensusVote(CNode* pnode, CConsensusVote& ctx)
         }
 #endif
 
-        LogPrint("swiftx", "SwiftX::ProcessConsensusVote - Transaction Lock Votes %d - %s !\n", (*i).second.CountSignatures(), ctx.GetHash().ToString().c_str());
+        LogPrint("swiftx", "%s : Transaction Lock Votes %d - %s !\n", __func__, (*i).second.CountSignatures(), ctx.GetHash().ToString().c_str());
 
         if ((*i).second.CountSignatures() >= SWIFTTX_SIGNATURES_REQUIRED) {
-            LogPrint("swiftx", "SwiftX::ProcessConsensusVote - Transaction Lock Is Complete %s !\n", (*i).second.GetHash().ToString().c_str());
+            LogPrint("swiftx", "%s : Transaction Lock Is Complete %s !\n", __func__, (*i).second.GetHash().ToString().c_str());
 
             CTransaction& tx = mapTxLockReq[ctx.txHash];
             if (!CheckForConflictingLocks(tx)) {
@@ -387,7 +388,6 @@ bool ProcessConsensusVote(CNode* pnode, CConsensusVote& ctx)
         return true;
     }
 
-
     return false;
 }
 
@@ -403,7 +403,8 @@ bool CheckForConflictingLocks(CTransaction& tx)
     for (const CTxIn& in : tx.vin) {
         if (mapLockedInputs.count(in.prevout)) {
             if (mapLockedInputs[in.prevout] != tx.GetHash()) {
-                LogPrintf("SwiftX::CheckForConflictingLocks - found two complete conflicting locks - removing both. %s %s", tx.GetHash().ToString().c_str(), mapLockedInputs[in.prevout].ToString().c_str());
+                LogPrintf("%s : found two complete conflicting locks - removing both. %s %s", __func__,
+                        tx.GetHash().ToString().c_str(), mapLockedInputs[in.prevout].ToString().c_str());
                 if (mapTxLocks.count(tx.GetHash())) mapTxLocks[tx.GetHash()].nExpiration = GetTime();
                 if (mapTxLocks.count(mapLockedInputs[in.prevout])) mapTxLocks[mapLockedInputs[in.prevout]].nExpiration = GetTime();
                 return true;
@@ -437,7 +438,8 @@ void CleanTransactionLocksList()
 
     while (it != mapTxLocks.end()) {
         if (GetTime() > it->second.nExpiration) { //keep them for an hour
-            LogPrintf("Removing old transaction lock %s\n", it->second.txHash.ToString().c_str());
+            LogPrintf("%s : Removing old transaction lock %s\n", __func__,
+                    it->second.txHash.ToString().c_str());
 
             if (mapTxLockReq.count(it->second.txHash)) {
                 CTransaction& tx = mapTxLockReq[it->second.txHash];
@@ -520,11 +522,11 @@ bool CConsensusVote::Sign()
         std::string strMessage = GetStrMessage();
 
         if (!CMessageSigner::SignMessage(strMessage, vchSig, key2)) {
-            return error("%s - SignMessage() failed", __func__);
+            return error("%s : SignMessage() failed", __func__);
         }
 
         if (!CMessageSigner::VerifyMessage(pubkey2, vchSig, strMessage, strError)) {
-            return error("%s - VerifyMessage() failed, error: %s\n", __func__, strError);
+            return error("%s : VerifyMessage() failed, error: %s\n", __func__, strError);
         }
     }
 
@@ -549,7 +551,7 @@ bool CConsensusVote::CheckSignature() const
     std::string strMessage = GetStrMessage();
 
     if (!CMessageSigner::VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, strError)) {
-        return error("%s - Got bad masternode signature for %s: %s\n", __func__,
+        return error("%s : Got bad masternode signature for %s: %s\n", __func__,
                 vinMasternode.prevout.hash.ToString(), strError);
     }
 
@@ -563,18 +565,15 @@ bool CTransactionLock::SignaturesValid()
         int n = mnodeman.GetMasternodeRank(vote.vinMasternode, vote.nBlockHeight, MIN_SWIFTTX_PROTO_VERSION);
 
         if (n == -1) {
-            LogPrintf("CTransactionLock::SignaturesValid() - Unknown Masternode\n");
-            return false;
+            return error("%s : Unknown Masternode", __func__);
         }
 
         if (n > SWIFTTX_SIGNATURES_TOTAL) {
-            LogPrintf("CTransactionLock::SignaturesValid() - Masternode not in the top %s\n", SWIFTTX_SIGNATURES_TOTAL);
-            return false;
+            return error("%s : Masternode not in the top %s", __func__, SWIFTTX_SIGNATURES_TOTAL);
         }
 
         if (!vote.CheckSignature()) {
-            LogPrintf("CTransactionLock::SignaturesValid() - Signature not valid\n");
-            return false;
+            return error("%s : Signature not valid", __func__);
         }
     }
 

--- a/src/swifttx.h
+++ b/src/swifttx.h
@@ -70,12 +70,21 @@ public:
     CTxIn vinMasternode;
     uint256 txHash;
     int nBlockHeight;
-    std::vector<unsigned char> vchMasterNodeSignature;
+    std::vector<unsigned char> vchSig;
+
+    CConsensusVote() :
+        vinMasternode(),
+        txHash(),
+        nBlockHeight(0),
+        vchSig()
+    {}
 
     uint256 GetHash() const;
+    uint256 GetSignatureHash() const;
+    std::string GetStrMessage() const;
 
-    bool SignatureValid();
     bool Sign();
+    bool SignatureValid() const;
 
     ADD_SERIALIZE_METHODS;
 
@@ -84,7 +93,7 @@ public:
     {
         READWRITE(txHash);
         READWRITE(vinMasternode);
-        READWRITE(vchMasterNodeSignature);
+        READWRITE(vchSig);
         READWRITE(nBlockHeight);
     }
 };

--- a/src/swifttx.h
+++ b/src/swifttx.h
@@ -84,7 +84,7 @@ public:
     std::string GetStrMessage() const;
 
     bool Sign();
-    bool SignatureValid() const;
+    bool CheckSignature() const;
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/swifttx.h
+++ b/src/swifttx.h
@@ -66,17 +66,19 @@ int64_t GetAverageVoteTime();
 
 class CConsensusVote
 {
+private:
+    std::vector<unsigned char> vchSig;
+
 public:
     CTxIn vinMasternode;
     uint256 txHash;
     int nBlockHeight;
-    std::vector<unsigned char> vchSig;
 
     CConsensusVote() :
+        vchSig(),
         vinMasternode(),
         txHash(),
-        nBlockHeight(0),
-        vchSig()
+        nBlockHeight(0)
     {}
 
     uint256 GetHash() const;

--- a/src/swifttx.h
+++ b/src/swifttx.h
@@ -70,6 +70,7 @@ private:
     std::vector<unsigned char> vchSig;
 
 public:
+    int nMessVersion;
     CTxIn vinMasternode;
     uint256 txHash;
     int nBlockHeight;
@@ -93,10 +94,20 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
     {
-        READWRITE(txHash);
-        READWRITE(vinMasternode);
-        READWRITE(vchSig);
-        READWRITE(nBlockHeight);
+        try
+        {
+            READWRITE(nMessVersion);
+            READWRITE(txHash);
+            READWRITE(vinMasternode);
+            READWRITE(vchSig);
+            READWRITE(nBlockHeight);
+        } catch (...) {
+            nMessVersion = MessageVersion::MESS_VER_STRMESS;
+            READWRITE(txHash);
+            READWRITE(vinMasternode);
+            READWRITE(vchSig);
+            READWRITE(nBlockHeight);
+        }
     }
 };
 

--- a/src/swifttx.h
+++ b/src/swifttx.h
@@ -64,30 +64,26 @@ int GetTransactionLockSignatures(uint256 txHash);
 
 int64_t GetAverageVoteTime();
 
-class CConsensusVote
+class CConsensusVote : public CSignedMessage
 {
-private:
-    std::vector<unsigned char> vchSig;
-
 public:
-    int nMessVersion;
     CTxIn vinMasternode;
     uint256 txHash;
     int nBlockHeight;
 
     CConsensusVote() :
-        vchSig(),
+        CSignedMessage(),
         vinMasternode(),
         txHash(),
         nBlockHeight(0)
     {}
 
     uint256 GetHash() const;
-    uint256 GetSignatureHash() const;
-    std::string GetStrMessage() const;
 
-    bool Sign();
-    bool CheckSignature() const;
+    // override CSignedMessage functions
+    uint256 GetSignatureHash() const override;
+    std::string GetStrMessage() const override;
+    const CTxIn GetVin() const override { return vinMasternode; };
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/swifttx.h
+++ b/src/swifttx.h
@@ -90,19 +90,15 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
     {
+        READWRITE(txHash);
+        READWRITE(vinMasternode);
+        READWRITE(vchSig);
+        READWRITE(nBlockHeight);
         try
         {
             READWRITE(nMessVersion);
-            READWRITE(txHash);
-            READWRITE(vinMasternode);
-            READWRITE(vchSig);
-            READWRITE(nBlockHeight);
         } catch (...) {
             nMessVersion = MessageVersion::MESS_VER_STRMESS;
-            READWRITE(txHash);
-            READWRITE(vinMasternode);
-            READWRITE(vchSig);
-            READWRITE(nBlockHeight);
         }
     }
 };


### PR DESCRIPTION
Sign the following messages based on the hash of their binary content instead of their string representation:

* masternode payment winner
* masternode ping
* budget vote
* finalized budget vote
* consensus vote
* masternode broadcast
* obfuscation relay
* spork message