### PR TITLE
[GUI][Trivial] Remove every pushButton focus decoration property.

### DIFF
--- a/src/qt/pivx/forms/addnewaddressdialog.ui
+++ b/src/qt/pivx/forms/addnewaddressdialog.ui
@@ -170,6 +170,9 @@
             <height>50</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
           <property name="text">
            <string>CANCEL</string>
           </property>
@@ -182,6 +185,9 @@
             <width>0</width>
             <height>50</height>
            </size>
+          </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
           </property>
           <property name="text">
            <string>OK</string>

--- a/src/qt/pivx/forms/addnewcontactdialog.ui
+++ b/src/qt/pivx/forms/addnewcontactdialog.ui
@@ -126,6 +126,9 @@
             <height>24</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
           <property name="text">
            <string/>
           </property>
@@ -240,6 +243,9 @@
             <height>50</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
           <property name="text">
            <string>CANCEL</string>
           </property>
@@ -252,6 +258,9 @@
             <width>200</width>
             <height>50</height>
            </size>
+          </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
           </property>
           <property name="text">
            <string>OK</string>

--- a/src/qt/pivx/forms/addresseswidget.ui
+++ b/src/qt/pivx/forms/addresseswidget.ui
@@ -209,6 +209,9 @@
                   <height>100</height>
                  </size>
                 </property>
+                <property name="focusPolicy">
+                 <enum>Qt::NoFocus</enum>
+                </property>
                 <property name="text">
                  <string/>
                 </property>
@@ -383,6 +386,9 @@
                  <width>160</width>
                  <height>50</height>
                 </size>
+               </property>
+               <property name="focusPolicy">
+                <enum>Qt::NoFocus</enum>
                </property>
                <property name="text">
                 <string>OK</string>

--- a/src/qt/pivx/forms/coincontrolpivwidget.ui
+++ b/src/qt/pivx/forms/coincontrolpivwidget.ui
@@ -493,6 +493,9 @@
             <height>50</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
           <property name="text">
            <string>CANCEL</string>
           </property>
@@ -505,6 +508,9 @@
             <width>200</width>
             <height>50</height>
            </size>
+          </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
           </property>
           <property name="text">
            <string>OK</string>

--- a/src/qt/pivx/forms/coldstakingwidget.ui
+++ b/src/qt/pivx/forms/coldstakingwidget.ui
@@ -183,8 +183,11 @@
                        <height>30</height>
                       </size>
                      </property>
+                     <property name="focusPolicy">
+                      <enum>Qt::NoFocus</enum>
+                     </property>
                      <property name="text">
-                      <string>PushButton</string>
+                      <string/>
                      </property>
                      <property name="checkable">
                       <bool>true</bool>
@@ -208,8 +211,11 @@
                        <height>30</height>
                       </size>
                      </property>
+                     <property name="focusPolicy">
+                      <enum>Qt::NoFocus</enum>
+                     </property>
                      <property name="text">
-                      <string>PushButton</string>
+                      <string/>
                      </property>
                      <property name="checkable">
                       <bool>true</bool>
@@ -443,6 +449,9 @@
                  <height>50</height>
                 </size>
                </property>
+               <property name="focusPolicy">
+                <enum>Qt::NoFocus</enum>
+               </property>
                <property name="text">
                 <string/>
                </property>
@@ -477,6 +486,9 @@
                  <width>200</width>
                  <height>50</height>
                 </size>
+               </property>
+               <property name="focusPolicy">
+                <enum>Qt::NoFocus</enum>
                </property>
                <property name="text">
                 <string/>
@@ -694,6 +706,9 @@
                     <width>100</width>
                     <height>100</height>
                    </size>
+                  </property>
+                  <property name="focusPolicy">
+                   <enum>Qt::NoFocus</enum>
                   </property>
                   <property name="text">
                    <string/>

--- a/src/qt/pivx/forms/csrow.ui
+++ b/src/qt/pivx/forms/csrow.ui
@@ -153,6 +153,9 @@
           <height>32</height>
          </size>
         </property>
+        <property name="focusPolicy">
+         <enum>Qt::NoFocus</enum>
+        </property>
         <property name="styleSheet">
          <string notr="true">border:none; background-color:transparent;</string>
         </property>
@@ -160,7 +163,7 @@
          <string/>
         </property>
         <property name="icon">
-         <iconset resource="resource.qrc">
+         <iconset>
           <normaloff>://ic-menu-hover</normaloff>://ic-menu-hover</iconset>
         </property>
         <property name="iconSize">

--- a/src/qt/pivx/forms/dashboardwidget.ui
+++ b/src/qt/pivx/forms/dashboardwidget.ui
@@ -399,6 +399,9 @@
                 <height>100</height>
                </size>
               </property>
+              <property name="focusPolicy">
+               <enum>Qt::NoFocus</enum>
+              </property>
               <property name="text">
                <string/>
               </property>
@@ -447,8 +450,11 @@
              <height>50</height>
             </size>
            </property>
+           <property name="focusPolicy">
+            <enum>Qt::NoFocus</enum>
+           </property>
            <property name="text">
-            <string>PushButton</string>
+            <string/>
            </property>
           </widget>
          </item>
@@ -847,6 +853,9 @@
                            <height>19</height>
                           </size>
                          </property>
+                         <property name="focusPolicy">
+                          <enum>Qt::NoFocus</enum>
+                         </property>
                          <property name="styleSheet">
                           <string notr="true"/>
                          </property>
@@ -868,6 +877,9 @@
                            <width>19</width>
                            <height>19</height>
                           </size>
+                         </property>
+                         <property name="focusPolicy">
+                          <enum>Qt::NoFocus</enum>
                          </property>
                          <property name="styleSheet">
                           <string notr="true"/>
@@ -968,6 +980,9 @@ margin:0px;</string>
                      <height>16777215</height>
                     </size>
                    </property>
+                   <property name="focusPolicy">
+                    <enum>Qt::NoFocus</enum>
+                   </property>
                    <property name="text">
                     <string>Days</string>
                    </property>
