### PR TITLE
[Wallet] Refactor MintableCoins

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -458,7 +458,7 @@ std::vector<COutput> CActiveMasternode::SelectCoinsMasternode()
     }
 
     // Retrieve all possible outputs
-    pwalletMain->AvailableCoins(vCoins);
+    pwalletMain->AvailableCoins(&vCoins);
 
     // Lock MN coins from masternode.conf back if they where temporary unlocked
     if (!confLockedCoins.empty()) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -680,7 +680,7 @@ void BitcoinMiner(CWallet* pwallet, bool fProofOfStake)
             if ((GetTime() - nMintableLastCheck > 5 * 60)) // 5 minute check time
             {
                 nMintableLastCheck = GetTime();
-                fMintableCoins = pwallet->MintableCoins();
+                fMintableCoins = pwallet->StakeableCoins();
             }
 
             while (vNodes.empty() || pwallet->IsLocked() || !fMintableCoins ||
@@ -690,7 +690,7 @@ void BitcoinMiner(CWallet* pwallet, bool fProofOfStake)
                 if (!fMintableCoins && (GetTime() - nMintableLastCheck > 1 * 60)) // 1 minute check time
                 {
                     nMintableLastCheck = GetTime();
-                    fMintableCoins = pwallet->MintableCoins();
+                    fMintableCoins = pwallet->StakeableCoins();
                 }
             }
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -662,8 +662,6 @@ void BitcoinMiner(CWallet* pwallet, bool fProofOfStake)
     // Each thread has its own key and counter
     CReserveKey reservekey(pwallet);
     unsigned int nExtraNonce = 0;
