### PR TITLE
[GUI] Segfault for a bad cast of the parent in the escape key press event

### DIFF
--- a/src/qt/coincontroltreewidget.cpp
+++ b/src/qt/coincontroltreewidget.cpp
@@ -21,7 +21,7 @@ void CoinControlTreeWidget::keyPressEvent(QKeyEvent* event)
     } else if (event->key() == Qt::Key_Escape) // press esc -> close dialog
     {
         event->ignore();
-        CoinControlDialog* coinControlDialog = (CoinControlDialog*)this->parentWidget();
+        auto* coinControlDialog = (CoinControlDialog*) this->parentWidget()->parentWidget();
         coinControlDialog->done(QDialog::Accepted);
     } else {
         this->QTreeWidget::keyPressEvent(event);


### PR DESCRIPTION
Auto-explanaible title. PR solving the escape key press event segfault in the coin control dialog.