### PR TITLE
[UI] Fix AA_EnableHighDpiScaling warning

### DIFF
--- a/src/qt/pivx.cpp
+++ b/src/qt/pivx.cpp
@@ -529,7 +529,6 @@ int main(int argc, char* argv[])
     Q_INIT_RESOURCE(pivx_locale);
     Q_INIT_RESOURCE(pivx);
 
-    BitcoinApplication app(argc, argv);
 #if QT_VERSION > 0x050100
     // Generate high-dpi pixmaps
     QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
@@ -540,6 +539,7 @@ int main(int argc, char* argv[])
 #ifdef Q_OS_MAC
     QApplication::setAttribute(Qt::AA_DontShowIconsInMenus);
 #endif
+    BitcoinApplication app(argc, argv);
 
     // Register meta types used for QMetaObject::invokeMethod
     qRegisterMetaType<bool*>();


### PR DESCRIPTION
Fixes the following warning

`Attribute Qt::AA_EnableHighDpiScaling must be set before QCoreApplication is created.`

Tested on macOS 10.14.6