### PR TITLE
[Qt] Define QT_NO_KEYWORDS

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -721,7 +721,7 @@ RES_MOVIES = $(wildcard $(srcdir)/qt/res/movies/spinner-*.png)
 BITCOIN_RC = qt/res/pivx-qt-res.rc
 
 BITCOIN_QT_INCLUDES = -I$(builddir)/qt -I$(srcdir)/qt -I$(srcdir)/qt/forms \
-  -I$(builddir)/qt/forms
+  -I$(builddir)/qt/forms -DQT_NO_KEYWORDS
 
 qt_libbitcoinqt_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BITCOIN_QT_INCLUDES) \
   $(QT_INCLUDES) $(QT_DBUS_INCLUDES) $(PROTOBUF_CFLAGS) $(QR_CFLAGS) $(SVG_CFLAGS) $(CHARTS_CFLAGS)

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -44,8 +44,9 @@ find_program(MOC_BIN NAMES moc moc-qt5 qt5-moc
         NO_SYSTEM_ENVIRONMENT_PATH)
 if (MOC_BIN)
     MESSAGE(STATUS "FOUND MOC ${MOC_BIN}")
-
 endif ()
+
+add_compile_options("-DQT_NO_KEYWORDS")
 
 # Why isn't this done automatically??
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -243,7 +243,7 @@ void AddressBookPage::done(int retval)
     // Figure out which address was selected, and return it
     QModelIndexList indexes = table->selectionModel()->selectedRows(AddressTableModel::Address);
 
-    foreach (QModelIndex index, indexes) {
+    Q_FOREACH (QModelIndex index, indexes) {
         QVariant address = table->model()->data(index);
         returnValue = address.toString();
     }

--- a/src/qt/addressbookpage.h
+++ b/src/qt/addressbookpage.h
@@ -47,7 +47,7 @@ public:
     void setModel(AddressTableModel* model);
     const QString& getReturnValue() const { return returnValue; }
 
-public slots:
+public Q_SLOTS:
     void done(int retval);
 
 private:
@@ -61,7 +61,7 @@ private:
     QAction* deleteAction; // to be able to explicitly disable it
     QString newAddressToSelect;
 
-private slots:
+private Q_SLOTS:
     /** Delete currently selected address entry */
     void on_deleteAddress_clicked();
     /** Create a new address for receiving coins and / or add a new address book entry */
@@ -82,7 +82,7 @@ private slots:
     /** New entry/entries were added to address table */
     void selectNewAddress(const QModelIndex& parent, int begin, int /*end*/);
 
-signals:
+Q_SIGNALS:
     void sendCoins(QString addr);
 };
 

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -599,7 +599,7 @@ QString AddressTableModel::getAddressToShow() const{
 
 void AddressTableModel::emitDataChanged(int idx)
 {
-    emit dataChanged(index(idx, 0, QModelIndex()), index(idx, columns.length() - 1, QModelIndex()));
+    Q_EMIT dataChanged(index(idx, 0, QModelIndex()), index(idx, columns.length() - 1, QModelIndex()));
 }
 
 void AddressTableModel::notifyChange(const QModelIndex &_index) {

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -110,7 +110,7 @@ private:
     /** Notify listeners that data changed. */
     void emitDataChanged(int index);
 
-public slots:
+public Q_SLOTS:
     /* Update address list from core.
      */
     void updateEntry(const QString& address, const QString& label, bool isMine, const QString& purpose, int status);

--- a/src/qt/askpassphrasedialog.h
+++ b/src/qt/askpassphrasedialog.h
@@ -72,7 +72,7 @@ private:
 
     void initWatch(QWidget *parent);
 
-private slots:
+private Q_SLOTS:
     void onWatchClicked();
     void textChanged();
     void warningMessage();

--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -61,7 +61,7 @@ public:
     void setValue(const CAmount& value)
     {
         lineEdit()->setText(BitcoinUnits::format(currentUnit, value, false, BitcoinUnits::separatorAlways));
-        emit valueChanged();
+        Q_EMIT valueChanged();
     }
 
     void stepBy(int steps)
@@ -175,7 +175,7 @@ protected:
         return rv;
     }
 
-signals:
+Q_SIGNALS:
     void valueChanged();
 };
 

--- a/src/qt/bitcoinamountfield.h
+++ b/src/qt/bitcoinamountfield.h
@@ -56,7 +56,7 @@ public:
     */
     QWidget* setupTabChain(QWidget* prev);
 
-signals:
+Q_SIGNALS:
     void valueChanged();
 
 protected:
@@ -67,7 +67,7 @@ private:
     AmountSpinBox* amount;
     QValueComboBox* unit;
 
-private slots:
+private Q_SLOTS:
     void unitChanged(int idx);
 };
 

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -153,10 +153,10 @@ void ClientModel::updateTimer()
         prevAttempt = masternodeSync.RequestedMasternodeAttempt;
         prevAssets = masternodeSync.RequestedMasternodeAssets;
 
-        emit numBlocksChanged(newNumBlocks);
+        Q_EMIT numBlocksChanged(newNumBlocks);
     }
 
-    emit bytesChanged(getTotalBytesRecv(), getTotalBytesSent());
+    Q_EMIT bytesChanged(getTotalBytesRecv(), getTotalBytesSent());
 }
 
 void ClientModel::updateMnTimer()
@@ -172,13 +172,13 @@ void ClientModel::updateMnTimer()
     if (cachedMasternodeCountString != newMasternodeCountString) {
         cachedMasternodeCountString = newMasternodeCountString;
 
-        emit strMasternodesChanged(cachedMasternodeCountString);
+        Q_EMIT strMasternodesChanged(cachedMasternodeCountString);
     }
 }
 
 void ClientModel::updateNumConnections(int numConnections)
 {
-    emit numConnectionsChanged(numConnections);
+    Q_EMIT numConnectionsChanged(numConnections);
 }
 
 void ClientModel::updateAlert(const QString& hash, int status)
@@ -189,11 +189,11 @@ void ClientModel::updateAlert(const QString& hash, int status)
         hash_256.SetHex(hash.toStdString());
         CAlert alert = CAlert::getAlertByHash(hash_256);
         if (!alert.IsNull()) {
-            emit message(tr("Network Alert"), QString::fromStdString(alert.strStatusBar), CClientUIInterface::ICON_ERROR);
+            Q_EMIT message(tr("Network Alert"), QString::fromStdString(alert.strStatusBar), CClientUIInterface::ICON_ERROR);
         }
     }
 
-    emit alertsChanged(getStatusBarWarnings());
+    Q_EMIT alertsChanged(getStatusBarWarnings());
 }
 
 bool ClientModel::inInitialBlockDownload() const

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -99,7 +99,7 @@ private:
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();
 
-signals:
+Q_SIGNALS:
     void numConnectionsChanged(int count);
     void numBlocksChanged(int count);
     void strMasternodesChanged(const QString& strMasternodes);
@@ -112,7 +112,7 @@ signals:
     // Show progress dialog e.g. for verifychain
     void showProgress(const QString& title, int nProgress);
 
-public slots:
+public Q_SLOTS:
     void updateTimer();
     void updateMnTimer();
     void updateNumConnections(int numConnections);

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -574,7 +574,7 @@ void CoinControlDialog::updateLabels(WalletModel* model, QDialog* dialog)
     CAmount nPayAmount = 0;
     bool fDust = false;
     CMutableTransaction txDummy;
-    foreach (const CAmount& amount, CoinControlDialog::payAmounts) {
+    Q_FOREACH (const CAmount& amount, CoinControlDialog::payAmounts) {
         nPayAmount += amount;
 
         if (amount > 0) {

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -89,7 +89,7 @@ private:
     };
     friend class CCoinControlWidgetItem;
 
-private slots:
+private Q_SLOTS:
     void showMenu(const QPoint&);
     void copyAmount();
     void copyLabel();

--- a/src/qt/editaddressdialog.h
+++ b/src/qt/editaddressdialog.h
@@ -42,7 +42,7 @@ public:
     QString getAddress() const;
     void setAddress(const QString& address);
 
-public slots:
+public Q_SLOTS:
     void accept();
 
 private:

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -190,7 +190,7 @@ private:
     void setViewHeaderResizeMode(int logicalIndex, QHeaderView::ResizeMode resizeMode);
     void resizeColumn(int nColumnIndex, int width);
 
-private slots:
+private Q_SLOTS:
     void on_sectionResized(int logicalIndex, int oldSize, int newSize);
     void on_geometriesChanged();
 };

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -44,10 +44,10 @@ public:
         ST_ERROR
     };
 
-public slots:
+public Q_SLOTS:
     void check();
 
-signals:
+Q_SIGNALS:
     void reply(int status, const QString& message, quint64 available);
 
 private:
@@ -100,7 +100,7 @@ void FreespaceChecker::check()
         replyStatus = ST_ERROR;
         replyMessage = tr("Cannot create data directory here.");
     }
-    emit reply(replyStatus, replyMessage, freeBytesAvailable);
+    Q_EMIT reply(replyStatus, replyMessage, freeBytesAvailable);
 }
 
 
@@ -139,7 +139,7 @@ Intro::~Intro()
 {
     delete ui;
     /* Ensure thread is finished before it is deleted */
-    emit stopThread();
+    Q_EMIT stopThread();
     thread->wait();
 }
 
@@ -304,7 +304,7 @@ void Intro::checkPath(const QString& dataDir)
     pathToCheck = dataDir;
     if (!signalled) {
         signalled = true;
-        emit requestCheck();
+        Q_EMIT requestCheck();
     }
     mutex.unlock();
 }

--- a/src/qt/intro.h
+++ b/src/qt/intro.h
@@ -50,14 +50,14 @@ public:
      */
     static QString getDefaultDataDirectory();
 
-signals:
+Q_SIGNALS:
     void requestCheck();
     void stopThread();
 
-public slots:
+public Q_SLOTS:
     void setStatus(int status, const QString& message, quint64 bytesAvailable);
 
-private slots:
+private Q_SLOTS:
     void on_dataDirectory_textChanged(const QString& arg1);
     void on_ellipsisButton_clicked();
     void on_dataDirDefault_clicked();

--- a/src/qt/macdockiconhandler.h
+++ b/src/qt/macdockiconhandler.h
@@ -30,7 +30,7 @@ public:
     static void cleanup();
     void handleDockIconClickEvent();
 
-signals:
+Q_SIGNALS:
     void dockIconClicked();
 
 private:

--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -124,5 +124,5 @@ void MacDockIconHandler::handleDockIconClickEvent()
         this->mainWindow->show();
     }
 
-    emit this->dockIconClicked();
+    Q_EMIT this->dockIconClicked();
 }

--- a/src/qt/notificator.h
+++ b/src/qt/notificator.h
@@ -40,7 +40,7 @@ public:
         Critical     /**< An error occurred */
     };
 
-public slots:
+public Q_SLOTS:
     /** Show notification message.
        @param[in] cls    general message class
        @param[in] title  title shown with message

--- a/src/qt/openuridialog.h
+++ b/src/qt/openuridialog.h
@@ -24,10 +24,10 @@ public:
     QString getURI();
     void showEvent(QShowEvent *event) override;
 
-protected slots:
+protected Q_SLOTS:
     void accept() override;
 
-private slots:
+private Q_SLOTS:
     void on_selectFileButton_clicked();
 
 private:

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -113,7 +113,7 @@ OptionsDialog::OptionsDialog(QWidget* parent, bool enableWallet) : QDialog(paren
     /* Language selector */
     QDir translations(":translations");
     ui->lang->addItem(QString("(") + tr("default") + QString(")"), QVariant(""));
