### PR TITLE
[Wallet] IsEquivalentTo commented, removing an extra round of ser+hash calculation.

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -486,7 +486,7 @@ void CWallet::SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator> ran
         CWalletTx* copyTo = &mapWallet[hash];
         if (copyFrom == copyTo) continue;
         assert(copyFrom && "Oldest wallet transaction in range assumed to have been found.");
-        if (!copyFrom->IsEquivalentTo(*copyTo)) continue;
+        //if (!copyFrom->IsEquivalentTo(*copyTo)) continue;
         copyTo->mapValue = copyFrom->mapValue;
         copyTo->vOrderForm = copyFrom->vOrderForm;
         // fTimeReceivedIsTxTime not copied on purpose


### PR DESCRIPTION
To explain the reason that forced me to hunt this for over a week..

In huge wallets (+100k txs wallets) the 4.0 startup time is taking +30 minutes. Which is crazy long and sounded much more as a regression over 3.4 which was taking less than 10 minutes.

Root cause:

After some time (and improvements over different areas #1217), found that the `IsEquivalentTo` method is adding an extra round of serialization + hash calculation on every transaction that is loaded into the wallet. Which gets really, time-wise, expensive in big wallets for a small benefit.

Test:

Environment:
- Wallet with 419,633 db records.
- MacOS i7, 16gb ram.

Pre-PR transactions load time:

30 minutes and i got bored and killed the process..

Post-PR transactions load time:

34.369 seconds.

For now, decided to just comment it to be able to release 4.0.1 as soon as possible with all of the improvements.

The final, future, goal of course it's not this one, we need to backport the whole `loadToWallet` flow from upstream + introduce our own changes there.

Just a first initial step solving the regression.