### PR TITLE
[GUI] ColdStaking widget: fix "total staking" amount

### DIFF
--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -564,6 +564,11 @@ int AddressTableModel::lookupAddress(const QString& address) const
     }
 }
 
+bool AddressTableModel::isWhitelisted(const std::string& address) const
+{
+    return purposeForAddress(address).compare(AddressBook::AddressBookPurpose::DELEGATOR) == 0;
+}
+
 /**
  * Return last created unused address --> TODO: complete "unused" and "last".. basically everything..
  * @return

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -89,6 +89,11 @@ public:
     std::string purposeForAddress(const std::string& address) const;
 
     /**
+     * Checks if the address is whitelisted
+     */
+    bool isWhitelisted(const std::string& address) const;
+
+    /**
      * Return last unused address
      */
     QString getAddressToShow() const;

--- a/src/qt/pivx/coldstakingmodel.h
+++ b/src/qt/pivx/coldstakingmodel.h
@@ -66,8 +66,9 @@ public:
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
     bool whitelist(const QModelIndex& modelIndex);
     bool blacklist(const QModelIndex& index);
+    void removeRowAndEmitDataChanged(const int idx);
     void updateCSList();
-    CAmount getTotalAmount() { return cachedAmount; }
+    CAmount getTotalAmount() const { return cachedAmount; }
 
     void refresh();
 

--- a/src/qt/pivx/coldstakingwidget.cpp
+++ b/src/qt/pivx/coldstakingwidget.cpp
@@ -252,11 +252,7 @@ void ColdStakingWidget::onDelegationsRefreshed() {
     isLoading = false;
     bool hasDel = csModel->rowCount() > 0;
 
-    // Update the total value.
-    CAmount total = csModel->getTotalAmount();
-    ui->labelStakingTotal->setText(tr("Total Staking: %1").arg(
-            (total == 0) ? "0.00 PIV" : GUIUtil::formatBalance(total, nDisplayUnit))
-    );
+    updateStakingTotalLabel();
 
     // Update list if we are showing that section.
     if (!isInDelegation) {
@@ -646,6 +642,7 @@ void ColdStakingWidget::onEditClicked() {
     if (label.isEmpty()) {
         label = index.data(Qt::DisplayRole).toString();
     }
+    updateStakingTotalLabel();
     inform(label + tr(" staking!"));
 }
 
@@ -659,6 +656,7 @@ void ColdStakingWidget::onDeleteClicked() {
     if (label.isEmpty()) {
         label = index.data(Qt::DisplayRole).toString();
     }
+    updateStakingTotalLabel();
     inform(label + tr(" blacklisted from staking"));
 }
 
@@ -729,6 +727,14 @@ void ColdStakingWidget::changeTheme(bool isLightTheme, QString& theme){
     static_cast<CSDelegationHolder*>(delegate->getRowFactory())->isLightTheme = isLightTheme;
     static_cast<AddressHolder*>(addressDelegate->getRowFactory())->isLightTheme = isLightTheme;
     ui->listView->update();
+}
+
+void ColdStakingWidget::updateStakingTotalLabel()
+{
+    const CAmount& total = csModel->getTotalAmount();
+    ui->labelStakingTotal->setText(tr("Total Staking: %1").arg(
+            (total == 0) ? "0.00 PIV" : GUIUtil::formatBalance(total, nDisplayUnit))
+    );
 }
 
 ColdStakingWidget::~ColdStakingWidget(){

--- a/src/qt/pivx/coldstakingwidget.h
+++ b/src/qt/pivx/coldstakingwidget.h
@@ -113,6 +113,7 @@ private:
     void tryRefreshDelegations();
     bool refreshDelegations();
     void onLabelClicked(QString dialogTitle, const QModelIndex &index, const bool& isMyColdStakingAddresses);
+    void updateStakingTotalLabel();
 };
 
 #endif // COLDSTAKINGWIDGET_H


### PR DESCRIPTION
Currently the label in cold-staking widget states "Total **Staking**:", but then the amount is calculated summing up all the delegated utxos (staking or not).

This fixes it, considering only owned delegations and/or received delegations from whitelisted owners in the sum.
Also, refresh the total amount after a whitelist/blacklist operation (in order to achieve this, the update of the cachedAmount has been separated from the update of the delegations in the model). 