@@ -992,6 +1007,9 @@ margin:0px;</string>
                      <width>16777215</width>
                      <height>16777215</height>
                     </size>
+                   </property>
+                   <property name="focusPolicy">
+                    <enum>Qt::NoFocus</enum>
                    </property>
                    <property name="text">
                     <string>Months</string>
@@ -1023,6 +1041,9 @@ margin:0px;</string>
                      <width>16777215</width>
                      <height>16777215</height>
                     </size>
+                   </property>
+                   <property name="focusPolicy">
+                    <enum>Qt::NoFocus</enum>
                    </property>
                    <property name="text">
                     <string>Years</string>
@@ -1249,6 +1270,9 @@ margin:0px;</string>
                   <width>100</width>
                   <height>100</height>
                  </size>
+                </property>
+                <property name="focusPolicy">
+                 <enum>Qt::NoFocus</enum>
                 </property>
                 <property name="text">
                  <string/>

--- a/src/qt/pivx/forms/defaultdialog.ui
+++ b/src/qt/pivx/forms/defaultdialog.ui
@@ -129,6 +129,9 @@
             <height>24</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
           <property name="text">
            <string/>
           </property>
@@ -210,6 +213,9 @@
             <height>16777215</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
           <property name="text">
            <string>CANCEL</string>
           </property>
@@ -228,6 +234,9 @@
             <width>170</width>
             <height>16777215</height>
            </size>
+          </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
           </property>
           <property name="text">
            <string>SAVE</string>

--- a/src/qt/pivx/forms/denomgenerationdialog.ui
+++ b/src/qt/pivx/forms/denomgenerationdialog.ui
@@ -129,8 +129,11 @@
             <height>24</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
           <property name="text">
-           <string>PushButton</string>
+           <string/>
           </property>
          </widget>
         </item>
@@ -311,6 +314,9 @@
             <height>50</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
           <property name="text">
            <string>CANCEL</string>
           </property>
@@ -323,6 +329,9 @@
             <width>0</width>
             <height>50</height>
            </size>
+          </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
           </property>
           <property name="text">
            <string>SAVE</string>

--- a/src/qt/pivx/forms/expandablebutton.ui
+++ b/src/qt/pivx/forms/expandablebutton.ui
@@ -55,6 +55,9 @@
        <height>36</height>
       </size>
      </property>
+     <property name="focusPolicy">
+      <enum>Qt::NoFocus</enum>
+     </property>
      <property name="styleSheet">
       <string notr="true">padding-right:5px;padding-left:5px;</string>
      </property>

--- a/src/qt/pivx/forms/masternodeswidget.ui
+++ b/src/qt/pivx/forms/masternodeswidget.ui
@@ -206,6 +206,9 @@
                   <height>100</height>
                  </size>
                 </property>
+                <property name="focusPolicy">
+                 <enum>Qt::NoFocus</enum>
+                </property>
                 <property name="text">
                  <string/>
                 </property>
@@ -271,8 +274,11 @@
               <height>50</height>
              </size>
             </property>
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
+            </property>
             <property name="text">
-             <string>PushButton</string>
+             <string/>
             </property>
            </widget>
           </item>

--- a/src/qt/pivx/forms/masternodewizarddialog.ui
+++ b/src/qt/pivx/forms/masternodewizarddialog.ui
@@ -82,6 +82,9 @@
             <height>20</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
           <property name="text">
            <string/>
           </property>
@@ -504,6 +507,9 @@
                 <height>16777215</height>
                </size>
               </property>
+              <property name="focusPolicy">
+               <enum>Qt::NoFocus</enum>
+              </property>
               <property name="text">
                <string>Intro</string>
               </property>
@@ -545,6 +551,9 @@
                 <height>16777215</height>
                </size>
               </property>
+              <property name="focusPolicy">
+               <enum>Qt::NoFocus</enum>
+              </property>
               <property name="text">
                <string>Name</string>
               </property>
@@ -582,6 +591,9 @@
                 <width>80</width>
                 <height>16777215</height>
                </size>
+              </property>
+              <property name="focusPolicy">
+               <enum>Qt::NoFocus</enum>
               </property>
               <property name="text">
                <string>Address</string>
@@ -1039,6 +1051,9 @@
             <height>16777215</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
           <property name="text">
            <string>CANCEL</string>
           </property>
@@ -1057,6 +1072,9 @@
             <width>180</width>
             <height>16777215</height>
            </size>
+          </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
           </property>
           <property name="text">
            <string>OK</string>

--- a/src/qt/pivx/forms/mninfodialog.ui
+++ b/src/qt/pivx/forms/mninfodialog.ui
@@ -289,6 +289,9 @@ background:transparent;
                        <height>34</height>
                       </size>
                      </property>
+                     <property name="focusPolicy">
+                      <enum>Qt::NoFocus</enum>
+                     </property>
                      <property name="text">
                       <string/>
                      </property>
@@ -409,6 +412,9 @@ background:transparent;
                        <width>34</width>
                        <height>34</height>
                       </size>
+                     </property>
+                     <property name="focusPolicy">
+                      <enum>Qt::NoFocus</enum>
                      </property>
                      <property name="text">
                       <string/>
@@ -571,6 +577,9 @@ background:transparent;
                        <width>34</width>
                        <height>34</height>
                       </size>
+                     </property>
+                     <property name="focusPolicy">
+                      <enum>Qt::NoFocus</enum>
                      </property>
                      <property name="text">
                       <string/>

--- a/src/qt/pivx/forms/mnrow.ui
+++ b/src/qt/pivx/forms/mnrow.ui
@@ -116,6 +116,9 @@
       </item>
       <item>
        <widget class="QPushButton" name="pushButtonMenu">
+        <property name="focusPolicy">
+         <enum>Qt::NoFocus</enum>
+        </property>
         <property name="styleSheet">
          <string notr="true">border:none; background-color:transparent; padding:0px;</string>
         </property>

