### PR TITLE
[GUI][Trivial] Rewording of Error message when wallet is unlocked for staking only

### DIFF
--- a/src/qt/pivx/guitransactionsutils.cpp
+++ b/src/qt/pivx/guitransactionsutils.cpp
@@ -50,7 +50,7 @@ namespace GuiTransactionsUtils {
                 if (!fPrepare)
                     fAskForUnlock = true;
                 else
-                    msgParams.first = parent->translate("Error: The wallet was unlocked only to anonymize coins.");
+                    msgParams.first = parent->translate("Error: The wallet is unlocked for staking only. Fully unlock the wallet to send the transaction.");
                 break;
 
             case WalletModel::InsaneFee:


### PR DESCRIPTION
Not sure if this is good or it needs to be:

> Error: The wallet is unlocked for anonymization and staking only.**\n**Unlock the wallet to send the transaction.

![check](https://user-images.githubusercontent.com/57232689/69903529-c50bd600-139a-11ea-96db-45c83cd19e3c.JPG)
