### PR TITLE
[Model][Wallet][Performance] Several changes in txRecord updateStatus.

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -14,7 +14,7 @@
 #include "zpivchain.h"
 #include "main.h"
 
-#include <iostream>
+#include <algorithm>
 #include <stdint.h>
 
 /*
@@ -436,13 +436,15 @@ bool IsZPIVType(TransactionRecord::Type type)
 void TransactionRecord::updateStatus(const CWalletTx& wtx)
 {
     AssertLockHeld(cs_main);
-    // Determine transaction status
+    int chainHeight = chainActive.Height();
 
+    CBlockIndex *pindex = nullptr;
     // Find the block the tx is in
-    CBlockIndex* pindex = NULL;
     BlockMap::iterator mi = mapBlockIndex.find(wtx.hashBlock);
     if (mi != mapBlockIndex.end())
         pindex = (*mi).second;
+
+    // Determine transaction status
 
     // Sort order, unrecorded transactions sort to the top
     status.sortKey = strprintf("%010d-%01d-%010u-%03d",
@@ -450,22 +452,22 @@ void TransactionRecord::updateStatus(const CWalletTx& wtx)
         (wtx.IsCoinBase() ? 1 : 0),
         wtx.nTimeReceived,
         idx);
-    //status.countsForBalance = wtx.IsTrusted() && !(wtx.GetBlocksToMaturity() > 0);
-    bool fConflicted;
-    status.depth = wtx.GetDepthAndMempool(fConflicted);
+
+    bool fConflicted = false;
+    int depth = 0;
+    bool isTrusted = wtx.IsTrusted(depth, fConflicted);
     const bool isOffline = (GetAdjustedTime() - wtx.nTimeReceived > 2 * 60 && wtx.GetRequestCount() == 0);
+    int nBlocksToMaturity = (wtx.IsCoinBase() || wtx.IsCoinStake()) ? std::max(0, (Params().COINBASE_MATURITY() + 1) - depth) : 0;
 
-    //Determine the depth of the block
-    int nBlocksToMaturity = wtx.GetBlocksToMaturity();
-
-    status.countsForBalance = wtx.IsTrusted() && !(nBlocksToMaturity > 0);
-    status.cur_num_blocks = chainActive.Height();
+    status.countsForBalance = isTrusted && !(nBlocksToMaturity > 0);
+    status.cur_num_blocks = chainHeight;
+    status.depth = depth;
     status.cur_num_ix_locks = nCompleteTXLocks;
 
-    if (!IsFinalTx(wtx, chainActive.Height() + 1)) {
+    if (!IsFinalTx(wtx, chainHeight + 1)) {
         if (wtx.nLockTime < LOCKTIME_THRESHOLD) {
             status.status = TransactionStatus::OpenUntilBlock;
-            status.open_for = wtx.nLockTime - chainActive.Height();
+            status.open_for = wtx.nLockTime - chainHeight;
         } else {
             status.status = TransactionStatus::OpenUntilDate;
             status.open_for = wtx.nLockTime;
@@ -477,7 +479,7 @@ void TransactionRecord::updateStatus(const CWalletTx& wtx)
             status.status = TransactionStatus::Immature;
             status.matures_in = nBlocksToMaturity;
 
-            if (pindex && chainActive.Contains(pindex)) {
+            if (status.depth >= 0 && !fConflicted) {
                 // Check if the block was requested by anyone
                 if (isOffline)
                     status.status = TransactionStatus::MaturesWarning;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5458,12 +5458,18 @@ void CWalletTx::Init(const CWallet* pwalletIn)
 
 bool CWalletTx::IsTrusted() const
 {
+    bool fConflicted = false;
+    int nDepth = 0;
+    return IsTrusted(nDepth, fConflicted);
+}
+
+bool CWalletTx::IsTrusted(int& nDepth, bool& fConflicted) const
+{
     // Quick answer in most cases
     if (!IsFinalTx(*this))
         return false;
 
-    bool fConflicted;
-    int nDepth = GetDepthAndMempool(fConflicted);
+    nDepth = GetDepthAndMempool(fConflicted);
 
     if (fConflicted) // Don't trust unconfirmed transactions from us unless they are in the mempool.
         return false;
@@ -5478,7 +5484,7 @@ bool CWalletTx::IsTrusted() const
     for (const CTxIn& txin : vin) {
         // Transactions not sent by us: not trusted
         const CWalletTx* parent = pwallet->GetWalletTx(txin.prevout.hash);
-        if (parent == NULL)
+        if (parent == nullptr)
             return false;
         const CTxOut& parentOut = parent->vout[txin.prevout.n];
         if (pwallet->IsMine(parentOut) != ISMINE_SPENDABLE)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -841,6 +841,7 @@ public:
     bool IsEquivalentTo(const CWalletTx& tx) const;
 
     bool IsTrusted() const;
+    bool IsTrusted(int& nDepth, bool& fConflicted) const;
 
     bool WriteToDisk(CWalletDB *pwalletdb);
 


### PR DESCRIPTION
Several improvements on the `updateStatus` method solving the not accepted stake type not set bug, plus performance improvements.

* The transaction record status update was not taking into account the negative depth calculation, neither if it was conflicted, for not accepted coin stakes

* GetDepth method was called in three different ways. 1) GetDepthAndMempool, 2) IsTrusted, 3) GetBlocksToMaturity. This PR unifies every call into a single call to IsTrusted(&depth, &fConflicted).

* Several calls to chainActive->Height unified into a single one in record statusUpdate.