--- a/src/qt/pivx/forms/navmenuwidget.ui
+++ b/src/qt/pivx/forms/navmenuwidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>102</width>
-    <height>706</height>
+    <height>786</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -36,7 +36,7 @@ margin:0px;</string>
    </property>
    <item>
     <widget class="QWidget" name="navContainer_2" native="true">
-     <layout class="QVBoxLayout" name="navContainer" stretch="0,0,0,0,0,0,0,0,1,0">
+     <layout class="QVBoxLayout" name="navContainer" stretch="0,0,0,0,0,0,0,0,1,0,0">
       <property name="spacing">
        <number>0</number>
       </property>
@@ -59,6 +59,9 @@ margin:0px;</string>
           <width>0</width>
           <height>120</height>
          </size>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::NoFocus</enum>
         </property>
         <property name="text">
          <string/>

--- a/src/qt/pivx/forms/optionbutton.ui
+++ b/src/qt/pivx/forms/optionbutton.ui
@@ -154,6 +154,9 @@
           <height>24</height>
          </size>
         </property>
+        <property name="focusPolicy">
+         <enum>Qt::NoFocus</enum>
+        </property>
         <property name="text">
          <string/>
         </property>

--- a/src/qt/pivx/forms/privacywidget.ui
+++ b/src/qt/pivx/forms/privacywidget.ui
@@ -158,6 +158,9 @@
                       <height>30</height>
                      </size>
                     </property>
+                    <property name="focusPolicy">
+                     <enum>Qt::NoFocus</enum>
+                    </property>
                     <property name="text">
                      <string>PushButton</string>
                     </property>
@@ -182,6 +185,9 @@
                       <width>120</width>
                       <height>30</height>
                      </size>
+                    </property>
+                    <property name="focusPolicy">
+                     <enum>Qt::NoFocus</enum>
                     </property>
                     <property name="text">
                      <string>PushButton</string>
@@ -298,6 +304,9 @@
                     <width>180</width>
                     <height>50</height>
                    </size>
+                  </property>
+                  <property name="focusPolicy">
+                   <enum>Qt::NoFocus</enum>
                   </property>
                   <property name="text">
                    <string>PushButton</string>
@@ -462,6 +471,9 @@
                     <width>100</width>
                     <height>100</height>
                    </size>
+                  </property>
+                  <property name="focusPolicy">
+                   <enum>Qt::NoFocus</enum>
                   </property>
                   <property name="text">
                    <string/>

--- a/src/qt/pivx/forms/receivedialog.ui
+++ b/src/qt/pivx/forms/receivedialog.ui
@@ -129,8 +129,11 @@
             <height>24</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
           <property name="text">
-           <string>PushButton</string>
+           <string/>
           </property>
          </widget>
         </item>
@@ -242,6 +245,9 @@
             <height>50</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
           <property name="text">
            <string>CANCEL</string>
           </property>
@@ -254,6 +260,9 @@
             <width>0</width>
             <height>50</height>
            </size>
+          </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
           </property>
           <property name="text">
            <string>OK</string>

--- a/src/qt/pivx/forms/receivewidget.ui
+++ b/src/qt/pivx/forms/receivewidget.ui
@@ -262,6 +262,9 @@
             <layout class="QHBoxLayout" name="horizontalLayout_4">
              <item alignment="Qt::AlignHCenter">
               <widget class="QPushButton" name="pushButtonLabel">
+               <property name="focusPolicy">
+                <enum>Qt::NoFocus</enum>
+               </property>
                <property name="text">
                 <string>Add Label</string>
                </property>
@@ -269,6 +272,9 @@
              </item>
              <item alignment="Qt::AlignHCenter">
               <widget class="QPushButton" name="pushButtonNewAddress">
+               <property name="focusPolicy">
+                <enum>Qt::NoFocus</enum>
+               </property>
                <property name="text">
                 <string>Generate Address</string>
                </property>
@@ -276,6 +282,9 @@
              </item>
              <item alignment="Qt::AlignHCenter">
               <widget class="QPushButton" name="pushButtonCopy">
+               <property name="focusPolicy">
+                <enum>Qt::NoFocus</enum>
+               </property>
                <property name="text">
                 <string>Copy</string>
                </property>

--- a/src/qt/pivx/forms/requestdialog.ui
+++ b/src/qt/pivx/forms/requestdialog.ui
@@ -129,6 +129,9 @@
             <height>24</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
           <property name="text">
            <string/>
           </property>
@@ -649,6 +652,9 @@
              <height>50</height>
             </size>
            </property>
+           <property name="focusPolicy">
+            <enum>Qt::NoFocus</enum>
+           </property>
            <property name="text">
             <string>CANCEL</string>
            </property>
@@ -661,6 +667,9 @@
              <width>180</width>
              <height>50</height>
             </size>
+           </property>
+           <property name="focusPolicy">
+            <enum>Qt::NoFocus</enum>
            </property>
            <property name="text">
             <string>REQUEST</string>

--- a/src/qt/pivx/forms/send.ui
+++ b/src/qt/pivx/forms/send.ui
@@ -143,8 +143,11 @@
                    <height>30</height>
                   </size>
                  </property>
+                 <property name="focusPolicy">
+                  <enum>Qt::NoFocus</enum>
+                 </property>
                  <property name="text">
-                  <string>PushButton</string>
+                  <string/>
                  </property>
                  <property name="checkable">
                   <bool>true</bool>
@@ -168,8 +171,11 @@
                    <height>30</height>
                   </size>
                  </property>
+                 <property name="focusPolicy">
+                  <enum>Qt::NoFocus</enum>
+                 </property>
                  <property name="text">
-                  <string>PushButton</string>
+                  <string/>
                  </property>
                  <property name="checkable">
                   <bool>true</bool>
@@ -378,6 +384,9 @@
           </item>
           <item>
            <widget class="QPushButton" name="pushButtonFee">
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
+            </property>
             <property name="text">
              <string>PushButton</string>
             </property>
