### PR TITLE
[Qt] Show display unit option as text

### DIFF
--- a/src/qt/pivx/settings/forms/settingsdisplayoptionswidget.ui
+++ b/src/qt/pivx/settings/forms/settingsdisplayoptionswidget.ui
@@ -175,7 +175,7 @@
            </spacer>
           </item>
           <item>
-           <widget class="QComboBox" name="comboBoxUnit">
+           <widget class="QValueComboBox" name="comboBoxUnit">
             <property name="minimumSize">
              <size>
               <width>180</width>


### PR DESCRIPTION
Quick fix for the display unit option showing a numeric value when
saving instead of the proper text value.

Before: 
![Screen Shot 2019-11-03 at 4 02 44 PM](https://user-images.githubusercontent.com/7393257/68094267-6ca4ef80-fe53-11e9-9b2a-fcd156ba4ed0.png)

After:
![Screen Shot 2019-11-03 at 4 01 01 PM](https://user-images.githubusercontent.com/7393257/68094230-310a2580-fe53-11e9-9d72-79efdf5ce488.png)
