### PR TITLE
[Consensus] Define TestNet changeover block for PIVX v4.0 RC

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -209,7 +209,8 @@ public:
         nRejectOldSporkKey = 1569538800; //!> Fully reject old spork key after Thursday, September 26, 2019 11:00:00 PM GMT
         nBlockStakeModifierlV2 = 1967000;
         nBIP65ActivationHeight = 1808634;
-        nBlockTimeProtocolV2 = 2967000;
+        // Activation height for TimeProtocolV2, Blocks V7 and newMessageSignatures
+        nBlockTimeProtocolV2 = 2967000; // !TODO: change me
 
         // Public coin spend enforcement
         nPublicZCSpends = 1880000;
@@ -219,7 +220,7 @@ public:
 
         // Blocks v7
         nBlockLastAccumulatorCheckpoint = 1686240;
-        nBlockV7StartHeight = 2967000;
+        nBlockV7StartHeight = nBlockTimeProtocolV2;
 
         // Fake Serial Attack
         nFakeSerialBlockheightEnd = 1686229;
@@ -354,7 +355,8 @@ public:
         nRejectOldSporkKey = 1569538800; //!> Reject old spork key after Thursday, September 26, 2019 11:00:00 PM GMT
         nBlockStakeModifierlV2 = 1214000;
         nBIP65ActivationHeight = 851019;
-        nBlockTimeProtocolV2 = 2214000;
+        // Activation height for TimeProtocolV2, Blocks V7 and newMessageSignatures
+        nBlockTimeProtocolV2 = 1347000;
 
         // Public coin spend enforcement
         nPublicZCSpends = 1106100;
@@ -364,7 +366,7 @@ public:
 
         // Blocks v7
         nBlockLastAccumulatorCheckpoint = nPublicZCSpends - 10;
-        nBlockV7StartHeight = 2214000;
+        nBlockV7StartHeight = nBlockTimeProtocolV2;
 
         // Fake Serial Attack
         nFakeSerialBlockheightEnd = -1;


### PR DESCRIPTION
The changeover block height for new P2P message signatures, new time protocol and v7 blocks is still set at placeholder values (mainnet: `2967000`, testnet: `2214000`).

These need to be changed to the actual values to use.

EDIT: This PR will change only the testnet height. Mainnet will be fixed in a subsequent PR.