@@ -401,6 +410,9 @@
           </item>
           <item>
            <widget class="QPushButton" name="pushButtonClear">
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
+            </property>
             <property name="layoutDirection">
              <enum>Qt::RightToLeft</enum>
             </property>
@@ -427,6 +439,9 @@
           </item>
           <item>
            <widget class="QPushButton" name="pushButtonAddRecipient">
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
+            </property>
             <property name="text">
              <string>PushButton</string>
             </property>
@@ -657,8 +672,11 @@
               <height>50</height>
              </size>
             </property>
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
+            </property>
             <property name="text">
-             <string>PushButton</string>
+             <string/>
             </property>
            </widget>
           </item>
@@ -760,6 +778,9 @@
               <width>200</width>
               <height>50</height>
              </size>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
             </property>
             <property name="text">
              <string>PushButton</string>

--- a/src/qt/pivx/forms/sendchangeaddressdialog.ui
+++ b/src/qt/pivx/forms/sendchangeaddressdialog.ui
@@ -129,8 +129,11 @@
             <height>24</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
           <property name="text">
-           <string>PushButton</string>
+           <string/>
           </property>
          </widget>
         </item>
@@ -239,6 +242,9 @@
             <height>50</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
           <property name="text">
            <string>CANCEL</string>
           </property>
@@ -251,6 +257,9 @@
             <width>180</width>
             <height>50</height>
            </size>
+          </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
           </property>
           <property name="text">
            <string>OK</string>

--- a/src/qt/pivx/forms/sendconfirmdialog.ui
+++ b/src/qt/pivx/forms/sendconfirmdialog.ui
@@ -138,6 +138,9 @@
             <height>24</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
           <property name="text">
            <string/>
           </property>
@@ -202,9 +205,9 @@ background:transparent;
             <property name="geometry">
              <rect>
               <x>0</x>
-              <y>-178</y>
+              <y>0</y>
               <width>556</width>
-              <height>680</height>
+              <height>672</height>
              </rect>
             </property>
             <property name="autoFillBackground">
@@ -286,6 +289,9 @@ background:transparent;
                        <height>34</height>
                       </size>
                      </property>
+                     <property name="focusPolicy">
+                      <enum>Qt::NoFocus</enum>
+                     </property>
                      <property name="text">
                       <string/>
                      </property>
@@ -361,6 +367,9 @@ background:transparent;
                        <width>38</width>
                        <height>20</height>
                       </size>
+                     </property>
+                     <property name="focusPolicy">
+                      <enum>Qt::NoFocus</enum>
                      </property>
                      <property name="styleSheet">
                       <string notr="true"/>
@@ -509,6 +518,9 @@ background:transparent;
                        <width>34</width>
                        <height>20</height>
                       </size>
+                     </property>
+                     <property name="focusPolicy">
+                      <enum>Qt::NoFocus</enum>
                      </property>
                      <property name="styleSheet">
                       <string notr="true"/>
@@ -898,6 +910,9 @@ background:transparent;
              <height>50</height>
             </size>
            </property>
+           <property name="focusPolicy">
+            <enum>Qt::NoFocus</enum>
+           </property>
            <property name="text">
             <string>CANCEL</string>
            </property>
@@ -910,6 +925,9 @@ background:transparent;
              <width>200</width>
              <height>50</height>
             </size>
+           </property>
+           <property name="focusPolicy">
+            <enum>Qt::NoFocus</enum>
            </property>
            <property name="text">
             <string>OK</string>

--- a/src/qt/pivx/forms/sendcustomfeedialog.ui
+++ b/src/qt/pivx/forms/sendcustomfeedialog.ui
@@ -328,6 +328,9 @@
             <height>50</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
           <property name="text">
            <string>CANCEL</string>
           </property>
@@ -340,6 +343,9 @@
             <width>180</width>
             <height>50</height>
            </size>
+          </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
           </property>
           <property name="text">
            <string>OK</string>

--- a/src/qt/pivx/forms/sendmultirow.ui
+++ b/src/qt/pivx/forms/sendmultirow.ui
@@ -218,6 +218,9 @@
               <height>16777215</height>
              </size>
             </property>
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
+            </property>
             <property name="text">
              <string/>
             </property>

--- a/src/qt/pivx/forms/snackbar.ui
+++ b/src/qt/pivx/forms/snackbar.ui
@@ -95,6 +95,9 @@ color:white;</string>
           <height>24</height>
          </size>
         </property>
+        <property name="focusPolicy">
+         <enum>Qt::NoFocus</enum>
+        </property>
         <property name="autoFillBackground">
          <bool>true</bool>
         </property>

--- a/src/qt/pivx/forms/topbar.ui
+++ b/src/qt/pivx/forms/topbar.ui
@@ -641,6 +641,9 @@ border:none;</string>
                 <height>70</height>
                </size>
               </property>
+              <property name="focusPolicy">
+               <enum>Qt::NoFocus</enum>
+              </property>
               <property name="text">
                <string/>
               </property>
@@ -681,6 +684,9 @@ border:none;</string>
                 <width>36</width>
                 <height>36</height>
                </size>
+              </property>
+              <property name="focusPolicy">
+               <enum>Qt::NoFocus</enum>
               </property>
               <property name="text">
                <string/>

--- a/src/qt/pivx/forms/txrow.ui
+++ b/src/qt/pivx/forms/txrow.ui
@@ -79,6 +79,9 @@
          </property>
          <item>
           <widget class="QPushButton" name="icon">
+           <property name="focusPolicy">
+            <enum>Qt::NoFocus</enum>
+           </property>
            <property name="styleSheet">
             <string notr="true">border:none;</string>
            </property>

--- a/src/qt/pivx/forms/walletpassworddialog.ui
+++ b/src/qt/pivx/forms/walletpassworddialog.ui
@@ -129,8 +129,11 @@
             <height>24</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
           <property name="text">
-           <string>PushButton</string>
+           <string/>
           </property>
          </widget>
         </item>
@@ -379,6 +382,9 @@
             <height>50</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
           <property name="text">
            <string>CANCEL</string>
           </property>
