### PR TITLE
[Wallet][RPC][GUI] nStakeSplitThreshold as CAmount

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -39,6 +39,9 @@ Automatic zPIV backup has been disabled. Thus, the following configuration optio
 - `backupzpiv`
 - `zpivbackuppath`
 
+### Stake-Split threshold
+The stake split threshold is no longer required to be integer. It can be a fractional amount. A threshold value of 0 disables the stake-split functionality.
+
 
 
 RPC Changes
@@ -60,6 +63,8 @@ RPC Changes
  - `spendzerocoin`
 
  Mints are disabled, therefore it is no longer possible to mint the change of a zerocoin spend. The change is minimized by default.
+
+- `setstakesplitthreshold` now accepts decimal amounts. If the provided value is `0`, split staking gets disabled. `getstakesplitthreshold` returns a double.
 
 ### Removed commands
 

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -69,7 +69,7 @@ public:
     /** Updates current unit in memory, settings and emits displayUnitChanged(newUnit) signal */
     void setDisplayUnit(const QVariant& value);
     /* Update StakeSplitThreshold's value in wallet */
-    void setStakeSplitThreshold(int value);
+    void setStakeSplitThreshold(const CAmount value);
 
     /* Explicit getters */
     bool getMinimizeToTray() { return fMinimizeToTray; }

--- a/src/qt/pivx/res/css/style_dark.css
+++ b/src/qt/pivx/res/css/style_dark.css
@@ -2044,7 +2044,7 @@ HH       SPIN BOX
 HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH*/
 
 
