### PR TITLE
[WIP] Optimize reindex process

### DIFF
--- a/src/guiinterface.h
+++ b/src/guiinterface.h
@@ -105,6 +105,9 @@ public:
     /** New block has been accepted */
     boost::signals2::signal<void(bool fInitialDownload, const CBlockIndex* newTip)> NotifyBlockTip;
 
+    /** Best header has changed */
+    boost::signals2::signal<void (bool, const CBlockIndex *)> NotifyHeaderTip;
+
     /** New block has been accepted and is over a certain size */
     boost::signals2::signal<void(int size, const uint256& hash)> NotifyBlockSize;
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -639,6 +639,26 @@ static void BlockSizeNotifyCallback(int size, const uint256& hashNewTip)
     boost::thread t(runCommand, strCmd); // thread runs free
 }
 
+////////////////////////////////////////////////////
+
+static bool fHaveGenesis = false;
+static std::mutex cs_GenesisWait;
+static CConditionVariable condvar_GenesisWait;
+
+static void BlockNotifyGenesisWait(bool, const CBlockIndex *pBlockIndex)
+{
+    if (pBlockIndex != nullptr) {
+        {
+            std::unique_lock<std::mutex> lock_GenesisWait(cs_GenesisWait);
+            fHaveGenesis = true;
+        }
+        condvar_GenesisWait.notify_all();
+    }
+}
+
+////////////////////////////////////////////////////
+
+
 struct CImportingNow {
     CImportingNow()
     {
@@ -1743,6 +1763,17 @@ bool AppInit2()
 #endif // !ENABLE_WALLET
     // ********************************************************* Step 9: import blocks
 
+    if (!CheckDiskSpace())
+        return false;
+
+    // Either install a handler to notify us when genesis activates, or set fHaveGenesis directly.
+    // No locking, as this happens before any background thread is started.
+    if (chainActive.Tip() == nullptr) {
+        uiInterface.NotifyBlockTip.connect(BlockNotifyGenesisWait);
+    } else {
+        fHaveGenesis = true;
+    }
+
     if (mapArgs.count("-blocknotify"))
         uiInterface.NotifyBlockTip.connect(BlockNotifyCallback);
 
@@ -1760,10 +1791,15 @@ bool AppInit2()
             vImportFiles.push_back(strFile);
     }
     threadGroup.create_thread(boost::bind(&ThreadImport, vImportFiles));
-    if (chainActive.Tip() == NULL) {
-        LogPrintf("Waiting for genesis block to be imported...\n");
-        while (!fRequestShutdown && chainActive.Tip() == NULL)
-            MilliSleep(10);
+
+    // Wait for genesis block to be processed
+    LogPrintf("Waiting for genesis block to be imported...\n");
+    {
+        std::unique_lock<std::mutex> lockG(cs_GenesisWait);
+        while (!fHaveGenesis) {
+            condvar_GenesisWait.wait(lockG);
+        }
+        uiInterface.NotifyBlockTip.disconnect(BlockNotifyGenesisWait);
     }
 
     // ********************************************************* Step 10: setup ObfuScation
@@ -1910,9 +1946,6 @@ bool AppInit2()
     }
 
     // ********************************************************* Step 11: start node
-
-    if (!CheckDiskSpace())
-        return false;
 
     if (!strErrors.str().empty())
         return InitError(strErrors.str());

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -693,8 +693,6 @@ void ThreadImport(std::vector<boost::filesystem::path> vImportFiles)
                 LoadExternalBlockFile(file, &pos);
                 nFile++;
             }
-            pblocktree->WriteReindexing(false);
-            fReindex = false;
             LogPrintf("Reindexing finished\n");
             // To avoid ending up in a situation without genesis block, re-try initializing (no-op if reindexing worked):
             InitBlockIndex();
