### PR TITLE
[Tests] Set '-staking' disabled by default on RegTest

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1986,8 +1986,8 @@ bool AppInit2()
         // Run a thread to flush wallet periodically
         threadGroup.create_thread(boost::bind(&ThreadFlushWalletDB, boost::ref(pwalletMain->strWalletFile)));
 
-        if (GetBoolArg("-staking", true)) {
-            // ppcoin:mint proof-of-stake blocks in the background
+        // StakeMiner thread disabled by default on regtest
+        if (GetBoolArg("-staking", !Params().IsRegTestNet())) {
             threadGroup.create_thread(boost::bind(&ThreadStakeMinter));
         }
     }

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -295,7 +295,6 @@ def initialize_datadir(dirname, n):
         f.write("port=" + str(p2p_port(n)) + "\n")
         f.write("rpcport=" + str(rpc_port(n)) + "\n")
         f.write("listenonion=0\n")
-        f.write("staking=0\n")
         f.write("spendzeroconfchange=1\n")
     return datadir
 


### PR DESCRIPTION
Ref: https://github.com/PIVX-Project/PIVX/pull/1278#issuecomment-576646698
Hardcoded default `false` value, instead of having it in the config file for the test nodes.