### PR TITLE
[Trivial] Remove time offset warning when it gets back within range

### DIFF
--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -74,6 +74,7 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample, int nOffsetLimit)
         // Only let other nodes change our time by so much
         if (abs64(nMedian) < nOffsetLimit) {
             nTimeOffset = nMedian;
+            strMiscWarning = "";
         } else {
             nTimeOffset = (nMedian > 0 ? 1 : -1) * nOffsetLimit;
             std::string strMessage = _("Warning: Please check that your computer's date and time are correct! If your clock is wrong PIVX Core will not work properly.");


### PR DESCRIPTION
Simple update (related to #1128 and #1138).
Clear `strMiscWarning` if the median gets back within the offset limit (after being off, for example during startup when the node has very few time samples).