### PR TITLE
[BUG] Masternodes wizard, IPv6 addresses storage in .conf file.

### DIFF
--- a/src/qt/pivx/masternodewizarddialog.cpp
+++ b/src/qt/pivx/masternodewizarddialog.cpp
@@ -10,6 +10,7 @@
 #include "activemasternode.h"
 #include <QFile>
 #include <QIntValidator>
+#include <QHostAddress>
 #include <QRegExpValidator>
 
 MasterNodeWizardDialog::MasterNodeWizardDialog(WalletModel *model, QWidget *parent) :
@@ -283,6 +284,13 @@ bool MasterNodeWizardDialog::createMN(){
                     return false;
                 }
                 std::string indexOutStr = std::to_string(indexOut);
+
+                // Check IP address type
+                QHostAddress hostAddress(addressStr);
+                QAbstractSocket::NetworkLayerProtocol layerProtocol = hostAddress.protocol();
+                if (layerProtocol == QAbstractSocket::IPv6Protocol) {
+                    ipAddress = "["+ipAddress+"]";
+                }
 
                 boost::filesystem::path pathConfigFile("masternode_temp.conf");
                 if (!pathConfigFile.is_complete()) pathConfigFile = GetDataDir() / pathConfigFile;


### PR DESCRIPTION
In the masternodes creation wizard, IPv6 addresses are not being stored in the `masternode.conf` in the core's expected format. This solves the issue adding the needed brackets.