### PR TITLE
[Wallet] Remove reserve balance

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -77,6 +77,7 @@ RPC Changes
 The following commands have been removed from the RPC interface:
 - `createrawzerocoinstake`
 - `getmintsinblocks`
+- `reservebalance`
 
 
 ### Newly introduced commands
@@ -103,6 +104,8 @@ Detailed release notes follow. This overview includes changes that affect behavi
 ### RPC/REST
 
 ### Wallet
+
+The `-reservebalance` configuration/startup option has been removed ([PR #1373](https://github.com/PIVX-Project/PIVX/pull/1373)).
 
 ### Miscellaneous
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -918,13 +918,6 @@ bool AppInit2()
             LogPrintf("AppInit2 : parameter interaction: -enableswifttx=false -> setting -nSwiftTXDepth=0\n");
     }
 
-    if (mapArgs.count("-reservebalance")) {
-        if (!ParseMoney(mapArgs["-reservebalance"], nReserveBalance)) {
-            InitError(_("Invalid amount for -reservebalance=<amount>"));
-            return false;
-        }
-    }
-
     // Make sure enough file descriptors are available
     int nBind = std::max((int)mapArgs.count("-bind") + (int)mapArgs.count("-whitebind"), 1);
     nMaxConnections = GetArg("-maxconnections", 125);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -100,8 +100,6 @@ bool fAlerts = DEFAULT_ALERTS;
 /* If the tip is older than this (in seconds), the node is considered to be in initial block download. */
 int64_t nMaxTipAge = DEFAULT_MAX_TIP_AGE;
 
-int64_t nReserveBalance = 0;
-
 /** Fees smaller than this (in upiv) are considered zero fee (for relaying and mining)
  * We are ~100 times smaller then bitcoin now (2015-06-23), set minRelayTxFee only 10 times higher
  * so it's still 10 times lower comparing to bitcoin.

--- a/src/main.h
+++ b/src/main.h
@@ -150,8 +150,6 @@ extern bool fVerifyingBlocks;
 extern bool fLargeWorkForkFound;
 extern bool fLargeWorkInvalidChainFound;
 
-extern int64_t nReserveBalance;
-
 extern std::map<uint256, int64_t> mapRejectedBlocks;
 
 /** Best header we've seen so far (used for getheaders queries' starting points). */

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -130,8 +130,6 @@ static const CRPCConvertParam vRPCConvertParams[] =
         //{"startmasternode", 1},
         {"mnvoteraw", 1},
         {"mnvoteraw", 4},
-        {"reservebalance", 0},
-        {"reservebalance", 1},
         {"setstakesplitthreshold", 0},
         {"autocombinerewards", 0},
         {"autocombinerewards", 1},

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -325,7 +325,6 @@ static const CRPCCommand vRPCCommands[] =
         {"mining", "getnetworkhashps", &getnetworkhashps, true, false, false},
         {"mining", "prioritisetransaction", &prioritisetransaction, true, false, false},
         {"mining", "submitblock", &submitblock, true, true, false},
-        {"mining", "reservebalance", &reservebalance, true, true, false},
 
 #ifdef ENABLE_WALLET
         /* Coin generation */

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -256,7 +256,6 @@ extern UniValue encryptwallet(const UniValue& params, bool fHelp);
 extern UniValue getwalletinfo(const UniValue& params, bool fHelp);
 extern UniValue getblockchaininfo(const UniValue& params, bool fHelp);
 extern UniValue getnetworkinfo(const UniValue& params, bool fHelp);
-extern UniValue reservebalance(const UniValue& params, bool fHelp);
 extern UniValue setstakesplitthreshold(const UniValue& params, bool fHelp);
 extern UniValue getstakesplitthreshold(const UniValue& params, bool fHelp);
 extern UniValue multisend(const UniValue& params, bool fHelp);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2744,51 +2744,6 @@ UniValue getwalletinfo(const UniValue& params, bool fHelp)
     return obj;
 }
 
