### PR TITLE
[WIP][GUI] Include MN Rewards in the dashboard chart.

### DIFF
--- a/src/qt/pivx/coldstakingwidget.cpp
+++ b/src/qt/pivx/coldstakingwidget.cpp
@@ -222,7 +222,7 @@ void ColdStakingWidget::loadWalletModel(){
 
 }
 
-void ColdStakingWidget::onTxArrived(const QString& hash, const bool& isCoinStake, const bool& isCSAnyType) {
+void ColdStakingWidget::onTxArrived(const QString& hash, const bool& isCoinStake, const bool& isMNReward, const bool& isCSAnyType) {
     if (isCSAnyType) {
         tryRefreshDelegations();
     }

--- a/src/qt/pivx/coldstakingwidget.h
+++ b/src/qt/pivx/coldstakingwidget.h
@@ -67,7 +67,7 @@ private Q_SLOTS:
     void onCopyOwnerClicked();
     void onAddressCopyClicked();
     void onAddressEditClicked();
-    void onTxArrived(const QString& hash, const bool& isCoinStake, const bool& isCSAnyType);
+    void onTxArrived(const QString& hash, const bool& isCoinStake, const bool& isMNReward, const bool& isCSAnyType);
     void onContactsClicked(bool ownerAdd);
     void clearAll();
     void onLabelClicked();

--- a/src/qt/pivx/dashboardwidget.cpp
+++ b/src/qt/pivx/dashboardwidget.cpp
@@ -230,7 +230,7 @@ void DashboardWidget::loadWalletModel(){
         stakesFilter->setSortCaseSensitivity(Qt::CaseInsensitive);
         stakesFilter->setFilterCaseSensitivity(Qt::CaseInsensitive);
         stakesFilter->setSortRole(Qt::EditRole);
-        stakesFilter->setOnlyStakes(true);
+        stakesFilter->setOnlyStakes(true, true);
         stakesFilter->setSourceModel(txModel);
         stakesFilter->sort(TransactionTableModel::Date, Qt::AscendingOrder);
         hasStakes = stakesFilter->rowCount() > 0;

--- a/src/qt/pivx/dashboardwidget.h
+++ b/src/qt/pivx/dashboardwidget.h
@@ -122,7 +122,7 @@ private Q_SLOTS:
     void onSortTypeChanged(const QString& value);
     void updateDisplayUnit();
     void showList();
-    void onTxArrived(const QString& hash, const bool& isCoinStake, const bool& isCSAnyType);
+    void onTxArrived(const QString& hash, const bool& isCoinStake, const bool& isMNReward, const bool& isCSAnyType);
 
 #ifdef USE_QTCHARTS
     void windowResizeEvent(QResizeEvent *event);
@@ -177,7 +177,7 @@ private:
     bool loadChartData(bool withMonthNames);
     void updateAxisX(const QStringList *arg = nullptr);
     void setChartShow(ChartShowType type);
-    std::pair<int, int> getChartRange(QMap<int, std::pair<qint64, qint64>> amountsBy);
+    std::pair<int, int> getChartRange(const QMap<int, std::pair<qint64, qint64>>& amountsBy);
 
 private Q_SLOTS:
     void onChartRefreshed();

--- a/src/qt/pivx/forms/dashboardwidget.ui
+++ b/src/qt/pivx/forms/dashboardwidget.ui
@@ -655,7 +655,7 @@
                 <item>
                  <widget class="QLabel" name="labelChart">
                   <property name="text">
-                   <string>Staking statistics</string>
+                   <string>Rewards statistics</string>
                   </property>
                  </widget>
                 </item>
@@ -694,7 +694,7 @@
                 <item>
                  <widget class="QLabel" name="labelPiv">
                   <property name="text">
-                   <string>PIV</string>
+                   <string>Stakes</string>
                   </property>
                  </widget>
                 </item>
@@ -736,7 +736,7 @@
                 <item>
                  <widget class="QLabel" name="labelZpiv">
                   <property name="text">
-                   <string>zPIV</string>
+                   <string>MN Rewards</string>
                   </property>
                  </widget>
                 </item>

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -63,7 +63,7 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex& 
     if (fOnlyZc && !isZcTx(type)){
         return false;
     }
-    if (fOnlyStakes && !isStakeTx(type))
+    if ((fOnlyStakes && !isStakeTx(type)) && (fShowOwnColdStakes && !isColdStakeMine(type)))
         return false;
 
     if (fOnlyColdStaking && !isColdStake(type))
@@ -128,9 +128,10 @@ void TransactionFilterProxy::setShowZcTxes(bool fOnlyZc)
     invalidateFilter();
 }
 
-void TransactionFilterProxy::setOnlyStakes(bool fOnlyStakes)
+void TransactionFilterProxy::setOnlyStakes(bool fOnlyStakes, bool fShowColdStakes)
 {
     this->fOnlyStakes = fOnlyStakes;
+    this->fShowOwnColdStakes = fShowColdStakes;
     invalidateFilter();
 }
 
@@ -162,11 +163,15 @@ bool TransactionFilterProxy::isZcTx(int type) const {
 }
 
 bool TransactionFilterProxy::isStakeTx(int type) const {
-    return (type == TransactionRecord::StakeMint || type == TransactionRecord::Generated || type == TransactionRecord::StakeZPIV);
+    return type == TransactionRecord::StakeMint || type == TransactionRecord::Generated || type == TransactionRecord::StakeZPIV;
+}
+
+bool TransactionFilterProxy::isColdStakeMine(int type) const {
+    return type == TransactionRecord::StakeDelegated;
 }
 
 bool TransactionFilterProxy::isColdStake(int type) const {
-    return (type == TransactionRecord::P2CSDelegation || type == TransactionRecord::P2CSDelegationSent || type == TransactionRecord::P2CSDelegationSentOwner || type == TransactionRecord::StakeDelegated || type == TransactionRecord::StakeHot);
+    return type == TransactionRecord::P2CSDelegation || type == TransactionRecord::P2CSDelegationSent || type == TransactionRecord::P2CSDelegationSentOwner || isColdStakeMine(type) || type == TransactionRecord::StakeHot;
 }
 
 /*QVariant TransactionFilterProxy::dataFromSourcePos(int sourceRow, int role) const {

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -63,7 +63,9 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex& 
     if (fOnlyZc && !isZcTx(type)){
         return false;
     }
-    if ((fOnlyStakes && !isStakeTx(type)) && (fShowOwnColdStakes && !isColdStakeMine(type)))
+    if ((fOnlyStakes && !isStakeTx(type)) &&
+        (fShowOwnColdStakes && !isColdStakeMine(type)) &&
+        (fIncludeMNReward && !(type == TransactionRecord::MNReward) ))
         return false;
 
     if (fOnlyColdStaking && !isColdStake(type))
@@ -128,10 +130,12 @@ void TransactionFilterProxy::setShowZcTxes(bool fOnlyZc)
     invalidateFilter();
 }
 
-void TransactionFilterProxy::setOnlyStakes(bool fOnlyStakes, bool fShowColdStakes)
+void TransactionFilterProxy::setOnlyStakes(const bool& fOnlyStakes, const bool& fIncludeZPIV, const bool& fShowColdStakes, const bool& fIncludeMNReward)
 {
     this->fOnlyStakes = fOnlyStakes;
     this->fShowOwnColdStakes = fShowColdStakes;
+    this->fShowZpivStakes = fIncludeZPIV;
+    this->fIncludeMNReward = fIncludeMNReward;
     invalidateFilter();
 }
 
@@ -163,7 +167,7 @@ bool TransactionFilterProxy::isZcTx(int type) const {
 }
 
 bool TransactionFilterProxy::isStakeTx(int type) const {
-    return type == TransactionRecord::StakeMint || type == TransactionRecord::Generated || type == TransactionRecord::StakeZPIV;
+    return type == TransactionRecord::StakeMint || type == TransactionRecord::Generated || (fShowZpivStakes && type == TransactionRecord::StakeZPIV);
 }
 
 bool TransactionFilterProxy::isColdStakeMine(int type) const {

--- a/src/qt/transactionfilterproxy.h
+++ b/src/qt/transactionfilterproxy.h
@@ -63,7 +63,7 @@ public:
     void setShowZcTxes(bool fOnlyZc);
 
     /** Only stakes txes **/
-    void setOnlyStakes(bool fOnlyStakes);
+    void setOnlyStakes(bool fOnlyStakes, bool fShowColdStakes = false);
 
     /** Shows only p2cs-p2cs && xxx-p2cs **/
     void setOnlyColdStakes(bool fOnlyColdStakes);
@@ -88,11 +88,13 @@ private:
     bool fHideOrphans = true;
     bool fOnlyZc = false;
     bool fOnlyStakes = false;
+    bool fShowOwnColdStakes = false;
     bool fOnlyColdStaking = false;
 
     bool isZcTx(int type) const;
     bool isStakeTx(int type) const;
     bool isColdStake(int type) const;
+    bool isColdStakeMine(int type) const;
 };
 
 #endif // BITCOIN_QT_TRANSACTIONFILTERPROXY_H

--- a/src/qt/transactionfilterproxy.h
+++ b/src/qt/transactionfilterproxy.h
@@ -63,7 +63,7 @@ public:
     void setShowZcTxes(bool fOnlyZc);
 
     /** Only stakes txes **/
-    void setOnlyStakes(bool fOnlyStakes, bool fShowColdStakes = false);
+    void setOnlyStakes(const bool& fOnlyStakes, const bool& fIncludeZPIV = false, const bool& fShowColdStakes = false, const bool& fIncludeMNReward = false);
 
     /** Shows only p2cs-p2cs && xxx-p2cs **/
     void setOnlyColdStakes(bool fOnlyColdStakes);
@@ -89,6 +89,8 @@ private:
     bool fOnlyZc = false;
     bool fOnlyStakes = false;
     bool fShowOwnColdStakes = false;
+    bool fShowZpivStakes = true;
+    bool fIncludeMNReward = true;
     bool fOnlyColdStaking = false;
 
     bool isZcTx(int type) const;

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -538,6 +538,11 @@ bool TransactionRecord::isCoinStake() const
     return (type == TransactionRecord::StakeMint || type == TransactionRecord::Generated || type == TransactionRecord::StakeZPIV);
 }
 