@@ -730,6 +728,12 @@ void ThreadImport(std::vector<boost::filesystem::path> vImportFiles)
         if (!ActivateBestChain(state)) {
             LogPrintf("Failed to connect best block");
             StartShutdown();
+        }
+
+        // Now that the best chain was activated, reset reindex flag.
+        if (fReindex) {
+            pblocktree->WriteReindexing(false);
+            fReindex = false;
         }
 
         if (GetBoolArg("-stopafterblockimport", false)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5302,8 +5302,6 @@ bool InitBlockIndex()
             CBlockIndex* pindex = AddToBlockIndex(block);
             if (!ReceivedBlockTransactions(block, state, pindex, blockPos))
                 return error("LoadBlockIndex() : genesis block not accepted");
-            if (!ActivateBestChain(state, &block))
-                return error("LoadBlockIndex() : genesis block cannot be activated");
             // Force a chainstate write so that when we VerifyDB in a moment, it doesnt check stale data
             return FlushStateToDisk(state, FLUSH_STATE_ALWAYS);
         } catch (const std::runtime_error& e) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -77,8 +77,8 @@ std::condition_variable g_best_block_cv;
 uint256 g_best_block;
 
 int nScriptCheckThreads = 0;
-bool fImporting = false;
-bool fReindex = false;
+std::atomic<bool> fImporting{false};
+std::atomic<bool> fReindex{false};
 bool fTxIndex = true;
 bool fIsBareMultisigStd = true;
 bool fCheckBlockIndex = false;
@@ -5123,7 +5123,7 @@ bool static LoadBlockIndexDB(std::string& strError)
     // Check whether we need to continue reindexing
     bool fReindexing = false;
     pblocktree->ReadReindexing(fReindexing);
-    fReindex |= fReindexing;
+    if(fReindexing) fReindex = true;
 
     // Check whether we have a transaction index
     pblocktree->ReadFlag("txindex", fTxIndex);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4518,7 +4518,7 @@ bool AcceptBlockHeader(const CBlock& block, CValidationState& state, CBlockIndex
     return true;
 }
 
-bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, CDiskBlockPos* dbp, bool fAlreadyCheckedBlock)
+bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, const CDiskBlockPos* dbp, bool fAlreadyCheckedBlock)
 {
     AssertLockHeld(cs_main);
 
@@ -4856,7 +4856,7 @@ void CBlockIndex::BuildSkip()
         pskip = pprev->GetAncestor(GetSkipHeight(nHeight));
 }
 
