### PR TITLE
[GUI][BUG] Bad top padding on the dashboard nav icon in dark theme fix.

### DIFF
--- a/src/qt/pivx/res/css/style_dark.css
+++ b/src/qt/pivx/res/css/style_dark.css
@@ -237,7 +237,6 @@ QPushButton[cssClass="btn-check-cold-staking"]:checked {
 
 *[cssClass="btn-nav-dash"]:checked {
     background-color: #0f0b16;
-    padding-top: 25px;
     font-size:14px;
     color: #B088FF;
 }


### PR DESCRIPTION
Auto-explainable title, 

The dashboard nav button css class, in the dark theme, is pushing down the icon when the button gets checked, this fixes it.