### PR TITLE
[Wallet][GUI][Model] Cold staking addresses contacts flow.

### DIFF
--- a/src/addressbook.cpp
+++ b/src/addressbook.cpp
@@ -14,6 +14,28 @@ namespace AddressBook {
         const std::string DELEGABLE{"delegable"};
         const std::string DELEGATOR{"delegator"};
         const std::string COLD_STAKING{"coldstaking"};
+        const std::string COLD_STAKING_SEND{"coldstaking_send"};
     }
+
+
+    bool CAddressBookData::isColdStakingPurpose() const {
+        return purpose == AddressBookPurpose::DELEGABLE
+               || purpose == AddressBookPurpose::DELEGATOR
+               || purpose == AddressBookPurpose::COLD_STAKING
+               || purpose == AddressBookPurpose::COLD_STAKING_SEND;
+    }
+
+    bool CAddressBookData::isSendColdStakingPurpose() const {
+        return purpose == AddressBookPurpose::COLD_STAKING_SEND;
+    }
+
+    bool CAddressBookData::isSendPurpose() const {
+        return purpose == AddressBookPurpose::SEND;
+    }
+    bool CAddressBookData::isReceivePurpose() const {
+        return purpose == AddressBookPurpose::RECEIVE;
+    }
+
+
 }
 

--- a/src/addressbook.cpp
+++ b/src/addressbook.cpp
@@ -17,11 +17,8 @@ namespace AddressBook {
         const std::string COLD_STAKING_SEND{"coldstaking_send"};
     }
 
-
-    bool CAddressBookData::isColdStakingPurpose() const {
-        return purpose == AddressBookPurpose::DELEGABLE
-               || purpose == AddressBookPurpose::DELEGATOR
-               || purpose == AddressBookPurpose::COLD_STAKING
+    bool IsColdStakingPurpose(const std::string& purpose) {
+        return purpose == AddressBookPurpose::COLD_STAKING
                || purpose == AddressBookPurpose::COLD_STAKING_SEND;
     }
 

--- a/src/addressbook.h
+++ b/src/addressbook.h
@@ -17,6 +17,14 @@ namespace AddressBook {
         extern const std::string DELEGABLE;
         extern const std::string DELEGATOR;
         extern const std::string COLD_STAKING;
+        extern const std::string COLD_STAKING_SEND;
+    }
+
+    bool IsColdStakingPurpose(const std::string& purpose) {
+        return purpose == AddressBookPurpose::DELEGABLE
+               || purpose == AddressBookPurpose::DELEGATOR
+               || purpose == AddressBookPurpose::COLD_STAKING
+               || purpose == AddressBookPurpose::COLD_STAKING_SEND;
     }
 
 /** Address book data */
@@ -32,6 +40,11 @@ namespace AddressBook {
 
         typedef std::map<std::string, std::string> StringMap;
         StringMap destdata;
+
+        bool isColdStakingPurpose() const;
+        bool isSendColdStakingPurpose() const;
+        bool isSendPurpose() const;
+        bool isReceivePurpose() const;
     };
 
 }

--- a/src/addressbook.h
+++ b/src/addressbook.h
@@ -20,12 +20,7 @@ namespace AddressBook {
         extern const std::string COLD_STAKING_SEND;
     }
 
