### PR TITLE
[Build] Bump snapcraft nightlies to 4.0.99

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -2,7 +2,7 @@
 # Copyright (c) 2019 The PIVX developers
 name: pivx-core
 base: core18
-version: 3.4.99
+version: 4.0.99
 summary:   PIVX (Private – Instant – Verified – Transaction)
 description: |
   PIVX is an MIT licensed,


### PR DESCRIPTION
Snapcraft nightly build version bump. Missed doing this in #1200