### PR TITLE
[GUI] Quick minor GUI startup useful changes.

### DIFF
--- a/src/qt/pivx/navmenuwidget.cpp
+++ b/src/qt/pivx/navmenuwidget.cpp
@@ -164,6 +164,13 @@ void NavMenuWidget::onShowHideColdStakingChanged(bool show) {
         ui->scrollAreaNav->verticalScrollBar()->setValue(ui->btnColdStaking->y());
 }
 
+void NavMenuWidget::showEvent(QShowEvent *event) {
+    if (!init) {
+        init = true;
+        ui->scrollAreaNav->verticalScrollBar()->setValue(ui->btnDashboard->y());
+    }
+}
+
 void NavMenuWidget::updateButtonStyles(){
     forceUpdateStyle({
          ui->btnDashboard,

--- a/src/qt/pivx/navmenuwidget.h
+++ b/src/qt/pivx/navmenuwidget.h
@@ -23,6 +23,7 @@ public:
     ~NavMenuWidget();
 
     void loadWalletModel() override;
+    virtual void showEvent(QShowEvent *event) override;
 
 public slots:
     void selectSettings();
@@ -44,6 +45,8 @@ private:
 
     void connectActions();
     void onNavSelected(QWidget* active, bool startup = false);
+
+    bool init = false;
 };
 
 #endif // NAVMENUWIDGET_H

--- a/src/qt/pivx/pivxgui.cpp
+++ b/src/qt/pivx/pivxgui.cpp
@@ -18,6 +18,7 @@
 #include "qt/pivx/defaultdialog.h"
 #include "qt/pivx/settings/settingsfaqwidget.h"
 
+#include <QDesktopWidget>
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QApplication>
@@ -42,7 +43,16 @@ PIVXGUI::PIVXGUI(const NetworkStyle* networkStyle, QWidget* parent) :
     /* Open CSS when configured */
     this->setStyleSheet(GUIUtil::loadStyleSheet());
     this->setMinimumSize(BASE_WINDOW_WIDTH, BASE_WINDOW_MIN_HEIGHT);
-    GUIUtil::restoreWindowGeometry("nWindow", QSize(BASE_WINDOW_WIDTH, BASE_WINDOW_HEIGHT), this);
+
+
+    // Adapt screen size
+    QRect rec = QApplication::desktop()->screenGeometry();
+    int adaptedHeight = (rec.height() < BASE_WINDOW_HEIGHT) ?  BASE_WINDOW_MIN_HEIGHT : BASE_WINDOW_HEIGHT;
+    GUIUtil::restoreWindowGeometry(
+            "nWindow",
+            QSize(BASE_WINDOW_WIDTH, adaptedHeight),
+            this
+    );
 
 #ifdef ENABLE_WALLET
     /* if compiled with wallet support, -disablewallet can still disable the wallet */


### PR DESCRIPTION
Two simple changes:

1) App's window opening in the smallest possible size if the screen size is lower than our base height.

2) NavMenu was not showing the dashboard button due the new scroll area in the startup, this fixes it.