### PR TITLE
[Trivial] Remove spammy log in in StakeV1

### DIFF
--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -396,9 +396,10 @@ bool StakeV1(const CBlockIndex* pindexPrev, CStakeInput* stakeInput, const uint3
         minTime = prevBlockTime;
     unsigned int nTryTime = maxTime;
 
-    // check required maturity for stake
-    if (maxTime <= minTime)
-        return error("%s : stake age violation, nTimeBlockFrom = %d, prevBlockTime = %d -- maxTime = %d ", __func__, nTimeBlockFrom, prevBlockTime, maxTime);
+    if (maxTime <= minTime) {
+        // too early to stake
+        return false;
+    }
 
     while (nTryTime > minTime) {
         // store a time stamp of when we last hashed on this block


### PR DESCRIPTION
This is not an error, the function should just return false. No need to spam the debug.log.
This will become a non-issue after time v2 enforcement, but better to fix it anyway.
