### PR TITLE
[RPC][Bug] Fix masternodecurrent: return next winner, not rank-1 mn

### DIFF
--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -198,24 +198,25 @@ UniValue masternodecurrent (const UniValue& params, bool fHelp)
     if (fHelp || (params.size() != 0))
         throw std::runtime_error(
             "masternodecurrent\n"
-            "\nGet current masternode winner\n"
+            "\nGet current masternode winner (scheduled to be paid next).\n"
 
             "\nResult:\n"
             "{\n"
             "  \"protocol\": xxxx,        (numeric) Protocol version\n"
             "  \"txhash\": \"xxxx\",      (string) Collateral transaction hash\n"
             "  \"pubkey\": \"xxxx\",      (string) MN Public key\n"
-            "  \"lastseen\": xxx,       (numeric) Time since epoch of last seen\n"
-            "  \"activeseconds\": xxx,  (numeric) Seconds MN has been active\n"
+            "  \"lastseen\": xxx,         (numeric) Time since epoch of last seen\n"
+            "  \"activeseconds\": xxx,    (numeric) Seconds MN has been active\n"
             "}\n"
 
             "\nExamples:\n" +
             HelpExampleCli("masternodecurrent", "") + HelpExampleRpc("masternodecurrent", ""));
 
-    CMasternode* winner = mnodeman.GetCurrentMasterNode(1);
+    const int nHeight = WITH_LOCK(cs_main, return chainActive.Height() + 1);
+    int nCount = 0;
+    CMasternode* winner = mnodeman.GetNextMasternodeInQueueForPayment(nHeight, true, nCount);
     if (winner) {
         UniValue obj(UniValue::VOBJ);
-
         obj.push_back(Pair("protocol", (int64_t)winner->protocolVersion));
         obj.push_back(Pair("txhash", winner->vin.prevout.hash.ToString()));
         obj.push_back(Pair("pubkey", CBitcoinAddress(winner->pubKeyCollateralAddress.GetID()).ToString()));


### PR DESCRIPTION
`masternodecurrent` RPC is improperly returning the masternode with rank 1 instead of the next winner.
Closes #1348 

```
> getblockcount
2236241

> masternodecurrent
{
  "protocol": 70918,
  "txhash": "cfa69f018741e0960a436788391d9d2cec0f9aceed30e883a78818f7c073fba1",
  "pubkey": "DHeEycDFe9pWr3FahcnTbavy8Urb1832HU",
  "lastseen": 1583439177,
  "activeseconds": 6690804
}

> getmasternodewinners 0
[
  {
    "nHeight": 2236242,
    "winner": {
      "address": "DHeEycDFe9pWr3FahcnTbavy8Urb1832HU",
      "nVotes": 10
    }
  },
  ...
]
```
<https://explorer.pivx.link/block/9fe33eedf5f61a8e9f8d50b9007c25d1b0260f0c97f88265feda4c06dfa86725>

Note: `GetCurrentMasterNode` returns the masternode with lower rank and it's used as winner only when no valid block payee can be found. We should probably change its name to something more meaningful (`GetLowestRankMasterNode` ?) and change the comment calling it "winner". Same goes for the comment above `CMasternode::CalculateScore` (masternodes are not even paid based on their scores, but only on the time of their last payment).