### PR TITLE
[GUI] Set width and default minimum scrollbar height

### DIFF
--- a/src/qt/pivx/res/css/style_dark.css
+++ b/src/qt/pivx/res/css/style_dark.css
@@ -2225,14 +2225,14 @@ HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH*/
 QScrollBar:vertical {
     border: 0px solid #bababa;
     background:#0f0b16;
-    width:4px;
+    width:7px;
     margin: 0px 0px 0px 0px;
 }
 
 
 QScrollBar::handle:vertical {
     background: #5c4b7d;
-    min-height: 0px;
+    min-height: 10px;
 }
 
 QScrollBar::add-line:vertical {

--- a/src/qt/pivx/res/css/style_light.css
+++ b/src/qt/pivx/res/css/style_light.css
@@ -2228,14 +2228,14 @@ HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH*/
 QScrollBar:vertical {
     border: 0px solid #bababa;
     background:white;
-    width:4px;
+    width:7px;
     margin: 0px 0px 0px 0px;
 }
 
 
 QScrollBar::handle:vertical {
     background: #bababa;
-    min-height: 0px;
+    min-height: 10px;
 }
 
 QScrollBar::add-line:vertical {


### PR DESCRIPTION
When a user has lots of transactions (or other long lists) the scrollbar-handle isn't visible anymore:
![01-Scrollbar-Before](https://user-images.githubusercontent.com/22873440/72591052-822ca000-38ff-11ea-9875-d02c19fa0a33.png)

The default handle-width of 4 pixel is also to small to be used on touchscreens, so both the default width and the minimum height of the handle are changed to 10 pixel now.

The result looks like this:
![02-Scrollbar-After](https://user-images.githubusercontent.com/22873440/72591218-e3ed0a00-38ff-11ea-98cc-7ec57115a218.png)
