### PR TITLE
[Model][Performance] Unnecessary double cs_wallet and cs_main lock.

### DIFF
--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -792,7 +792,7 @@ QModelIndex TransactionTableModel::index(int row, int column, const QModelIndex&
     Q_UNUSED(parent);
     TransactionRecord* data = priv->index(row);
     if (data) {
-        return createIndex(row, column, priv->index(row));
+        return createIndex(row, column, data);
     }
     return QModelIndex();
 }


### PR DESCRIPTION
Fix a double `index` call locking cs_wallet and cs_main twice in every single model record index request.