### PR TITLE
[Qt] Fix for dead link to wrong PIVX website

### DIFF
--- a/src/qt/pivx/settings/forms/settingsfaqwidget.ui
+++ b/src/qt/pivx/settings/forms/settingsfaqwidget.ui
@@ -1313,10 +1313,10 @@
                          <string>
                            &lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;justify&quot;&gt;
                            We have support channels in most of our official chat groups, for example
-                           &lt;a style='color: #b088ff' href='https://Discord.PIVX.com'&gt;
+                           &lt;a style='color: #b088ff' href='https://discord.PIVX.org'&gt;
                            #support in our Discord&lt;/a&gt;.
                            If you prefer to submit a ticket, One can be
-                           &lt;a style='color: #b088ff' href='https://PIVX.FreshDesk.com'&gt;
+                           &lt;a style='color: #b088ff' href='https://PIVX.freshdesk.com'&gt;
                            our Freshdesk support site&lt;/a&gt;.
                            &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
                          </string>


### PR DESCRIPTION
discord.PIVX.com changed to discord.PIVX.org