### PR TITLE
[Cleanup] Get rid of compiler warnings

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1094,8 +1094,6 @@ bool AppInit2()
             return InitError(_("Unable to start HTTP server. See debug log for details."));
     }
 
-    int64_t nStart;
-
 // ********************************************************* Step 5: Backup wallet and verify wallet database integrity
 #ifdef ENABLE_WALLET
     if (!fDisableWallet) {
@@ -1411,6 +1409,7 @@ bool AppInit2()
     nCoinCacheSize = nTotalCache / 300; // coins in memory require around 300 bytes
 
     bool fLoaded = false;
+    int64_t nStart = GetTimeMillis();
     while (!fLoaded && !ShutdownRequested()) {
         bool fReset = fReindex;
         std::string strLoadError;

--- a/src/qt/pivx/qtutils.cpp
+++ b/src/qt/pivx/qtutils.cpp
@@ -13,6 +13,13 @@
 #include <QListView>
 #include <QGraphicsDropShadowEffect>
 
+Qt::Modifier SHORT_KEY
+#ifdef Q_OS_MAC
+        = Qt::CTRL;
+#else
+        = Qt::ALT;
+#endif
+
 // Open dialog at the bottom
 bool openDialog(QDialog *widget, QWidget *gui){
     widget->setWindowFlags(Qt::CustomizeWindowHint);

--- a/src/qt/pivx/qtutils.h
+++ b/src/qt/pivx/qtutils.h
@@ -19,12 +19,7 @@
 #include <initializer_list>
 #include "qt/pivx/pivxgui.h"
 
-static Qt::Modifier SHORT_KEY
-#ifdef Q_OS_MAC
-        = Qt::CTRL;
-#else
-        = Qt::ALT;
-#endif
+extern Qt::Modifier SHORT_KEY;
 
 bool openDialog(QDialog *widget, QWidget *gui);
 void closeDialog(QDialog *widget, PIVXGUI *gui);

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -55,7 +55,7 @@ bool validateURL(std::string strURL, std::string& strErr, unsigned int maxSize) 
 
     // check fronts
     bool found = false;
-    for (int i=0; i < reqPre.size() && !found; i++) {
+    for (int i=0; i < (int) reqPre.size() && !found; i++) {
         if (strURL.find(reqPre[i]) == 0) found = true;
     }
     if ((!found) && (reqPre.size() > 0)) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2435,7 +2435,7 @@ bool CWallet::CreateCoinStake(
             CAmount nMinFee = 0;
             if (!stakeInput->IsZPIV()) {
                 // Set output amount
-                unsigned int outputs = txNew.vout.size() - 1;
+                int outputs = txNew.vout.size() - 1;
                 CAmount nRemaining = nCredit - nMinFee;
                 if (outputs > 1) {
                     // Split the stake across the outputs


### PR DESCRIPTION
This removes a few compiler warnings:

uninitialized variables:
<code>
init.cpp:1620:47: warning: ‘nStart’ may be used uninitialized in this function [-Wmaybe-uninitialized]
</code>
<strike>
leveldb/port/port_posix.cc:60:15: warning: ‘ecx’ may be used uninitialized in this function [-Wmaybe-uninitialized]
</strike>
<br>

signed/unsigned int comparison:
<code>
wallet/wallet.cpp:2446:39: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
</code>
<code>
utilstrencodings.cpp:58:21: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
</code>
<br>

variables defined/set but not used
<strike>
qt/privacydialog.cpp:710:13: warning: variable ‘nLockedBalance’ set but not used [-Wunused-but-set-variable]
</strike>
<code>
./qt/pivx/qtutils.h:22:21: warning: ‘SHORT_KEY’ defined but not used [-Wunused-variable]
</code>