### PR TITLE
[Wallet] Unlock spent outputs

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -493,6 +493,8 @@ bool CWallet::IsSpent(const uint256& hash, unsigned int n) const
 void CWallet::AddToSpends(const COutPoint& outpoint, const uint256& wtxid)
 {
     mapTxSpends.insert(std::make_pair(outpoint, wtxid));
+    setLockedCoins.erase(outpoint);
+
     std::pair<TxSpends::iterator, TxSpends::iterator> range;
     range = mapTxSpends.equal_range(outpoint);
     SyncMetaData(range);


### PR DESCRIPTION
Straightforward update backported from https://github.com/bitcoin/bitcoin/pull/13160

NOTE: the update to wallet_basic functional test for this particular changes will be included in a successive PR (which collects updates for the whole test suite).