### PR TITLE
[Build] Set file permissions for bdb depend package

### DIFF
--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -14,6 +14,7 @@ $(package)_cppflags_mingw32=-DUNICODE -D_UNICODE
 endef
 
 define $(package)_preprocess_cmds
+  chmod u+rw dbinc/atomic.h && \
   sed -i.old 's/__atomic_compare_exchange/__atomic_compare_exchange_db/' dbinc/atomic.h && \
   sed -i.old 's/atomic_init/atomic_init_db/' dbinc/atomic.h mp/mp_region.c mp/mp_mvcc.c mp/mp_fget.c mutex/mut_method.c mutex/mut_tas.c && \
   cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub dist


### PR DESCRIPTION
I don't know why but recently I've been getting errors when trying to build depends on several different configurations. I'm curious to know if anyone else has been experiencing the issue.
Anyway this simple change fixes the error for me. 