### PR TITLE
[Qt] Make CoinControlTreeWidget focusable

### DIFF
--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -456,9 +456,6 @@
         </property>
         <item>
          <widget class="CoinControlTreeWidget" name="treeWidget">
-          <property name="focusPolicy">
-           <enum>Qt::NoFocus</enum>
-          </property>
           <property name="contextMenuPolicy">
            <enum>Qt::CustomContextMenu</enum>
           </property>


### PR DESCRIPTION
Making this widget focusable allows for using the keyboard to navigate
and select inputs using the arrow keys and spacebar.