### PR TITLE
[GUI] Add address-label to sendconfirm-popup

### DIFF
--- a/src/qt/pivx/forms/sendconfirmdialog.ui
+++ b/src/qt/pivx/forms/sendconfirmdialog.ui
@@ -219,7 +219,7 @@ background:transparent;
               <x>0</x>
               <y>0</y>
               <width>556</width>
-              <height>672</height>
+              <height>703</height>
              </rect>
             </property>
             <property name="autoFillBackground">
@@ -335,8 +335,8 @@ background:transparent;
                  </widget>
                 </item>
                 <item>
-                 <widget class="QWidget" name="contentOutputs" native="true">
-                  <layout class="QHBoxLayout" name="horizontalLayout_11" stretch="0,3,0">
+                 <widget class="QWidget" name="contentOutputsLabel" native="true">
+                  <layout class="QHBoxLayout" name="horizontalLayout_11" stretch="0,0,0">
                    <property name="spacing">
                     <number>0</number>
                    </property>
@@ -346,11 +346,20 @@ background:transparent;
                    <property name="rightMargin">
                     <number>12</number>
                    </property>
+                   <property name="bottomMargin">
+                    <number>0</number>
+                   </property>
                    <item>
                     <widget class="QLabel" name="labelSend">
+                     <property name="minimumSize">
+                      <size>
+                       <width>120</width>
+                       <height>0</height>
+                      </size>
+                     </property>
                      <property name="maximumSize">
                       <size>
-                       <width>16777215</width>
+                       <width>120</width>
                        <height>16777215</height>
                       </size>
                      </property>
@@ -360,9 +369,9 @@ background:transparent;
                     </widget>
                    </item>
                    <item>
-                    <widget class="QLabel" name="textSend">
+                    <widget class="QLabel" name="textSendLabel">
                      <property name="text">
-                      <string>D7VFR83SQbiezrW72hjcWJtcfip5krte2Z </string>
+                      <string>Name/Label</string>
                      </property>
                     </widget>
                    </item>
@@ -388,6 +397,53 @@ background:transparent;
                      </property>
                      <property name="text">
                       <string/>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QWidget" name="contentOutputsAddress" native="true">
+                  <layout class="QHBoxLayout" name="horizontalLayout_outputs" stretch="0,0">
+                   <property name="spacing">
+                    <number>0</number>
+                   </property>
+                   <property name="leftMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>12</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>9</number>
+                   </property>
+                   <item>
+                    <widget class="QLabel" name="labelSendLabel">
+                     <property name="minimumSize">
+                      <size>
+                       <width>120</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                     <property name="maximumSize">
+                      <size>
+                       <width>120</width>
+                       <height>16777215</height>
+                      </size>
+                     </property>
+                     <property name="text">
+                      <string/>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="textSend">
+                     <property name="text">
+                      <string>D7VFR83SQbiezrW72hjcWJtcfip5krte2Z</string>
                      </property>
                     </widget>
                    </item>
@@ -458,7 +514,7 @@ background:transparent;
                       </size>
                      </property>
                      <property name="text">
-                      <string>Total amount</string>
+                      <string>Total amount:</string>
                      </property>
                     </widget>
                    </item>

--- a/src/qt/pivx/forms/sendconfirmdialog.ui
+++ b/src/qt/pivx/forms/sendconfirmdialog.ui
@@ -219,7 +219,7 @@ background:transparent;
               <x>0</x>
               <y>0</y>
               <width>556</width>
-              <height>703</height>
+              <height>690</height>
              </rect>
             </property>
             <property name="autoFillBackground">
@@ -336,11 +336,14 @@ background:transparent;
                 </item>
                 <item>
                  <widget class="QWidget" name="contentOutputsLabel" native="true">
-                  <layout class="QHBoxLayout" name="horizontalLayout_11" stretch="0,0,0">
+                  <layout class="QHBoxLayout" name="horizontalLayout_11" stretch="0,1,0">
                    <property name="spacing">
                     <number>0</number>
                    </property>
                    <property name="leftMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="topMargin">
                     <number>0</number>
                    </property>
                    <property name="rightMargin">
@@ -351,15 +354,9 @@ background:transparent;
                    </property>
                    <item>
                     <widget class="QLabel" name="labelSend">
-                     <property name="minimumSize">
-                      <size>
-                       <width>120</width>
-                       <height>0</height>
-                      </size>
-                     </property>
                      <property name="maximumSize">
                       <size>
-                       <width>120</width>
+                       <width>16777215</width>
                        <height>16777215</height>
                       </size>
                      </property>
@@ -369,10 +366,23 @@ background:transparent;
                     </widget>
                    </item>
                    <item>
-                    <widget class="QLabel" name="textSendLabel">
-                     <property name="text">
-                      <string>Name/Label</string>
-                     </property>
+                    <widget class="QWidget" name="widget" native="true">
+                      <layout class="QVBoxLayout" name="verticalLayout_6">
+                       <item>
+                        <widget class="QLabel" name="textSendLabel">
+                         <property name="text">
+                          <string>Name/Label</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QLabel" name="textSend">
+                         <property name="text">
+                          <string>D7VFR83SQbiezrW72hjcWJtcfip5krte2Z</string>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
                     </widget>
                    </item>
                    <item>
@@ -397,53 +407,6 @@ background:transparent;
                      </property>
                      <property name="text">
                       <string/>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QWidget" name="contentOutputsAddress" native="true">
-                  <layout class="QHBoxLayout" name="horizontalLayout_outputs" stretch="0,0">
-                   <property name="spacing">
-                    <number>0</number>
-                   </property>
-                   <property name="leftMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="topMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="rightMargin">
-                    <number>12</number>
-                   </property>
-                   <property name="bottomMargin">
-                    <number>9</number>
-                   </property>
-                   <item>
-                    <widget class="QLabel" name="labelSendLabel">
-                     <property name="minimumSize">
-                      <size>
-                       <width>120</width>
-                       <height>0</height>
-                      </size>
-                     </property>
-                     <property name="maximumSize">
-                      <size>
-                       <width>120</width>
-                       <height>16777215</height>
-                      </size>
-                     </property>
-                     <property name="text">
-                      <string/>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QLabel" name="textSend">
-                     <property name="text">
-                      <string>D7VFR83SQbiezrW72hjcWJtcfip5krte2Z</string>
                      </property>
                     </widget>
                    </item>

