### PR TITLE
[BUG][RPC] fix signature check (against old format) in mnbudgetrawvote

### DIFF
--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -733,7 +733,9 @@ UniValue mnbudgetrawvote(const UniValue& params, bool fHelp)
     vote.SetVchSig(vchSig);
 
     if (!vote.CheckSignature(true)) {
-        return "Failure to verify signature.";
+        // try old message version
+        vote.nMessVersion = MessageVersion::MESS_VER_STRMESS;
+        if (!vote.CheckSignature(true)) return "Failure to verify signature.";
     }
 
     std::string strError = "";


### PR DESCRIPTION
`CBudgetVote` object in `mnbudgetrawvote` is initialized with default nMessVersion (`MessageVersion::MESS_VER_HASH`). Thus the signature validation fails when the user provides an external signature performed over the old message format.