### PR TITLE
[GUI] Dashboard chart map first segfault, background task error catching.

### DIFF
--- a/src/qt/pivx/dashboardwidget.cpp
+++ b/src/qt/pivx/dashboardwidget.cpp
@@ -522,7 +522,7 @@ QMap<int, std::pair<qint64, qint64>> DashboardWidget::getAmountBy() {
     return amountBy;
 }
 
-void DashboardWidget::loadChartData(bool withMonthNames) {
+bool DashboardWidget::loadChartData(bool withMonthNames) {
 
     if (chartData) {
         delete chartData;
@@ -530,9 +530,14 @@ void DashboardWidget::loadChartData(bool withMonthNames) {
     }
 
     chartData = new ChartData();
-
     chartData->amountsByCache = getAmountBy(); // pair PIV, zPIV
+
     std::pair<int,int> range = getChartRange(chartData->amountsByCache);
+    if (range.first == 0 && range.second == 0) {
+        // Problem loading the chart.
+        return false;
+    }
+
     bool isOrderedByMonth = chartShow == MONTH;
     int daysInMonth = QDate(yearFilter, monthFilter, 1).daysInMonth();
 
@@ -558,6 +563,8 @@ void DashboardWidget::loadChartData(bool withMonthNames) {
             chartData->maxValue = max;
         }
     }
+
+    return true;
 }
 
 void DashboardWidget::onChartYearChanged(const QString& yearStr) {
@@ -699,6 +706,11 @@ std::pair<int, int> DashboardWidget::getChartRange(QMap<int, std::pair<qint64, q
             return std::make_pair(1, 13);
         case ALL: {
             QList<int> keys = amountsBy.uniqueKeys();
+            if (keys.isEmpty()) {
+                // This should never happen, ALL means from the beginning of time and if this is called then it must have at least one stake..
+                inform(tr("Error loading chart, invalid data"));
+                return std::make_pair(0, 0);
+            }
             qSort(keys);
             return std::make_pair(keys.first(), keys.last() + 1);
         }
@@ -770,8 +782,8 @@ void DashboardWidget::run(int type) {
 #ifdef USE_QTCHARTS
     if (type == REQUEST_LOAD_TASK) {
         bool withMonthNames = !isChartMin && (chartShow == YEAR);
-        loadChartData(withMonthNames);
-        QMetaObject::invokeMethod(this, "onChartRefreshed", Qt::QueuedConnection);
+        if (loadChartData(withMonthNames))
+            QMetaObject::invokeMethod(this, "onChartRefreshed", Qt::QueuedConnection);
     }
 #endif
 }

--- a/src/qt/pivx/dashboardwidget.h
+++ b/src/qt/pivx/dashboardwidget.h
@@ -166,6 +166,7 @@ private:
     bool hasZpivStakes = false;
 
     ChartData* chartData = nullptr;
+    bool hasStakes = false;
 
     void initChart();
     void showHideEmptyChart(bool show, bool loading, bool forceView = false);
@@ -177,7 +178,6 @@ private:
     void updateAxisX(const QStringList *arg = nullptr);
     void setChartShow(ChartShowType type);
     std::pair<int, int> getChartRange(QMap<int, std::pair<qint64, qint64>> amountsBy);
-    bool hasStakes();
 
 private slots:
     void onChartRefreshed();

--- a/src/qt/pivx/dashboardwidget.h
+++ b/src/qt/pivx/dashboardwidget.h
@@ -173,7 +173,7 @@ private:
     void tryChartRefresh();
     void updateStakeFilter();
     QMap<int, std::pair<qint64, qint64>> getAmountBy();
-    void loadChartData(bool withMonthNames);
+    bool loadChartData(bool withMonthNames);
     void updateAxisX(const QStringList *arg = nullptr);
     void setChartShow(ChartShowType type);
     std::pair<int, int> getChartRange(QMap<int, std::pair<qint64, qint64>> amountsBy);

--- a/src/qt/pivx/loadingdialog.cpp
+++ b/src/qt/pivx/loadingdialog.cpp
@@ -14,6 +14,10 @@ void Worker::process(){
         QString errorStr = QString::fromStdString(e.what());
         runnable->onError(errorStr, type);
         emit error(errorStr, type);
+    } catch (...) {
+        QString errorStr = QString::fromStdString("Unknown error running background task");
+        runnable->onError(errorStr, type);
+        emit error(errorStr, type);
     }
     emit finished();
 };

--- a/src/qt/pivx/settings/settingswidget.cpp
+++ b/src/qt/pivx/settings/settingswidget.cpp
@@ -176,7 +176,7 @@ void SettingsWidget::loadClientModel(){
             settingsDisplayOptionsWidget->setClientModel(clientModel);
             settingsWalletOptionsWidget->setClientModel(clientModel);
             /* keep consistency for action triggered elsewhere */
-            connect(optionsModel, SIGNAL(hideOrphansChanged(bool)), this, SLOT(updateHideOrphans(bool)));
+            //connect(optionsModel, SIGNAL(hideOrphansChanged(bool)), this, SLOT(updateHideOrphans(bool)));
 
             // TODO: Connect show restart needed and apply changes.
         }


### PR DESCRIPTION
PR covering an empty list pointer segfault when the wallet has no stakes on the yearly filtered data when, for some reason, the chart got visible (when it shouldn't as there are no stakes..). It happened to me when was doing a reindex and the internal wallet state is not clear/final.

Plus added a catch all in the background worker to not crash and inform to the user if there was an unexpected error running any UI background task.