### PR TITLE
[Trivial] Remove a duplicate variable definition

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -189,7 +189,6 @@ public:
         nMasternodeCountDrift = 20;
         nMaxMoneyOut = 21000000 * COIN;
         nMinColdStakingAmount = 1 * COIN;
-        nTimeSlotLength = 15;           // 15 seconds
 
         /** Height or Time Based Activations **/
         nLastPOWBlock = 259200;


### PR DESCRIPTION
`nTimeSlotLength` was set twice to `15`. Line 182 and 192 of `chainparams.cpp`.