### PR TITLE
[Wallet] Enable miner with mnsync incomplete

### DIFF
--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -29,6 +29,25 @@ bool CMasternodeSync::IsSynced()
     return RequestedMasternodeAssets == MASTERNODE_SYNC_FINISHED;
 }
 
+bool CMasternodeSync::IsSporkListSynced()
+{
+    return RequestedMasternodeAssets > MASTERNODE_SYNC_SPORKS;
+}
+
+bool CMasternodeSync::IsMasternodeListSynced()
+{
+    return RequestedMasternodeAssets > MASTERNODE_SYNC_LIST;
+}
+
+bool CMasternodeSync::NotCompleted()
+{
+    return (!IsSynced() && (
+            !IsSporkListSynced() ||
+            sporkManager.IsSporkActive(SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT) ||
+            sporkManager.IsSporkActive(SPORK_9_MASTERNODE_BUDGET_ENFORCEMENT) ||
+            sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS)));
+}
+
 bool CMasternodeSync::IsBlockchainSynced()
 {
     static bool fBlockchainSynced = false;

--- a/src/masternode-sync.h
+++ b/src/masternode-sync.h
@@ -71,8 +71,10 @@ public:
     void Reset();
     void Process();
     bool IsSynced();
+    bool NotCompleted();
     bool IsBlockchainSynced();
-    bool IsMasternodeListSynced() { return RequestedMasternodeAssets > MASTERNODE_SYNC_LIST; }
+    bool IsSporkListSynced();
+    bool IsMasternodeListSynced();
     void ClearFulfilledRequest();
 };
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -680,7 +680,7 @@ void BitcoinMiner(CWallet* pwallet, bool fProofOfStake)
             }
 
             while (vNodes.empty() || pwallet->IsLocked() || !fMintableCoins ||
-                   (stakingBalance > 0 && nReserveBalance >= stakingBalance) || !masternodeSync.IsSynced()) {
+                   (stakingBalance > 0 && nReserveBalance >= stakingBalance) || masternodeSync.NotCompleted()) {
                 nLastCoinStakeSearchInterval = 0;
                 MilliSleep(5000);
                 // Do a separate 1 minute check here to ensure fMintableCoins is updated


### PR DESCRIPTION
Instead of outright preventing the generation of new blocks when mnsync is incomplete, use a different logic: prevent the creation of new block when:
- mnsync is incomplete
**AND**
- _either_ the spork list is not synced (we are at the very start of mnsync) _or one_ between sporks 8,9 or 13 is active

In other words, try to stake a new block only if
- mnsync is complete
**OR**
- the spork list is synced _and all three_ sporks (8,9 and 13) are not active.