### PR TITLE
[GUI][Trivial] Allow immediate typing in dialogs / tools widget

### DIFF
--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -156,7 +156,8 @@ AskPassphraseDialog::~AskPassphraseDialog()
 
 void AskPassphraseDialog::showEvent(QShowEvent *event)
 {
-    if (ui->passEdit1) ui->passEdit1->setFocus();
+    if (mode == Mode::Encrypt && ui->passEdit2) ui->passEdit2->setFocus();
+    else if (ui->passEdit1) ui->passEdit1->setFocus();
 }
 
 void AskPassphraseDialog::accept()

--- a/src/qt/pivx/addnewcontactdialog.cpp
+++ b/src/qt/pivx/addnewcontactdialog.cpp
@@ -56,6 +56,11 @@ void AddNewContactDialog::setData(QString address, QString label){
     if (!label.isEmpty()) ui->lineEditName->setText(label);
 }
 
+void AddNewContactDialog::showEvent(QShowEvent *event)
+{
+    if (ui->lineEditName) ui->lineEditName->setFocus();
+}
+
 void AddNewContactDialog::ok() {
     this->res = true;
     accept();

--- a/src/qt/pivx/addnewcontactdialog.h
+++ b/src/qt/pivx/addnewcontactdialog.h
@@ -21,6 +21,7 @@ public:
 
     void setTexts(QString title, const char* message = nullptr);
     void setData(QString address, QString label);
+    void showEvent(QShowEvent *event) override;
     QString getLabel();
 
     bool res = false;

--- a/src/qt/pivx/masternodewizarddialog.cpp
+++ b/src/qt/pivx/masternodewizarddialog.cpp
@@ -90,6 +90,11 @@ MasterNodeWizardDialog::MasterNodeWizardDialog(WalletModel *model, QWidget *pare
     connect(ui->btnBack, SIGNAL(clicked()), this, SLOT(onBackClicked()));
 }
 
+void MasterNodeWizardDialog::showEvent(QShowEvent *event)
+{
+    if (ui->btnNext) ui->btnNext->setFocus();
+}
+
 void MasterNodeWizardDialog::onNextClicked(){
     switch(pos){
         case 0:{
@@ -99,8 +104,8 @@ void MasterNodeWizardDialog::onNextClicked(){
             ui->pushName1->setChecked(true);
             icConfirm1->setVisible(true);
             ui->pushNumber3->setChecked(true);
-
             ui->btnBack->setVisible(true);
+            ui->lineEditName->setFocus();
             break;
         }
         case 1:{
@@ -119,6 +124,7 @@ void MasterNodeWizardDialog::onNextClicked(){
             icConfirm3->setVisible(true);
             ui->pushNumber4->setChecked(true);
             ui->btnBack->setVisible(true);
+            ui->lineEditIpAddress->setFocus();
             break;
         }
         case 2:{
@@ -328,6 +334,7 @@ void MasterNodeWizardDialog::onBackClicked(){
     switch(pos){
         case 0:{
             ui->stackedWidget->setCurrentIndex(0);
+            ui->btnNext->setFocus();
             ui->pushNumber1->setChecked(true);
             ui->pushNumber4->setChecked(false);
             ui->pushNumber3->setChecked(false);
@@ -340,6 +347,7 @@ void MasterNodeWizardDialog::onBackClicked(){
         }
         case 1:{
             ui->stackedWidget->setCurrentIndex(1);
+            ui->lineEditName->setFocus();
             ui->pushNumber4->setChecked(false);
             ui->pushNumber3->setChecked(true);
             ui->pushName4->setChecked(false);

--- a/src/qt/pivx/masternodewizarddialog.h
+++ b/src/qt/pivx/masternodewizarddialog.h
@@ -24,6 +24,7 @@ class MasterNodeWizardDialog : public QDialog
 public:
     explicit MasterNodeWizardDialog(WalletModel *walletMode, QWidget *parent = nullptr);
     ~MasterNodeWizardDialog();
+    void showEvent(QShowEvent *event) override;
 
     QString returnStr = "";
     bool isOk = false;

--- a/src/qt/pivx/requestdialog.cpp
+++ b/src/qt/pivx/requestdialog.cpp
@@ -171,6 +171,11 @@ void RequestDialog::onCopyUriClicked(){
     }
 }
 
+void RequestDialog::showEvent(QShowEvent *event)
+{
+    if (ui->lineEditAmount) ui->lineEditAmount->setFocus();
+}
+
 void RequestDialog::updateQr(QString str){
     QString uri = GUIUtil::formatBitcoinURI(*info);
     ui->labelQrImg->setText("");

--- a/src/qt/pivx/requestdialog.h
+++ b/src/qt/pivx/requestdialog.h
@@ -27,6 +27,7 @@ public:
 
     void setWalletModel(WalletModel *model);
     void setPaymentRequest(bool isPaymentRequest);
+    void showEvent(QShowEvent *event) override;
     int res = -1;
 
 private slots:

--- a/src/qt/pivx/settings/settingsconsolewidget.cpp
+++ b/src/qt/pivx/settings/settingsconsolewidget.cpp
@@ -369,6 +369,11 @@ void SettingsConsoleWidget::loadClientModel() {
     }
 }
 
+void SettingsConsoleWidget::showEvent(QShowEvent *event)
+{
+    if (ui->lineEdit) ui->lineEdit->setFocus();
+}
+
 static QString categoryClass(int category)
 {
     switch (category) {

--- a/src/qt/pivx/settings/settingsconsolewidget.h
+++ b/src/qt/pivx/settings/settingsconsolewidget.h
@@ -32,6 +32,7 @@ public:
     ~SettingsConsoleWidget();
 
     void loadClientModel() override;
+    void showEvent(QShowEvent *event) override;
 
     enum MessageClass {
         MC_ERROR,

--- a/src/qt/pivx/settings/settingssignmessagewidgets.cpp
+++ b/src/qt/pivx/settings/settingssignmessagewidgets.cpp
@@ -97,6 +97,11 @@ SettingsSignMessageWidgets::~SettingsSignMessageWidgets(){
     delete ui;
 }
 
+void SettingsSignMessageWidgets::showEvent(QShowEvent *event)
+{
+    if (ui->addressIn_SM) ui->addressIn_SM->setFocus();
+}
+
 void SettingsSignMessageWidgets::onModeSelected(bool isSign){
     this->isSign = isSign;
     updateMode();

--- a/src/qt/pivx/settings/settingssignmessagewidgets.h
+++ b/src/qt/pivx/settings/settingssignmessagewidgets.h
@@ -22,6 +22,7 @@ public:
     ~SettingsSignMessageWidgets();
 
     void setAddress_SM(const QString& address);
+    void showEvent(QShowEvent *event) override;
 protected:
     void resizeEvent(QResizeEvent *event) override;
 public slots:


### PR DESCRIPTION
Follow up to #1161 .
Fixes focus in `AskPassphraseDialog` when mode is `Encrypt` (in which case the default-focused `passEdit1` is hidden). 
Also applies the same ideology in other instances:
- Receive addresses --> change label
- Receive addresses --> new payment request
- Contacts --> edit contact
- Cold Stake --> Create cold stake address
- Cold Stake --> my staking address --> change label
- Tools --> sign/verify message
- Tools --> BIP38 Tool
- Debug --> Console
- Masternode wizard

Closes #1150 