### PR TITLE
[Qt] Add more information to settings info panel

### DIFF
--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -55,7 +55,6 @@ public:
     //! Return number of connections, default is in- and outbound (total)
     int getNumConnections(unsigned int flags = CONNECTIONS_ALL) const;
     int getNumBlocksAtStartup();
-    QString getMasternodeCountString() const;
 
     // from cached block index
     int getNumBlocks() const;
@@ -88,6 +87,7 @@ public:
     bool getTorInfo(std::string& ip_port) const;
 
 private:
+    QString getMasternodeCountString() const;
     OptionsModel* optionsModel;
     PeerTableModel* peerTableModel;
     BanTableModel *banTableModel;

--- a/src/qt/pivx/res/css/style_dark.css
+++ b/src/qt/pivx/res/css/style_dark.css
@@ -1020,6 +1020,10 @@ HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH*/
     font-size:17px;
 }
 
+*[cssClass="text-main-hash"] {
+    color:#FFFFFF;
+    font-size:12px;
+}
 
 *[cssClass="text-main-settings"] {
     color:#FFFFFF;

--- a/src/qt/pivx/res/css/style_light.css
+++ b/src/qt/pivx/res/css/style_light.css
@@ -1025,6 +1025,11 @@ HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH*/
     font-size:17px;
 }
 
