### PR TITLE
[Doxygen] Generate Todo list

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -939,7 +939,7 @@ IMAGE_PATH             =
 # need to set EXTENSION_MAPPING for the extension otherwise the files are not
 # properly processed by doxygen.
 
-INPUT_FILTER           =
+INPUT_FILTER           = "sed -r 's/\/\/.*(TODO|FIXME)/\/\/\/ \\todo/i'"
 
 # The FILTER_PATTERNS tag can be used to specify filters on a per file pattern
 # basis. Doxygen will compare the file name with each pattern and apply the


### PR DESCRIPTION
Pre-process source files by searching for comment strings containing
`TODO` or `FIXME` and replacing with the doxygen `\todo` flag.

This is an internal conversion only, and won't change the source view of
affected files.