### PR TITLE
[Init] Fix locked coins - don't include non-existent or spent coins

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1901,7 +1901,9 @@ bool AppInit2()
             LogPrintf("  %s %s\n", mne.getTxHash(), mne.getOutputIndex());
             mnTxHash.SetHex(mne.getTxHash());
             COutPoint outpoint = COutPoint(mnTxHash, (unsigned int) std::stoul(mne.getOutputIndex().c_str()));
-            pwalletMain->LockCoin(outpoint);
+            // Add to Locked coins only if in the wallet and still unspent
+            if (pwalletMain->mapWallet.count(mnTxHash) && !pwalletMain->IsSpent(outpoint.hash, outpoint.n))
+                pwalletMain->LockCoin(outpoint);
         }
     }
 


### PR DESCRIPTION
During init, add to `setLockedCoins` only those masternode collateral outputs that reference unspent in-wallet txes.
This prevents possible issues with `GetLockedCoins` showing an incorrect locked balance (e.g. for stale records in "masternode.conf").