### PR TITLE
[Chain][Bug] Fix mapZerocoinSupply recalculation

### DIFF
--- a/src/consensus/zerocoin_verify.cpp
+++ b/src/consensus/zerocoin_verify.cpp
@@ -297,31 +297,24 @@ bool RecalculatePIVSupply(int nHeightStart)
 
 bool UpdateZPIVSupply(const CBlock& block, CBlockIndex* pindex, bool fJustCheck)
 {
-    std::list<CZerocoinMint> listMints;
-    bool fFilterInvalid = pindex->nHeight >= Params().GetConsensus().height_ZC_RecalcAccumulators;
-    BlockToZerocoinMintList(block, listMints, fFilterInvalid);
-    std::list<libzerocoin::CoinDenomination> listSpends = ZerocoinSpendListFromBlock(block, fFilterInvalid);
+    const Consensus::Params& consensus = Params().GetConsensus();
+    if (pindex->nHeight < consensus.height_start_ZC)
+        return true;
 
-    // Initialize zerocoin supply to the supply from previous block
-    if (pindex->pprev && pindex->pprev->GetBlockHeader().nVersion > 3) {
-        for (auto& denom : libzerocoin::zerocoinDenomList) {
-            pindex->mapZerocoinSupply.at(denom) = pindex->pprev->GetZcMints(denom);
-        }
-    }
+    //Reset the supply to previous block
+    pindex->mapZerocoinSupply = pindex->pprev->mapZerocoinSupply;
 
-    // Track zerocoin money supply
-    CAmount nAmountZerocoinSpent = 0;
-    if (pindex->pprev) {
+    //Add mints to zPIV supply (mints are forever disabled after last checkpoint)
+    if (pindex->nHeight < consensus.height_last_ZC_AccumCheckpoint) {
+        std::list<CZerocoinMint> listMints;
         std::set<uint256> setAddedToWallet;
-        for (auto& m : listMints) {
-            libzerocoin::CoinDenomination denom = m.GetDenomination();
-            pindex->mapZerocoinSupply.at(denom)++;
-
+        BlockToZerocoinMintList(block, listMints, true);
+        for (const auto& m : listMints) {
+            pindex->mapZerocoinSupply.at(m.GetDenomination())++;
             //Remove any of our own mints from the mintpool
             if (!fJustCheck && pwalletMain) {
                 if (pwalletMain->IsMyMint(m.GetValue())) {
                     pwalletMain->UpdateMint(m.GetValue(), pindex->nHeight, m.GetTxHash(), m.GetDenomination());
-
                     // Add the transaction to the wallet
                     for (auto& tx : block.vtx) {
                         uint256 txid = tx.GetHash();
@@ -338,29 +331,28 @@ bool UpdateZPIVSupply(const CBlock& block, CBlockIndex* pindex, bool fJustCheck)
                 }
             }
         }
-
-        for (auto& denom : listSpends) {
-            pindex->mapZerocoinSupply.at(denom)--;
-            nAmountZerocoinSpent += libzerocoin::ZerocoinDenominationToAmount(denom);
-
-            // zerocoin failsafe
-            if (pindex->GetZcMints(denom) < 0)
-                return error("Block contains zerocoins that spend more than are in the available supply to spend");
-        }
     }
 
-    for (auto& denom : libzerocoin::zerocoinDenomList)
-        LogPrint("zero", "%s coins for denomination %d pubcoin %s\n", __func__, denom, pindex->mapZerocoinSupply.at(denom));
+    //Remove spends from zPIV supply
+    std::list<libzerocoin::CoinDenomination> listDenomsSpent = ZerocoinSpendListFromBlock(block, true);
+    for (const auto& denom : listDenomsSpent) {
+        pindex->mapZerocoinSupply.at(denom)--;
+        // zerocoin failsafe
+        if (pindex->mapZerocoinSupply.at(denom) < 0)
+            return error("Block contains zerocoins that spend more than are in the available supply to spend");
+    }
 
     // Update Wrapped Serials amount
     // A one-time event where only the zPIV supply was off (due to serial duplication off-chain on main net)
-    const Consensus::Params& consensus = Params().GetConsensus();
     if (Params().NetworkID() == CBaseChainParams::MAIN && pindex->nHeight == consensus.height_last_ZC_WrappedSerials + 1
             && pindex->GetZerocoinSupply() < consensus.ZC_WrappedSerialsSupply + GetWrapppedSerialInflationAmount()) {
-        for (auto denom : libzerocoin::zerocoinDenomList) {
+        for (const auto& denom : libzerocoin::zerocoinDenomList)
             pindex->mapZerocoinSupply.at(denom) += GetWrapppedSerialInflation(denom);
-        }
     }
+
+    for (const auto& denom : libzerocoin::zerocoinDenomList)
+        LogPrint("zero", "%s coins for denomination %d pubcoin %s\n", __func__, denom, pindex->mapZerocoinSupply.at(denom));
+
     return true;
 }
 

--- a/src/consensus/zerocoin_verify.h
+++ b/src/consensus/zerocoin_verify.h
@@ -21,7 +21,7 @@ bool CheckPublicCoinSpendVersion(int version);
 bool ContextualCheckZerocoinSpend(const CTransaction& tx, const libzerocoin::CoinSpend* spend, int nHeight, const uint256& hashBlock);
 bool ContextualCheckZerocoinSpendNoSerialCheck(const CTransaction& tx, const libzerocoin::CoinSpend* spend, int nHeight, const uint256& hashBlock);
 void AddWrappedSerialsInflation();
-bool RecalculatePIVSupply(int nHeightStart);
+bool RecalculatePIVSupply(int nHeightStart, bool fSkipZpiv = true);
 bool UpdateZPIVSupply(const CBlock& block, CBlockIndex* pindex, bool fJustCheck);
 CAmount GetInvalidUTXOValue();
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1548,9 +1548,8 @@ bool AppInit2()
                 // Recalculate money supply for blocks that are impacted by accounting issue after zerocoin activation
                 if (GetBoolArg("-reindexmoneysupply", false) || reindexZerocoin) {
                     // Recalculate from the zerocoin activation or from scratch.
-                    RecalculatePIVSupply(reindexZerocoin ? consensus.height_start_ZC : 1);
+                    RecalculatePIVSupply((reindexZerocoin ? consensus.height_start_ZC : 1), false);
                 }
-
 
                 if (!fReindex) {
                     uiInterface.InitMessage(_("Verifying blocks..."));


### PR DESCRIPTION
df932b8ff85c1e668f5fea7169b0e6256b864546 introduced a bug preventing resync on mainnet due to zerocoin supply recalculation missing.
ZPIV supply recalculation shouldn't be needed in the first place, if the client is syncing from scratch and correctly filtering invalid mints.
So, instead of restoring `RecalculateZPIVMinted`/`RecalculateZPIVSpent`, this PR does 2 things:

- fixes `UpdateZPIVSupply` filtering the invalid mints/spends since the start of zerocoin (not only after `Zerocoin_Block_RecalculateAccumulators`). So, syncing from scratch doesn not trigger any recalculation at the next startup.

- inserts a call to `UpdateZPIVSupply` directly in `RecalculatePIVSupply`, to be used during init, e.g. by those clients updating from old versions (with wrong supply in the index), or when using `-reindexmoneysupply`.
This removes the additional I/O operations that were originally required with `RecalculateZPIVMinted` and `RecalculateZPIVSpent` (as blocks are already read inside `RecalculatePIVSupply`, and the relative indexes also already updated there).