@@ -391,6 +397,9 @@
             <width>180</width>
             <height>50</height>
            </size>
+          </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
           </property>
           <property name="text">
            <string>OK</string>

--- a/src/qt/pivx/forms/welcomecontentwidget.ui
+++ b/src/qt/pivx/forms/welcomecontentwidget.ui
@@ -237,6 +237,9 @@
                       <height>22</height>
                      </size>
                     </property>
+                    <property name="focusPolicy">
+                     <enum>Qt::NoFocus</enum>
+                    </property>
                     <property name="text">
                      <string>1</string>
                     </property>
@@ -319,6 +322,9 @@
                       <width>22</width>
                       <height>22</height>
                      </size>
+                    </property>
+                    <property name="focusPolicy">
+                     <enum>Qt::NoFocus</enum>
                     </property>
                     <property name="text">
                      <string>2</string>
@@ -403,6 +409,9 @@
                       <height>22</height>
                      </size>
                     </property>
+                    <property name="focusPolicy">
+                     <enum>Qt::NoFocus</enum>
+                    </property>
                     <property name="text">
                      <string>3</string>
                     </property>
@@ -485,6 +494,9 @@
                       <width>22</width>
                       <height>22</height>
                      </size>
+                    </property>
+                    <property name="focusPolicy">
+                     <enum>Qt::NoFocus</enum>
                     </property>
                     <property name="text">
                      <string>4</string>
@@ -597,6 +609,9 @@
                       <height>16777215</height>
                      </size>
                     </property>
+                    <property name="focusPolicy">
+                     <enum>Qt::NoFocus</enum>
+                    </property>
                     <property name="text">
                      <string>Language</string>
                     </property>
@@ -638,6 +653,9 @@
                       <height>16777215</height>
                      </size>
                     </property>
+                    <property name="focusPolicy">
+                     <enum>Qt::NoFocus</enum>
+                    </property>
                     <property name="text">
                      <string>Welcome</string>
                     </property>
@@ -676,6 +694,9 @@
                       <height>16777215</height>
                      </size>
                     </property>
+                    <property name="focusPolicy">
+                     <enum>Qt::NoFocus</enum>
+                    </property>
                     <property name="text">
                      <string>Privacy</string>
                     </property>
@@ -713,6 +734,9 @@
                       <width>100</width>
                       <height>16777215</height>
                      </size>
+                    </property>
+                    <property name="focusPolicy">
+                     <enum>Qt::NoFocus</enum>
                     </property>
                     <property name="text">
                      <string>Masternodes</string>

--- a/src/qt/pivx/settings/forms/settingsbackupwallet.ui
+++ b/src/qt/pivx/settings/forms/settingsbackupwallet.ui
@@ -107,8 +107,11 @@
             <height>50</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
           <property name="text">
-           <string>PushButton</string>
+           <string/>
           </property>
          </widget>
         </item>
@@ -162,8 +165,11 @@
             <height>50</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
           <property name="text">
-           <string>PushButton</string>
+           <string/>
           </property>
          </widget>
         </item>
@@ -283,8 +289,11 @@
             <height>50</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
           <property name="text">
-           <string>PushButton</string>
+           <string/>
           </property>
          </widget>
         </item>

--- a/src/qt/pivx/settings/forms/settingsbittoolwidget.ui
+++ b/src/qt/pivx/settings/forms/settingsbittoolwidget.ui
@@ -129,8 +129,11 @@
                  <height>30</height>
                 </size>
                </property>
+               <property name="focusPolicy">
+                <enum>Qt::NoFocus</enum>
+               </property>
                <property name="text">
-                <string>PushButton</string>
+                <string/>
                </property>
                <property name="checkable">
                 <bool>true</bool>
@@ -154,8 +157,11 @@
                  <height>30</height>
                 </size>
                </property>
+               <property name="focusPolicy">
+                <enum>Qt::NoFocus</enum>
+               </property>
                <property name="text">
-                <string>PushButton</string>
+                <string/>
                </property>
                <property name="checkable">
                 <bool>true</bool>
@@ -864,6 +870,9 @@
                   <height>50</height>
                  </size>
                 </property>
+                <property name="focusPolicy">
+                 <enum>Qt::NoFocus</enum>
+                </property>
                 <property name="text">
                  <string>Clear</string>
                 </property>
@@ -899,8 +908,11 @@
                   <height>50</height>
                  </size>
                 </property>
+                <property name="focusPolicy">
+                 <enum>Qt::NoFocus</enum>
+                </property>
                 <property name="text">
-                 <string>PushButton</string>
+                 <string/>
                 </property>
                </widget>
               </item>

--- a/src/qt/pivx/settings/forms/settingsconsolewidget.ui
+++ b/src/qt/pivx/settings/forms/settingsconsolewidget.ui
@@ -82,6 +82,9 @@
               <height>40</height>
              </size>
             </property>
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
+            </property>
             <property name="text">
              <string/>
             </property>
@@ -100,6 +103,9 @@
               <width>16777215</width>
               <height>40</height>
              </size>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
             </property>
             <property name="text">
              <string/>

--- a/src/qt/pivx/settings/forms/settingsdisplayoptionswidget.ui
+++ b/src/qt/pivx/settings/forms/settingsdisplayoptionswidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>493</width>
+    <width>511</width>
     <height>434</height>
    </rect>
   </property>
@@ -175,7 +175,7 @@
            </spacer>
           </item>
           <item>
-           <widget class="QValueComboBox" name="comboBoxUnit">
+           <widget class="QValueComboBox" name="comboBoxUnit" native="true">
             <property name="minimumSize">
              <size>
               <width>180</width>
@@ -272,8 +272,11 @@
             <height>30</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
           <property name="text">
-           <string>PushButton</string>
+           <string/>
           </property>
           <property name="checkable">
            <bool>true</bool>
@@ -358,6 +361,9 @@
               <height>16777215</height>
              </size>
             </property>
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
+            </property>
             <property name="text">
              <string>Reset to default</string>
             </property>
