### PR TITLE
[Wallet] Create label for addresses generated via masternode wizard

### DIFF
--- a/src/qt/pivx/masternodewizarddialog.cpp
+++ b/src/qt/pivx/masternodewizarddialog.cpp
@@ -181,7 +181,7 @@ bool MasterNodeWizardDialog::createMN(){
         CBitcoinAddress address = walletModel->getNewAddress(alias);
 
         // const QString& addr, const QString& label, const CAmount& amount, const QString& message
-        SendCoinsRecipient sendCoinsRecipient(QString::fromStdString(address.ToString()), "", CAmount(10000) * COIN, "");
+        SendCoinsRecipient sendCoinsRecipient(QString::fromStdString(address.ToString()), QString::fromStdString(alias), CAmount(10000) * COIN, "");
 
         // Send the 10 tx to one of your address
         QList<SendCoinsRecipient> recipients;


### PR DESCRIPTION
At the moment, whilst correctly labelled on the masternode.conf file and within the masternode tab, there is no label stored for the actual masternode address generated via the masternode wizard.

The labeling of these addresses with the masternode alias allows for easier identification of the coins within the coin control dialog and the transaction history. where one is easier able to identify whether rewards for any particular node are missing (signalling potential VPS issues).