### PR TITLE
[GUI] Accept dialogs with ENTER, reject with ESC

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -40,7 +40,7 @@ Wallets under a tree derivation structure in which keypairs are generated determ
 
 Enabling major improvements over the keystore management, the PIVX wallet doesn't require regular backups as before, keys are following a deterministic creation path that can be verified at any time (before HD Wallet, every keypair was randomly created and added to the keypool, forcing the user to backup the wallet every certain amount of time or could end up loosing coins forever if the latest `wallet.dat` was not being used).
 As well as new possibilities like the account extended public key that enables deterministic public keys creation without the private keys requisite inside the wallet (A good use case could be online stores generating fresh addresses).
- 
+
 This work includes a customization/extension to the [BIP44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) standard. We have included an unique staking keys derivation path which introduced the deterministic generation/recovery of staking addresses.
 
 An extended description of this large work can be found in the PR [here](https://github.com/PIVX-Project/PIVX/pull/1327).
@@ -48,7 +48,7 @@ An extended description of this large work can be found in the PR [here](https:/
 #### HD Wallet FAQ
 
  - How do i upgrade to HD Wallet?
- 
+
     GUI:
     1) A dialog will appear on every wallet startup notifying you that you are running a pre-HD wallet and letting you upgrade it from there.
     2) If you haven't upgraded your wallet, the topbar (bar with icons that appears at the top of your wallet) will have an "HD" icon. Click it and the upgrade dialog will be launched.
@@ -56,12 +56,12 @@ An extended description of this large work can be found in the PR [here](https:/
     RPC:
     1) If your wallet is unlocked, use the `-upgradewallet` flag at startup and will automatically upgrade your wallet.
     2) If your wallet is encrypted, use the `upgradewallet` rpc command. It will upgrade your wallet to the latest wallet version.
-    
+
  - How do i know if i'm already running an HD Wallet?
- 
+
     1) GUI: Go to settings, press on the Debug option, then Information.
     2) RPC: call `getwalletinfo`, the `walletversion` field must be `169900` (HD Wallet Feature).
-       
+
 
 ### Functional Changes
 