@@ -370,6 +376,9 @@
               <width>0</width>
               <height>50</height>
              </size>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
             </property>
             <property name="text">
              <string>Discard changes</string>
@@ -406,8 +415,11 @@
               <height>50</height>
              </size>
             </property>
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
+            </property>
             <property name="text">
-             <string>PushButton</string>
+             <string/>
             </property>
            </widget>
           </item>
@@ -420,6 +432,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QValueComboBox</class>
+   <extends>QWidget</extends>
+   <header>qvaluecombobox.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/qt/pivx/settings/forms/settingsfaqwidget.ui
+++ b/src/qt/pivx/settings/forms/settingsfaqwidget.ui
@@ -159,6 +159,9 @@
                        <height>50</height>
                       </size>
                      </property>
+                     <property name="focusPolicy">
+                      <enum>Qt::NoFocus</enum>
+                     </property>
                      <property name="text">
                       <string>1) What is PIVX?</string>
                      </property>
@@ -187,6 +190,9 @@
                        <height>50</height>
                       </size>
                      </property>
+                     <property name="focusPolicy">
+                      <enum>Qt::NoFocus</enum>
+                     </property>
                      <property name="text">
                       <string>2) Why are my PIV unspendable?</string>
                      </property>
@@ -211,6 +217,9 @@
                        <width>16777215</width>
                        <height>16777215</height>
                       </size>
+                     </property>
+                     <property name="focusPolicy">
+                      <enum>Qt::NoFocus</enum>
                      </property>
                      <property name="text">
                       <string>3) PIVX privacy? What is Zerocoin (zPIV)?</string>
@@ -237,6 +246,9 @@
                        <height>16777215</height>
                       </size>
                      </property>
+                     <property name="focusPolicy">
+                      <enum>Qt::NoFocus</enum>
+                     </property>
                      <property name="text">
                       <string>4) Why are my zPIV unspendable?</string>
                      </property>
@@ -255,6 +267,9 @@
                        <width>0</width>
                        <height>50</height>
                       </size>
+                     </property>
+                     <property name="focusPolicy">
+                      <enum>Qt::NoFocus</enum>
                      </property>
                      <property name="text">
                       <string>5) Why did my wallet convert the balance
@@ -276,6 +291,9 @@
                        <height>50</height>
                       </size>
                      </property>
+                     <property name="focusPolicy">
+                      <enum>Qt::NoFocus</enum>
+                     </property>
                      <property name="text">
                       <string>6) How do I receive PIV/zPIV?</string>
                      </property>
@@ -294,6 +312,9 @@
                        <width>0</width>
                        <height>50</height>
                       </size>
+                     </property>
+                     <property name="focusPolicy">
+                      <enum>Qt::NoFocus</enum>
                      </property>
                      <property name="text">
                       <string>7) How do I stake PIV/zPIV?</string>
@@ -314,6 +335,9 @@
                        <height>50</height>
                       </size>
                      </property>
+                     <property name="focusPolicy">
+                      <enum>Qt::NoFocus</enum>
+                     </property>
                      <property name="text">
                       <string>8) Where I should go if I need support?</string>
                      </property>
@@ -333,6 +357,9 @@
                        <height>50</height>
                       </size>
                      </property>
+                     <property name="focusPolicy">
+                      <enum>Qt::NoFocus</enum>
+                     </property>
                      <property name="text">
                       <string>9) What is a Master Node?</string>
                      </property>
@@ -351,6 +378,9 @@
                        <width>0</width>
                        <height>50</height>
                       </size>
+                     </property>
+                     <property name="focusPolicy">
+                      <enum>Qt::NoFocus</enum>
                      </property>
                      <property name="text">
                       <string>10) What is a Master Node Controller?</string>
@@ -409,6 +439,9 @@
                </item>
                <item>
                 <widget class="QPushButton" name="pushButtonWebLink">
+                 <property name="focusPolicy">
+                  <enum>Qt::NoFocus</enum>
+                 </property>
                  <property name="text">
                   <string>PushButton</string>
                  </property>

--- a/src/qt/pivx/settings/forms/settingsinformationwidget.ui
+++ b/src/qt/pivx/settings/forms/settingsinformationwidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>474</width>
-    <height>454</height>
+    <height>464</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -109,6 +109,9 @@
                  <height>40</height>
                 </size>
                </property>
+               <property name="focusPolicy">
+                <enum>Qt::NoFocus</enum>
+               </property>
                <property name="text">
                 <string>Network Monitor</string>
                </property>
@@ -127,6 +130,9 @@
                  <width>120</width>
                  <height>40</height>
                 </size>
+               </property>
+               <property name="focusPolicy">
+                <enum>Qt::NoFocus</enum>
                </property>
                <property name="text">
                 <string/>
@@ -152,6 +158,9 @@
                  <width>125</width>
                  <height>40</height>
                 </size>
+               </property>
+               <property name="focusPolicy">
+                <enum>Qt::NoFocus</enum>
                </property>
                <property name="text">
                 <string/>

--- a/src/qt/pivx/settings/forms/settingsmainoptionswidget.ui
+++ b/src/qt/pivx/settings/forms/settingsmainoptionswidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>428</width>
+    <width>511</width>
     <height>434</height>
    </rect>
   </property>
@@ -385,6 +385,9 @@
               <height>16777215</height>
              </size>
             </property>
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
+            </property>
             <property name="text">
              <string>Reset to default</string>
             </property>
@@ -397,6 +400,9 @@
               <width>0</width>
               <height>50</height>
              </size>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
             </property>
             <property name="text">
              <string>Discard changes</string>
@@ -432,6 +438,9 @@
               <width>200</width>
               <height>50</height>
              </size>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
             </property>
             <property name="text">
              <string>SAVE</string>

--- a/src/qt/pivx/settings/forms/settingsmultisenddialog.ui
+++ b/src/qt/pivx/settings/forms/settingsmultisenddialog.ui
@@ -129,6 +129,9 @@
             <height>24</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
           <property name="text">
            <string/>
           </property>
