### PR TITLE
[RPC] Add optional arguments to delegatoradd and listdelegators

### DIFF
--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -363,7 +363,9 @@ bool AddressTableModel::setData(const QModelIndex& index, const QVariant& value,
     if (!index.isValid())
         return false;
     AddressTableEntry* rec = static_cast<AddressTableEntry*>(index.internalPointer());
-    std::string strPurpose = (rec->type == AddressTableEntry::Sending ? "send" : "receive");
+    std::string strPurpose = (rec->type == AddressTableEntry::Sending ?
+                                AddressBook::AddressBookPurpose::SEND :
+                                AddressBook::AddressBookPurpose::RECEIVE);
     editStatus = OK;
 
     if (role == Qt::EditRole) {
@@ -507,7 +509,7 @@ QString AddressTableModel::addRow(const QString& type, const QString& label, con
     {
         LOCK(wallet->cs_wallet);
         wallet->SetAddressBook(CBitcoinAddress(strAddress).Get(), strLabel,
-            (type == Send ? "send" : "receive"));
+            (type == Send ? AddressBook::AddressBookPurpose::SEND : AddressBook::AddressBookPurpose::RECEIVE));
     }
     return QString::fromStdString(strAddress);
 }

--- a/src/qt/pivx/receivewidget.cpp
+++ b/src/qt/pivx/receivewidget.cpp
@@ -189,7 +189,7 @@ void ReceiveWidget::onLabelClicked(){
             if (!label.isEmpty() && walletModel->updateAddressBookLabels(
                     address.Get(),
                     label.toUtf8().constData(),
-                    "receive"
+                    AddressBook::AddressBookPurpose::RECEIVE
             )
                     ) {
                 // update label status (icon color)

--- a/src/qt/pivx/send.cpp
+++ b/src/qt/pivx/send.cpp
@@ -500,7 +500,9 @@ void SendWidget::updateEntryLabels(QList<SendCoinsRecipient> recipients){
             if(label.compare(labelOld) != 0) {
                 CTxDestination dest = CBitcoinAddress(rec.address.toStdString()).Get();
                 if (!walletModel->updateAddressBookLabels(dest, label.toStdString(),
-                                                          this->walletModel->isMine(dest) ? "receive" : "send")) {
+                                                          this->walletModel->isMine(dest) ?
+                                                                  AddressBook::AddressBookPurpose::RECEIVE :
+                                                                  AddressBook::AddressBookPurpose::SEND)) {
                     // Label update failed
                     emit message("", tr("Address label update failed for address: %1").arg(rec.address), CClientUIInterface::MSG_ERROR);
                     return;
@@ -733,7 +735,8 @@ void SendWidget::onContactMultiClicked(){
             if (label == dialog->getLabel()) {
                 return;
             }
-            if (walletModel->updateAddressBookLabels(pivAdd.Get(), dialog->getLabel().toStdString(), "send")) {
+            if (walletModel->updateAddressBookLabels(pivAdd.Get(), dialog->getLabel().toStdString(),
+                    AddressBook::AddressBookPurpose::SEND)) {
                 inform(tr("New Contact Stored"));
             } else {
                 inform(tr("Error Storing Contact"));

--- a/src/qt/pivx/settings/settingsbittoolwidget.cpp
+++ b/src/qt/pivx/settings/settingsbittoolwidget.cpp
@@ -307,7 +307,7 @@ void SettingsBitToolWidget::importAddressFromDecKey(){
         ui->statusLabel_DEC->setText(tr("Please wait while key is imported"));
 
         pwalletMain->MarkDirty();
-        pwalletMain->SetAddressBook(vchAddress, "", "receive");
+        pwalletMain->SetAddressBook(vchAddress, "", AddressBook::AddressBookPurpose::RECEIVE);
 
         // Don't throw error in case a key is already there
         if (pwalletMain->HaveKey(vchAddress)) {

--- a/src/qt/pivx/settings/settingsmultisendwidget.cpp
+++ b/src/qt/pivx/settings/settingsmultisendwidget.cpp
@@ -288,7 +288,8 @@ void SettingsMultisendWidget::addMultiSend(QString address, int percentage, QStr
         // update the address book with the label given or no label if none was given.
         CBitcoinAddress address(strAddress);
         std::string userInputLabel = addressLabel.toStdString();
-        walletModel->updateAddressBookLabels(address.Get(), (userInputLabel.empty()) ? "(no label)" : userInputLabel, "send");
+        walletModel->updateAddressBookLabels(address.Get(), (userInputLabel.empty()) ? "(no label)" : userInputLabel,
+                AddressBook::AddressBookPurpose::SEND);
     }
 
     CWalletDB walletdb(pwalletMain->strWalletFile);

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -48,6 +48,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
         {"getreceivedbyaddress", 1},
         {"getreceivedbyaccount", 1},
         {"listcoldutxos", 0},
+        {"listdelegators", 0},
         {"listreceivedbyaddress", 0},
         {"listreceivedbyaddress", 1},
         {"listreceivedbyaddress", 2},

--- a/src/test/rpc_wallet_tests.cpp
+++ b/src/test/rpc_wallet_tests.cpp
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(rpc_wallet)
     CBitcoinAddress demoAddress = CBitcoinAddress(CTxDestination(demoPubkey.GetID()));
     UniValue retValue;
     std::string strAccount = "walletDemoAccount";
-    std::string strPurpose = "receive";
+    std::string strPurpose = AddressBook::AddressBookPurpose::RECEIVE;
     BOOST_CHECK_NO_THROW({ /*Initialize Wallet with an account */
         CWalletDB walletdb(pwalletMain->strWalletFile);
         CAccount account;

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -125,7 +125,7 @@ UniValue importprivkey(const UniValue& params, bool fHelp)
     CKeyID vchAddress = pubkey.GetID();
     {
         pwalletMain->MarkDirty();
-        pwalletMain->SetAddressBook(vchAddress, strLabel, "receive");
+        pwalletMain->SetAddressBook(vchAddress, strLabel, AddressBook::AddressBookPurpose::RECEIVE);
 
         // Don't throw error in case a key is already there
         if (pwalletMain->HaveKey(vchAddress))
@@ -198,7 +198,7 @@ UniValue importaddress(const UniValue& params, bool fHelp)
 
         // add to address book or update label
         if (address.IsValid())
-            pwalletMain->SetAddressBook(address.Get(), strLabel, "receive");
+            pwalletMain->SetAddressBook(address.Get(), strLabel, AddressBook::AddressBookPurpose::RECEIVE);
 
         // Don't throw error in case an address is already there
         if (pwalletMain->HaveWatchOnly(script))
@@ -298,7 +298,7 @@ UniValue importwallet(const UniValue& params, bool fHelp)
         }
         pwalletMain->mapKeyMetadata[keyid].nCreateTime = nTime;
         if (fLabel)
-            pwalletMain->SetAddressBook(keyid, strLabel, "receive");
+            pwalletMain->SetAddressBook(keyid, strLabel, AddressBook::AddressBookPurpose::RECEIVE);
         nTimeBegin = std::min(nTimeBegin, nTime);
     }
     file.close();
@@ -521,7 +521,7 @@ UniValue bip38decrypt(const UniValue& params, bool fHelp)
     CKeyID vchAddress = pubkey.GetID();
     {
         pwalletMain->MarkDirty();
-        pwalletMain->SetAddressBook(vchAddress, "", "receive");
+        pwalletMain->SetAddressBook(vchAddress, "", AddressBook::AddressBookPurpose::RECEIVE);
 
         // Don't throw error in case a key is already there
         if (pwalletMain->HaveKey(vchAddress))

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -116,7 +116,7 @@ UniValue getnewaddress(const UniValue& params, bool fHelp)
             HelpExampleCli("getnewaddress", "") + HelpExampleRpc("getnewaddress", "\"\"") +
             HelpExampleCli("getnewaddress", "\"myaccount\"") + HelpExampleRpc("getnewaddress", "\"myaccount\""));
 
-    return GetNewAddressFromAccount("receive", params).ToString();
+    return GetNewAddressFromAccount(AddressBook::AddressBookPurpose::RECEIVE, params).ToString();
 }
 
 UniValue getnewstakingaddress(const UniValue& params, bool fHelp)
@@ -286,7 +286,7 @@ UniValue liststakingaddresses(const UniValue& params, bool fHelp)
             HelpExampleCli("liststakingaddresses" , "") +
             HelpExampleRpc("liststakingaddresses", ""));
 
-    return ListaddressesForPurpose("coldstaking");
+    return ListaddressesForPurpose(AddressBook::AddressBookPurpose::COLD_STAKING);
 }
 
 CBitcoinAddress GetAccountAddress(std::string strAccount, bool bForceNew = false)
@@ -316,7 +316,7 @@ CBitcoinAddress GetAccountAddress(std::string strAccount, bool bForceNew = false
         if (!pwalletMain->GetKeyFromPool(account.vchPubKey))
             throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, "Error: Keypool ran out, please call keypoolrefill first");
 
-        pwalletMain->SetAddressBook(account.vchPubKey.GetID(), strAccount, "receive");
+        pwalletMain->SetAddressBook(account.vchPubKey.GetID(), strAccount, AddressBook::AddressBookPurpose::RECEIVE);
         walletdb.WriteAccount(strAccount, account);
     }
 
@@ -417,7 +417,7 @@ UniValue setaccount(const UniValue& params, bool fHelp)
             if (address == GetAccountAddress(strOldAccount))
                 GetAccountAddress(strOldAccount, true);
         }
-        pwalletMain->SetAddressBook(address.Get(), strAccount, "receive");
+        pwalletMain->SetAddressBook(address.Get(), strAccount, AddressBook::AddressBookPurpose::RECEIVE);
     } else
         throw JSONRPCError(RPC_MISC_ERROR, "setaccount can only be used with own address");
 
@@ -1483,7 +1483,7 @@ UniValue addmultisigaddress(const UniValue& params, bool fHelp)
     CScriptID innerID(inner);
     pwalletMain->AddCScript(inner);
 
-    pwalletMain->SetAddressBook(innerID, strAccount, "send");
+    pwalletMain->SetAddressBook(innerID, strAccount, AddressBook::AddressBookPurpose::SEND);
     return CBitcoinAddress(innerID).ToString();
 }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -143,31 +143,35 @@ UniValue getnewstakingaddress(const UniValue& params, bool fHelp)
 
 UniValue delegatoradd(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1)
+    if (fHelp || params.size() < 1 || params.size() > 2)
         throw std::runtime_error(
-            "delegatoradd \"addr\"\n"
+            "delegatoradd \"addr\" ( \"label\" )\n"
             "\nAdd the provided address <addr> into the allowed delegators AddressBook.\n"
             "This enables the staking of coins delegated to this wallet, owned by <addr>\n"
 
             "\nArguments:\n"
             "1. \"addr\"        (string, required) The address to whitelist\n"
+            "2. \"label\"       (string, optional) A label for the address to whitelist\n"
 
             "\nResult:\n"
             "true|false           (boolean) true if successful.\n"
 
             "\nExamples:\n" +
             HelpExampleCli("delegatoradd", "DMJRSsuU9zfyrvxVaAEFQqK4MxZg6vgeS6") +
-            HelpExampleRpc("delegatoradd", "\"DMJRSsuU9zfyrvxVaAEFQqK4MxZg6vgeS6\""));
+            HelpExampleRpc("delegatoradd", "\"DMJRSsuU9zfyrvxVaAEFQqK4MxZg6vgeS6\"") +
+            HelpExampleRpc("delegatoradd", "\"DMJRSsuU9zfyrvxVaAEFQqK4MxZg6vgeS6\" \"myPaperWallet\""));
 
     CBitcoinAddress address(params[0].get_str());
     if (!address.IsValid() || address.IsStakingAddress())
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid PIVX address");
 
+    const std::string strLabel = (params.size() > 1 ? params[1].get_str() : "");
+
     CKeyID keyID;
     if (!address.GetKeyID(keyID))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Unable to get KeyID from PIVX address");
 
-    return pwalletMain->SetAddressBook(keyID, "", AddressBook::AddressBookPurpose::DELEGATOR);
+    return pwalletMain->SetAddressBook(keyID, strLabel, AddressBook::AddressBookPurpose::DELEGATOR);
 }
 
 UniValue delegatorremove(const UniValue& params, bool fHelp)
@@ -179,7 +183,7 @@ UniValue delegatorremove(const UniValue& params, bool fHelp)
             "This disables the staking of coins delegated to this wallet, owned by <addr>\n"
 
             "\nArguments:\n"
-            "1. \"addr\"        (string, required) The address to whitelist\n"
+            "1. \"addr\"        (string, required) The address to blacklist\n"
 
             "\nResult:\n"
             "true|false           (boolean) true if successful.\n"

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -237,15 +237,19 @@ UniValue ListaddressesForPurpose(const std::string strPurpose)
 
 UniValue listdelegators(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 0)
+    if (fHelp || params.size() > 1)
         throw std::runtime_error(
-            "listdelegators \"addr\"\n"
+            "listdelegators ( fBlacklist )\n"
             "\nShows the list of allowed delegator addresses for cold staking.\n"
+
+            "\nArguments:\n"
+            "1. fBlacklist             (boolean, optional, default = false) Show addresses removed\n"
+            "                          from the delegators whitelist\n"
 
             "\nResult:\n"
             "[\n"
             "   {\n"
-            "   \"label\": \"yyy\",  (string) account label\n"
+            "   \"label\": \"yyy\",    (string) account label\n"
             "   \"address\": \"xxx\",  (string) PIVX address string\n"
             "   }\n"
             "  ...\n"
@@ -255,7 +259,10 @@ UniValue listdelegators(const UniValue& params, bool fHelp)
             HelpExampleCli("listdelegators" , "") +
             HelpExampleRpc("listdelegators", ""));
 
-    return ListaddressesForPurpose("delegator");
+    const bool fBlacklist = (params.size() > 0 ? params[0].get_bool() : false);
+    return (fBlacklist ?
+            ListaddressesForPurpose(AddressBook::AddressBookPurpose::DELEGABLE) :
+            ListaddressesForPurpose(AddressBook::AddressBookPurpose::DELEGATOR));
 }
 
 UniValue liststakingaddresses(const UniValue& params, bool fHelp)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -217,9 +217,10 @@ UniValue delegatorremove(const UniValue& params, bool fHelp)
 
 UniValue ListaddressesForPurpose(const std::string strPurpose)
 {
-    const CChainParams::Base58Type addrType =
-            strPurpose == "coldstaking" ?
-            CChainParams::STAKING_ADDRESS : CChainParams::PUBKEY_ADDRESS;
+    const CChainParams::Base58Type addrType = (
+            AddressBook::IsColdStakingPurpose(strPurpose) ?
+                    CChainParams::STAKING_ADDRESS :
+                    CChainParams::PUBKEY_ADDRESS);
     UniValue ret(UniValue::VARR);
     {
         LOCK(pwalletMain->cs_wallet);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -183,7 +183,7 @@ CBitcoinAddress CWallet::GenerateNewAutoMintKey()
     CKeyID keyID = GenerateNewKey().GetID();
     btcAddress.Set(keyID);
     CWalletDB(strWalletFile).WriteAutoConvertKey(btcAddress);
-    SetAddressBook(keyID, "automint-address", "receive");
+    SetAddressBook(keyID, "automint-address", AddressBook::AddressBookPurpose::RECEIVE);
     setAutoConvertAddresses.emplace(btcAddress);
     return btcAddress;
 }
@@ -3071,7 +3071,7 @@ bool CWallet::HasDelegator(const CTxOut& out) const
         std::map<CTxDestination, AddressBook::CAddressBookData>::const_iterator mi = mapAddressBook.find(delegator);
         if (mi == mapAddressBook.end())
             return false;
-        return (*mi).second.purpose == "delegator";
+        return (*mi).second.purpose == AddressBook::AddressBookPurpose::DELEGATOR;
     }
 }
 


### PR DESCRIPTION
This PR collects a few additions/fixes on the rpc interface to the addressbook.

- 1. First commit adds a optional string argument to `delegatoradd` to include a label (as already available from the GUI interface, and as already shown with `listdelegators` rpc).
- 2. Second commit adds a optional boolean argument (defaulted to `false`) to `listdelegators`. When `true`, the function returns the list of addresses blacklisted (i.e. removed from the whitelist, i.e. with purpose `AddressBookPurpose::DELEGABLE`).
- 3. Third commit fixes the auxiliary function `ListaddressesForPurpose` in order to use the correct Base58Type when called with purpose `COLD_STAKING_SEND` (which currently never happens anyway, but better to have it corrected).
- 4. Last commit removes all the purpose variable strings (such as `"send"`, `"receive"` or `"cold-staking"`) throughout the code, replacing them with the correct `AddressBook::AddressBookPurpose` constants.