### PR TITLE
[Core] CheckColdStakeFreeOutput: skip SPORK checks if mnsync incomplete

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4180,10 +4180,12 @@ bool CheckColdStakeFreeOutput(const CTransaction& tx, const int nHeight)
         if (lastOut.nValue == 3 * COIN)
             return true;
 
-        if (budget.IsBudgetPaymentBlock(nHeight) &
-                sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS) &&
-                sporkManager.IsSporkActive(SPORK_9_MASTERNODE_BUDGET_ENFORCEMENT))
-            return true;
+        if (budget.IsBudgetPaymentBlock(nHeight)) {
+            // if this is a budget payment, check that SPORK_9 and SPORK_13 are active (if spork list synced)
+            return (!masternodeSync.IsSporkListSynced() ||
+                    (sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS) &&
+                    sporkManager.IsSporkActive(SPORK_9_MASTERNODE_BUDGET_ENFORCEMENT)));
+        }
 
         return error("%s: Wrong cold staking outputs: vout[%d].scriptPubKey (%s) != vout[%d].scriptPubKey (%s) - value: %s",
                 __func__, outs-1, HexStr(lastOut.scriptPubKey), outs-2, HexStr(tx.vout[outs-2].scriptPubKey), FormatMoney(lastOut.nValue).c_str());
@@ -4320,7 +4322,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
             }
         } else {
             if (fDebug)
-                LogPrintf("%s: Masternode payment check skipped on sync - skipping IsBlockPayeeValid()\n", __func__);
+                LogPrintf("%s: Masternode/Budget payment checks skipped on sync\n", __func__);
         }
     }
 


### PR DESCRIPTION
Currently `CheckBlock` skips the masternode (or budget) payment check in coinstakes when `IsInitialBlockDownload()` returns true (essentially when the current best block time is older than nMaxTipAge seconds).

Since, in order to verify the block payee, the masternode list needs to be up to date, `IsBlockPayeeValid`also skips the checks when mnsync has not finished.
`CheckColdStakeFreeOutput` however, does not, so, when the spork list is not updated, SPORK_13 and SPORK_9 cannot be verified (in case of budget payment blocks) resulting in CheckBlock failures with
```
ERROR: CheckColdStakeFreeOutput: Wrong cold staking outputs:
```
(Unless the user doesn't manually set a lower nMaxTipAge to force IsInitialBlockDownload to true).


This fixes it.