-bool ProcessNewBlock(CValidationState& state, CNode* pfrom, CBlock* pblock, CDiskBlockPos* dbp)
+bool ProcessNewBlock(CValidationState& state, CNode* pfrom, CBlock* pblock, const CDiskBlockPos* dbp)
 {
     // Preliminary checks
     int64_t nStartTime = GetTimeMillis();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3662,12 +3662,11 @@ static void PruneBlockIndexCandidates()
  * Try to make some progress towards making pindexMostWork the active block.
  * pblock is either NULL or a pointer to a CBlock corresponding to pindexMostWork.
  */
-static bool ActivateBestChainStep(CValidationState& state, CBlockIndex* pindexMostWork, CBlock* pblock, bool fAlreadyChecked)
+static bool ActivateBestChainStep(CValidationState& state, CBlockIndex* pindexMostWork, CBlock* pblock, bool& fInvalidFound, bool fAlreadyChecked)
 {
     AssertLockHeld(cs_main);
     if (pblock == NULL)
         fAlreadyChecked = false;
-    bool fInvalidFound = false;
     const CBlockIndex* pindexOldTip = chainActive.Tip();
     const CBlockIndex* pindexFork = chainActive.FindFork(pindexMostWork);
 
@@ -3751,14 +3750,26 @@ bool ActivateBestChain(CValidationState& state, CBlock* pblock, bool fAlreadyChe
             }
 
             CBlockIndex *pindexOldTip = chainActive.Tip();
-            pindexMostWork = FindMostWorkChain();
+            if (!pindexMostWork) {
+                pindexMostWork = FindMostWorkChain();
+            }
 
             // Whether we have anything to do at all.
             if (pindexMostWork == NULL || pindexMostWork == chainActive.Tip())
                 return true;
 
-            if (!ActivateBestChainStep(state, pindexMostWork, pblock && pblock->GetHash() == pindexMostWork->GetBlockHash() ? pblock : NULL, fAlreadyChecked))
+            bool fInvalidFound = false;
+            if (!ActivateBestChainStep(state,
+                    pindexMostWork,
+                    pblock && pblock->GetHash() == pindexMostWork->GetBlockHash() ? pblock : nullptr,
+                    fInvalidFound,
+                    fAlreadyChecked))
                 return false;
+
+            if (fInvalidFound) {
+                // Wipe cache, we may need another branch now.
+                pindexMostWork = nullptr;
+            }
 
             pindexNewTip = chainActive.Tip();
             pindexFork = chainActive.FindFork(pindexOldTip);

--- a/src/main.h
+++ b/src/main.h
@@ -172,10 +172,10 @@ void UnregisterNodeSignals(CNodeSignals& nodeSignals);
  * @param[out]  state   This may be set to an Error state if any error occurred processing it, including during validation/connection/etc of otherwise unrelated blocks during reorganisation; or it may be set to an Invalid state if pblock is itself invalid (but this is not guaranteed even when the block is checked). If you want to *possibly* get feedback on whether pblock is valid, you must also install a CValidationInterface - this will have its BlockChecked method called whenever *any* block completes validation.
  * @param[in]   pfrom   The node which we are receiving the block from; it is added to mapBlockSource and may be penalised if the block is invalid.
  * @param[in]   pblock  The block we want to process.
- * @param[out]  dbp     If pblock is stored to disk (or already there), this will be set to its location.
+ * @param[out]  dbp     The already known disk position of pblock, or NULL if not yet stored.
  * @return True if state.IsValid()
  */
-bool ProcessNewBlock(CValidationState& state, CNode* pfrom, CBlock* pblock, CDiskBlockPos* dbp = NULL);
+bool ProcessNewBlock(CValidationState& state, CNode* pfrom, CBlock* pblock, const CDiskBlockPos* dbp = nullptr);
 /** Check whether enough disk space is available for an incoming block */
 bool CheckDiskSpace(uint64_t nAdditionalBytes = 0);
 /** Open a block file (blk?????.dat) */
@@ -385,7 +385,7 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
 bool TestBlockValidity(CValidationState& state, const CBlock& block, CBlockIndex* pindexPrev, bool fCheckPOW = true, bool fCheckMerkleRoot = true);
 
 /** Store block on disk. If dbp is provided, the file is known to already reside on disk */
-bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** pindex, CDiskBlockPos* dbp = NULL, bool fAlreadyCheckedBlock = false);
+bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** pindex, const CDiskBlockPos* dbp = nullptr, bool fAlreadyCheckedBlock = false);
 bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, CBlockIndex** ppindex = NULL);
 
 

--- a/src/main.h
+++ b/src/main.h
@@ -134,8 +134,8 @@ extern CWaitableCriticalSection g_best_block_mutex;
 extern std::condition_variable g_best_block_cv;
 extern uint256 g_best_block;
 
-extern bool fImporting;
-extern bool fReindex;
+extern std::atomic<bool> fImporting;
+extern std::atomic<bool> fReindex;
 extern int nScriptCheckThreads;
 extern bool fTxIndex;
 extern bool fIsBareMultisigStd;

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -105,7 +105,7 @@ private:
 
 Q_SIGNALS:
     void numConnectionsChanged(int count);
-    void numBlocksChanged(int count);
+    void numBlocksChanged(int count, const bool& header);
     void strMasternodesChanged(const QString& strMasternodes);
     void alertsChanged(const QString& warnings);
     void bytesChanged(quint64 totalBytesIn, quint64 totalBytesOut);

--- a/src/qt/pivx/settings/settingsinformationwidget.cpp
+++ b/src/qt/pivx/settings/settingsinformationwidget.cpp
@@ -131,8 +131,8 @@ void SettingsInformationWidget::loadClientModel(){
         setNumConnections(clientModel->getNumConnections());
         connect(clientModel, SIGNAL(numConnectionsChanged(int)), this, SLOT(setNumConnections(int)));
 
-        setNumBlocks(clientModel->getNumBlocks());
-        connect(clientModel, SIGNAL(numBlocksChanged(int)), this, SLOT(setNumBlocks(int)));
+        setNumBlocks(clientModel->getNumBlocks(), false);
+        connect(clientModel, SIGNAL(numBlocksChanged(int, const bool&)), this, SLOT(setNumBlocks(int, const bool&)));
     }
 }
 
