### PR TITLE
[GUI] Workaround to the OSX border-image pink stripes.

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -154,6 +154,7 @@ QT_MOC_CPP = \
   qt/pivx/moc_furabstractlistitemdelegate.cpp \
   qt/pivx/moc_receivedialog.cpp \
   qt/pivx/moc_walletpassworddialog.cpp \
+  qt/pivx/moc_pfborderimage.cpp \
   qt/pivx/moc_topbar.cpp \
   qt/pivx/moc_txrow.cpp \
   qt/pivx/moc_dashboardwidget.cpp \
@@ -267,6 +268,7 @@ BITCOIN_QT_H = \
   qt/walletmodel.h \
   qt/walletmodeltransaction.h \
   qt/pivx/prunnable.h \
+  qt/pivx/pfborderimage.h \
   qt/pivx/loadingdialog.h \
   qt/winshutdownmonitor.h \
   qt/zpivcontroldialog.h \

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -178,6 +178,12 @@ execute_process(
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/pivx/settings
 )
 
+execute_process(
+        COMMAND ${MOC_BIN} -o moc_pfborderimage.cpp pfborderimage.h
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/pivx
+)
+list(APPEND QT_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/pivx/moc_pfborderimage.cpp)
+
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     list(APPEND QT_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/macdockiconhandler.mm)
     list(APPEND QT_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/macnotificationhandler.mm)

--- a/src/qt/pivx/forms/topbar.ui
+++ b/src/qt/pivx/forms/topbar.ui
@@ -42,7 +42,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QWidget" name="containerTop" native="true">
+    <widget class="PFBorderImage" name="containerTop" native="true">
      <layout class="QVBoxLayout" name="verticalLayout_11">
       <property name="spacing">
        <number>0</number>
@@ -709,6 +709,12 @@ border:none;</string>
    <class>ExpandableButton</class>
    <extends>QWidget</extends>
    <header>qt/pivx/expandablebutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>PFBorderImage</class>
+   <extends>QFrame</extends>
+   <header>qt/pivx/pfborderimage.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/qt/pivx/forms/welcomecontentwidget.ui
+++ b/src/qt/pivx/forms/welcomecontentwidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string></string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">
@@ -30,7 +30,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QWidget" name="frame_2" native="true">
+    <widget class="PFBorderImage" name="frame_2" native="true">
      <layout class="QVBoxLayout" name="verticalLayout_1">
       <property name="spacing">
        <number>0</number>
@@ -1177,6 +1177,14 @@ PIVX Core Wallet</string>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PFBorderImage</class>
+   <extends>QFrame</extends>
+   <header>qt/pivx/pfborderimage.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/qt/pivx/pfborderimage.h
+++ b/src/qt/pivx/pfborderimage.h
@@ -1,0 +1,51 @@
+#ifndef PIVX_PFBorderImage_H
+#define PIVX_PFBorderImage_H
+
+#include <QPainter>
+#include <QPixmap>
+#include <QWidget>
+#include <QFrame>
+
+class PFBorderImage : public QFrame
+{
+    Q_OBJECT
+
+public:
+    PFBorderImage(QWidget *parent = nullptr) : QFrame(parent) {};
+    ~PFBorderImage() {};
+
+#if defined(Q_OS_MAC)
+
+    void load(QString path) {
+        if (img.isNull() && !path.isNull()) img = QPixmap(path);
+    }
+
+protected:
+
+    void paintEvent(QPaintEvent *event) override {
+        QSize currentSize = size();
+        if (cachedSize != currentSize && checkSize(currentSize)) {
+            cachedSize = currentSize;
+            scaledImg = img.scaled(cachedSize);
+        }
+        QPainter painter(this);
+        painter.drawPixmap(0, 0, scaledImg);
+        QWidget::paintEvent(event);
+    }
+
+    bool checkSize(QSize currentSize) {
+        // Do not scale the image if the window change are imperceptible for the human's eye.
+        int pixelatedImageValue = 50;
+        return (currentSize.width() > cachedSize.width() + pixelatedImageValue) || (currentSize.width() < cachedSize.width() - pixelatedImageValue)
+                || (currentSize.height() > cachedSize.height() + pixelatedImageValue) || (currentSize.height() < cachedSize.height() - pixelatedImageValue);
+    }
+
+    QPixmap img;
+    QPixmap scaledImg;
+    QSize cachedSize;
+
+#endif
+
+};
+
+#endif //PIVX_PFBorderImage_H

--- a/src/qt/pivx/res/css/style_dark.css
+++ b/src/qt/pivx/res/css/style_dark.css
@@ -399,7 +399,11 @@ HH       TOP BAR
 HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH*/
 
 *[cssClass="container-top"] {
+    background-color:#000000;
     border-image: url("://bg-dashboard-banner") 0 0 0 0 stretch stretch;
+}
+
+*[cssClass="container-topbar-no-image"] {
     background-color:#000000;
 }
 