--- a/src/qt/pivx/forms/sendconfirmdialog.ui
+++ b/src/qt/pivx/forms/sendconfirmdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>574</width>
-    <height>680</height>
+    <width>604</width>
+    <height>698</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -218,8 +218,8 @@ background:transparent;
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>556</width>
-              <height>690</height>
+              <width>586</width>
+              <height>644</height>
              </rect>
             </property>
             <property name="autoFillBackground">
@@ -263,29 +263,36 @@ background:transparent;
                 </property>
                 <item>
                  <widget class="QWidget" name="contentID" native="true">
-                  <layout class="QHBoxLayout" name="horizontalLayout_12" stretch="0,1,0">
+                  <layout class="QHBoxLayout" name="horizontalLayout_12" stretch="0,0">
                    <property name="leftMargin">
                     <number>0</number>
                    </property>
+                   <property name="rightMargin">
+                    <number>0</number>
+                   </property>
                    <item>
-                    <widget class="QLabel" name="labelId">
-                     <property name="maximumSize">
-                      <size>
-                       <width>16777215</width>
-                       <height>16777215</height>
-                      </size>
-                     </property>
-                     <property name="text">
-                      <string>ID:</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QLabel" name="textId">
-                     <property name="text">
-                      <string>492526e7fa3c810b35016...40a5df85ee227ab00b1156994</string>
-                     </property>
-                    </widget>
+                    <layout class="QVBoxLayout" name="contentID_int">
+                     <item>
+                      <widget class="QLabel" name="labelId">
+                       <property name="maximumSize">
+                        <size>
+                         <width>16777215</width>
+                         <height>16777215</height>
+                        </size>
+                       </property>
+                       <property name="text">
+                        <string>ID</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLabel" name="textId">
+                       <property name="text">
+                        <string>492526e7fa3c810b35016...40a5df85ee227ab00b1156994</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
                    </item>
                    <item>
                     <widget class="QPushButton" name="pushCopy">
@@ -319,7 +326,7 @@ background:transparent;
                  </widget>
                 </item>
                 <item>
-                 <widget class="QLabel" name="labelDivider9">
+                 <widget class="QLabel" name="labelDividerID">
                   <property name="maximumSize">
                    <size>
                     <width>16777215</width>
@@ -336,54 +343,82 @@ background:transparent;
                 </item>
                 <item>
                  <widget class="QWidget" name="contentOutputsLabel" native="true">
-                  <layout class="QHBoxLayout" name="horizontalLayout_11" stretch="0,1,0">
+                  <layout class="QHBoxLayout" name="horizontalLayout_11" stretch="0,0">
                    <property name="spacing">
-                    <number>0</number>
+                    <number>6</number>
                    </property>
                    <property name="leftMargin">
                     <number>0</number>
                    </property>
                    <property name="topMargin">
-                    <number>0</number>
+                    <number>9</number>
                    </property>
                    <property name="rightMargin">
-                    <number>12</number>
-                   </property>
-                   <property name="bottomMargin">
                     <number>0</number>
                    </property>
+                   <property name="bottomMargin">
+                    <number>9</number>
+                   </property>
                    <item>
-                    <widget class="QLabel" name="labelSend">
-                     <property name="maximumSize">
-                      <size>
-                       <width>16777215</width>
-                       <height>16777215</height>
-                      </size>
+                    <layout class="QVBoxLayout" name="contentOutputsLabel_int">
+                     <property name="leftMargin">
+                      <number>0</number>
                      </property>
-                     <property name="text">
-                      <string>Sending to: </string>
+                     <property name="topMargin">
+                      <number>1</number>
                      </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QWidget" name="widget" native="true">
-                      <layout class="QVBoxLayout" name="verticalLayout_6">
-                       <item>
-                        <widget class="QLabel" name="textSendLabel">
-                         <property name="text">
-                          <string>Name/Label</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item>
-                        <widget class="QLabel" name="textSend">
-                         <property name="text">
-                          <string>D7VFR83SQbiezrW72hjcWJtcfip5krte2Z</string>
-                         </property>
-                        </widget>
-                       </item>
-                      </layout>
-                    </widget>
+                     <property name="rightMargin">
+                      <number>6</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>1</number>
+                     </property>
+                     <item>
+                      <widget class="QLabel" name="labelSend">
+                       <property name="maximumSize">
+                        <size>
+                         <width>16777215</width>
+                         <height>16777215</height>
+                        </size>
+                       </property>
+                       <property name="text">
+                        <string>Sending to</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QWidget" name="widget" native="true">
+                       <layout class="QVBoxLayout" name="verticalLayout_6">
+                        <property name="leftMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="topMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="rightMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="bottomMargin">
+                         <number>0</number>
+                        </property>
+                        <item>
+                         <widget class="QLabel" name="textSendLabel">
+                          <property name="text">
+                           <string>Name/Label</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item>
+                         <widget class="QLabel" name="textSend">
+                          <property name="text">
+                           <string>D7VFR83SQbiezrW72hjcWJtcfip5krte2Z</string>
+                          </property>
+                         </widget>
+                        </item>
+                       </layout>
+                      </widget>
+                     </item>
+                    </layout>
                    </item>
                    <item>
                     <widget class="QPushButton" name="pushOutputs">
@@ -434,7 +469,7 @@ background:transparent;
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>522</width>
+                     <width>552</width>
                      <height>48</height>
                     </rect>
                    </property>
@@ -447,7 +482,7 @@ background:transparent;
                  </widget>
                 </item>
                 <item>
-                 <widget class="QLabel" name="labelDivider8">
+                 <widget class="QLabel" name="labelDividerOutputs">
                   <property name="maximumSize">
                    <size>
                     <width>16777215</width>
@@ -463,12 +498,31 @@ background:transparent;
                  </widget>
                 </item>
                 <item>
