### PR TITLE
[WIP][GUI] New double amount transaction row.

### DIFF
--- a/src/qt/pivx/dashboardwidget.cpp
+++ b/src/qt/pivx/dashboardwidget.cpp
@@ -112,7 +112,7 @@ DashboardWidget::DashboardWidget(PIVXGUI* parent) :
     ui->comboBoxSortType->addItem(tr("To yourself"), TransactionFilterProxy::TYPE(TransactionRecord::SendToSelf));
     ui->comboBoxSortType->addItem(tr("Cold stakes"), TransactionFilterProxy::TYPE(TransactionRecord::StakeDelegated));
     ui->comboBoxSortType->addItem(tr("Hot stakes"), TransactionFilterProxy::TYPE(TransactionRecord::StakeHot));
-    ui->comboBoxSortType->addItem(tr("Delegated"), TransactionFilterProxy::TYPE(TransactionRecord::P2CSDelegationSent) | TransactionFilterProxy::TYPE(TransactionRecord::P2CSDelegationSentOwner));
+    ui->comboBoxSortType->addItem(tr("Delegated"), TransactionFilterProxy::TYPE(TransactionRecord::P2CSDelegationSent) | TransactionFilterProxy::TYPE(TransactionRecord::P2CSDelegationSentOwner) | TransactionFilterProxy::TYPE(TransactionRecord::P2CSDelegationSentStaker));
     ui->comboBoxSortType->addItem(tr("Delegations"), TransactionFilterProxy::TYPE(TransactionRecord::P2CSDelegation));
     ui->comboBoxSortType->setCurrentIndex(0);
     connect(ui->comboBoxSortType, SIGNAL(currentIndexChanged(const QString&)), this, SLOT(onSortTypeChanged(const QString&)));

--- a/src/qt/pivx/forms/txrow.ui
+++ b/src/qt/pivx/forms/txrow.ui
@@ -133,13 +133,47 @@
           </layout>
          </item>
          <item>
-          <widget class="QLabel" name="lblAmount">
-           <property name="styleSheet">
-            <string notr="true"/>
+          <widget class="QWidget" name="containerAmounts" native="true">
+           <property name="minimumSize">
+            <size>
+             <width>80</width>
+             <height>0</height>
+            </size>
            </property>
-           <property name="text">
-            <string>+0.000585 PIV</string>
-           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_4">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item alignment="Qt::AlignRight">
+             <widget class="QLabel" name="lblAmountTop">
+              <property name="styleSheet">
+               <string notr="true"/>
+              </property>
+              <property name="text">
+               <string>+0.000585 PIV</string>
+              </property>
+             </widget>
+            </item>
+            <item alignment="Qt::AlignRight">
+             <widget class="QLabel" name="lblAmountBottom">
+              <property name="styleSheet">
+               <string notr="true"/>
+              </property>
+              <property name="text">
+               <string>-0.000585 PIV</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </widget>
          </item>
         </layout>

