### PR TITLE
[Qt] Re-work settings restart and saving flow

### DIFF
--- a/src/qt/pivx/qtutils.h
+++ b/src/qt/pivx/qtutils.h
@@ -19,6 +19,15 @@
 #include <initializer_list>
 #include "qt/pivx/pivxgui.h"
 
+// Repair parameters
+const QString SALVAGEWALLET("-salvagewallet");
+const QString RESCAN("-rescan");
+const QString ZAPTXES1("-zapwallettxes=1");
+const QString ZAPTXES2("-zapwallettxes=2");
+const QString UPGRADEWALLET("-upgradewallet");
+const QString REINDEX("-reindex");
+const QString RESYNC("-resync");
+
 extern Qt::Modifier SHORT_KEY;
 
 bool openDialog(QDialog *widget, QWidget *gui);

--- a/src/qt/pivx/settings/settingswalletrepairwidget.cpp
+++ b/src/qt/pivx/settings/settingswalletrepairwidget.cpp
@@ -6,15 +6,6 @@
 #include "qt/pivx/settings/forms/ui_settingswalletrepairwidget.h"
 #include "qt/pivx/qtutils.h"
 
-// Repair parameters
-const QString SALVAGEWALLET("-salvagewallet");
-const QString RESCAN("-rescan");
-const QString ZAPTXES1("-zapwallettxes=1");
-const QString ZAPTXES2("-zapwallettxes=2");
-const QString UPGRADEWALLET("-upgradewallet");
-const QString REINDEX("-reindex");
-const QString RESYNC("-resync");
-
 SettingsWalletRepairWidget::SettingsWalletRepairWidget(PIVXGUI* _window, QWidget *parent) :
     PWidget(_window, parent),
     ui(new Ui::SettingsWalletRepairWidget)

--- a/src/qt/pivx/settings/settingswidget.cpp
+++ b/src/qt/pivx/settings/settingswidget.cpp
@@ -206,8 +206,12 @@ void SettingsWidget::onSaveOptionsClicked(){
     if(mapper->submit()) {
         pwalletMain->MarkDirty();
         if (this->clientModel->getOptionsModel()->isRestartRequired()) {
+            // Get command-line arguments and remove the application name
+            QStringList args = QApplication::arguments();
+            args.removeFirst();
+
             openStandardDialog(tr("Restart required"), tr("You wallet will be restarted to apply the changes\n"), tr("OK"));
-            emit handleRestart(QStringList());
+            emit handleRestart(args);
         } else {
             inform(tr("Options stored"));
         }

--- a/src/qt/pivx/settings/settingswidget.cpp
+++ b/src/qt/pivx/settings/settingswidget.cpp
@@ -210,6 +210,14 @@ void SettingsWidget::onSaveOptionsClicked(){
             QStringList args = QApplication::arguments();
             args.removeFirst();
 
+            // Remove existing repair-options
+            args.removeAll(SALVAGEWALLET);
+            args.removeAll(RESCAN);
+            args.removeAll(ZAPTXES1);
+            args.removeAll(ZAPTXES2);
+            args.removeAll(UPGRADEWALLET);
+            args.removeAll(REINDEX);
+
             openStandardDialog(tr("Restart required"), tr("You wallet will be restarted to apply the changes\n"), tr("OK"));
             emit handleRestart(args);
         } else {

--- a/src/qt/pivx/settings/settingswidget.cpp
+++ b/src/qt/pivx/settings/settingswidget.cpp
@@ -206,20 +206,25 @@ void SettingsWidget::onSaveOptionsClicked(){
     if(mapper->submit()) {
         pwalletMain->MarkDirty();
         if (this->clientModel->getOptionsModel()->isRestartRequired()) {
-            // Get command-line arguments and remove the application name
-            QStringList args = QApplication::arguments();
-            args.removeFirst();
+            bool fAcceptRestart = openStandardDialog(tr("Restart required"), tr("Your wallet needs to be restarted to apply the changes\n"), tr("Restart Now"), tr("Restart Later"));
 
-            // Remove existing repair-options
-            args.removeAll(SALVAGEWALLET);
-            args.removeAll(RESCAN);
-            args.removeAll(ZAPTXES1);
-            args.removeAll(ZAPTXES2);
-            args.removeAll(UPGRADEWALLET);
-            args.removeAll(REINDEX);
+            if (fAcceptRestart) {
+                // Get command-line arguments and remove the application name
+                QStringList args = QApplication::arguments();
+                args.removeFirst();
 
-            openStandardDialog(tr("Restart required"), tr("You wallet will be restarted to apply the changes\n"), tr("OK"));
-            emit handleRestart(args);
+                // Remove existing repair-options
+                args.removeAll(SALVAGEWALLET);
+                args.removeAll(RESCAN);
+                args.removeAll(ZAPTXES1);
+                args.removeAll(ZAPTXES2);
+                args.removeAll(UPGRADEWALLET);
+                args.removeAll(REINDEX);
+
+                emit handleRestart(args);
+            } else {
+                inform(tr("Options will be applied on next wallet restart"));
+            }
         } else {
             inform(tr("Options stored"));
         }
@@ -405,13 +410,14 @@ void SettingsWidget::setMapper(){
     settingsDisplayOptionsWidget->setMapper(mapper);
 }
 
-void SettingsWidget::openStandardDialog(QString title, QString body, QString okBtn, QString cancelBtn){
+bool SettingsWidget::openStandardDialog(QString title, QString body, QString okBtn, QString cancelBtn){
     showHideOp(true);
     DefaultDialog *confirmDialog = new DefaultDialog(window);
     confirmDialog->setText(title, body, okBtn, cancelBtn);
     confirmDialog->adjustSize();
     openDialogWithOpaqueBackground(confirmDialog, window);
     confirmDialog->deleteLater();
+    return confirmDialog->isOk;
 }
 
 SettingsWidget::~SettingsWidget(){

--- a/src/qt/pivx/settings/settingswidget.h
+++ b/src/qt/pivx/settings/settingswidget.h
@@ -95,7 +95,7 @@ private:
     QList<QPushButton*> options;
 
     void selectOption(QPushButton* option);
-    void openStandardDialog(QString title = "", QString body = "", QString okBtn = "OK", QString cancelBtn = "");
+    bool openStandardDialog(QString title = "", QString body = "", QString okBtn = "OK", QString cancelBtn = "");
 };
 
 #endif // SETTINGSWIDGET_H


### PR DESCRIPTION
After changing a settings option that requires a wallet restart, retain
any command line argument that was passed to the current program session
and pass them to the restarted program session.

Also, address #1114 by allowing the option to postpone wallet restart on settings change.