+bool TransactionRecord::isMNReward() const
+{
+    return type == TransactionRecord::MNReward;
+}
+
 bool TransactionRecord::isAnyColdStakingType() const
 {
     return (type == TransactionRecord::P2CSDelegation || type == TransactionRecord::P2CSDelegationSent

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -173,6 +173,9 @@ public:
      */
     bool isCoinStake() const;
 
+    /** Return true if the tx is a MN reward */
+    bool isMNReward() const;
+
     /** Return true if the tx is a any cold staking type tx.
      */
     bool isAnyColdStakingType() const;

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -339,7 +339,7 @@ void TransactionTableModel::updateTransaction(const QString& hash, int status, b
     priv->updateWallet(updated, status, showTransaction, rec);
 
     if (!rec.isNull())
-        Q_EMIT txArrived(hash, rec.isCoinStake(), rec.isAnyColdStakingType());
+        Q_EMIT txArrived(hash, rec.isCoinStake(), rec.isMNReward(), rec.isAnyColdStakingType());
 }
 
 void TransactionTableModel::updateConfirmations()

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -80,7 +80,7 @@ public:
     bool processingQueuedTransactions() { return fProcessingQueuedTransactions; }
 
 Q_SIGNALS:
-    void txArrived(const QString& hash, const bool& isCoinStake, const bool& isCSAnyType);
+    void txArrived(const QString& hash, const bool& isCoinStake, const bool& isMNReward, const bool& isCSAnyType);
 
 private:
     CWallet* wallet;


### PR DESCRIPTION
Describing this work briefly: 
As we don't have zPIV staking anymore, this PR removes it from the dashboard chart and includes the Masternodes rewards instead.

It was coded on top of #1361 (first commit doesn't count and we need to merge that PR first).

TODO: 
Rename variable names from zpiv-something to MN instead in the dashboard file.