-                 <widget class="QWidget" name="contentAmount" native="true">
-                  <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="0,1">
+                 <widget class="QWidget" name="gridAmounts" native="true">
+                  <layout class="QGridLayout" name="contentAmountInputs">
                    <property name="leftMargin">
                     <number>0</number>
                    </property>
-                   <item>
+                   <property name="topMargin">
+                    <number>9</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>9</number>
+                   </property>
+                   <property name="horizontalSpacing">
+                    <number>12</number>
+                   </property>
+                   <item row="1" column="0">
+                    <widget class="QLabel" name="textAmount">
+                     <property name="text">
+                      <string>2 PIV</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="0" column="0">
                     <widget class="QLabel" name="labelAmount">
                      <property name="maximumSize">
                       <size>
@@ -477,46 +531,11 @@ background:transparent;
                       </size>
                      </property>
                      <property name="text">
-                      <string>Total amount:</string>
+                      <string>Total amount</string>
                      </property>
                     </widget>
                    </item>
-                   <item>
-                    <widget class="QLabel" name="textAmount">
-                     <property name="text">
-                      <string>2 PIV</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLabel" name="labelDivider6">
-                  <property name="maximumSize">
-                   <size>
-                    <width>16777215</width>
-                    <height>1</height>
-                   </size>
-                  </property>
-                  <property name="styleSheet">
-                   <string notr="true">background-color:#bababa;</string>
-                  </property>
-                  <property name="text">
-                   <string/>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QWidget" name="contentInputs" native="true">
-                  <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,2,0">
-                   <property name="leftMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="rightMargin">
-                    <number>12</number>
-                   </property>
-                   <item>
+                   <item row="0" column="3">
                     <widget class="QLabel" name="labelInputs">
                      <property name="sizePolicy">
                       <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
@@ -531,35 +550,48 @@ background:transparent;
                       </size>
                      </property>
                      <property name="text">
-                      <string>Coin inputs:</string>
+                      <string>Coin inputs</string>
+                     </property>
+                     <property name="alignment">
+                      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                      </property>
                     </widget>
                    </item>
-                   <item>
-                    <widget class="QLabel" name="textInputs">
-                     <property name="text">
-                      <string>1 Inputs</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QPushButton" name="pushInputs">
-                     <property name="maximumSize">
-                      <size>
-                       <width>34</width>
-                       <height>20</height>
-                      </size>
-                     </property>
-                     <property name="focusPolicy">
-                      <enum>Qt::NoFocus</enum>
-                     </property>
-                     <property name="styleSheet">
-                      <string notr="true"/>
-                     </property>
-                     <property name="text">
-                      <string/>
-                     </property>
-                    </widget>
+                   <item row="1" column="3">
+                    <layout class="QHBoxLayout" name="horizontalLayout">
+                     <item>
+                      <widget class="QLabel" name="textInputs">
+                       <property name="text">
+                        <string>1 Inputs</string>
+                       </property>
+                       <property name="alignment">
+                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QPushButton" name="pushInputs">
+                       <property name="maximumSize">
+                        <size>
+                         <width>34</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                       <property name="focusPolicy">
+                        <enum>Qt::NoFocus</enum>
+                       </property>
+                       <property name="layoutDirection">
+                        <enum>Qt::LeftToRight</enum>
+                       </property>
+                       <property name="styleSheet">
+                        <string notr="true"/>
+                       </property>
+                       <property name="text">
+                        <string/>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
                    </item>
                   </layout>
                  </widget>
@@ -578,13 +610,41 @@ background:transparent;
                     <height>90</height>
                    </size>
                   </property>
-                  <layout class="QGridLayout" name="gridLayoutInput" columnstretch="5,2" rowminimumheight="0">
+                  <property name="lineWidth">
+                   <number>0</number>
+                  </property>
+                  <layout class="QGridLayout" name="gridLayoutInput" columnstretch="5,0">
                    <property name="sizeConstraint">
                     <enum>QLayout::SetMaximumSize</enum>
+                   </property>
+                   <property name="leftMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>0</number>
                    </property>
                    <property name="verticalSpacing">
                     <number>0</number>
                    </property>
+                   <item row="0" column="1">
+                    <widget class="QLabel" name="labelOutputIndex">
+                     <property name="layoutDirection">
+                      <enum>Qt::LeftToRight</enum>
+                     </property>
+                     <property name="text">
+                      <string>Output Index</string>
+                     </property>
+                     <property name="textFormat">
+                      <enum>Qt::AutoText</enum>
+                     </property>
+                     <property name="alignment">
+                      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                     </property>
+                     <property name="margin">
+                      <number>0</number>
+                     </property>
+                    </widget>
+                   </item>
                    <item row="0" column="0" alignment="Qt::AlignLeft">
                     <widget class="QLabel" name="labelTitlePrevTx">
                      <property name="text">
@@ -592,21 +652,11 @@ background:transparent;
                      </property>
                     </widget>
                    </item>
-                   <item row="0" column="1" alignment="Qt::AlignLeft">
-                    <widget class="QLabel" name="labelOutputIndex">
-                     <property name="text">
-                      <string>Output Index</string>
-                     </property>
-                     <property name="alignment">
-                      <set>Qt::AlignCenter</set>
-                     </property>
-                    </widget>
-                   </item>
                   </layout>
                  </widget>
                 </item>
                 <item>
-                 <widget class="QLabel" name="labelDivider1">
+                 <widget class="QLabel" name="labelDividerPrevtx">
                   <property name="maximumSize">
                    <size>
                     <width>16777215</width>
@@ -622,36 +672,88 @@ background:transparent;
                  </widget>
                 </item>
                 <item>
