### PR TITLE
[Qt] Fixup topbar balance calculation

### DIFF
--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -527,13 +527,13 @@ void TopBar::updateBalances(const CAmount& balance, const CAmount& unconfirmedBa
                             const CAmount& delegatedBalance, const CAmount& coldStakedBalance){
 
     CAmount nLockedBalance = 0;
-    if (!walletModel) {
+    if (walletModel) {
         nLockedBalance = walletModel->getLockedBalance();
     }
 
     // PIV Balance
-    //CAmount nTotalBalance = balance + unconfirmedBalance;
-    CAmount pivAvailableBalance = balance + delegatedBalance - immatureBalance - nLockedBalance;
+    //CAmount nTotalBalance = balance + unconfirmedBalance + immatureBalance;
+    CAmount pivAvailableBalance = balance + delegatedBalance - nLockedBalance;
 
     // zPIV Balance
     CAmount matureZerocoinBalance = zerocoinBalance - unconfirmedZerocoinBalance - immatureZerocoinBalance;


### PR DESCRIPTION
Prevents negative balance results

Before:
![Screen Shot 2019-11-04 at 1 48 55 AM](https://user-images.githubusercontent.com/7393257/68112047-56278400-fea5-11e9-9b86-0cc06fe18cc1.png)

After:
![Screen Shot 2019-11-04 at 1 51 14 AM](https://user-images.githubusercontent.com/7393257/68112168-9edf3d00-fea5-11e9-9d8e-ab9174bf587b.png)
