### PR TITLE
[UI] Copy correct data from mninfo dialog

### DIFF
--- a/src/qt/pivx/mninfodialog.cpp
+++ b/src/qt/pivx/mninfodialog.cpp
@@ -25,8 +25,8 @@ MnInfoDialog::MnInfoDialog(QWidget *parent) :
     setCssProperty({ui->pushCopy, ui->pushCopyId, ui->pushExport}, "ic-copy-big");
     setCssProperty(ui->btnEsc, "ic-close");
     connect(ui->btnEsc, SIGNAL(clicked()), this, SLOT(closeDialog()));
-    connect(ui->pushCopy, &QPushButton::clicked, [this](){ copyInform(txId, "Master Node public key copied"); });
-    connect(ui->pushCopyId, &QPushButton::clicked, [this](){ copyInform(pubKey, "Collateral tx id copied"); });
+    connect(ui->pushCopy, &QPushButton::clicked, [this](){ copyInform(pubKey, "Master Node public key copied"); });
+    connect(ui->pushCopyId, &QPushButton::clicked, [this](){ copyInform(txId, "Collateral tx id copied"); });
     connect(ui->pushExport, &QPushButton::clicked, [this](){ exportMN = true; accept(); });
 }
 


### PR DESCRIPTION
This PR fixes the mninfodialog code to copy the pubkey or txid correctly.