+*[cssClass="text-main-hash"] {
+    color:#707070;
+    font-size:12px;
+}
+
 *[cssClass="text-main-settings"] {
     color:#707070;
     font-size:18px;

--- a/src/qt/pivx/settings/forms/settingsinformationwidget.ui
+++ b/src/qt/pivx/settings/forms/settingsinformationwidget.ui
@@ -601,8 +601,47 @@
          </layout>
         </item>
         <item>
+         <layout class="QHBoxLayout" name="horizontalBlockTime" stretch="0,1">
+          <property name="spacing">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="labelTitleBlockTime">
+            <property name="minimumSize">
+             <size>
+              <width>290</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>290</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>TextLabel</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="labelInfoBlockTime">
+            <property name="cursor">
+             <cursorShape>IBeamCursor</cursorShape>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+            <property name="text">
+             <string>TextLabel</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
          <widget class="QWidget" name="layoutOptions3" native="true">
-          <layout class="QHBoxLayout" name="horizontalBlockTime" stretch="0,1">
+          <layout class="QHBoxLayout" name="horizontalBlockHash" stretch="0,1">
            <property name="spacing">
             <number>0</number>
            </property>
@@ -619,7 +658,7 @@
             <number>10</number>
            </property>
            <item>
-            <widget class="QLabel" name="labelTitleBlockTime">
+            <widget class="QLabel" name="labelTitleBlockHash">
              <property name="minimumSize">
               <size>
                <width>290</width>
@@ -638,7 +677,7 @@
             </widget>
            </item>
            <item>
-            <widget class="QLabel" name="labelInfoBlockTime">
+            <widget class="QLabel" name="labelInfoBlockHash">
              <property name="cursor">
               <cursorShape>IBeamCursor</cursorShape>
              </property>

--- a/src/qt/pivx/settings/forms/settingsinformationwidget.ui
+++ b/src/qt/pivx/settings/forms/settingsinformationwidget.ui
@@ -248,6 +248,12 @@
              </item>
              <item>
               <widget class="QLabel" name="labelInfoClient">
+               <property name="cursor">
+                <cursorShape>IBeamCursor</cursorShape>
+               </property>
+               <property name="textInteractionFlags">
+                <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+               </property>
                <property name="text">
                 <string>TextLabel</string>
                </property>
@@ -281,6 +287,12 @@
              </item>
              <item>
               <widget class="QLabel" name="labelInfoAgent">
+               <property name="cursor">
+                <cursorShape>IBeamCursor</cursorShape>
+               </property>
+               <property name="textInteractionFlags">
+                <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+               </property>
                <property name="text">
                 <string>TextLabel</string>
                </property>
@@ -314,6 +326,12 @@
              </item>
              <item>
               <widget class="QLabel" name="labelInfoBerkeley">
+               <property name="cursor">
+                <cursorShape>IBeamCursor</cursorShape>
+               </property>
+               <property name="textInteractionFlags">
+                <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+               </property>
                <property name="text">
                 <string>TextLabel</string>
                </property>
@@ -347,6 +365,12 @@
              </item>
              <item>
               <widget class="QLabel" name="labelInfoDataDir">
+               <property name="cursor">
+                <cursorShape>IBeamCursor</cursorShape>
+               </property>
+               <property name="textInteractionFlags">
+                <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+               </property>
                <property name="text">
                 <string>TextLabel</string>
                </property>
@@ -383,6 +407,12 @@
              </item>
              <item>
               <widget class="QLabel" name="labelInfoTime">
+               <property name="cursor">
+                <cursorShape>IBeamCursor</cursorShape>
+               </property>
+               <property name="textInteractionFlags">
+                <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+               </property>
                <property name="text">
                 <string>TextLabel</string>
                </property>
@@ -442,6 +472,12 @@
           </item>
           <item>
            <widget class="QLabel" name="labelInfoName">
+            <property name="cursor">
+             <cursorShape>IBeamCursor</cursorShape>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
             <property name="text">
              <string>TextLabel</string>
             </property>
@@ -488,6 +524,12 @@
            </item>
            <item>
             <widget class="QLabel" name="labelInfoConnections">
+             <property name="cursor">
+              <cursorShape>IBeamCursor</cursorShape>
+             </property>
+             <property name="textInteractionFlags">
+              <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+             </property>
              <property name="text">
               <string>TextLabel</string>
              </property>
@@ -545,6 +587,12 @@
           </item>
           <item>
            <widget class="QLabel" name="labelInfoBlockNumber">
+            <property name="cursor">
+             <cursorShape>IBeamCursor</cursorShape>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
             <property name="text">
              <string>TextLabel</string>
             </property>
@@ -591,6 +639,12 @@
            </item>
            <item>
             <widget class="QLabel" name="labelInfoBlockTime">
+             <property name="cursor">
+              <cursorShape>IBeamCursor</cursorShape>
+             </property>
+             <property name="textInteractionFlags">
+              <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+             </property>
              <property name="text">
               <string>TextLabel</string>
              </property>

--- a/src/qt/pivx/settings/forms/settingsinformationwidget.ui
+++ b/src/qt/pivx/settings/forms/settingsinformationwidget.ui
@@ -486,10 +486,49 @@
          </layout>
         </item>
         <item>
+         <layout class="QHBoxLayout" name="horizontalConnections" stretch="0,1">
+          <property name="spacing">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="labelTitleConnections">
+            <property name="minimumSize">
+             <size>
+              <width>290</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>290</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>TextLabel</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="labelInfoConnections">
+            <property name="cursor">
+             <cursorShape>IBeamCursor</cursorShape>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+            <property name="text">
+             <string>TextLabel</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
          <widget class="QWidget" name="layoutOptions2" native="true">
-          <layout class="QHBoxLayout" name="horizontalConnections" stretch="0,1">
+          <layout class="QHBoxLayout" name="horizontalMasternodes" stretch="0,1">
            <property name="spacing">
-            <number>0</number>
+             <number>0</number>
            </property>
            <property name="leftMargin">
             <number>0</number>
@@ -504,7 +543,7 @@
             <number>10</number>
            </property>
            <item>
-            <widget class="QLabel" name="labelTitleConnections">
+            <widget class="QLabel" name="labelTitleMasternodes">
              <property name="minimumSize">
               <size>
                <width>290</width>
@@ -523,7 +562,7 @@
             </widget>
            </item>
            <item>
-            <widget class="QLabel" name="labelInfoConnections">
+            <widget class="QLabel" name="labelInfoMasternodes">
              <property name="cursor">
               <cursorShape>IBeamCursor</cursorShape>
              </property>

--- a/src/qt/pivx/settings/forms/settingsinformationwidget.ui
+++ b/src/qt/pivx/settings/forms/settingsinformationwidget.ui
@@ -57,7 +57,7 @@
           <item>
            <widget class="QLabel" name="labelTitle">
             <property name="text">
-             <string>TextLabel</string>
+             <string>Information</string>
             </property>
            </widget>
           </item>
@@ -135,7 +135,7 @@
                 <enum>Qt::NoFocus</enum>
                </property>
                <property name="text">
-                <string/>
+                <string>Backups</string>
                </property>
                <property name="checkable">
                 <bool>false</bool>
@@ -163,7 +163,7 @@
                 <enum>Qt::NoFocus</enum>
                </property>
                <property name="text">
-                <string/>
+                <string>Wallet Conf</string>
                </property>
                <property name="checkable">
                 <bool>false</bool>
@@ -218,7 +218,7 @@
            <item>
             <widget class="QLabel" name="labelTitleGeneral">
              <property name="text">
-              <string>TextLabel</string>
+              <string>General</string>
              </property>
             </widget>
            </item>
@@ -242,7 +242,7 @@
                 </size>
                </property>
                <property name="text">
-                <string>TextLabel</string>
+                <string>Client Version:</string>
                </property>
               </widget>
              </item>
@@ -255,7 +255,7 @@
                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
                </property>
                <property name="text">
-                <string>TextLabel</string>
+                <string notr="true">N/A</string>
                </property>
               </widget>
              </item>
@@ -281,7 +281,7 @@
                 </size>
                </property>
                <property name="text">
-                <string>TextLabel</string>
+                <string>User Agent:</string>
                </property>
               </widget>
              </item>
@@ -294,7 +294,7 @@
                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
                </property>
                <property name="text">
-                <string>TextLabel</string>
+                <string notr="true">N/A</string>
                </property>
               </widget>
              </item>
@@ -320,7 +320,7 @@
                 </size>
                </property>
                <property name="text">
-                <string>TextLabel</string>
+                <string>BerkeleyDB version:</string>
                </property>
               </widget>
              </item>
@@ -333,7 +333,7 @@
                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
                </property>
                <property name="text">
-                <string>TextLabel</string>
+                <string notr="true">N/A</string>
                </property>
               </widget>
              </item>
@@ -359,7 +359,7 @@
                 </size>
                </property>
                <property name="text">
-                <string>TextLabel</string>
+                <string>Datadir:</string>
                </property>
               </widget>
              </item>
@@ -372,7 +372,7 @@
                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
                </property>
                <property name="text">
-                <string>TextLabel</string>
+                <string notr="true">N/A</string>
                </property>
                <property name="wordWrap">
                 <bool>true</bool>
@@ -401,7 +401,7 @@
                 </size>
                </property>
                <property name="text">
-                <string>TextLabel</string>
+                <string>Startup time:</string>
                </property>
               </widget>
              </item>
@@ -414,7 +414,7 @@
                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
                </property>
                <property name="text">
-                <string>TextLabel</string>
+                <string notr="true">N/A</string>
                </property>
               </widget>
              </item>
@@ -442,7 +442,7 @@
         <item>
          <widget class="QLabel" name="labelTitleNetwork">
           <property name="text">
-           <string>TextLabel</string>
+           <string>Network</string>
           </property>
          </widget>
         </item>
@@ -466,7 +466,7 @@
              </size>
             </property>
             <property name="text">
-             <string>TextLabel</string>
+             <string>Name:</string>
             </property>
            </widget>
           </item>
@@ -479,7 +479,7 @@
              <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
             </property>
             <property name="text">
-             <string>TextLabel</string>
+             <string notr="true">N/A</string>
             </property>
            </widget>
           </item>
@@ -505,7 +505,7 @@
              </size>
             </property>
             <property name="text">
-             <string>TextLabel</string>
+             <string>Connections:</string>
             </property>
            </widget>
           </item>
@@ -518,7 +518,7 @@
              <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
             </property>
             <property name="text">
-             <string>TextLabel</string>
+             <string notr="true">N/A</string>
             </property>
            </widget>
           </item>
@@ -557,7 +557,7 @@
               </size>
              </property>
              <property name="text">
-              <string>TextLabel</string>
+              <string>Number of Masternodes:</string>
              </property>
             </widget>
            </item>
@@ -570,7 +570,7 @@
               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
              </property>
              <property name="text">
-              <string>TextLabel</string>
+              <string notr="true">N/A</string>
              </property>
             </widget>
            </item>
@@ -596,7 +596,7 @@
         <item>
          <widget class="QLabel" name="labelTitleBlockchain">
           <property name="text">
-           <string>TextLabel</string>
+           <string>Blockchain</string>
           </property>
          </widget>
         </item>
@@ -620,7 +620,7 @@
              </size>
             </property>
             <property name="text">
-             <string>TextLabel</string>
+             <string>Current number of blocks:</string>
             </property>
            </widget>
           </item>
@@ -633,7 +633,7 @@
              <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
             </property>
             <property name="text">
-             <string>TextLabel</string>
+             <string notr="true">N/A</string>
             </property>
            </widget>
           </item>
@@ -659,7 +659,7 @@
              </size>
             </property>
             <property name="text">
-             <string>TextLabel</string>
+             <string>Last block time:</string>
             </property>
            </widget>
           </item>
@@ -672,7 +672,7 @@
              <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
             </property>
             <property name="text">
-             <string>TextLabel</string>
+             <string notr="true">N/A</string>
             </property>
            </widget>
           </item>
@@ -711,7 +711,7 @@
               </size>
              </property>
              <property name="text">
-              <string>TextLabel</string>
+              <string>Last block hash:</string>
              </property>
             </widget>
            </item>
@@ -724,7 +724,7 @@
               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
              </property>
              <property name="text">
-              <string>TextLabel</string>
+              <string notr="true">N/A</string>
              </property>
             </widget>
            </item>
@@ -750,7 +750,7 @@
         <item>
          <widget class="QLabel" name="labelTitleMemory">
           <property name="text">
-           <string>TextLabel</string>
+           <string>Memory Pool</string>
           </property>
          </widget>
         </item>
@@ -774,14 +774,14 @@
              </size>
             </property>
             <property name="text">
-             <string>TextLabel</string>
+             <string>Current number of transactions:</string>
             </property>
            </widget>
           </item>
           <item>
            <widget class="QLabel" name="labelInfoNumberTransactions">
             <property name="text">
-             <string>TextLabel</string>
+             <string notr="true">N/A</string>
             </property>
            </widget>
           </item>

--- a/src/qt/pivx/settings/settingsinformationwidget.cpp
+++ b/src/qt/pivx/settings/settingsinformationwidget.cpp
@@ -4,12 +4,14 @@
 
 #include "qt/pivx/settings/settingsinformationwidget.h"
 #include "qt/pivx/settings/forms/ui_settingsinformationwidget.h"
+
 #include "clientmodel.h"
 #include "chainparams.h"
 #include "db.h"
 #include "util.h"
 #include "guiutil.h"
 #include "qt/pivx/qtutils.h"
+
 #include <QDir>
 
 SettingsInformationWidget::SettingsInformationWidget(PIVXGUI* _window,QWidget *parent) :
@@ -127,7 +129,8 @@ SettingsInformationWidget::SettingsInformationWidget(PIVXGUI* _window,QWidget *p
 }
 
 
-void SettingsInformationWidget::loadClientModel(){
+void SettingsInformationWidget::loadClientModel()
+{
     if (clientModel && clientModel->getPeerTableModel() && clientModel->getBanTableModel()) {
         // Provide initial values
         ui->labelInfoClient->setText(clientModel->formatFullVersion());
@@ -145,7 +148,8 @@ void SettingsInformationWidget::loadClientModel(){
     }
 }
 
-void SettingsInformationWidget::setNumConnections(int count){
+void SettingsInformationWidget::setNumConnections(int count)
+{
     if (!clientModel)
         return;
 
@@ -156,7 +160,8 @@ void SettingsInformationWidget::setNumConnections(int count){
     ui->labelInfoConnections->setText(connections);
 }
 
-void SettingsInformationWidget::setNumBlocks(int count){
+void SettingsInformationWidget::setNumBlocks(int count)
+{
     ui->labelInfoBlockNumber->setText(QString::number(count));
     if (clientModel) {
         ui->labelInfoBlockTime->setText(clientModel->getLastBlockDate().toString());
@@ -169,7 +174,8 @@ void SettingsInformationWidget::setMasternodeCount(const QString& strMasternodes
     ui->labelInfoMasternodes->setText(strMasternodes);
 }
 
-void SettingsInformationWidget::openNetworkMonitor(){
+void SettingsInformationWidget::openNetworkMonitor()
+{
     if(!rpcConsole){
         rpcConsole = new RPCConsole(0);
         rpcConsole->setClientModel(clientModel);
@@ -177,6 +183,7 @@ void SettingsInformationWidget::openNetworkMonitor(){
     rpcConsole->showNetwork();
 }
 
-SettingsInformationWidget::~SettingsInformationWidget(){
+SettingsInformationWidget::~SettingsInformationWidget()
+{
     delete ui;
 }

--- a/src/qt/pivx/settings/settingsinformationwidget.cpp
+++ b/src/qt/pivx/settings/settingsinformationwidget.cpp
@@ -28,19 +28,7 @@ SettingsInformationWidget::SettingsInformationWidget(PIVXGUI* _window,QWidget *p
     setCssProperty({ui->layoutOptions1, ui->layoutOptions2, ui->layoutOptions3}, "container-options");
 
     // Title
-    ui->labelTitle->setText(tr("Information"));
     setCssTitleScreen(ui->labelTitle);
-
-    ui->labelTitleGeneral->setText(tr("General"));
-    ui->labelTitleClient->setText(tr("Client Version: "));
-    ui->labelTitleAgent->setText(tr("User Agent:"));
-    ui->labelTitleBerkeley->setText(tr("BerkeleyDB version:"));
-    ui->labelTitleDataDir->setText(tr("Datadir: "));
-    ui->labelTitleTime->setText(tr("Startup time:  "));
-    ui->labelTitleNetwork->setText(tr("Network"));
-    ui->labelTitleName->setText(tr("Name:"));
-    ui->labelTitleConnections->setText(tr("Connections:"));
-    ui->labelTitleMasternodes->setText(tr("Number of Masternodes:"));
 
     setCssProperty({
         ui->labelTitleDataDir,
@@ -74,24 +62,16 @@ SettingsInformationWidget::SettingsInformationWidget(PIVXGUI* _window,QWidget *p
 
     },"text-title");
 
-    ui->labelTitleBlockchain->setText(tr("Blockchain"));
-    ui->labelTitleBlockNumber->setText(tr("Current number of blocks:"));
-    ui->labelTitleBlockTime->setText(tr("Last block time:"));
-    ui->labelTitleBlockHash->setText(tr("Last block hash:"));
-
-    ui->labelTitleMemory->setText(tr("Memory Pool"));
+    // TODO: Mempool section is not currently implemented and instead, hidden for now
     ui->labelTitleMemory->setVisible(false);
-
-    ui->labelTitleNumberTransactions->setText(tr("Current number of transactions:"));
     ui->labelTitleNumberTransactions->setVisible(false);
-
     ui->labelInfoNumberTransactions->setText("0");
     ui->labelInfoNumberTransactions->setVisible(false);
 
     // Information Network
     ui->labelInfoName->setText(tr("Main"));
     ui->labelInfoName->setProperty("cssClass", "text-main-settings");
-    ui->labelInfoConnections->setText("0 (In: 0 / Out:0)");
+    ui->labelInfoConnections->setText("0 (In: 0 / Out: 0)");
     ui->labelInfoMasternodes->setText("Total: 0 (IPv4: 0 / IPv6: 0 / Tor: 0 / Unknown: 0");
 
     // Information Blockchain
@@ -101,9 +81,6 @@ SettingsInformationWidget::SettingsInformationWidget(PIVXGUI* _window,QWidget *p
     ui->labelInfoBlockHash->setProperty("cssClass", "text-main-hash");
 
     // Buttons
-    ui->pushButtonFile->setText(tr("Wallet Conf"));
-    ui->pushButtonNetworkMonitor->setText(tr("Network Monitor"));
-    ui->pushButtonBackups->setText(tr("Backups"));
     setCssBtnSecondary(ui->pushButtonBackups);
     setCssBtnSecondary(ui->pushButtonFile);
     setCssBtnSecondary(ui->pushButtonNetworkMonitor);

--- a/src/qt/pivx/settings/settingsinformationwidget.cpp
+++ b/src/qt/pivx/settings/settingsinformationwidget.cpp
@@ -49,6 +49,7 @@ SettingsInformationWidget::SettingsInformationWidget(PIVXGUI* _window,QWidget *p
         ui->labelTitleConnections,
         ui->labelTitleBlockNumber,
         ui->labelTitleBlockTime,
+        ui->labelTitleBlockHash,
         ui->labelTitleNumberTransactions,
         ui->labelInfoNumberTransactions,
         ui->labelInfoClient,
@@ -71,6 +72,7 @@ SettingsInformationWidget::SettingsInformationWidget(PIVXGUI* _window,QWidget *p
     ui->labelTitleBlockchain->setText(tr("Blockchain"));
     ui->labelTitleBlockNumber->setText(tr("Current number of blocks:"));
     ui->labelTitleBlockTime->setText(tr("Last block time:"));
+    ui->labelTitleBlockHash->setText(tr("Last block hash:"));
 
     ui->labelTitleMemory->setText(tr("Memory Pool"));
     ui->labelTitleMemory->setVisible(false);
@@ -90,6 +92,7 @@ SettingsInformationWidget::SettingsInformationWidget(PIVXGUI* _window,QWidget *p
     ui->labelInfoBlockNumber->setText("0");
     ui->labelInfoBlockTime->setText("Sept 6, 2018. Thursday, 8:21:49 PM");
     ui->labelInfoBlockTime->setProperty("cssClass", "text-main-grey");
+    ui->labelInfoBlockHash->setProperty("cssClass", "text-main-hash");
 
     // Buttons
     ui->pushButtonFile->setText(tr("Wallet Conf"));
@@ -149,8 +152,10 @@ void SettingsInformationWidget::setNumConnections(int count){
 
 void SettingsInformationWidget::setNumBlocks(int count){
     ui->labelInfoBlockNumber->setText(QString::number(count));
-    if (clientModel)
+    if (clientModel) {
         ui->labelInfoBlockTime->setText(clientModel->getLastBlockDate().toString());
+        ui->labelInfoBlockHash->setText(clientModel->getLastBlockHash());
+    }
 }
 
 void SettingsInformationWidget::openNetworkMonitor(){

--- a/src/qt/pivx/settings/settingsinformationwidget.cpp
+++ b/src/qt/pivx/settings/settingsinformationwidget.cpp
@@ -38,6 +38,7 @@ SettingsInformationWidget::SettingsInformationWidget(PIVXGUI* _window,QWidget *p
     ui->labelTitleNetwork->setText(tr("Network"));
     ui->labelTitleName->setText(tr("Name:"));
     ui->labelTitleConnections->setText(tr("Connections:"));
+    ui->labelTitleMasternodes->setText(tr("Number of Masternodes:"));
 
     setCssProperty({
         ui->labelTitleDataDir,
@@ -47,6 +48,7 @@ SettingsInformationWidget::SettingsInformationWidget(PIVXGUI* _window,QWidget *p
         ui->labelTitleTime,
         ui->labelTitleName,
         ui->labelTitleConnections,
+        ui->labelTitleMasternodes,
         ui->labelTitleBlockNumber,
         ui->labelTitleBlockTime,
         ui->labelTitleBlockHash,
@@ -58,6 +60,7 @@ SettingsInformationWidget::SettingsInformationWidget(PIVXGUI* _window,QWidget *p
         ui->labelInfoDataDir,
         ui->labelInfoTime,
         ui->labelInfoConnections,
+        ui->labelInfoMasternodes,
         ui->labelInfoBlockNumber
         }, "text-main-settings");
 
@@ -87,6 +90,7 @@ SettingsInformationWidget::SettingsInformationWidget(PIVXGUI* _window,QWidget *p
     ui->labelInfoName->setText(tr("Main"));
     ui->labelInfoName->setProperty("cssClass", "text-main-settings");
     ui->labelInfoConnections->setText("0 (In: 0 / Out:0)");
+    ui->labelInfoMasternodes->setText("Total: 0 (IPv4: 0 / IPv6: 0 / Tor: 0 / Unknown: 0");
 
     // Information Blockchain
     ui->labelInfoBlockNumber->setText("0");
@@ -136,6 +140,8 @@ void SettingsInformationWidget::loadClientModel(){
 
         setNumBlocks(clientModel->getNumBlocks());
         connect(clientModel, &ClientModel::numBlocksChanged, this, &SettingsInformationWidget::setNumBlocks);
+
+        connect(clientModel, &ClientModel::strMasternodesChanged, this, &SettingsInformationWidget::setMasternodeCount);
     }
 }
 
@@ -156,6 +162,11 @@ void SettingsInformationWidget::setNumBlocks(int count){
         ui->labelInfoBlockTime->setText(clientModel->getLastBlockDate().toString());
         ui->labelInfoBlockHash->setText(clientModel->getLastBlockHash());
     }
+}
+
+void SettingsInformationWidget::setMasternodeCount(const QString& strMasternodes)
+{
+    ui->labelInfoMasternodes->setText(strMasternodes);
 }
 
 void SettingsInformationWidget::openNetworkMonitor(){

--- a/src/qt/pivx/settings/settingsinformationwidget.h
+++ b/src/qt/pivx/settings/settingsinformationwidget.h
@@ -26,6 +26,7 @@ public:
 private Q_SLOTS:
     void setNumConnections(int count);
     void setNumBlocks(int count);
+    void setMasternodeCount(const QString& strMasternodes);
     void openNetworkMonitor();
 
 private:

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -390,7 +390,6 @@ void RPCConsole::setClientModel(ClientModel* model)
         setNumBlocks(model->getNumBlocks());
         connect(model, &ClientModel::numBlocksChanged, this, &RPCConsole::setNumBlocks);
 
-        setMasternodeCount(model->getMasternodeCountString());
         connect(model, &ClientModel::strMasternodesChanged, this, &RPCConsole::setMasternodeCount);
 
         updateTrafficStats(model->getTotalBytesRecv(), model->getTotalBytesSent());


### PR DESCRIPTION
This adds the masternode count(s) and last block hash to the new settings info panel (ported from the old RPCConsole UI Window), as well as makes the informational text select-able (good for copy/pasting information, like last block height/hash).

Also, initialize static strings directly in the `.ui` file.