@@ -2748,7 +2752,11 @@ QPushButton[cssClass="ic-step-confirm-welcome"] {
 
 
 *[cssClass="container-welcome"] {
+    background-color: #000000;
     border-image: url("://bg-welcome") 0 0 0 0 stretch stretch;
+}
+
+*[cssClass="container-welcome-no-image"] {
     background-color:#000000;
 }
 

--- a/src/qt/pivx/res/css/style_light.css
+++ b/src/qt/pivx/res/css/style_light.css
@@ -358,7 +358,11 @@ HH       TOP BAR
 HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH*/
 
 *[cssClass="container-top"] {
+    background-color:#000000;
     border-image: url("://bg-dashboard-banner") 0 0 0 0 stretch stretch;
+}
+
+*[cssClass="container-topbar-no-image"] {
     background-color:#000000;
 }
 
@@ -2748,7 +2752,11 @@ QPushButton[cssClass="ic-step-confirm-welcome"] {
 
 
 *[cssClass="container-welcome"] {
+    background-color: #000000;
     border-image: url("://bg-welcome") 0 0 0 0 stretch stretch;
+}
+
+*[cssClass="container-welcome-no-image"] {
     background-color:#000000;
 }
 

--- a/src/qt/pivx/settings/forms/settingsfaqwidget.ui
+++ b/src/qt/pivx/settings/forms/settingsfaqwidget.ui
@@ -30,7 +30,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QFrame" name="container">
+    <widget class="PFBorderImage" name="container">
      <layout class="QVBoxLayout" name="verticalLayoutcont">
       <property name="leftMargin">
        <number>36</number>
@@ -1617,6 +1617,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PFBorderImage</class>
+   <extends>QFrame</extends>
+   <header>qt/pivx/pfborderimage.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/qt/pivx/settings/settingsdisplayoptionswidget.cpp
+++ b/src/qt/pivx/settings/settingsdisplayoptionswidget.cpp
@@ -50,6 +50,7 @@ SettingsDisplayOptionsWidget::SettingsDisplayOptionsWidget(PIVXGUI* _window, QWi
     // Switch
     ui->pushButtonSwitchBalance->setText(tr("Hide empty balances"));
     ui->pushButtonSwitchBalance->setProperty("cssClass", "btn-switch");
+    ui->pushButtonSwitchBalance->setVisible(false);
 
     // Combobox
     ui->comboBoxLanguage->setProperty("cssClass", "btn-combo");

--- a/src/qt/pivx/settings/settingsfaqwidget.cpp
+++ b/src/qt/pivx/settings/settingsfaqwidget.cpp
@@ -18,7 +18,12 @@ SettingsFaqWidget::SettingsFaqWidget(QWidget *parent) :
 
     ui->labelTitle->setText(tr("Frequently Asked Questions"));
     ui->labelWebLink->setText(tr("You can read more here"));
+#ifdef Q_OS_MAC
+    ui->container->load("://bg-welcome");
+    setCssProperty(ui->container, "container-welcome-no-image");
+#else
     setCssProperty(ui->container, "container-welcome");
+#endif
     setCssProperty(ui->labelTitle, "text-title-faq");
     setCssProperty(ui->labelWebLink, "text-content-white");
 

--- a/src/qt/pivx/settings/settingswidget.cpp
+++ b/src/qt/pivx/settings/settingswidget.cpp
@@ -189,6 +189,7 @@ void SettingsWidget::loadWalletModel(){
     this->settingsSingMessageWidgets->setWalletModel(this->walletModel);
     this->settingsBitToolWidget->setWalletModel(this->walletModel);
     this->settingsMultisendWidget->setWalletModel(this->walletModel);
+    this->settingsDisplayOptionsWidget->setWalletModel(this->walletModel);
 }
 
 void SettingsWidget::onResetAction(){

--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -30,10 +30,14 @@ TopBar::TopBar(PIVXGUI* _mainWindow, QWidget *parent) :
 
     // Set parent stylesheet
     this->setStyleSheet(_mainWindow->styleSheet());
-
     /* Containers */
+    ui->containerTop->setContentsMargins(10, 4, 10, 10);
+#ifdef Q_OS_MAC
+    ui->containerTop->load("://bg-dashboard-banner");
+    setCssProperty(ui->containerTop,"container-topbar-no-image");
+#else
     ui->containerTop->setProperty("cssClass", "container-top");
-    ui->containerTop->setContentsMargins(10,4,10,10);
+#endif
 
     std::initializer_list<QWidget*> lblTitles = {ui->labelTitle1, ui->labelTitle2, ui->labelTitle3, ui->labelTitle4, ui->labelTitle5, ui->labelTitle6};
     setCssProperty(lblTitles, "text-title-topbar");
@@ -478,7 +482,6 @@ void TopBar::loadWalletModel(){
             SLOT(updateBalances(CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount, CAmount)));
     connect(walletModel->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
     connect(walletModel, &WalletModel::encryptionStatusChanged, this, &TopBar::refreshStatus);
-
     // update the display unit, to not use the default ("PIVX")
     updateDisplayUnit();
 

--- a/src/qt/pivx/welcomecontentwidget.cpp
+++ b/src/qt/pivx/welcomecontentwidget.cpp
@@ -27,7 +27,12 @@ WelcomeContentWidget::WelcomeContentWidget(QWidget *parent) :
     this->setStyleSheet(GUIUtil::loadStyleSheet());
 
     ui->frame->setProperty("cssClass", "container-welcome-stack");
+#ifdef Q_OS_MAC
+    ui->frame_2->load("://bg-welcome");
+    ui->frame_2->setProperty("cssClass", "container-welcome-no-image");
+#else
     ui->frame_2->setProperty("cssClass", "container-welcome");
+#endif
 
     backButton = new QPushButton(ui->container);
     nextButton = new QPushButton(ui->container);


### PR DESCRIPTION
In some computers running OSX, gitian deployment seems to not like the `border-image` css property and the deployed binary paint it with pink stripes (this is most likely a missing plugin because local deployment and people running the deployed binaries with QT installed in their systems don't have the issue at all).

To solve this up until gitian problems gets discovered, have created a new component that scales and paints the topbar image on every window resize event (caching the last size) + added a settings option and its visual connection to enable/disable it (this is mainly because not every user has the pink stripes and cause has not been detected to make it visible only for them).

In this way, the users who are running OSX and have the issue, only need to go to settings and check the "Fix top bar pink stripes" switch and done. This switch will only appear in OSX.