### PR TITLE
[GUI] Don't change selected address after editing its label

### DIFF
--- a/src/qt/pivx/receivewidget.cpp
+++ b/src/qt/pivx/receivewidget.cpp
@@ -112,11 +112,18 @@ void ReceiveWidget::loadWalletModel(){
         refreshView();
 
         // data change
-        connect(this->addressTableModel, SIGNAL(dataChanged(QModelIndex,QModelIndex)), this, SLOT(refreshView()));
+        connect(this->addressTableModel, SIGNAL(dataChanged(QModelIndex, QModelIndex)), this, SLOT(refreshView(QModelIndex, QModelIndex)));
     }
 }
 
-void ReceiveWidget::refreshView(QString refreshAddress){
+void ReceiveWidget::refreshView(const QModelIndex& tl, const QModelIndex& br)
+{
+    const QModelIndex& index = tl.sibling(tl.row(), AddressTableModel::Address);
+    return refreshView(index.data(Qt::DisplayRole).toString());
+}
+
+void ReceiveWidget::refreshView(QString refreshAddress)
+{
     try {
         QString latestAddress = (refreshAddress.isEmpty()) ? this->addressTableModel->getAddressToShow() : refreshAddress;
         if (latestAddress.isEmpty()) { // new default address

--- a/src/qt/pivx/receivewidget.h
+++ b/src/qt/pivx/receivewidget.h
@@ -44,6 +44,7 @@ private Q_SLOTS:
     void changeTheme(bool isLightTheme, QString &theme) override ;
     void onLabelClicked();
     void onCopyClicked();
+    void refreshView(const QModelIndex& tl, const QModelIndex& br);
     void refreshView(QString refreshAddress = QString());
     void handleAddressClicked(const QModelIndex &index);
 private:


### PR DESCRIPTION
After editing an address label in Receive widget, the address presented (along with its QR code and label) automatically changes to another one, while the edited address is still highlited in the address list.
This could generate confusion and errors by the users.

Cause: `ReceiveWidget::refreshView()` (with no arguments) was connected to the `dataChanged(QModelIndex, QModelIndex)` signal.
Therefore, after editing the model (changing the label), the view was always restoring the first address in the addressbook (`getAddressToShow`) instead of keeping the one being modified.

Fix: This introduces an overloaded `ReceiveWidget::refreshView(QModelIndex, QModelIndex)`, taking the topleft and bottomright indexes (connected to `dataChanged`) and calling `refreshView(QString)` with the address relative to the index modified.

Closes #1258