### PR TITLE
[Bug][GUI] Tx list row amount color changing invalidly.

### DIFF
--- a/src/qt/pivx/txrow.cpp
+++ b/src/qt/pivx/txrow.cpp
@@ -115,7 +115,7 @@ void TxRow::setType(bool isLightTheme, int type, bool isConfirmed){
     }else{
         setConfirmStatus(true);
     }
-    setCssProperty(ui->lblAmount, css);
+    setCssProperty(ui->lblAmount, css, true);
     ui->icon->setIcon(QIcon(path));
 }
 


### PR DESCRIPTION
The row colors were changing invalidly when the user was scrolling the list and/or just moving along the showed rows. Essentially a bad internal state of the widget properties that needed a forced update to re paint the component using the correct css class.

Solving #1093 .