### PR TITLE
[Qt] Initialize isLoading to false for CS view

### DIFF
--- a/src/qt/pivx/coldstakingwidget.cpp
+++ b/src/qt/pivx/coldstakingwidget.cpp
@@ -69,7 +69,8 @@ private:
 
 ColdStakingWidget::ColdStakingWidget(PIVXGUI* parent) :
     PWidget(parent),
-    ui(new Ui::ColdStakingWidget)
+    ui(new Ui::ColdStakingWidget),
+    isLoading(false)
 {
     ui->setupUi(this);
     this->setStyleSheet(parent->styleSheet());


### PR DESCRIPTION
Loading of the cold staking delegations list checks to see if `isLoading`
is true, and exit's out if it is. this check is used to prevent double
loading, but on some systems `isLoading` is initialized as `true`, so
the loading of CS delegations will never occur.

This changes to initialization to be explicitly `false`.