### PR TITLE
[Wallet] fix CreateZerocoinSpendTransaction with empty addressesTo

### DIFF
--- a/src/qt/pivx/privacywidget.cpp
+++ b/src/qt/pivx/privacywidget.cpp
@@ -291,8 +291,7 @@ void PrivacyWidget::spend(CAmount value){
             selectedMints,
             mintChange,
             minimizeChange,
-            receipt,
-            walletModel->getNewAddress()
+            receipt
     )){
         inform(receipt.GetStatusMessage().data());
     }else{

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -554,16 +554,8 @@ bool WalletModel::convertBackZpiv(
         std::vector<CZerocoinMint> &vMintsSelected,
         bool fMintChange,
         bool fMinimizeChange,
-        CZerocoinSpendReceipt &receipt,
-        CBitcoinAddress addressTo
+        CZerocoinSpendReceipt &receipt
 ){
-
-    // address to must be from us.
-    if(!isMine(addressTo)){
-        receipt.SetStatus(_("To convert zPIV back to PIV the return address must be from your wallet"), ZPIV_SPEND_ERROR);
-        return false;
-    }
-
     CWalletTx wtxNew;
     return wallet->SpendZerocoin(
             value,
@@ -573,7 +565,7 @@ bool WalletModel::convertBackZpiv(
             false, // No more mints
             fMinimizeChange,
             std::list<std::pair<CBitcoinAddress*, CAmount>>(),
-            &addressTo
+            nullptr
     );
 }
 

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -204,8 +204,7 @@ public:
             std::vector<CZerocoinMint> &vMintsSelected,
             bool fMintChange,
             bool fMinimizeChange,
-            CZerocoinSpendReceipt &receipt,
-            CBitcoinAddress addressTo
+            CZerocoinSpendReceipt &receipt
     );
 
     // Wallet encryption

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3021,9 +3021,9 @@ extern UniValue DoZpivSpend(const CAmount nAmount, bool fMintChange, bool fMinim
         if(!address.IsValid())
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid PIVX address");
         outputs.push_back(std::pair<CBitcoinAddress*, CAmount>(&address, nAmount));
-        fSuccess = pwalletMain->SpendZerocoin(nAmount, wtx, receipt, vMintsSelected, fMintChange, fMinimizeChange, outputs);
-    } else                   // Spend to newly generated local address
-        fSuccess = pwalletMain->SpendZerocoin(nAmount, wtx, receipt, vMintsSelected, fMintChange, fMinimizeChange, outputs);
+    }
+
+    fSuccess = pwalletMain->SpendZerocoin(nAmount, wtx, receipt, vMintsSelected, fMintChange, fMinimizeChange, outputs);
 
     if (!fSuccess)
         throw JSONRPCError(RPC_WALLET_ERROR, receipt.GetStatusMessage());


### PR DESCRIPTION
Small bug with the recently added ability to spend zPIV to multiple addresses.
In `CWallet::CreateZerocoinSpendTransaction` the wallet does not create a destination address when the user does not supply it directly.

Also `convertBackZpiv` passes the generated destination as change address even when there is no change.

This PR restores the previous functionality so that the destination address is created in the wallet's `CreateZerocoinSpendTransaction` and changes `convertBackZpiv` and `PrivacyWidget::spend` so that they pass an empty list.