### PR TITLE
Clean up 4.0 compiler warnings

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1439,7 +1439,6 @@ bool AppInit2()
     nCoinCacheSize = nTotalCache / 300; // coins in memory require around 300 bytes
 
     bool fLoaded = false;
-    int64_t nStart = GetTimeMillis();
     while (!fLoaded && !ShutdownRequested()) {
         bool fReset = fReindex;
         std::string strLoadError;

--- a/src/qt/pivx/welcomecontentwidget.cpp
+++ b/src/qt/pivx/welcomecontentwidget.cpp
@@ -15,11 +15,11 @@
 WelcomeContentWidget::WelcomeContentWidget(QWidget *parent) :
     QDialog(parent, Qt::FramelessWindowHint | Qt::WindowSystemMenuHint),
     ui(new Ui::WelcomeContentWidget),
-    backButton(new QPushButton()),
     icConfirm1(new QPushButton()),
     icConfirm2(new QPushButton()),
     icConfirm3(new QPushButton()),
     icConfirm4(new QPushButton()),
+    backButton(new QPushButton()),
     nextButton(new QPushButton())
 {
     ui->setupUi(this);

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -218,7 +218,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet* 
             if (fAllToMe > mine) fAllToMe = mine;
         }
 
-        if (fAllFromMeDenom && fAllToMeDenom && nFromMe * nToMe) {
+        if (fAllFromMeDenom && fAllToMeDenom && ((nFromMe * nToMe) != 0)) {
             parts.append(TransactionRecord(hash, nTime, wtx.GetTotalSize(), TransactionRecord::ObfuscationDenominate, "", -nDebit, nCredit));
             parts.last().involvesWatchAddress = false; // maybe pass to TransactionRecord as constructor argument
         } else if (fAllFromMe && fAllToMe) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5642,7 +5642,7 @@ CAmount CWallet::GetDebit(const CTransaction& tx, const isminefilter& filter) co
 CAmount CWallet::GetCredit(const CTransaction& tx, const isminefilter& filter, const bool fUnspent) const
 {
     CAmount nCredit = 0;
-    for (int i = 0; i < tx.vout.size(); i++) {
+    for (unsigned int i = 0; i < tx.vout.size(); i++) {
         if (fUnspent && IsSpent(tx.GetHash(), i)) continue;
         nCredit += GetCredit(tx.vout[i], filter);
     }


### PR DESCRIPTION
### Problem
Compiler warnings when building off the v4.0 tag

### Root Cause
Several different issues:
```
init.cpp: In function ‘bool AppInit2()’:
init.cpp:1442:13: warning: unused variable ‘nStart’ [-Wunused-variable]
     int64_t nStart = GetTimeMillis();
             ^~~~~~
```
```
wallet/wallet.cpp: In member function ‘CAmount CWallet::GetCredit(const CTransaction&, const isminefilter&, bool) const’:
wallet/wallet.cpp:5649:23: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     for (int i = 0; i < tx.vout.size(); i++) {
                     ~~^~~~~~~~~~~~~~~~
```
```
leveldb/util/logging.cc: In function ‘bool leveldb::ConsumeDecimalNumber(leveldb::Slice*, uint64_t*)’:
leveldb/util/logging.cc:58:40: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
           (v == kMaxUint64/10 && delta > kMaxUint64%10)) {
                                  ~~~~~~^~~~~~~~~~~~~~~
```
```
qt/transactionrecord.cpp: In static member function ‘static QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet*, const CWalletTx&)’:
qt/transactionrecord.cpp:221:57: warning: ‘*’ in boolean context, suggest ‘&&’ instead [-Wint-in-bool-context]
         if (fAllFromMeDenom && fAllToMeDenom && nFromMe * nToMe) {
                                                 ~~~~~~~~^~~~~~~
```
```
In file included from qt/pivx/welcomecontentwidget.cpp:5:0:
./qt/pivx/welcomecontentwidget.h: In constructor ‘WelcomeContentWidget::WelcomeContentWidget (QWidget*)’:
./qt/pivx/welcomecontentwidget.h:44:18: warning: ‘WelcomeContentWidget::backButton’ will be initialized after  -Wreorder]
     QPushButton *backButton;
                  ^~~~~~~~~~
./qt/pivx/welcomecontentwidget.h:40:18: warning:   ‘QPushButton* 

WelcomeContentWidget::icConfirm1’ [-Wreorder]
     QPushButton *icConfirm1;
                  ^~~~~~~~~~
qt/pivx/welcomecontentwidget.cpp:15:1: warning:   when initialized here [-Wreorder]
 WelcomeContentWidget::WelcomeContentWidget(QWidget *parent) :
 ^~~~~~~~~~~~~~~~~~~~
```

### Additional
One other I didn't touch.
```
qt/pivx/walletpassworddialog.cpp: In constructor ‘WalletPasswordDialog::WalletPasswordDialog(QWidget*)’:
qt/pivx/walletpassworddialog.cpp:85:9: warning: unused variable ‘posXX’ [-Wunused-variable]
     int posXX = ui->lineEditPassword->width() - 30;
         ^~~~~
```
Since I wasn't sure where exactly that dialog pops up to see if the posXX is actually needed and should have a `btnWatch->move()`; so i figured I would leave that to @furszy to take care of.