### PR TITLE
[Travis] Increase functional tests reserved time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -152,7 +152,7 @@ jobs:
         #TEST_RUNNER_EXTRA="--coverage --extended"  # Run extended tests so that coverage does not fail, but exclude the very slow dbcrash
         GOAL="install"
         BITCOIN_CONFIG="--enable-zmq --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports"
-        BUILD_TIMEOUT=1300
+        BUILD_TIMEOUT=800
 
     - stage: test
       name: 'x86_64 Linux  [GOAL: install]  [trusty]  [no functional tests, no depends, only system libs]'


### PR DESCRIPTION
Functional tests run in travis are given 1700 seconds. We are seeing more and more builds where it's not enough. So change the compile phase timeout to 800 seconds in order to have 2200 seconds for tests or cache the built binaries and restart with a full 3000 seconds for tests. Only for the full functional tests travis build.