@@ -388,6 +391,9 @@
             <height>16777215</height>
            </size>
           </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
           <property name="text">
            <string>CANCEL</string>
           </property>
@@ -406,6 +412,9 @@
             <width>200</width>
             <height>16777215</height>
            </size>
+          </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
           </property>
           <property name="text">
            <string>SAVE</string>

--- a/src/qt/pivx/settings/forms/settingsmultisendwidget.ui
+++ b/src/qt/pivx/settings/forms/settingsmultisendwidget.ui
@@ -129,6 +129,9 @@
                   <height>30</height>
                  </size>
                 </property>
+                <property name="focusPolicy">
+                 <enum>Qt::NoFocus</enum>
+                </property>
                 <property name="text">
                  <string/>
                 </property>
@@ -153,6 +156,9 @@
                   <width>120</width>
                   <height>30</height>
                  </size>
+                </property>
+                <property name="focusPolicy">
+                 <enum>Qt::NoFocus</enum>
                 </property>
                 <property name="text">
                  <string/>
@@ -283,6 +289,9 @@
                   <width>100</width>
                   <height>100</height>
                  </size>
+                </property>
+                <property name="focusPolicy">
+                 <enum>Qt::NoFocus</enum>
                 </property>
                 <property name="text">
                  <string/>
@@ -428,6 +437,9 @@
               <height>50</height>
              </size>
             </property>
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
+            </property>
             <property name="text">
              <string/>
             </property>
@@ -462,6 +474,9 @@
               <width>200</width>
               <height>50</height>
              </size>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
             </property>
             <property name="text">
              <string/>

--- a/src/qt/pivx/settings/forms/settingssignmessagewidgets.ui
+++ b/src/qt/pivx/settings/forms/settingssignmessagewidgets.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>438</width>
-    <height>574</height>
+    <height>579</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -158,8 +158,11 @@
                      <height>30</height>
                     </size>
                    </property>
+                   <property name="focusPolicy">
+                    <enum>Qt::NoFocus</enum>
+                   </property>
                    <property name="text">
-                    <string>PushButton</string>
+                    <string/>
                    </property>
                    <property name="checkable">
                     <bool>true</bool>
@@ -183,8 +186,11 @@
                      <height>30</height>
                     </size>
                    </property>
+                   <property name="focusPolicy">
+                    <enum>Qt::NoFocus</enum>
+                   </property>
                    <property name="text">
-                    <string>PushButton</string>
+                    <string/>
                    </property>
                    <property name="checkable">
                     <bool>true</bool>
@@ -481,6 +487,9 @@
                <height>50</height>
               </size>
              </property>
+             <property name="focusPolicy">
+              <enum>Qt::NoFocus</enum>
+             </property>
              <property name="text">
               <string>Clear</string>
              </property>
@@ -500,8 +509,11 @@
                <height>50</height>
               </size>
              </property>
+             <property name="focusPolicy">
+              <enum>Qt::NoFocus</enum>
+             </property>
              <property name="text">
-              <string>PushButton</string>
+              <string/>
              </property>
             </widget>
            </item>

--- a/src/qt/pivx/settings/forms/settingswalletoptionswidget.ui
+++ b/src/qt/pivx/settings/forms/settingswalletoptionswidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>493</width>
+    <width>511</width>
     <height>654</height>
    </rect>
   </property>
@@ -435,6 +435,9 @@
               <height>16777215</height>
              </size>
             </property>
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
+            </property>
             <property name="text">
              <string>Reset to default</string>
             </property>
@@ -447,6 +450,9 @@
               <width>0</width>
               <height>50</height>
              </size>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
             </property>
             <property name="text">
              <string>Discard changes</string>
@@ -483,8 +489,11 @@
               <height>50</height>
              </size>
             </property>
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
+            </property>
             <property name="text">
-             <string>PushButton</string>
+             <string/>
             </property>
            </widget>
           </item>

--- a/src/qt/pivx/settings/forms/settingswalletrepairwidget.ui
+++ b/src/qt/pivx/settings/forms/settingswalletrepairwidget.ui
@@ -163,8 +163,11 @@
                   <height>40</height>
                  </size>
                 </property>
+                <property name="focusPolicy">
+                 <enum>Qt::NoFocus</enum>
+                </property>
                 <property name="text">
-                 <string>PushButton</string>
+                 <string/>
                 </property>
                </widget>
               </item>
@@ -225,8 +228,11 @@
                   <height>40</height>
                  </size>
                 </property>
+                <property name="focusPolicy">
+                 <enum>Qt::NoFocus</enum>
+                </property>
                 <property name="text">
-                 <string>PushButton</string>
+                 <string/>
                 </property>
                </widget>
               </item>
@@ -287,8 +293,11 @@
                   <height>40</height>
                  </size>
                 </property>
+                <property name="focusPolicy">
+                 <enum>Qt::NoFocus</enum>
+                </property>
                 <property name="text">
-                 <string>PushButton</string>
+                 <string/>
                 </property>
                </widget>
               </item>
@@ -349,8 +358,11 @@
                   <height>40</height>
                  </size>
                 </property>
+                <property name="focusPolicy">
+                 <enum>Qt::NoFocus</enum>
+                </property>
                 <property name="text">
-                 <string>PushButton</string>
+                 <string/>
                 </property>
                </widget>
               </item>
@@ -411,8 +423,11 @@
                   <height>40</height>
                  </size>
                 </property>
+                <property name="focusPolicy">
+                 <enum>Qt::NoFocus</enum>
+                </property>
                 <property name="text">
-                 <string>PushButton</string>
+                 <string/>
                 </property>
                </widget>
               </item>
@@ -473,8 +488,11 @@
                   <height>40</height>
                  </size>
                 </property>
+                <property name="focusPolicy">
+                 <enum>Qt::NoFocus</enum>
+                </property>
                 <property name="text">
-                 <string>PushButton</string>
+                 <string/>
                 </property>
                </widget>
               </item>
@@ -535,8 +553,11 @@
                   <height>40</height>
                  </size>
                 </property>
