### PR TITLE
[Qt] properly copy IPv6 externalip MN info

### DIFF
--- a/src/qt/pivx/masternodeswidget.cpp
+++ b/src/qt/pivx/masternodeswidget.cpp
@@ -240,7 +240,7 @@ void MasterNodesWidget::onInfoMNClicked(){
                 ))) {
             // export data
             QString exportedMN = "masternode=1\n"
-                                 "externalip=" + address.split(":")[0] + "\n" +
+                                 "externalip=" + address.left(address.lastIndexOf(":")) + "\n" +
                                  "masternodeaddr=" + address + + "\n" +
                                  "masternodeprivkey=" + index.sibling(index.row(), MNModel::PRIV_KEY).data(Qt::DisplayRole).toString() + "\n";
             GUIUtil::setClipboard(exportedMN);


### PR DESCRIPTION
IPv6 addresses use `:` rather than `.` characters in their notation,
so needed to change the way `externalip` was being copied here.