### PR TITLE
[GUI] Send-tab: set default focus on recipient-address

### DIFF
--- a/src/qt/pivx/send.cpp
+++ b/src/qt/pivx/send.cpp
@@ -249,15 +249,17 @@ void SendWidget::clearEntries(){
     addEntry();
 }
 
-void SendWidget::addEntry(){
-    if(entries.isEmpty()){
-        createEntry();
+void SendWidget::addEntry() {
+    if (entries.isEmpty()) {
+        SendMultiRow *sendMultiRow = createEntry();
+        sendMultiRow->setFocus();
     } else {
         if (entries.length() == 1) {
             SendMultiRow *entry = entries.at(0);
             entry->hideLabels();
             entry->setNumber(1);
-        }else if(entries.length() == MAX_SEND_POPUP_ENTRIES){
+            entry->setFocus();
+        } else if (entries.length() == MAX_SEND_POPUP_ENTRIES) {
             inform(tr("Maximum amount of outputs reached"));
             return;
         }
@@ -265,6 +267,7 @@ void SendWidget::addEntry(){
         SendMultiRow *sendMultiRow = createEntry();
         sendMultiRow->setNumber(entries.length());
         sendMultiRow->hideLabels();
+        sendMultiRow->setFocus();
     }
 }
 
@@ -295,6 +298,9 @@ void SendWidget::resizeEvent(QResizeEvent *event){
     QWidget::resizeEvent(event);
 }
 
+void SendWidget::showEvent(QShowEvent *event) {
+    setFocusOnLastRecipient(); // Set focus on last recipient address when Send-window is displayed
+}
 
 void SendWidget::onSendClicked(){
 
@@ -333,6 +339,7 @@ void SendWidget::onSendClicked(){
 
     if((sendPiv) ? send(recipients) : sendZpiv(recipients)) {
         updateEntryLabels(recipients);
+        setFocusOnLastRecipient();
     }
 }
 
@@ -484,6 +491,14 @@ bool SendWidget::sendZpiv(QList<SendCoinsRecipient> recipients){
     }
 }
 
+void SendWidget::setFocusOnLastRecipient() {
+    for (SendMultiRow* entry : entries) {
+        if (entry) {
+            entry->setFocus(); // Set focus on last recipient address when Send-window is displayed
+        }
+    }
+}
+
 QString SendWidget::recipientsToString(QList<SendCoinsRecipient> recipients){
     QString s = "";
     for (SendCoinsRecipient rec : recipients){
@@ -512,7 +527,6 @@ void SendWidget::updateEntryLabels(QList<SendCoinsRecipient> recipients){
 
     }
 }
-
 
 void SendWidget::onChangeAddressClicked(){
     showHideOp(true);
@@ -761,6 +775,7 @@ void SendWidget::onDeleteClicked(){
                 it.remove();
             } else if (focusedEntry && entry->getNumber() > entryNumber){
                 entry->setNumber(entry->getNumber() - 1);
+                entry->setFocus();
             }
         }
 
@@ -768,6 +783,7 @@ void SendWidget::onDeleteClicked(){
             SendMultiRow* sendMultiRow = QMutableListIterator<SendMultiRow*>(entries).next();
             sendMultiRow->setNumber(entries.length());
             sendMultiRow->showLabels();
+            sendMultiRow->setFocus();
         }
 
         focusedEntry = nullptr;

--- a/src/qt/pivx/send.h
+++ b/src/qt/pivx/send.h
@@ -57,6 +57,7 @@ public slots:
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
+    void showEvent(QShowEvent *event) override;
 
 private slots:
     void onPIVSelected(bool _isPIV);
@@ -93,6 +94,7 @@ private:
     SendMultiRow* createEntry();
     bool send(QList<SendCoinsRecipient> recipients);
     bool sendZpiv(QList<SendCoinsRecipient> recipients);
+    void setFocusOnLastRecipient();
     void updateEntryLabels(QList<SendCoinsRecipient> recipients);
 
 };


### PR DESCRIPTION
When you click on the "Send" tab you always have to additionally click on the address (or any other) input field to enter your data. Same problem when you add recipients, or after you've send some funds after the send-popup was confirmed.
It's also annoying that when absolutely no input field has focus the navigation via the tab-key is also not possible.

This PR automatically sets the focus to the address field, or, when you add a new recipient, to the address field of the last recipient.