@@ -147,7 +147,7 @@ void SettingsInformationWidget::setNumConnections(int count){
     ui->labelInfoConnections->setText(connections);
 }
 
-void SettingsInformationWidget::setNumBlocks(int count){
+void SettingsInformationWidget::setNumBlocks(int count, const bool& fHeader){
     ui->labelInfoBlockNumber->setText(QString::number(count));
     if (clientModel)
         ui->labelInfoBlockTime->setText(clientModel->getLastBlockDate().toString());

--- a/src/qt/pivx/settings/settingsinformationwidget.h
+++ b/src/qt/pivx/settings/settingsinformationwidget.h
@@ -25,7 +25,7 @@ public:
 
 private Q_SLOTS:
     void setNumConnections(int count);
-    void setNumBlocks(int count);
+    void setNumBlocks(int count, const bool& fHeader);
     void openNetworkMonitor();
 
 private:

--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -385,13 +385,13 @@ void TopBar::setNumBlocks(int count, const bool& fHeader) {
 
     // Acquire current block source
     enum BlockSource blockSource = clientModel->getBlockSource();
-    std::string text = "";
+    std::string text;
     switch (blockSource) {
         case BLOCK_SOURCE_NETWORK:
             text = "Synchronizing..";
             break;
         case BLOCK_SOURCE_DISK:
-            text = "Importing blocks from disk..";
+            text = fHeader ? "Indexing blocks on disk..." : "Processing blocks on disk...";
             break;
         case BLOCK_SOURCE_REINDEX:
             text = "Reindexing blocks on disk..";

--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -337,8 +337,8 @@ void TopBar::loadClientModel(){
         setNumConnections(clientModel->getNumConnections());
         connect(clientModel, SIGNAL(numConnectionsChanged(int)), this, SLOT(setNumConnections(int)));
 
-        setNumBlocks(clientModel->getNumBlocks());
-        connect(clientModel, SIGNAL(numBlocksChanged(int)), this, SLOT(setNumBlocks(int)));
+        setNumBlocks(clientModel->getNumBlocks(), false);
+        connect(clientModel, SIGNAL(numBlocksChanged(int, const bool&)), this, SLOT(setNumBlocks(int, const bool&)));
 
         timerStakingIcon = new QTimer(ui->pushButtonStack);
         connect(timerStakingIcon, SIGNAL(timeout()), this, SLOT(updateStakingStatus()));
@@ -379,7 +379,7 @@ void TopBar::setNumConnections(int count) {
     ui->pushButtonConnection->setButtonText(tr("%n active connection(s)", "", count));
 }
 
-void TopBar::setNumBlocks(int count) {
+void TopBar::setNumBlocks(int count, const bool& fHeader) {
     if (!clientModel)
         return;
 

--- a/src/qt/pivx/topbar.h
+++ b/src/qt/pivx/topbar.h
@@ -43,7 +43,7 @@ public Q_SLOTS:
     void updateDisplayUnit();
 
     void setNumConnections(int count);
-    void setNumBlocks(int count);
+    void setNumBlocks(int count, const bool& fHeader);
     void setStakingStatusActive(bool fActive);
     void updateStakingStatus();
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -388,8 +388,8 @@ void RPCConsole::setClientModel(ClientModel* model)
         setNumConnections(model->getNumConnections());
         connect(model, SIGNAL(numConnectionsChanged(int)), this, SLOT(setNumConnections(int)));
 
-        setNumBlocks(model->getNumBlocks());
-        connect(model, SIGNAL(numBlocksChanged(int)), this, SLOT(setNumBlocks(int)));
+        setNumBlocks(model->getNumBlocks(), false);
+        connect(model, SIGNAL(numBlocksChanged(int, const bool&)), this, SLOT(setNumBlocks(int, const bool&)));
 
         setMasternodeCount(model->getMasternodeCountString());
         connect(model, SIGNAL(strMasternodesChanged(QString)), this, SLOT(setMasternodeCount(QString)));
@@ -673,12 +673,14 @@ void RPCConsole::setNumConnections(int count)
     ui->numberOfConnections->setText(connections);
 }
 
-void RPCConsole::setNumBlocks(int count)
+void RPCConsole::setNumBlocks(int count, const bool& fHeader)
 {
-    ui->numberOfBlocks->setText(QString::number(count));
-    if (clientModel) {
-        ui->lastBlockTime->setText(clientModel->getLastBlockDate().toString());
-        ui->lastBlockHash->setText(clientModel->getLastBlockHash());
+    if (!fHeader) {
+        ui->numberOfBlocks->setText(QString::number(count));
+        if (clientModel) {
+            ui->lastBlockTime->setText(clientModel->getLastBlockDate().toString());
+            ui->lastBlockHash->setText(clientModel->getLastBlockHash());
+        }
     }
 }
 

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -87,7 +87,7 @@ public Q_SLOTS:
     /** Set number of connections shown in the UI */
     void setNumConnections(int count);
     /** Set number of blocks shown in the UI */
-    void setNumBlocks(int count);
+    void setNumBlocks(int count, const bool& fHeader);
     /** Set number of masternodes shown in the UI */
     void setMasternodeCount(const QString& strMasternodes);
     /** Go forward or back in history */

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -175,8 +175,22 @@ bool WalletModel::isWalletLocked() const {
     return getEncryptionStatus() == Locked;
 }
 
+bool IsImportingOrReindexing() {
+    return fImporting || fReindex;
+}
+
 void WalletModel::pollBalanceChanged()
 {
+
+    // Wait a little bit more when the wallet is reindexing and/or importing, no need to lock cs_main so often.
+    if (IsImportingOrReindexing()) {
+        static uint8_t waitLonger = 0;
+        waitLonger++;
+        if (waitLonger < 10) // 10 seconds
+            return;
+        waitLonger = 0;
+    }
+
     // Get required locks upfront. This avoids the GUI from getting stuck on
     // periodical polls if the core is holding the locks for a longer time -
     // for example, during a wallet rescan.
@@ -187,11 +201,12 @@ void WalletModel::pollBalanceChanged()
     if (!lockWallet)
         return;
 
-    if (fForceCheckBalanceChanged || chainActive.Height() != cachedNumBlocks || cachedTxLocks != nCompleteTXLocks) {
+    int chainHeight = chainActive.Height();
+    if (fForceCheckBalanceChanged || chainHeight != cachedNumBlocks) {
         fForceCheckBalanceChanged = false;
 
         // Balance and number of transactions might have changed
-        cachedNumBlocks = chainActive.Height();
+        cachedNumBlocks = chainHeight;
 
         checkBalanceChanged();
         if (transactionTableModel) {

--- a/src/test/test_pivx.cpp
+++ b/src/test/test_pivx.cpp
@@ -55,6 +55,11 @@ TestingSetup::TestingSetup()
         pcoinsdbview = new CCoinsViewDB(1 << 23, true);
         pcoinsTip = new CCoinsViewCache(pcoinsdbview);
         InitBlockIndex();
+        {
+            CValidationState state;
+            bool ok = ActivateBestChain(state);
+            BOOST_CHECK(ok);
+        }
 #ifdef ENABLE_WALLET
         bool fFirstRun;
         pwalletMain = new CWallet("wallet.dat");


### PR DESCRIPTION
This is on top of #1333 and #1332 . (First three commits).

Several changes:

* Make reindex/import use AcceptBlock rather than ProcessNewBlock, so activation of the resulting best chain is delayed.
* That delayed activation is handled by the existing "Activating best chain" step in the startup process, which is moved to ThreadImport.
* Optimize ActivateBestChain to not walk the entire chain to find the most work chain to connect for each block (O(n^2) -> O(n)).

More information in upstream@[7917](https://github.com/bitcoin/bitcoin/pull/7917).

----------------------

Current issues: seems that the reindex process starts the sync all over once it's completed.