### PR TITLE
[Wallet][GUI] Set default stake-split threshold to 500

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -41,6 +41,7 @@ Automatic zPIV backup has been disabled. Thus, the following configuration optio
 
 ### Stake-Split threshold
 The stake split threshold is no longer required to be integer. It can be a fractional amount. A threshold value of 0 disables the stake-split functionality.
+The default value for the stake-split threshold has been lowered from 2000 PIV, down  to 500 PIV.
 
 
 Dependencies

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -123,9 +123,6 @@ void OptionsModel::setWalletDefaultOptions(QSettings& settings, bool reset){
     if (!SoftSetBoolArg("-spendzeroconfchange", settings.value("bSpendZeroConfChange").toBool()))
         addOverriddenOption("-spendzeroconfchange");
 
-    if (!settings.contains("nStakeSplitThreshold") || reset)
-        settings.setValue("nStakeSplitThreshold", static_cast<qlonglong>(CWallet::DEFAULT_STAKE_SPLIT_THRESHOLD));
-
     if (reset){
         setStakeSplitThreshold(CWallet::DEFAULT_STAKE_SPLIT_THRESHOLD);
         refreshDataView();
@@ -255,15 +252,14 @@ QVariant OptionsModel::data(const QModelIndex& index, int role) const
             return settings.value("bSpendZeroConfChange");
         case ShowMasternodesTab:
             return settings.value("fShowMasternodesTab");
-#endif
         case StakeSplitThreshold:
+        {
             // Return CAmount/qlonglong as double
-            if (pwalletMain) {
-                return QVariant(static_cast<double>(pwalletMain->nStakeSplitThreshold) / static_cast<double>(COIN));
-            }
-            return QVariant(static_cast<double>(settings.value("nStakeSplitThreshold").toLongLong()) / static_cast<double>(COIN));
+            const CAmount nStakeSplitThreshold = (pwalletMain) ? pwalletMain->nStakeSplitThreshold : CWallet::DEFAULT_STAKE_SPLIT_THRESHOLD;
+            return QVariant(static_cast<double>(nStakeSplitThreshold / static_cast<double>(COIN)));
+        }
+#endif
         case DisplayUnit:
-
             return nDisplayUnit;
         case ThirdPartyTxUrls:
             return strThirdPartyTxUrls;
@@ -362,7 +358,6 @@ bool OptionsModel::setData(const QModelIndex& index, const QVariant& value, int 
 #endif
         case StakeSplitThreshold:
             // Write double as qlonglong/CAmount
-            settings.setValue("nStakeSplitThreshold", static_cast<qlonglong>(value.toDouble() * COIN));
             setStakeSplitThreshold(static_cast<CAmount>(value.toDouble() * COIN));
             break;
         case DisplayUnit:

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -202,7 +202,7 @@ private:
 
 public:
 
-    static const CAmount DEFAULT_STAKE_SPLIT_THRESHOLD = 2000 * COIN;
+    static const CAmount DEFAULT_STAKE_SPLIT_THRESHOLD = 500 * COIN;
 
     bool StakeableCoins(std::vector<COutput>* pCoins = nullptr);
     bool IsCollateralAmount(CAmount nInputAmount) const;


### PR DESCRIPTION
- Lower default value of stake-split threshold
- Do not save it directly in QSettings (just in the wallet db).

Built on #1345 
Closes #1350 