-// ppcoin: reserve balance from being staked for network protection
-UniValue reservebalance(const UniValue& params, bool fHelp)
-{
-    if (fHelp || params.size() > 2)
-        throw std::runtime_error(
-            "reservebalance ( reserve amount )\n"
-            "\nShow or set the reserve amount not participating in network protection\n"
-            "If no parameters provided current setting is printed.\n"
-
-            "\nArguments:\n"
-            "1. reserve     (boolean, optional) is true or false to turn balance reserve on or off.\n"
-            "2. amount      (numeric, optional) is a real and rounded to cent.\n"
-
-            "\nResult:\n"
-            "{\n"
-            "  \"reserve\": true|false,     (boolean) Status of the reserve balance\n"
-            "  \"amount\": x.xxxx       (numeric) Amount reserved\n"
-            "}\n"
-
-            "\nExamples:\n" +
-            HelpExampleCli("reservebalance", "true 5000") + HelpExampleRpc("reservebalance", "true 5000"));
-
-    if (params.size() > 0) {
-        bool fReserve = params[0].get_bool();
-        if (fReserve) {
-            if (params.size() == 1)
-                throw std::runtime_error("must provide amount to reserve balance.\n");
-            CAmount nAmount = AmountFromValue(params[1]);
-            nAmount = (nAmount / CENT) * CENT; // round to cent
-            if (nAmount < 0)
-                throw std::runtime_error("amount cannot be negative.\n");
-            nReserveBalance = nAmount;
-        } else {
-            if (params.size() > 1)
-                throw std::runtime_error("cannot specify amount to turn off reserve.\n");
-            nReserveBalance = 0;
-        }
-    }
-
-    UniValue result(UniValue::VOBJ);
-    result.push_back(Pair("reserve", (nReserveBalance > 0)));
-    result.push_back(Pair("amount", ValueFromAmount(nReserveBalance)));
-    return result;
-}
-
 UniValue setstakesplitthreshold(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 1)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2035,33 +2035,10 @@ bool less_then_denom(const COutput& out1, const COutput& out2)
 
 bool CWallet::StakeableCoins(std::vector<COutput>* pCoins)
 {
-    CAmount nBalance = GetStakingBalance(GetBoolArg("-coldstaking", true));
-
-    if (nBalance == 0) return false;
-    if (mapArgs.count("-reservebalance") && !ParseMoney(mapArgs["-reservebalance"], nReserveBalance))
-        return error("%s : invalid reserve balance amount", __func__);
-    if (nBalance <= nReserveBalance) return false;
-
     const bool fIncludeCold = (sporkManager.IsSporkActive(SPORK_17_COLDSTAKING_ENFORCEMENT) &&
                                GetBoolArg("-coldstaking", true));
 
-    if (!AvailableCoins(pCoins, true, nullptr, false, STAKEABLE_COINS,  false, 1, fIncludeCold, false))
-        return false;
-
-    if (!pCoins || nReserveBalance == 0)
-        // there is at least one stakeable utxo
-        return true;
-
-    CAmount nTargetAmount = nBalance - nReserveBalance;
-    CAmount nAmountSelected = 0;
-    // leave some utxo for reserve balance
-    for (const COutput &out : *pCoins) {
-        const CAmount& nAmountUtxo = out.tx->vout[out.i].nValue;
-        if (nAmountSelected + nAmountUtxo > nTargetAmount) continue;
-        nAmountSelected += out.tx->vout[out.i].nValue;
-    }
-
-    return (pCoins->size() > 0);
+    return AvailableCoins(pCoins, true, nullptr, false, STAKEABLE_COINS,  false, 1, fIncludeCold, false);
 }
 
 bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*, unsigned int> >& setCoinsRet, CAmount& nValueRet) const


### PR DESCRIPTION
`reservebalance` is a leftover from peercoin code which was probably never used.
Currently it is also broken: the final loop in `CWallet::StakeableCoins` is useless (updating an un-used local variable `nAmountSelected` and not removing any utxo from the vector of stakeable coins).

Failing to see a valid use-case for it (not already provided by the stake-split threshold), I propose to just remove it.

This also makes the call to `GetStakingBalance` from `StakeableCoins` not needed (thus one less loop over mapWallet txes).

If this is accepted (at least conceptually) will update the release notes, and close #1366 (superseded by this one).