### PR TITLE
[GUI] Hide privacy widget when the wallet has no zPIV balance

### DIFF
--- a/src/qt/pivx/navmenuwidget.cpp
+++ b/src/qt/pivx/navmenuwidget.cpp
@@ -36,10 +36,6 @@ NavMenuWidget::NavMenuWidget(PIVXGUI *mainWindow, QWidget *parent) :
     ui->btnAddress->setText("CONTACTS\n");
     ui->btnAddress->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
 
-    ui->btnPrivacy->setProperty("name", "privacy");
-    ui->btnPrivacy->setText("PRIVACY\n");
-    ui->btnPrivacy->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-
     ui->btnMaster->setProperty("name", "master");
     ui->btnMaster->setText("MASTER\r\nNODES");
     ui->btnMaster->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
@@ -56,6 +52,7 @@ NavMenuWidget::NavMenuWidget(PIVXGUI *mainWindow, QWidget *parent) :
     ui->btnReceive->setText("RECEIVE\n");
     ui->btnReceive->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
 
+    ui->btnPrivacy->setProperty("name", "privacy");
     btns = {ui->btnDashboard, ui->btnSend, ui->btnReceive, ui->btnAddress, ui->btnPrivacy, ui->btnMaster, ui->btnColdStaking, ui->btnSettings, ui->btnColdStaking};
     onNavSelected(ui->btnDashboard, true);
 
@@ -73,8 +70,17 @@ NavMenuWidget::NavMenuWidget(PIVXGUI *mainWindow, QWidget *parent) :
 }
 
 void NavMenuWidget::loadWalletModel() {
-    if (walletModel && walletModel->getOptionsModel()) {
-        ui->btnColdStaking->setVisible(walletModel->getOptionsModel()->isColdStakingScreenEnabled());
+    if (walletModel) {
+        if (walletModel->getZerocoinBalance() > 0) {
+            ui->btnPrivacy->setText("PRIVACY\n");
+            ui->btnPrivacy->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+            connect(ui->btnPrivacy,SIGNAL(clicked()),this, SLOT(onPrivacyClicked()));
+        } else {
+            ui->btnPrivacy->setVisible(false);
+        }
+
+        if (walletModel->getOptionsModel())
+            ui->btnColdStaking->setVisible(walletModel->getOptionsModel()->isColdStakingScreenEnabled());
     }
 }
 
@@ -85,7 +91,6 @@ void NavMenuWidget::connectActions() {
     connect(ui->btnDashboard,SIGNAL(clicked()),this, SLOT(onDashboardClicked()));
     connect(ui->btnSend,SIGNAL(clicked()),this, SLOT(onSendClicked()));
     connect(ui->btnAddress,SIGNAL(clicked()),this, SLOT(onAddressClicked()));
-    connect(ui->btnPrivacy,SIGNAL(clicked()),this, SLOT(onPrivacyClicked()));
     connect(ui->btnMaster,SIGNAL(clicked()),this, SLOT(onMasterNodesClicked()));
     connect(ui->btnSettings,SIGNAL(clicked()),this, SLOT(onSettingsClicked()));
     connect(ui->btnReceive,SIGNAL(clicked()),this, SLOT(onReceiveClicked()));

--- a/src/qt/pivx/pivxgui.cpp
+++ b/src/qt/pivx/pivxgui.cpp
@@ -128,7 +128,6 @@ PIVXGUI::PIVXGUI(const NetworkStyle* networkStyle, QWidget* parent) :
         sendWidget = new SendWidget(this);
         receiveWidget = new ReceiveWidget(this);
         addressesWidget = new AddressesWidget(this);
-        privacyWidget = new PrivacyWidget(this);
         masterNodesWidget = new MasterNodesWidget(this);
         coldStakingWidget = new ColdStakingWidget(this);
         settingsWidget = new SettingsWidget(this);
@@ -138,7 +137,6 @@ PIVXGUI::PIVXGUI(const NetworkStyle* networkStyle, QWidget* parent) :
         stackedContainer->addWidget(sendWidget);
         stackedContainer->addWidget(receiveWidget);
         stackedContainer->addWidget(addressesWidget);
-        stackedContainer->addWidget(privacyWidget);
         stackedContainer->addWidget(masterNodesWidget);
         stackedContainer->addWidget(coldStakingWidget);
         stackedContainer->addWidget(settingsWidget);
@@ -202,7 +200,6 @@ void PIVXGUI::connectActions() {
     connect(sendWidget, &SendWidget::showHide, this, &PIVXGUI::showHide);
     connect(receiveWidget, &ReceiveWidget::showHide, this, &PIVXGUI::showHide);
     connect(addressesWidget, &AddressesWidget::showHide, this, &PIVXGUI::showHide);
-    connect(privacyWidget, &PrivacyWidget::showHide, this, &PIVXGUI::showHide);
     connect(masterNodesWidget, &MasterNodesWidget::showHide, this, &PIVXGUI::showHide);
     connect(masterNodesWidget, &MasterNodesWidget::execDialog, this, &PIVXGUI::execDialog);
     connect(coldStakingWidget, &ColdStakingWidget::showHide, this, &PIVXGUI::showHide);
@@ -481,7 +478,7 @@ void PIVXGUI::goToAddresses(){
 }
 
 void PIVXGUI::goToPrivacy(){
-    showTop(privacyWidget);
+    if (privacyWidget) showTop(privacyWidget);
 }
 
 void PIVXGUI::goToMasterNodes(){
@@ -586,13 +583,21 @@ bool PIVXGUI::addWallet(const QString& name, WalletModel* walletModel)
     receiveWidget->setWalletModel(walletModel);
     sendWidget->setWalletModel(walletModel);
     addressesWidget->setWalletModel(walletModel);
-    privacyWidget->setWalletModel(walletModel);
     masterNodesWidget->setWalletModel(walletModel);
     coldStakingWidget->setWalletModel(walletModel);
     settingsWidget->setWalletModel(walletModel);
 
+    // Privacy screen
+    if (walletModel->getZerocoinBalance() > 0) {
+        privacyWidget = new PrivacyWidget(this);
+        stackedContainer->addWidget(privacyWidget);
+
+        privacyWidget->setWalletModel(walletModel);
+        connect(privacyWidget, &PrivacyWidget::message, this, &PIVXGUI::message);
+        connect(privacyWidget, &PrivacyWidget::showHide, this, &PIVXGUI::showHide);
+    }
+
     // Connect actions..
-    connect(privacyWidget, &PrivacyWidget::message, this, &PIVXGUI::message);
     connect(masterNodesWidget, &MasterNodesWidget::message, this, &PIVXGUI::message);
     connect(coldStakingWidget, &MasterNodesWidget::message, this, &PIVXGUI::message);
     connect(topBar, &TopBar::message, this, &PIVXGUI::message);


### PR DESCRIPTION
Auto-descriptive title.

 if the wallet has not zPIV, the privacy widget is not presented in the screen, nor loaded into ram. 