### PR TITLE
[Wallet] Don't initialize zpivwallet on first run

### DIFF
--- a/src/crypter.cpp
+++ b/src/crypter.cpp
@@ -260,15 +260,6 @@ bool CCryptoKeyStore::Unlock(const CKeyingMaterial& vMasterKeyIn)
                 return error("Failed to read zPIV seed from DB. Wallet is probably corrupt.");
             }
             pwalletMain->zwalletMain->SetMasterSeed(nSeed, false);
-        } else {
-            // First time this wallet has been unlocked with dzPIV
-            // Borrow random generator from the key class so that we don't have to worry about randomness
-            CKey key;
-            key.MakeNewKey(true);
-            uint256 seed = key.GetPrivKey_256();
-            LogPrintf("%s: first run of zpiv wallet detected, new seed generated. Seedhash=%s\n", __func__, Hash(seed.begin(), seed.end()).GetHex());
-            pwalletMain->zwalletMain->SetMasterSeed(seed, true);
-            pwalletMain->zwalletMain->GenerateMintPool();
         }
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1750,13 +1750,15 @@ bool AppInit2()
         }
         fVerifyingBlocks = false;
 
-        //Inititalize zPIVWallet
-        uiInterface.InitMessage(_("Syncing zPIV wallet..."));
+        if (zwalletMain->GetMasterSeed() != 0) {
+            //Inititalize zPIVWallet
+            uiInterface.InitMessage(_("Syncing zPIV wallet..."));
 
-        //Load zerocoin mint hashes to memory
-        pwalletMain->zpivTracker->Init();
-        zwalletMain->LoadMintPoolFromDB();
-        zwalletMain->SyncWithChain();
+            //Load zerocoin mint hashes to memory
+            pwalletMain->zpivTracker->Init();
+            zwalletMain->LoadMintPoolFromDB();
+            zwalletMain->SyncWithChain();
+        }
     }  // (!fDisableWallet)
 #else  // ENABLE_WALLET
     LogPrintf("No wallet compiled in!\n");

--- a/src/zpiv/zpivwallet.cpp
+++ b/src/zpiv/zpivwallet.cpp
@@ -16,6 +16,7 @@ CzPIVWallet::CzPIVWallet(std::string strWalletFile)
 {
     this->strWalletFile = strWalletFile;
     CWalletDB walletdb(strWalletFile);
+    bool fRegtest = Params().IsRegTestNet();
 
     uint256 hashSeed;
     bool fFirstRun = !walletdb.ReadCurrentSeedHash(hashSeed);
@@ -39,7 +40,7 @@ CzPIVWallet::CzPIVWallet(std::string strWalletFile)
     }
 
     //Don't try to do anything if the wallet is locked.
-    if (pwalletMain->IsLocked()) {
+    if (pwalletMain->IsLocked() || (!fRegtest && fFirstRun)) {
         seedMaster = 0;
         nCountLastUsed = 0;
         this->mintPool = CMintPool();
@@ -48,7 +49,7 @@ CzPIVWallet::CzPIVWallet(std::string strWalletFile)
 
     //First time running, generate master seed
     uint256 seed;
-    if (fFirstRun) {
+    if (fRegtest && fFirstRun) {
         // Borrow random generator from the key class so that we don't have to worry about randomness
         CKey key;
         key.MakeNewKey(true);


### PR DESCRIPTION
With zPIV minting being disabled, there is no reason to initialize the zPIV wallet nor a default mint pool.

This simply disables that flow.