### PR TITLE
[Trivial][GUI] Fix typos in welcome widget

### DIFF
--- a/src/qt/pivx/forms/welcomecontentwidget.ui
+++ b/src/qt/pivx/forms/welcomecontentwidget.ui
@@ -1032,7 +1032,7 @@ PIVX Core Wallet</string>
                 <item>
                  <widget class="QLabel" name="labelMessage3">
                   <property name="text">
-                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;As our manifesto says: Privacy is a non-negotiable basic human right; it grants users the freedom the share their data whenever and with whomever they want - PIVX believes in self sovereignty&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;As our manifesto says: Privacy is a non-negotiable basic human right; it grants users the freedom to share their data whenever and with whomever they want - PIVX believes in self sovereignty.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignHCenter|Qt::AlignTop</set>


### PR DESCRIPTION
One-liner in welcomecontentwidget.ui. Closes https://github.com/PIVX-Project/PIVX/issues/1101 .
(As a non-native speaker, I think "whomever" is correct as it refers to the object of the sentence, not the subject).