-                 <widget class="QWidget" name="contentFee" native="true">
-                  <layout class="QHBoxLayout" name="horizontalLayout_7" stretch="0,1">
-                   <property name="leftMargin">
-                    <number>0</number>
-                   </property>
-                   <item>
-                    <widget class="QLabel" name="labelFee">
-                     <property name="maximumSize">
-                      <size>
-                       <width>16777215</width>
-                       <height>16777215</height>
-                      </size>
+                 <layout class="QHBoxLayout" name="contentFeeSize">
+                  <property name="topMargin">
+                   <number>9</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>9</number>
+                  </property>
+                  <item>
+                   <layout class="QVBoxLayout" name="contentFee">
+                    <property name="topMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="bottomMargin">
+                     <number>0</number>
+                    </property>
+                    <item>
+                     <widget class="QLabel" name="labelFee">
+                      <property name="maximumSize">
+                       <size>
+                        <width>16777215</width>
+                        <height>16777215</height>
+                       </size>
+                      </property>
+                      <property name="text">
+                       <string>Fee</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QLabel" name="textFee">
+                      <property name="text">
+                       <string>0.0001 PIV</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <widget class="QWidget" name="contentSize" native="true">
+                    <layout class="QVBoxLayout" name="contentSize_layout">
+                     <property name="topMargin">
+                      <number>0</number>
                      </property>
-                     <property name="text">
-                      <string>Fee:</string>
+                     <property name="rightMargin">
+                      <number>0</number>
                      </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QLabel" name="textFee">
-                     <property name="text">
-                      <string>0.0001 PIV</string>
+                     <property name="bottomMargin">
+                      <number>0</number>
                      </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
+                     <item>
+                      <widget class="QLabel" name="labelSize">
+                       <property name="maximumSize">
+                        <size>
+                         <width>16777215</width>
+                         <height>16777215</height>
+                        </size>
+                       </property>
+                       <property name="text">
+                        <string>Size</string>
+                       </property>
+                       <property name="alignment">
+                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLabel" name="textSize">
+                       <property name="text">
+                        <string>2 kB</string>
+                       </property>
+                       <property name="alignment">
+                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                 </layout>
                 </item>
                 <item>
-                 <widget class="QLabel" name="labelDivider2">
+                 <widget class="QLabel" name="labelDividerFeeSize">
                   <property name="maximumSize">
                    <size>
                     <width>16777215</width>
@@ -668,9 +770,18 @@ background:transparent;
                 </item>
                 <item>
                  <widget class="QWidget" name="contentChangeAddress" native="true">
-                  <layout class="QHBoxLayout" name="horizontalLayout_6" stretch="0,1">
+                  <layout class="QVBoxLayout" name="contentChangeAddress_layout">
                    <property name="leftMargin">
                     <number>0</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>9</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>9</number>
                    </property>
                    <item>
                     <widget class="QLabel" name="labelChange">
@@ -681,7 +792,7 @@ background:transparent;
                       </size>
                      </property>
                      <property name="text">
-                      <string>Change address:</string>
+                      <string>Change address</string>
                      </property>
                     </widget>
                    </item>
@@ -696,7 +807,7 @@ background:transparent;
                  </widget>
                 </item>
                 <item>
-                 <widget class="QLabel" name="labelDivider4">
+                 <widget class="QLabel" name="labelDividerChange">
                   <property name="maximumSize">
                    <size>
                     <width>16777215</width>
@@ -712,12 +823,25 @@ background:transparent;
                  </widget>
                 </item>
                 <item>
-                 <widget class="QWidget" name="contentConfirmations" native="true">
-                  <layout class="QHBoxLayout" name="horizontalLayout_8" stretch="0,1">
+                 <widget class="QWidget" name="gridConfDateStatus" native="true">
+                  <layout class="QGridLayout" name="contentConfDateStatus">
                    <property name="leftMargin">
                     <number>0</number>
                    </property>
-                   <item>
+                   <property name="rightMargin">
+                    <number>0</number>
+                   </property>
+                   <item row="1" column="3">
+                    <widget class="QLabel" name="textStatus">
+                     <property name="text">
+                      <string>Spendable</string>
+                     </property>
+                     <property name="alignment">
+                      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="0" column="1">
                     <widget class="QLabel" name="labelConfirmations">
                      <property name="maximumSize">
                       <size>
@@ -726,133 +850,14 @@ background:transparent;
                       </size>
                      </property>
                      <property name="text">
-                      <string>Confirmations:</string>
+                      <string>Confirmations</string>
+                     </property>
+                     <property name="alignment">
+                      <set>Qt::AlignCenter</set>
                      </property>
                     </widget>
                    </item>
-                   <item>
-                    <widget class="QLabel" name="textConfirmations">
-                     <property name="text">
-                      <string>12</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLabel" name="labelDivider7">
-                  <property name="maximumSize">
-                   <size>
-                    <width>16777215</width>
-                    <height>1</height>
-                   </size>
-                  </property>
-                  <property name="styleSheet">
-                   <string notr="true">background-color:#bababa;</string>
-                  </property>
-                  <property name="text">
-                   <string/>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QWidget" name="contentSize" native="true">
-                  <layout class="QHBoxLayout" name="horizontalLayout_9" stretch="0,1">
-                   <property name="leftMargin">
-                    <number>0</number>
-                   </property>
-                   <item>
-                    <widget class="QLabel" name="labelSize">
-                     <property name="maximumSize">
-                      <size>
-                       <width>16777215</width>
-                       <height>16777215</height>
-                      </size>
-                     </property>
-                     <property name="text">
-                      <string>Size:</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QLabel" name="textSize">
-                     <property name="text">
-                      <string>2 kB</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLabel" name="labelDivider3">
-                  <property name="maximumSize">
-                   <size>
-                    <width>16777215</width>
-                    <height>1</height>
-                   </size>
-                  </property>
-                  <property name="styleSheet">
-                   <string notr="true">background-color:#bababa;</string>
-                  </property>
-                  <property name="text">
-                   <string/>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QWidget" name="contentDate" native="true">
-                  <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="0,1">
-                   <property name="leftMargin">
-                    <number>0</number>
-                   </property>
-                   <item>
-                    <widget class="QLabel" name="labelDate">
-                     <property name="maximumSize">
-                      <size>
-                       <width>16777215</width>
-                       <height>16777215</height>
-                      </size>
-                     </property>
-                     <property name="text">
-                      <string>Date:</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QLabel" name="textDate">
-                     <property name="text">
-                      <string>May 25, 2017</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLabel" name="labelDivider5">
-                  <property name="maximumSize">
-                   <size>
-                    <width>16777215</width>
-                    <height>1</height>
-                   </size>
-                  </property>
-                  <property name="styleSheet">
-                   <string notr="true">background-color:#bababa;</string>
-                  </property>
-                  <property name="text">
-                   <string/>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QWidget" name="contentStatus" native="true">
-                  <layout class="QHBoxLayout" name="horizontalLayout_10" stretch="0,1">
-                   <property name="leftMargin">
-                    <number>0</number>
-                   </property>
-                   <item>
+                   <item row="0" column="3">
                     <widget class="QLabel" name="labelStatus">
                      <property name="maximumSize">
                       <size>
