### PR TITLE
[zPIV][Cleanup] Zerocoin Cleanup 2: remove CZPivStake class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,6 +357,7 @@ set(WALLET_SOURCES
         ./src/zpiv/zpivwallet.cpp
         ./src/zpiv/zpivtracker.cpp
         ./src/zpiv/zpivmodule.cpp
+        ./src/zpiv/zpos.cpp
         ./src/stakeinput.cpp
         )
 add_library(WALLET_A STATIC ${BitcoinHeaders} ${WALLET_SOURCES})

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -34,340 +34,36 @@ Notable Changes
 
 (Developers: add your notes here as part of your pull requests whenever possible)
 
-New Wallet UI
--------------------
 
-v4.0.0 introduces a completely new GUI for the wallet, designed and coded from the ground up by the [Krubit](https://krubit.com/) team.
-
-This new UI, aside from the overall design large implementation, includes user-focused improvements and features such as a brief introduction on first load, a FAQ section, one-click QRCode compatible receiving addresses, masternode creation wizard, dark and light themes, filterable staking charts, and much more.
-
-You can read more details about this extensive work in ([PR #954](https://github.com/PIVX-Project/PIVX/pull/954))
-
-There are some legacy features that have not been included, however, notably the in-wallet block explorer and the governance page. The in-wallet block explorer was sorely outdated, and the governance page was a newer addition that will be seeing a return in a future version.
-
-Cold Staking
--------------------
-
-A brand new feature is being introduced with the release of v4.0.0: Cold Staking ([PR #955](https://github.com/PIVX-Project/PIVX/pull/955))! This feature allows a coin owner to keep coins in a "cold" (or locked) wallet whilst a "hot" wallet carries out the burden of staking those coins.
-
-This brings added security to coin owners as they are no longer required to use an unlocked or partially unlocked wallet (with the ability to spend coins anywhere) in order to gain staking rewards. Users who have chosen to store their coins on hardware devices such as a Ledger or Trezor<sup>1</sup> can also gain staking rewards with those coins.
-
-A full technical writup is available on the [PIVX Wiki](https://github.com/PIVX-Project/PIVX/wiki/ColdStaking), and an initial video showcase is available on [YouTube](https://www.youtube.com/watch?v=utxB5TzAeXc).
-A brief guide to setup cold staking with GUI and RPC is available [here](https://github.com/random-zebra/PIVX-Wiki/blob/master/User-Documentation/Cold-Staking-HowTo.md).
-
-<sup>1</sup> Spending cold stakes from HW wallets currently available only for Ledger devices via [PET4L](https://github.com/PIVX-Project/PET4L) tool.
-
-Multi-Split Stake Splitting
--------------------
-
-Stake splitting has received a makeover and now supports splitting to more than two (2) outputs. [PR #968](https://github.com/PIVX-Project/PIVX/pull/968) introduced the change, which is controlled by the wallet's `stakesplitthreshold` setting.
-
-The default split threshold remains at 2000 PIV, and can be adjusted in the GUI's Settings page, or via the RPC `setstakesplitthreshold` command.
-
-For a real example, with a stake split threshold of 1500, and a UTXO of 4708.1557; the current stake split algorithm would break that into two outputs of approximately 2355.07785. With this new logic; it will be broken into 3 outputs instead of two; each sized 1570.0519 (4708.1557 input + 2 stake = 4710.1557 / 3 outputs = 1570.0519.
-
-The maximum number of outputs is currently capped at 48. Also, in relation to the new Cold Staking feature described above; the stake split threshold is set by the staker wallet and **NOT** the owner wallet.
-
-New Consensus Rules
--------------------
-
-The following consensus rule changes will be enforced on or shortly after block `2153200`. Note that **Upgrade Enforcement** (mentioned above) will occur prior to this block height.
-
-### V1 zPIV Spending (Public Spends Version 4)
-
-Since the discovery of a critical exploit within the libzerocoin library in early 2019, remaining legacy v1 zPIV have been un-spendable. We're happy to say that, once the new consensus rules are in effect, users will once again be able to spend their v1 zPIV with public spends version 4 ([PR #936](https://github.com/PIVX-Project/PIVX/pull/936)).
-
-As with the previous version 3 public spends introduced in core wallet version 3.3.0 (enabling the spending of v2 zPIV), version 4 spends will also be public. A full technical writeup is available on the [PIVX Wiki](https://github.com/PIVX-Project/PIVX/wiki/CoinRandomnessSchnorrSignature).
-
-### OP_CHECKCOLDSTAKEVERIFY and P2CS
-
-Cold staking introduces a new opcode, `OP_CHECKCOLDSTAKEVERIFY`, in the scripting language, and a new standard transaction type using it, named `P2CS` (Pay-To-Cold-Staking). A P2CS script is defined as follows:
-```
-OP_DUP OP_HASH160 OP_ROT OP_IF OP_CHECKCOLDSTAKEVERIFY [HASH160(stakerPubKey]
-OP_ELSE [HASH160(ownerPubKey)] OP_ENDIF OP_EQUALVERIFY OP_CHECKSIG
-```
-`OP_CHECKCOLDSTAKEVERIFY` is used to ensure that the staker can only spend the output in a valid coinstake transaction (using the same P2CS script in the new output).
-
-### Time Protocol v2
-
-[#PR1002](https://github.com/PIVX-Project/PIVX/pull/1002) introduces a new time protocol for the Proof-Of-Stake consensus mechanism, to ensure better efficiency, fairness and security. The time is now divided in 15-seconds slots and valid blocktimes are at the beginning of each slot (i.e. the block timestamp's seconds can only be `00`, or `15`, or `30` or `45`).<br>
-The maximum future time limit is lowered from 3 minutes to 14 seconds and the past limit is set to the previous blocktime (i.e. a block can no longer have a timestamp earlier than its previous block).<br>
-This means that, when looking for a valid kernel, each stakeable input can be hashed only once every 15 seconds (once per timeslot), and it is not possible to submit blocks with timestamp higher than the current time slot. This ultimately enables the removal of the "hashdrift" concept.<br>
-
-**NOTE:** Given the much stricter time constraints, a node's clock synchronization is required for P2P connections: the maximum time offset is 15 seconds and peers with a time drift higher than 30 seconds (in absolute value) will be outright disconnected.
-
- For advanced users, we recommend the setup of NTP clients and own servers. This will provide to your node a higher level of time accuracy and the best, time wise, synchronization with the peers in the network.
-
-### Block Version 7
-
-[#PR1022](https://github.com/PIVX-Project/PIVX/pull/1022) defines Version 7 blocks, which remove the (now-unused) accumulator checkpoint from the block header. This results in an overall data reduction of ~256 bits from each block as well as the in-memory indexes.
-
-### New Network Message Signatures
-
-Layer 2 network messages (MN, Budget, Spork, etc) are now signed based on the hash of their **binary** content instead of their **string** representation ([#PR1024](https://github.com/PIVX-Project/PIVX/pull/1024)).
-
-### New SPORKS
-
-Two new SPORKS are introduced, `SPORK_17` ([#PR975](https://github.com/PIVX-Project/PIVX/pull/975)) and `SPORK_18` ([#PR995](https://github.com/PIVX-Project/PIVX/pull/995)).<br>
-`SPORK_17` (off by default) is used to activate the [Cold Staking](#cold-staking) protocol. When this spork is off, no cold-staked block is accepted by the network and new delegations are rejected, but coin-owners are still able to spend previously created pay-to-cold-stake delegations.
-
-`SPORK_18` (off by default) is used to switch between Version 3 and [Version 4 Public Spends](#v1-zpiv-spending-public-spends-version-4). When this spork is active, only version 4 spends are accepted by the network. When it's not, only version 3 spends are accepted.
 
 RPC Changes
 --------------
 
-### New options for existing wallet commands
+### Modified input/output for existing commands
 
-A new (optional) argument, `includeDelegated`, has been added to the following commands that allows these commands to include delegated coins/information in their operation:
-- `getbalance` - Boolean (Default: True)
-- `sendfrom` - Boolean (Default: False)
-- `sendmany` - Boolean (Default: False)
-- `listtransactions` - Boolean (Default: True)
+- "CoinStake" JSON object in `getblock` output is removed, and replaced with the string "hashProofOfStake"
 
-Additionally, a new (optional) argument, `includeCold`, has been added to the `listtransactions` command (Boolean - Default: True), which allows for filtering of cold-staker delegated transactions.
+- "isPublicSpend" boolean (optional) input parameter is removed from the following commands:
+ - `createrawzerocoinspend`
+ - `spendzerocoin`
+ - `spendzerocoinmints`
+ - `spendrawzerocoin`
 
-### New return fields for existing commands
+ These commands are now able to create only *public* spends (private spends were already enabled only on regtest).
 
-The `validateaddress` command now includes an additional response field, `isstaking`, to indicate wither or not the specified address is a cold staking address.
+### Removed commands
 
-The `getwalletinfo` command now includes two additional response fields:
-- `delegated_balance` - PIV balance held in P2CS contracts (delegated amount total).
-- `cold_staking_balance` - PIV balance held in cold staking addresses.
+The following commands have been removed from the RPC interface:
+- `createrawzerocoinstake`
+
 
 ### Newly introduced commands
 
 The following new commands have been added to the RPC interface:
-- `getnewstakingaddress`
-- `delegatestake`
-- `rawdelegatestake`
-- `getcoldstakingbalance`
-- `delegatoradd`
-- `delegatorremove`
-- `listcoldutxos`
-- `liststakingaddresses`
-- `listdelegators`
+- `...`
 
 Details about each new command can be found below.
 
-`getnewstakingaddress` generates a new cold staking address:
-```
-getnewstakingaddress ( "account" )
-
-Returns a new PIVX cold staking address for receiving delegated cold stakes.
-
-Arguments:
-1. "account"        (string, optional) The account name for the address to be linked to. if not provided, the default account "" is used. It can also be set to the empty string "" to represent the default account. The account does not need to exist, it will be created if there is no account by the given name.
-
-Result:
-"pivxaddress"    (string) The new pivx address
-```
-
-`delegatestake` sends a cold staking delegation transaction:
-```
-delegatestake "stakingaddress" amount ( "owneraddress" fExternalOwner fUseDelegated fForceNotEnabled )
-
-Delegate an amount to a given address for cold staking. The amount is a real and is rounded to the nearest 0.00000001
-
-Requires wallet passphrase to be set with walletpassphrase call.
-
-Arguments:
-1. "stakingaddress"      (string, required) The pivx staking address to delegate.
-2. "amount"              (numeric, required) The amount in PIV to delegate for staking. eg 100
-3. "owneraddress"        (string, optional) The pivx address corresponding to the key that will be able to spend the stake.
-                               If not provided, or empty string, a new wallet address is generated.
-4. "fExternalOwner"      (boolean, optional, default = false) use the provided 'owneraddress' anyway, even if not present in this wallet.
-                               WARNING: The owner of the keys to 'owneraddress' will be the only one allowed to spend these coins.
-5. "fUseDelegated"       (boolean, optional, default = false) include already delegated inputs if needed.6. "fForceNotEnabled"    (boolean, optional, default = false) force the creation even if SPORK 17 is disabled (for tests).
-
-Result:
-{
-   "owner_address": "xxx"   (string) The owner (delegator) owneraddress.
-   "staker_address": "xxx"  (string) The cold staker (delegate) stakingaddress.
-   "txid": "xxx"            (string) The stake delegation transaction id.
-}
-```
-
-`rawdelegatestake` creates a raw cold staking delegation transaction without broadcasting it to the network:
-```
-rawdelegatestake "stakingaddress" amount ( "owneraddress" fExternalOwner fUseDelegated )
-
-Delegate an amount to a given address for cold staking. The amount is a real and is rounded to the nearest 0.00000001
-
-Delegate transaction is returned as json object.
-Requires wallet passphrase to be set with walletpassphrase call.
-
-Arguments:
-1. "stakingaddress"      (string, required) The pivx staking address to delegate.
-2. "amount"              (numeric, required) The amount in PIV to delegate for staking. eg 100
-3. "owneraddress"        (string, optional) The pivx address corresponding to the key that will be able to spend the stake.
-                               If not provided, or empty string, a new wallet address is generated.
-4. "fExternalOwner"      (boolean, optional, default = false) use the provided 'owneraddress' anyway, even if not present in this wallet.
-                               WARNING: The owner of the keys to 'owneraddress' will be the only one allowed to spend these coins.
-5. "fUseDelegated         (boolean, optional, default = false) include already delegated inputs if needed.
-
-Result:
-{
-  "txid" : "id",        (string) The transaction id (same as provided)
-  "version" : n,          (numeric) The version
-  "size" : n,             (numeric) The serialized transaction size
-  "locktime" : ttt,       (numeric) The lock time
-  "vin" : [               (array of json objects)
-     {
-       "txid": "id",    (string) The transaction id
-       "vout": n,         (numeric)
-       "scriptSig": {     (json object) The script
-         "asm": "asm",  (string) asm
-         "hex": "hex"   (string) hex
-       },
-       "sequence": n      (numeric) The script sequence number
-     }
-     ,...
-  ],
-  "vout" : [              (array of json objects)
-     {
-       "value" : x.xxx,            (numeric) The value in btc
-       "n" : n,                    (numeric) index
-       "scriptPubKey" : {          (json object)
-         "asm" : "asm",          (string) the asm
-         "hex" : "hex",          (string) the hex
-         "reqSigs" : n,            (numeric) The required sigs
-         "type" : "pubkeyhash",  (string) The type, eg 'pubkeyhash'
-         "addresses" : [           (json array of string)
-           "pivxaddress"        (string) pivx address
-           ,...
-         ]
-       }
-     }
-     ,...
-  ],
-  "hex" : "data",       (string) The serialized, hex-encoded data for 'txid'
-}
-```
-
-`getcoldstakingbalance` returns the cold balance of the wallet:
-```
-getcoldstakingbalance ( "account" )
-
-If account is not specified, returns the server's total available cold balance.
-If account is specified, returns the cold balance in the account.
-Note that the account "" is not the same as leaving the parameter out.
-The server total may be different to the balance in the default "" account.
-
-Arguments:
-1. "account"      (string, optional) The selected account, or "*" for entire wallet. It may be the default account using "".
-
-Result:
-amount              (numeric) The total amount in PIV received for this account in P2CS contracts.
-```
-
-`delegatoradd` whitelists a delegated owner address for cold staking:
-```
-delegatoradd "addr"
-
-Add the provided address <addr> into the allowed delegators AddressBook.
-This enables the staking of coins delegated to this wallet, owned by <addr>
-
-Arguments:
-1. "addr"        (string, required) The address to whitelist
-
-Result:
-true|false           (boolean) true if successful.
-```
-
-`delegatorremove` to remove previously whitelisted owner address:
-```
-delegatoradd "addr"
-
-Add the provided address <addr> into the allowed delegators AddressBook.
-This enables the staking of coins delegated to this wallet, owned by <addr>
-
-Arguments:
-1. "addr"        (string, required) The address to whitelist
-
-Result:
-true|false           (boolean) true if successful.
-```
-
-`listcoldutxos` lists all P2CS UTXOs belonging to the wallet (both delegator and cold staker):
-```
-listcoldutxos ( nonWhitelistedOnly )
-
-List P2CS unspent outputs received by this wallet as cold-staker-
-
-Arguments:
-1. nonWhitelistedOnly   (boolean, optional, default=false) Whether to exclude P2CS from whitelisted delegators.
-
-Result:
-[
-  {
-    "txid" : "true",            (string) The transaction id of the P2CS utxo
-    "txidn" : "accountname",    (string) The output number of the P2CS utxo
-    "amount" : x.xxx,             (numeric) The amount of the P2CS utxo
-    "confirmations" : n           (numeric) The number of confirmations of the P2CS utxo
-    "cold-staker" : n             (string) The cold-staker address of the P2CS utxo
-    "coin-owner" : n              (string) The coin-owner address of the P2CS utxo
-    "whitelisted" : n             (string) "true"/"false" coin-owner in delegator whitelist
-  }
-  ,...
-]
-```
-
-`liststakingaddresses` lists all cold staking addresses generated by the wallet:
-```
-liststakingaddresses "addr"
-
-Shows the list of staking addresses for this wallet.
-
-Result:
-[
-   {
-   "label": "yyy",  (string) account label
-   "address": "xxx",  (string) PIVX address string
-   }
-  ...
-]
-```
-
-`listdelegators` lists the whitelisted owner addresses
-```
-listdelegators "addr"
-
-Shows the list of allowed delegator addresses for cold staking.
-
-Result:
-[
-   {
-   "label": "yyy",  (string) account label
-   "address": "xxx",  (string) PIVX address string
-   }
-  ...
-]
-```
-
-Snapcraft Packages
-------------------
-
-For our linux users, in addition to the [Ubuntu PPA](https://launchpad.net/~pivx) repository, we are now offering a [Snap package](https://snapcraft.io/pivx-core) as quick way to install and update a PIVX wallet.
-
-Release versions are available via the `Stable` branch, and (for testing-only purposes) nightly builds are available in the `Beta` branch.
-
-Internal Miner/Staker Change
---------------
-
-The wallet's internal miner/staker is no longer prevented from running prior to having synced all the additional layer 2 (MN/Budget) data. Instead, mining/staking uses better logic to allow block creation without fully synced layer 2 data when the full data set wouldn't be required.
-
-In other words, try to stake a new block only if:
-
-- full layer 2 sync is complete
-OR
-- The spork list is synced and all three sporks (8,9 and 13) are **not** active.
-
-Faster Shutdown During Initial Loading
---------------
-
-Previously, if a user wanted to close/quit the wallet before it had finished its initial loading process, they would need to wait until that loading process actually completed before the wallet would fully close.
-
-Now, the new behavior is to gracefully close the wallet once the current step is complete.
 
 *version* Change log
 ==============
@@ -387,7 +83,6 @@ Detailed release notes follow. This overview includes changes that affect behavi
 ### Wallet
 
 ### Miscellaneous
-
 
 ## Credits
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -187,6 +187,7 @@ BITCOIN_CORE_H = \
   zpiv/zpivtracker.h \
   zpiv/zpivwallet.h \
   zpiv/zpivmodule.h \
+  zpiv/zpos.h \
   zmq/zmqabstractnotifier.h \
   zmq/zmqconfig.h \
   zmq/zmqnotificationinterface.h \
@@ -281,6 +282,7 @@ libbitcoin_wallet_a_SOURCES = \
   zpiv/zpivtracker.cpp \
   stakeinput.cpp \
   zpiv/zpivmodule.cpp \
+  zpiv/zpos.cpp \
   $(BITCOIN_CORE_H)
 
 # crypto primitives library

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -16,26 +16,243 @@
 #include "zpivchain.h"
 #include "zpiv/zpos.h"
 
-// v1 modifier interval.
+/*
+ * PoS Validation
+ */
+
+bool GetHashProofOfStake(const CBlockIndex* pindexPrev, CStakeInput* stake, const unsigned int nTimeTx, const bool fVerify, uint256& hashProofOfStakeRet) {
+    // Grab the stake data
+    CBlockIndex* pindexfrom = stake->GetIndexFrom();
+    if (!pindexfrom) return error("%s : Failed to find the block index for stake origin", __func__);
+    const CDataStream& ssUniqueID = stake->GetUniqueness();
+    const unsigned int nTimeBlockFrom = pindexfrom->nTime;
+    CDataStream modifier_ss(SER_GETHASH, 0);
+
+    // Hash the modifier
+    if (!Params().IsStakeModifierV2(pindexPrev->nHeight + 1)) {
+        // Modifier v1
+        uint64_t nStakeModifier = 0;
+        if (!GetOldStakeModifier(stake, nStakeModifier))
+            return error("%s : Failed to get kernel stake modifier", __func__);
+        modifier_ss << nStakeModifier;
+    } else {
+        // Modifier v2
+        modifier_ss << pindexPrev->nStakeModifierV2;
+    }
+
+    CDataStream ss(modifier_ss);
+    // Calculate hash
+    ss << nTimeBlockFrom << ssUniqueID << nTimeTx;
+    hashProofOfStakeRet = Hash(ss.begin(), ss.end());
+
+    if (fVerify) {
+        LogPrint("staking", "%s : nStakeModifier=%s\nnTimeBlockFrom=%d\nssUniqueIDD=%s\n-->DATA=%s",
+            __func__, HexStr(modifier_ss), nTimeBlockFrom, HexStr(ssUniqueID), HexStr(ss));
+    }
+    return true;
+}
+
+bool CheckStakeKernelHash(const CBlockIndex* pindexPrev, const unsigned int nBits, CStakeInput* stake, const unsigned int nTimeTx, uint256& hashProofOfStake, const bool fVerify)
+{
+    // Calculate the proof of stake hash
+    if (!GetHashProofOfStake(pindexPrev, stake, nTimeTx, fVerify, hashProofOfStake)) {
+        return error("%s : Failed to calculate the proof of stake hash", __func__);
+    }
+
+    const CAmount& nValueIn = stake->GetValue();
+    const CDataStream& ssUniqueID = stake->GetUniqueness();
+
+    // Base target
+    uint256 bnTarget;
+    bnTarget.SetCompact(nBits);
+
+    // Weighted target
+    uint256 bnWeight = uint256(nValueIn) / 100;
+    bnTarget *= bnWeight;
+
+    // Check if proof-of-stake hash meets target protocol
+    const bool res = (hashProofOfStake < bnTarget);
+
+    if (fVerify || res) {
+        LogPrint("staking", "%s : Proof Of Stake:"
+                            "\nssUniqueID=%s"
+                            "\nnTimeTx=%d"
+                            "\nhashProofOfStake=%s"
+                            "\nnBits=%d"
+                            "\nweight=%d"
+                            "\nbnTarget=%s (res: %d)\n\n",
+            __func__, HexStr(ssUniqueID), nTimeTx, hashProofOfStake.GetHex(),
+            nBits, nValueIn, bnTarget.GetHex(), res);
+    }
+    return res;
+}
+
+bool CheckProofOfStake(const CBlock& block, uint256& hashProofOfStake, std::unique_ptr<CStakeInput>& stake, int nPreviousBlockHeight)
+{
+    // Initialize the stake object
+    if(!initStakeInput(block, stake, nPreviousBlockHeight))
+        return error("%s : stake input object initialization failed", __func__);
+
+    const CTransaction tx = block.vtx[1];
+    // Kernel (input 0) must match the stake hash target per coin age (nBits)
+    const CTxIn& txin = tx.vin[0];
+    CBlockIndex* pindexPrev = mapBlockIndex[block.hashPrevBlock];
+    CBlockIndex* pindexfrom = stake->GetIndexFrom();
+    if (!pindexfrom)
+        return error("%s : Failed to find the block index for stake origin", __func__);
+
+    unsigned int nBlockFromTime = pindexfrom->nTime;
+    unsigned int nTxTime = block.nTime;
+    const int nBlockFromHeight = pindexfrom->nHeight;
+
+    if (!txin.IsZerocoinSpend() && nPreviousBlockHeight >= Params().Zerocoin_Block_Public_Spend_Enabled() - 1) {
+        //check for maturity (min age/depth) requirements
+        if (!Params().HasStakeMinAgeOrDepth(nPreviousBlockHeight+1, nTxTime, nBlockFromHeight, nBlockFromTime))
+            return error("%s : min age violation - height=%d - nTimeTx=%d, nTimeBlockFrom=%d, nHeightBlockFrom=%d",
+                             __func__, nPreviousBlockHeight, nTxTime, nBlockFromTime, nBlockFromHeight);
+    }
+
+    if (!CheckStakeKernelHash(pindexPrev, block.nBits, stake.get(), nTxTime, hashProofOfStake, true))
+        return error("%s : INFO: check kernel failed on coinstake %s, hashProof=%s", __func__,
+                     tx.GetHash().GetHex(), hashProofOfStake.GetHex());
+
+    return true;
+}
+
+// Initialize the stake input object
+bool initStakeInput(const CBlock& block, std::unique_ptr<CStakeInput>& stake, int nPreviousBlockHeight) {
+    const CTransaction tx = block.vtx[1];
+    if (!tx.IsCoinStake())
+        return error("%s : called on non-coinstake %s", __func__, tx.GetHash().ToString().c_str());
+
+    // Kernel (input 0) must match the stake hash target per coin age (nBits)
+    const CTxIn& txin = tx.vin[0];
+
+    // Construct the stakeinput object
+    if (txin.IsZerocoinSpend()) {
+        libzerocoin::CoinSpend spend = TxInToZerocoinSpend(txin);
+        if (spend.getSpendType() != libzerocoin::SpendType::STAKE)
+            return error("%s : spend is using the wrong SpendType (%d)", __func__, (int)spend.getSpendType());
+
+        stake = std::unique_ptr<CStakeInput>(new CLegacyZPivStake(spend));
+
+        // zPoS contextual checks
+        /* Only for IBD (between Zerocoin_Block_V2_Start and Zerocoin_Block_Last_Checkpoint) */
+        if (nPreviousBlockHeight < Params().Zerocoin_Block_V2_Start() ||
+                nPreviousBlockHeight > Params().Zerocoin_Block_Last_Checkpoint())
+            return error("%s : zPIV stake block: height %d outside range", __func__, (nPreviousBlockHeight+1));
+        CLegacyZPivStake* zPIV = dynamic_cast<CLegacyZPivStake*>(stake.get());
+        if (!zPIV) return error("%s : dynamic_cast of stake ptr failed", __func__);
+        // The checkpoint needs to be from 200 blocks ago
+        const int cpHeight = nPreviousBlockHeight - Params().Zerocoin_RequiredStakeDepth();
+        const libzerocoin::CoinDenomination denom = libzerocoin::AmountToZerocoinDenomination(zPIV->GetValue());
+        if (ParseAccChecksum(chainActive[cpHeight]->nAccumulatorCheckpoint, denom) != zPIV->GetChecksum())
+            return error("%s : accum. checksum at height %d is wrong.", __func__, (nPreviousBlockHeight+1));
+
+    } else {
+        // First try finding the previous transaction in database
+        uint256 hashBlock;
+        CTransaction txPrev;
+        if (!GetTransaction(txin.prevout.hash, txPrev, hashBlock, true))
+            return error("%s : INFO: read txPrev failed, tx id prev: %s, block id %s",
+                         __func__, txin.prevout.hash.GetHex(), block.GetHash().GetHex());
+
+        //verify signature and script
+        ScriptError serror;
+        if (!VerifyScript(txin.scriptSig, txPrev.vout[txin.prevout.n].scriptPubKey, STANDARD_SCRIPT_VERIFY_FLAGS, TransactionSignatureChecker(&tx, 0), &serror)) {
+            std::string strErr = "";
+            if (serror && ScriptErrorString(serror))
+                strErr = strprintf("with the following error: %s", ScriptErrorString(serror));
+            return error("%s : VerifyScript failed on coinstake %s %s", __func__, tx.GetHash().ToString(), strErr);
+        }
+
+        CPivStake* pivInput = new CPivStake();
+        pivInput->SetInput(txPrev, txin.prevout.n);
+        stake = std::unique_ptr<CStakeInput>(pivInput);
+    }
+    return true;
+}
+
+// Stake Modifier (hash modifier of proof-of-stake):
+// The purpose of stake modifier is to prevent a txout (coin) owner from
+// computing future proof-of-stake generated by this txout at the time
+// of transaction confirmation. To meet kernel protocol, the txout
+// must hash with a future stake modifier to generate the proof.
+uint256 ComputeStakeModifier(const CBlockIndex* pindexPrev, const uint256& kernel)
+{
+    // genesis block's modifier is 0
+    // all block's modifiers are 0 on regtest
+    if (!pindexPrev || Params().IsRegTestNet())
+        return uint256();
+
+    CHashWriter ss(SER_GETHASH, 0);
+    ss << kernel;
+
+    // switch with old modifier on upgrade block
+    if (!Params().IsStakeModifierV2(pindexPrev->nHeight + 1))
+        ss << pindexPrev->nStakeModifier;
+    else
+        ss << pindexPrev->nStakeModifierV2;
+
+    return ss.GetHash();
+}
+
+bool Stake(const CBlockIndex* pindexPrev, CStakeInput* stakeInput, unsigned int nBits, int64_t& nTimeTx, uint256& hashProofOfStake)
+{
+    const int nHeight = pindexPrev->nHeight + 1;
+    // get stake input pindex
+    CBlockIndex* pindexFrom = stakeInput->GetIndexFrom();
+    if (!pindexFrom || pindexFrom->nHeight < 1) return error("%s : no pindexfrom", __func__);
+
+    // check required min depth for stake
+    const int nHeightBlockFrom = pindexFrom->nHeight;
+    if (nHeight < nHeightBlockFrom + Params().COINSTAKE_MIN_DEPTH())
+        return error("%s : min depth violation, nHeight=%d, nHeightBlockFrom=%d", __func__, nHeight, nHeightBlockFrom);
+
+    nTimeTx = (Params().IsRegTestNet() ? GetAdjustedTime() : GetCurrentTimeSlot());
+    // double check that we are not on the same slot as prev block
+    if (nTimeTx <= pindexPrev->nTime) return false;
+
+    // check stake kernel
+    return CheckStakeKernelHash(pindexPrev, nBits, stakeInput, nTimeTx, hashProofOfStake);
+}
+
+
+/*
+ * UTILS
+ */
+
+// Timestamp for time protocol V2: slot duration 15 seconds
+int64_t GetTimeSlot(const int64_t nTime)
+{
+    const int slotLen = Params().TimeSlotLength();
+    return (nTime / slotLen) * slotLen;
+}
+
+int64_t GetCurrentTimeSlot()
+{
+    return GetTimeSlot(GetAdjustedTime());
+}
+
+uint32_t ParseAccChecksum(uint256 nCheckpoint, const libzerocoin::CoinDenomination denom)
+{
+    int pos = distance(libzerocoin::zerocoinDenomList.begin(),
+            find(libzerocoin::zerocoinDenomList.begin(), libzerocoin::zerocoinDenomList.end(), denom));
+    nCheckpoint = nCheckpoint >> (32*((libzerocoin::zerocoinDenomList.size() - 1) - pos));
+    return nCheckpoint.Get32();
+}
+
+
+/*
+ * OLD MODIFIER
+ */
+static const unsigned int MODIFIER_INTERVAL = 60;
+static const int MODIFIER_INTERVAL_RATIO = 3;
 static const int64_t OLD_MODIFIER_INTERVAL = 2087;
 
 // Hard checkpoints of stake modifiers to ensure they are deterministic
 static std::map<int, unsigned int> mapStakeModifierCheckpoints =
     boost::assign::map_list_of(0, 0xfd11f4e7u);
-
-// Get the last stake modifier and its generation time from a given block
-static bool GetLastStakeModifier(const CBlockIndex* pindex, uint64_t& nStakeModifier, int64_t& nModifierTime)
-{
-    if (!pindex)
-        return error("%s : null pindex", __func__);
-    while (pindex && pindex->pprev && !pindex->GeneratedStakeModifier())
-        pindex = pindex->pprev;
-    if (!pindex->GeneratedStakeModifier())
-        return error("%s : no generation at genesis block", __func__);
-    nStakeModifier = pindex->nStakeModifier;
-    nModifierTime = pindex->GetBlockTime();
-    return true;
-}
 
 // Get selection interval section (in seconds)
 static int64_t GetStakeModifierSelectionIntervalSection(int nSection)
@@ -108,30 +325,74 @@ static bool SelectBlockFromCandidates(
     return fSelected;
 }
 
-/* NEW MODIFIER */
-
-// Stake Modifier (hash modifier of proof-of-stake):
-// The purpose of stake modifier is to prevent a txout (coin) owner from
-// computing future proof-of-stake generated by this txout at the time
-// of transaction confirmation. To meet kernel protocol, the txout
-// must hash with a future stake modifier to generate the proof.
-uint256 ComputeStakeModifier(const CBlockIndex* pindexPrev, const uint256& kernel)
+unsigned int GetStakeModifierChecksum(const CBlockIndex* pindex)
 {
-    // genesis block's modifier is 0
-    // all block's modifiers are 0 on regtest
-    if (!pindexPrev || Params().IsRegTestNet())
-        return uint256();
+    assert(pindex->pprev || pindex->GetBlockHash() == Params().HashGenesisBlock());
+    // Hash previous checksum with flags, hashProofOfStake and nStakeModifier
+    CDataStream ss(SER_GETHASH, 0);
+    if (pindex->pprev)
+        ss << pindex->pprev->nStakeModifierChecksum;
+    ss << pindex->nFlags << pindex->hashProofOfStake << pindex->nStakeModifier;
+    uint256 hashChecksum = Hash(ss.begin(), ss.end());
+    hashChecksum >>= (256 - 32);
+    return hashChecksum.Get64();
+}
 
-    CHashWriter ss(SER_GETHASH, 0);
-    ss << kernel;
+bool GetOldStakeModifier(CStakeInput* stake, uint64_t& nStakeModifier)
+{
+    if(Params().IsRegTestNet()) {
+        nStakeModifier = 0;
+        return true;
+    }
+    CBlockIndex* pindexFrom = stake->GetIndexFrom();
+    if (!pindexFrom) return error("%s : failed to get index from", __func__);
+    if (stake->IsZPIV()) {
+        int64_t nTimeBlockFrom = pindexFrom->GetBlockTime();
+        const int nHeightStop = std::min(chainActive.Height(), Params().Zerocoin_Block_Last_Checkpoint()-1);
+        while (pindexFrom && pindexFrom->nHeight + 1 <= nHeightStop) {
+            if (pindexFrom->GetBlockTime() - nTimeBlockFrom > 60 * 60) {
+                nStakeModifier = pindexFrom->nAccumulatorCheckpoint.Get64();
+                return true;
+            }
+            pindexFrom = chainActive.Next(pindexFrom);
+        }
+        return false;
 
-    // switch with old modifier on upgrade block
-    if (!Params().IsStakeModifierV2(pindexPrev->nHeight + 1))
-        ss << pindexPrev->nStakeModifier;
-    else
-        ss << pindexPrev->nStakeModifierV2;
+    } else if (!GetOldModifier(pindexFrom->GetBlockHash(), nStakeModifier))
+        return error("%s : failed to get kernel stake modifier", __func__);
 
-    return ss.GetHash();
+    return true;
+}
+
+// The stake modifier used to hash for a stake kernel is chosen as the stake
+// modifier about a selection interval later than the coin generating the kernel
+bool GetOldModifier(const uint256& hashBlockFrom, uint64_t& nStakeModifier)
+{
+    if (!mapBlockIndex.count(hashBlockFrom))
+        return error("%s : block not indexed", __func__);
+    const CBlockIndex* pindexFrom = mapBlockIndex[hashBlockFrom];
+    int64_t nStakeModifierTime = pindexFrom->GetBlockTime();
+    // Fixed stake modifier only for regtest
+    if (Params().IsRegTestNet()) {
+        nStakeModifier = pindexFrom->nStakeModifier;
+        return true;
+    }
+    const CBlockIndex* pindex = pindexFrom;
+    CBlockIndex* pindexNext = chainActive[pindex->nHeight + 1];
+
+    // loop to find the stake modifier later by a selection interval
+    do {
+        if (!pindexNext) {
+            // Should never happen
+            return error("%s : Null pindexNext, current block %s ", __func__, pindex->phashBlock->GetHex());
+        }
+        pindex = pindexNext;
+        if (pindex->GeneratedStakeModifier()) nStakeModifierTime = pindex->GetBlockTime();
+        pindexNext = chainActive[pindex->nHeight + 1];
+    } while (nStakeModifierTime < pindexFrom->GetBlockTime() + OLD_MODIFIER_INTERVAL);
+
+    nStakeModifier = pindex->nStakeModifier;
+    return true;
 }
 
 // Stake Modifier (hash modifier of proof-of-stake):
@@ -170,8 +431,11 @@ bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeMod
     // First find current stake modifier and its generation block time
     // if it's not old enough, return the same stake modifier
     int64_t nModifierTime = 0;
-    if (!GetLastStakeModifier(pindexPrev, nStakeModifier, nModifierTime))
-        return error("%s : unable to get last modifier", __func__);
+    const CBlockIndex* p = pindexPrev;
+    while (p && p->pprev && !p->GeneratedStakeModifier()) p = p->pprev;
+    if (!p->GeneratedStakeModifier()) return error("%s : unable to get last modifier", __func__);
+    nStakeModifier = p->nStakeModifier;
+    nModifierTime = p->GetBlockTime();
 
     if (GetBoolArg("-printstakemodifier", false))
         LogPrintf("%s : prev modifier= %s time=%s\n", __func__, std::to_string(nStakeModifier).c_str(), DateTimeStrFormat("%Y-%m-%d %H:%M:%S", nModifierTime).c_str());
@@ -243,272 +507,3 @@ bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeMod
     fGeneratedStakeModifier = true;
     return true;
 }
-
-// The stake modifier used to hash for a stake kernel is chosen as the stake
-// modifier about a selection interval later than the coin generating the kernel
-bool GetKernelStakeModifier(const uint256& hashBlockFrom, uint64_t& nStakeModifier, int& nStakeModifierHeight, int64_t& nStakeModifierTime, bool fPrintProofOfStake)
-{
-    nStakeModifier = 0;
-    // modifier 0 on RegTest
-    if (Params().IsRegTestNet()) {
-        return true;
-    }
-    if (!mapBlockIndex.count(hashBlockFrom))
-        return error("%s : block not indexed", __func__);
-    const CBlockIndex* pindexFrom = mapBlockIndex[hashBlockFrom];
-    nStakeModifierHeight = pindexFrom->nHeight;
-    nStakeModifierTime = pindexFrom->GetBlockTime();
-    // Fixed stake modifier only for regtest
-    if (Params().IsRegTestNet()) {
-        nStakeModifier = pindexFrom->nStakeModifier;
-        return true;
-    }
-    const CBlockIndex* pindex = pindexFrom;
-    CBlockIndex* pindexNext = chainActive[pindex->nHeight + 1];
-
-    // loop to find the stake modifier later by a selection interval
-    do {
-        if (!pindexNext) {
-            // Should never happen
-            return error("%s : Null pindexNext, current block %s ", __func__, pindex->phashBlock->GetHex());
-        }
-        pindex = pindexNext;
-        if (pindex->GeneratedStakeModifier()) {
-            nStakeModifierHeight = pindex->nHeight;
-            nStakeModifierTime = pindex->GetBlockTime();
-        }
-        pindexNext = chainActive[pindex->nHeight + 1];
-    } while (nStakeModifierTime < pindexFrom->GetBlockTime() + OLD_MODIFIER_INTERVAL);
-
-    nStakeModifier = pindex->nStakeModifier;
-    return true;
-}
-
-bool CheckStakeKernelHash(const CBlockIndex* pindexPrev, const unsigned int nBits, CStakeInput* stake, const unsigned int nTimeTx, uint256& hashProofOfStake, const bool fVerify)
-{
-    // Calculate the proof of stake hash
-    if (!GetHashProofOfStake(pindexPrev, stake, nTimeTx, fVerify, hashProofOfStake)) {
-        return error("%s : Failed to calculate the proof of stake hash", __func__);
-    }
-
-    const CAmount& nValueIn = stake->GetValue();
-    const CDataStream& ssUniqueID = stake->GetUniqueness();
-
-    // Base target
-    uint256 bnTarget;
-    bnTarget.SetCompact(nBits);
-
-    // Weighted target
-    uint256 bnWeight = uint256(nValueIn) / 100;
-    bnTarget *= bnWeight;
-
-    // Check if proof-of-stake hash meets target protocol
-    const bool res = (hashProofOfStake < bnTarget);
-
-    if (fVerify || res) {
-        LogPrint("staking", "%s : Proof Of Stake:"
-                            "\nssUniqueID=%s"
-                            "\nnTimeTx=%d"
-                            "\nhashProofOfStake=%s"
-                            "\nnBits=%d"
-                            "\nweight=%d"
-                            "\nbnTarget=%s (res: %d)\n\n",
-            __func__, HexStr(ssUniqueID), nTimeTx, hashProofOfStake.GetHex(),
-            nBits, nValueIn, bnTarget.GetHex(), res);
-    }
-    return res;
-}
-
-bool GetHashProofOfStake(const CBlockIndex* pindexPrev, CStakeInput* stake, const unsigned int nTimeTx, const bool fVerify, uint256& hashProofOfStakeRet) {
-    // Grab the stake data
-    CBlockIndex* pindexfrom = stake->GetIndexFrom();
-    if (!pindexfrom) return error("%s : Failed to find the block index for stake origin", __func__);
-    const CDataStream& ssUniqueID = stake->GetUniqueness();
-    const unsigned int nTimeBlockFrom = pindexfrom->nTime;
-    CDataStream modifier_ss(SER_GETHASH, 0);
-
-    // Hash the modifier
-    if (!Params().IsStakeModifierV2(pindexPrev->nHeight + 1)) {
-        // Modifier v1
-        uint64_t nStakeModifier = 0;
-        if (!stake->GetModifier(nStakeModifier))
-            return error("%s : Failed to get kernel stake modifier", __func__);
-        modifier_ss << nStakeModifier;
-    } else {
-        // Modifier v2
-        modifier_ss << pindexPrev->nStakeModifierV2;
-    }
-
-    CDataStream ss(modifier_ss);
-    // Calculate hash
-    ss << nTimeBlockFrom << ssUniqueID << nTimeTx;
-    hashProofOfStakeRet = Hash(ss.begin(), ss.end());
-
-    if (fVerify) {
-        LogPrint("staking", "%s : nStakeModifier=%s\nnTimeBlockFrom=%d\nssUniqueIDD=%s\n-->DATA=%s",
-            __func__, HexStr(modifier_ss), nTimeBlockFrom, HexStr(ssUniqueID), HexStr(ss));
-    }
-    return true;
-}
-
-bool Stake(const CBlockIndex* pindexPrev, CStakeInput* stakeInput, unsigned int nBits, int64_t& nTimeTx, uint256& hashProofOfStake)
-{
-    const int nHeight = pindexPrev->nHeight + 1;
-
-    // get stake input pindex
-    CBlockIndex* pindexFrom = stakeInput->GetIndexFrom();
-    if (!pindexFrom || pindexFrom->nHeight < 1) return error("%s : no pindexfrom", __func__);
-
-    // check required min depth for stake
-    const int nHeightBlockFrom = pindexFrom->nHeight;
-    if (nHeight < nHeightBlockFrom + Params().COINSTAKE_MIN_DEPTH())
-        return error("%s : min depth violation, nHeight=%d, nHeightBlockFrom=%d", __func__, nHeight, nHeightBlockFrom);
-
-    nTimeTx = (Params().IsRegTestNet() ? GetAdjustedTime() : GetCurrentTimeSlot());
-    // double check that we are not on the same slot as prev block
-    if (nTimeTx <= pindexPrev->nTime) return false;
-
-    // check stake kernel
-    return CheckStakeKernelHash(pindexPrev, nBits, stakeInput, nTimeTx, hashProofOfStake);
-}
-
-uint32_t ParseAccChecksum(uint256 nCheckpoint, const libzerocoin::CoinDenomination denom)
-{
-    int pos = distance(libzerocoin::zerocoinDenomList.begin(),
-            find(libzerocoin::zerocoinDenomList.begin(), libzerocoin::zerocoinDenomList.end(), denom));
-    nCheckpoint = nCheckpoint >> (32*((libzerocoin::zerocoinDenomList.size() - 1) - pos));
-    return nCheckpoint.Get32();
-}
-
-/* Only for IBD (between Zerocoin_Block_V2_Start and Zerocoin_Block_Last_Checkpoint) */
-bool ContextualCheckZerocoinStake(int nPreviousBlockHeight, CStakeInput* stake)
-{
-    if (nPreviousBlockHeight < Params().Zerocoin_Block_V2_Start() ||
-            nPreviousBlockHeight > Params().Zerocoin_Block_Last_Checkpoint())
-        return error("%s : zPIV stake block: height %d outside range", __func__, (nPreviousBlockHeight+1));
-
-    CLegacyZPivStake* zPIV = dynamic_cast<CLegacyZPivStake*>(stake);
-    if (!zPIV) return error("%s : dynamic_cast of stake ptr failed", __func__);
-
-    // The checkpoint needs to be from 200 blocks ago
-    const int cpHeight = nPreviousBlockHeight - Params().Zerocoin_RequiredStakeDepth();
-    const libzerocoin::CoinDenomination denom = libzerocoin::AmountToZerocoinDenomination(zPIV->GetValue());
-    if (ParseAccChecksum(chainActive[cpHeight]->nAccumulatorCheckpoint, denom) != zPIV->GetChecksum())
-        return error("%s : accum. checksum at height %d is wrong.", __func__, (nPreviousBlockHeight+1));
-
-    return true;
-}
-
-bool initStakeInput(const CBlock& block, std::unique_ptr<CStakeInput>& stake, int nPreviousBlockHeight) {
-    const CTransaction tx = block.vtx[1];
-    if (!tx.IsCoinStake())
-        return error("%s : called on non-coinstake %s", __func__, tx.GetHash().ToString().c_str());
-
-    // Kernel (input 0) must match the stake hash target per coin age (nBits)
-    const CTxIn& txin = tx.vin[0];
-
-    //Construct the stakeinput object
-    if (txin.IsZerocoinSpend()) {
-        libzerocoin::CoinSpend spend = TxInToZerocoinSpend(txin);
-        if (spend.getSpendType() != libzerocoin::SpendType::STAKE)
-            return error("%s : spend is using the wrong SpendType (%d)", __func__, (int)spend.getSpendType());
-
-        stake = std::unique_ptr<CStakeInput>(new CLegacyZPivStake(spend));
-        if (!ContextualCheckZerocoinStake(nPreviousBlockHeight, stake.get()))
-            return error("%s : staked zPIV fails context checks", __func__);
-
-    } else {
-        // First try finding the previous transaction in database
-        uint256 hashBlock;
-        CTransaction txPrev;
-        if (!GetTransaction(txin.prevout.hash, txPrev, hashBlock, true))
-            return error("%s : INFO: read txPrev failed, tx id prev: %s, block id %s",
-                         __func__, txin.prevout.hash.GetHex(), block.GetHash().GetHex());
-
-        //verify signature and script
-        ScriptError serror;
-        if (!VerifyScript(txin.scriptSig, txPrev.vout[txin.prevout.n].scriptPubKey, STANDARD_SCRIPT_VERIFY_FLAGS, TransactionSignatureChecker(&tx, 0), &serror)) {
-            std::string strErr = "";
-            if (serror && ScriptErrorString(serror))
-                strErr = strprintf("with the following error: %s", ScriptErrorString(serror));
-            return error("%s : VerifyScript failed on coinstake %s %s", __func__, tx.GetHash().ToString(), strErr);
-        }
-
-        CPivStake* pivInput = new CPivStake();
-        pivInput->SetInput(txPrev, txin.prevout.n);
-        stake = std::unique_ptr<CStakeInput>(pivInput);
-    }
-    return true;
-}
-
-// Check kernel hash target and coinstake signature
-bool CheckProofOfStake(const CBlock& block, uint256& hashProofOfStake, std::unique_ptr<CStakeInput>& stake, int nPreviousBlockHeight)
-{
-    // Initialize the stake object
-    if(!initStakeInput(block, stake, nPreviousBlockHeight))
-        return error("%s : stake input object initialization failed", __func__);
-
-    const CTransaction tx = block.vtx[1];
-    // Kernel (input 0) must match the stake hash target per coin age (nBits)
-    const CTxIn& txin = tx.vin[0];
-    CBlockIndex* pindexPrev = mapBlockIndex[block.hashPrevBlock];
-    CBlockIndex* pindexfrom = stake->GetIndexFrom();
-    if (!pindexfrom)
-        return error("%s : Failed to find the block index for stake origin", __func__);
-
-    unsigned int nBlockFromTime = pindexfrom->nTime;
-    unsigned int nTxTime = block.nTime;
-    const int nBlockFromHeight = pindexfrom->nHeight;
-
-    if (!txin.IsZerocoinSpend() && nPreviousBlockHeight >= Params().Zerocoin_Block_Public_Spend_Enabled() - 1) {
-        //check for maturity (min age/depth) requirements
-        if (!Params().HasStakeMinAgeOrDepth(nPreviousBlockHeight+1, nTxTime, nBlockFromHeight, nBlockFromTime))
-            return error("%s : min age violation - height=%d - nTimeTx=%d, nTimeBlockFrom=%d, nHeightBlockFrom=%d",
-                             __func__, nPreviousBlockHeight, nTxTime, nBlockFromTime, nBlockFromHeight);
-    }
-
-    if (!CheckStakeKernelHash(pindexPrev, block.nBits, stake.get(), nTxTime, hashProofOfStake, true))
-        return error("%s : INFO: check kernel failed on coinstake %s, hashProof=%s", __func__,
-                     tx.GetHash().GetHex(), hashProofOfStake.GetHex());
-
-    return true;
-}
-
-// Get stake modifier checksum
-unsigned int GetStakeModifierChecksum(const CBlockIndex* pindex)
-{
-    assert(pindex->pprev || pindex->GetBlockHash() == Params().HashGenesisBlock());
-    // Hash previous checksum with flags, hashProofOfStake and nStakeModifier
-    CDataStream ss(SER_GETHASH, 0);
-    if (pindex->pprev)
-        ss << pindex->pprev->nStakeModifierChecksum;
-    ss << pindex->nFlags << pindex->hashProofOfStake << pindex->nStakeModifier;
-    uint256 hashChecksum = Hash(ss.begin(), ss.end());
-    hashChecksum >>= (256 - 32);
-    return hashChecksum.Get64();
-}
-
-// Check stake modifier hard checkpoints
-bool CheckStakeModifierCheckpoints(int nHeight, unsigned int nStakeModifierChecksum)
-{
-    if (Params().NetworkID() != CBaseChainParams::MAIN) return true; // Testnet has no checkpoints
-    if (mapStakeModifierCheckpoints.count(nHeight)) {
-        return nStakeModifierChecksum == mapStakeModifierCheckpoints[nHeight];
-    }
-    return true;
-}
-
-// Timestamp for time protocol V2: slot duration 15 seconds
-int64_t GetTimeSlot(const int64_t nTime)
-{
-    const int slotLen = Params().TimeSlotLength();
-    return (nTime / slotLen) * slotLen;
-}
-
-int64_t GetCurrentTimeSlot()
-{
-    return GetTimeSlot(GetAdjustedTime());
-}
-
-
-

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -14,6 +14,7 @@
 #include "stakeinput.h"
 #include "utilmoneystr.h"
 #include "zpivchain.h"
+#include "zpiv/zpos.h"
 
 // v1 modifier interval.
 static const int64_t OLD_MODIFIER_INTERVAL = 2087;
@@ -344,10 +345,8 @@ bool GetHashProofOfStake(const CBlockIndex* pindexPrev, CStakeInput* stake, cons
     hashProofOfStakeRet = Hash(ss.begin(), ss.end());
 
     if (fVerify) {
-        LogPrint("staking", "%s : nStakeModifier=%s (nStakeModifierHeight=%s)\n"
-                "nTimeBlockFrom=%d\nssUniqueIDD=%s\n-->DATA=%s",
-            __func__, HexStr(modifier_ss), ((stake->IsZPIV()) ? "Not available" : std::to_string(stake->getStakeModifierHeight())),
-            nTimeBlockFrom, HexStr(ssUniqueID), HexStr(ss));
+        LogPrint("staking", "%s : nStakeModifier=%s\nnTimeBlockFrom=%d\nssUniqueIDD=%s\n-->DATA=%s",
+            __func__, HexStr(modifier_ss), nTimeBlockFrom, HexStr(ssUniqueID), HexStr(ss));
     }
     return true;
 }
@@ -388,7 +387,7 @@ bool ContextualCheckZerocoinStake(int nPreviousBlockHeight, CStakeInput* stake)
             nPreviousBlockHeight > Params().Zerocoin_Block_Last_Checkpoint())
         return error("%s : zPIV stake block: height %d outside range", __func__, (nPreviousBlockHeight+1));
 
-    CZPivStake* zPIV = dynamic_cast<CZPivStake*>(stake);
+    CLegacyZPivStake* zPIV = dynamic_cast<CLegacyZPivStake*>(stake);
     if (!zPIV) return error("%s : dynamic_cast of stake ptr failed", __func__);
 
     // The checkpoint needs to be from 200 blocks ago
@@ -414,7 +413,7 @@ bool initStakeInput(const CBlock& block, std::unique_ptr<CStakeInput>& stake, in
         if (spend.getSpendType() != libzerocoin::SpendType::STAKE)
             return error("%s : spend is using the wrong SpendType (%d)", __func__, (int)spend.getSpendType());
 
-        stake = std::unique_ptr<CStakeInput>(new CZPivStake(spend));
+        stake = std::unique_ptr<CStakeInput>(new CLegacyZPivStake(spend));
         if (!ContextualCheckZerocoinStake(nPreviousBlockHeight, stake.get()))
             return error("%s : staked zPIV fails context checks", __func__);
 

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -1,47 +1,37 @@
 // Copyright (c) 2011-2013 The PPCoin developers
 // Copyright (c) 2013-2014 The NovaCoin Developers
 // Copyright (c) 2014-2018 The BlackCoin Developers
-// Copyright (c) 2015-2019 The PIVX developers
+// Copyright (c) 2015-2020 The PIVX developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_KERNEL_H
-#define BITCOIN_KERNEL_H
+#ifndef PIVX_KERNEL_H
+#define PIVX_KERNEL_H
 
 #include "main.h"
 #include "stakeinput.h"
 
-
-// MODIFIER_INTERVAL: time to elapse before new modifier is computed
-static const unsigned int MODIFIER_INTERVAL = 60;
-
-// MODIFIER_INTERVAL_RATIO:
-// ratio of group interval length between the last group and the first group
-static const int MODIFIER_INTERVAL_RATIO = 3;
-
-// Compute the hash modifier for proof-of-stake
-bool GetKernelStakeModifier(const uint256& hashBlockFrom, uint64_t& nStakeModifier, int& nStakeModifierHeight, int64_t& nStakeModifierTime, bool fPrintProofOfStake);
-bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeModifier, bool& fGeneratedStakeModifier);
-uint256 ComputeStakeModifier(const CBlockIndex* pindexPrev, const uint256& kernel);
-bool Stake(const CBlockIndex* pindexPrev, CStakeInput* stakeInput, unsigned int nBits, int64_t& nTimeTx, uint256& hashProofOfStake);
-
+/* PoS Validation */
+bool GetHashProofOfStake(const CBlockIndex* pindexPrev, CStakeInput* stake, const unsigned int nTimeTx, const bool fVerify, uint256& hashProofOfStakeRet);
+bool CheckStakeKernelHash(const CBlockIndex* pindexPrev, const unsigned int nBits, CStakeInput* stake, const unsigned int nTimeTx, uint256& hashProofOfStake, const bool fVerify = false);
+bool CheckProofOfStake(const CBlock& block, uint256& hashProofOfStake, std::unique_ptr<CStakeInput>& stake, int nPreviousBlockHeight);
 // Initialize the stake input object
 bool initStakeInput(const CBlock& block, std::unique_ptr<CStakeInput>& stake, int nPreviousBlockHeight);
+// (New) Stake Modifier
+uint256 ComputeStakeModifier(const CBlockIndex* pindexPrev, const uint256& kernel);
+// Stake (find valid kernel)
+bool Stake(const CBlockIndex* pindexPrev, CStakeInput* stakeInput, unsigned int nBits, int64_t& nTimeTx, uint256& hashProofOfStake);
 
-// Check kernel hash target and coinstake signature
-// Sets hashProofOfStake on success return
-bool CheckProofOfStake(const CBlock& block, uint256& hashProofOfStake, std::unique_ptr<CStakeInput>& stake, int nPreviousBlockHeight);
-bool CheckStakeKernelHash(const CBlockIndex* pindexPrev, const unsigned int nBits, CStakeInput* stake, const unsigned int nTimeTx, uint256& hashProofOfStake, const bool fVerify = false);
-// Returns the proof of stake hash
-bool GetHashProofOfStake(const CBlockIndex* pindexPrev, CStakeInput* stake, const unsigned int nTimeTx, const bool fVerify, uint256& hashProofOfStakeRet);
-// Get stake modifier checksum
-unsigned int GetStakeModifierChecksum(const CBlockIndex* pindex);
-
-// Check stake modifier hard checkpoints
-bool CheckStakeModifierCheckpoints(int nHeight, unsigned int nStakeModifierChecksum);
-
+/* Utils */
 int64_t GetTimeSlot(const int64_t nTime);
 int64_t GetCurrentTimeSlot();
 uint32_t ParseAccChecksum(uint256 nCheckpoint, const libzerocoin::CoinDenomination denom);
 
-#endif // BITCOIN_KERNEL_H
+
+/* Old Stake Modifier */
+unsigned int GetStakeModifierChecksum(const CBlockIndex* pindex);
+bool GetOldStakeModifier(CStakeInput* stake, uint64_t& nStakeModifier);
+bool GetOldModifier(const uint256& hashBlockFrom, uint64_t& nStakeModifier);
+bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeModifier, bool& fGeneratedStakeModifier);
+
+#endif // PIVX_KERNEL_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4128,8 +4128,6 @@ CBlockIndex* AddToBlockIndex(const CBlock& block)
                 LogPrintf("AddToBlockIndex() : ComputeNextStakeModifier() failed \n");
             pindexNew->SetStakeModifier(nStakeModifier, fGeneratedStakeModifier);
             pindexNew->nStakeModifierChecksum = GetStakeModifierChecksum(pindexNew);
-            if (!CheckStakeModifierCheckpoints(pindexNew->nHeight, pindexNew->nStakeModifierChecksum))
-                LogPrintf("AddToBlockIndex() : Rejected by stake modifier checkpoint height=%d, modifier=%s \n", pindexNew->nHeight, std::to_string(nStakeModifier));
         } else {
             // compute v2 stake modifier
             pindexNew->nStakeModifierV2 = ComputeStakeModifier(pindexNew->pprev, block.vtx[1].vin[0].prevout.hash);

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -574,7 +574,7 @@ bool WalletModel::createZpivSpend(
 
     CReserveKey reserveKey(wallet);
     std::vector<CDeterministicMint> vNewMints;
-    if (!wallet->CreateZerocoinSpendTransaction(
+    if (!wallet->CreateZCPublicSpendTransaction(
             value,
             wtxNew,
             reserveKey,

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -161,11 +161,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
         if (!GetHashProofOfStake(blockindex->pprev, stake.get(), nTxTime, false, hashProofOfStakeRet))
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Cannot get proof of stake hash");
 
-        UniValue stakeData(UniValue::VOBJ);
-        stakeData.push_back(Pair("hashProofOfStake", hashProofOfStakeRet.GetHex()));
-        stakeData.push_back(Pair("stakeModifierHeight", ((stake->IsZPIV()) ? "Not available" : std::to_string(
-                stake->getStakeModifierHeight()))));
-        result.push_back(Pair("CoinStake", stakeData));
+        result.push_back(Pair("hashProofOfStake", hashProofOfStakeRet.GetHex()));
     }
 
     return result;
@@ -521,9 +517,7 @@ UniValue getblock(const UniValue& params, bool fHelp)
             "     \"5000\" : n,         (numeric) supply of 5000 zPIV denomination\n"
             "     \"total\" : n,        (numeric) The total supply of all zPIV denominations\n"
             "  },\n"
-            "  \"CoinStake\" :\n"
-            "    \"hashProofOfStake\" : \"hash\",   (string) Proof of Stake hash\n"
-            "    \"stakeModifierHeight\" : \"nnn\"  (string) Stake modifier block height\n"
+            "  \"hashProofOfStake\" : \"hash\",   (string) Proof of Stake hash\n"
             "  }\n"
             "}\n"
 

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -450,7 +450,6 @@ static const CRPCCommand vRPCCommands[] =
         {"wallet", "delegatoradd", &delegatoradd, true, false, true},
         {"wallet", "delegatorremove", &delegatorremove, true, false, true},
 
-        {"zerocoin", "createrawzerocoinstake", &createrawzerocoinstake, false, false, true},
         {"zerocoin", "createrawzerocoinspend", &createrawzerocoinspend, false, false, true},
         {"zerocoin", "getzerocoinbalance", &getzerocoinbalance, false, false, true},
         {"zerocoin", "listmintedzerocoins", &listmintedzerocoins, false, false, true},

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -179,7 +179,7 @@ extern std::string HelpExampleCli(std::string methodname, std::string args);
 extern std::string HelpExampleRpc(std::string methodname, std::string args);
 
 extern void EnsureWalletIsUnlocked(bool fAllowAnonOnly = false);
-extern UniValue DoZpivSpend(const CAmount nAmount, bool fMintChange, bool fMinimizeChange, std::vector<CZerocoinMint>& vMintsSelected, std::string address_str, bool isPublicSpend = true);
+extern UniValue DoZpivSpend(const CAmount nAmount, bool fMintChange, bool fMinimizeChange, std::vector<CZerocoinMint>& vMintsSelected, std::string address_str);
 
 extern UniValue getconnectioncount(const UniValue& params, bool fHelp); // in rpc/net.cpp
 extern UniValue getpeerinfo(const UniValue& params, bool fHelp);
@@ -291,7 +291,6 @@ extern UniValue decoderawtransaction(const UniValue& params, bool fHelp);
 extern UniValue decodescript(const UniValue& params, bool fHelp);
 extern UniValue signrawtransaction(const UniValue& params, bool fHelp);
 extern UniValue sendrawtransaction(const UniValue& params, bool fHelp);
-extern UniValue createrawzerocoinstake(const UniValue& params, bool fHelp);
 extern UniValue createrawzerocoinspend(const UniValue& params, bool fHelp);
 
 extern UniValue findserial(const UniValue& params, bool fHelp); // in rpc/blockchain.cpp

--- a/src/stakeinput.cpp
+++ b/src/stakeinput.cpp
@@ -10,119 +10,7 @@
 #include "zpiv/deterministicmint.h"
 #include "wallet/wallet.h"
 
-/*
- * LEGACY: Kept for IBD in order to verify zerocoin stakes occurred when zPoS was active
- * Find the first occurrence of a certain accumulator checksum.
- * Return block index pointer or nullptr if not found
- */
 
-CZPivStake::CZPivStake(const libzerocoin::CoinSpend& spend)
-{
-    this->nChecksum = spend.getAccumulatorChecksum();
-    this->denom = spend.getDenomination();
-    uint256 nSerial = spend.getCoinSerialNumber().getuint256();
-    this->hashSerial = Hash(nSerial.begin(), nSerial.end());
-    fMint = false;
-}
-
-uint32_t CZPivStake::GetChecksum()
-{
-    return nChecksum;
-}
-
-CBlockIndex* CZPivStake::GetIndexFrom()
-{
-    // First look in the legacy database
-    int nHeightChecksum = 0;
-    if (zerocoinDB->ReadAccChecksum(nChecksum, denom, nHeightChecksum)) {
-        return chainActive[nHeightChecksum];
-    }
-
-    // Not found. Scan the chain.
-    CBlockIndex* pindex = chainActive[Params().Zerocoin_StartHeight()];
-    if (!pindex) return nullptr;
-    const int last_block = Params().Zerocoin_Block_Last_Checkpoint();
-    while (pindex && pindex->nHeight <= last_block) {
-        if (ParseAccChecksum(pindex->nAccumulatorCheckpoint, denom) == nChecksum) {
-            // Found. Save to database and return
-            zerocoinDB->WriteAccChecksum(nChecksum, denom, pindex->nHeight);
-            return pindex;
-        }
-        //Skip forward in groups of 10 blocks since checkpoints only change every 10 blocks
-        if (pindex->nHeight % 10 == 0) {
-            pindex = chainActive[pindex->nHeight + 10];
-            continue;
-        }
-        pindex = chainActive.Next(pindex);
-    }
-    return nullptr;
-}
-
-CAmount CZPivStake::GetValue()
-{
-    return denom * COIN;
-}
-
-// Use the first accumulator checkpoint that occurs 60 minutes after the block being staked from
-bool CZPivStake::GetModifier(uint64_t& nStakeModifier)
-{
-    CBlockIndex* pindex = GetIndexFrom();
-    if (!pindex)
-        return error("%s: failed to get index from", __func__);
-
-    if(Params().IsRegTestNet()) {
-        nStakeModifier = 0;
-        return true;
-    }
-
-    int64_t nTimeBlockFrom = pindex->GetBlockTime();
-    const int nHeightStop = std::min(chainActive.Height(), Params().Zerocoin_Block_Last_Checkpoint()-1);
-    while (pindex && pindex->nHeight + 1 <= nHeightStop) {
-        if (pindex->GetBlockTime() - nTimeBlockFrom > 60 * 60) {
-            nStakeModifier = pindex->nAccumulatorCheckpoint.Get64();
-            return true;
-        }
-        pindex = chainActive.Next(pindex);
-    }
-
-    return false;
-}
-
-CDataStream CZPivStake::GetUniqueness()
-{
-    //The unique identifier for a zPIV is a hash of the serial
-    CDataStream ss(SER_GETHASH, 0);
-    ss << hashSerial;
-    return ss;
-}
-
-bool CZPivStake::CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut)
-{
-    return error("%s: zPOS Disabled", __func__);
-}
-
-bool CZPivStake::CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal)
-{
-    return error("%s: zPOS Disabled", __func__);
-}
-
-bool CZPivStake::GetTxFrom(CTransaction& tx)
-{
-    return false;
-}
-
-bool CZPivStake::MarkSpent(CWallet *pwallet, const uint256& txid)
-{
-    CzPIVTracker* zpivTracker = pwallet->zpivTracker.get();
-    CMintMeta meta;
-    if (!zpivTracker->GetMetaFromStakeHash(hashSerial, meta))
-        return error("%s: tracker does not have serialhash", __func__);
-
-    zpivTracker->SetPubcoinUsed(meta.hashPubcoin, txid);
-    return true;
-}
-
-//!PIV Stake
 bool CPivStake::SetInput(CTransaction txPrev, unsigned int n)
 {
     this->txFrom = txPrev;
@@ -130,7 +18,7 @@ bool CPivStake::SetInput(CTransaction txPrev, unsigned int n)
     return true;
 }
 
-bool CPivStake::GetTxFrom(CTransaction& tx)
+bool CPivStake::GetTxFrom(CTransaction& tx) const
 {
     tx = txFrom;
     return true;
@@ -142,7 +30,7 @@ bool CPivStake::CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut)
     return true;
 }
 
-CAmount CPivStake::GetValue()
+CAmount CPivStake::GetValue() const
 {
     return txFrom.vout[nPosition].nValue;
 }
@@ -210,7 +98,7 @@ bool CPivStake::GetModifier(uint64_t& nStakeModifier)
     return true;
 }
 
-CDataStream CPivStake::GetUniqueness()
+CDataStream CPivStake::GetUniqueness() const
 {
     //The unique identifier for a PIV stake is the outpoint
     CDataStream ss(SER_NETWORK, 0);

--- a/src/stakeinput.cpp
+++ b/src/stakeinput.cpp
@@ -83,21 +83,6 @@ bool CPivStake::CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmoun
     return true;
 }
 
-bool CPivStake::GetModifier(uint64_t& nStakeModifier)
-{
-    if (this->nStakeModifier == 0) {
-        // look for the modifier
-        GetIndexFrom();
-        if (!pindexFrom)
-            return error("%s: failed to get index from", __func__);
-        // TODO: This method must be removed from here in the short terms.. it's a call to an static method in kernel.cpp when this class method is only called from kernel.cpp, no comments..
-        if (!GetKernelStakeModifier(pindexFrom->GetBlockHash(), this->nStakeModifier, this->nStakeModifierHeight, this->nStakeModifierTime, false))
-            return error("CheckStakeKernelHash(): failed to get kernel stake modifier");
-    }
-    nStakeModifier = this->nStakeModifier;
-    return true;
-}
-
 CDataStream CPivStake::GetUniqueness() const
 {
     //The unique identifier for a PIV stake is the outpoint

--- a/src/stakeinput.cpp
+++ b/src/stakeinput.cpp
@@ -10,6 +10,12 @@
 #include "zpiv/deterministicmint.h"
 #include "wallet/wallet.h"
 
+/*
+ * LEGACY: Kept for IBD in order to verify zerocoin stakes occurred when zPoS was active
+ * Find the first occurrence of a certain accumulator checksum.
+ * Return block index pointer or nullptr if not found
+ */
+
 CZPivStake::CZPivStake(const libzerocoin::CoinSpend& spend)
 {
     this->nChecksum = spend.getAccumulatorChecksum();
@@ -23,12 +29,6 @@ uint32_t CZPivStake::GetChecksum()
 {
     return nChecksum;
 }
-
-/*
- * LEGACY: Kept for IBD in order to verify zerocoin stakes occurred when zPoS was active
- * Find the first occurrence of a certain accumulator checksum.
- * Return block index pointer or nullptr if not found
- */
 
 CBlockIndex* CZPivStake::GetIndexFrom()
 {
@@ -98,50 +98,12 @@ CDataStream CZPivStake::GetUniqueness()
 
 bool CZPivStake::CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut)
 {
-    CBlockIndex* pindexCheckpoint = GetIndexFrom();
-    if (!pindexCheckpoint)
-        return error("%s: failed to find checkpoint block index", __func__);
-
-    CZerocoinMint mint;
-    if (!pwallet->GetMintFromStakeHash(hashSerial, mint))
-        return error("%s: failed to fetch mint associated with serial hash %s", __func__, hashSerial.GetHex());
-
-    if (libzerocoin::ExtractVersionFromSerial(mint.GetSerialNumber()) < 2)
-        return error("%s: serial extract is less than v2", __func__);
-
-    CZerocoinSpendReceipt receipt;
-    if (!pwallet->MintToTxIn(mint, hashTxOut, txIn, receipt, libzerocoin::SpendType::STAKE, pindexCheckpoint))
-        return error("%s", receipt.GetStatusMessage());
-
-    return true;
+    return error("%s: zPOS Disabled", __func__);
 }
 
 bool CZPivStake::CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal)
 {
-    //Create an output returning the zPIV that was staked
-    CTxOut outReward;
-    libzerocoin::CoinDenomination denomStaked = libzerocoin::AmountToZerocoinDenomination(this->GetValue());
-    CDeterministicMint dMint;
-    if (!pwallet->CreateZPIVOutPut(denomStaked, outReward, dMint))
-        return error("%s: failed to create zPIV output", __func__);
-    vout.emplace_back(outReward);
-
-    //Add new staked denom to our wallet
-    if (!pwallet->DatabaseMint(dMint))
-        return error("%s: failed to database the staked zPIV", __func__);
-
-    for (unsigned int i = 0; i < 3; i++) {
-        CTxOut out;
-        CDeterministicMint dMintReward;
-        if (!pwallet->CreateZPIVOutPut(libzerocoin::CoinDenomination::ZQ_ONE, out, dMintReward))
-            return error("%s: failed to create zPIV output", __func__);
-        vout.emplace_back(out);
-
-        if (!pwallet->DatabaseMint(dMintReward))
-            return error("%s: failed to database mint reward", __func__);
-    }
-
-    return true;
+    return error("%s: zPOS Disabled", __func__);
 }
 
 bool CZPivStake::GetTxFrom(CTransaction& tx)

--- a/src/stakeinput.h
+++ b/src/stakeinput.h
@@ -22,52 +22,13 @@ public:
     virtual ~CStakeInput(){};
     virtual CBlockIndex* GetIndexFrom() = 0;
     virtual bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = 0) = 0;
-    virtual bool GetTxFrom(CTransaction& tx) = 0;
-    virtual CAmount GetValue() = 0;
+    virtual bool GetTxFrom(CTransaction& tx) const = 0;
+    virtual CAmount GetValue() const = 0;
     virtual bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) = 0;
     virtual bool GetModifier(uint64_t& nStakeModifier) = 0;
-    virtual bool IsZPIV() = 0;
-    virtual CDataStream GetUniqueness() = 0;
-    virtual uint256 GetSerialHash() const = 0;
+    virtual bool IsZPIV() const = 0;
+    virtual CDataStream GetUniqueness() const = 0;
 
-    virtual uint64_t getStakeModifierHeight() const {
-        return 0;
-    }
-};
-
-
-// zPIVStake can take two forms
-// 1) the stake candidate, which is a zcmint that is attempted to be staked
-// 2) a staked zpiv, which is a zcspend that has successfully staked
-class CZPivStake : public CStakeInput
-{
-private:
-    uint32_t nChecksum;
-    bool fMint;
-    libzerocoin::CoinDenomination denom;
-    uint256 hashSerial;
-
-public:
-    explicit CZPivStake(libzerocoin::CoinDenomination denom, const uint256& hashSerial)
-    {
-        this->denom = denom;
-        this->hashSerial = hashSerial;
-        fMint = true;
-    }
-
-    explicit CZPivStake(const libzerocoin::CoinSpend& spend);
-
-    CBlockIndex* GetIndexFrom() override;
-    bool GetTxFrom(CTransaction& tx) override;
-    CAmount GetValue() override;
-    bool GetModifier(uint64_t& nStakeModifier) override;
-    CDataStream GetUniqueness() override;
-    bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = 0) override;
-    bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) override;
-    bool MarkSpent(CWallet* pwallet, const uint256& txid);
-    bool IsZPIV() override { return true; }
-    uint256 GetSerialHash() const override { return hashSerial; }
-    uint32_t GetChecksum();
 };
 
 class CPivStake : public CStakeInput
@@ -86,16 +47,13 @@ public:
     bool SetInput(CTransaction txPrev, unsigned int n);
 
     CBlockIndex* GetIndexFrom() override;
-    bool GetTxFrom(CTransaction& tx) override;
-    CAmount GetValue() override;
+    bool GetTxFrom(CTransaction& tx) const override;
+    CAmount GetValue() const override;
     bool GetModifier(uint64_t& nStakeModifier) override;
-    CDataStream GetUniqueness() override;
+    CDataStream GetUniqueness() const override;
     bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = 0) override;
     bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) override;
-    bool IsZPIV() override { return false; }
-    uint256 GetSerialHash() const override { return uint256(0); }
-
-    uint64_t getStakeModifierHeight() const override { return nStakeModifierHeight; }
+    bool IsZPIV() const override { return false; }
 };
 
 

--- a/src/stakeinput.h
+++ b/src/stakeinput.h
@@ -25,7 +25,6 @@ public:
     virtual bool GetTxFrom(CTransaction& tx) const = 0;
     virtual CAmount GetValue() const = 0;
     virtual bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) = 0;
-    virtual bool GetModifier(uint64_t& nStakeModifier) = 0;
     virtual bool IsZPIV() const = 0;
     virtual CDataStream GetUniqueness() const = 0;
 
@@ -37,10 +36,6 @@ private:
     CTransaction txFrom;
     unsigned int nPosition;
 
-    // cached data
-    uint64_t nStakeModifier = 0;
-    int nStakeModifierHeight = 0;
-    int64_t nStakeModifierTime = 0;
 public:
     CPivStake(){}
 
@@ -49,7 +44,6 @@ public:
     CBlockIndex* GetIndexFrom() override;
     bool GetTxFrom(CTransaction& tx) const override;
     CAmount GetValue() const override;
-    bool GetModifier(uint64_t& nStakeModifier) override;
     CDataStream GetUniqueness() const override;
     bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = 0) override;
     bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) override;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3442,7 +3442,7 @@ UniValue spendzerocoin(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() > 5 || params.size() < 3)
         throw std::runtime_error(
-            "spendzerocoin amount mintchange minimizechange ( \"address\" isPublicSpend)\n"
+            "spendzerocoin amount mintchange minimizechange ( \"address\" )\n"
             "\nSpend zPIV to a PIV address.\n" +
             HelpRequiringPassphrase() + "\n"
 
@@ -3452,8 +3452,6 @@ UniValue spendzerocoin(const UniValue& params, bool fHelp)
             "3. minimizechange  (boolean, required) Try to minimize the returning change  [false]\n"
             "4. \"address\"     (string, optional, default=change) Send to specified address or to a new change address.\n"
             "                       If there is change then an address is required\n"
-            "5. isPublicSpend   (boolean, optional, default=true) create a public zc spend."
-            "                       If false, instead create spend version 2 (only for regression tests)"
 
             "\nResult:\n"
             "{\n"
@@ -3491,18 +3489,12 @@ UniValue spendzerocoin(const UniValue& params, bool fHelp)
     const bool fMintChange = params[1].get_bool();       // Mint change to zPIV
     const bool fMinimizeChange = params[2].get_bool();    // Minimize change
     const std::string address_str = (params.size() > 3 ? params[3].get_str() : "");
-    const bool isPublicSpend = (params.size() > 4 ? params[4].get_bool() : true);
 
-    if (!Params().IsRegTestNet()) {
-        if (fMintChange)
-            throw JSONRPCError(RPC_WALLET_ERROR, "zPIV minting is DISABLED (except for regtest), cannot mint change");
-
-        if (!isPublicSpend)
-            throw JSONRPCError(RPC_WALLET_ERROR, "zPIV old spend only available in regtest for tests purposes");
-    }
+    if (!Params().IsRegTestNet() && fMintChange)
+        throw JSONRPCError(RPC_WALLET_ERROR, "zPIV minting is DISABLED (except for regtest), cannot mint change");
 
     std::vector<CZerocoinMint> vMintsSelected;
-    return DoZpivSpend(nAmount, fMintChange, fMinimizeChange, vMintsSelected, address_str, isPublicSpend);
+    return DoZpivSpend(nAmount, fMintChange, fMinimizeChange, vMintsSelected, address_str);
 }
 
 
@@ -3510,15 +3502,13 @@ UniValue spendzerocoinmints(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() < 1 || params.size() > 3)
         throw std::runtime_error(
-            "spendzerocoinmints mints_list (\"address\" isPublicSpend) \n"
+            "spendzerocoinmints mints_list ( \"address\" ) \n"
             "\nSpend zPIV mints to a PIV address.\n" +
             HelpRequiringPassphrase() + "\n"
 
             "\nArguments:\n"
             "1. mints_list     (string, required) A json array of zerocoin mints serial hashes\n"
             "2. \"address\"     (string, optional, default=change) Send to specified address or to a new change address.\n"
-            "3. isPublicSpend  (boolean, optional, default=true) create a public zc spend."
-            "                       If false, instead create spend version 2 (only for regression tests)"
 
             "\nResult:\n"
             "{\n"
@@ -3554,14 +3544,9 @@ UniValue spendzerocoinmints(const UniValue& params, bool fHelp)
 
     UniValue arrMints = params[0].get_array();
     const std::string address_str = (params.size() > 1 ? params[1].get_str() : "");
-    const bool isPublicSpend = (params.size() > 2 ? params[2].get_bool() : true);
 
     if (arrMints.size() == 0)
         throw JSONRPCError(RPC_WALLET_ERROR, "No zerocoin selected");
-
-    if (!isPublicSpend && !Params().IsRegTestNet()) {
-        throw JSONRPCError(RPC_WALLET_ERROR, "zPIV old spend only available in regtest for tests purposes");
-    }
 
     // check mints supplied and save serial hash (do this here so we don't fetch if any is wrong)
     std::vector<uint256> vSerialHashes;
@@ -3585,20 +3570,15 @@ UniValue spendzerocoinmints(const UniValue& params, bool fHelp)
         nAmount += mint.GetDenominationAsAmount();
     }
 
-    return DoZpivSpend(nAmount, false, true, vMintsSelected, address_str, isPublicSpend);
+    return DoZpivSpend(nAmount, false, true, vMintsSelected, address_str);
 }
 
 
-extern UniValue DoZpivSpend(const CAmount nAmount, bool fMintChange, bool fMinimizeChange, std::vector<CZerocoinMint>& vMintsSelected, std::string address_str, bool isPublicSpend)
+extern UniValue DoZpivSpend(const CAmount nAmount, bool fMintChange, bool fMinimizeChange, std::vector<CZerocoinMint>& vMintsSelected, std::string address_str)
 {
-    // zerocoin mint / v2 spend is disabled. fMintChange/isPublicSpend should be false here. Double check
-    if (!Params().IsRegTestNet()) {
-        if (fMintChange)
-            throw JSONRPCError(RPC_WALLET_ERROR, "zPIV minting is DISABLED (except for regtest), cannot mint change");
-
-        if (!isPublicSpend)
-            throw JSONRPCError(RPC_WALLET_ERROR, "zPIV old spend only available in regtest for tests purposes");
-    }
+    // zerocoin mint / v2 spend is disabled. fMintChange should be false here. Double check
+    if (!Params().IsRegTestNet() && fMintChange)
+        throw JSONRPCError(RPC_WALLET_ERROR, "zPIV minting is DISABLED (except for regtest), cannot mint change");
 
     int64_t nTimeStart = GetTimeMillis();
     CBitcoinAddress address = CBitcoinAddress(); // Optional sending address. Dummy initialization here.
@@ -3615,7 +3595,7 @@ extern UniValue DoZpivSpend(const CAmount nAmount, bool fMintChange, bool fMinim
     }
 
     EnsureWalletIsUnlocked();
-    fSuccess = pwalletMain->SpendZerocoin(nAmount, wtx, receipt, vMintsSelected, fMintChange, fMinimizeChange, outputs, nullptr, isPublicSpend);
+    fSuccess = pwalletMain->SpendZerocoin(nAmount, wtx, receipt, vMintsSelected, fMintChange, fMinimizeChange, outputs, nullptr);
 
     if (!fSuccess)
         throw JSONRPCError(RPC_WALLET_ERROR, receipt.GetStatusMessage());
@@ -4275,7 +4255,7 @@ UniValue spendrawzerocoin(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() < 4 || params.size() > 7)
         throw std::runtime_error(
-            "spendrawzerocoin \"serialHex\" denom \"randomnessHex\" \"priv key\" ( \"address\" \"mintTxId\" isPublicSpend)\n"
+            "spendrawzerocoin \"serialHex\" denom \"randomnessHex\" \"priv key\" ( \"address\" \"mintTxId\" )\n"
             "\nCreate and broadcast a TX spending the provided zericoin.\n"
 
             "\nArguments:\n"
@@ -4287,8 +4267,6 @@ UniValue spendrawzerocoin(const UniValue& params, bool fHelp)
             "                        or empty string, spend to change address.\n"
             "6. \"mintTxId\"         (string, optional) txid of the transaction containing the mint. If not"
             "                        specified, or empty string, the blockchain will be scanned (could take a while)"
-            "7. isPublicSpend        (boolean, optional, default=true) create a public zc spend."
-            "                        If false, instead create spend version 2 (only for regression tests)"
 
             "\nResult:\n"
                 "\"txid\"             (string) The transaction txid in hex\n"
@@ -4296,10 +4274,6 @@ UniValue spendrawzerocoin(const UniValue& params, bool fHelp)
             "\nExamples\n" +
             HelpExampleCli("spendrawzerocoin", "\"f80892e78c30a393ef4ab4d5a9d5a2989de6ebc7b976b241948c7f489ad716a2\" \"a4fd4d7248e6a51f1d877ddd2a4965996154acc6b8de5aa6c83d4775b283b600\" 100 \"xxx\"") +
             HelpExampleRpc("spendrawzerocoin", "\"f80892e78c30a393ef4ab4d5a9d5a2989de6ebc7b976b241948c7f489ad716a2\", \"a4fd4d7248e6a51f1d877ddd2a4965996154acc6b8de5aa6c83d4775b283b600\", 100, \"xxx\""));
-
-    const bool isPublicSpend = (params.size() > 6 ? params[6].get_bool() : true);
-    if (!Params().IsRegTestNet() && !isPublicSpend)
-        throw JSONRPCError(RPC_WALLET_ERROR, "zPIV old spend only available in regtest for tests purposes");
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
@@ -4370,6 +4344,6 @@ UniValue spendrawzerocoin(const UniValue& params, bool fHelp)
     }
 
     std::vector<CZerocoinMint> vMintsSelected = {mint};
-    return DoZpivSpend(mint.GetDenominationAsAmount(), false, true, vMintsSelected, address_str, isPublicSpend);
+    return DoZpivSpend(mint.GetDenominationAsAmount(), false, true, vMintsSelected, address_str);
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2611,6 +2611,12 @@ bool CWallet::CreateCoinStake(
         // Make sure the wallet is unlocked and shutdown hasn't been requested
         if (IsLocked() || ShutdownRequested()) return false;
 
+        // This should never happen
+        if (stakeInput->IsZPIV()) {
+            LogPrintf("%s: ERROR - zPOS is disabled\n");
+            continue;
+        }
+
         nCredit = 0;
         uint256 hashProofOfStake = 0;
         nAttempts++;
@@ -2639,22 +2645,20 @@ bool CWallet::CreateCoinStake(
         txNew.vout.insert(txNew.vout.end(), vout.begin(), vout.end());
 
         CAmount nMinFee = 0;
-        if (!stakeInput->IsZPIV()) {
-            // Set output amount
-            int outputs = txNew.vout.size() - 1;
-            CAmount nRemaining = nCredit - nMinFee;
-            if (outputs > 1) {
-                // Split the stake across the outputs
-                CAmount nShare = nRemaining / outputs;
-                for (int i = 1; i < outputs; i++) {
-                    // loop through all but the last one.
-                    txNew.vout[i].nValue = nShare;
-                    nRemaining -= nShare;
-                }
+        // Set output amount
+        int outputs = txNew.vout.size() - 1;
+        CAmount nRemaining = nCredit - nMinFee;
+        if (outputs > 1) {
+            // Split the stake across the outputs
+            CAmount nShare = nRemaining / outputs;
+            for (int i = 1; i < outputs; i++) {
+                // loop through all but the last one.
+                txNew.vout[i].nValue = nShare;
+                nRemaining -= nShare;
             }
-            // put the remaining on the last output (which all into the first if only one output)
-            txNew.vout[outputs].nValue += nRemaining;
         }
+        // put the remaining on the last output (which all into the first if only one output)
+        txNew.vout[outputs].nValue += nRemaining;
 
         // Limit size
         unsigned int nBytes = ::GetSerializeSize(txNew, SER_NETWORK, PROTOCOL_VERSION);
@@ -2662,7 +2666,7 @@ bool CWallet::CreateCoinStake(
             return error("CreateCoinStake : exceeded coinstake size limit");
 
         //Masternode payment
-        FillBlockPayee(txNew, nMinFee, true, stakeInput->IsZPIV());
+        FillBlockPayee(txNew, nMinFee, true, false);
 
         uint256 hashTxOut = txNew.GetHash();
         CTxIn in;
@@ -2673,14 +2677,6 @@ bool CWallet::CreateCoinStake(
             continue;
         }
         txNew.vin.emplace_back(in);
-
-
-        //Mark mints as spent
-        if (stakeInput->IsZPIV()) {
-            CZPivStake* z = (CZPivStake*)stakeInput.get();
-            if (!z->MarkSpent(this, txNew.GetHash()))
-                return error("%s: failed to mark mint as used\n", __func__);
-        }
 
         break;
     }
@@ -3990,40 +3986,6 @@ bool CWallet::CheckCoinSpend(libzerocoin::CoinSpend& spend, libzerocoin::Accumul
     return true;
 }
 
-bool CWallet::MintToTxIn(
-        CZerocoinMint mint,
-        const uint256& hashTxOut,
-        CTxIn& newTxIn,
-        CZerocoinSpendReceipt& receipt,
-        libzerocoin::SpendType spendType,
-        CBlockIndex* pindexCheckpoint,
-        bool isPublicSpend)
-{
-    std::map<CBigNum, CZerocoinMint> mapMints;
-    mapMints.insert(std::make_pair(mint.GetValue(), mint));
-    std::vector<CTxIn> vin;
-    if (isPublicSpend) {
-        if (MintsToInputVectorPublicSpend(mapMints, hashTxOut, vin, receipt, spendType, pindexCheckpoint)) {
-            newTxIn = vin[0];
-            return true;
-        }
-    } else {
-        if (MintsToInputVector(mapMints, hashTxOut, vin, receipt, spendType, pindexCheckpoint)) {
-            newTxIn = vin[0];
-            return true;
-        }
-    }
-
-    return false;
-}
-
-bool CWallet::MintsToInputVector(std::map<CBigNum, CZerocoinMint>& mapMintsSelected, const uint256& hashTxOut, std::vector<CTxIn>& vin,
-                         CZerocoinSpendReceipt& receipt, libzerocoin::SpendType spendType, CBlockIndex* pindexCheckpoint)
-{
-    // !TODO: remove me (old spends)
-    return false;
-}
-
 bool CWallet::MintsToInputVectorPublicSpend(std::map<CBigNum, CZerocoinMint>& mapMintsSelected, const uint256& hashTxOut, std::vector<CTxIn>& vin,
                                     CZerocoinSpendReceipt& receipt, libzerocoin::SpendType spendType, CBlockIndex* pindexCheckpoint)
 {
@@ -4093,7 +4055,7 @@ bool CWallet::MintsToInputVectorPublicSpend(std::map<CBigNum, CZerocoinMint>& ma
     return true;
 }
 
-bool CWallet::CreateZerocoinSpendTransaction(
+bool CWallet::CreateZCPublicSpendTransaction(
         CAmount nValue,
         CWalletTx& wtxNew,
         CReserveKey& reserveKey,
@@ -4103,8 +4065,7 @@ bool CWallet::CreateZerocoinSpendTransaction(
         bool fMintChange,
         bool fMinimizeChange,
         std::list<std::pair<CBitcoinAddress*,CAmount>> addressesTo,
-        CBitcoinAddress* changeAddress,
-        bool isPublicSpend)
+        CBitcoinAddress* changeAddress)
 {
     // Check available funds
     int nStatus = ZPIV_TRX_FUNDS_PROBLEMS;
@@ -4304,15 +4265,9 @@ bool CWallet::CreateZerocoinSpendTransaction(
 
             //add all of the mints to the transaction as inputs
             std::vector<CTxIn> vin;
-            if (isPublicSpend) {
-                if (!MintsToInputVectorPublicSpend(mapSelectedMints, hashTxOut, vin, receipt,
-                                                   libzerocoin::SpendType::SPEND, pindexCheckpoint))
-                    return false;
-            } else {
-                if (!MintsToInputVector(mapSelectedMints, hashTxOut, vin, receipt,
-                                                   libzerocoin::SpendType::SPEND, pindexCheckpoint))
-                    return false;
-            }
+            if (!MintsToInputVectorPublicSpend(mapSelectedMints, hashTxOut, vin, receipt,
+                                               libzerocoin::SpendType::SPEND, pindexCheckpoint))
+                return false;
             txNew.vin = vin;
 
             // Limit size
@@ -4626,8 +4581,7 @@ bool CWallet::SpendZerocoin(
         bool fMintChange,
         bool fMinimizeChange,
         std::list<std::pair<CBitcoinAddress*,CAmount>> addressesTo,
-        CBitcoinAddress* changeAddress,
-        bool isPublicSpend
+        CBitcoinAddress* changeAddress
 )
 {
     // Default: assume something goes wrong. Depending on the problem this gets more specific below
@@ -4640,7 +4594,7 @@ bool CWallet::SpendZerocoin(
 
     CReserveKey reserveKey(this);
     std::vector<CDeterministicMint> vNewMints;
-    if (!CreateZerocoinSpendTransaction(
+    if (!CreateZCPublicSpendTransaction(
             nAmount,
             wtxNew,
             reserveKey,
@@ -4650,8 +4604,7 @@ bool CWallet::SpendZerocoin(
             fMintChange,
             fMinimizeChange,
             addressesTo,
-            changeAddress,
-            isPublicSpend
+            changeAddress
     )) {
         return false;
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2613,7 +2613,7 @@ bool CWallet::CreateCoinStake(
 
         // This should never happen
         if (stakeInput->IsZPIV()) {
-            LogPrintf("%s: ERROR - zPOS is disabled\n");
+            LogPrintf("%s: ERROR - zPOS is disabled\n", __func__);
             continue;
         }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -99,7 +99,7 @@ enum ZerocoinSpendStatus {
     ZPIV_TRX_FUNDS_PROBLEMS = 6,                    // Everything related to available funds
     ZPIV_TRX_CREATE = 7,                            // Everything related to create the transaction
     ZPIV_TRX_CHANGE = 8,                            // Everything related to transaction change
-    ZPIV_TXMINT_GENERAL = 9,                        // General errors in MintToTxIn
+    ZPIV_TXMINT_GENERAL = 9,                        // General errors in MintsToInputVectorPublicSpend
     ZPIV_INVALID_COIN = 10,                         // Selected mint coin is not valid
     ZPIV_FAILED_ACCUMULATOR_INITIALIZATION = 11,    // Failed to initialize witness
     ZPIV_INVALID_WITNESS = 12,                      // Spend coin transaction did not verify
@@ -209,7 +209,7 @@ public:
     // Zerocoin additions
     bool CreateZerocoinMintTransaction(const CAmount nValue, CMutableTransaction& txNew, std::vector<CDeterministicMint>& vDMints, CReserveKey* reservekey, int64_t& nFeeRet, std::string& strFailReason, const CCoinControl* coinControl = NULL, const bool isZCSpendChange = false);
 
-    bool CreateZerocoinSpendTransaction(
+    bool CreateZCPublicSpendTransaction(
             CAmount nValue,
             CWalletTx& wtxNew,
             CReserveKey& reserveKey,
@@ -219,13 +219,9 @@ public:
             bool fMintChange,
             bool fMinimizeChange,
             std::list<std::pair<CBitcoinAddress*,CAmount>> addressesTo,
-            CBitcoinAddress* changeAddress = nullptr,
-            bool isPublicSpend = true);
+            CBitcoinAddress* changeAddress = nullptr);
 
     bool CheckCoinSpend(libzerocoin::CoinSpend& spend, libzerocoin::Accumulator& accumulator, CZerocoinSpendReceipt& receipt);
-    bool MintToTxIn(CZerocoinMint zerocoinSelected, const uint256& hashTxOut, CTxIn& newTxIn, CZerocoinSpendReceipt& receipt, libzerocoin::SpendType spendType, CBlockIndex* pindexCheckpoint = nullptr, bool isPublicSpend = true);
-    bool MintsToInputVector(std::map<CBigNum, CZerocoinMint>& mapMintsSelected, const uint256& hashTxOut, std::vector<CTxIn>& vin,
-                            CZerocoinSpendReceipt& receipt, libzerocoin::SpendType spendType, CBlockIndex* pindexCheckpoint = nullptr);
     // Public coin spend input creation
     bool MintsToInputVectorPublicSpend(std::map<CBigNum, CZerocoinMint>& mapMintsSelected, const uint256& hashTxOut, std::vector<CTxIn>& vin,
                                        CZerocoinSpendReceipt& receipt, libzerocoin::SpendType spendType, CBlockIndex* pindexCheckpoint = nullptr);
@@ -241,8 +237,7 @@ public:
             bool fMintChange,
             bool fMinimizeChange,
             std::list<std::pair<CBitcoinAddress*,CAmount>> addressesTo,
-            CBitcoinAddress* changeAddress = nullptr,
-            bool isPublicSpend = true
+            CBitcoinAddress* changeAddress = nullptr
     );
 
     std::string ResetMintZerocoin();

--- a/src/zpiv/zpos.cpp
+++ b/src/zpiv/zpos.cpp
@@ -1,0 +1,85 @@
+// Copyright (c) 2017-2019 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "zpiv/zpos.h"
+
+
+/*
+ * LEGACY: Kept for IBD in order to verify zerocoin stakes occurred when zPoS was active
+ * Find the first occurrence of a certain accumulator checksum.
+ * Return block index pointer or nullptr if not found
+ */
+
+
+CLegacyZPivStake::CLegacyZPivStake(const libzerocoin::CoinSpend& spend)
+{
+    this->nChecksum = spend.getAccumulatorChecksum();
+    this->denom = spend.getDenomination();
+    uint256 nSerial = spend.getCoinSerialNumber().getuint256();
+    this->hashSerial = Hash(nSerial.begin(), nSerial.end());
+}
+
+CBlockIndex* CLegacyZPivStake::GetIndexFrom()
+{
+    // First look in the legacy database
+    int nHeightChecksum = 0;
+    if (zerocoinDB->ReadAccChecksum(nChecksum, denom, nHeightChecksum)) {
+        return chainActive[nHeightChecksum];
+    }
+
+    // Not found. Scan the chain.
+    CBlockIndex* pindex = chainActive[Params().Zerocoin_StartHeight()];
+    if (!pindex) return nullptr;
+    const int last_block = Params().Zerocoin_Block_Last_Checkpoint();
+    while (pindex && pindex->nHeight <= last_block) {
+        if (ParseAccChecksum(pindex->nAccumulatorCheckpoint, denom) == nChecksum) {
+            // Found. Save to database and return
+            zerocoinDB->WriteAccChecksum(nChecksum, denom, pindex->nHeight);
+            return pindex;
+        }
+        //Skip forward in groups of 10 blocks since checkpoints only change every 10 blocks
+        if (pindex->nHeight % 10 == 0) {
+            pindex = chainActive[pindex->nHeight + 10];
+            continue;
+        }
+        pindex = chainActive.Next(pindex);
+    }
+    return nullptr;
+}
+
+CAmount CLegacyZPivStake::GetValue() const
+{
+    return denom * COIN;
+}
+
+bool CLegacyZPivStake::GetModifier(uint64_t& nStakeModifier)
+{
+    CBlockIndex* pindex = GetIndexFrom();
+    if (!pindex)
+        return error("%s: failed to get index from", __func__);
+
+    if(Params().IsRegTestNet()) {
+        nStakeModifier = 0;
+        return true;
+    }
+
+    int64_t nTimeBlockFrom = pindex->GetBlockTime();
+    const int nHeightStop = std::min(chainActive.Height(), Params().Zerocoin_Block_Last_Checkpoint()-1);
+    while (pindex && pindex->nHeight + 1 <= nHeightStop) {
+        if (pindex->GetBlockTime() - nTimeBlockFrom > 60 * 60) {
+            nStakeModifier = pindex->nAccumulatorCheckpoint.Get64();
+            return true;
+        }
+        pindex = chainActive.Next(pindex);
+    }
+
+    return false;
+}
+
+CDataStream CLegacyZPivStake::GetUniqueness() const
+{
+    CDataStream ss(SER_GETHASH, 0);
+    ss << hashSerial;
+    return ss;
+}

--- a/src/zpiv/zpos.cpp
+++ b/src/zpiv/zpos.cpp
@@ -53,30 +53,6 @@ CAmount CLegacyZPivStake::GetValue() const
     return denom * COIN;
 }
 
-bool CLegacyZPivStake::GetModifier(uint64_t& nStakeModifier)
-{
-    CBlockIndex* pindex = GetIndexFrom();
-    if (!pindex)
-        return error("%s: failed to get index from", __func__);
-
-    if(Params().IsRegTestNet()) {
-        nStakeModifier = 0;
-        return true;
-    }
-
-    int64_t nTimeBlockFrom = pindex->GetBlockTime();
-    const int nHeightStop = std::min(chainActive.Height(), Params().Zerocoin_Block_Last_Checkpoint()-1);
-    while (pindex && pindex->nHeight + 1 <= nHeightStop) {
-        if (pindex->GetBlockTime() - nTimeBlockFrom > 60 * 60) {
-            nStakeModifier = pindex->nAccumulatorCheckpoint.Get64();
-            return true;
-        }
-        pindex = chainActive.Next(pindex);
-    }
-
-    return false;
-}
-
 CDataStream CLegacyZPivStake::GetUniqueness() const
 {
     CDataStream ss(SER_GETHASH, 0);

--- a/src/zpiv/zpos.h
+++ b/src/zpiv/zpos.h
@@ -23,7 +23,6 @@ public:
     uint32_t GetChecksum() const { return nChecksum; }
     CBlockIndex* GetIndexFrom() override;
     CAmount GetValue() const override;
-    bool GetModifier(uint64_t& nStakeModifier) override;
     CDataStream GetUniqueness() const override;
     bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = 0) override { return false; /* creation disabled */}
     bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) override { return false; /* creation disabled */}

--- a/src/zpiv/zpos.h
+++ b/src/zpiv/zpos.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef PIVX_LEGACY_ZPOS_H
+#define PIVX_LEGACY_ZPOS_H
+
+#include "stakeinput.h"
+#include "main.h"
+#include "kernel.h"
+#include "txdb.h"
+
+class CLegacyZPivStake : public CStakeInput
+{
+private:
+    uint32_t nChecksum;
+    libzerocoin::CoinDenomination denom;
+    uint256 hashSerial;
+
+public:
+    explicit CLegacyZPivStake(const libzerocoin::CoinSpend& spend);
+    bool IsZPIV() const override { return true; }
+    uint32_t GetChecksum() const { return nChecksum; }
+    CBlockIndex* GetIndexFrom() override;
+    CAmount GetValue() const override;
+    bool GetModifier(uint64_t& nStakeModifier) override;
+    CDataStream GetUniqueness() const override;
+    bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = 0) override { return false; /* creation disabled */}
+    bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) override { return false; /* creation disabled */}
+    bool GetTxFrom(CTransaction& tx) const override { return false; /* not available */ }
+};
+
+#endif //PIVX_LEGACY_ZPOS_H

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -847,12 +847,8 @@ class PivxTestFramework():
         prevout = None
         isZPoS = is_zerocoin(block.prevoutStake)
         if isZPoS:
-            _, serialHash, _ = stakeableUtxos[block.prevoutStake]
-            raw_stake = rpc_conn.createrawzerocoinstake(serialHash)
-            stake_tx_signed_raw_hex = raw_stake["hex"]
-            stake_pkey = raw_stake["private-key"]
-            block_sig_key.set_compressed(True)
-            block_sig_key.set_secretbytes(bytes.fromhex(stake_pkey))
+            # !TODO: remove me
+            raise Exception("zPOS tests discontinued")
 
         else:
             coinstakeTx_unsigned = CTransaction()


### PR DESCRIPTION
This removes (now unused) code to produce old zerocoin spends and zPOS stakes.
`CZPivStake` class is replaced with a `CLegacyZPivStake` (moved in new files `zpiv/zpos.*`) used exclusively to validate the chain.
This also refactors `CStakeInput` class, removing the modifier functions (put back in kernel) and cleans up `kernel.*` files, removing old code and reorganizing them.

This PR is based on top of:
- [x] #1259 
- [x] #1290

and it will be rebased after their merge. Only last **3** commits are relevant