### PR TITLE
[UI] Fix macdockiconhandler for 10.15 macOS SDK

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -543,7 +543,7 @@ case $host in
      fi
 
      AX_CHECK_LINK_FLAG([[-Wl,-headerpad_max_install_names]], [LDFLAGS="$LDFLAGS -Wl,-headerpad_max_install_names"])
-     CPPFLAGS="$CPPFLAGS -DMAC_OSX"
+     CPPFLAGS="$CPPFLAGS -DMAC_OSX -DOBJC_OLD_DISPATCH_PROTOTYPES=0"
      OBJCXXFLAGS="$CXXFLAGS"
      ;;
    *android*)

--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -11,8 +11,8 @@
 
 #undef slots
 #include <Cocoa/Cocoa.h>
-#include <objc/objc.h>
-#include <objc/message.h>
+#include <AppKit/AppKit.h>
+#include <objc/runtime.h>
 
 static MacDockIconHandler *s_instance = nullptr;
 
@@ -28,17 +28,12 @@ bool dockClickHandler(id self,SEL _cmd,...) {
 
 void setupDockClickHandler() {
     Class cls = objc_getClass("NSApplication");
-    id appInst = objc_msgSend((id)cls, sel_registerName("sharedApplication"));
-
-    if (appInst != NULL) {
-        id delegate = objc_msgSend(appInst, sel_registerName("delegate"));
-        Class delClass = (Class)objc_msgSend(delegate,  sel_registerName("class"));
+    Class delClass = (Class)[[[NSApplication sharedApplication] delegate] class];
         SEL shouldHandle = sel_registerName("applicationShouldHandleReopen:hasVisibleWindows:");
         if (class_getInstanceMethod(delClass, shouldHandle))
             class_replaceMethod(delClass, shouldHandle, (IMP)dockClickHandler, "B@:");
         else
             class_addMethod(delClass, shouldHandle, (IMP)dockClickHandler,"B@:");
-    }
 }
 
 
@@ -125,4 +120,13 @@ void MacDockIconHandler::handleDockIconClickEvent()
     }
 
     emit this->dockIconClicked();
+}
+/**
+ * Force application activation on macOS. With Qt 5.5.1 this is required when
+ * an action in the Dock menu is triggered.
+ * TODO: Define a Qt version where it's no-longer necessary.
+ */
+void ForceActivation()
+{
+    [[NSApplication sharedApplication] activateIgnoringOtherApps:YES];
 }


### PR DESCRIPTION
This Pull request backports updates to macdockiconhandler to allow it to be compilable and usable by the 10.15 macOS SDK.

backported from https://github.com/bitcoin/bitcoin/commit/0bb33b5348dbddd65b88a7f00449c965562355d3