@@ -861,18 +866,66 @@ background:transparent;
                       </size>
                      </property>
                      <property name="text">
-                      <string>Status:</string>
+                      <string>Status</string>
+                     </property>
+                     <property name="alignment">
+                      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                      </property>
                     </widget>
                    </item>
-                   <item>
-                    <widget class="QLabel" name="textStatus">
+                   <item row="1" column="1">
+                    <widget class="QLabel" name="textConfirmations">
                      <property name="text">
-                      <string>Spendable</string>
+                      <string>12</string>
+                     </property>
+                     <property name="alignment">
+                      <set>Qt::AlignCenter</set>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="0" column="0">
+                    <widget class="QLabel" name="labelDate">
+                     <property name="maximumSize">
+                      <size>
+                       <width>16777215</width>
+                       <height>16777215</height>
+                      </size>
+                     </property>
+                     <property name="text">
+                      <string>Date</string>
+                     </property>
+                     <property name="alignment">
+                      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="1" column="0">
+                    <widget class="QLabel" name="textDate">
+                     <property name="text">
+                      <string>May 25, 2017</string>
+                     </property>
+                     <property name="alignment">
+                      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
                      </property>
                     </widget>
                    </item>
                   </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="labelDividerConfs">
+                  <property name="maximumSize">
+                   <size>
+                    <width>16777215</width>
+                    <height>1</height>
+                   </size>
+                  </property>
+                  <property name="styleSheet">
+                   <string notr="true">background-color:#bababa;</string>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
                  </widget>
                 </item>
                 <item>

