### PR TITLE
[Wallet] Do not use p2cs outputs in the autocombine flow.

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3782,6 +3782,10 @@ void CWallet::AutoCombineDust()
             if (out.tx->IsCoinStake() && out.tx->GetDepthInMainChain() < Params().COINBASE_MATURITY() + 1)
                 continue;
 
+            // no p2cs accepted, those coins are "locked"
+            if (out.tx->vout[out.i].scriptPubKey.IsPayToColdStaking())
+                continue;
+
             COutPoint outpt(out.tx->GetHash(), out.i);
             coinControl->Select(outpt);
             vRewardCoins.push_back(out);


### PR DESCRIPTION
Stop using the non-locked P2CS outputs as part of the auto combine flow.