-    foreach (const QString& langStr, translations.entryList()) {
+    Q_FOREACH (const QString& langStr, translations.entryList()) {
         QLocale locale(langStr);
 
         /** check if the locale name consists of 2 parts (language_country) */
@@ -343,7 +343,7 @@ bool OptionsDialog::eventFilter(QObject* object, QEvent* event)
 {
     if (event->type() == QEvent::FocusOut) {
         if (object == ui->proxyIp || object == ui->proxyPort) {
-            emit proxyIpChecks(ui->proxyIp, ui->proxyPort);
+            Q_EMIT proxyIpChecks(ui->proxyIp, ui->proxyPort);
         }
     }
     return QDialog::eventFilter(object, event);

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -37,7 +37,7 @@ public:
 protected:
     bool eventFilter(QObject* object, QEvent* event);
 
-private slots:
+private Q_SLOTS:
     /* enable OK button */
     void enableOkButton();
     /* disable OK button */
@@ -54,7 +54,7 @@ private slots:
     void clearStatusLabel();
     void doProxyIpChecks(QValidatedLineEdit* pUiProxyIp, QLineEdit* pUiProxyPort);
 
-signals:
+Q_SIGNALS:
     void proxyIpChecks(QValidatedLineEdit* pUiProxyIp, QLineEdit* pUiProxyPort);
 
 private:

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -90,7 +90,7 @@ void OptionsModel::Init()
 }
 
 void OptionsModel::refreshDataView(){
-    emit dataChanged(index(0), index(rowCount(QModelIndex()) - 1));
+    Q_EMIT dataChanged(index(0), index(rowCount(QModelIndex()) - 1));
 }
 
 void OptionsModel::setMainDefaultOptions(QSettings& settings, bool reset){
@@ -393,22 +393,22 @@ bool OptionsModel::setData(const QModelIndex& index, const QVariant& value, int 
         case HideZeroBalances:
             fHideZeroBalances = value.toBool();
             settings.setValue("fHideZeroBalances", fHideZeroBalances);
-            emit hideZeroBalancesChanged(fHideZeroBalances);
+            Q_EMIT hideZeroBalancesChanged(fHideZeroBalances);
             break;
         case HideOrphans:
             fHideOrphans = value.toBool();
             settings.setValue("fHideOrphans", fHideOrphans);
-            emit hideOrphansChanged(fHideOrphans);
+            Q_EMIT hideOrphansChanged(fHideOrphans);
             break;
         case CoinControlFeatures:
             fCoinControlFeatures = value.toBool();
             settings.setValue("fCoinControlFeatures", fCoinControlFeatures);
-            emit coinControlFeaturesChanged(fCoinControlFeatures);
+            Q_EMIT coinControlFeaturesChanged(fCoinControlFeatures);
             break;
         case ShowColdStakingScreen:
             this->showColdStakingScreen = value.toBool();
             settings.setValue("fShowColdStakingScreen", this->showColdStakingScreen);
-            emit showHideColdStakingScreen(this->showColdStakingScreen);
+            Q_EMIT showHideColdStakingScreen(this->showColdStakingScreen);
             break;
         case DatabaseCache:
             if (settings.value("nDatabaseCache") != value) {
@@ -433,7 +433,7 @@ bool OptionsModel::setData(const QModelIndex& index, const QVariant& value, int 
         }
     }
 
-    emit dataChanged(index, index);
+    Q_EMIT dataChanged(index, index);
 
     return successful;
 }
@@ -445,7 +445,7 @@ void OptionsModel::setDisplayUnit(const QVariant& value)
         QSettings settings;
         nDisplayUnit = value.toInt();
         settings.setValue("nDisplayUnit", nDisplayUnit);
-        emit displayUnitChanged(nDisplayUnit);
+        Q_EMIT displayUnitChanged(nDisplayUnit);
     }
 }
 

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -119,7 +119,7 @@ private:
     /// Add option to list of GUI options overridden through command line/config file
     void addOverriddenOption(const std::string& option);
 
-signals:
+Q_SIGNALS:
     void displayUnitChanged(int unit);
     void zeromintEnableChanged(bool);
     void zeromintAddressesChanged(bool);

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -131,7 +131,7 @@ void PaymentServer::LoadRootCAs(X509_STORE* _store)
 
     int nRootCerts = 0;
     const QDateTime currentTime = QDateTime::currentDateTime();
-    foreach (const QSslCertificate& cert, certList) {
+    Q_FOREACH (const QSslCertificate& cert, certList) {
         if (currentTime < cert.effectiveDate() || currentTime > cert.expiryDate()) {
             ReportInvalidCertificate(cert);
             continue;
@@ -230,7 +230,7 @@ void PaymentServer::ipcParseCommandLine(int argc, char* argv[])
 bool PaymentServer::ipcSendCommandLine()
 {
     bool fResult = false;
-    foreach (const QString& r, savedPaymentRequests) {
+    Q_FOREACH (const QString& r, savedPaymentRequests) {
         QLocalSocket* socket = new QLocalSocket();
         socket->connectToServer(ipcServerName(), QIODevice::WriteOnly);
         if (!socket->waitForConnected(BITCOIN_IPC_CONNECT_TIMEOUT)) {
@@ -349,7 +349,7 @@ void PaymentServer::uiReady()
     initNetManager();
 
     saveURIs = false;
-    foreach (const QString& s, savedPaymentRequests) {
+    Q_FOREACH (const QString& s, savedPaymentRequests) {
         handleURIOrFile(s);
     }
     savedPaymentRequests.clear();
@@ -377,7 +377,7 @@ void PaymentServer::handleURIOrFile(const QString& s)
                 fetchRequest(fetchUrl);
             } else {
                 qWarning() << "PaymentServer::handleURIOrFile : Invalid URL: " << fetchUrl;
-                emit message(tr("URI handling"),
+                Q_EMIT message(tr("URI handling"),
                     tr("Payment request fetch URL is invalid: %1").arg(fetchUrl.toString()),
                     CClientUIInterface::ICON_WARNING);
             }
@@ -389,12 +389,12 @@ void PaymentServer::handleURIOrFile(const QString& s)
             if (GUIUtil::parseBitcoinURI(s, &recipient)) {
                 CBitcoinAddress address(recipient.address.toStdString());
                 if (!address.IsValid()) {
-                    emit message(tr("URI handling"), tr("Invalid payment address %1").arg(recipient.address),
+                    Q_EMIT message(tr("URI handling"), tr("Invalid payment address %1").arg(recipient.address),
                         CClientUIInterface::MSG_ERROR);
                 } else
-                    emit receivedPaymentRequest(recipient);
+                    Q_EMIT receivedPaymentRequest(recipient);
             } else
-                emit message(tr("URI handling"),
+                Q_EMIT message(tr("URI handling"),
                     tr("URI cannot be parsed! This can be caused by an invalid PIVX address or malformed URI parameters."),
                     CClientUIInterface::ICON_WARNING);
 
@@ -407,11 +407,11 @@ void PaymentServer::handleURIOrFile(const QString& s)
         PaymentRequestPlus request;
         SendCoinsRecipient recipient;
         if (!readPaymentRequestFromFile(s, request)) {
-            emit message(tr("Payment request file handling"),
+            Q_EMIT message(tr("Payment request file handling"),
                 tr("Payment request file cannot be read! This can be caused by an invalid payment request file."),
                 CClientUIInterface::ICON_WARNING);
         } else if (processPaymentRequest(request, recipient))
-            emit receivedPaymentRequest(recipient);
+            Q_EMIT receivedPaymentRequest(recipient);
 
         return;
     }
@@ -475,7 +475,7 @@ bool PaymentServer::processPaymentRequest(PaymentRequestPlus& request, SendCoins
 
         // Payment request network matches client network?
         if (details.network() != Params().NetworkIDString()) {
-            emit message(tr("Payment request rejected"), tr("Payment request network doesn't match client network."),
+            Q_EMIT message(tr("Payment request rejected"), tr("Payment request network doesn't match client network."),
                 CClientUIInterface::MSG_ERROR);
 
             return false;
@@ -483,13 +483,13 @@ bool PaymentServer::processPaymentRequest(PaymentRequestPlus& request, SendCoins
 
         // Expired payment request?
         if (details.has_expires() && (int64_t)details.expires() < GetTime()) {
-            emit message(tr("Payment request rejected"), tr("Payment request has expired."),
+            Q_EMIT message(tr("Payment request rejected"), tr("Payment request has expired."),
                 CClientUIInterface::MSG_ERROR);
 
             return false;
         }
     } else {
-        emit message(tr("Payment request error"), tr("Payment request is not initialized."),
+        Q_EMIT message(tr("Payment request error"), tr("Payment request is not initialized."),
             CClientUIInterface::MSG_ERROR);
 
         return false;
@@ -503,7 +503,7 @@ bool PaymentServer::processPaymentRequest(PaymentRequestPlus& request, SendCoins
     QList<std::pair<CScript, CAmount> > sendingTos = request.getPayTo();
     QStringList addresses;
 
-    foreach (const PAIRTYPE(CScript, CAmount) & sendingTo, sendingTos) {
+    Q_FOREACH (const PAIRTYPE(CScript, CAmount) & sendingTo, sendingTos) {
         // Extract and check destination addresses
         CTxDestination dest;
         if (ExtractDestination(sendingTo.first, dest)) {
@@ -513,7 +513,7 @@ bool PaymentServer::processPaymentRequest(PaymentRequestPlus& request, SendCoins
             // Insecure payments to custom pivx addresses are not supported
             // (there is no good way to tell the user where they are paying in a way
             // they'd have a chance of understanding).
-            emit message(tr("Payment request rejected"),
+            Q_EMIT message(tr("Payment request rejected"),
                 tr("Unverified payment requests to custom payment scripts are unsupported."),
                 CClientUIInterface::MSG_ERROR);
             return false;
@@ -522,7 +522,7 @@ bool PaymentServer::processPaymentRequest(PaymentRequestPlus& request, SendCoins
         // Extract and check amounts
         CTxOut txOut(sendingTo.second, sendingTo.first);
         if (txOut.IsDust(::minRelayTxFee)) {
-            emit message(tr("Payment request error"), tr("Requested payment amount of %1 is too small (considered dust).").arg(BitcoinUnits::formatWithUnit(optionsModel->getDisplayUnit(), sendingTo.second)),
+            Q_EMIT message(tr("Payment request error"), tr("Requested payment amount of %1 is too small (considered dust).").arg(BitcoinUnits::formatWithUnit(optionsModel->getDisplayUnit(), sendingTo.second)),
                 CClientUIInterface::MSG_ERROR);
 
             return false;
@@ -616,7 +616,7 @@ void PaymentServer::netRequestFinished(QNetworkReply* reply)
                           .arg(BIP70_MAX_PAYMENTREQUEST_SIZE);
 
         qWarning() << QString("PaymentServer::%1:").arg(__func__) << msg;
-        emit message(tr("Payment request DoS protection"), msg, CClientUIInterface::MSG_ERROR);
+        Q_EMIT message(tr("Payment request DoS protection"), msg, CClientUIInterface::MSG_ERROR);
         return;
     }
 
@@ -626,7 +626,7 @@ void PaymentServer::netRequestFinished(QNetworkReply* reply)
                           .arg(reply->errorString());
 
         qWarning() << "PaymentServer::netRequestFinished: " << msg;
-        emit message(tr("Payment request error"), msg, CClientUIInterface::MSG_ERROR);
+        Q_EMIT message(tr("Payment request error"), msg, CClientUIInterface::MSG_ERROR);
         return;
     }
 
@@ -638,11 +638,11 @@ void PaymentServer::netRequestFinished(QNetworkReply* reply)
         SendCoinsRecipient recipient;
         if (!request.parse(data)) {
             qWarning() << "PaymentServer::netRequestFinished : Error parsing payment request";
-            emit message(tr("Payment request error"),
+            Q_EMIT message(tr("Payment request error"),
                 tr("Payment request cannot be parsed!"),
                 CClientUIInterface::MSG_ERROR);
         } else if (processPaymentRequest(request, recipient))
-            emit receivedPaymentRequest(recipient);
+            Q_EMIT receivedPaymentRequest(recipient);
 
         return;
     } else if (requestType == BIP70_MESSAGE_PAYMENTACK) {
@@ -652,9 +652,9 @@ void PaymentServer::netRequestFinished(QNetworkReply* reply)
                               .arg(reply->request().url().toString());
 
             qWarning() << "PaymentServer::netRequestFinished : " << msg;
-            emit message(tr("Payment request error"), msg, CClientUIInterface::MSG_ERROR);
+            Q_EMIT message(tr("Payment request error"), msg, CClientUIInterface::MSG_ERROR);
         } else {
-            emit receivedPaymentACK(GUIUtil::HtmlEscape(paymentACK.memo()));
+            Q_EMIT receivedPaymentACK(GUIUtil::HtmlEscape(paymentACK.memo()));
         }
     }
 }
@@ -664,11 +664,11 @@ void PaymentServer::reportSslErrors(QNetworkReply* reply, const QList<QSslError>
     Q_UNUSED(reply);
 
     QString errString;
-    foreach (const QSslError& err, errs) {
+    Q_FOREACH (const QSslError& err, errs) {
         qWarning() << "PaymentServer::reportSslErrors : " << err;
         errString += err.errorString() + "\n";
     }
-    emit message(tr("Network request error"), errString, CClientUIInterface::MSG_ERROR);
+    Q_EMIT message(tr("Network request error"), errString, CClientUIInterface::MSG_ERROR);
 }
 
 void PaymentServer::setOptionsModel(OptionsModel* optionsModel)
@@ -679,7 +679,7 @@ void PaymentServer::setOptionsModel(OptionsModel* optionsModel)
 void PaymentServer::handlePaymentACK(const QString& paymentACKMsg)
 {
     // currently we don't futher process or store the paymentACK message
-    emit message(tr("Payment acknowledged"), paymentACKMsg, CClientUIInterface::ICON_INFORMATION | CClientUIInterface::MODAL);
+    Q_EMIT message(tr("Payment acknowledged"), paymentACKMsg, CClientUIInterface::ICON_INFORMATION | CClientUIInterface::MODAL);
 }
 
 X509_STORE* PaymentServer::getCertStore()

--- a/src/qt/paymentserver.h
+++ b/src/qt/paymentserver.h
@@ -91,7 +91,7 @@ public:
     // This is now public, because we use it in paymentservertests.cpp
     static bool readPaymentRequestFromFile(const QString& filename, PaymentRequestPlus& request);
 
-signals:
+Q_SIGNALS:
     // Fired when a valid payment request is received
     void receivedPaymentRequest(SendCoinsRecipient);
 
@@ -101,7 +101,7 @@ signals:
     // Fired when a message should be reported to the user
     void message(const QString& title, const QString& message, unsigned int style);
 
-public slots:
+public Q_SLOTS:
     // Signal this when the main window's UI is ready
     // to display payment requests to the user
     void uiReady();
@@ -112,7 +112,7 @@ public slots:
     // Handle an incoming URI, URI with local file scheme or file
     void handleURIOrFile(const QString& s);
 
-private slots:
+private Q_SLOTS:
     void handleURIConnection();
     void netRequestFinished(QNetworkReply*);
     void reportSslErrors(QNetworkReply*, const QList<QSslError>&);

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -61,7 +61,7 @@ public:
             cachedNodeStats.clear();
 
             cachedNodeStats.reserve(vNodes.size());
-            foreach (CNode* pnode, vNodes) {
+            Q_FOREACH (CNode* pnode, vNodes) {
                 CNodeCombinedStats stats;
                 stats.nodeStateStats.nMisbehavior = 0;
                 stats.nodeStateStats.nSyncHeight = -1;
@@ -88,7 +88,7 @@ public:
         // build index map
         mapNodeRows.clear();
         int row = 0;
-        foreach (const CNodeCombinedStats& stats, cachedNodeStats)
+        Q_FOREACH (const CNodeCombinedStats& stats, cachedNodeStats)
             mapNodeRows.insert(std::pair<NodeId, int>(stats.nodeStats.nodeid, row++));
     }
 
@@ -210,9 +210,9 @@ const CNodeCombinedStats* PeerTableModel::getNodeStats(int idx)
 
 void PeerTableModel::refresh()
 {
-    emit layoutAboutToBeChanged();
+    Q_EMIT layoutAboutToBeChanged();
     priv->refreshPeers();
-    emit layoutChanged();
+    Q_EMIT layoutChanged();
 }
 
 int PeerTableModel::getRowByNodeId(NodeId nodeid)

--- a/src/qt/peertablemodel.h
+++ b/src/qt/peertablemodel.h
@@ -68,7 +68,7 @@ public:
     void sort(int column, Qt::SortOrder order);
     /*@}*/
 
-public slots:
+public Q_SLOTS:
     void refresh();
 
 private:

--- a/src/qt/pivx.cpp
+++ b/src/qt/pivx.cpp
@@ -157,12 +157,12 @@ class BitcoinCore : public QObject
 public:
     explicit BitcoinCore();
 
-public slots:
+public Q_SLOTS:
     void initialize();
     void shutdown();
     void restart(QStringList args);
 
-signals:
+Q_SIGNALS:
     void initializeResult(int retval);
     void shutdownResult(int retval);
     void runawayException(const QString& message);
@@ -208,14 +208,14 @@ public:
     /// Get window identifier of QMainWindow (PIVXGUI)
     WId getMainWinId() const;
 
-public slots:
+public Q_SLOTS:
     void initializeResult(int retval);
     void shutdownResult(int retval);
     /// Handle runaway exceptions. Shows a message box with the problem and quits the program.
     void handleRunawayException(const QString& message);
     void updateTranslation();
 
-signals:
+Q_SIGNALS:
     void requestedInitialize();
     void requestedRestart(QStringList args);
     void requestedShutdown();
@@ -247,7 +247,7 @@ BitcoinCore::BitcoinCore() : QObject()
 void BitcoinCore::handleRunawayException(const std::exception* e)
 {
     PrintExceptionContinue(e, "Runaway exception");
-    emit runawayException(QString::fromStdString(strMiscWarning));
+    Q_EMIT runawayException(QString::fromStdString(strMiscWarning));
 }
 
 void BitcoinCore::initialize()
@@ -257,7 +257,7 @@ void BitcoinCore::initialize()
     try {
         qDebug() << __func__ << ": Running AppInit2 in thread";
         int rv = AppInit2();
-        emit initializeResult(rv);
+        Q_EMIT initializeResult(rv);
     } catch (const std::exception& e) {
         handleRunawayException(&e);
     } catch (...) {
@@ -274,7 +274,7 @@ void BitcoinCore::restart(QStringList args)
             Interrupt();
             PrepareShutdown();
             qDebug() << __func__ << ": Shutdown finished";
-            emit shutdownResult(1);
+            Q_EMIT shutdownResult(1);
             CExplicitNetCleanup::callCleanup();
             QProcess::startDetached(QApplication::applicationFilePath(), args);
             qDebug() << __func__ << ": Restart initiated...";
@@ -294,7 +294,7 @@ void BitcoinCore::shutdown()
         Interrupt();
         Shutdown();
         qDebug() << __func__ << ": Shutdown finished";
-        emit shutdownResult(1);
+        Q_EMIT shutdownResult(1);
     } catch (const std::exception& e) {
         handleRunawayException(&e);
     } catch (...) {
@@ -321,7 +321,7 @@ BitcoinApplication::~BitcoinApplication()
 {
     if (coreThread) {
         qDebug() << __func__ << ": Stopping thread";
-        emit stopThread();
+        Q_EMIT stopThread();
         coreThread->wait();
         qDebug() << __func__ << ": Stopped thread";
     }
@@ -418,7 +418,7 @@ void BitcoinApplication::requestInitialize()
 {
     qDebug() << __func__ << ": Requesting initialize";
     startThread();
-    emit requestedInitialize();
+    Q_EMIT requestedInitialize();
 }
 
 void BitcoinApplication::requestShutdown()
@@ -441,7 +441,7 @@ void BitcoinApplication::requestShutdown()
     ShutdownWindow::showShutdownWindow(window);
 
     // Request shutdown from core thread
-    emit requestedShutdown();
+    Q_EMIT requestedShutdown();
 }
 
 void BitcoinApplication::initializeResult(int retval)
@@ -476,7 +476,7 @@ void BitcoinApplication::initializeResult(int retval)
         } else {
             window->show();
         }
-        emit splashFinished(window);
+        Q_EMIT splashFinished(window);
 
 #ifdef ENABLE_WALLET
         // Now that initialization/startup is done, process any command-line

--- a/src/qt/pivx/addnewcontactdialog.h
+++ b/src/qt/pivx/addnewcontactdialog.h
@@ -26,7 +26,7 @@ public:
 
     bool res = false;
 
-public slots:
+public Q_SLOTS:
     void ok();
 private:
     Ui::AddNewContactDialog *ui;

--- a/src/qt/pivx/addresseswidget.h
+++ b/src/qt/pivx/addresseswidget.h
@@ -37,7 +37,7 @@ public:
     void loadWalletModel() override;
     void onNewContactClicked();
 
-private slots:
+private Q_SLOTS:
     void handleAddressClicked(const QModelIndex &index);
     void onStoreContactClicked();
     void onEditClicked();

--- a/src/qt/pivx/coldstakingmodel.cpp
+++ b/src/qt/pivx/coldstakingmodel.cpp
@@ -21,7 +21,7 @@ void ColdStakingModel::updateCSList() {
 }
 
 void ColdStakingModel::emitDataSetChanged() {
-    emit dataChanged(index(0, 0, QModelIndex()), index(cachedDelegations.size(), COLUMN_COUNT, QModelIndex()) );
+    Q_EMIT dataChanged(index(0, 0, QModelIndex()), index(cachedDelegations.size(), COLUMN_COUNT, QModelIndex()) );
 }
 
 void ColdStakingModel::refresh() {
@@ -178,6 +178,6 @@ void ColdStakingModel::removeRowAndEmitDataChanged(const int idx)
 {
     beginRemoveRows(QModelIndex(), idx, idx);
     endRemoveRows();
-    emit dataChanged(index(idx, 0, QModelIndex()), index(idx, COLUMN_COUNT, QModelIndex()) );
+    Q_EMIT dataChanged(index(idx, 0, QModelIndex()), index(idx, COLUMN_COUNT, QModelIndex()) );
 }
 

--- a/src/qt/pivx/coldstakingmodel.h
+++ b/src/qt/pivx/coldstakingmodel.h
@@ -72,7 +72,7 @@ public:
 
     void refresh();
 
-public slots:
+public Q_SLOTS:
     void emitDataSetChanged();
 
 private:

--- a/src/qt/pivx/coldstakingwidget.h
+++ b/src/qt/pivx/coldstakingwidget.h
@@ -48,10 +48,10 @@ public:
     void run(int type) override;
     void onError(QString error, int type) override;
 
-public slots:
+public Q_SLOTS:
     void walletSynced(bool sync);
 
-private slots:
+private Q_SLOTS:
     void changeTheme(bool isLightTheme, QString &theme) override;
     void handleAddressClicked(const QModelIndex &index);
     void handleMyColdAddressClicked(const QModelIndex &rIndex);

--- a/src/qt/pivx/contactsdropdown.cpp
+++ b/src/qt/pivx/contactsdropdown.cpp
@@ -118,7 +118,7 @@ void ContactsDropdown::handleClick(const QModelIndex &index){
     QString address = rIndex.data(Qt::DisplayRole).toString();
     QModelIndex sibling = rIndex.sibling(rIndex.row(), AddressTableModel::Label);
     QString label = sibling.data(Qt::DisplayRole).toString();
-    emit contactSelected(address, label);
+    Q_EMIT contactSelected(address, label);
     close();
 }
 

--- a/src/qt/pivx/contactsdropdown.h
+++ b/src/qt/pivx/contactsdropdown.h
@@ -34,7 +34,7 @@ public:
     void setWalletModel(WalletModel* _model, const QString& type);
     void setType(const QString& type);
     void changeTheme(bool isLightTheme, QString& theme) override;
-signals:
+Q_SIGNALS:
     void contactSelected(QString address, QString label);
 private:
     FurAbstractListItemDelegate* delegate = nullptr;
@@ -42,7 +42,7 @@ private:
     AddressFilterProxyModel *filter = nullptr;
     QListView *list;
     QFrame *frameList;
-private slots:
+private Q_SLOTS:
     void handleClick(const QModelIndex &index);
 };
 

--- a/src/qt/pivx/dashboardwidget.cpp
+++ b/src/qt/pivx/dashboardwidget.cpp
@@ -831,7 +831,7 @@ void DashboardWidget::processNewTransaction(const QModelIndex& parent, int start
     QString type = txModel->index(start, TransactionTableModel::Type, parent).data().toString();
     QString address = txModel->index(start, TransactionTableModel::ToAddress, parent).data().toString();
 
-    emit incomingTransaction(date, walletModel->getOptionsModel()->getDisplayUnit(), amount, type, address);
+    Q_EMIT incomingTransaction(date, walletModel->getOptionsModel()->getDisplayUnit(), amount, type, address);
 }
 
 DashboardWidget::~DashboardWidget(){

--- a/src/qt/pivx/dashboardwidget.h
+++ b/src/qt/pivx/dashboardwidget.h
@@ -50,12 +50,12 @@ public:
     explicit SortEdit(QWidget* parent = nullptr) : QLineEdit(parent){}
 
     inline void mousePressEvent(QMouseEvent *) override{
-        emit Mouse_Pressed();
+        Q_EMIT Mouse_Pressed();
     }
 
     ~SortEdit() override{}
 
-signals:
+Q_SIGNALS:
     void Mouse_Pressed();
 
 };
@@ -105,17 +105,17 @@ public:
     void run(int type) override;
     void onError(QString error, int type) override;
 
-public slots:
+public Q_SLOTS:
     void walletSynced(bool isSync);
     /**
      * Show incoming transaction notification for new transactions.
      * The new items are those between start and end inclusive, under the given parent item.
     */
     void processNewTransaction(const QModelIndex& parent, int start, int /*end*/);
-signals:
+Q_SIGNALS:
     /** Notify that a new transaction appeared */
     void incomingTransaction(const QString& date, int unit, const CAmount& amount, const QString& type, const QString& address);
-private slots:
+private Q_SLOTS:
     void handleTransactionClicked(const QModelIndex &index);
     void changeTheme(bool isLightTheme, QString &theme) override;
     void onSortChanged(const QString&);
@@ -179,7 +179,7 @@ private:
     void setChartShow(ChartShowType type);
     std::pair<int, int> getChartRange(QMap<int, std::pair<qint64, qint64>> amountsBy);
 
-private slots:
+private Q_SLOTS:
     void onChartRefreshed();
 
 #endif

--- a/src/qt/pivx/expandablebutton.cpp
+++ b/src/qt/pivx/expandablebutton.cpp
@@ -78,7 +78,7 @@ void ExpandableButton::setExpanded(){
 void ExpandableButton::enterEvent(QEvent *) {
     if(!this->isAnimating){
         setExpanded();
-        emit Mouse_Hover();
+        Q_EMIT Mouse_Hover();
     }
     update();
 }
@@ -87,16 +87,16 @@ void ExpandableButton::leaveEvent(QEvent *) {
     if(!keepExpanded){
         this->setSmall();
     }
-    emit Mouse_HoverLeave();
+    Q_EMIT Mouse_HoverLeave();
 }
 
 void ExpandableButton::mousePressEvent(){
-    emit Mouse_Pressed();
+    Q_EMIT Mouse_Pressed();
 }
 
 void ExpandableButton::mousePressEvent(QMouseEvent *ev)
 {
-    emit Mouse_Pressed();
+    Q_EMIT Mouse_Pressed();
 }
 
 void ExpandableButton::on_pushButton_clicked(bool checked)

--- a/src/qt/pivx/expandablebutton.h
+++ b/src/qt/pivx/expandablebutton.h
@@ -36,12 +36,12 @@ public:
     }
     void setSmall();
     void setExpanded();
-signals:
+Q_SIGNALS:
     void Mouse_Pressed();
     void Mouse_Hover();
     void Mouse_HoverLeave();
 
-public slots:
+public Q_SLOTS:
     void setText2(QString text2);
 
     QString getText(){
@@ -55,7 +55,7 @@ protected:
     //virtual void mouseMoveEvent(QMouseEvent *ev);
     virtual void mousePressEvent(QMouseEvent *ev);
 
-private slots:
+private Q_SLOTS:
 
     void on_pushButton_clicked(bool checked);
 

--- a/src/qt/pivx/loadingdialog.cpp
+++ b/src/qt/pivx/loadingdialog.cpp
@@ -13,16 +13,16 @@ void Worker::process(){
         } catch (std::exception &e) {
             QString errorStr = QString::fromStdString(e.what());
             runnable->onError(errorStr, type);
-            emit error(errorStr, type);
+            Q_EMIT error(errorStr, type);
         } catch (...) {
             QString errorStr = QString::fromStdString("Unknown error running background task");
             runnable->onError(errorStr, type);
-            emit error(errorStr, type);
+            Q_EMIT error(errorStr, type);
         }
     } else {
-        emit error("Null runnable", type);
+        Q_EMIT error("Null runnable", type);
     }
-    emit finished();
+    Q_EMIT finished();
 };
 
 LoadingDialog::LoadingDialog(QWidget *parent) :

--- a/src/qt/pivx/loadingdialog.h
+++ b/src/qt/pivx/loadingdialog.h
@@ -23,9 +23,9 @@ public:
     ~Worker(){
         runnable = nullptr;
     }
-public slots:
+public Q_SLOTS:
     void process();
-signals:
+Q_SIGNALS:
     void finished();
     void error(QString err, int type);
 
@@ -45,7 +45,7 @@ public:
 
     void execute(Runnable *runnable, int type);
 
-public slots:
+public Q_SLOTS:
     void finished();
     void loadingTextChange();
 

--- a/src/qt/pivx/lockunlock.cpp
+++ b/src/qt/pivx/lockunlock.cpp
@@ -62,29 +62,29 @@ void LockUnlock::updateStatus(WalletModel::EncryptionStatus status){
 
 void LockUnlock::onLockClicked(){
     lock = 0;
-    emit lockClicked(StateClicked::LOCK);
+    Q_EMIT lockClicked(StateClicked::LOCK);
 }
 
 void LockUnlock::onUnlockClicked(){
     lock = 1;
-    emit lockClicked(StateClicked::UNLOCK);
+    Q_EMIT lockClicked(StateClicked::UNLOCK);
 }
 
 void LockUnlock::onStakingClicked(){
     lock = 2;
-    emit lockClicked(StateClicked::UNLOCK_FOR_STAKING);
+    Q_EMIT lockClicked(StateClicked::UNLOCK_FOR_STAKING);
 }
 
 void LockUnlock::enterEvent(QEvent *)
 {
     isOnHover = true;
-    emit Mouse_Entered();
+    Q_EMIT Mouse_Entered();
 }
 
 void LockUnlock::leaveEvent(QEvent *)
 {
     isOnHover = false;
-    emit Mouse_Leave();
+    Q_EMIT Mouse_Leave();
 }
 
 bool LockUnlock::isHovered(){

--- a/src/qt/pivx/lockunlock.h
+++ b/src/qt/pivx/lockunlock.h
@@ -27,7 +27,7 @@ public:
     void updateStatus(WalletModel::EncryptionStatus status);
     int lock = 0;
     bool isHovered();
-signals:
+Q_SIGNALS:
     void Mouse_Entered();
     void Mouse_Leave();
 
@@ -36,7 +36,7 @@ protected:
     virtual void enterEvent(QEvent *);
     virtual void leaveEvent(QEvent *);
 
-public slots:
+public Q_SLOTS:
     void onLockClicked();
     void onUnlockClicked();
     void onStakingClicked();

--- a/src/qt/pivx/masternodeswidget.h
+++ b/src/qt/pivx/masternodeswidget.h
@@ -40,7 +40,7 @@ public:
     void showEvent(QShowEvent *event) override;
     void hideEvent(QHideEvent *event) override;
 
-private slots:
+private Q_SLOTS:
     void onCreateMNClicked();
     void onStartAllClicked(int type);
     void changeTheme(bool isLightTheme, QString &theme) override;

--- a/src/qt/pivx/masternodewizarddialog.h
+++ b/src/qt/pivx/masternodewizarddialog.h
@@ -32,7 +32,7 @@ public:
     bool isOk = false;
     CMasternodeConfig::CMasternodeEntry* mnEntry = nullptr;
 
-private slots:
+private Q_SLOTS:
     void onNextClicked();
     void onBackClicked();
 private:

--- a/src/qt/pivx/mninfodialog.h
+++ b/src/qt/pivx/mninfodialog.h
@@ -26,7 +26,7 @@ public:
 
     void setData(QString privKey, QString name, QString address, QString txId, QString outputIndex, QString status);
 
-public slots:
+public Q_SLOTS:
     void closeDialog();
 
 private:

--- a/src/qt/pivx/mnmodel.cpp
+++ b/src/qt/pivx/mnmodel.cpp
@@ -44,7 +44,7 @@ void MNModel::updateMNList(){
             collateralTxAccepted.insert(mne.getTxHash(), txAccepted);
         }
     }
-    emit dataChanged(index(0, 0, QModelIndex()), index(end, 5, QModelIndex()) );
+    Q_EMIT dataChanged(index(0, 0, QModelIndex()), index(end, 5, QModelIndex()) );
 }
 
 int MNModel::rowCount(const QModelIndex &parent) const
@@ -135,7 +135,7 @@ bool MNModel::removeMn(const QModelIndex& modelIndex) {
     beginRemoveRows(QModelIndex(), idx, idx);
     nodes.take(alias);
     endRemoveRows();
-    emit dataChanged(index(idx, 0, QModelIndex()), index(idx, 5, QModelIndex()) );
+    Q_EMIT dataChanged(index(idx, 0, QModelIndex()), index(idx, 5, QModelIndex()) );
     return true;
 }
 

--- a/src/qt/pivx/mnrow.h
+++ b/src/qt/pivx/mnrow.h
@@ -21,7 +21,7 @@ public:
 
     void updateView(QString address, QString label, QString status, bool wasCollateralAccepted);
 
-signals:
+Q_SIGNALS:
     void onMenuClicked();
 private:
     Ui::MNRow *ui;

--- a/src/qt/pivx/navmenuwidget.cpp
+++ b/src/qt/pivx/navmenuwidget.cpp
@@ -144,7 +144,7 @@ void NavMenuWidget::onReceiveClicked(){
 
 void NavMenuWidget::onNavSelected(QWidget* active, bool startup) {
     QString start = "btn-nav-";
-    foreach (QWidget* w, btns) {
+    Q_FOREACH (QWidget* w, btns) {
         QString clazz = start + w->property("name").toString();
         if (w == active) {
             clazz += "-active";

--- a/src/qt/pivx/navmenuwidget.h
+++ b/src/qt/pivx/navmenuwidget.h
@@ -25,11 +25,11 @@ public:
     void loadWalletModel() override;
     virtual void showEvent(QShowEvent *event) override;
 
-public slots:
+public Q_SLOTS:
     void selectSettings();
     void onShowHideColdStakingChanged(bool show);
 
-private slots:
+private Q_SLOTS:
     void onSendClicked();
     void onDashboardClicked();
     void onPrivacyClicked();

--- a/src/qt/pivx/optionbutton.cpp
+++ b/src/qt/pivx/optionbutton.cpp
@@ -61,7 +61,7 @@ void OptionButton::setActive(bool isActive){
 
 void OptionButton::setChecked(bool checked){
     ui->labelArrow3->setChecked(checked);
-    emit clicked();
+    Q_EMIT clicked();
 }
 
 void OptionButton::mousePressEvent(QMouseEvent *qevent){

--- a/src/qt/pivx/optionbutton.h
+++ b/src/qt/pivx/optionbutton.h
@@ -26,7 +26,7 @@ public:
     void setRightIcon(QPixmap icon);
     void setActive(bool);
     void setChecked(bool checked);
-signals:
+Q_SIGNALS:
     void clicked();
 
 protected:

--- a/src/qt/pivx/pivxgui.cpp
+++ b/src/qt/pivx/pivxgui.cpp
@@ -239,7 +239,7 @@ PIVXGUI::~PIVXGUI() {
 /** Get restart command-line parameters and request restart */
 void PIVXGUI::handleRestart(QStringList args){
     if (!ShutdownRequested())
-        emit requestedRestart(args);
+        Q_EMIT requestedRestart(args);
 }
 
 
@@ -513,7 +513,7 @@ void PIVXGUI::changeTheme(bool isLightTheme){
     this->setStyleSheet(css);
 
     // Notify
-    emit themeChanged(isLightTheme, css);
+    Q_EMIT themeChanged(isLightTheme, css);
 
     // Update style
     updateStyle(this);
@@ -525,7 +525,7 @@ void PIVXGUI::resizeEvent(QResizeEvent* event){
     // background
     showHide(opEnabled);
     // Notify
-    emit windowResizeEvent(event);
+    Q_EMIT windowResizeEvent(event);
 }
 
 bool PIVXGUI::execDialog(QDialog *dialog, int xDiv, int yDiv){

--- a/src/qt/pivx/pivxgui.h
+++ b/src/qt/pivx/pivxgui.h
@@ -57,10 +57,10 @@ public:
     void resizeEvent(QResizeEvent *event) override;
     void showHide(bool show);
     int getNavWidth();
-signals:
+Q_SIGNALS:
     void themeChanged(bool isLightTheme, QString& theme);
     void windowResizeEvent(QResizeEvent* event);
-public slots:
+public Q_SLOTS:
     void changeTheme(bool isLightTheme);
     void goToDashboard();
     void goToSend();
@@ -162,7 +162,7 @@ private:
     /** Disconnect core signals from GUI client */
     void unsubscribeFromCoreSignals();
 
-private slots:
+private Q_SLOTS:
     /** Show window if hidden, unminimize when minimized, rise when obscured or show if hidden and fToggleHidden is true */
     void showNormalIfMinimized(bool fToggleHidden = false);
 
@@ -177,7 +177,7 @@ private slots:
     void trayIconActivated(QSystemTrayIcon::ActivationReason reason);
 #endif
 
-signals:
+Q_SIGNALS:
     /** Signal raised when a URI was entered or dragged to the GUI */
     void receivedURI(const QString& uri);
     /** Restart handling */

--- a/src/qt/pivx/privacywidget.h
+++ b/src/qt/pivx/privacywidget.h
@@ -35,7 +35,7 @@ public:
     ~PrivacyWidget();
 
     void loadWalletModel() override;
-private slots:
+private Q_SLOTS:
     void changeTheme(bool isLightTheme, QString &theme) override;
     void onCoinControlClicked();
     void onDenomClicked();

--- a/src/qt/pivx/pwidget.cpp
+++ b/src/qt/pivx/pwidget.cpp
@@ -33,7 +33,7 @@ void PWidget::onChangeTheme(bool isLightTheme, QString& theme){
 }
 
 void PWidget::showHideOp(bool show){
-    emit showHide(show);
+    Q_EMIT showHide(show);
 }
 
 void PWidget::inform(const QString& message){
@@ -51,11 +51,11 @@ bool PWidget::ask(const QString& title, const QString& message){
 }
 
 void PWidget::showDialog(QDialog *dlg, int xDiv, int yDiv){
-    emit execDialog(dlg, xDiv, yDiv);
+    Q_EMIT execDialog(dlg, xDiv, yDiv);
 }
 
 void PWidget::emitMessage(const QString& title, const QString& body, unsigned int style, bool* ret){
-    emit message(title, body, style, ret);
+    Q_EMIT message(title, body, style, ret);
 }
 
 class WorkerTask : public QRunnable {

--- a/src/qt/pivx/pwidget.h
+++ b/src/qt/pivx/pwidget.h
@@ -45,12 +45,12 @@ public:
 
     QString translate(const char *msg) override { return tr(msg); }
 
-signals:
+Q_SIGNALS:
     void message(const QString& title, const QString& body, unsigned int style, bool* ret = nullptr);
     void showHide(bool show);
     bool execDialog(QDialog *dialog, int xDiv = 3, int yDiv = 5);
 
-protected slots:
+protected Q_SLOTS:
     virtual void changeTheme(bool isLightTheme, QString &theme);
     void onChangeTheme(bool isLightTheme, QString &theme);
 
@@ -74,7 +74,7 @@ private:
     QSharedPointer<WorkerTask> task;
 
     void init();
-private slots:
+private Q_SLOTS:
     void errorString(QString, int);
 
 };

--- a/src/qt/pivx/qtutils.cpp
+++ b/src/qt/pivx/qtutils.cpp
@@ -225,7 +225,7 @@ void setCssBtnSecondary(QPushButton *btn, bool forceUpdate){
 }
 
 void setCssTextBodyDialog(std::initializer_list<QWidget*> args){
-    foreach (QWidget* w, args) { setCssTextBodyDialog(w); }
+    Q_FOREACH (QWidget* w, args) { setCssTextBodyDialog(w); }
 }
 
 void setCssTextBodyDialog(QWidget* widget) {
@@ -241,7 +241,7 @@ void setCssSubtitleScreen(QWidget* wid) {
 }
 
 void setCssProperty(std::initializer_list<QWidget*> args, QString value){
-    foreach (QWidget* w, args) { setCssProperty(w, value); }
+    Q_FOREACH (QWidget* w, args) { setCssProperty(w, value); }
 }
 
 void setCssProperty(QWidget *wid, QString value, bool forceUpdate){
@@ -255,5 +255,5 @@ void forceUpdateStyle(QWidget *widget, bool forceUpdate){
 }
 
 void forceUpdateStyle(std::initializer_list<QWidget*> args){
-    foreach (QWidget* w, args) { forceUpdateStyle(w, true); }
+    Q_FOREACH (QWidget* w, args) { forceUpdateStyle(w, true); }
 }

--- a/src/qt/pivx/receivedialog.h
+++ b/src/qt/pivx/receivedialog.h
@@ -24,7 +24,7 @@ public:
 
     void updateQr(QString address);
 
-private slots:
+private Q_SLOTS:
     void onCopy();
 private:
     Ui::ReceiveDialog *ui;

--- a/src/qt/pivx/receivewidget.h
+++ b/src/qt/pivx/receivewidget.h
@@ -35,12 +35,12 @@ public:
 
     void loadWalletModel() override;
 
-public slots:
+public Q_SLOTS:
     void onRequestClicked();
     void onMyAddressesClicked();
     void onNewAddressClicked();
 
-private slots:
+private Q_SLOTS:
     void changeTheme(bool isLightTheme, QString &theme) override ;
     void onLabelClicked();
     void onCopyClicked();

--- a/src/qt/pivx/requestdialog.h
+++ b/src/qt/pivx/requestdialog.h
@@ -30,7 +30,7 @@ public:
     void showEvent(QShowEvent *event) override;
     int res = -1;
 
-private slots:
+private Q_SLOTS:
     void onNextClicked();
     void onCopyClicked();
     void onCopyUriClicked();

--- a/src/qt/pivx/send.cpp
+++ b/src/qt/pivx/send.cpp
@@ -396,7 +396,7 @@ bool SendWidget::sendZpiv(QList<SendCoinsRecipient> recipients){
         return false;
 
     if(sporkManager.IsSporkActive(SPORK_16_ZEROCOIN_MAINTENANCE_MODE)) {
-        emit message(tr("Spend Zerocoin"), tr("zPIV is currently undergoing maintenance."), CClientUIInterface::MSG_ERROR);
+        Q_EMIT message(tr("Spend Zerocoin"), tr("zPIV is currently undergoing maintenance."), CClientUIInterface::MSG_ERROR);
         return false;
     }
 
@@ -433,7 +433,7 @@ bool SendWidget::sendZpiv(QList<SendCoinsRecipient> recipients){
            .arg(recipientsToString(recipients));
 
     bool ret = false;
-    emit message(
+    Q_EMIT message(
             tr("Spend Zerocoin"),
             sendBody,
             CClientUIInterface::MSG_INFORMATION | CClientUIInterface::BTN_MASK | CClientUIInterface::MODAL,
@@ -479,7 +479,7 @@ bool SendWidget::sendZpiv(QList<SendCoinsRecipient> recipients){
                 body = QString::fromStdString(receipt.GetStatusMessage());
             }
         }
-        emit message("zPIV transaction failed", body, CClientUIInterface::MSG_ERROR);
+        Q_EMIT message("zPIV transaction failed", body, CClientUIInterface::MSG_ERROR);
         return false;
     }
 }
@@ -504,7 +504,7 @@ void SendWidget::updateEntryLabels(QList<SendCoinsRecipient> recipients){
                                                                   AddressBook::AddressBookPurpose::RECEIVE :
                                                                   AddressBook::AddressBookPurpose::SEND)) {
                     // Label update failed
-                    emit message("", tr("Address label update failed for address: %1").arg(rec.address), CClientUIInterface::MSG_ERROR);
+                    Q_EMIT message("", tr("Address label update failed for address: %1").arg(rec.address), CClientUIInterface::MSG_ERROR);
                     return;
                 }
             }
@@ -565,7 +565,7 @@ void SendWidget::onOpenUriClicked(){
             entry->setAddressAndLabelOrDescription(rcp.address, rcp.message);
             entry->setAmount(BitcoinUnits::format(nDisplayUnit, rcp.amount, false));
         }
-        emit receivedURI(dlg->getURI());
+        Q_EMIT receivedURI(dlg->getURI());
     }
     dlg->deleteLater();
 }

--- a/src/qt/pivx/send.h
+++ b/src/qt/pivx/send.h
@@ -42,11 +42,11 @@ public:
     void loadClientModel() override;
     void loadWalletModel() override;
 
-signals:
+Q_SIGNALS:
     /** Signal raised when a URI was entered or dragged to the GUI */
     void receivedURI(const QString& uri);
 
-public slots:
+public Q_SLOTS:
     void onChangeAddressClicked();
     void onChangeCustomFeeClicked();
     void onCoinControlClicked();
@@ -58,7 +58,7 @@ public slots:
 protected:
     void resizeEvent(QResizeEvent *event) override;
 
-private slots:
+private Q_SLOTS:
     void onPIVSelected(bool _isPIV);
     void onSendClicked();
     void onContactsClicked(SendMultiRow* entry);

--- a/src/qt/pivx/sendconfirmdialog.h
+++ b/src/qt/pivx/sendconfirmdialog.h
@@ -35,7 +35,7 @@ public:
     void setData(WalletModel *model, const QModelIndex &index);
     void setDisplayUnit(int unit){this->nDisplayUnit = unit;};
 
-public slots:
+public Q_SLOTS:
     void acceptTx();
     void onInputsClicked();
     void onOutputsClicked();

--- a/src/qt/pivx/sendcustomfeedialog.h
+++ b/src/qt/pivx/sendcustomfeedialog.h
@@ -27,7 +27,7 @@ public:
     CFeeRate getFeeRate();
     void clear();
 
-public slots:
+public Q_SLOTS:
     void onRecommendedChecked();
     void onCustomChecked();
     void updateFee();

--- a/src/qt/pivx/sendmultirow.cpp
+++ b/src/qt/pivx/sendmultirow.cpp
@@ -58,8 +58,8 @@ SendMultiRow::SendMultiRow(PWidget *parent) :
 
     connect(ui->lineEditAmount, SIGNAL(textChanged(const QString&)), this, SLOT(amountChanged(const QString&)));
     connect(ui->lineEditAddress, SIGNAL(textChanged(const QString&)), this, SLOT(addressChanged(const QString&)));
-    connect(btnContact, &QAction::triggered, [this](){emit onContactsClicked(this);});
-    connect(ui->btnMenu, &QPushButton::clicked, [this](){emit onMenuClicked(this);});
+    connect(btnContact, &QAction::triggered, [this](){Q_EMIT onContactsClicked(this);});
+    connect(ui->btnMenu, &QPushButton::clicked, [this](){Q_EMIT onMenuClicked(this);});
 }
 
 void SendMultiRow::amountChanged(const QString& amount){
@@ -71,7 +71,7 @@ void SendMultiRow::amountChanged(const QString& amount){
             setCssEditLine(ui->lineEditAmount, true, true);
         }
     }
-    emit onValueChanged();
+    Q_EMIT onValueChanged();
 }
 
 /**
@@ -100,7 +100,7 @@ bool SendMultiRow::addressChanged(const QString& str){
                 } else if(!rcp.message.isEmpty())
                     ui->lineEditDescription->setText(rcp.message);
 
-                emit onUriParsed(rcp);
+                Q_EMIT onUriParsed(rcp);
             } else {
                 setCssProperty(ui->lineEditAddress, "edit-primary-multi-book-error");
             }
@@ -132,7 +132,7 @@ void SendMultiRow::updateDisplayUnit(){
 }
 
 void SendMultiRow::deleteClicked() {
-    emit removeEntry(this);
+    Q_EMIT removeEntry(this);
 }
 
 void SendMultiRow::clear() {

--- a/src/qt/pivx/sendmultirow.h
+++ b/src/qt/pivx/sendmultirow.h
@@ -55,11 +55,11 @@ public:
     int getEditWidth();
     int getMenuBtnWidth();
 
-public slots:
+public Q_SLOTS:
     void clear();
     void updateDisplayUnit();
 
-signals:
+Q_SIGNALS:
     void removeEntry(SendMultiRow* entry);
     void onContactsClicked(SendMultiRow* entry);
     void onMenuClicked(SendMultiRow* entry);
@@ -71,7 +71,7 @@ protected:
     virtual void enterEvent(QEvent *) override ;
     virtual void leaveEvent(QEvent *) override ;
 
-private slots:
+private Q_SLOTS:
     void amountChanged(const QString&);
     bool addressChanged(const QString&);
     void deleteClicked();

--- a/src/qt/pivx/settings/settingsbackupwallet.cpp
+++ b/src/qt/pivx/settings/settingsbackupwallet.cpp
@@ -92,7 +92,7 @@ void SettingsBackupWallet::changePassphrase()
                 walletModel, AskPassphraseDialog::Context::ChangePass);
     }
     dlg->adjustSize();
-    emit execDialog(dlg);
+    Q_EMIT execDialog(dlg);
     dlg->deleteLater();
 }
 

--- a/src/qt/pivx/settings/settingsbackupwallet.h
+++ b/src/qt/pivx/settings/settingsbackupwallet.h
@@ -20,7 +20,7 @@ public:
     explicit SettingsBackupWallet(PIVXGUI* _window, QWidget *parent = nullptr);
     ~SettingsBackupWallet();
 
-private slots:
+private Q_SLOTS:
     void backupWallet();
     void selectFileOutput();
     void changePassphrase();

--- a/src/qt/pivx/settings/settingsbittoolwidget.h
+++ b/src/qt/pivx/settings/settingsbittoolwidget.h
@@ -23,7 +23,7 @@ public:
     ~SettingsBitToolWidget();
 protected:
     void resizeEvent(QResizeEvent *event) override;
-public slots:
+public Q_SLOTS:
     void onEncryptSelected(bool isEncr);
     void setAddress_ENC(const QString& address);
     void onEncryptKeyButtonENCClicked();

--- a/src/qt/pivx/settings/settingsconsolewidget.cpp
+++ b/src/qt/pivx/settings/settingsconsolewidget.cpp
@@ -57,10 +57,10 @@ class RPCExecutor : public QObject
 {
     Q_OBJECT
 
-public slots:
+public Q_SLOTS:
      void requestCommand(const QString& command);
 
-signals:
+Q_SIGNALS:
      void reply(int category, const QString& command);
 };
 
@@ -79,7 +79,7 @@ public:
         timer.start(millis);
     }
     ~QtRPCTimerBase() {}
-private slots:
+private Q_SLOTS:
             void timeout() { func(); }
 private:
     QTimer timer;
@@ -124,7 +124,7 @@ bool parseCommandLineSettings(std::vector<std::string>& args, const std::string&
         STATE_ESCAPE_DOUBLEQUOTED
     } state = STATE_EATING_SPACES;
     std::string curarg;
-    foreach (char ch, strCommand) {
+    Q_FOREACH (char ch, strCommand) {
         switch (state) {
             case STATE_ARGUMENT:      // In or after argument
             case STATE_EATING_SPACES: // Handle runs of whitespace
@@ -201,7 +201,7 @@ void RPCExecutor::requestCommand(const QString& command)
 {
     std::vector<std::string> args;
     if (!parseCommandLineSettings(args, command.toStdString())) {
-        emit reply(SettingsConsoleWidget::CMD_ERROR, QString("Parse error: unbalanced ' or \""));
+        Q_EMIT reply(SettingsConsoleWidget::CMD_ERROR, QString("Parse error: unbalanced ' or \""));
         return;
     }
     if (args.empty())
@@ -222,19 +222,19 @@ void RPCExecutor::requestCommand(const QString& command)
         else
             strPrint = result.write(2);
 
-        emit reply(SettingsConsoleWidget::CMD_REPLY, QString::fromStdString(strPrint));
+        Q_EMIT reply(SettingsConsoleWidget::CMD_REPLY, QString::fromStdString(strPrint));
     } catch (UniValue& objError) {
         try // Nice formatting for standard-format error
         {
             int code = find_value(objError, "code").get_int();
             std::string message = find_value(objError, "message").get_str();
-            emit reply(SettingsConsoleWidget::CMD_ERROR, QString::fromStdString(message) + " (code " + QString::number(code) + ")");
+            Q_EMIT reply(SettingsConsoleWidget::CMD_ERROR, QString::fromStdString(message) + " (code " + QString::number(code) + ")");
         } catch (std::runtime_error&) // raised when converting to invalid type, i.e. missing code or message
         {                             // Show raw JSON object
-            emit reply(SettingsConsoleWidget::CMD_ERROR, QString::fromStdString(objError.write()));
+            Q_EMIT reply(SettingsConsoleWidget::CMD_ERROR, QString::fromStdString(objError.write()));
         }
     } catch (std::exception& e) {
-        emit reply(SettingsConsoleWidget::CMD_ERROR, QString("Error: ") + QString::fromStdString(e.what()));
+        Q_EMIT reply(SettingsConsoleWidget::CMD_ERROR, QString("Error: ") + QString::fromStdString(e.what()));
     }
 }
 
@@ -293,7 +293,7 @@ SettingsConsoleWidget::SettingsConsoleWidget(PIVXGUI* _window, QWidget *parent) 
 SettingsConsoleWidget::~SettingsConsoleWidget()
 {
     GUIUtil::saveWindowGeometry("nRPCConsoleWindow", this);
-    emit stopExecutor();
+    Q_EMIT stopExecutor();
     RPCUnsetTimerInterface(rpcTimerInterface);
     delete rpcTimerInterface;
     delete ui;
@@ -445,7 +445,7 @@ void SettingsConsoleWidget::on_lineEdit_returnPressed()
 
     if (!cmd.isEmpty()) {
         message(CMD_REQUEST, cmd);
-        emit cmdCommandRequest(cmd);
+        Q_EMIT cmdCommandRequest(cmd);
         // Remove command, if already in history
         history.removeOne(cmd);
         // Append command to history

--- a/src/qt/pivx/settings/settingsconsolewidget.h
+++ b/src/qt/pivx/settings/settingsconsolewidget.h
@@ -42,7 +42,7 @@ public:
         CMD_ERROR
     };
 
-public slots:
+public Q_SLOTS:
     void clear();
     void message(int category, const QString& message, bool html = false);
     /** Go forward or back in history */
@@ -54,10 +54,10 @@ public slots:
 protected:
     virtual bool eventFilter(QObject* obj, QEvent* event) override;
 
-protected slots:
+protected Q_SLOTS:
     void changeTheme(bool isLightTheme, QString &theme) override;
 
-signals:
+Q_SIGNALS:
     // For RPC command executor
     void stopExecutor();
     void cmdCommandRequest(const QString& command);
@@ -72,7 +72,7 @@ private:
 
     void startExecutor();
 
-private slots:
+private Q_SLOTS:
     void on_lineEdit_returnPressed();
 
 

--- a/src/qt/pivx/settings/settingsdisplayoptionswidget.cpp
+++ b/src/qt/pivx/settings/settingsdisplayoptionswidget.cpp
@@ -111,7 +111,7 @@ void SettingsDisplayOptionsWidget::initLanguages(){
     QDir translations(":translations");
     QString defaultStr = QString("(") + tr("default") + QString(")");
     ui->comboBoxLanguage->addItem(defaultStr, QVariant(""));
-    foreach (const QString& langStr, translations.entryList()) {
+    Q_FOREACH (const QString& langStr, translations.entryList()) {
         QLocale locale(langStr);
 
         /** check if the locale name consists of 2 parts (language_country) */

--- a/src/qt/pivx/settings/settingsdisplayoptionswidget.h
+++ b/src/qt/pivx/settings/settingsdisplayoptionswidget.h
@@ -25,7 +25,7 @@ public:
     void initLanguages();
     void loadClientModel() override;
 
-public slots:
+public Q_SLOTS:
     void onResetClicked();
 
 private:

--- a/src/qt/pivx/settings/settingsfaqwidget.h
+++ b/src/qt/pivx/settings/settingsfaqwidget.h
@@ -21,10 +21,10 @@ public:
 
     void showEvent(QShowEvent *event) override;
 
-public slots:
+public Q_SLOTS:
    void windowResizeEvent(QResizeEvent* event);
    void setSection(int num);
-private slots:
+private Q_SLOTS:
     void onFaq1Clicked();
     void onFaq2Clicked();
     void onFaq3Clicked();

--- a/src/qt/pivx/settings/settingsinformationwidget.h
+++ b/src/qt/pivx/settings/settingsinformationwidget.h
@@ -23,7 +23,7 @@ public:
 
     void loadClientModel() override;
 
-private slots:
+private Q_SLOTS:
     void setNumConnections(int count);
     void setNumBlocks(int count);
     void openNetworkMonitor();

--- a/src/qt/pivx/settings/settingsmainoptionswidget.h
+++ b/src/qt/pivx/settings/settingsmainoptionswidget.h
@@ -27,7 +27,7 @@ public:
 
     void setMapper(QDataWidgetMapper *mapper);
 
-public slots:
+public Q_SLOTS:
     void onResetClicked();
 
 private:

--- a/src/qt/pivx/settings/settingsmultisendwidget.cpp
+++ b/src/qt/pivx/settings/settingsmultisendwidget.cpp
@@ -21,7 +21,7 @@ MultiSendModel::MultiSendModel(QObject *parent) : QAbstractTableModel(parent){
 }
 
 void MultiSendModel::updateList(){
-    emit dataChanged(index(0, 0, QModelIndex()), index((int) pwalletMain->vMultiSend.size(), 5, QModelIndex()) );
+    Q_EMIT dataChanged(index(0, 0, QModelIndex()), index((int) pwalletMain->vMultiSend.size(), 5, QModelIndex()) );
 }
 
 int MultiSendModel::rowCount(const QModelIndex &parent) const{

--- a/src/qt/pivx/settings/settingsmultisendwidget.h
+++ b/src/qt/pivx/settings/settingsmultisendwidget.h
@@ -48,7 +48,7 @@ public:
     void loadWalletModel() override;
     void changeTheme(bool isLightTheme, QString &theme) override;
 
-private slots:
+private Q_SLOTS:
     void onAddRecipientClicked();
     void clearAll();
     void checkBoxChanged();

--- a/src/qt/pivx/settings/settingssignmessagewidgets.h
+++ b/src/qt/pivx/settings/settingssignmessagewidgets.h
@@ -25,7 +25,7 @@ public:
     void showEvent(QShowEvent *event) override;
 protected:
     void resizeEvent(QResizeEvent *event) override;
-public slots:
+public Q_SLOTS:
     void onSignMessageButtonSMClicked();
     void onVerifyMessage();
     void onPasteButtonSMClicked();

--- a/src/qt/pivx/settings/settingswalletoptionswidget.h
+++ b/src/qt/pivx/settings/settingswalletoptionswidget.h
@@ -22,7 +22,7 @@ public:
 
     void setMapper(QDataWidgetMapper *mapper);
 
-public slots:
+public Q_SLOTS:
     void onResetClicked();
 
 private:

--- a/src/qt/pivx/settings/settingswalletrepairwidget.cpp
+++ b/src/qt/pivx/settings/settingswalletrepairwidget.cpp
@@ -157,7 +157,7 @@ void SettingsWalletRepairWidget::buildParameterlist(QString arg)
     args.append(arg);
 
     // Send command-line arguments to PIVXGUI::handleRestart()
-    emit handleRestart(args);
+    Q_EMIT handleRestart(args);
 }
 
 SettingsWalletRepairWidget::~SettingsWalletRepairWidget()

--- a/src/qt/pivx/settings/settingswalletrepairwidget.h
+++ b/src/qt/pivx/settings/settingswalletrepairwidget.h
@@ -23,11 +23,11 @@ public:
     /** Build parameter list for restart */
     void buildParameterlist(QString arg);
 
-signals:
+Q_SIGNALS:
     /** Get restart command-line parameters and handle restart */
     void handleRestart(QStringList args);
 
-public slots:
+public Q_SLOTS:
     void walletSalvage();
     void walletRescan();
     void walletZaptxes1();

--- a/src/qt/pivx/settings/settingswidget.cpp
+++ b/src/qt/pivx/settings/settingswidget.cpp
@@ -145,7 +145,7 @@ SettingsWidget::SettingsWidget(PIVXGUI* parent) :
     connect(ui->pushButtonHelp2, SIGNAL(clicked()), this, SLOT(onAboutClicked()));
 
     // Get restart command-line parameters and handle restart
-    connect(settingsWalletRepairWidget, &SettingsWalletRepairWidget::handleRestart, [this](QStringList arg){emit handleRestart(arg);});
+    connect(settingsWalletRepairWidget, &SettingsWalletRepairWidget::handleRestart, [this](QStringList arg){Q_EMIT handleRestart(arg);});
 
     connect(settingsBackupWallet,&SettingsBackupWallet::message,this, &SettingsWidget::message);
     connect(settingsBackupWallet, &SettingsBackupWallet::showHide, this, &SettingsWidget::showHide);
@@ -223,7 +223,7 @@ void SettingsWidget::onSaveOptionsClicked(){
                 args.removeAll(UPGRADEWALLET);
                 args.removeAll(REINDEX);
 
-                emit handleRestart(args);
+                Q_EMIT handleRestart(args);
             } else {
                 inform(tr("Options will be applied on next wallet restart"));
             }

--- a/src/qt/pivx/settings/settingswidget.h
+++ b/src/qt/pivx/settings/settingswidget.h
@@ -41,11 +41,11 @@ public:
     void setMapper();
     void showDebugConsole();
 
-signals:
+Q_SIGNALS:
     /** Get restart command-line parameters and handle restart */
     void handleRestart(QStringList args);
 
-private slots:
+private Q_SLOTS:
     // File
     void onFileClicked();
     void onBackupWalletClicked();

--- a/src/qt/pivx/snackbar.h
+++ b/src/qt/pivx/snackbar.h
@@ -24,7 +24,7 @@ public:
     virtual void showEvent(QShowEvent *event) override;
     void sizeTo(QWidget *widget);
     void setText(QString text);
-private slots:
+private Q_SLOTS:
     void hideAnim();
     void windowResizeEvent(QResizeEvent *event);
 private:

--- a/src/qt/pivx/splash.h
+++ b/src/qt/pivx/splash.h
@@ -21,7 +21,7 @@ public:
     explicit Splash(Qt::WindowFlags f, const NetworkStyle* networkStyle);
     ~Splash();
 
-public slots:
+public Q_SLOTS:
     /** Slot to call finish() method as it's not defined as slot */
     void slotFinish(QWidget* mainWin);
 

--- a/src/qt/pivx/tooltipmenu.cpp
+++ b/src/qt/pivx/tooltipmenu.cpp
@@ -58,22 +58,22 @@ void TooltipMenu::setLastBtnVisible(bool visible) {
 
 void TooltipMenu::deleteClicked(){
     hide();
-    emit onDeleteClicked();
+    Q_EMIT onDeleteClicked();
 }
 
 void TooltipMenu::copyClicked(){
     hide();
-    emit onCopyClicked();
+    Q_EMIT onCopyClicked();
 }
 
 void TooltipMenu::editClicked(){
     hide();
-    emit onEditClicked();
+    Q_EMIT onEditClicked();
 }
 
 void TooltipMenu::lastClicked() {
     hide();
-    emit onLastClicked();
+    Q_EMIT onLastClicked();
 }
 
 void TooltipMenu::showEvent(QShowEvent *event){

--- a/src/qt/pivx/tooltipmenu.h
+++ b/src/qt/pivx/tooltipmenu.h
@@ -40,13 +40,13 @@ public:
     void setEditBtnVisible(bool visible);
     void setLastBtnVisible(bool visible);
 
-signals:
+Q_SIGNALS:
     void onDeleteClicked();
     void onCopyClicked();
     void onEditClicked();
     void onLastClicked();
 
-private slots:
+private Q_SLOTS:
     void deleteClicked();
     void copyClicked();
     void editClicked();

--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -43,7 +43,7 @@ TopBar::TopBar(PIVXGUI* _mainWindow, QWidget *parent) :
     setCssProperty(lblTitles, "text-title-topbar");
     QFont font;
     font.setWeight(QFont::Light);
-    foreach (QWidget* w, lblTitles) { w->setFont(font); }
+    Q_FOREACH (QWidget* w, lblTitles) { w->setFont(font); }
 
     // Amount information top
     ui->widgetTopAmount->setVisible(false);
@@ -130,7 +130,7 @@ void TopBar::onThemeClicked(){
     }
     updateStyle(ui->pushButtonTheme);
 
-    emit themeChanged(lightTheme);
+    Q_EMIT themeChanged(lightTheme);
 }
 
 
@@ -321,7 +321,7 @@ void TopBar::onColdStakingClicked() {
     ui->pushButtonColdStaking->setButtonText(text);
     updateStyle(ui->pushButtonColdStaking);
 
-    emit onShowHideColdStakingChanged(show);
+    Q_EMIT onShowHideColdStakingChanged(show);
 }
 
 TopBar::~TopBar(){
@@ -406,7 +406,7 @@ void TopBar::setNumBlocks(int count) {
     bool needState = true;
     if (masternodeSync.IsBlockchainSynced()) {
         // chain synced
-        emit walletSynced(true);
+        Q_EMIT walletSynced(true);
         if (masternodeSync.IsSynced()) {
             // Node synced
             ui->pushButtonSync->setButtonText(tr("Synchronized - Block: %1").arg(QString::number(count)));
@@ -429,7 +429,7 @@ void TopBar::setNumBlocks(int count) {
             }
         }
     } else {
-        emit walletSynced(false);
+        Q_EMIT walletSynced(false);
     }
 
     if(needState) {

--- a/src/qt/pivx/topbar.h
+++ b/src/qt/pivx/topbar.h
@@ -35,7 +35,7 @@ public:
     void loadClientModel() override;
 
     void encryptWallet();
-public slots:
+public Q_SLOTS:
     void updateBalances(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance,
                         const CAmount& zerocoinBalance, const CAmount& unconfirmedZerocoinBalance, const CAmount& immatureZerocoinBalance,
                         const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance,
@@ -47,14 +47,14 @@ public slots:
     void setStakingStatusActive(bool fActive);
     void updateStakingStatus();
 
-signals:
+Q_SIGNALS:
     void themeChanged(bool isLight);
     void walletSynced(bool isSync);
     void onShowHideColdStakingChanged(bool show);
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
-private slots:
+private Q_SLOTS:
     void onBtnReceiveClicked();
     void onThemeClicked();
     void onBtnLockClicked();

--- a/src/qt/pivx/walletpassworddialog.h
+++ b/src/qt/pivx/walletpassworddialog.h
@@ -21,7 +21,7 @@ public:
     explicit WalletPasswordDialog(QWidget *parent = nullptr);
     ~WalletPasswordDialog();
 
-private slots:
+private Q_SLOTS:
     void onWatchClicked();
 private:
     Ui::WalletPasswordDialog *ui;

--- a/src/qt/pivx/welcomecontentwidget.cpp
+++ b/src/qt/pivx/welcomecontentwidget.cpp
@@ -176,7 +176,7 @@ void WelcomeContentWidget::initLanguages(){
     /* Language selector */
     QDir translations(":translations");
     ui->comboBoxLanguage->addItem(QString("(") + tr("default") + QString(")"), QVariant(""));
-    foreach (const QString& langStr, translations.entryList()) {
+    Q_FOREACH (const QString& langStr, translations.entryList()) {
         QLocale locale(langStr);
 
         /** check if the locale name consists of 2 parts (language_country) */
@@ -200,7 +200,7 @@ void WelcomeContentWidget::checkLanguage(){
     QSettings settings;
     if (settings.value("language") != sel){
         settings.setValue("language", sel);
-        emit onLanguageSelected();
+        Q_EMIT onLanguageSelected();
     }
 }
 

--- a/src/qt/pivx/welcomecontentwidget.h
+++ b/src/qt/pivx/welcomecontentwidget.h
@@ -27,10 +27,10 @@ public:
     void setModel(OptionsModel *model);
     void checkLanguage();
 
-signals:
+Q_SIGNALS:
     void onLanguageSelected();
 
-public slots:
+public Q_SLOTS:
     void onNextClicked();
     void onBackClicked();
     void onSkipClicked();

--- a/src/qt/qvalidatedlineedit.h
+++ b/src/qt/qvalidatedlineedit.h
@@ -27,11 +27,11 @@ private:
     bool valid;
     const QValidator* checkValidator;
 
-public slots:
+public Q_SLOTS:
     void setValid(bool valid);
     void setEnabled(bool enabled);
 
-private slots:
+private Q_SLOTS:
     void markValid();
     void checkValidity();
 };

--- a/src/qt/qvaluecombobox.cpp
+++ b/src/qt/qvaluecombobox.cpp
@@ -27,5 +27,5 @@ void QValueComboBox::setRole(int role)
 
 void QValueComboBox::handleSelectionChanged(int idx)
 {
-    emit valueChanged();
+    Q_EMIT valueChanged();
 }

--- a/src/qt/qvaluecombobox.h
+++ b/src/qt/qvaluecombobox.h
@@ -24,13 +24,13 @@ public:
     /** Specify model role to use as ordinal value (defaults to Qt::UserRole) */
     void setRole(int role);
 
-signals:
+Q_SIGNALS:
     void valueChanged();
 
 private:
     int role;
 
-private slots:
+private Q_SLOTS:
     void handleSelectionChanged(int idx);
 };
 

--- a/src/qt/recentrequeststablemodel.cpp
+++ b/src/qt/recentrequeststablemodel.cpp
@@ -107,7 +107,7 @@ QVariant RecentRequestsTableModel::headerData(int section, Qt::Orientation orien
 void RecentRequestsTableModel::updateAmountColumnTitle()
 {
     columns[Amount] = getAmountTitle();
-    emit headerDataChanged(Qt::Horizontal, Amount, Amount);
+    Q_EMIT headerDataChanged(Qt::Horizontal, Amount, Amount);
 }
 
 /** Gets title for amount column including current display unit if optionsModel reference available. */
@@ -199,7 +199,7 @@ void RecentRequestsTableModel::addNewRequest(RecentRequestEntry& recipient)
 void RecentRequestsTableModel::sort(int column, Qt::SortOrder order)
 {
     qSort(list.begin(), list.end(), RecentRequestEntryLessThan(column, order));
-    emit dataChanged(index(0, 0, QModelIndex()), index(list.size() - 1, NUMBER_OF_COLUMNS - 1, QModelIndex()));
+    Q_EMIT dataChanged(index(0, 0, QModelIndex()), index(list.size() - 1, NUMBER_OF_COLUMNS - 1, QModelIndex()));
 }
 
 void RecentRequestsTableModel::updateDisplayUnit()

--- a/src/qt/recentrequeststablemodel.h
+++ b/src/qt/recentrequeststablemodel.h
@@ -91,7 +91,7 @@ public:
     void addNewRequest(const std::string& recipient);
     void addNewRequest(RecentRequestEntry& recipient);
 
-public slots:
+public Q_SLOTS:
     void sort(int column, Qt::SortOrder order = Qt::AscendingOrder);
     void updateDisplayUnit();
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -71,10 +71,10 @@ class RPCExecutor : public QObject
 {
     Q_OBJECT
 
-public slots:
+public Q_SLOTS:
     void request(const QString& command);
 
-signals:
+Q_SIGNALS:
     void reply(int category, const QString& command);
 };
 
@@ -93,7 +93,7 @@ public:
         timer.start(millis);
     }
     ~QtRPCTimerBase() {}
-private slots:
+private Q_SLOTS:
     void timeout() { func(); }
 private:
     QTimer timer;
@@ -138,7 +138,7 @@ bool parseCommandLine(std::vector<std::string>& args, const std::string& strComm
         STATE_ESCAPE_DOUBLEQUOTED
     } state = STATE_EATING_SPACES;
     std::string curarg;
-    foreach (char ch, strCommand) {
+    Q_FOREACH (char ch, strCommand) {
         switch (state) {
         case STATE_ARGUMENT:      // In or after argument
         case STATE_EATING_SPACES: // Handle runs of whitespace
@@ -215,7 +215,7 @@ void RPCExecutor::request(const QString& command)
 {
     std::vector<std::string> args;
     if (!parseCommandLine(args, command.toStdString())) {
-        emit reply(RPCConsole::CMD_ERROR, QString("Parse error: unbalanced ' or \""));
+        Q_EMIT reply(RPCConsole::CMD_ERROR, QString("Parse error: unbalanced ' or \""));
         return;
     }
     if (args.empty())
@@ -236,19 +236,19 @@ void RPCExecutor::request(const QString& command)
         else
             strPrint = result.write(2);
 
-        emit reply(RPCConsole::CMD_REPLY, QString::fromStdString(strPrint));
+        Q_EMIT reply(RPCConsole::CMD_REPLY, QString::fromStdString(strPrint));
     } catch (const UniValue& objError) {
         try // Nice formatting for standard-format error
         {
             int code = find_value(objError, "code").get_int();
             std::string message = find_value(objError, "message").get_str();
-            emit reply(RPCConsole::CMD_ERROR, QString::fromStdString(message) + " (code " + QString::number(code) + ")");
+            Q_EMIT reply(RPCConsole::CMD_ERROR, QString::fromStdString(message) + " (code " + QString::number(code) + ")");
         } catch (const std::runtime_error&) // raised when converting to invalid type, i.e. missing code or message
         {                             // Show raw JSON object
-            emit reply(RPCConsole::CMD_ERROR, QString::fromStdString(objError.write()));
+            Q_EMIT reply(RPCConsole::CMD_ERROR, QString::fromStdString(objError.write()));
         }
     } catch (const std::exception& e) {
-        emit reply(RPCConsole::CMD_ERROR, QString("Error: ") + QString::fromStdString(e.what()));
+        Q_EMIT reply(RPCConsole::CMD_ERROR, QString("Error: ") + QString::fromStdString(e.what()));
     }
 }
 
@@ -331,7 +331,7 @@ RPCConsole::RPCConsole(QWidget* parent) : QDialog(parent, Qt::WindowSystemMenuHi
 RPCConsole::~RPCConsole()
 {
     GUIUtil::saveWindowGeometry("nRPCConsoleWindow", this);
-    emit stopExecutor();
+    Q_EMIT stopExecutor();
     RPCUnsetTimerInterface(rpcTimerInterface);
     delete rpcTimerInterface;
     delete ui;
@@ -601,7 +601,7 @@ void RPCConsole::buildParameterlist(QString arg)
     args.append(arg);
 
     // Send command-line arguments to BitcoinGUI::handleRestart()
-    emit handleRestart(args);
+    Q_EMIT handleRestart(args);
 }
 
 void RPCConsole::clear()
@@ -702,7 +702,7 @@ void RPCConsole::on_lineEdit_returnPressed()
 
     if (!cmd.isEmpty()) {
         message(CMD_REQUEST, cmd);
-        emit cmdRequest(cmd);
+        Q_EMIT cmdRequest(cmd);
         // Remove command, if already in history
         history.removeOne(cmd);
         // Append command to history

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -49,7 +49,7 @@ public:
 protected:
     virtual bool eventFilter(QObject* obj, QEvent* event);
 
-private slots:
+private Q_SLOTS:
     void on_lineEdit_returnPressed();
     void on_tabWidget_currentChanged(int index);
     /** open the debug.log from the current datadir */
@@ -70,7 +70,7 @@ private slots:
     /** clear the selected node */
     void clearSelectedNode();
 
-public slots:
+public Q_SLOTS:
     void clear();
 
     /** Wallet repair options */
@@ -121,7 +121,7 @@ public slots:
     /** Show folder with wallet backups in default browser */
     void showBackups();
 
-signals:
+Q_SIGNALS:
     // For RPC command executor
     void stopExecutor();
     void cmdRequest(const QString& command);

--- a/src/qt/splashscreen.h
+++ b/src/qt/splashscreen.h
@@ -27,7 +27,7 @@ protected:
     void paintEvent(QPaintEvent* event);
     void closeEvent(QCloseEvent* event);
 
-public slots:
+public Q_SLOTS:
     /** Slot to call finish() method as it's not defined as slot */
     void slotFinish(QWidget* mainWin);
 

--- a/src/qt/test/paymentservertests.h
+++ b/src/qt/test/paymentservertests.h
@@ -14,7 +14,7 @@ class PaymentServerTests : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void paymentServerTests();
 };
 
@@ -25,7 +25,7 @@ class RecipientCatcher : public QObject
 {
     Q_OBJECT
 
-public slots:
+public Q_SLOTS:
     void getRecipient(SendCoinsRecipient r);
 
 public:

--- a/src/qt/test/uritests.h
+++ b/src/qt/test/uritests.h
@@ -12,7 +12,7 @@ class URITests : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void uriTests();
 };
 

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -139,10 +139,10 @@ void TrafficGraphWidget::updateRates()
     }
 
     float tmax = 0.0f;
-    foreach (float f, vSamplesIn) {
+    Q_FOREACH (float f, vSamplesIn) {
         if (f > tmax) tmax = f;
     }
-    foreach (float f, vSamplesOut) {
+    Q_FOREACH (float f, vSamplesOut) {
         if (f > tmax) tmax = f;
     }
     fMax = tmax;

--- a/src/qt/trafficgraphwidget.h
+++ b/src/qt/trafficgraphwidget.h
@@ -28,7 +28,7 @@ public:
 protected:
     void paintEvent(QPaintEvent*);
 
-public slots:
+public Q_SLOTS:
     void updateRates();
     void setGraphRangeMins(int mins);
     void clear();

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -249,14 +249,14 @@ QString TransactionDesc::toHTML(CWallet* wallet, CWalletTx& wtx, TransactionReco
     strHTML += "<b>" + tr("Output index") + ":</b> " + QString::number(rec->getOutputIndex()) + "<br>";
 
     // Message from normal pivx:URI (pivx:XyZ...?message=example)
-    foreach (const PAIRTYPE(std::string, std::string) & r, wtx.vOrderForm)
+    Q_FOREACH (const PAIRTYPE(std::string, std::string) & r, wtx.vOrderForm)
         if (r.first == "Message")
             strHTML += "<br><b>" + tr("Message") + ":</b><br>" + GUIUtil::HtmlEscape(r.second, true) + "<br>";
 
     //
     // PaymentRequest info:
     //
-    foreach (const PAIRTYPE(std::string, std::string) & r, wtx.vOrderForm) {
+    Q_FOREACH (const PAIRTYPE(std::string, std::string) & r, wtx.vOrderForm) {
         if (r.first == "PaymentRequest") {
             PaymentRequestPlus req;
             req.parse(QByteArray::fromRawData(r.second.data(), r.second.size()));

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -327,7 +327,7 @@ TransactionTableModel::~TransactionTableModel()
 void TransactionTableModel::updateAmountColumnTitle()
 {
     columns[Amount] = BitcoinUnits::getAmountColumnTitle(walletModel->getOptionsModel()->getDisplayUnit());
-    emit headerDataChanged(Qt::Horizontal, Amount, Amount);
+    Q_EMIT headerDataChanged(Qt::Horizontal, Amount, Amount);
 }
 
 void TransactionTableModel::updateTransaction(const QString& hash, int status, bool showTransaction)
@@ -339,7 +339,7 @@ void TransactionTableModel::updateTransaction(const QString& hash, int status, b
     priv->updateWallet(updated, status, showTransaction, rec);
 
     if (!rec.isNull())
-        emit txArrived(hash, rec.isCoinStake(), rec.isAnyColdStakingType());
+        Q_EMIT txArrived(hash, rec.isCoinStake(), rec.isAnyColdStakingType());
 }
 
 void TransactionTableModel::updateConfirmations()
@@ -348,8 +348,8 @@ void TransactionTableModel::updateConfirmations()
     // Invalidate status (number of confirmations) and (possibly) description
     //  for all rows. Qt is smart enough to only actually request the data for the
     //  visible rows.
-    emit dataChanged(index(0, Status), index(priv->size() - 1, Status));
-    emit dataChanged(index(0, ToAddress), index(priv->size() - 1, ToAddress));
+    Q_EMIT dataChanged(index(0, Status), index(priv->size() - 1, Status));
+    Q_EMIT dataChanged(index(0, ToAddress), index(priv->size() - 1, ToAddress));
 }
 
 int TransactionTableModel::rowCount(const QModelIndex& parent) const
@@ -801,7 +801,7 @@ void TransactionTableModel::updateDisplayUnit()
 {
     // emit dataChanged to update Amount column with the current unit
     updateAmountColumnTitle();
-    emit dataChanged(index(0, Amount), index(priv->size() - 1, Amount));
+    Q_EMIT dataChanged(index(0, Amount), index(priv->size() - 1, Amount));
 }
 
 // queue notifications to show a non freezing progress dialog e.g. for rescan

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -79,7 +79,7 @@ public:
     QModelIndex index(int row, int column, const QModelIndex& parent = QModelIndex()) const;
     bool processingQueuedTransactions() { return fProcessingQueuedTransactions; }
 
-signals:
+Q_SIGNALS:
     void txArrived(const QString& hash, const bool& isCoinStake, const bool& isCSAnyType);
 
 private:
@@ -104,7 +104,7 @@ private:
     QVariant txWatchonlyDecoration(const TransactionRecord* wtx) const;
     QVariant txAddressDecoration(const TransactionRecord* wtx) const;
 
-public slots:
+public Q_SLOTS:
     /* New transaction, or transaction changed status */
     void updateTransaction(const QString& hash, int status, bool showTransaction);
     void updateConfirmations();

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -163,7 +163,7 @@ void WalletModel::updateStatus()
     EncryptionStatus newEncryptionStatus = getEncryptionStatus();
 
     if (cachedEncryptionStatus != newEncryptionStatus)
-        emit encryptionStatusChanged(newEncryptionStatus);
+        Q_EMIT encryptionStatusChanged(newEncryptionStatus);
 }
 
 bool WalletModel::isWalletUnlocked() const {
@@ -199,7 +199,7 @@ void WalletModel::pollBalanceChanged()
         }
 
         // Address in receive tab may have been used
-        emit notifyReceiveAddressChanged();
+        Q_EMIT notifyReceiveAddressChanged();
     }
 }
 
@@ -207,7 +207,7 @@ void WalletModel::emitBalanceChanged()
 {
     // TODO: Improve all of this..
     // Force update of UI elements even when no values have changed
-    emit balanceChanged(cachedBalance, cachedUnconfirmedBalance, cachedImmatureBalance,
+    Q_EMIT balanceChanged(cachedBalance, cachedUnconfirmedBalance, cachedImmatureBalance,
                         cachedZerocoinBalance, cachedUnconfirmedZerocoinBalance, cachedImmatureZerocoinBalance,
                         cachedWatchOnlyBalance, cachedWatchUnconfBalance, cachedWatchImmatureBalance,
                         cachedDelegatedBalance, cachedColdStakedBalance);
@@ -254,7 +254,7 @@ void WalletModel::checkBalanceChanged()
         cachedWatchImmatureBalance = newWatchImmatureBalance;
         cachedColdStakedBalance = newColdStakedBalance;
         cachedDelegatedBalance = newDelegatedBalance;
-        emit balanceChanged(newBalance, newUnconfirmedBalance, newImmatureBalance,
+        Q_EMIT balanceChanged(newBalance, newUnconfirmedBalance, newImmatureBalance,
                             newZerocoinBalance, newUnconfirmedZerocoinBalance, newImmatureZerocoinBalance,
                             newWatchOnlyBalance, newWatchUnconfBalance, newWatchImmatureBalance,
                             newDelegatedBalance, newColdStakedBalance);
@@ -295,13 +295,13 @@ void WalletModel::updateAddressBook(const QString &pubCoin, const QString &isUse
 void WalletModel::updateWatchOnlyFlag(bool fHaveWatchonly)
 {
     fHaveWatchOnly = fHaveWatchonly;
-    emit notifyWatchonlyChanged(fHaveWatchonly);
+    Q_EMIT notifyWatchonlyChanged(fHaveWatchonly);
 }
 
 void WalletModel::updateMultiSigFlag(bool fHaveMultiSig)
 {
     this->fHaveMultiSig = fHaveMultiSig;
-    emit notifyMultiSigChanged(fHaveMultiSig);
+    Q_EMIT notifyMultiSigChanged(fHaveMultiSig);
 }
 
 bool WalletModel::getMint(const uint256& hashSerial, CZerocoinMint& mint){
@@ -361,7 +361,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
     int nAddresses = 0;
 
     // Pre-check input data for validity
-    foreach (const SendCoinsRecipient& rcp, recipients) {
+    Q_FOREACH (const SendCoinsRecipient& rcp, recipients) {
         if (rcp.paymentRequest.IsInitialized()) { // PaymentRequest...
             CAmount subtotal = 0;
             const payments::PaymentDetails& details = rcp.paymentRequest.getDetails();
@@ -438,7 +438,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
 
 
         if (recipients[0].useSwiftTX && total > sporkManager.GetSporkValue(SPORK_5_MAX_VALUE) * COIN) {
-            emit message(tr("Send Coins"), tr("SwiftX doesn't support sending values that high yet. Transactions are currently limited to %1 PIV.").arg(sporkManager.GetSporkValue(SPORK_5_MAX_VALUE)),
+            Q_EMIT message(tr("Send Coins"), tr("SwiftX doesn't support sending values that high yet. Transactions are currently limited to %1 PIV.").arg(sporkManager.GetSporkValue(SPORK_5_MAX_VALUE)),
                 CClientUIInterface::MSG_ERROR);
             return TransactionCreationFailed;
         }
@@ -456,7 +456,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
         transaction.setTransactionFee(nFeeRequired);
 
         if (recipients[0].useSwiftTX && newTx->GetValueOut() > sporkManager.GetSporkValue(SPORK_5_MAX_VALUE) * COIN) {
-            emit message(tr("Send Coins"), tr("SwiftX doesn't support sending values that high yet. Transactions are currently limited to %1 PIV.").arg(sporkManager.GetSporkValue(SPORK_5_MAX_VALUE)),
+            Q_EMIT message(tr("Send Coins"), tr("SwiftX doesn't support sending values that high yet. Transactions are currently limited to %1 PIV.").arg(sporkManager.GetSporkValue(SPORK_5_MAX_VALUE)),
                 CClientUIInterface::MSG_ERROR);
             return TransactionCreationFailed;
         }
@@ -465,7 +465,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
             if ((total + nFeeRequired) > nBalance) {
                 return SendCoinsReturn(AmountWithFeeExceedsBalance);
             }
-            emit message(tr("Send Coins"), QString::fromStdString(strFailReason),
+            Q_EMIT message(tr("Send Coins"), QString::fromStdString(strFailReason),
                 CClientUIInterface::MSG_ERROR);
             return TransactionCreationFailed;
         }
@@ -500,7 +500,7 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(WalletModelTransaction& tran
         QList<SendCoinsRecipient> recipients = transaction.getRecipients();
 
         // Store PaymentRequests in wtx.vOrderForm in wallet.
-        foreach (const SendCoinsRecipient& rcp, recipients) {
+        Q_FOREACH (const SendCoinsRecipient& rcp, recipients) {
             if (rcp.paymentRequest.IsInitialized()) {
                 std::string key("PaymentRequest");
                 std::string value;
@@ -524,7 +524,7 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(WalletModelTransaction& tran
 
     // Add addresses / update labels that we've sent to to the address book,
     // and emit coinsSent signal for each recipient
-    foreach (const SendCoinsRecipient& rcp, transaction.getRecipients()) {
+    Q_FOREACH (const SendCoinsRecipient& rcp, transaction.getRecipients()) {
         // Don't touch the address book when we have a payment request
         if (!rcp.paymentRequest.IsInitialized()) {
             CBitcoinAddress address = CBitcoinAddress(rcp.address.toStdString());
@@ -532,7 +532,7 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(WalletModelTransaction& tran
             std::string strLabel = rcp.label.toStdString();
             updateAddressBookLabels(address.Get(), strLabel, purpose);
         }
-        emit coinsSent(wallet, rcp, transaction_array);
+        Q_EMIT coinsSent(wallet, rcp, transaction_array);
     }
     checkBalanceChanged(); // update balance immediately, otherwise there could be a short noticeable delay until pollBalanceChanged hits
 
@@ -881,7 +881,7 @@ WalletModel::UnlockContext WalletModel::requestUnlock(AskPassphraseDialog::Conte
 
     if (was_locked) {
         // Request UI to unlock wallet
-        emit requireUnlock(context);
+        Q_EMIT requireUnlock(context);
     }
     // If wallet is still locked, unlock was failed or cancelled, mark context as invalid
     bool valid = getEncryptionStatus() != Locked;

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -341,7 +341,7 @@ private:
     void unsubscribeFromCoreSignals();
     Q_INVOKABLE void checkBalanceChanged();
 
-signals:
+Q_SIGNALS:
     // Signal that balance in wallet changed
     void balanceChanged(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance,
                         const CAmount& zerocoinBalance, const CAmount& unconfirmedZerocoinBalance, const CAmount& immatureZerocoinBalance,
@@ -374,7 +374,7 @@ signals:
     // Receive tab address may have changed
     void notifyReceiveAddressChanged();
 
-public slots:
+public Q_SLOTS:
     /* Wallet status might have changed */
     void updateStatus();
     /* New transaction, or transaction changed status */

--- a/src/qt/walletmodeltransaction.cpp
+++ b/src/qt/walletmodeltransaction.cpp
@@ -49,7 +49,7 @@ void WalletModelTransaction::setTransactionFee(const CAmount& newFee)
 CAmount WalletModelTransaction::getTotalTransactionAmount()
 {
     CAmount totalTransactionAmount = 0;
-    foreach (const SendCoinsRecipient& rcp, recipients) {
+    Q_FOREACH (const SendCoinsRecipient& rcp, recipients) {
         totalTransactionAmount += rcp.amount;
     }
     return totalTransactionAmount;

--- a/src/qt/zpivcontroldialog.h
+++ b/src/qt/zpivcontroldialog.h
@@ -57,7 +57,7 @@ private:
     };
     friend class CZPivControlWidgetItem;
 
-private slots:
+private Q_SLOTS:
     void updateSelection(QTreeWidgetItem* item, int column);
     void ButtonAllClicked();
 };


### PR DESCRIPTION
QT_NO_KEYWORDS prevents Qt from defining the `foreach`, `signals`, `slots` and `emit` macros.

This avoids overlap between Qt macros and boost, and enforces the standard.

Marked as [WIP] for the time being so as to not merge and create conflicts with existing open PRs. Can still be reviewed however.

Ported mostly from https://github.com/bitcoin/bitcoin/pull/6433