### PR TITLE
[TravisCI] Run CMake tests earlier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,13 +37,14 @@ cache:
     - $HOME/.ccache
 stages:
   - lint
-  - test
   - cmake
+  - test
+
 env:
   global:
     - MAKEJOBS=-j3
     - RUN_UNIT_TESTS=true
-    - RUN_FUNCTIONAL_TESTS=false # Not Yet Implemented
+    - RUN_FUNCTIONAL_TESTS=false
     - RUN_BENCH=false  # Set to true for any one job that has debug enabled, to quickly check bench is not crashing or hitting assertions
     - DOCKER_NAME_TAG=ubuntu:18.04
     - BOOST_TEST_RANDOM=1$TRAVIS_BUILD_ID

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ jobs:
         GOAL="install"
         # -Wno-psabi is to disable ABI warnings: "note: parameter passing for argument of type ... changed in GCC 7.1"
         # This could be removed once the ABI change warning does not show up by default
-        BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports CXXFLAGS=-Wno-psabi"
+        BITCOIN_CONFIG="--with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports CXXFLAGS=-Wno-psabi"
 
     - stage: test
       name: 'ARM 64-bit  [GOAL:install] [no unit or functional tests]'
@@ -112,7 +112,7 @@ jobs:
         RUN_UNIT_TESTS=false
         RUN_FUNCTIONAL_TESTS=false
         GOAL="install"
-        BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
+        BITCOIN_CONFIG="--with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports"
 
     - stage: test
       name: 'Win32  [GOAL: deploy] [no functional tests]'
@@ -122,7 +122,7 @@ jobs:
         PACKAGES="python3 nsis g++-mingw-w64-i686 wine-binfmt wine32"
         RUN_FUNCTIONAL_TESTS=false
         GOAL="deploy"
-        BITCOIN_CONFIG="--enable-reduce-exports"
+        BITCOIN_CONFIG="--with-gui=qt5 --enable-reduce-exports"
 
     - stage: test
       name: 'Win64  [GOAL: deploy] [no functional tests]'
@@ -131,10 +131,10 @@ jobs:
         PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine-binfmt wine64"
         RUN_FUNCTIONAL_TESTS=false
         GOAL="deploy"
-        BITCOIN_CONFIG="--enable-reduce-exports"
+        BITCOIN_CONFIG="--with-gui=qt5 --enable-reduce-exports"
 
     - stage: test
-      name: '32-bit + dash  [GOAL: install] [no gui]'
+      name: '32-bit + dash  [GOAL: install]'
       env: >-
         HOST=i686-pc-linux-gnu
         PACKAGES="g++-multilib python3-zmq"
@@ -163,7 +163,7 @@ jobs:
         NO_DEPENDS=1
         RUN_FUNCTIONAL_TESTS=false
         GOAL="install"
-        BITCOIN_CONFIG="--enable-zmq --with-incompatible-bdb --with-gui=no"
+        BITCOIN_CONFIG="--enable-zmq --with-incompatible-bdb --with-gui=qt5"
 
     - stage: test
       name: 'x86_64 Linux  [GOAL: install]  [xenial]  [no depends, only system libs]'


### PR DESCRIPTION
This shifts the cmake stage up so as to run between the lint and test stages.

Rationale here is to reduce the need to manually restart the cmake tests due to job timeouts experienced in the standard autotools/depends stage.

The cmake stage is still allowed to fail, and will simply move on to the next stage if a failure occurs.

Also adjusted a some of the autotools builds to explicitly build the GUI front end