### PR TITLE
[Core][Trivial] Don't log missing MNs during CleanAndRemove

### DIFF
--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -742,7 +742,7 @@ std::vector<CBudgetProposal*> CBudgetManager::GetAllProposals()
 
     std::map<uint256, CBudgetProposal>::iterator it = mapProposals.begin();
     while (it != mapProposals.end()) {
-        (*it).second.CleanAndRemove(false);
+        (*it).second.CleanAndRemove();
 
         CBudgetProposal* pbudgetProposal = &((*it).second);
         vBudgetProposalRet.push_back(pbudgetProposal);
@@ -776,7 +776,7 @@ std::vector<CBudgetProposal*> CBudgetManager::GetBudget()
 
     std::map<uint256, CBudgetProposal>::iterator it = mapProposals.begin();
     while (it != mapProposals.end()) {
-        (*it).second.CleanAndRemove(false);
+        (*it).second.CleanAndRemove();
         vBudgetPorposalsSort.push_back(std::make_pair(&((*it).second), (*it).second.GetYeas() - (*it).second.GetNays()));
         ++it;
     }
@@ -995,14 +995,14 @@ void CBudgetManager::NewBlock()
     LogPrint("mnbudget","CBudgetManager::NewBlock - mapProposals cleanup - size: %d\n", mapProposals.size());
     std::map<uint256, CBudgetProposal>::iterator it2 = mapProposals.begin();
     while (it2 != mapProposals.end()) {
-        (*it2).second.CleanAndRemove(false);
+        (*it2).second.CleanAndRemove();
         ++it2;
     }
 
     LogPrint("mnbudget","CBudgetManager::NewBlock - mapFinalizedBudgets cleanup - size: %d\n", mapFinalizedBudgets.size());
     std::map<uint256, CFinalizedBudget>::iterator it3 = mapFinalizedBudgets.begin();
     while (it3 != mapFinalizedBudgets.end()) {
-        (*it3).second.CleanAndRemove(false);
+        (*it3).second.CleanAndRemove();
         ++it3;
     }
 
@@ -1141,7 +1141,7 @@ void CBudgetManager::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
 
 
         mapSeenMasternodeBudgetVotes.insert(std::make_pair(vote.GetHash(), vote));
-        if (!vote.CheckSignature(true)) {
+        if (!vote.CheckSignature()) {
             if (masternodeSync.IsSynced()) {
                 LogPrintf("CBudgetManager::ProcessMessage() : mvote - signature invalid\n");
                 Misbehaving(pfrom->GetId(), 20);
@@ -1215,7 +1215,7 @@ void CBudgetManager::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         }
 
         mapSeenFinalizedBudgetVotes.insert(std::make_pair(vote.GetHash(), vote));
-        if (!vote.CheckSignature(true)) {
+        if (!vote.CheckSignature()) {
             if (masternodeSync.IsSynced()) {
                 LogPrintf("CBudgetManager::ProcessMessage() : fbvote - signature from masternode %s invalid\n", HexStr(pmn->pubKeyMasternode));
                 Misbehaving(pfrom->GetId(), 20);
@@ -1616,12 +1616,13 @@ bool CBudgetProposal::AddOrUpdateVote(CBudgetVote& vote, std::string& strError)
 }
 
 // If masternode voted for a proposal, but is now invalid -- remove the vote
-void CBudgetProposal::CleanAndRemove(bool fSignatureCheck)
+void CBudgetProposal::CleanAndRemove()
 {
     std::map<uint256, CBudgetVote>::iterator it = mapVotes.begin();
 
     while (it != mapVotes.end()) {
-        (*it).second.fValid = (*it).second.CheckSignature(fSignatureCheck);
+        CMasternode* pmn = mnodeman.Find((*it).second.GetVin());
+        (*it).second.fValid = (pmn != nullptr);
         ++it;
     }
 }
@@ -1959,12 +1960,13 @@ void CFinalizedBudget::CheckAndVote()
 }
 
 // Remove votes from masternodes which are not valid/existent anymore
-void CFinalizedBudget::CleanAndRemove(bool fSignatureCheck)
+void CFinalizedBudget::CleanAndRemove()
 {
     std::map<uint256, CFinalizedBudgetVote>::iterator it = mapVotes.begin();
 
     while (it != mapVotes.end()) {
-        (*it).second.fValid = (*it).second.CheckSignature(fSignatureCheck);
+        CMasternode* pmn = mnodeman.Find((*it).second.GetVin());
+        (*it).second.fValid = (pmn != nullptr);
         ++it;
     }
 }

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -327,7 +327,7 @@ public:
     CFinalizedBudget();
     CFinalizedBudget(const CFinalizedBudget& other);
 
-    void CleanAndRemove(bool fSignatureCheck);
+    void CleanAndRemove();
     bool AddOrUpdateVote(CFinalizedBudgetVote& vote, std::string& strError);
     double GetScore();
     bool HasMinimumRequiredSupport();
@@ -509,7 +509,7 @@ public:
     void SetAllotted(CAmount nAllotedIn) { nAlloted = nAllotedIn; }
     CAmount GetAllotted() { return nAlloted; }
 
-    void CleanAndRemove(bool fSignatureCheck);
+    void CleanAndRemove();
 
     uint256 GetHash() const
     {

--- a/src/messagesigner.cpp
+++ b/src/messagesigner.cpp
@@ -140,15 +140,15 @@ bool CSignedMessage::CheckSignature(const CPubKey& pubKey) const
     return true;
 }
 
-bool CSignedMessage::CheckSignature(const bool fSignatureCheck) const
+bool CSignedMessage::CheckSignature() const
 {
     std::string strError = "";
 
     const CPubKey pubkey = GetPublicKey(strError);
     if (pubkey == CPubKey())
-        return error("%s : ERROR: %s", __func__, strError);
+        return error("%s : %s", __func__, strError);
 
-    return !fSignatureCheck || CheckSignature(pubkey);
+    return CheckSignature(pubkey);
 }
 
 const CPubKey CSignedMessage::GetPublicKey(std::string& strErrorRet) const

--- a/src/messagesigner.h
+++ b/src/messagesigner.h
@@ -70,7 +70,7 @@ public:
     bool Sign(const CKey& key, const CPubKey& pubKey, const bool fNewSigs);
     bool Sign(const std::string strSignKey, const bool fNewSigs);
     bool CheckSignature(const CPubKey& pubKey) const;
-    bool CheckSignature(const bool fSignatureCheck = true) const;
+    bool CheckSignature() const;
 
     // Pure virtual functions (used in Sign-Verify functions)
     // Must be implemented in child classes

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -732,10 +732,10 @@ UniValue mnbudgetrawvote(const UniValue& params, bool fHelp)
     vote.nTime = nTime;
     vote.SetVchSig(vchSig);
 
-    if (!vote.CheckSignature(true)) {
+    if (!vote.CheckSignature()) {
         // try old message version
         vote.nMessVersion = MessageVersion::MESS_VER_STRMESS;
-        if (!vote.CheckSignature(true)) return "Failure to verify signature.";
+        if (!vote.CheckSignature()) return "Failure to verify signature.";
     }
 
     std::string strError = "";


### PR DESCRIPTION
Currently the log is spammed with `ERROR: CheckSignature : ERROR: Unable to find masternode vin` triggered during `CBudgetProposal::CleanAndRemove` and `CFinalizedBudget::CleanAndRemove` when the signature is not even checked.
Since the purpose, as stated in the comment, is to "*remove votes from masternodes which are not valid/existent anymore*"  there is no need to report those as errors in the logs.

Furthermore, those are the only places where we use `fSignatureCheck=false` in `CheckSignature` . This is not needed, we can check directly `mnodeman` and don't call `CheckSignature` (since the signature is **NOT** checked anyway).
This way there is no need to include the boolean argument in the function at all.