+                <property name="focusPolicy">
+                 <enum>Qt::NoFocus</enum>
+                </property>
                 <property name="text">
-                 <string>PushButton</string>
+                 <string/>
                 </property>
                </widget>
               </item>

--- a/src/qt/pivx/settings/forms/settingswidget.ui
+++ b/src/qt/pivx/settings/forms/settingswidget.ui
@@ -133,7 +133,7 @@
              <property name="geometry">
               <rect>
                <x>0</x>
-               <y>0</y>
+               <y>-490</y>
                <width>230</width>
                <height>887</height>
               </rect>
@@ -220,6 +220,9 @@
                          <height>50</height>
                         </size>
                        </property>
+                       <property name="focusPolicy">
+                        <enum>Qt::NoFocus</enum>
+                       </property>
                        <property name="text">
                         <string>Wallet Data</string>
                        </property>
@@ -265,6 +268,9 @@
                           <height>50</height>
                          </size>
                         </property>
+                        <property name="focusPolicy">
+                         <enum>Qt::NoFocus</enum>
+                        </property>
                         <property name="text">
                          <string>Wallet</string>
                         </property>
@@ -289,6 +295,9 @@
                           <width>16777215</width>
                           <height>50</height>
                          </size>
+                        </property>
+                        <property name="focusPolicy">
+                         <enum>Qt::NoFocus</enum>
                         </property>
                         <property name="text">
                          <string>Multisend</string>
@@ -328,6 +337,9 @@
                          <width>16777215</width>
                          <height>50</height>
                         </size>
+                       </property>
+                       <property name="focusPolicy">
+                        <enum>Qt::NoFocus</enum>
                        </property>
                        <property name="text">
                         <string>Tools</string>
@@ -374,6 +386,9 @@
                           <height>50</height>
                          </size>
                         </property>
+                        <property name="focusPolicy">
+                         <enum>Qt::NoFocus</enum>
+                        </property>
                         <property name="text">
                          <string>Sign/Verify Message</string>
                         </property>
@@ -398,6 +413,9 @@
                           <width>16777215</width>
                           <height>50</height>
                          </size>
+                        </property>
+                        <property name="focusPolicy">
+                         <enum>Qt::NoFocus</enum>
                         </property>
                         <property name="text">
                          <string>BIP38 Tool</string>
@@ -437,6 +455,9 @@
                          <width>16777215</width>
                          <height>50</height>
                         </size>
+                       </property>
+                       <property name="focusPolicy">
+                        <enum>Qt::NoFocus</enum>
                        </property>
                        <property name="text">
                         <string>Options</string>
@@ -483,6 +504,9 @@
                           <height>50</height>
                          </size>
                         </property>
+                        <property name="focusPolicy">
+                         <enum>Qt::NoFocus</enum>
+                        </property>
                         <property name="text">
                          <string>Main</string>
                         </property>
@@ -511,6 +535,9 @@
                           <height>50</height>
                          </size>
                         </property>
+                        <property name="focusPolicy">
+                         <enum>Qt::NoFocus</enum>
+                        </property>
                         <property name="text">
                          <string>Wallet</string>
                         </property>
@@ -535,6 +562,9 @@
                           <width>16777215</width>
                           <height>50</height>
                          </size>
+                        </property>
+                        <property name="focusPolicy">
+                         <enum>Qt::NoFocus</enum>
                         </property>
                         <property name="text">
                          <string>Display</string>
@@ -574,6 +604,9 @@
                          <width>16777215</width>
                          <height>50</height>
                         </size>
+                       </property>
+                       <property name="focusPolicy">
+                        <enum>Qt::NoFocus</enum>
                        </property>
                        <property name="text">
                         <string>Debug</string>
@@ -620,6 +653,9 @@
                           <height>50</height>
                          </size>
                         </property>
+                        <property name="focusPolicy">
+                         <enum>Qt::NoFocus</enum>
+                        </property>
                         <property name="text">
                          <string>Information</string>
                         </property>
@@ -648,6 +684,9 @@
                           <height>50</height>
                          </size>
                         </property>
+                        <property name="focusPolicy">
+                         <enum>Qt::NoFocus</enum>
+                        </property>
                         <property name="text">
                          <string>Console</string>
                         </property>
@@ -672,6 +711,9 @@
                           <width>16777215</width>
                           <height>50</height>
                          </size>
+                        </property>
+                        <property name="focusPolicy">
+                         <enum>Qt::NoFocus</enum>
                         </property>
                         <property name="text">
                          <string>Wallet Repair</string>
@@ -711,6 +753,9 @@
                          <width>16777215</width>
                          <height>50</height>
                         </size>
+                       </property>
+                       <property name="focusPolicy">
+                        <enum>Qt::NoFocus</enum>
                        </property>
                        <property name="text">
                         <string>Help</string>
@@ -757,6 +802,9 @@
                           <height>50</height>
                          </size>
                         </property>
+                        <property name="focusPolicy">
+                         <enum>Qt::NoFocus</enum>
+                        </property>
                         <property name="text">
                          <string>FAQ</string>
                         </property>
@@ -784,6 +832,9 @@
                           <width>16777215</width>
                           <height>50</height>
                          </size>
+                        </property>
+                        <property name="focusPolicy">
+                         <enum>Qt::NoFocus</enum>
                         </property>
                         <property name="text">
                          <string>About PIVX</string>


### PR DESCRIPTION
This is because a **linux-only** issue in which the button focus highlight decoration seems to come from the style `QStyle::PE_FrameFocusRect` which is not the one set in the css files.


<img width="426" alt="Screen Shot 2019-12-05 at 12 16 35 AM" src="https://user-images.githubusercontent.com/5377650/70201174-8d7f8f80-16f4-11ea-9e6b-1a6b4827feb2.png">
. Screenshot examples:
<img width="550" alt="Screen Shot 2019-12-05 at 12 16 28 AM" src="https://user-images.githubusercontent.com/5377650/70201180-983a2480-16f4-11ea-8b7f-bc29f3d4d614.png">


