### PR TITLE
[UI] Guard a call to GetDepthInMainChain

### DIFF
--- a/src/qt/pivx/sendconfirmdialog.cpp
+++ b/src/qt/pivx/sendconfirmdialog.cpp
@@ -93,7 +93,7 @@ void TxDetailDialog::setData(WalletModel *model, QModelIndex &index){
             ui->textSend->setText(QString::number(tx->vout.size()) + " recipients");
         }
         ui->textInputs->setText(QString::number(tx->vin.size()));
-        ui->textConfirmations->setText(QString::number(tx->GetDepthInMainChain()));
+        ui->textConfirmations->setText(QString::number(rec->status.depth));
         ui->textDate->setText(GUIUtil::dateTimeStrWithSeconds(date));
         ui->textStatus->setText(QString::fromStdString(rec->statusToString()));
         ui->textSize->setText(QString::number(rec->size) + " bytes");


### PR DESCRIPTION
With windows, the wallet was crashing without any error message or log each time I would click a tx in the overview page. That was happening consistently on one device but not others.
This fix should not lead to any performance concern. As far as I know this function is only triggered by user input in the GUI.