### PR TITLE
[GUI] Connect P2CSUnlockOwner and P2CSUnlockStaker records to the model

### DIFF
--- a/src/qt/pivx/txrow.cpp
+++ b/src/qt/pivx/txrow.cpp
@@ -101,6 +101,11 @@ void TxRow::setType(bool isLightTheme, int type, bool isConfirmed){
             path = "://ic-transaction-cs-contract";
             css = "text-list-amount-unconfirmed";
             break;
+        case TransactionRecord::P2CSUnlockOwner:
+        case TransactionRecord::P2CSUnlockStaker:
+            path = "://ic-transaction-cs-contract";
+            css = "text-list-amount-send";
+            break;
         default:
             path = "://ic-pending";
             sameIcon = true;

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -464,6 +464,9 @@ QString TransactionTableModel::formatTxType(const TransactionRecord* wtx) const
     case TransactionRecord::P2CSDelegationSentOwner:
     case TransactionRecord::P2CSDelegation:
         return tr("Stake delegation");
+    case TransactionRecord::P2CSUnlockOwner:
+    case TransactionRecord::P2CSUnlockStaker:
+        return tr("Stake delegation spent by");
     case TransactionRecord::Generated:
         return tr("Mined");
     case TransactionRecord::ObfuscationDenominate:
@@ -545,6 +548,8 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord* wtx, b
     case TransactionRecord::P2CSDelegation:
     case TransactionRecord::P2CSDelegationSent:
     case TransactionRecord::P2CSDelegationSentOwner:
+    case TransactionRecord::P2CSUnlockOwner:
+    case TransactionRecord::P2CSUnlockStaker:
     case TransactionRecord::StakeDelegated:
     case TransactionRecord::StakeHot:
     case TransactionRecord::SendToSelf: {


### PR DESCRIPTION
Transactions spending P2CS utxos (voiding the delegations) were not displaying properly both in the staker and the owner wallet.
Although the TransactionRecord was correctly parsed as either `P2CSUnlockOwner` or `P2CSUnlockStaker`, these were never connected in the table model.
This closes #1262, fixing it.

For the moment, it is shown with the same icon as the delegation received and a negative amount in red. 
We can, alternatively, use the "sending" red icon, or (later) design a new one, specifically for this kind of record.
Examples on the staker wallet:

*--Before*
![Screenshot from 2020-01-14 11-52-03](https://user-images.githubusercontent.com/18186894/72339633-e7e21780-36c6-11ea-8083-f25194a4f461.png)
<br>

*--After*
![Screenshot from 2020-01-14 12-12-25](https://user-images.githubusercontent.com/18186894/72339764-2d9ee000-36c7-11ea-8a5c-fa3b20f3c4aa.png)
<br>

*--After (with outgoing icon)*
![Screenshot from 2020-01-14 11-47-39](https://user-images.githubusercontent.com/18186894/72339642-f03a5280-36c6-11ea-8cae-e80f14a92155.png)

