### PR TITLE
[UI] TransactionFilter, do not invalidate filter if range is already set.

### DIFF
--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -69,6 +69,8 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex& 
 
 void TransactionFilterProxy::setDateRange(const QDateTime& from, const QDateTime& to)
 {
+    if (from == this->dateFrom && to == this->dateTo)
+        return; // No need to set the range.
     this->dateFrom = from;
     this->dateTo = to;
     invalidateFilter();


### PR DESCRIPTION
Straightforward change, do not invalidate filter if datetime range is already set.