### PR TITLE
[GUI] Customize the timeout of the SnackBar based on its message length

### DIFF
--- a/src/qt/pivx/snackbar.cpp
+++ b/src/qt/pivx/snackbar.cpp
@@ -11,7 +11,8 @@
 SnackBar::SnackBar(PIVXGUI* _window, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::SnackBar),
-    window(_window)
+    window(_window),
+    timeout(MIN_TIMEOUT)
 {
     ui->setupUi(this);
 
@@ -34,25 +35,38 @@ void SnackBar::windowResizeEvent(QResizeEvent* event) {
     this->move(QPoint(0, window->height() - this->height() ));
 }
 
-void SnackBar::showEvent(QShowEvent *event){
-    QTimer::singleShot(3000, this, &SnackBar::hideAnim);
+void SnackBar::showEvent(QShowEvent *event)
+{
+    QTimer::singleShot(timeout, this, &SnackBar::hideAnim);
 }
 
-void SnackBar::hideAnim(){
+void SnackBar::hideAnim()
+{
     if (window) closeDialog(this, window);
     QTimer::singleShot(310, this, &SnackBar::hide);
 }
 
-
-
-void SnackBar::sizeTo(QWidget* widget){
-
-}
-
-void SnackBar::setText(QString text){
+void SnackBar::setText(const QString& text)
+{
     ui->label->setText(text);
+    setTimeoutForText(text);
 }
 
-SnackBar::~SnackBar(){
+void SnackBar::setTimeoutForText(const QString& text)
+{
+    timeout = std::max(MIN_TIMEOUT, std::min(MAX_TIMEOUT, GetTimeout(text)));
+}
+
+int SnackBar::GetTimeout(const QString& message)
+{
+    // 50 milliseconds per char
+    return (50 * message.length());
+}
+
+SnackBar::~SnackBar()
+{
     delete ui;
 }
+
+const int SnackBar::MIN_TIMEOUT;
+const int SnackBar::MAX_TIMEOUT;

--- a/src/qt/pivx/snackbar.h
+++ b/src/qt/pivx/snackbar.h
@@ -23,14 +23,20 @@ public:
     ~SnackBar();
 
     virtual void showEvent(QShowEvent *event) override;
-    void sizeTo(QWidget *widget);
-    void setText(QString text);
+    void setText(const QString& text);
+
 private Q_SLOTS:
     void hideAnim();
     void windowResizeEvent(QResizeEvent* event);
 private:
     Ui::SnackBar *ui;
     PIVXGUI* window = nullptr;
+    int timeout;
+    // timeout based on message length, always between 2 (default) and 10 seconds.
+    static const int MIN_TIMEOUT = 2000;          // < 40 chars
+    static const int MAX_TIMEOUT = 10000;         // > 200 chars
+    static int GetTimeout(const QString& message);
+    void setTimeoutForText(const QString& text);
 };
 
 #endif // SNACKBAR_H


### PR DESCRIPTION
The default 3-seconds timeout for the snackbar is not optimal in all the situations.
Sometimes the message is longer, and the user has not enough time to read it before it hides.
Other times the message is very short (e.g. "Wallet Unlocked"), and 3 seconds seem a bit much.

This PR proposes to use a variable timeout, based on the length of the message to display (50 milliseconds per character), with a minimum set at 2 seconds and a maximum at 10.