### PR TITLE
[Core] Remove StakeV1

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -470,8 +470,8 @@ public:
         nPublicZCSpends = 400;
 
         // Blocks v7
-        nBlockV7StartHeight = nPublicZCSpends + 1;
-        nBlockLastAccumulatorCheckpoint = nPublicZCSpends - 10;
+        nBlockV7StartHeight = nBlockZerocoinV2;
+        nBlockLastAccumulatorCheckpoint = nBlockZerocoinV2-1; // no accumul. checkpoints check on regtest
 
         // New P2P messages signatures
         nBlockEnforceNewMessageSignatures = 1;

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -24,7 +24,6 @@ bool GetKernelStakeModifier(const uint256& hashBlockFrom, uint64_t& nStakeModifi
 bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeModifier, bool& fGeneratedStakeModifier);
 uint256 ComputeStakeModifier(const CBlockIndex* pindexPrev, const uint256& kernel);
 bool Stake(const CBlockIndex* pindexPrev, CStakeInput* stakeInput, unsigned int nBits, int64_t& nTimeTx, uint256& hashProofOfStake);
-bool StakeV1(const CBlockIndex* pindexPrev, CStakeInput* stakeInput, const uint32_t nTimeBlockFrom, unsigned int nBits, int64_t& nTimeTx, uint256& hashProofOfStake);
 
 // Initialize the stake input object
 bool initStakeInput(const CBlock& block, std::unique_ptr<CStakeInput>& stake, int nPreviousBlockHeight);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -129,13 +129,14 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, 
     if (!pindexPrev) return nullptr;
     const int nHeight = pindexPrev->nHeight + 1;
 
-    // block version
+    // Make sure to create the correct block version
     pblock->nVersion = 7;       //!> Removes accumulator checkpoints
     // -regtest only: allow overriding block.nVersion with
     // -blockversion=N to test forking scenarios
-    bool fZerocoinActive = nHeight >= Params().Zerocoin_StartHeight();
-    if (Params().MineBlocksOnDemand()) pblock->nVersion = (fZerocoinActive ? 5 : 3);
-    pblock->nVersion = GetArg("-blockversion", pblock->nVersion);
+    if (Params().MineBlocksOnDemand()) {
+        if (nHeight < Params().Zerocoin_StartHeight()) pblock->nVersion = 3;
+        pblock->nVersion = GetArg("-blockversion", pblock->nVersion);
+    }
 
     // Create coinbase tx
     CMutableTransaction txNew;


### PR DESCRIPTION
This removes the old StakeV1 function and does some minor optimizations in the miner code (removing redundant signature and IncrementExtraNonce calls).

This is based on top of the following three pull requests and will be rebased after their merge into master.
So, they should be reviewed before this one.
- [x] #1276 
- [x] #1277 
- [x] #1278 
