### PR TITLE
[GUI][Model][Performance] Dashboard, remove call to isCoinStakeMine method.

### DIFF
--- a/src/qt/pivx/dashboardwidget.cpp
+++ b/src/qt/pivx/dashboardwidget.cpp
@@ -235,10 +235,10 @@ void DashboardWidget::loadWalletModel(){
     updateDisplayUnit();
 }
 
-void DashboardWidget::onTxArrived(const QString& hash) {
+void DashboardWidget::onTxArrived(const QString& hash, const bool& isCoinStake) {
     showList();
 #ifdef USE_QTCHARTS
-    if (walletModel->isCoinStakeMine(hash)) {
+    if (isCoinStake) {
         // Update value if this is our first stake
         if (!hasStakes)
             hasStakes = stakesFilter->rowCount() > 0;

--- a/src/qt/pivx/dashboardwidget.h
+++ b/src/qt/pivx/dashboardwidget.h
@@ -122,7 +122,7 @@ private slots:
     void onSortTypeChanged(const QString& value);
     void updateDisplayUnit();
     void showList();
-    void onTxArrived(const QString& hash);
+    void onTxArrived(const QString& hash, const bool& isCoinStake);
 
 #ifdef USE_QTCHARTS
     void windowResizeEvent(QResizeEvent *event);

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -416,6 +416,15 @@ int TransactionRecord::getOutputIndex() const
     return idx;
 }
 
+bool TransactionRecord::isCoinStake() const
+{
+    return (type == TransactionRecord::StakeMint || type == TransactionRecord::Generated || type == TransactionRecord::StakeZPIV);
+}
+
+bool TransactionRecord::isNull() const
+{
+    return hash.IsNull() || size == 0;
+}
 
 std::string TransactionRecord::statusToString(){
     switch (status.status){

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -156,6 +156,14 @@ public:
     /** Return transaction status
      */
     std::string statusToString();
+
+    /** Return true if the tx is a coinstake
+     */
+    bool isCoinStake() const;
+
+    /** Return true if the tx hash is null and/or if the size is 0
+     */
+    bool isNull() const;
 };
 
 #endif // BITCOIN_QT_TRANSACTIONRECORD_H

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -79,7 +79,7 @@ public:
     bool processingQueuedTransactions() { return fProcessingQueuedTransactions; }
 
 signals:
-    void txArrived(const QString& hash);
+    void txArrived(const QString& hash, const bool& isCoinStake);
 
 private:
     CWallet* wallet;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -455,20 +455,6 @@ const CWalletTx* WalletModel::getTx(uint256 id){
     return wallet->GetWalletTx(id);
 }
 
-bool WalletModel::isCoinStake(QString id){
-    uint256 hashTx;
-    hashTx.SetHex(id.toStdString());
-    const CWalletTx* tx = getTx(hashTx);
-    return tx->IsCoinStake();
-}
-
-bool WalletModel::isCoinStakeMine(QString id){
-    uint256 hashTx;
-    hashTx.SetHex(id.toStdString());
-    const CWalletTx* tx = getTx(hashTx);
-    return tx->IsCoinStake() && wallet->IsMine(tx->vin[0]);
-}
-
 bool WalletModel::mintCoins(CAmount value, CCoinControl* coinControl ,std::string &strError){
     CWalletTx wtx;
     std::vector<CDeterministicMint> vMints;

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -169,8 +169,6 @@ public:
     void setWalletDefaultFee(CAmount fee = DEFAULT_TRANSACTION_FEE);
 
     const CWalletTx* getTx(uint256 id);
-    bool isCoinStake(QString id);
-    bool isCoinStakeMine(QString id);
 
     // prepare transaction for getting txfee before sending coins
     SendCoinsReturn prepareTransaction(WalletModelTransaction& transaction, const CCoinControl* coinControl = NULL);


### PR DESCRIPTION
Instead of ask twice (locking the cs_wallet) if the arriving/updated tx it's a coin stake or not, use the already parsed record and include the flag as an argument into the signal.

This removes the `isCoinStakeMine` and its subsequent `getWalletTx` method call, which locks cs_wallet, making the UI sync update process smoother, preventing any wait or thread interception between locks.