### PR TITLE
[Wallet] Graceful shutdown in the unlock corrupted wallet.

### DIFF
--- a/src/crypter.cpp
+++ b/src/crypter.cpp
@@ -246,7 +246,7 @@ bool CCryptoKeyStore::Unlock(const CKeyingMaterial& vMasterKeyIn)
         }
         if (keyPass && keyFail) {
             LogPrintf("The wallet is probably corrupted: Some keys decrypt but not all.");
-            assert(false);
+            throw std::runtime_error("Error unlocking wallet: some keys decrypt but not all. Your wallet file may be corrupt.");
         }
         if (keyFail || !keyPass)
             return false;


### PR DESCRIPTION
Showing the proper error message in screen and permitting the node to shutdown properly.