### PR TITLE
[GUI] Prevent worker constant creation and invalid removal

### DIFF
--- a/src/qt/pivx/loadingdialog.cpp
+++ b/src/qt/pivx/loadingdialog.cpp
@@ -7,17 +7,20 @@
 #include <QMovie>
 
 void Worker::process(){
-    try {
-        if (runnable)
+    if (runnable) {
+        try {
             runnable->run(type);
-    } catch (std::exception& e) {
-        QString errorStr = QString::fromStdString(e.what());
-        runnable->onError(errorStr, type);
-        emit error(errorStr, type);
-    } catch (...) {
-        QString errorStr = QString::fromStdString("Unknown error running background task");
-        runnable->onError(errorStr, type);
-        emit error(errorStr, type);
+        } catch (std::exception &e) {
+            QString errorStr = QString::fromStdString(e.what());
+            runnable->onError(errorStr, type);
+            emit error(errorStr, type);
+        } catch (...) {
+            QString errorStr = QString::fromStdString("Unknown error running background task");
+            runnable->onError(errorStr, type);
+            emit error(errorStr, type);
+        }
+    } else {
+        emit error("Null runnable", type);
     }
     emit finished();
 };

--- a/src/qt/pivx/loadingdialog.h
+++ b/src/qt/pivx/loadingdialog.h
@@ -7,6 +7,7 @@
 
 #include <QDialog>
 #include <QThread>
+#include <QPointer>
 #include <iostream>
 #include <QTimer>
 #include "qt/pivx/prunnable.h"
@@ -19,7 +20,9 @@ class Worker : public QObject {
     Q_OBJECT
 public:
     Worker(Runnable* runnable, int type):runnable(runnable), type(type){}
-    ~Worker(){}
+    ~Worker(){
+        runnable = nullptr;
+    }
 public slots:
     void process();
 signals:

--- a/src/qt/pivx/pwidget.h
+++ b/src/qt/pivx/pwidget.h
@@ -13,6 +13,7 @@
 class PIVXGUI;
 class ClientModel;
 class WalletModel;
+class WorkerTask;
 
 namespace Ui {
 class PWidget;
@@ -66,6 +67,8 @@ protected:
     bool verifyWalletUnlocked();
 
 private:
+    QSharedPointer<WorkerTask> task;
+
     void init();
 private slots:
     void errorString(QString, int);


### PR DESCRIPTION
This prevents a segfault that is happening most of the time in linux when the QThreadPool auto-delete property forces a deletion of the worker object which runnable is the parent widget that shouldn't be deleted.

Extra information: This has been running fine on the `testnet_multi_pr` branch since we launched the public segregated testnet.