### PR TITLE
[Startup][GUI][Performance] Optimizations for huge wallets.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1604,7 +1604,7 @@ bool AppInit2()
                     }
 
                     // Zerocoin must check at level 4
-                    if (!CVerifyDB().VerifyDB(pcoinsdbview, 4, GetArg("-checkblocks", 100))) {
+                    if (!CVerifyDB().VerifyDB(pcoinsdbview, 4, GetArg("-checkblocks", 10))) {
                         strLoadError = _("Corrupted block database detected");
                         fVerifyingBlocks = false;
                         break;

--- a/src/qt/pivx/addresseswidget.cpp
+++ b/src/qt/pivx/addresseswidget.cpp
@@ -94,6 +94,7 @@ AddressesWidget::AddressesWidget(PIVXGUI* parent) :
     ui->listAddresses->setMinimumHeight(NUM_ITEMS * (DECORATION_SIZE + 2));
     ui->listAddresses->setAttribute(Qt::WA_MacShowFocusRect, false);
     ui->listAddresses->setSelectionBehavior(QAbstractItemView::SelectRows);
+    ui->listAddresses->setUniformItemSizes(true);
 
     //Empty List
     ui->emptyContainer->setVisible(false);

--- a/src/qt/pivx/coldstakingwidget.cpp
+++ b/src/qt/pivx/coldstakingwidget.cpp
@@ -185,6 +185,7 @@ ColdStakingWidget::ColdStakingWidget(PIVXGUI* parent) :
     ui->listViewStakingAddress->setMinimumHeight(NUM_ITEMS * (DECORATION_SIZE + 2));
     ui->listViewStakingAddress->setAttribute(Qt::WA_MacShowFocusRect, false);
     ui->listViewStakingAddress->setSelectionBehavior(QAbstractItemView::SelectRows);
+    ui->listViewStakingAddress->setUniformItemSizes(true);
 
     connect(ui->pushButtonSend, &QPushButton::clicked, this, &ColdStakingWidget::onSendClicked);
     connect(btnOwnerContact, &QAction::triggered, [this](){ onContactsClicked(true); });

--- a/src/qt/pivx/dashboardwidget.cpp
+++ b/src/qt/pivx/dashboardwidget.cpp
@@ -124,6 +124,9 @@ DashboardWidget::DashboardWidget(PIVXGUI* parent) :
     ui->listTransactions->setMinimumHeight(NUM_ITEMS * (DECORATION_SIZE + 2));
     ui->listTransactions->setAttribute(Qt::WA_MacShowFocusRect, false);
     ui->listTransactions->setSelectionBehavior(QAbstractItemView::SelectRows);
+    ui->listTransactions->setLayoutMode(QListView::LayoutMode::Batched);
+    ui->listTransactions->setBatchSize(50);
+    ui->listTransactions->setUniformItemSizes(true);
 
     // Sync Warning
     ui->layoutWarning->setVisible(true);

--- a/src/qt/pivx/privacywidget.cpp
+++ b/src/qt/pivx/privacywidget.cpp
@@ -158,6 +158,9 @@ PrivacyWidget::PrivacyWidget(PIVXGUI* parent) :
     ui->listView->setMinimumHeight(NUM_ITEMS * (DECORATION_SIZE + 2));
     ui->listView->setAttribute(Qt::WA_MacShowFocusRect, false);
     ui->listView->setSelectionBehavior(QAbstractItemView::SelectRows);
+    ui->listView->setLayoutMode(QListView::LayoutMode::Batched);
+    ui->listView->setBatchSize(30);
+    ui->listView->setUniformItemSizes(true);
 }
 
 void PrivacyWidget::loadWalletModel(){

--- a/src/qt/pivx/receivewidget.cpp
+++ b/src/qt/pivx/receivewidget.cpp
@@ -84,6 +84,7 @@ ReceiveWidget::ReceiveWidget(PIVXGUI* parent) :
     ui->listViewAddress->setMinimumHeight(NUM_ITEMS * (DECORATION_SIZE + 2));
     ui->listViewAddress->setAttribute(Qt::WA_MacShowFocusRect, false);
     ui->listViewAddress->setSelectionBehavior(QAbstractItemView::SelectRows);
+    ui->listViewAddress->setUniformItemSizes(true);
 
     spacer = new QSpacerItem(40, 20, QSizePolicy::Maximum, QSizePolicy::Expanding);
     ui->btnMyAddresses->setChecked(true);

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -31,9 +31,8 @@
 #define SINGLE_THREAD_MAX_TXES_SIZE 4000
 
 // Maximum amount of loaded records in ram in the first load.
-// If the user has more and want to load them, could add a load on demand in pages.
-// but.. to be realistic, it's not useful anyway, why someone would ever want to have more than 20,000 txs loaded in the UI??
-// The person would be essentially spamming himself..
+// If the user has more and want to load them:
+// TODO, add load on demand in pages (not every tx loaded all the time into the records list).
 #define MAX_AMOUNT_LOADED_RECORDS 20000
 
 // Amount column is right-aligned it contains numbers


### PR DESCRIPTION
Made several changes in order to improve the wallet startup and navigation performance in huge wallets (wallets with more than 20,000 transactions).
&nbsp;

1) Maximum amount of loaded transaction records in the GUI set to 20,000. 
* If the wallet has more, then it will not load them into the UI anymore. Hard to think that any user will be benefited from having 100k txs that he/she made in 2 years always visible when them are most likely all spent and only the latest 5k txs have utxo.. 

2) Optimized every listview load in the GUI.
* The list items are laid out in batches of a certain size, instead of all of the items loaded at once in the first run.
* Uniform row size flag enabled in every list optimizing their painting.

3) Db verification decreased to 10 blocks.
* Previously our wallet was checking, disconnecting and reconnecting the last 100 blocks in the startup, looking for inconsistencies. That is really too much, if we have any inconsistency, it should appear in the last 10 blocks.