--- a/src/qt/pivx/sendconfirmdialog.cpp
+++ b/src/qt/pivx/sendconfirmdialog.cpp
@@ -30,7 +30,7 @@ TxDetailDialog::TxDetailDialog(QWidget *parent, bool isConfirmDialog, QString wa
     setCssProperty(ui->labelWarning, "text-title2-dialog");
     setCssTextBodyDialog({ui->labelAmount, ui->labelSend, ui->labelInputs, ui->labelFee, ui->labelChange, ui->labelId, ui->labelSize, ui->labelStatus, ui->labelConfirmations, ui->labelDate});
     setCssProperty({ui->labelDivider1, ui->labelDivider2, ui->labelDivider3, ui->labelDivider4, ui->labelDivider5, ui->labelDivider6, ui->labelDivider7, ui->labelDivider8, ui->labelDivider9}, "container-divider");
-    setCssTextBodyDialog({ui->textAmount, ui->textSend, ui->textInputs, ui->textFee, ui->textChange, ui->textId, ui->textSize, ui->textStatus, ui->textConfirmations, ui->textDate});
+    setCssTextBodyDialog({ui->textAmount, ui->textSendLabel, ui->textInputs, ui->textFee, ui->textChange, ui->textId, ui->textSize, ui->textStatus, ui->textConfirmations, ui->textDate});
 
     setCssProperty(ui->pushCopy, "ic-copy-big");
     setCssProperty({ui->pushInputs, ui->pushOutputs}, "ic-arrow-down");
@@ -42,7 +42,7 @@ TxDetailDialog::TxDetailDialog(QWidget *parent, bool isConfirmDialog, QString wa
     ui->contentChangeAddress->setVisible(false);
     ui->labelDivider4->setVisible(false);
 
-    setCssProperty({ui->labelOutputIndex, ui->labelTitlePrevTx}, "text-body2-dialog");
+    setCssProperty({ui->labelOutputIndex, ui->textSend, ui->labelTitlePrevTx}, "text-body2-dialog");
 
     if(isConfirmDialog){
         ui->labelTitle->setText(tr("Confirm Your Transaction"));
@@ -118,18 +118,22 @@ void TxDetailDialog::setData(WalletModel *model, const QModelIndex &index){
 
 }
 
-void TxDetailDialog::setData(WalletModel *model, WalletModelTransaction &tx){
+void TxDetailDialog::setData(WalletModel *model, WalletModelTransaction &tx) {
     this->model = model;
     this->tx = &tx;
     CAmount txFee = tx.getTransactionFee();
     CAmount totalAmount = tx.getTotalTransactionAmount() + txFee;
 
     ui->textAmount->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, totalAmount, false, BitcoinUnits::separatorAlways) + " (Fee included)");
-    if(tx.getRecipients().size() == 1){
-        ui->textSend->setText(tx.getRecipients().at(0).address);
+    int nRecipients = tx.getRecipients().size();
+    if (nRecipients == 1) {
+        SendCoinsRecipient recipient = tx.getRecipients().at(0);
+        ui->textSend->setText(recipient.address);
+        ui->textSendLabel->setText(recipient.label);
         ui->pushOutputs->setVisible(false);
-    }else{
-        ui->textSend->setText(QString::number(tx.getRecipients().size()) + " recipients");
+    } else {
+        ui->textSendLabel->setText(QString::number(nRecipients) + " recipients");
+        ui->textSend->setText("");
     }
     ui->textInputs->setText(QString::number(tx.getTransaction()->vin.size()));
     ui->textFee->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, txFee, false, BitcoinUnits::separatorAlways));

--- a/src/qt/pivx/sendconfirmdialog.cpp
+++ b/src/qt/pivx/sendconfirmdialog.cpp
@@ -44,7 +44,7 @@ TxDetailDialog::TxDetailDialog(QWidget *parent, bool isConfirmDialog, QString wa
 
     setCssProperty({ui->labelOutputIndex, ui->textSend, ui->labelTitlePrevTx}, "text-body2-dialog");
 
-    if(isConfirmDialog){
+    if (isConfirmDialog) {
         ui->labelTitle->setText(tr("Confirm Your Transaction"));
         setCssProperty(ui->btnCancel, "btn-dialog-cancel");
         ui->btnSave->setText(tr("SEND"));
@@ -70,7 +70,7 @@ TxDetailDialog::TxDetailDialog(QWidget *parent, bool isConfirmDialog, QString wa
 
         connect(ui->btnCancel, SIGNAL(clicked()), this, SLOT(close()));
         connect(ui->btnSave, &QPushButton::clicked, [this](){acceptTx();});
-    }else{
+    } else {
         ui->labelTitle->setText(tr("Transaction Details"));
         ui->containerButtons->setVisible(false);
     }
@@ -80,7 +80,8 @@ TxDetailDialog::TxDetailDialog(QWidget *parent, bool isConfirmDialog, QString wa
     connect(ui->pushOutputs, SIGNAL(clicked()), this, SLOT(onOutputsClicked()));
 }
 
-void TxDetailDialog::setData(WalletModel *model, const QModelIndex &index){
+void TxDetailDialog::setData(WalletModel *model, const QModelIndex &index)
+{
     this->model = model;
     TransactionRecord *rec = static_cast<TransactionRecord*>(index.internalPointer());
     QDateTime date = index.data(TransactionTableModel::DateRole).toDateTime();
@@ -90,7 +91,7 @@ void TxDetailDialog::setData(WalletModel *model, const QModelIndex &index){
     ui->textAmount->setText(amountText);
 
     const CWalletTx* tx = model->getTx(rec->hash);
-    if(tx) {
+    if (tx) {
         this->txHash = rec->hash;
         QString hash = QString::fromStdString(tx->GetHash().GetHex());
         ui->textId->setText(hash.left(20) + "..." + hash.right(20));
@@ -119,7 +120,8 @@ void TxDetailDialog::setData(WalletModel *model, const QModelIndex &index){
 
 }
 
-void TxDetailDialog::setData(WalletModel *model, WalletModelTransaction &tx) {
+void TxDetailDialog::setData(WalletModel *model, WalletModelTransaction &tx)
+{
     this->model = model;
     this->tx = &tx;
     CAmount txFee = tx.getTransactionFee();
@@ -145,13 +147,15 @@ void TxDetailDialog::setData(WalletModel *model, WalletModelTransaction &tx) {
     ui->textFee->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, txFee, false, BitcoinUnits::separatorAlways));
 }
 
-void TxDetailDialog::acceptTx(){
+void TxDetailDialog::acceptTx()
+{
     this->confirm = true;
     this->sendStatus = model->sendCoins(*this->tx);
     accept();
 }
 
-void TxDetailDialog::onInputsClicked() {
+void TxDetailDialog::onInputsClicked()
+{
     if (ui->gridInputs->isVisible()) {
         ui->gridInputs->setVisible(false);
         ui->contentInputs->layout()->setContentsMargins(0,9,12,9);
@@ -161,7 +165,7 @@ void TxDetailDialog::onInputsClicked() {
         if (!inputsLoaded) {
             inputsLoaded = true;
             const CWalletTx* tx = (this->tx) ? this->tx->getTransaction() : model->getTx(this->txHash);
-            if(tx) {
+            if (tx) {
                 ui->gridInputs->setMinimumHeight(50 + (50 * tx->vin.size()));
                 int i = 1;
                 for (const CTxIn &in : tx->vin) {
@@ -193,7 +197,7 @@ void TxDetailDialog::onOutputsClicked() {
             ui->container_outputs_base->setLayout(layoutVertical);
 
             const CWalletTx* tx = (this->tx) ? this->tx->getTransaction() : model->getTx(this->txHash);
-            if(tx) {
+            if (tx) {
                 for (const CTxOut &out : tx->vout) {
                     QFrame *frame = new QFrame(ui->container_outputs_base);
 
@@ -227,12 +231,14 @@ void TxDetailDialog::onOutputsClicked() {
     }
 }
 
-void TxDetailDialog::closeDialog(){
-    if(snackBar && snackBar->isVisible()) snackBar->hide();
+void TxDetailDialog::closeDialog()
+{
+    if (snackBar && snackBar->isVisible()) snackBar->hide();
     close();
 }
 
-TxDetailDialog::~TxDetailDialog(){
-    if(snackBar) delete snackBar;
+TxDetailDialog::~TxDetailDialog()
+{
+    if (snackBar) delete snackBar;
     delete ui;
 }

--- a/src/qt/pivx/sendconfirmdialog.cpp
+++ b/src/qt/pivx/sendconfirmdialog.cpp
@@ -28,9 +28,9 @@ TxDetailDialog::TxDetailDialog(QWidget *parent, bool isConfirmDialog, QString wa
 
     // Labels
     setCssProperty(ui->labelWarning, "text-title2-dialog");
-    setCssTextBodyDialog({ui->labelAmount, ui->labelSend, ui->labelInputs, ui->labelFee, ui->labelChange, ui->labelId, ui->labelSize, ui->labelStatus, ui->labelConfirmations, ui->labelDate});
-    setCssProperty({ui->labelDivider1, ui->labelDivider2, ui->labelDivider3, ui->labelDivider4, ui->labelDivider5, ui->labelDivider6, ui->labelDivider7, ui->labelDivider8, ui->labelDivider9}, "container-divider");
-    setCssTextBodyDialog({ui->textAmount, ui->textSendLabel, ui->textInputs, ui->textFee, ui->textChange, ui->textId, ui->textSize, ui->textStatus, ui->textConfirmations, ui->textDate});
+    setCssProperty({ui->labelAmount, ui->labelSend, ui->labelInputs, ui->labelFee, ui->labelChange, ui->labelId, ui->labelSize, ui->labelStatus, ui->labelConfirmations, ui->labelDate}, "text-subtitle");
+    setCssProperty({ui->labelDividerID, ui->labelDividerOutputs, ui->labelDividerPrevtx, ui->labelDividerFeeSize, ui->labelDividerChange, ui->labelDividerConfs}, "container-divider");
+    setCssProperty({ui->textAmount, ui->textSendLabel, ui->textInputs, ui->textFee, ui->textChange, ui->textId, ui->textSize, ui->textStatus, ui->textConfirmations, ui->textDate} , "text-body3-dialog");
 
     setCssProperty(ui->pushCopy, "ic-copy-big");
     setCssProperty({ui->pushInputs, ui->pushOutputs}, "ic-arrow-down");
@@ -39,8 +39,10 @@ TxDetailDialog::TxDetailDialog(QWidget *parent, bool isConfirmDialog, QString wa
     ui->labelWarning->setVisible(false);
     ui->gridInputs->setVisible(false);
     ui->outputsScrollArea->setVisible(false);
+
+    // hide change address for now
     ui->contentChangeAddress->setVisible(false);
-    ui->labelDivider4->setVisible(false);
+    ui->labelDividerChange->setVisible(false);
 
     setCssProperty({ui->labelOutputIndex, ui->textSend, ui->labelTitlePrevTx}, "text-body2-dialog");
 
@@ -56,17 +58,12 @@ TxDetailDialog::TxDetailDialog(QWidget *parent, bool isConfirmDialog, QString wa
             ui->labelWarning->setVisible(false);
         }
 
-        // hide change address for now
-        ui->contentConfirmations->setVisible(false);
-        ui->contentStatus->setVisible(false);
-        ui->contentDate->setVisible(false);
-        ui->contentSize->setVisible(false);
-        ui->contentConfirmations->setVisible(false);
+        // hide id / confirmations / date / status / size
         ui->contentID->setVisible(false);
-        ui->labelDivider7->setVisible(false);
-        ui->labelDivider5->setVisible(false);
-        ui->labelDivider3->setVisible(false);
-        ui->labelDivider9->setVisible(false);
+        ui->labelDividerID->setVisible(false);
+        ui->gridConfDateStatus->setVisible(false);
+        ui->labelDividerConfs->setVisible(false);
+        ui->contentSize->setVisible(false);
 
         connect(ui->btnCancel, SIGNAL(clicked()), this, SLOT(close()));
         connect(ui->btnSave, &QPushButton::clicked, [this](){acceptTx();});
@@ -158,10 +155,8 @@ void TxDetailDialog::onInputsClicked()
 {
     if (ui->gridInputs->isVisible()) {
         ui->gridInputs->setVisible(false);
-        ui->contentInputs->layout()->setContentsMargins(0,9,12,9);
     } else {
         ui->gridInputs->setVisible(true);
-        ui->contentInputs->layout()->setContentsMargins(0,9,12,0);
         if (!inputsLoaded) {
             inputsLoaded = true;
             const CWalletTx* tx = (this->tx) ? this->tx->getTransaction() : model->getTx(this->txHash);
@@ -170,13 +165,13 @@ void TxDetailDialog::onInputsClicked()
                 int i = 1;
                 for (const CTxIn &in : tx->vin) {
                     QString hash = QString::fromStdString(in.prevout.hash.GetHex());
-                    QLabel *label = new QLabel(hash.left(18) + "..." + hash.right(18));
-                    QLabel *label1 = new QLabel(QString::number(in.prevout.n));
-                    label1->setAlignment(Qt::AlignCenter);
-                    setCssProperty({label, label1}, "text-body2-dialog");
+                    QLabel *label_txid = new QLabel(hash.left(18) + "..." + hash.right(18));
+                    QLabel *label_txidn = new QLabel(QString::number(in.prevout.n));
+                    label_txidn->setAlignment(Qt::AlignCenter | Qt::AlignRight);
+                    setCssProperty({label_txid, label_txidn}, "text-body2-dialog");
 
-                    ui->gridLayoutInput->addWidget(label,i,0);
-                    ui->gridLayoutInput->addWidget(label1,i,1, Qt::AlignCenter);
+                    ui->gridLayoutInput->addWidget(label_txid,i,0);
+                    ui->gridLayoutInput->addWidget(label_txidn,i,1);
                     i++;
                 }
             }
@@ -191,22 +186,14 @@ void TxDetailDialog::onOutputsClicked() {
         ui->outputsScrollArea->setVisible(true);
         if (!outputsLoaded) {
             outputsLoaded = true;
-            QVBoxLayout* layoutVertical = new QVBoxLayout();
-            layoutVertical->setContentsMargins(0,0,12,0);
-            layoutVertical->setSpacing(6);
-            ui->container_outputs_base->setLayout(layoutVertical);
+            QGridLayout* layoutGrid = new QGridLayout();
+            layoutGrid->setContentsMargins(0,0,12,0);
+            ui->container_outputs_base->setLayout(layoutGrid);
 
             const CWalletTx* tx = (this->tx) ? this->tx->getTransaction() : model->getTx(this->txHash);
             if (tx) {
+                int i = 0;
                 for (const CTxOut &out : tx->vout) {
-                    QFrame *frame = new QFrame(ui->container_outputs_base);
-
-                    QHBoxLayout *layout = new QHBoxLayout();
-                    layout->setContentsMargins(0, 0, 0, 0);
-                    layout->setSpacing(12);
-                    frame->setLayout(layout);
-
-                    QLabel *label = nullptr;
                     QString labelRes;
                     CTxDestination dest;
                     bool isCsAddress = out.scriptPubKey.IsPayToColdStaking();
@@ -217,14 +204,13 @@ void TxDetailDialog::onOutputsClicked() {
                     } else {
                         labelRes = tr("Unknown");
                     }
-                    label = new QLabel(labelRes);
-                    QLabel *label1 = new QLabel(BitcoinUnits::formatWithUnit(nDisplayUnit, out.nValue, false, BitcoinUnits::separatorAlways));
-                    label1->setAlignment(Qt::AlignCenter | Qt::AlignRight);
-                    setCssProperty({label, label1}, "text-body2-dialog");
-
-                    layout->addWidget(label);
-                    layout->addWidget(label1);
-                    layoutVertical->addWidget(frame);
+                    QLabel *label_address = new QLabel(labelRes);
+                    QLabel *label_value = new QLabel(BitcoinUnits::formatWithUnit(nDisplayUnit, out.nValue, false, BitcoinUnits::separatorAlways));
+                    label_value->setAlignment(Qt::AlignCenter | Qt::AlignRight);
+                    setCssProperty({label_address, label_value}, "text-body2-dialog");
+                    layoutGrid->addWidget(label_address,i,0);
+                    layoutGrid->addWidget(label_value,i,0);
+                    i++;
                 }
             }
         }

--- a/src/qt/pivx/sendconfirmdialog.cpp
+++ b/src/qt/pivx/sendconfirmdialog.cpp
@@ -96,10 +96,11 @@ void TxDetailDialog::setData(WalletModel *model, const QModelIndex &index){
         ui->textId->setText(hash.left(20) + "..." + hash.right(20));
         ui->textId->setTextInteractionFlags(Qt::TextSelectableByMouse);
         if (tx->vout.size() == 1) {
-            ui->textSend->setText(address);
+            ui->textSendLabel->setText(address);
         } else {
-            ui->textSend->setText(QString::number(tx->vout.size()) + " recipients");
+            ui->textSendLabel->setText(QString::number(tx->vout.size()) + " recipients");
         }
+        ui->textSend->setVisible(false);
 
         ui->textInputs->setText(QString::number(tx->vin.size()));
         ui->textConfirmations->setText(QString::number(rec->status.depth));
@@ -128,12 +129,17 @@ void TxDetailDialog::setData(WalletModel *model, WalletModelTransaction &tx) {
     int nRecipients = tx.getRecipients().size();
     if (nRecipients == 1) {
         SendCoinsRecipient recipient = tx.getRecipients().at(0);
-        ui->textSend->setText(recipient.address);
-        ui->textSendLabel->setText(recipient.label);
+        if (recipient.label.isEmpty()) { // If there is no label, then do not show the blank space.
+            ui->textSendLabel->setText(recipient.address);
+            ui->textSend->setVisible(false);
+        } else {
+            ui->textSend->setText(recipient.address);
+            ui->textSendLabel->setText(recipient.label);
+        }
         ui->pushOutputs->setVisible(false);
     } else {
         ui->textSendLabel->setText(QString::number(nRecipients) + " recipients");
-        ui->textSend->setText("");
+        ui->textSend->setVisible(false);
     }
     ui->textInputs->setText(QString::number(tx.getTransaction()->vin.size()));
     ui->textFee->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, txFee, false, BitcoinUnits::separatorAlways));

--- a/src/test/signcompact_tests.cpp
+++ b/src/test/signcompact_tests.cpp
@@ -1,0 +1,64 @@
+// Copyright (c) 2013 The Bitcoin Core developers
+// Copyright (c) 2017-2019 The PIVX developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "test/test_pivx.h"
+#include <boost/test/unit_test.hpp>
+#include "wallet/wallet.h"
+#include "libzerocoin/bignum.h"
+
+BOOST_FIXTURE_TEST_SUITE(signcompact_tests, TestingSetup)
+
+BOOST_AUTO_TEST_CASE(low_r_malleability_test)
+{
+    //const int NUM_TESTS = 1;
+
+    // get a key from the keystore
+    CBasicKeyStore keystore;
+    CKey key;
+    key.MakeNewKey(true);
+    keystore.AddKey(key);
+    CPubKey pubKey = key.GetPubKey();
+
+    // get a random message
+    uint256 msgHash = CBigNum::randKBitBignum(256).getuint256();
+
+    // sign it
+    std::vector<unsigned char> vchSigRet;
+    BOOST_CHECK(key.SignCompact(msgHash, vchSigRet));
+
+    // check sig
+    CPubKey pubkeyFromSig;
+    BOOST_CHECK(pubkeyFromSig.RecoverCompact(msgHash, vchSigRet));
+    BOOST_CHECK(pubkeyFromSig == pubKey);
+    std::cout << "Sig: " << std::endl;
+    std::cout << "  R = " << HexStr(vchSigRet.begin()+1, vchSigRet.begin()+33) << std::endl;
+    std::cout << "  S = " << HexStr(vchSigRet.begin()+33, vchSigRet.end()) << std::endl;
+    std::cout << "  recovered key = " << HexStr(pubkeyFromSig.Raw()) << std::endl;
+
+    // new sig
+    CBigNum S_num(std::vector<unsigned char>(vchSigRet.begin()+33, vchSigRet.end()));
+    CBigNum order;
+    order.SetHex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141");
+    CBigNum newSig_num = order - S_num;
+    std::vector<unsigned char> newSig;
+    newSig.resize(CPubKey::COMPACT_SIGNATURE_SIZE);
+    std::copy(vchSigRet.begin(), vchSigRet.begin()+33, newSig.begin());
+    std::vector<unsigned char> newS = newSig_num.getvch();
+    std::copy(newS.begin(), newS.end(), newSig.begin()+33);
+
+    // check new sig
+    CPubKey pubkeyFromSig2;
+    BOOST_CHECK(pubkeyFromSig2.RecoverCompact(msgHash, newSig));
+    BOOST_CHECK(pubkeyFromSig2 == pubKey);
+    std::cout << "newSig: " << std::endl;
+    std::cout << "  R = " << HexStr(newSig.begin()+1, newSig.begin()+33) << std::endl;
+    std::cout << "  S = " << HexStr(newSig.begin()+33, newSig.end()) << std::endl;
+    std::cout << "  recovered key = " << HexStr(pubkeyFromSig2.Raw()) << std::endl;
+
+
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+


### PR DESCRIPTION
Adds the label of the recipient to the confirmation-popup when sending funds because the label is much easier to verify than the address itself.

It's intentionally NOT added to the list of recipients if you send to more than 1 recipient because the space on that list is already very crowded and would make it even less useful.

Screenshot:
![Sendpopup](https://user-images.githubusercontent.com/22873440/73354953-439bcb80-4297-11ea-9c8a-c8da1b676ec8.png)