@@ -160,6 +160,8 @@ Detailed release notes follow. This overview includes changes that affect behavi
 The p2p alert system has been removed in [#1372](https://github.com/PIVX-Project/PIVX/pull/1372) and the 'alert' message is no longer supported.
 
 ### GUI
+
+Keyboard navigation: dialogs can now be accepted with the `ENTER` (`RETURN`) key, and dismissed with the `ESC` key ([#1392](https://github.com/PIVX-Project/PIVX/pull/1392)).
 
 ### RPC/REST
 

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -32,6 +32,16 @@ class QUrl;
 class QWidget;
 QT_END_NAMESPACE
 
+/*
+ * General GUI exception
+ */
+class GUIException : public std::exception
+{
+public:
+    std::string message;
+    GUIException(const std::string &message) : message(message) {}
+};
+
 /** Utility functions used by the PIVX Qt UI.
  */
 namespace GUIUtil

--- a/src/qt/pivx/defaultdialog.cpp
+++ b/src/qt/pivx/defaultdialog.cpp
@@ -5,6 +5,8 @@
 #include "qt/pivx/defaultdialog.h"
 #include "qt/pivx/forms/ui_defaultdialog.h"
 #include "guiutil.h"
+#include <QKeyEvent>
+
 DefaultDialog::DefaultDialog(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::DefaultDialog)
@@ -35,10 +37,17 @@ DefaultDialog::DefaultDialog(QWidget *parent) :
 
     connect(ui->btnEsc, SIGNAL(clicked()), this, SLOT(close()));
     connect(ui->btnCancel, SIGNAL(clicked()), this, SLOT(close()));
-    connect(ui->btnSave, &QPushButton::clicked, [this](){this->isOk = true; accept();});
+    connect(ui->btnSave, &QPushButton::clicked, this, &DefaultDialog::accept);
 }
 
-void DefaultDialog::setText(QString title, QString message, QString okBtnText, QString cancelBtnText){
+void DefaultDialog::showEvent(QShowEvent *event)
+{
+    setFocus();
+}
+
+
+void DefaultDialog::setText(QString title, QString message, QString okBtnText, QString cancelBtnText)
+{
     if(!okBtnText.isNull()) ui->btnSave->setText(okBtnText);
     if(!cancelBtnText.isNull()){
         ui->btnCancel->setVisible(true);
@@ -48,6 +57,23 @@ void DefaultDialog::setText(QString title, QString message, QString okBtnText, Q
     }
     if(!message.isNull()) ui->labelMessage->setText(message);
     if(!title.isNull()) ui->labelTitle->setText(title);
+}
+
+void DefaultDialog::accept()
+{
+    this->isOk = true;
+    QDialog::accept();
+}
+
+void DefaultDialog::keyPressEvent(QKeyEvent *event)
+{
+    if (event->type() == QEvent::KeyPress) {
+        QKeyEvent* ke = static_cast<QKeyEvent*>(event);
+        // Detect Enter key press
+        if (ke->key() == Qt::Key_Enter || ke->key() == Qt::Key_Return) accept();
+        // Detect Esc key press
+        if (ke->key() == Qt::Key_Escape) close();
+    }
 }
 
 DefaultDialog::~DefaultDialog()

--- a/src/qt/pivx/defaultdialog.h
+++ b/src/qt/pivx/defaultdialog.h
@@ -19,11 +19,18 @@ public:
     explicit DefaultDialog(QWidget *parent = nullptr);
     ~DefaultDialog();
 
+    void showEvent(QShowEvent *event) override;
     void setText(QString title = "", QString message = "", QString okBtnText = "", QString cancelBtnText = "");
 
     bool isOk = false;
+
+public Q_SLOTS:
+    void accept() override;
+
 private:
     Ui::DefaultDialog *ui;
+protected:
+    void keyPressEvent(QKeyEvent *e) override;
 };
 
 #endif // DEFAULTDIALOG_H

--- a/src/qt/pivx/sendconfirmdialog.cpp
+++ b/src/qt/pivx/sendconfirmdialog.cpp
@@ -144,10 +144,10 @@ void TxDetailDialog::setData(WalletModel *model, WalletModelTransaction &tx){
 
 void TxDetailDialog::acceptTx()
 {
-    if (isConfirmDialog) {
-        this->confirm = true;
-        this->sendStatus = model->sendCoins(*this->tx);
-    }
+    if (!isConfirmDialog)
+        throw GUIException(strprintf("%s called on non confirm dialog", __func__));
+    this->confirm = true;
+    this->sendStatus = model->sendCoins(*this->tx);
     accept();
 }
 
@@ -232,9 +232,13 @@ void TxDetailDialog::keyPressEvent(QKeyEvent *event)
     if (event->type() == QEvent::KeyPress) {
         QKeyEvent* ke = static_cast<QKeyEvent*>(event);
         // Detect Enter key press
-        if (ke->key() == Qt::Key_Enter || ke->key() == Qt::Key_Return) acceptTx();
+        if (ke->key() == Qt::Key_Enter || ke->key() == Qt::Key_Return) {
+            if (isConfirmDialog) acceptTx();
+            else accept();
+        }
         // Detect Esc key press
-        if (ke->key() == Qt::Key_Escape) closeDialog();
+        if (ke->key() == Qt::Key_Escape)
+            closeDialog();
     }
 }
 

--- a/src/qt/pivx/sendconfirmdialog.h
+++ b/src/qt/pivx/sendconfirmdialog.h
@@ -28,6 +28,7 @@ public:
     explicit TxDetailDialog(QWidget *parent = nullptr, bool isConfirmDialog = true, QString warningStr = QString());
     ~TxDetailDialog();
 
+    void showEvent(QShowEvent *event) override;
     bool isConfirm() { return this->confirm;}
     WalletModel::SendCoinsReturn getStatus() { return this->sendStatus;}
 
@@ -45,6 +46,7 @@ private:
     Ui::TxDetailDialog *ui;
     SnackBar *snackBar = nullptr;
     int nDisplayUnit = 0;
+    bool isConfirmDialog = false;
     bool confirm = false;
     WalletModel *model = nullptr;
     WalletModel::SendCoinsReturn sendStatus;
@@ -53,6 +55,9 @@ private:
 
     bool inputsLoaded = false;
     bool outputsLoaded = false;
+
+protected:
+    void keyPressEvent(QKeyEvent *e) override;
 };
 
 #endif // SENDCONFIRMDIALOG_H


### PR DESCRIPTION
Ref: https://github.com/PIVX-Project/PIVX/pull/1163#pullrequestreview-328980277

Completes the ability to accept/dismiss modal dialogs with the keyboard, including:
- confirmation dialogs (`DefaultDialog`)
- tx detail / tx confirmation dialogs (`TxDetailDialog`)