### PR TITLE
[Trivial][Cleanup] Remove extra checks before GetBlocksToMaturity

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1237,7 +1237,7 @@ CAmount CWalletTx::GetCredit(const isminefilter& filter) const
 CAmount CWalletTx::GetImmatureCredit(bool fUseCache, const isminefilter& filter) const
 {
     LOCK(cs_main);
-    if ((IsCoinBase() || IsCoinStake()) && GetBlocksToMaturity() > 0 && IsInMainChain()) {
+    if (GetBlocksToMaturity() > 0 && IsInMainChain()) {
         if (fUseCache && fImmatureCreditCached && filter == ISMINE_SPENDABLE_ALL)
             return nImmatureCreditCached;
         nImmatureCreditCached = pwallet->GetCredit(*this, filter);


### PR DESCRIPTION
Ref: https://github.com/PIVX-Project/PIVX/pull/1263#discussion_r366282577

`GetBlocksToMaturity` returns `0` for txes that are neither coinbases nor coinstakes, so no need to check that before.
There are actually only two places needing this quick cleanup.

Note: there are, instead, several occurrences of `if (IsCoinBase() && GetBlocksToMaturity() > 0)` (i.e. test failing for coinstakes but not coinbases). 
These need further inspection because a change there affects reported balances (e.g. in `CWalletTx::UpdateAmount` or `CWalletTx::GetUnlockedCredit`).