-    bool fColdStake = GetBoolArg("-coldstaking", true);
-    CAmount stakingBalance = 0;
 
     while (fGenerateBitcoins || fProofOfStake) {
         CBlockIndex* pindexPrev = GetChainTip();
@@ -683,18 +681,16 @@ void BitcoinMiner(CWallet* pwallet, bool fProofOfStake)
             {
                 nMintableLastCheck = GetTime();
                 fMintableCoins = pwallet->MintableCoins();
-                stakingBalance = pwallet->GetStakingBalance(fColdStake);
             }
 
             while (vNodes.empty() || pwallet->IsLocked() || !fMintableCoins ||
-                   (stakingBalance > 0 && nReserveBalance >= stakingBalance) || masternodeSync.NotCompleted()) {
+                    masternodeSync.NotCompleted()) {
                 MilliSleep(5000);
                 // Do a separate 1 minute check here to ensure fMintableCoins is updated
                 if (!fMintableCoins && (GetTime() - nMintableLastCheck > 1 * 60)) // 1 minute check time
                 {
                     nMintableLastCheck = GetTime();
                     fMintableCoins = pwallet->MintableCoins();
-                    stakingBalance = pwallet->GetStakingBalance(fColdStake);
                 }
             }
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -75,7 +75,7 @@ CAmount WalletModel::getBalance(const CCoinControl* coinControl) const
     if (coinControl) {
         CAmount nBalance = 0;
         std::vector<COutput> vCoins;
-        wallet->AvailableCoins(vCoins, true, coinControl);
+        wallet->AvailableCoins(&vCoins, true, coinControl);
         for (const COutput& out : vCoins)
             if (out.fSpendable)
                 nBalance += out.tx->vout[out.i].nValue;
@@ -1003,7 +1003,7 @@ bool WalletModel::isSpent(const COutPoint& outpoint) const
 void WalletModel::listCoins(std::map<QString, std::vector<COutput> >& mapCoins) const
 {
     std::vector<COutput> vCoins;
-    wallet->AvailableCoins(vCoins);
+    wallet->AvailableCoins(&vCoins);
 
     LOCK2(cs_main, wallet->cs_wallet); // ListLockedCoins, mapWallet
     std::vector<COutPoint> vLockedCoins;

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -600,8 +600,7 @@ UniValue getstakingstatus(const UniValue& params, bool fHelp)
             "  \"haveconnections\": true|false,    (boolean) if network connections are present\n"
             "  \"mnsync\": true|false,             (boolean) if masternode data is synced\n"
             "  \"walletunlocked\": true|false,     (boolean) if the wallet is unlocked\n"
-            "  \"mintablecoins\": true|false,      (boolean) if the wallet has mintable coins\n"
-            "  \"enoughcoins\": true|false,        (boolean) if available coins are greater than reserve balance\n"
+            "  \"mintablecoins\": true|false,      (boolean) if the wallet has mintable balance (greater than reserve balance)\n"
             "  \"hashLastStakeAttempt\": xxx       (hex string) hash of last block on top of which the miner attempted to stake\n"
             "  \"heightLastStakeAttempt\": n       (integer) height of last block on top of which the miner attempted to stake\n"
             "  \"timeLastStakeAttempt\": n         (integer) time of last attempted stake\n"
@@ -623,7 +622,6 @@ UniValue getstakingstatus(const UniValue& params, bool fHelp)
         obj.push_back(Pair("mnsync", masternodeSync.IsSynced()));
         obj.push_back(Pair("walletunlocked", !pwalletMain->IsLocked()));
         obj.push_back(Pair("mintablecoins", pwalletMain->MintableCoins()));
-        obj.push_back(Pair("enoughcoins", nReserveBalance <= pwalletMain->GetStakingBalance(GetBoolArg("-coldstaking", true))));
         uint256 lastHash = pwalletMain->pStakerStatus->GetLastHash();
         obj.push_back(Pair("hashLastStakeAttempt", lastHash.GetHex()));
         obj.push_back(Pair("heightLastStakeAttempt", (mapBlockIndex.count(lastHash) > 0 ?

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -621,7 +621,7 @@ UniValue getstakingstatus(const UniValue& params, bool fHelp)
         obj.push_back(Pair("haveconnections", !vNodes.empty()));
         obj.push_back(Pair("mnsync", masternodeSync.IsSynced()));
         obj.push_back(Pair("walletunlocked", !pwalletMain->IsLocked()));
-        obj.push_back(Pair("mintablecoins", pwalletMain->MintableCoins()));
+        obj.push_back(Pair("mintablecoins", pwalletMain->StakeableCoins()));
         uint256 lastHash = pwalletMain->pStakerStatus->GetLastHash();
         obj.push_back(Pair("hashLastStakeAttempt", lastHash.GetHex()));
         obj.push_back(Pair("heightLastStakeAttempt", (mapBlockIndex.count(lastHash) > 0 ?

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -279,7 +279,7 @@ UniValue listunspent(const UniValue& params, bool fHelp)
     std::vector<COutput> vecOutputs;
     assert(pwalletMain != NULL);
     LOCK2(cs_main, pwalletMain->cs_wallet);
-    pwalletMain->AvailableCoins(vecOutputs, false, NULL, false, ALL_COINS, false, nWatchonlyConfig);
+    pwalletMain->AvailableCoins(&vecOutputs, false, NULL, false, ALL_COINS, false, nWatchonlyConfig);
     for (const COutput& out : vecOutputs) {
         if (out.nDepth < nMinDepth || out.nDepth > nMaxDepth)
             continue;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2919,7 +2919,7 @@ UniValue printMultiSend()
 UniValue printAddresses()
 {
     std::vector<COutput> vCoins;
-    pwalletMain->AvailableCoins(vCoins);
+    pwalletMain->AvailableCoins(&vCoins);
     std::map<std::string, double> mapAddresses;
     for (const COutput& out : vCoins) {
         CTxDestination utxoAddress;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1973,24 +1973,20 @@ void CWallet::AvailableCoins(
             const uint256& wtxid = it->first;
             const CWalletTx* pcoin = &(*it).second;
 
-            if (!CheckFinalTx(*pcoin))
-                continue;
-
-            if (fOnlyConfirmed && !pcoin->IsTrusted())
-                continue;
-
-            if ((pcoin->IsCoinBase() || pcoin->IsCoinStake()) && pcoin->GetBlocksToMaturity() > 0)
-                continue;
+            if (!CheckFinalTx(*pcoin)) continue;
+            if (fOnlyConfirmed && !pcoin->IsTrusted()) continue;
+            if (pcoin->GetBlocksToMaturity() > 0) continue;
 
             int nDepth = pcoin->GetDepthInMainChain(false);
             // do not use IX for inputs that have less then 6 blockchain confirmations
-            if (fUseIX && nDepth < 6)
-                continue;
+            if (fUseIX && nDepth < 6) continue;
 
             // We should not consider coins which aren't at least in our mempool
             // It's possible for these to be conflicted via ancestors which we may never be able to detect
-            if (nDepth == 0 && !pcoin->InMempool())
-                continue;
+            if (nDepth == 0 && !pcoin->InMempool()) continue;
+
+            // Check min depth requirement for stake inputs
+            if (nCoinType == STAKABLE_COINS && nDepth <= Params().COINSTAKE_MIN_DEPTH()) continue;
 
             for (unsigned int i = 0; i < pcoin->vout.size(); i++) {
                 bool found = false;
@@ -2009,29 +2005,17 @@ void CWallet::AvailableCoins(
                 }
                 if (!found) continue;
 
-                if (nCoinType == STAKABLE_COINS) {
-                    if (pcoin->vout[i].IsZerocoinMint())
-                        continue;
-                }
+                if (nCoinType == STAKABLE_COINS && pcoin->vout[i].IsZerocoinMint()) continue;
+                if (IsSpent(wtxid, i)) continue;
 
                 isminetype mine = IsMine(pcoin->vout[i]);
-                if (IsSpent(wtxid, i))
-                    continue;
-                if (mine == ISMINE_NO)
-                    continue;
-
-                if ((mine == ISMINE_MULTISIG || mine == ISMINE_SPENDABLE) && nWatchonlyConfig == 2)
-                    continue;
-
-                if (mine == ISMINE_WATCH_ONLY && nWatchonlyConfig == 1)
-                    continue;
-
-                if (IsLockedCoin((*it).first, i) && nCoinType != ONLY_10000)
-                    continue;
-                if (pcoin->vout[i].nValue <= 0 && !fIncludeZeroValue)
-                    continue;
-                if (fCoinsSelected && !coinControl->fAllowOtherInputs && !coinControl->IsSelected((*it).first, i))
-                    continue;
+                if (  (mine == ISMINE_NO) ||
+                      ((mine == ISMINE_MULTISIG || mine == ISMINE_SPENDABLE) && nWatchonlyConfig == 2) ||
+                      (mine == ISMINE_WATCH_ONLY && nWatchonlyConfig == 1) ||
+                      (IsLockedCoin((*it).first, i) && nCoinType != ONLY_10000) ||
+                      (pcoin->vout[i].nValue <= 0 && !fIncludeZeroValue) ||
+                      (fCoinsSelected && !coinControl->fAllowOtherInputs && !coinControl->IsSelected((*it).first, i))
+                   ) continue;
 
                 // --Skip P2CS outputs
                 // skip cold coins
@@ -2193,16 +2177,8 @@ bool CWallet::MintableCoins()
         const bool fIncludeCold = sporkManager.IsSporkActive(SPORK_17_COLDSTAKING_ENFORCEMENT) && GetBoolArg("-coldstaking", true);
         AvailableCoins(vCoins, true, NULL, false, STAKABLE_COINS, false, 1, fIncludeCold, false);
 
-        if (vCoins.size() > 0) {
-            // check that we have at least one utxo eligible for staking (min age/depth)
-            const int64_t time = GetAdjustedTime();
-            const int chainHeight = chainActive.Height();
-            for (const COutput& out : vCoins) {
-                CBlockIndex* utxoBlock = mapBlockIndex.at(out.tx->hashBlock);
-                if (Params().HasStakeMinAgeOrDepth(chainHeight, time, utxoBlock->nHeight, utxoBlock->nTime))
-                    return true;
-            }
-        }
+        // check that we have at least one utxo eligible for staking.
+        return (vCoins.size() > 0);
     }
 
     return false;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1986,7 +1986,7 @@ bool CWallet::AvailableCoins(
             if (nDepth == 0 && !pcoin->InMempool()) continue;
 
             // Check min depth requirement for stake inputs
-            if (nCoinType == STAKABLE_COINS && nDepth <= Params().COINSTAKE_MIN_DEPTH()) continue;
+            if (nCoinType == STAKEABLE_COINS && nDepth <= Params().COINSTAKE_MIN_DEPTH()) continue;
 
             for (unsigned int i = 0; i < pcoin->vout.size(); i++) {
                 bool found = false;
@@ -2005,7 +2005,7 @@ bool CWallet::AvailableCoins(
                 }
                 if (!found) continue;
 
-                if (nCoinType == STAKABLE_COINS && pcoin->vout[i].IsZerocoinMint()) continue;
+                if (nCoinType == STAKEABLE_COINS && pcoin->vout[i].IsZerocoinMint()) continue;
                 if (IsSpent(wtxid, i)) continue;
 
                 isminetype mine = IsMine(pcoin->vout[i]);
@@ -2123,7 +2123,7 @@ bool less_then_denom(const COutput& out1, const COutput& out2)
     return (!found1 && found2);
 }
 
-bool CWallet::MintableCoins(std::vector<COutput>* pCoins)
+bool CWallet::StakeableCoins(std::vector<COutput>* pCoins)
 {
     CAmount nBalance = GetStakingBalance(GetBoolArg("-coldstaking", true));
 
@@ -2135,7 +2135,7 @@ bool CWallet::MintableCoins(std::vector<COutput>* pCoins)
     const bool fIncludeCold = (sporkManager.IsSporkActive(SPORK_17_COLDSTAKING_ENFORCEMENT) &&
                                GetBoolArg("-coldstaking", true));
 
-    if (!AvailableCoins(pCoins, true, nullptr, false, STAKABLE_COINS,  false, 1, fIncludeCold, false))
+    if (!AvailableCoins(pCoins, true, nullptr, false, STAKEABLE_COINS,  false, 1, fIncludeCold, false))
         return false;
 
     if (!pCoins || nReserveBalance == 0)
@@ -2592,7 +2592,7 @@ bool CWallet::CreateCoinStake(
 {
     // Get the list of stakable utxos
     std::vector<COutput> vCoins;
-    if (!MintableCoins(&vCoins)) {
+    if (!StakeableCoins(&vCoins)) {
         LogPrintf("%s: No coin available to stake.\n", __func__);
         return false;
     }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -89,9 +89,9 @@ enum AvailableCoinsType {
     ALL_COINS = 1,
     ONLY_DENOMINATED = 2,
     ONLY_NOT10000IFMN = 3,
-    ONLY_NONDENOMINATED_NOT10000IFMN = 4, // ONLY_NONDENOMINATED and not 10000 PIV at the same time
-    ONLY_10000 = 5,                        // find masternode outputs including locked ones (use with caution)
-    STAKABLE_COINS = 6                          // UTXO's that are valid for staking
+    ONLY_NONDENOMINATED_NOT10000IFMN = 4,           // ONLY_NONDENOMINATED and not 10000 PIV at the same time
+    ONLY_10000 = 5,                                 // find masternode outputs including locked ones (use with caution)
+    STAKEABLE_COINS = 6                             // UTXO's that are valid for staking
 };
 
 // Possible states for zPIV send
@@ -209,7 +209,7 @@ public:
 
     static const int STAKE_SPLIT_THRESHOLD = 2000;
 
-    bool MintableCoins(std::vector<COutput>* pCoins = nullptr);
+    bool StakeableCoins(std::vector<COutput>* pCoins = nullptr);
     bool IsCollateralAmount(CAmount nInputAmount) const;
 
     // Zerocoin additions

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -350,7 +350,7 @@ public:
     //! check whether we are allowed to upgrade (or already support) to the named feature
     bool CanSupportFeature(enum WalletFeature wf);
 
-    void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed = true, const CCoinControl* coinControl = NULL, bool fIncludeZeroValue = false, AvailableCoinsType nCoinType = ALL_COINS, bool fUseIX = false, int nWatchonlyConfig = 1, bool fIncludeColdStaking=false, bool fIncludeDelegated=true) const;
+    void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed = true, const CCoinControl* coinControl = NULL, bool fIncludeZeroValue = false, AvailableCoinsType nCoinType = ALL_COINS, bool fUseIX = false, int nWatchonlyConfig = 1, bool fIncludeColdStaking=false, bool fIncludeDelegated=true, bool fJustOne=false) const;
 
     // Get available p2cs utxo
     void GetAvailableP2CSCoins(std::vector<COutput>& vCoins) const;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -209,8 +209,7 @@ public:
 
     static const int STAKE_SPLIT_THRESHOLD = 2000;
 
-    bool MintableCoins();
-    bool SelectStakeCoins(std::list<std::unique_ptr<CStakeInput> >& listInputs, CAmount nTargetAmount, int blockHeight);
+    bool MintableCoins(std::vector<COutput>* pCoins = nullptr);
     bool IsCollateralAmount(CAmount nInputAmount) const;
 
     // Zerocoin additions
@@ -350,7 +349,7 @@ public:
     //! check whether we are allowed to upgrade (or already support) to the named feature
     bool CanSupportFeature(enum WalletFeature wf);
 
-    void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlyConfirmed = true, const CCoinControl* coinControl = NULL, bool fIncludeZeroValue = false, AvailableCoinsType nCoinType = ALL_COINS, bool fUseIX = false, int nWatchonlyConfig = 1, bool fIncludeColdStaking=false, bool fIncludeDelegated=true, bool fJustOne=false) const;
+    bool AvailableCoins(std::vector<COutput>* pCoins, bool fOnlyConfirmed = true, const CCoinControl* coinControl = NULL, bool fIncludeZeroValue = false, AvailableCoinsType nCoinType = ALL_COINS, bool fUseIX = false, int nWatchonlyConfig = 1, bool fIncludeColdStaking=false, bool fIncludeDelegated=true) const;
 
     // Get available p2cs utxo
     void GetAvailableP2CSCoins(std::vector<COutput>& vCoins) const;


### PR DESCRIPTION
- 1st commit removes zPIV balance count in `CWallet::MintableCoins()` (as mints cannot stake anymore).

- 2nd commit removes `GetStakingBalance` calls in BitcoinMiner and `getstakingstatus` RPC (thus removing "enoughcoins", leaving only "mintablecoins" field there).
`MintableCoins()` already checks the staking balance and returns false if it is either non-positive or less than the reserve balance.

- 3rd commit removes the depth requirement check from `MintableCoins`, moving it directly in `AvailableCoins` (no need to check for age anymore, only depth).

- 4th commit introduces a performance improvement (which might be significative on wallets with many utxos). Since the only purpose of `MintableCoins` is to verify that there is *at least one* eligible utxo, there is no need to get the whole set of them from `AvailableCoins`.
And since this function is checked often when staking (`AvailableCoins` is called again from within `CreateCoinStake`) it's better to introduce a way to outright return from it, as soon as a valid utxo is found. This commit also removes the extra `LOCK(cs_main)` in the function.

- 5th commit reworks MintableCoins/AvailableCoins/CreateCoinStake to remove `SelectStakeCoins` and avoid duplicated code in yet another place.

- 6th commit finally renames `MintableCoins` --> `StakeableCoins` to avoid possible confusion.