### PR TITLE
[Core] Rework staking status

### DIFF
--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -362,10 +362,6 @@ bool Stake(const CBlockIndex* pindexPrev, CStakeInput* stakeInput, unsigned int 
 
     // Time protocol V2: one-try
     if (Params().IsTimeProtocolV2(nHeight)) {
-        // store a time stamp of when we last hashed on this block
-        mapHashedBlocks.clear();
-        mapHashedBlocks[pindexPrev->nHeight] = GetTime();
-
         // check required min depth for stake
         const int nHeightBlockFrom = pindexFrom->nHeight;
         if (nHeight < nHeightBlockFrom + Params().COINSTAKE_MIN_DEPTH())
@@ -402,10 +398,6 @@ bool StakeV1(const CBlockIndex* pindexPrev, CStakeInput* stakeInput, const uint3
     }
 
     while (nTryTime > minTime) {
-        // store a time stamp of when we last hashed on this block
-        mapHashedBlocks.clear();
-        mapHashedBlocks[pindexPrev->nHeight] = GetTime();
-
         //new block came in, move on
         if (chainActive.Height() != pindexPrev->nHeight) break;
 
@@ -420,10 +412,6 @@ bool StakeV1(const CBlockIndex* pindexPrev, CStakeInput* stakeInput, const uint3
     }
 
     nTimeTx = nTryTime;
-
-    mapHashedBlocks.clear();
-    mapHashedBlocks[pindexPrev->nHeight] = GetTime(); //store a time stamp of when we last hashed on this block
-
     return fSuccess;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,7 +66,6 @@ CCriticalSection cs_main;
 
 BlockMap mapBlockIndex;
 std::map<uint256, uint256> mapProofOfStake;
-std::map<unsigned int, unsigned int> mapHashedBlocks;
 CChain chainActive;
 CBlockIndex* pindexBestHeader = NULL;
 int64_t nTimeBestReceived = 0;

--- a/src/main.h
+++ b/src/main.h
@@ -166,12 +166,9 @@ extern bool fVerifyingBlocks;
 extern bool fLargeWorkForkFound;
 extern bool fLargeWorkInvalidChainFound;
 
-extern int64_t nLastCoinStakeSearchInterval;
-extern int64_t nLastCoinStakeSearchTime;
 extern int64_t nReserveBalance;
 
 extern std::map<uint256, int64_t> mapRejectedBlocks;
-extern std::map<unsigned int, unsigned int> mapHashedBlocks;
 extern std::map<uint256, int64_t> mapZerocoinspends; //txid, time received
 
 /** Best header we've seen so far (used for getheaders queries' starting points). */

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -121,14 +121,12 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, 
 
     // Create new block
     std::unique_ptr<CBlockTemplate> pblocktemplate(new CBlockTemplate());
-    if (!pblocktemplate.get())
-        return NULL;
+    if (!pblocktemplate.get()) return nullptr;
     CBlock* pblock = &pblocktemplate->block; // pointer for convenience
 
     // Tip
     CBlockIndex* pindexPrev = GetChainTip();
-    if (!pindexPrev)
-        return nullptr;
+    if (!pindexPrev) return nullptr;
 
     const int nHeight = pindexPrev->nHeight + 1;
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -157,30 +157,19 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, 
     pblocktemplate->vTxFees.push_back(-1);   // updated at end
     pblocktemplate->vTxSigOps.push_back(-1); // updated at end
 
-    // ppcoin: if coinstake available add coinstake tx
-    static int64_t nLastCoinStakeSearchTime = GetAdjustedTime(); // only initialized at startup
-
     if (fProofOfStake) {
         boost::this_thread::interruption_point();
         pblock->nTime = GetAdjustedTime();
         pblock->nBits = GetNextWorkRequired(pindexPrev, pblock);
         CMutableTransaction txCoinStake;
-        int64_t nSearchTime = pblock->nTime; // search to current time
-        bool fStakeFound = false;
-        if (nSearchTime >= nLastCoinStakeSearchTime) {
-            int64_t nTxNewTime = 0;
-            if (pwallet->CreateCoinStake(*pwallet, pindexPrev, pblock->nBits, txCoinStake, nTxNewTime)) {
-                pblock->nTime = nTxNewTime;
-                pblock->vtx[0].vout[0].SetEmpty();
-                pblock->vtx.push_back(CTransaction(txCoinStake));
-                fStakeFound = true;
-            }
-            nLastCoinStakeSearchTime = nSearchTime;
-        }
-
-        if (!fStakeFound) {
+        int64_t nTxNewTime = 0;
+        if (pwallet->CreateCoinStake(*pwallet, pindexPrev, pblock->nBits, txCoinStake, nTxNewTime)) {
+            pblock->nTime = nTxNewTime;
+            pblock->vtx[0].vout[0].SetEmpty();
+            pblock->vtx.push_back(CTransaction(txCoinStake));
+        } else {
             LogPrint("staking", "CreateNewBlock(): stake not found\n");
-            return NULL;
+            return nullptr;
         }
     }
 
@@ -671,7 +660,6 @@ void BitcoinMiner(CWallet* pwallet, bool fProofOfStake)
     // Each thread has its own key and counter
     CReserveKey reservekey(pwallet);
     unsigned int nExtraNonce = 0;
-    bool fLastLoopOrphan = false;
     bool fColdStake = GetBoolArg("-coldstaking", true);
     CAmount stakingBalance = 0;
 
@@ -705,8 +693,7 @@ void BitcoinMiner(CWallet* pwallet, bool fProofOfStake)
 
             const bool fTimeV2 = Params().IsTimeProtocolV2(chainActive.Height()+1);
             //search our map of hashed blocks, see if bestblock has been hashed yet
-            if (pwallet->pStakerStatus->GetLastHash() == chainActive.Tip()->GetBlockHash()
-                    && !fLastLoopOrphan)
+            if (pwallet->pStakerStatus->GetLastHash() == chainActive.Tip()->GetBlockHash())
             {
                 uint256 lastHashTime = pwallet->pStakerStatus->GetLastTime();
                 if (    (!fTimeV2 && GetTime() < lastHashTime + 22) ||
@@ -766,10 +753,10 @@ void BitcoinMiner(CWallet* pwallet, bool fProofOfStake)
                 continue;
             }
 
-            LogPrintf("CPUMiner : proof-of-stake block was signed %s \n", pblock->GetHash().ToString().c_str());
+            LogPrintf("%s : proof-of-stake block was signed %s \n", __func__, pblock->GetHash().ToString().c_str());
             SetThreadPriority(THREAD_PRIORITY_NORMAL);
             if (!ProcessBlockFound(pblock, *pwallet, reservekey)) {
-                fLastLoopOrphan = true;
+                LogPrintf("%s: New block orphaned\n", __func__);
                 continue;
             }
             SetThreadPriority(THREAD_PRIORITY_LOWEST);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -170,7 +170,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, 
         bool fStakeFound = false;
         if (nSearchTime >= nLastCoinStakeSearchTime) {
             int64_t nTxNewTime = 0;
-            if (pwallet->CreateCoinStake(*pwallet, pindexPrev, pblock->nBits, nSearchTime - nLastCoinStakeSearchTime, txCoinStake, nTxNewTime)) {
+            if (pwallet->CreateCoinStake(*pwallet, pindexPrev, pblock->nBits, txCoinStake, nTxNewTime)) {
                 pblock->nTime = nTxNewTime;
                 pblock->vtx[0].vout[0].SetEmpty();
                 pblock->vtx.push_back(CTransaction(txCoinStake));

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -702,7 +702,7 @@ void BitcoinMiner(CWallet* pwallet, bool fProofOfStake)
             //search our map of hashed blocks, see if bestblock has been hashed yet
             if (pwallet->pStakerStatus->GetLastHash() == pindexPrev->GetBlockHash())
             {
-                uint256 lastHashTime = pwallet->pStakerStatus->GetLastTime();
+                int64_t lastHashTime = pwallet->pStakerStatus->GetLastTime();
                 if (    (!fTimeV2 && GetTime() < lastHashTime + 22) ||
                         (fTimeV2 && GetCurrentTimeSlot() <= lastHashTime) )
                 {

--- a/src/miner.h
+++ b/src/miner.h
@@ -18,6 +18,8 @@ class CWallet;
 
 struct CBlockTemplate;
 
+/** Get reliable pointer to current chain tip */
+CBlockIndex* GetChainTip();
 /** Generate a new block, without valid proof-of-work */
 CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, bool fProofOfStake);
 /** Modify the extranonce in a block */

--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -367,7 +367,9 @@ void TopBar::setStakingStatusActive(bool fActive)
     }
 }
 void TopBar::updateStakingStatus(){
-    setStakingStatusActive(walletModel && walletModel->isStakingStatusActive());
+    setStakingStatusActive(walletModel &&
+                           !walletModel->isWalletLocked() &&
+                           walletModel->isStakingStatusActive());
 }
 
 void TopBar::setNumConnections(int count) {

--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -207,6 +207,9 @@ void TopBar::lockDropdownClicked(const StateClicked& state){
                 walletModel->setWalletLocked(true);
                 ui->pushButtonLock->setButtonText("Wallet Locked");
                 ui->pushButtonLock->setButtonClassStyle("cssClass", "btn-check-status-lock", true);
+                // Directly update the staking status icon when the wallet is manually locked here
+                // so the feedback is instant (no need to wait for the polling timeout)
+                setStakingStatusActive(false);
                 break;
             }
             case 1: {
@@ -353,20 +356,18 @@ void TopBar::updateAutoMintStatus(){
     ui->pushButtonMint->setChecked(fEnableZeromint);
 }
 
-void TopBar::updateStakingStatus(){
-    if (walletModel && walletModel->isStakingStatusActive()) {
-        if (!ui->pushButtonStack->isChecked()) {
-            ui->pushButtonStack->setButtonText(tr("Staking active"));
-            ui->pushButtonStack->setChecked(true);
-            ui->pushButtonStack->setButtonClassStyle("cssClass", "btn-check-stack", true);
-        }
-    }else{
-        if (ui->pushButtonStack->isChecked()) {
-            ui->pushButtonStack->setButtonText(tr("Staking not active"));
-            ui->pushButtonStack->setChecked(false);
-            ui->pushButtonStack->setButtonClassStyle("cssClass", "btn-check-stack-inactive", true);
-        }
+void TopBar::setStakingStatusActive(bool fActive)
+{
+    if (ui->pushButtonStack->isChecked() != fActive) {
+        ui->pushButtonStack->setButtonText(fActive ? tr("Staking active") : tr("Staking not active"));
+        ui->pushButtonStack->setChecked(fActive);
+        ui->pushButtonStack->setButtonClassStyle("cssClass", (fActive ?
+                                                                "btn-check-stack" :
+                                                                "btn-check-stack-inactive"), true);
     }
+}
+void TopBar::updateStakingStatus(){
+    setStakingStatusActive(walletModel && walletModel->isStakingStatusActive());
 }
 
 void TopBar::setNumConnections(int count) {

--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -354,7 +354,7 @@ void TopBar::updateAutoMintStatus(){
 }
 
 void TopBar::updateStakingStatus(){
-    if (nLastCoinStakeSearchInterval) {
+    if (walletModel && walletModel->isStakingStatusActive()) {
         if (!ui->pushButtonStack->isChecked()) {
             ui->pushButtonStack->setButtonText(tr("Staking active"));
             ui->pushButtonStack->setChecked(true);

--- a/src/qt/pivx/topbar.h
+++ b/src/qt/pivx/topbar.h
@@ -45,6 +45,7 @@ public slots:
     void setNumConnections(int count);
     void setNumBlocks(int count);
     void updateAutoMintStatus();
+    void setStakingStatusActive(bool fActive);
     void updateStakingStatus();
 
 signals:

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -66,6 +66,10 @@ bool WalletModel::isColdStakingNetworkelyEnabled() const {
     return sporkManager.IsSporkActive(SPORK_17_COLDSTAKING_ENFORCEMENT);
 }
 
+bool WalletModel::isStakingStatusActive() const {
+    return wallet->pStakerStatus->IsActive();
+}
+
 CAmount WalletModel::getBalance(const CCoinControl* coinControl) const
 {
     if (coinControl) {

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -171,6 +171,10 @@ bool WalletModel::isWalletUnlocked() const {
     return status == Unencrypted || status == Unlocked;
 }
 
+bool WalletModel::isWalletLocked() const {
+    return getEncryptionStatus() == Locked;
+}
+
 void WalletModel::pollBalanceChanged()
 {
     // Get required locks upfront. This avoids the GUI from getting stuck on

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -167,6 +167,7 @@ public:
 
     EncryptionStatus getEncryptionStatus() const;
     bool isWalletUnlocked() const;
+    bool isWalletLocked() const;
     CKey generateNewKey() const; //for temporary paper wallet key generation
     bool setAddressBook(const CTxDestination& address, const std::string& strName, const std::string& strPurpose);
     void encryptKey(const CKey key, const std::string& pwd, const std::string& slt, std::vector<unsigned char>& crypted);

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -145,6 +145,8 @@ public:
     /** Whether cold staking is enabled or disabled in the network **/
     bool isColdStakingNetworkelyEnabled() const;
     CAmount getMinColdStakingAmount() const;
+    /* current staking status from the miner thread **/
+    bool isStakingStatusActive() const;
 
     CAmount getBalance(const CCoinControl* coinControl = NULL) const;
     CAmount getUnconfirmedBalance() const;
@@ -222,18 +224,6 @@ public:
             bool fMinimizeChange,
             CZerocoinSpendReceipt &receipt
     );
-
-    // ###################
-    // Cold Staking
-    // ###################
-
-
-
-    // ###################
-    // End Cold Staking
-    // ###################
-
-
 
     // Wallet encryption
     bool setWalletEncrypted(bool encrypted, const SecureString& passphrase);

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -52,18 +52,19 @@ UniValue getinfo(const UniValue& params, bool fHelp)
 
             "\nResult:\n"
             "{\n"
-            "  \"version\": xxxxx,           (numeric) the server version\n"
-            "  \"protocolversion\": xxxxx,   (numeric) the protocol version\n"
-            "  \"walletversion\": xxxxx,     (numeric) the wallet version\n"
-            "  \"balance\": xxxxxxx,         (numeric) the total pivx balance of the wallet (excluding zerocoins)\n"
-            "  \"zerocoinbalance\": xxxxxxx, (numeric) the total zerocoin balance of the wallet\n"
-            "  \"blocks\": xxxxxx,           (numeric) the current number of blocks processed in the server\n"
-            "  \"timeoffset\": xxxxx,        (numeric) the time offset\n"
-            "  \"connections\": xxxxx,       (numeric) the number of connections\n"
-            "  \"proxy\": \"host:port\",     (string, optional) the proxy used by the server\n"
-            "  \"difficulty\": xxxxxx,       (numeric) the current difficulty\n"
-            "  \"testnet\": true|false,      (boolean) if the server is using testnet or not\n"
-            "  \"moneysupply\" : \"supply\"       (numeric) The money supply when this block was added to the blockchain\n"
+            "  \"version\": xxxxx,             (numeric) the server version\n"
+            "  \"protocolversion\": xxxxx,     (numeric) the protocol version\n"
+            "  \"walletversion\": xxxxx,       (numeric) the wallet version\n"
+            "  \"balance\": xxxxxxx,           (numeric) the total pivx balance of the wallet (excluding zerocoins)\n"
+            "  \"zerocoinbalance\": xxxxxxx,   (numeric) the total zerocoin balance of the wallet\n"
+            "  \"staking status\": true|false, (boolean) if the wallet is staking or not\n"
+            "  \"blocks\": xxxxxx,             (numeric) the current number of blocks processed in the server\n"
+            "  \"timeoffset\": xxxxx,          (numeric) the time offset\n"
+            "  \"connections\": xxxxx,         (numeric) the number of connections\n"
+            "  \"proxy\": \"host:port\",       (string, optional) the proxy used by the server\n"
+            "  \"difficulty\": xxxxxx,         (numeric) the current difficulty\n"
+            "  \"testnet\": true|false,        (boolean) if the server is using testnet or not\n"
+            "  \"moneysupply\" : \"supply\"    (numeric) The money supply when this block was added to the blockchain\n"
             "  \"zPIVsupply\" :\n"
             "  {\n"
             "     \"1\" : n,            (numeric) supply of 1 zPIV denomination\n"
@@ -76,13 +77,12 @@ UniValue getinfo(const UniValue& params, bool fHelp)
             "     \"5000\" : n,         (numeric) supply of 5000 zPIV denomination\n"
             "     \"total\" : n,        (numeric) The total supply of all zPIV denominations\n"
             "  }\n"
-            "  \"keypoololdest\": xxxxxx,    (numeric) the timestamp (seconds since GMT epoch) of the oldest pre-generated key in the key pool\n"
-            "  \"keypoolsize\": xxxx,        (numeric) how many new keys are pre-generated\n"
-            "  \"unlocked_until\": ttt,      (numeric) the timestamp in seconds since epoch (midnight Jan 1 1970 GMT) that the wallet is unlocked for transfers, or 0 if the wallet is locked\n"
-            "  \"paytxfee\": x.xxxx,         (numeric) the transaction fee set in pivx/kb\n"
-            "  \"relayfee\": x.xxxx,         (numeric) minimum relay fee for non-free transactions in pivx/kb\n"
-            "  \"staking status\": true|false,  (boolean) if the wallet is staking or not\n"
-            "  \"errors\": \"...\"           (string) any error messages\n"
+            "  \"keypoololdest\": xxxxxx,      (numeric) the timestamp (seconds since GMT epoch) of the oldest pre-generated key in the key pool\n"
+            "  \"keypoolsize\": xxxx,          (numeric) how many new keys are pre-generated\n"
+            "  \"unlocked_until\": ttt,        (numeric) the timestamp in seconds since epoch (midnight Jan 1 1970 GMT) that the wallet is unlocked for transfers, or 0 if the wallet is locked\n"
+            "  \"paytxfee\": x.xxxx,           (numeric) the transaction fee set in pivx/kb\n"
+            "  \"relayfee\": x.xxxx,           (numeric) minimum relay fee for non-free transactions in pivx/kb\n"
+            "  \"errors\": \"...\"             (string) any error messages\n"
             "}\n"
 
             "\nExamples:\n" +
@@ -127,6 +127,9 @@ UniValue getinfo(const UniValue& params, bool fHelp)
         obj.push_back(Pair("walletversion", pwalletMain->GetVersion()));
         obj.push_back(Pair("balance", ValueFromAmount(pwalletMain->GetBalance())));
         obj.push_back(Pair("zerocoinbalance", ValueFromAmount(pwalletMain->GetZerocoinBalance(true))));
+        obj.push_back(Pair("staking status", (pwalletMain->pStakerStatus->IsActive() ?
+                                                "Staking Active" :
+                                                "Staking Not Active")));
     }
 #endif
     obj.push_back(Pair("blocks", (int)chainActive.Height()));
@@ -160,9 +163,6 @@ UniValue getinfo(const UniValue& params, bool fHelp)
     obj.push_back(Pair("paytxfee", ValueFromAmount(payTxFee.GetFeePerK())));
 #endif
     obj.push_back(Pair("relayfee", ValueFromAmount(::minRelayTxFee.GetFeePerK())));
-    obj.push_back(Pair("staking status", (pwalletMain->pStakerStatus->IsActive() ?
-                                            "Staking Active" :
-                                            "Staking Not Active")));
     obj.push_back(Pair("errors", GetWarnings("statusbar")));
     return obj;
 }
@@ -598,10 +598,10 @@ UniValue getstakingstatus(const UniValue& params, bool fHelp)
             "  \"staking_enabled\": true|false,    (boolean) if staking is enabled/disabled in pivx.conf\n"
             "  \"tiptime\": n,                     (integer) chain tip blocktime\n"
             "  \"haveconnections\": true|false,    (boolean) if network connections are present\n"
+            "  \"mnsync\": true|false,             (boolean) if masternode data is synced\n"
             "  \"walletunlocked\": true|false,     (boolean) if the wallet is unlocked\n"
             "  \"mintablecoins\": true|false,      (boolean) if the wallet has mintable coins\n"
             "  \"enoughcoins\": true|false,        (boolean) if available coins are greater than reserve balance\n"
-            "  \"mnsync\": true|false,             (boolean) if masternode data is synced\n"
             "  \"hashLastStakeAttempt\": xxx       (hex string) hash of last block on top of which the miner attempted to stake\n"
             "  \"heightLastStakeAttempt\": n       (integer) height of last block on top of which the miner attempted to stake\n"
             "  \"timeLastStakeAttempt\": n         (integer) time of last attempted stake\n"
@@ -610,28 +610,28 @@ UniValue getstakingstatus(const UniValue& params, bool fHelp)
             "\nExamples:\n" +
             HelpExampleCli("getstakingstatus", "") + HelpExampleRpc("getstakingstatus", ""));
 
-#ifdef ENABLE_WALLET
-    LOCK2(cs_main, pwalletMain ? &pwalletMain->cs_wallet : NULL);
-#else
-    LOCK(cs_main);
-#endif
 
-    UniValue obj(UniValue::VOBJ);
-    obj.push_back(Pair("staking_status", pwalletMain->pStakerStatus->IsActive()));
-    obj.push_back(Pair("staking_enabled", GetBoolArg("-staking", true)));
-    obj.push_back(Pair("tiptime", (int)chainActive.Tip()->nTime));
-    obj.push_back(Pair("haveconnections", !vNodes.empty()));
-    if (pwalletMain) {
+    if (!pwalletMain)
+        throw JSONRPCError(RPC_IN_WARMUP, "Try again after active chain is loaded");
+    {
+        LOCK2(cs_main, &pwalletMain->cs_wallet);
+        UniValue obj(UniValue::VOBJ);
+        obj.push_back(Pair("staking_status", pwalletMain->pStakerStatus->IsActive()));
+        obj.push_back(Pair("staking_enabled", GetBoolArg("-staking", true)));
+        obj.push_back(Pair("tiptime", (int)chainActive.Tip()->nTime));
+        obj.push_back(Pair("haveconnections", !vNodes.empty()));
+        obj.push_back(Pair("mnsync", masternodeSync.IsSynced()));
         obj.push_back(Pair("walletunlocked", !pwalletMain->IsLocked()));
         obj.push_back(Pair("mintablecoins", pwalletMain->MintableCoins()));
         obj.push_back(Pair("enoughcoins", nReserveBalance <= pwalletMain->GetStakingBalance(GetBoolArg("-coldstaking", true))));
+        uint256 lastHash = pwalletMain->pStakerStatus->GetLastHash();
+        obj.push_back(Pair("hashLastStakeAttempt", lastHash.GetHex()));
+        obj.push_back(Pair("heightLastStakeAttempt", (mapBlockIndex.count(lastHash) > 0 ?
+                                                        mapBlockIndex.at(lastHash)->nHeight : -1)) );
+        obj.push_back(Pair("timeLastStakeAttempt", pwalletMain->pStakerStatus->GetLastTime()));
+        return obj;
     }
-    obj.push_back(Pair("mnsync", masternodeSync.IsSynced()));
-    uint256 lastHash = pwalletMain->pStakerStatus->GetLastHash();
-    obj.push_back(Pair("hashLastStakeAttempt", lastHash.GetHex()));
-    obj.push_back(Pair("heightLastStakeAttempt", (mapBlockIndex.count(lastHash) > 0 ?
-                                                    mapBlockIndex.at(lastHash)->nHeight : -1)) );
-    obj.push_back(Pair("timeLastStakeAttempt", pwalletMain->pStakerStatus->GetLastTime()));
-    return obj;
+
+
 }
 #endif // ENABLE_WALLET

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -160,12 +160,9 @@ UniValue getinfo(const UniValue& params, bool fHelp)
     obj.push_back(Pair("paytxfee", ValueFromAmount(payTxFee.GetFeePerK())));
 #endif
     obj.push_back(Pair("relayfee", ValueFromAmount(::minRelayTxFee.GetFeePerK())));
-    bool nStaking = false;
-    if (mapHashedBlocks.count(chainActive.Tip()->nHeight))
-        nStaking = true;
-    else if (mapHashedBlocks.count(chainActive.Tip()->nHeight - 1) && nLastCoinStakeSearchInterval)
-        nStaking = true;
-    obj.push_back(Pair("staking status", (nStaking ? "Staking Active" : "Staking Not Active")));
+    obj.push_back(Pair("staking status", (pwalletMain->pStakerStatus->IsActive() ?
+                                            "Staking Active" :
+                                            "Staking Not Active")));
     obj.push_back(Pair("errors", GetWarnings("statusbar")));
     return obj;
 }
@@ -624,13 +621,7 @@ UniValue getstakingstatus(const UniValue& params, bool fHelp)
         obj.push_back(Pair("enoughcoins", nReserveBalance <= pwalletMain->GetBalance()));
     }
     obj.push_back(Pair("mnsync", masternodeSync.IsSynced()));
-
-    bool nStaking = false;
-    if (mapHashedBlocks.count(chainActive.Tip()->nHeight))
-        nStaking = true;
-    else if (mapHashedBlocks.count(chainActive.Tip()->nHeight - 1) && nLastCoinStakeSearchInterval)
-        nStaking = true;
-    obj.push_back(Pair("staking status", nStaking));
+    obj.push_back(Pair("staking status", pwalletMain->pStakerStatus->IsActive()));
 
     return obj;
 }

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -594,6 +594,7 @@ UniValue getstakingstatus(const UniValue& params, bool fHelp)
 
             "\nResult:\n"
             "{\n"
+            "  \"staking_status\": true|false,     (boolean) if the wallet is staking or not\n"
             "  \"staking_enabled\": true|false,    (boolean) if staking is enabled/disabled in pivx.conf\n"
             "  \"tiptime\": n,                     (integer) chain tip blocktime\n"
             "  \"haveconnections\": true|false,    (boolean) if network connections are present\n"
@@ -604,7 +605,6 @@ UniValue getstakingstatus(const UniValue& params, bool fHelp)
             "  \"hashLastStakeAttempt\": xxx       (hex string) hash of last block on top of which the miner attempted to stake\n"
             "  \"heightLastStakeAttempt\": n       (integer) height of last block on top of which the miner attempted to stake\n"
             "  \"timeLastStakeAttempt\": n         (integer) time of last attempted stake\n"
-            "  \"staking_status\": true|false,     (boolean) if the wallet is staking or not\n"
             "}\n"
 
             "\nExamples:\n" +
@@ -617,6 +617,7 @@ UniValue getstakingstatus(const UniValue& params, bool fHelp)
 #endif
 
     UniValue obj(UniValue::VOBJ);
+    obj.push_back(Pair("staking_status", pwalletMain->pStakerStatus->IsActive()));
     obj.push_back(Pair("staking_enabled", GetBoolArg("-staking", true)));
     obj.push_back(Pair("tiptime", (int)chainActive.Tip()->nTime));
     obj.push_back(Pair("haveconnections", !vNodes.empty()));
@@ -631,8 +632,6 @@ UniValue getstakingstatus(const UniValue& params, bool fHelp)
     obj.push_back(Pair("heightLastStakeAttempt", (mapBlockIndex.count(lastHash) > 0 ?
                                                     mapBlockIndex.at(lastHash)->nHeight : -1)) );
     obj.push_back(Pair("timeLastStakeAttempt", pwalletMain->pStakerStatus->GetLastTime()));
-    obj.push_back(Pair("staking_status", pwalletMain->pStakerStatus->IsActive()));
-
     return obj;
 }
 #endif // ENABLE_WALLET

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2700,12 +2700,20 @@ bool CWallet::CreateCoinStake(
     bool fKernelFound = false;
     int nAttempts = 0;
 
-    for (std::unique_ptr<CStakeInput>& stakeInput : listInputs) {
-        nCredit = 0;
-        // Make sure the wallet is unlocked and shutdown hasn't been requested
-        if (IsLocked() || ShutdownRequested())
-            return false;
+    // update staker status (hash)
+    pStakerStatus->SetLastHash(pindexPrev->GetBlockHash());
 
+    for (std::unique_ptr<CStakeInput>& stakeInput : listInputs) {
+        //new block came in, move on
+        if (chainActive.Height() != pindexPrev->nHeight) return false;
+
+        // Make sure the wallet is unlocked and shutdown hasn't been requested
+        if (IsLocked() || ShutdownRequested()) return false;
+
+        // update staker status (time)
+        pStakerStatus->SetLastTime(GetCurrentTimeSlot());
+
+        nCredit = 0;
         uint256 hashProofOfStake = 0;
         nAttempts++;
         //iterates each utxo inside of CheckStakeKernelHash()
@@ -5135,6 +5143,7 @@ CWallet::CWallet(std::string strWalletFileIn)
 CWallet::~CWallet()
 {
     delete pwalletdbEncryption;
+    delete pStakerStatus;
 }
 
 void CWallet::SetNull()
@@ -5152,6 +5161,7 @@ void CWallet::SetNull()
     fBackupMints = false;
 
     // Stake Settings
+    pStakerStatus = new CStakerStatus();
     nStakeSplitThreshold = STAKE_SPLIT_THRESHOLD;
     nStakeSetUpdateTime = 300; // 5 minutes
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2701,7 +2701,7 @@ bool CWallet::CreateCoinStake(
     int nAttempts = 0;
 
     // update staker status (hash)
-    pStakerStatus->SetLastHash(pindexPrev->GetBlockHash());
+    pStakerStatus->SetLastTip(pindexPrev);
 
     for (std::unique_ptr<CStakeInput>& stakeInput : listInputs) {
         //new block came in, move on

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2655,7 +2655,6 @@ bool CWallet::CreateCoinStake(
         const CKeyStore& keystore,
         const CBlockIndex* pindexPrev,
         unsigned int nBits,
-        int64_t nSearchInterval,
         CMutableTransaction& txNew,
         int64_t& nTxNewTime
         )

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -150,7 +150,7 @@ public:
 /** Record info about last kernel stake operation (time and chainTip)**/
 class CStakerStatus {
 private:
-    const CBlockIndex* tipLastStakeAttempt;
+    const CBlockIndex* tipLastStakeAttempt = nullptr;
     int64_t timeLastStakeAttempt;
 public:
     const CBlockIndex* GetLastTip() const { return tipLastStakeAttempt; }
@@ -161,10 +161,10 @@ public:
     int64_t GetLastTime() const { return timeLastStakeAttempt; }
     void SetLastTip(const CBlockIndex* lastTip) { tipLastStakeAttempt = lastTip; }
     void SetLastTime(const uint64_t lastTime) { timeLastStakeAttempt = lastTime; }
-    void Update(CBlockIndex* lastTip, const uint64_t lastTime)
+    void SetNull()
     {
-        SetLastTip(lastTip);
-        SetLastTime(lastTime);
+        SetLastTip(nullptr);
+        SetLastTime(0);
     }
     bool IsActive() { return (timeLastStakeAttempt + 30) >= GetTime(); }
 };
@@ -300,7 +300,7 @@ public:
     // Stake Settings
     uint64_t nStakeSplitThreshold;
     int nStakeSetUpdateTime;
-    CStakerStatus* pStakerStatus;
+    CStakerStatus* pStakerStatus = nullptr;
 
     //MultiSend
     std::vector<std::pair<std::string, int> > vMultiSend;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -147,19 +147,23 @@ public:
     }
 };
 
-/** Record metadata about last kernel stake operation (time and prev hash)**/
+/** Record info about last kernel stake operation (time and chainTip)**/
 class CStakerStatus {
 private:
-    uint256 hashLastStakeAttempt;
+    const CBlockIndex* tipLastStakeAttempt;
     int64_t timeLastStakeAttempt;
 public:
-    uint256 GetLastHash() const { return hashLastStakeAttempt; }
-    int64_t GetLastTime() const { return timeLastStakeAttempt; }
-    void SetLastHash(const uint256& lastHash) { hashLastStakeAttempt = lastHash; }
-    void SetLastTime(const uint64_t lastTime) { timeLastStakeAttempt = lastTime; }
-    void Update(const uint256& lastHash, const uint64_t lastTime)
+    const CBlockIndex* GetLastTip() const { return tipLastStakeAttempt; }
+    uint256 GetLastHash() const
     {
-        SetLastHash(lastHash);
+        return (tipLastStakeAttempt == nullptr ? 0 : tipLastStakeAttempt->GetBlockHash());
+    }
+    int64_t GetLastTime() const { return timeLastStakeAttempt; }
+    void SetLastTip(const CBlockIndex* lastTip) { tipLastStakeAttempt = lastTip; }
+    void SetLastTime(const uint64_t lastTime) { timeLastStakeAttempt = lastTime; }
+    void Update(CBlockIndex* lastTip, const uint64_t lastTime)
+    {
+        SetLastTip(lastTip);
         SetLastTime(lastTime);
     }
     bool IsActive() { return (timeLastStakeAttempt + 30) >= GetTime(); }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -449,7 +449,7 @@ public:
     bool CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey, std::string strCommand = "tx");
     bool AddAccountingEntry(const CAccountingEntry&, CWalletDB & pwalletdb);
     int GenerateObfuscationOutputs(int nTotalValue, std::vector<CTxOut>& vout);
-    bool CreateCoinStake(const CKeyStore& keystore, const CBlockIndex* pindexPrev, unsigned int nBits, int64_t nSearchInterval, CMutableTransaction& txNew, int64_t& nTxNewTime);
+    bool CreateCoinStake(const CKeyStore& keystore, const CBlockIndex* pindexPrev, unsigned int nBits, CMutableTransaction& txNew, int64_t& nTxNewTime);
     bool MultiSend();
     void AutoCombineDust();
     void AutoZeromint();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -147,6 +147,24 @@ public:
     }
 };
 
+/** Record metadata about last kernel stake operation (time and prev hash)**/
+class CStakerStatus {
+private:
+    uint256 hashLastStakeAttempt;
+    int64_t timeLastStakeAttempt;
+public:
+    uint256 GetLastHash() const { return hashLastStakeAttempt; }
+    int64_t GetLastTime() const { return timeLastStakeAttempt; }
+    void SetLastHash(const uint256& lastHash) { hashLastStakeAttempt = lastHash; }
+    void SetLastTime(const uint64_t lastTime) { timeLastStakeAttempt = lastTime; }
+    void Update(const uint256& lastHash, const uint64_t lastTime)
+    {
+        SetLastHash(lastHash);
+        SetLastTime(lastTime);
+    }
+    bool IsActive() { return (timeLastStakeAttempt + 30) >= GetTime(); }
+};
+
 /**
  * A CWallet is an extension of a keystore, which also maintains a set of transactions and balances,
  * and provides the ability to create new transactions.
@@ -278,6 +296,7 @@ public:
     // Stake Settings
     uint64_t nStakeSplitThreshold;
     int nStakeSetUpdateTime;
+    CStakerStatus* pStakerStatus;
 
     //MultiSend
     std::vector<std::pair<std::string, int> > vMultiSend;


### PR DESCRIPTION
This PR cleans up the miner code and streamlines the logic used by the client (both in the RPC and in the GUI) to determine whether the wallet is staking or not. 
Currently it relies on a collection of variables (`mapHashedBlocks`, `nLastCoinStakeInterval`, `nSearchInterval`, etc...) updated in kernel.
These are here replaced with a new class `CStakerStatus`, updated in `CreateCoinStake` (thus directly in wallet), and an instance of  `CStakerStatus` is introduced as member of CWallet. 
This class keeps two variables, `timeLastStakeAttempt ` and `tipLastStakeAttempt`, containing respectively the time of last stake attempt and a pointer to the index of the block upon which last stake attempt was made.

The Staking Status is Active whenever timeLastStakeAttempt is less than
30 seconds in the past.

This PR also expands the output of `getstakingstatus` rpc call adding:

- `staking_enabled` to tell whether or not staking has been disabled via conf file / startup flag
- `hashLastStakeAttempt` and `timeLastStakeAttempt` values
- `heightLastStakeAttempt` (the height of the block with hash `hashLastStakeAttempt`)
- `tiptime` (the time of the chaintip block) to compare with `timeLastStakeAttempt`. This field replaces  `valid_time` which is unnecessary now).

and fixes `enoughcoins` with proper staking balance.
