### PR TITLE
[Wallet] Remove un-necessary CheckTransaction call when loading wallet.

### DIFF
--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -485,10 +485,7 @@ bool ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue, CW
             ssKey >> hash;
             CWalletTx wtx;
             ssValue >> wtx;
-            CValidationState state;
-            // fZerocoinActive false because there is no reason to go through the zerocoin checks for our own wallet
-            // fColdStakingActive true to unserialize old P2CS outputs.
-            if (!(CheckTransaction(wtx, false, false, state, false, true) && (wtx.GetHash() == hash) && state.IsValid()))
+            if (wtx.GetHash() != hash)
                 return false;
 
             // Undo serialize changes in 31600
@@ -733,8 +730,8 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
     bool fNoncriticalErrors = false;
     DBErrors result = DB_LOAD_OK;
 
+    LOCK(pwallet->cs_wallet);
     try {
-        LOCK(pwallet->cs_wallet);
         int nMinVersion = 0;
         if (Read((std::string) "minversion", nMinVersion)) {
             if (nMinVersion > CLIENT_VERSION)


### PR DESCRIPTION
Large wallets suffer from long loading times as it is, this call to
`CheckTransaction()` just adds to that loading time.

Further improvements of the wallet database load process need to be investigated as large wallets still suffer from very long load times.

Also, if there is an absolute need to check the validity of a transaction contained in the wallet's on-disk file (beyond the hash check), it could be handled elsewhere.