### PR TITLE
[Bug][GUI] Double counted delegated balance.

### DIFF
--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -548,7 +548,7 @@ void TopBar::updateBalances(const CAmount& balance, const CAmount& unconfirmedBa
     ui->labelTitle1->setText(nLockedBalance > 0 ? tr("Available (Locked included)") : tr("Available"));
 
     // PIV Total
-    CAmount pivAvailableBalance = balance + delegatedBalance;
+    CAmount pivAvailableBalance = balance;
     // zPIV Balance
     CAmount matureZerocoinBalance = zerocoinBalance - unconfirmedZerocoinBalance - immatureZerocoinBalance;
 


### PR DESCRIPTION
Bug emerged for the non-presented masternodes locked balance bug fix. 

The `GetLockedCoins` is counting the delegations by default, same as `GetBalance`. Before, this was badly subtracted by the `GetBalance` minus `GetLockedCoins` and showed in the GUI, which was removing the MNs locked coins balance **and** the double counted delegations.

This PR solves it.