### PR TITLE
[Qt] Fix segfault when running GUI client with --help or -?

### DIFF
--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -33,7 +33,7 @@ HelpMessageDialog::HelpMessageDialog(QWidget* parent, bool about) : QDialog(pare
                                                                     ui(new Ui::HelpMessageDialog)
 {
     ui->setupUi(this);
-    this->setStyleSheet(parent->styleSheet());
+    if (parent) this->setStyleSheet(parent->styleSheet());
     GUIUtil::restoreWindowGeometry("nHelpMessageDialogWindow", this->size(), this);
 
     QString version = tr("PIVX Core") + " " + tr("version") + " " + QString::fromStdString(FormatFullVersion());


### PR DESCRIPTION
Straight forward fix to avoid a segfault when running `pivx-qt --help`; which is supposed to simply output the help text to the console and exit.