### PR TITLE
[GUI] MasternodeWidget-Wizard bugfixes

### DIFF
--- a/src/qt/pivx/masternodeswidget.cpp
+++ b/src/qt/pivx/masternodeswidget.cpp
@@ -354,6 +354,8 @@ void MasterNodesWidget::onInfoMNClicked()
 
 void MasterNodesWidget::onDeleteMNClicked()
 {
+    QString txId = index.sibling(index.row(), MNModel::COLLATERAL_ID).data(Qt::DisplayRole).toString();
+    QString outIndex = index.sibling(index.row(), MNModel::COLLATERAL_OUT_INDEX).data(Qt::DisplayRole).toString();
     QString qAliasString = index.data(Qt::DisplayRole).toString();
     std::string aliasToRemove = qAliasString.toStdString();
 
@@ -433,6 +435,14 @@ void MasterNodesWidget::onDeleteMNClicked()
             boost::filesystem::path pathNewConfFile("masternode.conf");
             if (!pathNewConfFile.is_complete()) pathNewConfFile = GetDataDir() / pathNewConfFile;
             rename(pathConfigFile, pathNewConfFile);
+
+            // Unlock collateral
+            bool convertOK = false;
+            unsigned int indexOut = outIndex.toUInt(&convertOK);
+            if(convertOK) {
+                COutPoint collateralOut(uint256(txId.toStdString()), indexOut);
+                walletModel->unlockCoin(collateralOut);
+            }
 
             // Remove alias
             masternodeConfig.remove(aliasToRemove);

--- a/src/qt/pivx/masternodeswidget.cpp
+++ b/src/qt/pivx/masternodeswidget.cpp
@@ -207,8 +207,8 @@ bool MasterNodesWidget::checkMNsNetwork()
 
 void MasterNodesWidget::onEditMNClicked()
 {
-    if (walletModel) {
-        if (!Params().IsRegTestNet() && !checkMNsNetwork()) return;     // skip on RegNet: so we can test even if tier two not synced
+    if(walletModel) {
+        if (!walletModel->isRegTestNetwork() && !checkMNsNetwork()) return;
         if (index.sibling(index.row(), MNModel::WAS_COLLATERAL_ACCEPTED).data(Qt::DisplayRole).toBool()) {
             // Start MN
             QString strAlias = this->index.data(Qt::DisplayRole).toString();

--- a/src/qt/pivx/masternodeswidget.cpp
+++ b/src/qt/pivx/masternodeswidget.cpp
@@ -208,7 +208,7 @@ bool MasterNodesWidget::checkMNsNetwork()
 void MasterNodesWidget::onEditMNClicked()
 {
     if (walletModel) {
-        if (!checkMNsNetwork()) return;
+        if (!Params().IsRegTestNet() && !checkMNsNetwork()) return;     // skip on RegNet: so we can test even if tier two not synced
         if (index.sibling(index.row(), MNModel::WAS_COLLATERAL_ACCEPTED).data(Qt::DisplayRole).toBool()) {
             // Start MN
             QString strAlias = this->index.data(Qt::DisplayRole).toString();
@@ -216,8 +216,9 @@ void MasterNodesWidget::onEditMNClicked()
                 if (!verifyWalletUnlocked()) return;
                 startAlias(strAlias);
             }
-        }else {
-            inform(tr("Cannot start masternode, the collateral transaction has not been accepted by the network.\nPlease wait few more minutes."));
+        } else {
+            inform(tr("Cannot start masternode, the collateral transaction has not been confirmed by the network yet.\n"
+                    "Please wait few more minutes (masternode collaterals require %1 confirmations).").arg(MASTERNODE_MIN_CONFIRMATIONS));
         }
     }
 }

--- a/src/qt/pivx/masternodeswidget.cpp
+++ b/src/qt/pivx/masternodeswidget.cpp
@@ -37,14 +37,16 @@ class MNHolder : public FurListRow<QWidget*>
 public:
     MNHolder();
 
-    explicit MNHolder(bool _isLightTheme) : FurListRow(), isLightTheme(_isLightTheme){}
+    explicit MNHolder(bool _isLightTheme) : FurListRow(), isLightTheme(_isLightTheme) {}
 
-    MNRow* createHolder(int pos) override{
-        if(!cachedRow) cachedRow = new MNRow();
+    MNRow* createHolder(int pos) override
+    {
+        if (!cachedRow) cachedRow = new MNRow();
         return cachedRow;
     }
 
-    void init(QWidget* holder,const QModelIndex &index, bool isHovered, bool isSelected) const override{
+    void init(QWidget* holder,const QModelIndex &index, bool isHovered, bool isSelected) const override
+    {
         MNRow* row = static_cast<MNRow*>(holder);
         QString label = index.data(Qt::DisplayRole).toString();
         QString address = index.sibling(index.row(), MNModel::ADDRESS).data(Qt::DisplayRole).toString();
@@ -53,7 +55,8 @@ public:
         row->updateView("Address: " + address, label, status, wasCollateralAccepted);
     }
 
-    QColor rectColor(bool isHovered, bool isSelected) override{
+    QColor rectColor(bool isHovered, bool isSelected) override
+    {
         return getRowColor(isLightTheme, isHovered, isSelected);
     }
 
@@ -133,41 +136,46 @@ MasterNodesWidget::MasterNodesWidget(PIVXGUI *parent) :
     connect(ui->btnAboutController, &OptionButton::clicked, [this](){window->openFAQ(10);});
 }
 
-void MasterNodesWidget::showEvent(QShowEvent *event){
+void MasterNodesWidget::showEvent(QShowEvent *event)
+{
     if (mnModel) mnModel->updateMNList();
-    if(!timer) {
+    if (!timer) {
         timer = new QTimer(this);
         connect(timer, &QTimer::timeout, [this]() {mnModel->updateMNList();});
     }
     timer->start(30000);
 }
 
-void MasterNodesWidget::hideEvent(QHideEvent *event){
-    if(timer) timer->stop();
+void MasterNodesWidget::hideEvent(QHideEvent *event)
+{
+    if (timer) timer->stop();
 }
 
-void MasterNodesWidget::loadWalletModel(){
-    if(walletModel) {
+void MasterNodesWidget::loadWalletModel()
+{
+    if (walletModel) {
         ui->listMn->setModel(mnModel);
         ui->listMn->setModelColumn(AddressTableModel::Label);
         updateListState();
     }
 }
 
-void MasterNodesWidget::updateListState() {
+void MasterNodesWidget::updateListState()
+{
     bool show = mnModel->rowCount() > 0;
     ui->listMn->setVisible(show);
     ui->emptyContainer->setVisible(!show);
     ui->pushButtonStartAll->setVisible(show);
 }
 
-void MasterNodesWidget::onMNClicked(const QModelIndex &index){
+void MasterNodesWidget::onMNClicked(const QModelIndex &index)
+{
     ui->listMn->setCurrentIndex(index);
     QRect rect = ui->listMn->visualRect(index);
     QPoint pos = rect.topRight();
     pos.setX(pos.x() - (DECORATION_SIZE * 2));
     pos.setY(pos.y() + (DECORATION_SIZE * 1.5));
-    if(!this->menu){
+    if (!this->menu) {
         this->menu = new TooltipMenu(window, this);
         this->menu->setEditBtnText(tr("Start"));
         this->menu->setDeleteBtnText(tr("Delete"));
@@ -190,14 +198,16 @@ void MasterNodesWidget::onMNClicked(const QModelIndex &index){
     ui->listMn->setFocus();
 }
 
-bool MasterNodesWidget::checkMNsNetwork() {
+bool MasterNodesWidget::checkMNsNetwork()
+{
     bool isTierTwoSync = mnModel->isMNsNetworkSynced();
     if (!isTierTwoSync) inform(tr("Please wait until the node is fully synced"));
     return isTierTwoSync;
 }
 
-void MasterNodesWidget::onEditMNClicked(){
-    if(walletModel) {
+void MasterNodesWidget::onEditMNClicked()
+{
+    if (walletModel) {
         if (!checkMNsNetwork()) return;
         if (index.sibling(index.row(), MNModel::WAS_COLLATERAL_ACCEPTED).data(Qt::DisplayRole).toBool()) {
             // Start MN
@@ -212,7 +222,8 @@ void MasterNodesWidget::onEditMNClicked(){
     }
 }
 
-void MasterNodesWidget::startAlias(QString strAlias) {
+void MasterNodesWidget::startAlias(QString strAlias)
+{
     QString strStatusHtml;
     strStatusHtml += "Alias: " + strAlias + " ";
 
@@ -227,12 +238,14 @@ void MasterNodesWidget::startAlias(QString strAlias) {
     updateModelAndInform(strStatusHtml);
 }
 
-void MasterNodesWidget::updateModelAndInform(QString informText) {
+void MasterNodesWidget::updateModelAndInform(QString informText)
+{
     mnModel->updateMNList();
     inform(informText);
 }
 
-bool MasterNodesWidget::startMN(CMasternodeConfig::CMasternodeEntry mne, std::string& strError) {
+bool MasterNodesWidget::startMN(CMasternodeConfig::CMasternodeEntry mne, std::string& strError)
+{
     CMasternodeBroadcast mnb;
     if (!CMasternodeBroadcast::Create(mne.getIp(), mne.getPrivKey(), mne.getTxHash(), mne.getOutputIndex(), strError, mnb))
         return false;
@@ -242,7 +255,8 @@ bool MasterNodesWidget::startMN(CMasternodeConfig::CMasternodeEntry mne, std::st
     return true;
 }
 
-void MasterNodesWidget::onStartAllClicked(int type) {
+void MasterNodesWidget::onStartAllClicked(int type)
+{
     if (!verifyWalletUnlocked()) return;
     if (!checkMNsNetwork()) return;
     if (isLoading) {
@@ -256,7 +270,8 @@ void MasterNodesWidget::onStartAllClicked(int type) {
     }
 }
 
-bool MasterNodesWidget::startAll(QString& failText, bool onlyMissing) {
+bool MasterNodesWidget::startAll(QString& failText, bool onlyMissing)
+{
     int amountOfMnFailed = 0;
     int amountOfMnStarted = 0;
     for (CMasternodeConfig::CMasternodeEntry mne : masternodeConfig.getEntries()) {
@@ -282,7 +297,8 @@ bool MasterNodesWidget::startAll(QString& failText, bool onlyMissing) {
     return true;
 }
 
-void MasterNodesWidget::run(int type) {
+void MasterNodesWidget::run(int type)
+{
     bool isStartMissing = type == REQUEST_START_MISSING;
     if (type == REQUEST_START_ALL || isStartMissing) {
         QString failText;
@@ -294,15 +310,17 @@ void MasterNodesWidget::run(int type) {
     isLoading = false;
 }
 
-void MasterNodesWidget::onError(QString error, int type) {
+void MasterNodesWidget::onError(QString error, int type)
+{
     if (type == REQUEST_START_ALL) {
         QMetaObject::invokeMethod(this, "inform", Qt::QueuedConnection,
                                   Q_ARG(QString, "Error starting all Masternodes"));
     }
 }
 
-void MasterNodesWidget::onInfoMNClicked() {
-    if(!verifyWalletUnlocked()) return;
+void MasterNodesWidget::onInfoMNClicked()
+{
+    if (!verifyWalletUnlocked()) return;
     showHideOp(true);
     MnInfoDialog* dialog = new MnInfoDialog(window);
     QString label = index.data(Qt::DisplayRole).toString();
@@ -314,7 +332,7 @@ void MasterNodesWidget::onInfoMNClicked() {
     dialog->setData(pubKey, label, address, txId, outIndex, status);
     dialog->adjustSize();
     showDialog(dialog, 3, 17);
-    if (dialog->exportMN){
+    if (dialog->exportMN) {
         if (ask(tr("Remote Masternode Data"),
                 tr("You are just about to export the required data to run a Masternode\non a remote server to your clipboard.\n\n\n"
                    "You will only have to paste the data in the pivx.conf file\nof your remote server and start it, "
@@ -333,7 +351,8 @@ void MasterNodesWidget::onInfoMNClicked() {
     dialog->deleteLater();
 }
 
-void MasterNodesWidget::onDeleteMNClicked(){
+void MasterNodesWidget::onDeleteMNClicked()
+{
     QString qAliasString = index.data(Qt::DisplayRole).toString();
     std::string aliasToRemove = qAliasString.toStdString();
 
@@ -342,7 +361,7 @@ void MasterNodesWidget::onDeleteMNClicked(){
 
     std::string strConfFile = "masternode.conf";
     std::string strDataDir = GetDataDir().string();
-    if (strConfFile != boost::filesystem::basename(strConfFile) + boost::filesystem::extension(strConfFile)){
+    if (strConfFile != boost::filesystem::basename(strConfFile) + boost::filesystem::extension(strConfFile)) {
         throw std::runtime_error(strprintf(_("masternode.conf %s resides outside data directory %s"), strConfFile, strDataDir));
     }
 
@@ -425,15 +444,16 @@ void MasterNodesWidget::onDeleteMNClicked(){
     }
 }
 
-void MasterNodesWidget::onCreateMNClicked(){
-    if(verifyWalletUnlocked()) {
-        if(walletModel->getBalance() <= (COIN * 10000)){
+void MasterNodesWidget::onCreateMNClicked()
+{
+    if (verifyWalletUnlocked()) {
+        if (walletModel->getBalance() <= (COIN * 10000)) {
             inform(tr("Not enough balance to create a masternode, 10,000 PIV required."));
             return;
         }
         showHideOp(true);
         MasterNodeWizardDialog *dialog = new MasterNodeWizardDialog(walletModel, window);
-        if(openDialogWithOpaqueBackgroundY(dialog, window, 5, 7)) {
+        if (openDialogWithOpaqueBackgroundY(dialog, window, 5, 7)) {
             if (dialog->isOk) {
                 // Update list
                 mnModel->addMn(dialog->mnEntry);
@@ -448,7 +468,8 @@ void MasterNodesWidget::onCreateMNClicked(){
     }
 }
 
-void MasterNodesWidget::changeTheme(bool isLightTheme, QString& theme){
+void MasterNodesWidget::changeTheme(bool isLightTheme, QString& theme)
+{
     static_cast<MNHolder*>(this->delegate->getRowFactory())->isLightTheme = isLightTheme;
 }
 

--- a/src/qt/pivx/masternodewizarddialog.cpp
+++ b/src/qt/pivx/masternodewizarddialog.cpp
@@ -335,7 +335,7 @@ bool MasterNodeWizardDialog::createMN()
                 COutPoint collateralOut(walletTx->GetHash(), indexOut);
                 walletModel->lockCoin(collateralOut);
 
-                returnStr = tr("Master node created!");
+                returnStr = tr("Master node created! Wait %1 confirmations before starting it.").arg(MASTERNODE_MIN_CONFIRMATIONS);
                 return true;
             } else{
                 returnStr = tr("masternode.conf file doesn't exists");

--- a/src/qt/pivx/masternodewizarddialog.cpp
+++ b/src/qt/pivx/masternodewizarddialog.cpp
@@ -12,7 +12,6 @@
 #include <QFile>
 #include <QIntValidator>
 #include <QHostAddress>
-#include <QRegExpValidator>
 
 MasterNodeWizardDialog::MasterNodeWizardDialog(WalletModel *model, QWidget *parent) :
     QDialog(parent),
@@ -64,7 +63,7 @@ MasterNodeWizardDialog::MasterNodeWizardDialog(WalletModel *model, QWidget *pare
     initCssEditLine(ui->lineEditPort);
     ui->stackedWidget->setCurrentIndex(pos);
     ui->lineEditPort->setValidator(new QIntValidator(0, 9999999, ui->lineEditPort));
-    if(walletModel->isTestNetwork()){
+    if (walletModel->isTestNetwork()) {
         ui->lineEditPort->setEnabled(false);
         ui->lineEditPort->setText("51474");
     } else {
@@ -96,8 +95,9 @@ void MasterNodeWizardDialog::showEvent(QShowEvent *event)
     if (ui->btnNext) ui->btnNext->setFocus();
 }
 
-void MasterNodeWizardDialog::onNextClicked(){
-    switch(pos){
+void MasterNodeWizardDialog::onNextClicked()
+{
+    switch(pos) {
         case 0:{
             ui->stackedWidget->setCurrentIndex(1);
             ui->pushName4->setChecked(false);
@@ -145,7 +145,8 @@ void MasterNodeWizardDialog::onNextClicked(){
     pos++;
 }
 
-bool MasterNodeWizardDialog::createMN(){
+bool MasterNodeWizardDialog::createMN()
+{
     if (walletModel) {
         /**
          *
@@ -178,7 +179,7 @@ bool MasterNodeWizardDialog::createMN(){
         }
         // TODO: Validate IP address..
         int portInt = portStr.toInt();
-        if (portInt <= 0 && portInt > 999999){
+        if (portInt <= 0 && portInt > 999999) {
             returnStr = tr("Invalid port number");
             return false;
         }
@@ -238,7 +239,7 @@ bool MasterNodeWizardDialog::createMN(){
             // now change the conf
             std::string strConfFile = "masternode.conf";
             std::string strDataDir = GetDataDir().string();
-            if (strConfFile != boost::filesystem::basename(strConfFile) + boost::filesystem::extension(strConfFile)){
+            if (strConfFile != boost::filesystem::basename(strConfFile) + boost::filesystem::extension(strConfFile)) {
                 throw std::runtime_error(strprintf(_("masternode.conf %s resides outside data directory %s"), strConfFile, strDataDir));
             }
 
@@ -291,9 +292,9 @@ bool MasterNodeWizardDialog::createMN(){
                 CWalletTx* walletTx = currentTransaction.getTransaction();
                 std::string txID = walletTx->GetHash().GetHex();
                 int indexOut = -1;
-                for (int i=0; i < (int)walletTx->vout.size(); i++){
+                for (int i=0; i < (int)walletTx->vout.size(); i++) {
                     CTxOut& out = walletTx->vout[i];
-                    if (out.nValue == 10000 * COIN){
+                    if (out.nValue == 10000 * COIN) {
                         indexOut = i;
                     }
                 }
@@ -342,10 +343,11 @@ bool MasterNodeWizardDialog::createMN(){
     return false;
 }
 
-void MasterNodeWizardDialog::onBackClicked(){
+void MasterNodeWizardDialog::onBackClicked()
+{
     if (pos == 0) return;
     pos--;
-    switch(pos){
+    switch(pos) {
         case 0:{
             ui->stackedWidget->setCurrentIndex(0);
             ui->btnNext->setFocus();
@@ -373,7 +375,8 @@ void MasterNodeWizardDialog::onBackClicked(){
     }
 }
 
-void MasterNodeWizardDialog::inform(QString text){
+void MasterNodeWizardDialog::inform(QString text)
+{
     if (!snackBar)
         snackBar = new SnackBar(nullptr, this);
     snackBar->setText(text);
@@ -382,7 +385,8 @@ void MasterNodeWizardDialog::inform(QString text){
 }
 
 QSize BUTTON_SIZE = QSize(22, 22);
-void MasterNodeWizardDialog::initBtn(std::initializer_list<QPushButton*> args){
+void MasterNodeWizardDialog::initBtn(std::initializer_list<QPushButton*> args)
+{
     for (QPushButton* btn : args) {
         btn->setMinimumSize(BUTTON_SIZE);
         btn->setMaximumSize(BUTTON_SIZE);
@@ -393,7 +397,8 @@ void MasterNodeWizardDialog::initBtn(std::initializer_list<QPushButton*> args){
     }
 }
 
-MasterNodeWizardDialog::~MasterNodeWizardDialog(){
-    if(snackBar) delete snackBar;
+MasterNodeWizardDialog::~MasterNodeWizardDialog()
+{
+    if (snackBar) delete snackBar;
     delete ui;
 }

--- a/src/qt/pivx/masternodewizarddialog.cpp
+++ b/src/qt/pivx/masternodewizarddialog.cpp
@@ -63,7 +63,10 @@ MasterNodeWizardDialog::MasterNodeWizardDialog(WalletModel *model, QWidget *pare
     initCssEditLine(ui->lineEditPort);
     ui->stackedWidget->setCurrentIndex(pos);
     ui->lineEditPort->setValidator(new QIntValidator(0, 9999999, ui->lineEditPort));
-    if (walletModel->isTestNetwork()) {
+    if (walletModel->isRegTestNetwork()) {
+        ui->lineEditPort->setEnabled(false);
+        ui->lineEditPort->setText("51476");
+    } else if (walletModel->isTestNetwork()) {
         ui->lineEditPort->setEnabled(false);
         ui->lineEditPort->setText("51474");
     } else {

--- a/src/qt/pivx/masternodewizarddialog.cpp
+++ b/src/qt/pivx/masternodewizarddialog.cpp
@@ -331,6 +331,10 @@ bool MasterNodeWizardDialog::createMN()
 
                 mnEntry = masternodeConfig.add(alias, ipAddress+":"+port, mnKeyString, txID, indexOutStr);
 
+                // Lock collateral output
+                COutPoint collateralOut(walletTx->GetHash(), indexOut);
+                walletModel->lockCoin(collateralOut);
+
                 returnStr = tr("Master node created!");
                 return true;
             } else{

--- a/src/qt/pivx/mninfodialog.cpp
+++ b/src/qt/pivx/mninfodialog.cpp
@@ -29,15 +29,16 @@ MnInfoDialog::MnInfoDialog(QWidget *parent) :
     connect(ui->pushExport, &QPushButton::clicked, [this](){ exportMN = true; accept(); });
 }
 
-void MnInfoDialog::setData(QString pubKey, QString name, QString address, QString txId, QString outputIndex, QString status){
+void MnInfoDialog::setData(QString pubKey, QString name, QString address, QString txId, QString outputIndex, QString status)
+{
     this->pubKey = pubKey;
     this->txId = txId;
     QString shortPubKey = pubKey;
     QString shortTxId = txId;
-    if(shortPubKey.length() > 20) {
+    if (shortPubKey.length() > 20) {
         shortPubKey = shortPubKey.left(13) + "..." + shortPubKey.right(13);
     }
-    if(shortTxId.length() > 20) {
+    if (shortTxId.length() > 20) {
         shortTxId = shortTxId.left(12) + "..." + shortTxId.right(12);
     }
     ui->textId->setText(shortPubKey);
@@ -47,20 +48,23 @@ void MnInfoDialog::setData(QString pubKey, QString name, QString address, QStrin
     ui->textStatus->setText(status);
 }
 
-void MnInfoDialog::copyInform(QString& copyStr, QString message){
+void MnInfoDialog::copyInform(QString& copyStr, QString message)
+{
     GUIUtil::setClipboard(copyStr);
-    if(!snackBar) snackBar = new SnackBar(nullptr, this);
+    if (!snackBar) snackBar = new SnackBar(nullptr, this);
     snackBar->setText(tr(message.toStdString().c_str()));
     snackBar->resize(this->width(), snackBar->height());
     openDialog(snackBar, this);
 }
 
-void MnInfoDialog::closeDialog(){
-    if(snackBar && snackBar->isVisible()) snackBar->hide();
+void MnInfoDialog::closeDialog()
+{
+    if (snackBar && snackBar->isVisible()) snackBar->hide();
     close();
 }
 
-MnInfoDialog::~MnInfoDialog(){
-    if(snackBar) delete snackBar;
+MnInfoDialog::~MnInfoDialog()
+{
+    if (snackBar) delete snackBar;
     delete ui;
 }

--- a/src/qt/pivx/mnmodel.cpp
+++ b/src/qt/pivx/mnmodel.cpp
@@ -10,29 +10,31 @@
 #include "uint256.h"
 #include "wallet/wallet.h"
 
-MNModel::MNModel(QObject *parent) : QAbstractTableModel(parent){
+MNModel::MNModel(QObject *parent) : QAbstractTableModel(parent)
+{
     updateMNList();
 }
 
-void MNModel::updateMNList(){
+void MNModel::updateMNList()
+{
     int end = nodes.size();
     nodes.clear();
     collateralTxAccepted.clear();
     for (CMasternodeConfig::CMasternodeEntry mne : masternodeConfig.getEntries()) {
         int nIndex;
-        if(!mne.castOutputIndex(nIndex))
+        if (!mne.castOutputIndex(nIndex))
             continue;
 
         uint256 txHash(mne.getTxHash());
         CTxIn txIn(txHash, uint32_t(nIndex));
         CMasternode* pmn = mnodeman.Find(txIn);
-        if (!pmn){
+        if (!pmn) {
             pmn = new CMasternode();
             pmn->vin = txIn;
             pmn->activeState = CMasternode::MASTERNODE_MISSING;
         }
         nodes.insert(QString::fromStdString(mne.getAlias()), std::make_pair(QString::fromStdString(mne.getIp()), pmn));
-        if(pwalletMain) {
+        if (pwalletMain) {
             bool txAccepted = false;
             {
                 LOCK2(cs_main, pwalletMain->cs_wallet);
@@ -64,7 +66,7 @@ int MNModel::columnCount(const QModelIndex &parent) const
 
 QVariant MNModel::data(const QModelIndex &index, int role) const
 {
-    if(!index.isValid())
+    if (!index.isValid())
             return QVariant();
 
     // rec could be null, always verify it.
@@ -89,7 +91,7 @@ QVariant MNModel::data(const QModelIndex &index, int role) const
             }
             case PRIV_KEY: {
                 for (CMasternodeConfig::CMasternodeEntry mne : masternodeConfig.getEntries()) {
-                    if (mne.getTxHash().compare(rec->vin.prevout.hash.GetHex()) == 0){
+                    if (mne.getTxHash().compare(rec->vin.prevout.hash.GetHex()) == 0) {
                         return QString::fromStdString(mne.getPrivKey());
                     }
                 }
@@ -98,7 +100,7 @@ QVariant MNModel::data(const QModelIndex &index, int role) const
             case WAS_COLLATERAL_ACCEPTED:{
                 if (!isAvailable) return false;
                 std::string txHash = rec->vin.prevout.hash.GetHex();
-                if(!collateralTxAccepted.value(txHash)){
+                if (!collateralTxAccepted.value(txHash)) {
                     bool txAccepted = false;
                     {
                         LOCK2(cs_main, pwalletMain->cs_wallet);
@@ -121,7 +123,7 @@ QModelIndex MNModel::index(int row, int column, const QModelIndex& parent) const
     CMasternode* data = pair.second;
     if (data) {
         return createIndex(row, column, data);
-    } else if (!pair.first.isEmpty()){
+    } else if (!pair.first.isEmpty()) {
         return createIndex(row, column, nullptr);
     } else {
         return QModelIndex();
@@ -129,7 +131,8 @@ QModelIndex MNModel::index(int row, int column, const QModelIndex& parent) const
 }
 
 
-bool MNModel::removeMn(const QModelIndex& modelIndex) {
+bool MNModel::removeMn(const QModelIndex& modelIndex)
+{
     QString alias = modelIndex.data(Qt::DisplayRole).toString();
     int idx = modelIndex.row();
     beginRemoveRows(QModelIndex(), idx, idx);
@@ -139,10 +142,11 @@ bool MNModel::removeMn(const QModelIndex& modelIndex) {
     return true;
 }
 
-bool MNModel::addMn(CMasternodeConfig::CMasternodeEntry* mne){
+bool MNModel::addMn(CMasternodeConfig::CMasternodeEntry* mne)
+{
     beginInsertRows(QModelIndex(), nodes.size(), nodes.size());
     int nIndex;
-    if(!mne->castOutputIndex(nIndex))
+    if (!mne->castOutputIndex(nIndex))
         return false;
 
     CMasternode* pmn = mnodeman.Find(CTxIn(uint256S(mne->getTxHash()), uint32_t(nIndex)));
@@ -151,22 +155,26 @@ bool MNModel::addMn(CMasternodeConfig::CMasternodeEntry* mne){
     return true;
 }
 
-int MNModel::getMNState(QString mnAlias) {
+int MNModel::getMNState(QString mnAlias)
+{
     QMap<QString, std::pair<QString, CMasternode*>>::const_iterator it = nodes.find(mnAlias);
     if (it != nodes.end()) return it.value().second->activeState;
     throw std::runtime_error(std::string("Masternode alias not found"));
 }
 
-bool MNModel::isMNInactive(QString mnAlias) {
+bool MNModel::isMNInactive(QString mnAlias)
+{
     int activeState = getMNState(mnAlias);
     return activeState == CMasternode::MASTERNODE_MISSING || activeState == CMasternode::MASTERNODE_EXPIRED || activeState == CMasternode::MASTERNODE_REMOVE;
 }
 
-bool MNModel::isMNActive(QString mnAlias) {
+bool MNModel::isMNActive(QString mnAlias)
+{
     int activeState = getMNState(mnAlias);
     return activeState == CMasternode::MASTERNODE_PRE_ENABLED || activeState == CMasternode::MASTERNODE_ENABLED;
 }
 
-bool MNModel::isMNsNetworkSynced() {
+bool MNModel::isMNsNetworkSynced()
+{
     return masternodeSync.IsSynced();
 }

--- a/src/qt/pivx/mnmodel.cpp
+++ b/src/qt/pivx/mnmodel.cpp
@@ -39,7 +39,7 @@ void MNModel::updateMNList()
             {
                 LOCK2(cs_main, pwalletMain->cs_wallet);
                 const CWalletTx *walletTx = pwalletMain->GetWalletTx(txHash);
-                if (walletTx && walletTx->GetDepthInMainChain() > 0) {
+                if (walletTx && walletTx->GetDepthInMainChain() >= MASTERNODE_MIN_CONFIRMATIONS) {
                     txAccepted = true;
                 }
             }

--- a/src/qt/pivx/mnrow.cpp
+++ b/src/qt/pivx/mnrow.cpp
@@ -17,17 +17,19 @@ MNRow::MNRow(QWidget *parent) :
     ui->lblDivisory->setStyleSheet("background-color:#bababa;");
 }
 
-void MNRow::updateView(QString address, QString label, QString status, bool wasCollateralAccepted){
+void MNRow::updateView(QString address, QString label, QString status, bool wasCollateralAccepted)
+{
     ui->labelName->setText(label);
     ui->labelAddress->setText(address);
     ui->labelDate->setText("Status: " + status);
-    if (!wasCollateralAccepted){
+    if (!wasCollateralAccepted) {
         ui->labelDate->setText("Status: Collateral tx not found");
     } else {
         ui->labelDate->setText("Status: " + status);
     }
 }
 
-MNRow::~MNRow(){
+MNRow::~MNRow()
+{
     delete ui;
 }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -58,8 +58,14 @@ WalletModel::~WalletModel()
     unsubscribeFromCoreSignals();
 }
 
-bool WalletModel::isTestNetwork() const {
-    return Params().NetworkID() == CBaseChainParams::TESTNET || Params().IsRegTestNet();
+bool WalletModel::isTestNetwork() const
+{
+    return Params().NetworkID() == CBaseChainParams::TESTNET;
+}
+
+bool WalletModel::isRegTestNetwork() const
+{
+    return Params().IsRegTestNet();
 }
 
 bool WalletModel::isColdStakingNetworkelyEnabled() const {

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -142,6 +142,7 @@ public:
     RecentRequestsTableModel* getRecentRequestsTableModel();
 
     bool isTestNetwork() const;
+    bool isRegTestNetwork() const;
     /** Whether cold staking is enabled or disabled in the network **/
     bool isColdStakingNetworkelyEnabled() const;
     CAmount getMinColdStakingAmount() const;


### PR DESCRIPTION
This PR fixes some issue with the masternode GUI interaction.

**1)**  __MasternodeWizard: lock collateral output after MN creation.__
The masternode configuration file is only read during init, and then the `COutPoint`s relative to the collateral of each entry is locked for spending. Thus, after creating a MN controller with the wizard, the collateral remains unlocked until the wallet is restarted, and therefore could be potentially spent or staked.

**2)** __Enforce required depth for mn collaterals__
The masternode collateral transaction requires at least 15 confirmations before the mn broadcast can be considered valid. Properly inform the user after creating a controller with the wizard, and when trying to start a masternode not yet confirmed.

**3)** __MasternodeWidget: unlock collateral output coin after MN deletion__
Mirrors (1). Unlock the collateral utxo when the masternode is deleted, otherwise it remains locked until wallet restart.

**4)** __MasterNodeWizardDialog: fix RegTestNet default port__
RegTest was using the fixed port value of TestNet instead of the default 51476.