-QSpinBox[cssClass="btn-spin-box"] {
+QSpinBox[cssClass="btn-spin-box"], QDoubleSpinBox[cssClass="btn-spin-box"] {
     background-color:#0f0b16;
     padding:10px 20px 10px 10px;
     font-size:16px;
@@ -2055,7 +2055,7 @@ QSpinBox[cssClass="btn-spin-box"] {
 }
 
 
-QSpinBox[cssClass="btn-spin-box"]::up-button {
+QSpinBox[cssClass="btn-spin-box"]::up-button, QDoubleSpinBox[cssClass="btn-spin-box"]::up-button {
     image: url("://ic-arrow-drop-up-purple");
     subcontrol-position: top right; width: 20px; height: 20px;
     border: 0px;
@@ -2063,7 +2063,7 @@ QSpinBox[cssClass="btn-spin-box"]::up-button {
     margin:0px 5px 0px 0px;
 }
 
-QSpinBox[cssClass="btn-spin-box"]::down-button {
+QSpinBox[cssClass="btn-spin-box"]::down-button, QDoubleSpinBox[cssClass="btn-spin-box"]::down-button {
     image: url("://ic-arrow-drop-down-purple");
     subcontrol-position: bottom right; width: 20px; height: 20px;
     border: 0px;

--- a/src/qt/pivx/res/css/style_light.css
+++ b/src/qt/pivx/res/css/style_light.css
@@ -2046,7 +2046,7 @@ HH       SPIN BOX
 HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH*/
 
 
-QSpinBox[cssClass="btn-spin-box"] {
+QSpinBox[cssClass="btn-spin-box"], QDoubleSpinBox[cssClass="btn-spin-box"] {
     background-color:#FFFFFF;
     padding:10px 20px 10px 10px;
     font-size:16px;
@@ -2057,7 +2057,7 @@ QSpinBox[cssClass="btn-spin-box"] {
 }
 
 
-QSpinBox[cssClass="btn-spin-box"]::up-button {
+QSpinBox[cssClass="btn-spin-box"]::up-button, QDoubleSpinBox[cssClass="btn-spin-box"]::up-button {
     image: url("://ic-arrow-drop-up-purple");
     subcontrol-position: top right; width: 20px; height: 20px;
     border: 0px;
@@ -2065,7 +2065,7 @@ QSpinBox[cssClass="btn-spin-box"]::up-button {
     margin:0px 5px 0px 0px;
 }
 
-QSpinBox[cssClass="btn-spin-box"]::down-button {
+QSpinBox[cssClass="btn-spin-box"]::down-button, QDoubleSpinBox[cssClass="btn-spin-box"]::down-button {
     image: url("://ic-arrow-drop-down-purple");
     subcontrol-position: bottom right; width: 20px; height: 20px;
     border: 0px;

--- a/src/qt/pivx/settings/forms/settingswalletoptionswidget.ui
+++ b/src/qt/pivx/settings/forms/settingswalletoptionswidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>511</width>
+    <width>518</width>
     <height>654</height>
    </rect>
   </property>
@@ -122,7 +122,10 @@
            </spacer>
           </item>
           <item>
-           <widget class="QSpinBox" name="spinBoxStakeSplitThreshold">
+           <widget class="QDoubleSpinBox" name="spinBoxStakeSplitThreshold">
+            <property name="decimals">
+             <number>3</number>
+            </property>
             <property name="minimum">
              <number>1</number>
             </property>

--- a/src/stakeinput.cpp
+++ b/src/stakeinput.cpp
@@ -69,7 +69,7 @@ bool CPivStake::CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmoun
 
     // Calculate if we need to split the output
     if (pwallet->nStakeSplitThreshold > 0) {
-        int nSplit = nTotal / (static_cast<CAmount>(pwallet->nStakeSplitThreshold * COIN));
+        int nSplit = static_cast<int>(nTotal / pwallet->nStakeSplitThreshold);
         if (nSplit > 1) {
             // if nTotal is twice or more of the threshold; create more outputs
             int txSizeMax = MAX_STANDARD_TX_SIZE >> 11; // limit splits to <10% of the max TX size (/2048)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2789,36 +2789,34 @@ UniValue reservebalance(const UniValue& params, bool fHelp)
     return result;
 }
 
-// presstab HyperStake
 UniValue setstakesplitthreshold(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 1)
         throw std::runtime_error(
-            "setstakesplitthreshold value\n"
-            "\nThis will set the output size of your stakes to never be below this number\n" +
-            HelpRequiringPassphrase() + "\n"
+            "setstakesplitthreshold value\n\n"
+            "This will set the stake-split threshold value.\n"
+            "Whenever a successful stake is found, the stake amount is split across as many outputs (each with a value\n"
+            "higher than the threshold) as possible.\n"
+            "E.g. If the coinstake input + the block reward is 2000, and the split threshold is 499, the corresponding\n"
+            "coinstake transaction will have 4 outputs (of 500 PIV each)."
+            + HelpRequiringPassphrase() + "\n"
 
             "\nArguments:\n"
-            "1. value   (numeric, required) Threshold value between 1 and 999999 or 0 to disable stake-splitting\n"
+            "1. value                   (numeric, required) Threshold value (in PIV).\n"
+            "                                               Set to 0 to disable stake-splitting\n"
 
             "\nResult:\n"
             "{\n"
-            "  \"threshold\": n,    (numeric) Threshold value set\n"
+            "  \"threshold\": n,        (numeric) Threshold value set\n"
             "  \"saved\": true|false    (boolean) 'true' if successfully saved to the wallet file\n"
             "}\n"
 
             "\nExamples:\n" +
-            HelpExampleCli("setstakesplitthreshold", "5000") + HelpExampleRpc("setstakesplitthreshold", "5000"));
+            HelpExampleCli("setstakesplitthreshold", "500.12") + HelpExampleRpc("setstakesplitthreshold", "500.12"));
 
     EnsureWalletIsUnlocked();
 
-    uint64_t nStakeSplitThreshold = params[0].get_int();
-
-    if (nStakeSplitThreshold < 0)
-        throw std::runtime_error("Value out of range, min allowed is 0");
-
-    if (nStakeSplitThreshold > 999999)
-        throw std::runtime_error("Value out of range, max allowed is 999999");
+    CAmount nStakeSplitThreshold = AmountFromValue(params[0]);
 
     CWalletDB walletdb(pwalletMain->strWalletFile);
     LOCK(pwalletMain->cs_wallet);
@@ -2827,7 +2825,7 @@ UniValue setstakesplitthreshold(const UniValue& params, bool fHelp)
 
         UniValue result(UniValue::VOBJ);
         pwalletMain->nStakeSplitThreshold = nStakeSplitThreshold;
-        result.push_back(Pair("threshold", int(pwalletMain->nStakeSplitThreshold)));
+        result.push_back(Pair("threshold", ValueFromAmount(pwalletMain->nStakeSplitThreshold)));
         if (fFileBacked) {
             walletdb.WriteStakeSplitThreshold(nStakeSplitThreshold);
             result.push_back(Pair("saved", "true"));
@@ -2838,7 +2836,6 @@ UniValue setstakesplitthreshold(const UniValue& params, bool fHelp)
     }
 }
 
-// presstab HyperStake
 UniValue getstakesplitthreshold(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
@@ -2852,7 +2849,7 @@ UniValue getstakesplitthreshold(const UniValue& params, bool fHelp)
             "\nExamples:\n" +
             HelpExampleCli("getstakesplitthreshold", "") + HelpExampleRpc("getstakesplitthreshold", ""));
 
-    return int(pwalletMain->nStakeSplitThreshold);
+    return ValueFromAmount(pwalletMain->nStakeSplitThreshold);
 }
 
 UniValue autocombinerewards(const UniValue& params, bool fHelp)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3804,7 +3804,7 @@ void CWallet::SetNull()
         pStakerStatus = new CStakerStatus();
     }
     // Stake split threshold
-    nStakeSplitThreshold = STAKE_SPLIT_THRESHOLD;
+    nStakeSplitThreshold = DEFAULT_STAKE_SPLIT_THRESHOLD;
 
     //MultiSend
     vMultiSend.clear();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -202,7 +202,7 @@ private:
 
 public:
 
-    static const int STAKE_SPLIT_THRESHOLD = 2000;
+    static const CAmount DEFAULT_STAKE_SPLIT_THRESHOLD = 2000 * COIN;
 
     bool StakeableCoins(std::vector<COutput>* pCoins = nullptr);
     bool IsCollateralAmount(CAmount nInputAmount) const;
@@ -228,7 +228,7 @@ public:
     unsigned int nMasterKeyMaxID;
 
     // Stake split threshold
-    uint64_t nStakeSplitThreshold;
+    CAmount nStakeSplitThreshold;
     // Staker status (last hashed block and time)
     CStakerStatus* pStakerStatus = nullptr;
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -159,8 +159,7 @@ bool CWalletDB::WriteOrderPosNext(int64_t nOrderPosNext)
     return Write(std::string("orderposnext"), nOrderPosNext);
 }
 
-// presstab HyperStake
-bool CWalletDB::WriteStakeSplitThreshold(uint64_t nStakeSplitThreshold)
+bool CWalletDB::WriteStakeSplitThreshold(CAmount nStakeSplitThreshold)
 {
     nWalletDBUpdated++;
     return Write(std::string("stakeSplitThreshold"), nStakeSplitThreshold);
@@ -619,9 +618,11 @@ bool ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue, CW
             }
         } else if (strType == "orderposnext") {
             ssValue >> pwallet->nOrderPosNext;
-        } else if (strType == "stakeSplitThreshold") //presstab HyperStake
-        {
+        } else if (strType == "stakeSplitThreshold") {
             ssValue >> pwallet->nStakeSplitThreshold;
+            // originally saved as integer
+            if (pwallet->nStakeSplitThreshold < COIN)
+                pwallet->nStakeSplitThreshold *= COIN;
         } else if (strType == "multisend") //presstab HyperStake
         {
             unsigned int i;

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -115,8 +115,7 @@ public:
 
     bool WriteOrderPosNext(int64_t nOrderPosNext);
 
-    // presstab
-    bool WriteStakeSplitThreshold(uint64_t nStakeSplitThreshold);
+    bool WriteStakeSplitThreshold(CAmount nStakeSplitThreshold);
     bool WriteMultiSend(std::vector<std::pair<std::string, int> > vMultiSend);
     bool EraseMultiSend(std::vector<std::pair<std::string, int> > vMultiSend);
     bool WriteMSettings(bool fMultiSendStake, bool fMultiSendMasternode, int nLastMultiSendHeight);


### PR DESCRIPTION
Follow-up on #1343 
- Wallet: save/use nStakeSplitThreshold as CAmount
- RPC: setstakesplitthreshold takes decimal values
- RPC: getstakesplitthreshold returns a double
- GUI: widget in settingsoptions changed to QDoubleSpinBox
- GUI: QSetting saved as double.