### PR TITLE
[GUI] Use QRegexValidator instead of the QDoubleValidator.

### DIFF
--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -246,7 +246,7 @@ bool BitcoinUnits::parse(int unit, const QString& value, CAmount* val_out)
     int num_decimals = decimals(unit);
 
     // Ignore spaces and thin spaces when parsing
-    QStringList parts = removeSpaces(value).split(".");
+    QStringList parts = removeSpaces(value).replace(",", ".").split(".");
 
     if (parts.size() > 2) {
         return false; // More than one dot

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -49,7 +49,9 @@
 #include <QDateTime>
 #include <QDesktopServices>
 #include <QDesktopWidget>
-#include <QDoubleValidator>
+#include <QRegExp>
+#include <QRegularExpression>
+#include <QRegularExpressionValidator>
 #include <QFileDialog>
 #include <QFont>
 #include <QLineEdit>
@@ -145,11 +147,17 @@ void setupAddressWidget(QValidatedLineEdit* widget, QWidget* parent)
 
 void setupAmountWidget(QLineEdit* widget, QWidget* parent)
 {
-    QDoubleValidator* amountValidator = new QDoubleValidator(parent);
-    amountValidator->setDecimals(8);
-    amountValidator->setBottom(0.0);
-    widget->setValidator(amountValidator);
-    widget->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+    QRegularExpression rx("^(\\d{0,8})((\\.|,)\\d{1,8})?$");
+    QValidator *validator = new QRegularExpressionValidator(rx, widget);
+    widget->setValidator(validator);
+}
+
+void updateWidgetTextAndCursorPosition(QLineEdit* widget, const QString& str)
+{
+    const int cpos = widget->cursorPosition();
+    widget->setText(str);
+    if (cpos > str.size()) return;
+    widget->setCursorPosition(cpos);
 }
 
 bool parseBitcoinURI(const QUrl& uri, SendCoinsRecipient* out)

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -57,6 +57,9 @@ bool requestUnlock(WalletModel* walletModel, AskPassphraseDialog::Context contex
 void setupAddressWidget(QValidatedLineEdit* widget, QWidget* parent);
 void setupAmountWidget(QLineEdit* widget, QWidget* parent);
 
+// Update the cursor of the widget after a text change
+void updateWidgetTextAndCursorPosition(QLineEdit* widget, const QString& str);
+
 // Parse "pivx:" URI into recipient object, return true on successful parsing
 bool parseBitcoinURI(const QUrl& uri, SendCoinsRecipient* out);
 bool parseBitcoinURI(QString uri, SendCoinsRecipient* out);

--- a/src/qt/pivx/forms/sendmultirow.ui
+++ b/src/qt/pivx/forms/sendmultirow.ui
@@ -189,7 +189,7 @@
            </size>
           </property>
           <property name="maxLength">
-           <number>16</number>
+           <number>17</number>
           </property>
           <property name="alignment">
            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>

--- a/src/qt/pivx/requestdialog.cpp
+++ b/src/qt/pivx/requestdialog.cpp
@@ -5,7 +5,6 @@
 #include "qt/pivx/requestdialog.h"
 #include "qt/pivx/forms/ui_requestdialog.h"
 #include <QListView>
-#include <QDoubleValidator>
 
 #include "qt/pivx/qtutils.h"
 #include "guiutil.h"
@@ -44,10 +43,7 @@ RequestDialog::RequestDialog(QWidget *parent) :
     setCssProperty(ui->labelSubtitleAmount, "text-title2-dialog");
     ui->lineEditAmount->setPlaceholderText("0.00 PIV");
     setCssEditLineDialog(ui->lineEditAmount, true);
-
-    QDoubleValidator *doubleValidator = new QDoubleValidator(0, 9999999, 7, this);
-    doubleValidator->setNotation(QDoubleValidator::StandardNotation);
-    ui->lineEditAmount->setValidator(doubleValidator);
+    GUIUtil::setupAmountWidget(ui->lineEditAmount, this);
 
     // Description
     ui->labelSubtitleDescription->setText(tr("Description (optional)"));

--- a/src/qt/pivx/sendmultirow.cpp
+++ b/src/qt/pivx/sendmultirow.cpp
@@ -4,7 +4,6 @@
 
 #include "qt/pivx/sendmultirow.h"
 #include "qt/pivx/forms/ui_sendmultirow.h"
-#include <QDoubleValidator>
 
 #include "optionsmodel.h"
 #include "addresstablemodel.h"
@@ -27,9 +26,7 @@ SendMultiRow::SendMultiRow(PWidget *parent) :
 
     ui->lineEditAmount->setPlaceholderText("0.00 PIV ");
     initCssEditLine(ui->lineEditAmount);
-    QDoubleValidator *doubleValidator = new QDoubleValidator(0, 9999999, 8, this);
-    doubleValidator->setNotation(QDoubleValidator::StandardNotation);
-    ui->lineEditAmount->setValidator(doubleValidator);
+    GUIUtil::setupAmountWidget(ui->lineEditAmount, this);
 
     /* Description */
     ui->labelSubtitleDescription->setText("Label address (optional)");
@@ -68,13 +65,9 @@ SendMultiRow::SendMultiRow(PWidget *parent) :
 void SendMultiRow::amountChanged(const QString& amount){
     if(!amount.isEmpty()) {
         QString amountStr = amount;
-        int commaIndex = amountStr.indexOf(',');
-        if (commaIndex != -1) {
-            amountStr = amountStr.remove(commaIndex, 1);
-        }
         CAmount value = getAmountValue(amountStr);
         if (value > 0) {
-            ui->lineEditAmount->setText(amountStr);
+            GUIUtil::updateWidgetTextAndCursorPosition(ui->lineEditAmount, amountStr);
             setCssEditLine(ui->lineEditAmount, true, true);
         }
     }

--- a/src/qt/test/uritests.cpp
+++ b/src/qt/test/uritests.cpp
@@ -60,7 +60,7 @@ void URITests::uriTests()
     QVERIFY(GUIUtil::parseBitcoinURI(uri, &rv));
 
     uri.setUrl(QString("pivx:D72dLgywmL73JyTwQBfuU29CADz9yCJ99v?amount=1,000&label=Some Example"));
-    QVERIFY(!GUIUtil::parseBitcoinURI(uri, &rv));
+    QVERIFY(GUIUtil::parseBitcoinURI(uri, &rv));
 
     uri.setUrl(QString("pivx:D72dLgywmL73JyTwQBfuU29CADz9yCJ99v?amount=1,000.0&label=Some Example"));
     QVERIFY(!GUIUtil::parseBitcoinURI(uri, &rv));


### PR DESCRIPTION
Have received reports from linux users experiencing problems with the amount editable box, not being able to write large numbers with decimals (even when the QDoubleValidator decimal limit was set to 8..).
Have checked it in macOS and everything is fine there, so.. the issue is pointing to an internal QT QDoubleValidator class problem that has nothing to do with our UI code in some linux distributions.

To solve it without over complicate the code, have changed the QDoubleValidator for a QRegexValidator. 
Running fine in linux now too here, more eyes are welcome.