### PR TITLE
[Qt][Bug] Load the most recent instead of the first transactions

### DIFF
--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -100,7 +100,7 @@ public:
                 // txs are stored in order in the db, which is what should be happening)
                 sort(walletTxes.begin(), walletTxes.end(),
                         [](const CWalletTx & a, const CWalletTx & b) -> bool {
-                         return a.GetComputedTxTime() < b.GetComputedTxTime();
+                         return a.GetComputedTxTime() > b.GetComputedTxTime();
                      });
 
                 // Only latest ones.


### PR DESCRIPTION
Fixes a comparator bug when loading the initial `walletTxes` vector.
The design intention is to load the 20k most recent transactions, but it
 was loading the first 20k transactions in error, resulting in a
 potentially large gap in the UI's transaction history.