### PR TITLE
[RPC][Tests] Don't throw when generate doesn't create all blocks (PoS)

### DIFF
--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -209,9 +209,10 @@ bool Stake(const CBlockIndex* pindexPrev, CStakeInput* stakeInput, unsigned int 
     if (nHeight < nHeightBlockFrom + Params().COINSTAKE_MIN_DEPTH())
         return error("%s : min depth violation, nHeight=%d, nHeightBlockFrom=%d", __func__, nHeight, nHeightBlockFrom);
 
-    nTimeTx = (Params().IsRegTestNet() ? GetAdjustedTime() : GetCurrentTimeSlot());
+    const bool fRegTest = Params().IsRegTestNet();
+    nTimeTx = (fRegTest ? GetAdjustedTime() : GetCurrentTimeSlot());
     // double check that we are not on the same slot as prev block
-    if (nTimeTx <= pindexPrev->nTime) return false;
+    if (nTimeTx <= pindexPrev->nTime && !fRegTest) return false;
 
     // check stake kernel
     return CheckStakeKernelHash(pindexPrev, nBits, stakeInput, nTimeTx, hashProofOfStake);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -92,11 +92,7 @@ public:
 
 void UpdateTime(CBlockHeader* pblock, const CBlockIndex* pindexPrev)
 {
-    if (Params().IsTimeProtocolV2(pindexPrev->nHeight+1)) {
-        pblock->nTime = GetCurrentTimeSlot();
-    } else {
-        pblock->nTime = std::max(pindexPrev->GetMedianTimePast() + 1, GetAdjustedTime());
-    }
+    pblock->nTime = std::max(pindexPrev->GetMedianTimePast() + 1, GetAdjustedTime());
 
     // Updating time can change work required on testnet:
     if (Params().AllowMinDifficultyBlocks())
@@ -742,6 +738,7 @@ void BitcoinMiner(CWallet* pwallet, bool fProofOfStake)
                 // Changing pblock->nTime can change work required on testnet:
                 hashTarget.SetCompact(pblock->nBits);
             }
+
         }
     }
 }

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -158,11 +158,10 @@ UniValue generate(const UniValue& params, bool fHelp)
     unsigned int nExtraNonce = 0;
     while (nHeight < nHeightEnd && !ShutdownRequested())
     {
-        std::unique_ptr<CBlockTemplate> pblocktemplate(
-                fPoS ? CreateNewBlock(CScript(), pwalletMain, fPoS) : CreateNewBlockWithKey(reservekey, pwalletMain)
-                        );
-        if (!pblocktemplate.get())
-            throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");
+        std::unique_ptr<CBlockTemplate> pblocktemplate(fPoS ?
+                                                       CreateNewBlock(CScript(), pwalletMain, fPoS) :
+                                                       CreateNewBlockWithKey(reservekey, pwalletMain));
+        if (!pblocktemplate.get()) break;
         CBlock *pblock = &pblocktemplate->block;
 
         if(!fPoS) {
@@ -188,6 +187,11 @@ UniValue generate(const UniValue& params, bool fHelp)
         // Check PoS if needed.
         if (!fPoS) fPoS = (nHeight >= last_pow_block);
     }
+
+    const int nGenerated = blockHashes.size();
+    if (nGenerated == 0 || (!fPoS && nGenerated < nGenerate))
+        throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new blocks");
+
     return blockHashes;
 }
 


### PR DESCRIPTION
Just return the list of hashes for the blocks generated.
This affects only "live" usage of regtest wallet, as the functional tests use the utility function `generate_pos` which calls `generate(1)` and increases mocktime (or adds a `sleep`) when the node can actually stake but can't find a valid kernel at the current time.