### PR TITLE
[Wallet] Don't add P2CS automatically to GetLockedCredit

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1336,15 +1336,12 @@ CAmount CWalletTx::GetLockedCredit() const
         // Skip spent coins
         if (pwallet->IsSpent(hashTx, i)) continue;
 
-        // Add delegated coins
-        nCredit += pwallet->GetCredit(txout, ISMINE_SPENDABLE_DELEGATED);
-
         // Add locked coins
         if (pwallet->IsLockedCoin(hashTx, i)) {
-            nCredit += pwallet->GetCredit(txout, ISMINE_SPENDABLE);
+            nCredit += pwallet->GetCredit(txout, ISMINE_SPENDABLE_ALL);
         }
 
-        // Add masternode collaterals which are handled likc locked coins
+        // Add masternode collaterals which are handled like locked coins
         else if (fMasterNode && vout[i].nValue == 10000 * COIN) {
             nCredit += pwallet->GetCredit(txout, ISMINE_SPENDABLE);
         }


### PR DESCRIPTION
Prior to #1223 the total balance was calculated as `balance + delegatedBalance - nLockedBalance`, so the delegations (being part of each term) were counted only once.

#1223 removed `nLockedBalance` (changing the total balance calculation to `balance + delegatedBalance`) thus counting the delegation twice.

#1261 fixed the total balance calculation, removing `delegatedBalance`.

Finally, this PR fixes `nLockedBalance` (even though not part of the total balance anymore). The error is in `GetLockedCoins` which is returning the sum of locked coins **and** cold-stake delegations owned (regardless of their locking state).