### PR TITLE
[Bug] nStakeSplitThreshold: division by zero

### DIFF
--- a/src/stakeinput.cpp
+++ b/src/stakeinput.cpp
@@ -68,15 +68,17 @@ bool CPivStake::CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmoun
     vout.emplace_back(CTxOut(0, scriptPubKey));
 
     // Calculate if we need to split the output
-    int nSplit = nTotal / (static_cast<CAmount>(pwallet->nStakeSplitThreshold * COIN));
-    if (nSplit > 1) {
-        // if nTotal is twice or more of the threshold; create more outputs
-        int txSizeMax = MAX_STANDARD_TX_SIZE >> 11; // limit splits to <10% of the max TX size (/2048)
-        if (nSplit > txSizeMax)
-            nSplit = txSizeMax;
-        for (int i = nSplit; i > 1; i--) {
-            LogPrintf("%s: StakeSplit: nTotal = %d; adding output %d of %d\n", __func__, nTotal, (nSplit-i)+2, nSplit);
-            vout.emplace_back(CTxOut(0, scriptPubKey));
+    if (pwallet->nStakeSplitThreshold > 0) {
+        int nSplit = nTotal / (static_cast<CAmount>(pwallet->nStakeSplitThreshold * COIN));
+        if (nSplit > 1) {
+            // if nTotal is twice or more of the threshold; create more outputs
+            int txSizeMax = MAX_STANDARD_TX_SIZE >> 11; // limit splits to <10% of the max TX size (/2048)
+            if (nSplit > txSizeMax)
+                nSplit = txSizeMax;
+            for (int i = nSplit; i > 1; i--) {
+                LogPrintf("%s: StakeSplit: nTotal = %d; adding output %d of %d\n", __func__, nTotal, (nSplit-i)+2, nSplit);
+                vout.emplace_back(CTxOut(0, scriptPubKey));
+            }
         }
     }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2799,7 +2799,7 @@ UniValue setstakesplitthreshold(const UniValue& params, bool fHelp)
             HelpRequiringPassphrase() + "\n"
 
             "\nArguments:\n"
-            "1. value   (numeric, required) Threshold value between 1 and 999999\n"
+            "1. value   (numeric, required) Threshold value between 1 and 999999 or 0 to disable stake-splitting\n"
 
             "\nResult:\n"
             "{\n"
@@ -2813,6 +2813,9 @@ UniValue setstakesplitthreshold(const UniValue& params, bool fHelp)
     EnsureWalletIsUnlocked();
 
     uint64_t nStakeSplitThreshold = params[0].get_int();
+
+    if (nStakeSplitThreshold < 0)
+        throw std::runtime_error("Value out of range, min allowed is 0");
 
     if (nStakeSplitThreshold > 999999)
         throw std::runtime_error("Value out of range, max allowed is 999999");


### PR DESCRIPTION
RPC should accept only values between 1 and 999999 (as per `setstakesplitthreshold` help) but the input provided was only checked against the upper bound.
Setting a 0 value would result in a crash (division-by-zero) at the first stake.

Now prevent the wallet from splitting the stake if the threshold is set to zero.


Future work:
There is no reason why the split threshold should be an integer. 
Make it `CAmount` and enable decimal values for it.
Also use `JSONRPCError(RPC_INVALID_PARAMETER)` instead of runtime errors when the input is not valid.