### PR TITLE
[GUI] Fix bug in change wallet passphrase

### DIFF
--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -137,7 +137,8 @@ AskPassphraseDialog::AskPassphraseDialog(Mode mode, QWidget* parent, WalletModel
     connect(ui->btnEsc, SIGNAL(clicked()), this, SLOT(close()));
 }
 
-void AskPassphraseDialog::onWatchClicked(){
+void AskPassphraseDialog::onWatchClicked()
+{
     int state = btnWatch->checkState();
     ui->passEdit3->setEchoMode(state == Qt::Checked ? QLineEdit::Normal : QLineEdit::Password );
     ui->passEdit2->setEchoMode(state== Qt::Checked ? QLineEdit::Normal : QLineEdit::Password );
@@ -308,7 +309,8 @@ bool AskPassphraseDialog::eventFilter(QObject* object, QEvent* event)
     return QDialog::eventFilter(object, event);
 }
 
-bool AskPassphraseDialog::openStandardDialog(QString title, QString body, QString okBtn, QString cancelBtn){
+bool AskPassphraseDialog::openStandardDialog(QString title, QString body, QString okBtn, QString cancelBtn)
+{
     PIVXGUI* gui = static_cast<PIVXGUI*>(parentWidget());
     DefaultDialog *confirmDialog = new DefaultDialog(gui);
     confirmDialog->setText(title, body, okBtn, cancelBtn);
@@ -319,7 +321,8 @@ bool AskPassphraseDialog::openStandardDialog(QString title, QString body, QStrin
     return ret;
 }
 
-void AskPassphraseDialog::warningMessage() {
+void AskPassphraseDialog::warningMessage()
+{
     hide();
     static_cast<PIVXGUI*>(parentWidget())->showHide(true);
     openStandardDialog(
@@ -339,12 +342,14 @@ void AskPassphraseDialog::warningMessage() {
     QApplication::quit();
 }
 
-void AskPassphraseDialog::errorEncryptingWallet() {
+void AskPassphraseDialog::errorEncryptingWallet()
+{
     QMessageBox::critical(this, tr("Wallet encryption failed"),
                           tr("Wallet encryption failed due to an internal error. Your wallet was not encrypted."));
 }
 
-void AskPassphraseDialog::run(int type){
+void AskPassphraseDialog::run(int type)
+{
     if (type == 1) {
         if (!newpassCache.empty()) {
             QMetaObject::invokeMethod(this, "hide", Qt::QueuedConnection);
@@ -358,11 +363,13 @@ void AskPassphraseDialog::run(int type){
         }
     }
 }
-void AskPassphraseDialog::onError(QString error, int type){
+void AskPassphraseDialog::onError(QString error, int type)
+{
     newpassCache = "";
 }
 
-void AskPassphraseDialog::initWatch(QWidget *parent) {
+void AskPassphraseDialog::initWatch(QWidget *parent)
+{
     btnWatch = new QCheckBox(parent);
     setCssProperty(btnWatch, "btn-watch-password");
     btnWatch->setChecked(false);

--- a/src/qt/pivx/settings/settingsbackupwallet.cpp
+++ b/src/qt/pivx/settings/settingsbackupwallet.cpp
@@ -57,7 +57,8 @@ SettingsBackupWallet::SettingsBackupWallet(PIVXGUI* _window, QWidget *parent) :
     connect(ui->pushButtonSave_2, SIGNAL(clicked()), this, SLOT(changePassphrase()));
 }
 
-void SettingsBackupWallet::selectFileOutput(){
+void SettingsBackupWallet::selectFileOutput()
+{
     QString filenameRet = GUIUtil::getSaveFileName(this,
                                         tr("Backup Wallet"), QString(),
                                         tr("Wallet Data (*.dat)"), NULL);
@@ -68,7 +69,8 @@ void SettingsBackupWallet::selectFileOutput(){
     }
 }
 
-void SettingsBackupWallet::backupWallet(){
+void SettingsBackupWallet::backupWallet()
+{
     if(walletModel && !filename.isEmpty()) {
         inform(walletModel->backupWallet(filename) ? tr("Backup created") : tr("Backup creation failed"));
         filename = QString();
@@ -78,21 +80,23 @@ void SettingsBackupWallet::backupWallet(){
     }
 }
 
-void SettingsBackupWallet::changePassphrase(){
+void SettingsBackupWallet::changePassphrase()
+{
     showHideOp(true);
     AskPassphraseDialog *dlg = nullptr;
     if (walletModel->getEncryptionStatus() == WalletModel::Unencrypted) {
-        dlg = new AskPassphraseDialog(AskPassphraseDialog::Mode::ChangePass, window,
-                                  walletModel, AskPassphraseDialog::Context::ChangePass);
-    } else {
         dlg = new AskPassphraseDialog(AskPassphraseDialog::Mode::Encrypt, window,
-                                      walletModel, AskPassphraseDialog::Context::Encrypt);
+                walletModel, AskPassphraseDialog::Context::Encrypt);
+    } else {
+        dlg = new AskPassphraseDialog(AskPassphraseDialog::Mode::ChangePass, window,
+                walletModel, AskPassphraseDialog::Context::ChangePass);
     }
     dlg->adjustSize();
     emit execDialog(dlg);
     dlg->deleteLater();
 }
 
-SettingsBackupWallet::~SettingsBackupWallet(){
+SettingsBackupWallet::~SettingsBackupWallet()
+{
     delete ui;
 }


### PR DESCRIPTION
The mode and context when calling `AskPassphraseDialog::AskPassphraseDialog` from `SettingsBackupWallet::changePassphrase` were switched.
That resulted in
A) the old passphrase was not asked when changing it to a new one
B) the action was not even completed because, during `AskPassphraseDialog::run` it failed `model->setWalletEncrypted` (`CWallet::EncryptWallet` returns false, being the wallet already encrypted).
Closes https://github.com/PIVX-Project/PIVX/issues/1100