### PR TITLE
[GUI] Load persisted transaction filter during start

### DIFF
--- a/src/qt/pivx/dashboardwidget.h
+++ b/src/qt/pivx/dashboardwidget.h
@@ -61,10 +61,10 @@ Q_SIGNALS:
 };
 
 enum SortTx {
-    DATE_ASC = 0,
-    DATE_DESC = 1,
-    AMOUNT_ASC = 2,
-    AMOUNT_DESC = 3
+    DATE_DESC = 0,
+    DATE_ASC = 1,
+    AMOUNT_DESC = 2,
+    AMOUNT_ASC = 3
 };
 
 enum ChartShowType {
@@ -140,6 +140,7 @@ private:
     TransactionTableModel* txModel;
     int nDisplayUnit = -1;
     bool isSync = false;
+    void changeSort(int nSortIndex);
 
 #ifdef USE_QTCHARTS
 


### PR DESCRIPTION
The transaction filter settings were persisted, but never loaded when the wallet starts.

Since it would be tricky to compute the index of an item of the filter-combobox from the filter value this change does it in the other direction, it persists the index of the item and computes the filter value from it which is trivial.