-    bool IsColdStakingPurpose(const std::string& purpose) {
-        return purpose == AddressBookPurpose::DELEGABLE
-               || purpose == AddressBookPurpose::DELEGATOR
-               || purpose == AddressBookPurpose::COLD_STAKING
-               || purpose == AddressBookPurpose::COLD_STAKING_SEND;
-    }
+    bool IsColdStakingPurpose(const std::string& purpose);
 
 /** Address book data */
     class CAddressBookData {
@@ -41,7 +36,6 @@ namespace AddressBook {
         typedef std::map<std::string, std::string> StringMap;
         StringMap destdata;
 
-        bool isColdStakingPurpose() const;
         bool isSendColdStakingPurpose() const;
         bool isSendPurpose() const;
         bool isReceivePurpose() const;

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -104,7 +104,7 @@ public:
             for (const PAIRTYPE(CTxDestination, AddressBook::CAddressBookData) & item : wallet->mapAddressBook) {
 
                 const CChainParams::Base58Type addrType =
-                        item.second.isColdStakingPurpose() ?
+                        AddressBook::IsColdStakingPurpose(item.second.purpose) ?
                         CChainParams::STAKING_ADDRESS : CChainParams::PUBKEY_ADDRESS;
                 const CBitcoinAddress address = CBitcoinAddress(item.first, addrType);
 

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -48,8 +48,9 @@ public:
     static const QString Send;    /**< Specifies send address */
     static const QString Receive; /**< Specifies receive address */
     static const QString Zerocoin; /**< Specifies stealth address */
-    static const QString Delegators;
-    static const QString ColdStaking;
+    static const QString Delegators; /**< Specifies cold staking addresses which delegated tokens to this wallet */
+    static const QString ColdStaking; /**< Specifies cold staking own addresses */
+    static const QString ColdStakingSend; /**< Specifies send cold staking addresses (simil 'contacts')*/
 
     /** @name Methods overridden from QAbstractTableModel
         @{*/
@@ -58,6 +59,7 @@ public:
     int sizeSend() const;
     int sizeRecv() const;
     int sizeDell() const;
+    int sizeColdSend() const;
     void notifyChange(const QModelIndex &index);
     QVariant data(const QModelIndex& index, int role) const;
     bool setData(const QModelIndex& index, const QVariant& value, int role);

--- a/src/qt/pivx/addresseswidget.cpp
+++ b/src/qt/pivx/addresseswidget.cpp
@@ -153,7 +153,7 @@ void AddressesWidget::handleAddressClicked(const QModelIndex &index){
 void AddressesWidget::loadWalletModel(){
     if(walletModel) {
         addressTablemodel = walletModel->getAddressTableModel();
-        this->filter = new AddressFilterProxyModel(AddressTableModel::Send, this);
+        this->filter = new AddressFilterProxyModel(QStringList({AddressTableModel::Send, AddressTableModel::ColdStakingSend}), this);
         this->filter->setSourceModel(addressTablemodel);
         ui->listAddresses->setModel(this->filter);
         ui->listAddresses->setModelColumn(AddressTableModel::Address);
@@ -193,7 +193,9 @@ void AddressesWidget::onStoreContactClicked(){
             return;
         }
 
-        if (walletModel->updateAddressBookLabels(pivAdd.Get(), label.toUtf8().constData(), "send")) {
+        if (walletModel->updateAddressBookLabels(pivAdd.Get(), label.toUtf8().constData(),
+                pivAdd.IsStakingAddress() ? AddressBook::AddressBookPurpose::COLD_STAKING_SEND : AddressBook::AddressBookPurpose::SEND)
+                ) {
             ui->lineEditAddress->setText("");
             ui->lineEditName->setText("");
             setCssEditLine(ui->lineEditAddress, true, true);
@@ -218,7 +220,7 @@ void AddressesWidget::onEditClicked(){
     dialog->setData(address, currentLabel);
     if(openDialogWithOpaqueBackground(dialog, window)){
         if(walletModel->updateAddressBookLabels(
-                CBitcoinAddress(address.toStdString()).Get(), dialog->getLabel().toStdString(), "send")){
+                CBitcoinAddress(address.toStdString()).Get(), dialog->getLabel().toStdString(), addressTablemodel->purposeForAddress(address.toStdString()))){
             inform(tr("Contact edited"));
         }else{
             inform(tr("Contact edit failed"));

--- a/src/qt/pivx/addressfilterproxymodel.cpp
+++ b/src/qt/pivx/addressfilterproxymodel.cpp
@@ -11,7 +11,7 @@ bool AddressFilterProxyModel::filterAcceptsRow(int row, const QModelIndex& paren
     auto label = model->index(row, AddressTableModel::Label, parent);
 
     auto type = model->data(label, AddressTableModel::TypeRole).toString();
-    if (type != m_type)
+    if (!m_types.contains(type))
         return false;
 
     auto address = model->index(row, AddressTableModel::Address, parent);
@@ -26,7 +26,12 @@ bool AddressFilterProxyModel::filterAcceptsRow(int row, const QModelIndex& paren
 
 void AddressFilterProxyModel::setType(const QString& type)
 {
-    this->m_type = type;
+    setType(QStringList(type));
+}
+
+void AddressFilterProxyModel::setType(const QStringList& types)
+{
+    this->m_types = types;
     invalidateFilter();
 }
 

--- a/src/qt/pivx/addressfilterproxymodel.h
+++ b/src/qt/pivx/addressfilterproxymodel.h
@@ -15,7 +15,17 @@ class AddressFilterProxyModel final : public QSortFilterProxyModel
 public:
     AddressFilterProxyModel(const QString& type, QObject* parent)
             : QSortFilterProxyModel(parent)
-            , m_type(type) {
+            , m_types({type}) {
+        init();
+    }
+
+    AddressFilterProxyModel(const QStringList& types, QObject* parent)
+            : QSortFilterProxyModel(parent)
+            , m_types(types) {
+        init();
+    }
+
+    void init() {
         setDynamicSortFilter(true);
         setFilterCaseSensitivity(Qt::CaseInsensitive);
         setSortCaseSensitivity(Qt::CaseInsensitive);
@@ -24,12 +34,13 @@ public:
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
 
     void setType(const QString& type);
+    void setType(const QStringList& types);
 
 protected:
     bool filterAcceptsRow(int row, const QModelIndex& parent) const override;
 
 private:
-    QString m_type;
+    QStringList m_types;
 };
 
 

--- a/src/qt/pivx/coldstakingwidget.cpp
+++ b/src/qt/pivx/coldstakingwidget.cpp
@@ -281,7 +281,7 @@ void ColdStakingWidget::onContactsClicked(){
         menu->hide();
     }
 
-    int contactsSize = isContactOwnerSelected ? walletModel->getAddressTableModel()->sizeSend() : walletModel->getAddressTableModel()->sizeDell();
+    int contactsSize = isContactOwnerSelected ? walletModel->getAddressTableModel()->sizeSend() : walletModel->getAddressTableModel()->sizeColdSend();
     if(contactsSize == 0) {
         inform(tr("No contacts available, you can go to the contacts screen and add some there!"));
         return;
@@ -327,12 +327,7 @@ void ColdStakingWidget::onContactsClicked(){
         return;
     }
 
-    if (isContactOwnerSelected) {
-        menuContacts->setWalletModel(walletModel, AddressTableModel::Receive);
-    } else {
-        menuContacts->setWalletModel(walletModel, AddressTableModel::Delegators);
-    }
-
+    menuContacts->setWalletModel(walletModel, isContactOwnerSelected ? AddressTableModel::Receive : AddressTableModel::ColdStakingSend);
     menuContacts->resizeList(width, height);
     menuContacts->setStyleSheet(styleSheet());
     menuContacts->adjustSize();

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -506,12 +506,10 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(WalletModelTransaction& tran
     foreach (const SendCoinsRecipient& rcp, transaction.getRecipients()) {
         // Don't touch the address book when we have a payment request
         if (!rcp.paymentRequest.IsInitialized()) {
-
-            std::string strAddress = rcp.address.toStdString();
-            CTxDestination dest = CBitcoinAddress(strAddress).Get();
+            CBitcoinAddress address = CBitcoinAddress(rcp.address.toStdString());
+            std::string purpose = address.IsStakingAddress() ? AddressBook::AddressBookPurpose::COLD_STAKING_SEND : AddressBook::AddressBookPurpose::SEND;
             std::string strLabel = rcp.label.toStdString();
-
-            updateAddressBookLabels(dest, strLabel, "send");
+            updateAddressBookLabels(address.Get(), strLabel, purpose);
         }
         emit coinsSent(wallet, rcp, transaction_array);
     }
@@ -717,7 +715,7 @@ static void NotifyKeyStoreStatusChanged(WalletModel* walletmodel, CCryptoKeyStor
 
 static void NotifyAddressBookChanged(WalletModel* walletmodel, CWallet* wallet, const CTxDestination& address, const std::string& label, bool isMine, const std::string& purpose, ChangeType status)
 {
-    QString strAddress = QString::fromStdString(CBitcoinAddress(address).ToString());
+    QString strAddress = QString::fromStdString(pwalletMain->ParseIntoAddress(address, purpose).ToString());
     QString strLabel = QString::fromStdString(label);
     QString strPurpose = QString::fromStdString(purpose);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -506,10 +506,14 @@ public:
     DBErrors LoadWallet(bool& fFirstRunRet);
     DBErrors ZapWalletTx(std::vector<CWalletTx>& vWtx);
 
+    static CBitcoinAddress ParseIntoAddress(const CTxDestination& dest, const std::string& purpose);
+
     bool SetAddressBook(const CTxDestination& address, const std::string& strName, const std::string& purpose);
-    bool DelAddressBook(const CTxDestination& address);
+    bool DelAddressBook(const CTxDestination& address, const CChainParams::Base58Type addrType = CChainParams::PUBKEY_ADDRESS);
     bool HasAddressBook(const CTxDestination& address) const;
     bool HasDelegator(const CTxOut& out) const;
+
+    std::string purposeForAddress(const CTxDestination& address) const;
 
     bool UpdatedTransaction(const uint256& hashTx);
 


### PR DESCRIPTION
Essentially before there was no flow to store a remote cold staking address and the label field on the delegation screen was not storing the address properly in the address book ('send' purpose which was presenting the address in an invalid format).

 This PR has implemented a fully fledged CRUD over the external cold staking addresses. Every of the four actions running on top of the contacts screen and connected to the cold staking screen contacts dropdown.