--- a/src/qt/pivx/txrow.cpp
+++ b/src/qt/pivx/txrow.cpp
@@ -13,11 +13,19 @@ TxRow::TxRow(QWidget *parent) :
     ui(new Ui::TxRow)
 {
     ui->setupUi(this);
+    ui->lblAmountBottom->setVisible(false);
 }
 
 void TxRow::init(bool isLightTheme) {
     setConfirmStatus(true);
     updateStatus(isLightTheme, false, false);
+}
+
+void TxRow::showHideSecondAmount(bool show) {
+    if (show != isDoubleAmount) {
+        isDoubleAmount = show;
+        ui->lblAmountBottom->setVisible(show);
+    }
 }
 
 void TxRow::setConfirmStatus(bool isConfirm){
@@ -45,13 +53,15 @@ void TxRow::setLabel(QString str){
     ui->lblAddress->setText(str);
 }
 
-void TxRow::setAmount(QString str){
-    ui->lblAmount->setText(str);
+void TxRow::setAmount(QString top, QString bottom) {
+    ui->lblAmountTop->setText(top);
+    ui->lblAmountBottom->setText(bottom);
 }
 
 void TxRow::setType(bool isLightTheme, int type, bool isConfirmed){
     QString path;
     QString css;
+    QString cssAmountBottom;
     bool sameIcon = false;
     switch (type) {
         case TransactionRecord::ZerocoinMint:
@@ -92,6 +102,11 @@ void TxRow::setType(bool isLightTheme, int type, bool isConfirmed){
             path = "://ic-transaction-stake-hot";
             css = "text-list-amount-unconfirmed";
             break;
+        case TransactionRecord::P2CSDelegationSentStaker:
+            path = "://ic-transaction-cs-contract";
+            css = "text-list-amount-send";
+            cssAmountBottom = "text-list-amount-unconfirmed";
+            break;
         case TransactionRecord::P2CSDelegationSent:
         case TransactionRecord::P2CSDelegationSentOwner:
             path = "://ic-transaction-cs-contract";
@@ -119,12 +134,14 @@ void TxRow::setType(bool isLightTheme, int type, bool isConfirmed){
 
     if (!isConfirmed){
         css = "text-list-amount-unconfirmed";
+        cssAmountBottom = "text-list-amount-unconfirmed";
         path += "-inactive";
         setConfirmStatus(false);
     }else{
         setConfirmStatus(true);
     }
-    setCssProperty(ui->lblAmount, css, true);
+    setCssProperty(ui->lblAmountTop, css, true);
+    if (isDoubleAmount) setCssProperty(ui->lblAmountBottom, cssAmountBottom, true);
     ui->icon->setIcon(QIcon(path));
 }
 

--- a/src/qt/pivx/txrow.h
+++ b/src/qt/pivx/txrow.h
@@ -22,17 +22,19 @@ public:
     ~TxRow();
 
     void init(bool isLightTheme);
+    void showHideSecondAmount(bool show);
     void updateStatus(bool isLightTheme, bool isHover, bool isSelected);
 
     void setDate(QDateTime);
     void setLabel(QString);
-    void setAmount(QString);
+    void setAmount(QString top, QString bottom);
     void setType(bool isLightTheme, int type, bool isConfirmed);
     void setConfirmStatus(bool isConfirmed);
 
 private:
     Ui::TxRow *ui;
     bool isConfirmed = false;
+    bool isDoubleAmount = false;
 };
 
 #endif // TXROW_H

--- a/src/qt/pivx/txviewholder.cpp
+++ b/src/qt/pivx/txviewholder.cpp
@@ -15,17 +15,21 @@ QWidget* TxViewHolder::createHolder(int pos){
     return txRow;
 }
 
-void TxViewHolder::init(QWidget* holder,const QModelIndex &index, bool isHovered, bool isSelected) const{
+void TxViewHolder::init(QWidget* holder, const QModelIndex &index, bool isHovered, bool isSelected) const {
+
+    QModelIndex rIndex = (filter) ? filter->mapToSource(index) : index;
+    int type = rIndex.data(TransactionTableModel::TypeRole).toInt();
+
     TxRow *txRow = static_cast<TxRow*>(holder);
     txRow->updateStatus(isLightTheme, isHovered, isSelected);
 
-    QModelIndex rIndex = (filter) ? filter->mapToSource(index) : index;
     QDateTime date = rIndex.data(TransactionTableModel::DateRole).toDateTime();
     qint64 amount = rIndex.data(TransactionTableModel::AmountRole).toLongLong();
     QString amountText = BitcoinUnits::formatWithUnit(nDisplayUnit, amount, true, BitcoinUnits::separatorAlways);
     QModelIndex indexType = rIndex.sibling(rIndex.row(),TransactionTableModel::Type);
     QString label = indexType.data(Qt::DisplayRole).toString();
-    int type = rIndex.data(TransactionTableModel::TypeRole).toInt();
+
+    txRow->showHideSecondAmount(type == TransactionRecord::P2CSDelegationSentStaker);
 
     if(type != TransactionRecord::ZerocoinMint &&
             type !=  TransactionRecord::ZerocoinSpend_Change_zPiv &&
@@ -46,7 +50,8 @@ void TxViewHolder::init(QWidget* holder,const QModelIndex &index, bool isHovered
 
     txRow->setDate(date);
     txRow->setLabel(label);
-    txRow->setAmount(amountText);
+    // TODO: Complete me..
+    txRow->setAmount(amountText, tr("Delegation %1").arg("10.00 tPIV"));
     txRow->setType(isLightTheme, type, !isUnconfirmed);
 }
 

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -166,7 +166,7 @@ bool TransactionFilterProxy::isStakeTx(int type) const {
 }
 
 bool TransactionFilterProxy::isColdStake(int type) const {
-    return (type == TransactionRecord::P2CSDelegation || type == TransactionRecord::P2CSDelegationSent || type == TransactionRecord::P2CSDelegationSentOwner || type == TransactionRecord::StakeDelegated || type == TransactionRecord::StakeHot);
+    return (type == TransactionRecord::P2CSDelegation || type == TransactionRecord::P2CSDelegationSent || type == TransactionRecord::P2CSDelegationSentStaker || type == TransactionRecord::P2CSDelegationSentOwner || type == TransactionRecord::StakeDelegated || type == TransactionRecord::StakeHot);
 }
 
 /*QVariant TransactionFilterProxy::dataFromSourcePos(int sourceRow, int role) const {

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -99,7 +99,8 @@ public:
         StakeHot, // Staked via a delegated P2CS.
         P2CSDelegation, // Non-spendable P2CS, staker side.
         P2CSDelegationSent, // Non-spendable P2CS delegated utxo. (coin-owner transferred ownership to external wallet)
-        P2CSDelegationSentOwner, // Spendable P2CS delegated utxo. (coin-owner)
+        P2CSDelegationSentOwner, // Spendable P2CS delegated utxo. (coin-owner delegated balance and continued with the coin ownership)
+        P2CSDelegationSentStaker, // Non-spendable P2CS delegated utxo. (coin-owner transferred ownership to external wallet and received the delegation contract to hot stake)
         P2CSUnlockOwner, // Coin-owner spent the delegated utxo
         P2CSUnlockStaker // Staker watching the owner spent the delegated utxo
     };

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -464,6 +464,8 @@ QString TransactionTableModel::formatTxType(const TransactionRecord* wtx) const
     case TransactionRecord::P2CSDelegationSentOwner:
     case TransactionRecord::P2CSDelegation:
         return tr("Stake delegation");
+    case TransactionRecord::P2CSDelegationSentStaker:
+        return tr("Delegated to myself + ownership transfer");
     case TransactionRecord::P2CSUnlockOwner:
     case TransactionRecord::P2CSUnlockStaker:
         return tr("Stake delegation spent by");
@@ -545,6 +547,7 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord* wtx, b
     case TransactionRecord::ZerocoinSpend_Change_zPiv:
     case TransactionRecord::StakeZPIV:
         return tr("Anonymous");
+    case TransactionRecord::P2CSDelegationSentStaker: // TODO: Review me..
     case TransactionRecord::P2CSDelegation:
     case TransactionRecord::P2CSDelegationSent:
     case TransactionRecord::P2CSDelegationSentOwner:


### PR DESCRIPTION
This PR comes from #1270 issue, in which a special type of cold staking contract transaction is not presented in the best possible way in the GUI.

The PR adds a new transaction type and change the transaction row in the GUI + modifies the transaction record flow to support the special transaction.

* The new transaction record is contemplating the following scenario:

  coin-owner transferring ownership to external wallet and receiving the delegation contract to hot stake.

  So.. there are at least 2 utxo, and 3 utxo if there is a change utxo. The two amounts are:

  1) The outgoing amount: delegated amount + change + fee. ---> showed in red.

  2) The incoming delegation contract: delegated to myself amount. ---> showed in gray (for now).

----------------------------

TODO:

* Complete second amount flow (currently the record is only storing the outgoing amount, not parsing the incoming delegation to be shown in the GUI).
* Create a TransactionRecord subclass with the needed two amounts + two addresses information.


Will not rush here to include it in 4.0.2,  have been speaking with @random-zebra and most likely there are other scenarios that need the same treatment.

