### PR TITLE
[Qt] Hide option for 3rd party transaction URLs

### DIFF
--- a/src/qt/pivx/settings/settingsdisplayoptionswidget.cpp
+++ b/src/qt/pivx/settings/settingsdisplayoptionswidget.cpp
@@ -44,6 +44,8 @@ SettingsDisplayOptionsWidget::SettingsDisplayOptionsWidget(PIVXGUI* _window, QWi
 
     ui->labelTitleUrl->setText(tr("Third party transactions URLs"));
     ui->labelTitleUrl->setProperty("cssClass", "text-main-settings");
+    // TODO: Reconnect this option to an action. Hide it for now
+    ui->labelTitleUrl->hide();
 
     // Switch
     ui->pushButtonSwitchBalance->setText(tr("Hide empty balances"));
@@ -87,6 +89,8 @@ SettingsDisplayOptionsWidget::SettingsDisplayOptionsWidget(PIVXGUI* _window, QWi
     // Urls
     ui->lineEditUrl->setPlaceholderText("e.g. https://example.com/tx/%s");
     initCssEditLine(ui->lineEditUrl);
+    // TODO: Reconnect this option to an action. Hide it for now
+    ui->lineEditUrl->hide();
 
     // Buttons
     ui->pushButtonSave->setText(tr("SAVE"));


### PR DESCRIPTION
This option is currently not connected to any action; hide it for now.

To be re-connected in the future.

Before:
![Screen Shot 2019-11-03 at 4 04 36 PM](https://user-images.githubusercontent.com/7393257/68094292-af66c780-fe53-11e9-96fe-ed61e30223cc.png)

After:
![Screen Shot 2019-11-03 at 4 05 46 PM](https://user-images.githubusercontent.com/7393257/68094305-d1f8e080-fe53-11e9-995b-ca5cfaf0756b.png)

