### PR TITLE
[GUI] Customizable sorting for address books

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -161,7 +161,13 @@ The p2p alert system has been removed in [#1372](https://github.com/PIVX-Project
 
 ### GUI
 
-Keyboard navigation: dialogs can now be accepted with the `ENTER` (`RETURN`) key, and dismissed with the `ESC` key ([#1392](https://github.com/PIVX-Project/PIVX/pull/1392)).
+**Keyboard navigation**: dialogs can now be accepted with the `ENTER` (`RETURN`) key, and dismissed with the `ESC` key ([#1392](https://github.com/PIVX-Project/PIVX/pull/1392)).
+
+
+**Address sorting**: address sorting in "My Addresses" / "Contacts" / "Cold Staking" can now be customized, setting it either by label (default), by address, or by creation date, ascending (default) or descending order.
+Addresses in the dropdown of the "Send Transaction" and "Send Delegation" widgets are now automatically sorted by label with ascending order ([#1393](https://github.com/PIVX-Project/PIVX/pull/1393)).
+
+
 
 ### RPC/REST
 

--- a/src/qt/pivx/addresseswidget.cpp
+++ b/src/qt/pivx/addresseswidget.cpp
@@ -156,6 +156,7 @@ void AddressesWidget::loadWalletModel(){
         addressTablemodel = walletModel->getAddressTableModel();
         this->filter = new AddressFilterProxyModel(QStringList({AddressTableModel::Send, AddressTableModel::ColdStakingSend}), this);
         this->filter->setSourceModel(addressTablemodel);
+        this->filter->sort(AddressTableModel::Label, Qt::AscendingOrder);
         ui->listAddresses->setModel(this->filter);
         ui->listAddresses->setModelColumn(AddressTableModel::Address);
 

--- a/src/qt/pivx/addresseswidget.cpp
+++ b/src/qt/pivx/addresseswidget.cpp
@@ -83,7 +83,7 @@ AddressesWidget::AddressesWidget(PIVXGUI* parent) :
     setCssTitleScreen(ui->labelTitle);
     setCssSubtitleScreen(ui->labelSubtitle1);
 
-    // Change eddress option
+    // Change address option
     ui->btnAddContact->setTitleClassAndText("btn-title-grey", "Add new contact");
     ui->btnAddContact->setSubTitleClassAndText("text-subtitle", "Generate a new address to receive tokens.");
     ui->btnAddContact->setRightIconClass("ic-arrow-down");
@@ -95,6 +95,15 @@ AddressesWidget::AddressesWidget(PIVXGUI* parent) :
     ui->listAddresses->setAttribute(Qt::WA_MacShowFocusRect, false);
     ui->listAddresses->setSelectionBehavior(QAbstractItemView::SelectRows);
     ui->listAddresses->setUniformItemSizes(true);
+
+    // Sort Controls
+    SortEdit* lineEdit = new SortEdit(ui->comboBoxSort);
+    connect(lineEdit, &SortEdit::Mouse_Pressed, [this](){ui->comboBoxSort->showPopup();});
+    connect(ui->comboBoxSort, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &AddressesWidget::onSortChanged);
+    SortEdit* lineEditOrder = new SortEdit(ui->comboBoxSortOrder);
+    connect(lineEditOrder, &SortEdit::Mouse_Pressed, [this](){ui->comboBoxSortOrder->showPopup();});
+    connect(ui->comboBoxSortOrder, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &AddressesWidget::onSortOrderChanged);
+    fillAddressSortControls(lineEdit, lineEditOrder, ui->comboBoxSort, ui->comboBoxSortOrder);
 
     //Empty List
     ui->emptyContainer->setVisible(false);
@@ -151,12 +160,13 @@ void AddressesWidget::handleAddressClicked(const QModelIndex &index){
     menu->show();
 }
 
-void AddressesWidget::loadWalletModel(){
+void AddressesWidget::loadWalletModel()
+{
     if(walletModel) {
         addressTablemodel = walletModel->getAddressTableModel();
         this->filter = new AddressFilterProxyModel(QStringList({AddressTableModel::Send, AddressTableModel::ColdStakingSend}), this);
         this->filter->setSourceModel(addressTablemodel);
-        this->filter->sort(AddressTableModel::Label, Qt::AscendingOrder);
+        this->filter->sort(sortType, sortOrder);
         ui->listAddresses->setModel(this->filter);
         ui->listAddresses->setModelColumn(AddressTableModel::Address);
 
@@ -258,6 +268,24 @@ void AddressesWidget::onAddContactShowHideClicked(){
         ui->btnAddContact->setRightIconClass("ic-arrow", true);
         ui->layoutNewContact->setVisible(false);
     }
+}
+
+void AddressesWidget::onSortChanged(int idx)
+{
+    sortType = (AddressTableModel::ColumnIndex) ui->comboBoxSort->itemData(idx).toInt();
+    sortAddresses();
+}
+
+void AddressesWidget::onSortOrderChanged(int idx)
+{
+    sortOrder = (Qt::SortOrder) ui->comboBoxSortOrder->itemData(idx).toInt();
+    sortAddresses();
+}
+
+void AddressesWidget::sortAddresses()
+{
+    if (this->filter)
+        this->filter->sort(sortType, sortOrder);
 }
 
 void AddressesWidget::changeTheme(bool isLightTheme, QString& theme){

--- a/src/qt/pivx/addresseswidget.h
+++ b/src/qt/pivx/addresseswidget.h
@@ -44,6 +44,8 @@ private Q_SLOTS:
     void onDeleteClicked();
     void onCopyClicked();
     void onAddContactShowHideClicked();
+    void onSortChanged(int idx);
+    void onSortOrderChanged(int idx);
 
     void changeTheme(bool isLightTheme, QString &theme) override;
 private:
@@ -59,7 +61,12 @@ private:
     // Cached index
     QModelIndex index;
 
+    // Cached sort type and order
+    AddressTableModel::ColumnIndex sortType = AddressTableModel::Label;
+    Qt::SortOrder sortOrder = Qt::AscendingOrder;
+
     void updateListView();
+    void sortAddresses();
 };
 
 #endif // ADDRESSESWIDGET_H

--- a/src/qt/pivx/coldstakingwidget.cpp
+++ b/src/qt/pivx/coldstakingwidget.cpp
@@ -192,23 +192,12 @@ ColdStakingWidget::ColdStakingWidget(PIVXGUI* parent) :
     ui->listViewStakingAddress->setSelectionBehavior(QAbstractItemView::SelectRows);
     ui->listViewStakingAddress->setUniformItemSizes(true);
 
-    // Sort Addresses
-    setCssSubtitleScreen(ui->sortLabel);
+    // Sort Controls
     SortEdit* lineEdit = new SortEdit(ui->comboBoxSort);
-    initComboBox(ui->comboBoxSort, lineEdit, "btn-combo-small");
     connect(lineEdit, &SortEdit::Mouse_Pressed, [this](){ui->comboBoxSort->showPopup();});
-    ui->comboBoxSort->addItem(tr("by Label"), AddressTableModel::Label);
-    ui->comboBoxSort->addItem(tr("by Address"), AddressTableModel::Address);
-    ui->comboBoxSort->addItem(tr("by Date"), AddressTableModel::Date);
-    ui->comboBoxSort->setCurrentIndex(0);
     connect(ui->comboBoxSort, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &ColdStakingWidget::onSortChanged);
-    // Sort Order
     SortEdit* lineEditOrder = new SortEdit(ui->comboBoxSortOrder);
-    initComboBox(ui->comboBoxSortOrder, lineEditOrder, "btn-combo-small");
     connect(lineEditOrder, &SortEdit::Mouse_Pressed, [this](){ui->comboBoxSortOrder->showPopup();});
-    ui->comboBoxSortOrder->addItem("asc", Qt::AscendingOrder);
-    ui->comboBoxSortOrder->addItem("desc", Qt::DescendingOrder);
-    ui->comboBoxSortOrder->setCurrentIndex(0);
     connect(ui->comboBoxSortOrder, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &ColdStakingWidget::onSortOrderChanged);
     fillAddressSortControls(lineEdit, lineEditOrder, ui->comboBoxSort, ui->comboBoxSortOrder);
     ui->sortWidget->setVisible(false);

--- a/src/qt/pivx/coldstakingwidget.cpp
+++ b/src/qt/pivx/coldstakingwidget.cpp
@@ -192,6 +192,26 @@ ColdStakingWidget::ColdStakingWidget(PIVXGUI* parent) :
     ui->listViewStakingAddress->setSelectionBehavior(QAbstractItemView::SelectRows);
     ui->listViewStakingAddress->setUniformItemSizes(true);
 
+    // Sort Addresses
+    setCssSubtitleScreen(ui->sortLabel);
+    SortEdit* lineEdit = new SortEdit(ui->comboBoxSort);
+    initComboBox(ui->comboBoxSort, lineEdit, "btn-combo-small");
+    connect(lineEdit, &SortEdit::Mouse_Pressed, [this](){ui->comboBoxSort->showPopup();});
+    ui->comboBoxSort->addItem(tr("by Label"), AddressTableModel::Label);
+    ui->comboBoxSort->addItem(tr("by Address"), AddressTableModel::Address);
+    ui->comboBoxSort->addItem(tr("by Date"), AddressTableModel::Date);
+    ui->comboBoxSort->setCurrentIndex(0);
+    connect(ui->comboBoxSort, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &ColdStakingWidget::onSortChanged);
+    // Sort Order
+    SortEdit* lineEditOrder = new SortEdit(ui->comboBoxSortOrder);
+    initComboBox(ui->comboBoxSortOrder, lineEditOrder, "btn-combo-small");
+    connect(lineEditOrder, &SortEdit::Mouse_Pressed, [this](){ui->comboBoxSortOrder->showPopup();});
+    ui->comboBoxSortOrder->addItem("asc", Qt::AscendingOrder);
+    ui->comboBoxSortOrder->addItem("desc", Qt::DescendingOrder);
+    ui->comboBoxSortOrder->setCurrentIndex(0);
+    connect(ui->comboBoxSortOrder, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &ColdStakingWidget::onSortOrderChanged);
+    ui->sortWidget->setVisible(false);
+
     connect(ui->pushButtonSend, &QPushButton::clicked, this, &ColdStakingWidget::onSendClicked);
     connect(btnOwnerContact, &QAction::triggered, [this](){ onContactsClicked(true); });
     connect(ui->listView, &QListView::clicked, this, &ColdStakingWidget::handleAddressClicked);
@@ -377,8 +397,7 @@ void ColdStakingWidget::onDelegateSelected(bool delegate)
         ui->btnColdStaking->setVisible(false);
         ui->btnMyStakingAddresses->setVisible(false);
         ui->listViewStakingAddress->setVisible(false);
-        if (ui->rightContainer->count() == 2)
-            ui->rightContainer->addItem(spacerDiv);
+        ui->rightContainer->addItem(spacerDiv);
     } else {
         ui->btnCoinControl->setVisible(false);
         ui->containerSend->setVisible(false);
@@ -761,9 +780,11 @@ void ColdStakingWidget::onMyStakingAddressesClicked()
                                                   "btn-dropdown" : "ic-arrow"), true);
     ui->listViewStakingAddress->setVisible(isStakingAddressListVisible);
     if (isStakingAddressListVisible) {
+        ui->sortWidget->setVisible(true);
         ui->rightContainer->removeItem(spacerDiv);
         ui->listViewStakingAddress->update();
     } else {
+        ui->sortWidget->setVisible(false);
         ui->rightContainer->addItem(spacerDiv);
     }
 }
@@ -782,6 +803,12 @@ void ColdStakingWidget::updateStakingTotalLabel()
             (total == 0) ? "0.00 PIV" : GUIUtil::formatBalance(total, nDisplayUnit))
     );
 }
+
+void ColdStakingWidget::onSortChanged(int idx)
+{}
+
+void ColdStakingWidget::onSortOrderChanged(int idx)
+{}
 
 ColdStakingWidget::~ColdStakingWidget()
 {

--- a/src/qt/pivx/coldstakingwidget.cpp
+++ b/src/qt/pivx/coldstakingwidget.cpp
@@ -211,6 +211,7 @@ void ColdStakingWidget::loadWalletModel()
         addressTableModel = walletModel->getAddressTableModel();
         addressesFilter = new AddressFilterProxyModel(AddressTableModel::ColdStaking, this);
         addressesFilter->setSourceModel(addressTableModel);
+        addressesFilter->sort(AddressTableModel::Label, Qt::AscendingOrder);
         ui->listViewStakingAddress->setModel(addressesFilter);
         ui->listViewStakingAddress->setModelColumn(AddressTableModel::Address);
 

--- a/src/qt/pivx/coldstakingwidget.cpp
+++ b/src/qt/pivx/coldstakingwidget.cpp
@@ -210,6 +210,7 @@ ColdStakingWidget::ColdStakingWidget(PIVXGUI* parent) :
     ui->comboBoxSortOrder->addItem("desc", Qt::DescendingOrder);
     ui->comboBoxSortOrder->setCurrentIndex(0);
     connect(ui->comboBoxSortOrder, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &ColdStakingWidget::onSortOrderChanged);
+    fillAddressSortControls(lineEdit, lineEditOrder, ui->comboBoxSort, ui->comboBoxSortOrder);
     ui->sortWidget->setVisible(false);
 
     connect(ui->pushButtonSend, &QPushButton::clicked, this, &ColdStakingWidget::onSendClicked);
@@ -231,7 +232,7 @@ void ColdStakingWidget::loadWalletModel()
         addressTableModel = walletModel->getAddressTableModel();
         addressesFilter = new AddressFilterProxyModel(AddressTableModel::ColdStaking, this);
         addressesFilter->setSourceModel(addressTableModel);
-        addressesFilter->sort(AddressTableModel::Label, Qt::AscendingOrder);
+        addressesFilter->sort(sortType, sortOrder);
         ui->listViewStakingAddress->setModel(addressesFilter);
         ui->listViewStakingAddress->setModelColumn(AddressTableModel::Address);
 
@@ -397,6 +398,7 @@ void ColdStakingWidget::onDelegateSelected(bool delegate)
         ui->btnColdStaking->setVisible(false);
         ui->btnMyStakingAddresses->setVisible(false);
         ui->listViewStakingAddress->setVisible(false);
+        ui->sortWidget->setVisible(false);
         ui->rightContainer->addItem(spacerDiv);
     } else {
         ui->btnCoinControl->setVisible(false);
@@ -407,6 +409,7 @@ void ColdStakingWidget::onDelegateSelected(bool delegate)
         ui->btnMyStakingAddresses->setVisible(true);
         // Show address list, if it was previously open
         ui->listViewStakingAddress->setVisible(isStakingAddressListVisible);
+        ui->sortWidget->setVisible(isStakingAddressListVisible);
     }
 }
 
@@ -805,10 +808,23 @@ void ColdStakingWidget::updateStakingTotalLabel()
 }
 
 void ColdStakingWidget::onSortChanged(int idx)
-{}
+{
+    sortType = (AddressTableModel::ColumnIndex) ui->comboBoxSort->itemData(idx).toInt();
+    sortAddresses();
+}
 
 void ColdStakingWidget::onSortOrderChanged(int idx)
-{}
+{
+    sortOrder = (Qt::SortOrder) ui->comboBoxSortOrder->itemData(idx).toInt();
+    sortAddresses();
+}
+
+void ColdStakingWidget::sortAddresses()
+{
+    if (this->addressesFilter)
+        this->addressesFilter->sort(sortType, sortOrder);
+}
+
 
 ColdStakingWidget::~ColdStakingWidget()
 {

--- a/src/qt/pivx/coldstakingwidget.h
+++ b/src/qt/pivx/coldstakingwidget.h
@@ -73,6 +73,8 @@ private Q_SLOTS:
     void onLabelClicked();
     void onMyStakingAddressesClicked();
     void onDelegationsRefreshed();
+    void onSortChanged(int idx);
+    void onSortOrderChanged(int idx);
 
 private:
     Ui::ColdStakingWidget *ui = nullptr;

--- a/src/qt/pivx/coldstakingwidget.h
+++ b/src/qt/pivx/coldstakingwidget.h
@@ -108,6 +108,9 @@ private:
     QModelIndex index;
     QModelIndex addressIndex;
 
+    // Cached sort type and order
+    AddressTableModel::ColumnIndex sortType = AddressTableModel::Label;
+    Qt::SortOrder sortOrder = Qt::AscendingOrder;
 
     int nDisplayUnit;
 
@@ -117,6 +120,7 @@ private:
     bool refreshDelegations();
     void onLabelClicked(QString dialogTitle, const QModelIndex &index, const bool& isMyColdStakingAddresses);
     void updateStakingTotalLabel();
+    void sortAddresses();
 };
 
 #endif // COLDSTAKINGWIDGET_H

--- a/src/qt/pivx/contactsdropdown.cpp
+++ b/src/qt/pivx/contactsdropdown.cpp
@@ -86,6 +86,7 @@ void ContactsDropdown::setWalletModel(WalletModel* _model, const QString& type){
         model = _model->getAddressTableModel();
         this->filter = new AddressFilterProxyModel(type, this);
         this->filter->setSourceModel(model);
+        this->filter->sort(AddressTableModel::Label, Qt::AscendingOrder);
         list->setModel(this->filter);
         list->setModelColumn(AddressTableModel::Address);
     } else {

--- a/src/qt/pivx/dashboardwidget.cpp
+++ b/src/qt/pivx/dashboardwidget.cpp
@@ -291,7 +291,8 @@ void DashboardWidget::onSortChanged(const QString& value){
     ui->listTransactions->update();
 }
 
-void DashboardWidget::onSortTypeChanged(const QString& value){
+void DashboardWidget::onSortTypeChanged(const QString& value)
+{
     if (!filter) return;
     int filterByType = ui->comboBoxSortType->itemData(ui->comboBoxSortType->currentIndex()).toInt();
     filter->setTypeFilter(filterByType);

--- a/src/qt/pivx/forms/addresseswidget.ui
+++ b/src/qt/pivx/forms/addresseswidget.ui
@@ -88,11 +88,61 @@
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>40</width>
+              <width>60</width>
               <height>20</height>
              </size>
             </property>
            </spacer>
+          </item>
+          <item>
+           <widget class="QWidget" name="sortWidget" native="true">
+            <layout class="QHBoxLayout" name="horizontalLayout_6">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>22</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QComboBox" name="comboBoxSort">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>115</width>
+                 <height>0</height>
+                </size>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QComboBox" name="comboBoxSortOrder">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>75</width>
+                 <height>0</height>
+                </size>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
           </item>
          </layout>
         </item>

--- a/src/qt/pivx/forms/coldstakingwidget.ui
+++ b/src/qt/pivx/forms/coldstakingwidget.ui
@@ -733,6 +733,9 @@
    <item>
     <widget class="QWidget" name="right" native="true">
      <layout class="QVBoxLayout" name="rightContainer">
+      <property name="spacing">
+       <number>0</number>
+      </property>
       <property name="leftMargin">
        <number>1</number>
       </property>
@@ -763,6 +766,9 @@
          <property name="rightMargin">
           <number>19</number>
          </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
          <item>
           <widget class="OptionButton" name="btnCoinControl" native="true">
            <property name="minimumSize">
@@ -783,6 +789,66 @@
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="sortWidget" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_6">
+         <property name="leftMargin">
+          <number>19</number>
+         </property>
+         <property name="rightMargin">
+          <number>19</number>
+         </property>
+         <property name="bottomMargin">
+          <number>5</number>
+         </property>
+         <item>
+          <spacer name="horizontalSpacer_6">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QComboBox" name="comboBoxSort">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>115</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="comboBoxSortOrder">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>75</width>
+             <height>0</height>
+            </size>
            </property>
           </widget>
          </item>

--- a/src/qt/pivx/forms/receivewidget.ui
+++ b/src/qt/pivx/forms/receivewidget.ui
@@ -385,6 +385,66 @@
          </layout>
         </item>
         <item>
+         <widget class="QWidget" name="sortWidget" native="true">
+          <layout class="QHBoxLayout" name="horizontalLayout_6">
+           <property name="leftMargin">
+            <number>19</number>
+           </property>
+           <property name="rightMargin">
+            <number>19</number>
+           </property>
+           <property name="bottomMargin">
+            <number>5</number>
+           </property>
+           <item>
+            <spacer name="horizontalSpacer_3">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QComboBox" name="comboBoxSort">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>115</width>
+               <height>0</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="comboBoxSortOrder">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>75</width>
+               <height>0</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
          <widget class="QListView" name="listViewAddress"/>
         </item>
        </layout>

--- a/src/qt/pivx/qtutils.cpp
+++ b/src/qt/pivx/qtutils.cpp
@@ -214,8 +214,9 @@ QColor getRowColor(bool isLightTheme, bool isHovered, bool isSelected){
     }
 }
 
-void initComboBox(QComboBox* combo, QLineEdit* lineEdit){
-    setCssProperty(combo, "btn-combo");
+void initComboBox(QComboBox* combo, QLineEdit* lineEdit, QString cssClass)
+{
+    setCssProperty(combo, cssClass);
     combo->setEditable(true);
     if (lineEdit) {
         lineEdit->setReadOnly(true);

--- a/src/qt/pivx/qtutils.cpp
+++ b/src/qt/pivx/qtutils.cpp
@@ -227,6 +227,21 @@ void initComboBox(QComboBox* combo, QLineEdit* lineEdit, QString cssClass)
     combo->setView(new QListView());
 }
 
+void fillAddressSortControls(SortEdit* seType, SortEdit* seOrder, QComboBox* boxType, QComboBox* boxOrder)
+{
+    // Sort Type
+    initComboBox(boxType, seType, "btn-combo-small");
+    boxType->addItem(QObject::tr("by Label"), AddressTableModel::Label);
+    boxType->addItem(QObject::tr("by Address"), AddressTableModel::Address);
+    boxType->addItem(QObject::tr("by Date"), AddressTableModel::Date);
+    boxType->setCurrentIndex(0);
+    // Sort Order
+    initComboBox(boxOrder, seOrder, "btn-combo-small");
+    boxOrder->addItem("asc", Qt::AscendingOrder);
+    boxOrder->addItem("desc", Qt::DescendingOrder);
+    boxOrder->setCurrentIndex(0);
+}
+
 void initCssEditLine(QLineEdit *edit, bool isDialog){
     if (isDialog) setCssEditLineDialog(edit, true, false);
     else setCssEditLine(edit, true, false);

--- a/src/qt/pivx/qtutils.h
+++ b/src/qt/pivx/qtutils.h
@@ -56,7 +56,7 @@ void setupSettings(QSettings *settings);
 bool isLightTheme();
 void setTheme(bool isLight);
 
-void initComboBox(QComboBox* combo, QLineEdit* lineEdit = nullptr);
+void initComboBox(QComboBox* combo, QLineEdit* lineEdit = nullptr, QString cssClass = "btn-combo");
 
 void initCssEditLine(QLineEdit *edit, bool isDialog = false);
 void setCssEditLine(QLineEdit *edit, bool isValid, bool forceUpdate = false);

--- a/src/qt/pivx/qtutils.h
+++ b/src/qt/pivx/qtutils.h
@@ -57,7 +57,7 @@ bool isLightTheme();
 void setTheme(bool isLight);
 
 void initComboBox(QComboBox* combo, QLineEdit* lineEdit = nullptr, QString cssClass = "btn-combo");
-
+void fillAddressSortControls(SortEdit* seType, SortEdit* seOrder, QComboBox* boxType, QComboBox* boxOrder);
 void initCssEditLine(QLineEdit *edit, bool isDialog = false);
 void setCssEditLine(QLineEdit *edit, bool isValid, bool forceUpdate = false);
 void setCssEditLineDialog(QLineEdit *edit, bool isValid, bool forceUpdate = false);

--- a/src/qt/pivx/receivewidget.cpp
+++ b/src/qt/pivx/receivewidget.cpp
@@ -91,6 +91,26 @@ ReceiveWidget::ReceiveWidget(PIVXGUI* parent) :
     ui->container_right->addItem(spacer);
     ui->listViewAddress->setVisible(false);
 
+    // Sort Addresses
+    setCssSubtitleScreen(ui->sortLabel);
+    SortEdit* lineEdit = new SortEdit(ui->comboBoxSort);
+    initComboBox(ui->comboBoxSort, lineEdit, "btn-combo-small");
+    connect(lineEdit, &SortEdit::Mouse_Pressed, [this](){ui->comboBoxSort->showPopup();});
+    ui->comboBoxSort->addItem(tr("by Label"), AddressTableModel::Label);
+    ui->comboBoxSort->addItem(tr("by Address"), AddressTableModel::Address);
+    ui->comboBoxSort->addItem(tr("by Date"), AddressTableModel::Date);
+    ui->comboBoxSort->setCurrentIndex(0);
+    connect(ui->comboBoxSort, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &ReceiveWidget::onSortChanged);
+    // Sort Order
+    SortEdit* lineEditOrder = new SortEdit(ui->comboBoxSortOrder);
+    initComboBox(ui->comboBoxSortOrder, lineEditOrder, "btn-combo-small");
+    connect(lineEditOrder, &SortEdit::Mouse_Pressed, [this](){ui->comboBoxSortOrder->showPopup();});
+    ui->comboBoxSortOrder->addItem("asc", Qt::AscendingOrder);
+    ui->comboBoxSortOrder->addItem("desc", Qt::DescendingOrder);
+    ui->comboBoxSortOrder->setCurrentIndex(0);
+    connect(ui->comboBoxSortOrder, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &ReceiveWidget::onSortOrderChanged);
+    ui->sortWidget->setVisible(false);
+
     // Connect
     connect(ui->pushButtonLabel, &QPushButton::clicked, this, &ReceiveWidget::onLabelClicked);
     connect(ui->pushButtonCopy, &QPushButton::clicked, this, &ReceiveWidget::onCopyClicked);
@@ -287,14 +307,22 @@ void ReceiveWidget::onMyAddressesClicked()
     if (!isVisible) {
         ui->btnMyAddresses->setRightIconClass("btn-dropdown", true);
         ui->listViewAddress->setVisible(true);
+        ui->sortWidget->setVisible(true);
         ui->container_right->removeItem(spacer);
         ui->listViewAddress->update();
     } else {
         ui->btnMyAddresses->setRightIconClass("ic-arrow", true);
         ui->container_right->addItem(spacer);
         ui->listViewAddress->setVisible(false);
+        ui->sortWidget->setVisible(false);
     }
 }
+
+void ReceiveWidget::onSortChanged(int idx)
+{}
+
+void ReceiveWidget::onSortOrderChanged(int idx)
+{}
 
 void ReceiveWidget::changeTheme(bool isLightTheme, QString& theme)
 {

--- a/src/qt/pivx/receivewidget.cpp
+++ b/src/qt/pivx/receivewidget.cpp
@@ -106,6 +106,7 @@ void ReceiveWidget::loadWalletModel()
         this->addressTableModel = walletModel->getAddressTableModel();
         this->filter = new AddressFilterProxyModel(AddressTableModel::Receive, this);
         this->filter->setSourceModel(addressTableModel);
+        this->filter->sort(AddressTableModel::Label, Qt::AscendingOrder);
         ui->listViewAddress->setModel(this->filter);
         ui->listViewAddress->setModelColumn(AddressTableModel::Address);
 

--- a/src/qt/pivx/receivewidget.cpp
+++ b/src/qt/pivx/receivewidget.cpp
@@ -91,23 +91,12 @@ ReceiveWidget::ReceiveWidget(PIVXGUI* parent) :
     ui->container_right->addItem(spacer);
     ui->listViewAddress->setVisible(false);
 
-    // Sort Addresses
-    setCssSubtitleScreen(ui->sortLabel);
+    // Sort Controls
     SortEdit* lineEdit = new SortEdit(ui->comboBoxSort);
-    initComboBox(ui->comboBoxSort, lineEdit, "btn-combo-small");
     connect(lineEdit, &SortEdit::Mouse_Pressed, [this](){ui->comboBoxSort->showPopup();});
-    ui->comboBoxSort->addItem(tr("by Label"), AddressTableModel::Label);
-    ui->comboBoxSort->addItem(tr("by Address"), AddressTableModel::Address);
-    ui->comboBoxSort->addItem(tr("by Date"), AddressTableModel::Date);
-    ui->comboBoxSort->setCurrentIndex(0);
     connect(ui->comboBoxSort, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &ReceiveWidget::onSortChanged);
-    // Sort Order
     SortEdit* lineEditOrder = new SortEdit(ui->comboBoxSortOrder);
-    initComboBox(ui->comboBoxSortOrder, lineEditOrder, "btn-combo-small");
     connect(lineEditOrder, &SortEdit::Mouse_Pressed, [this](){ui->comboBoxSortOrder->showPopup();});
-    ui->comboBoxSortOrder->addItem("asc", Qt::AscendingOrder);
-    ui->comboBoxSortOrder->addItem("desc", Qt::DescendingOrder);
-    ui->comboBoxSortOrder->setCurrentIndex(0);
     connect(ui->comboBoxSortOrder, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &ReceiveWidget::onSortOrderChanged);
     fillAddressSortControls(lineEdit, lineEditOrder, ui->comboBoxSort, ui->comboBoxSortOrder);
     ui->sortWidget->setVisible(false);

--- a/src/qt/pivx/receivewidget.cpp
+++ b/src/qt/pivx/receivewidget.cpp
@@ -109,6 +109,7 @@ ReceiveWidget::ReceiveWidget(PIVXGUI* parent) :
     ui->comboBoxSortOrder->addItem("desc", Qt::DescendingOrder);
     ui->comboBoxSortOrder->setCurrentIndex(0);
     connect(ui->comboBoxSortOrder, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &ReceiveWidget::onSortOrderChanged);
+    fillAddressSortControls(lineEdit, lineEditOrder, ui->comboBoxSort, ui->comboBoxSortOrder);
     ui->sortWidget->setVisible(false);
 
     // Connect
@@ -126,7 +127,7 @@ void ReceiveWidget::loadWalletModel()
         this->addressTableModel = walletModel->getAddressTableModel();
         this->filter = new AddressFilterProxyModel(AddressTableModel::Receive, this);
         this->filter->setSourceModel(addressTableModel);
-        this->filter->sort(AddressTableModel::Label, Qt::AscendingOrder);
+        this->filter->sort(sortType, sortOrder);
         ui->listViewAddress->setModel(this->filter);
         ui->listViewAddress->setModelColumn(AddressTableModel::Address);
 
@@ -319,10 +320,22 @@ void ReceiveWidget::onMyAddressesClicked()
 }
 
 void ReceiveWidget::onSortChanged(int idx)
-{}
+{
+    sortType = (AddressTableModel::ColumnIndex) ui->comboBoxSort->itemData(idx).toInt();
+    sortAddresses();
+}
 
 void ReceiveWidget::onSortOrderChanged(int idx)
-{}
+{
+    sortOrder = (Qt::SortOrder) ui->comboBoxSortOrder->itemData(idx).toInt();
+    sortAddresses();
+}
+
+void ReceiveWidget::sortAddresses()
+{
+    if (this->filter)
+        this->filter->sort(sortType, sortOrder);
+}
 
 void ReceiveWidget::changeTheme(bool isLightTheme, QString& theme)
 {

--- a/src/qt/pivx/receivewidget.h
+++ b/src/qt/pivx/receivewidget.h
@@ -47,6 +47,8 @@ private Q_SLOTS:
     void refreshView(const QModelIndex& tl, const QModelIndex& br);
     void refreshView(QString refreshAddress = QString());
     void handleAddressClicked(const QModelIndex &index);
+    void onSortChanged(int idx);
+    void onSortOrderChanged(int idx);
 private:
     Ui::ReceiveWidget *ui;
 

--- a/src/qt/pivx/receivewidget.h
+++ b/src/qt/pivx/receivewidget.h
@@ -63,9 +63,14 @@ private:
     // Cached qr
     QPixmap *qrImage = nullptr;
 
+    // Cached sort type and order
+    AddressTableModel::ColumnIndex sortType = AddressTableModel::Label;
+    Qt::SortOrder sortOrder = Qt::AscendingOrder;
+
     void updateQr(QString address);
     void updateLabel();
     void showAddressGenerationDialog(bool isPaymentRequest);
+    void sortAddresses();
 
     bool isShowingDialog = false;
 

--- a/src/qt/pivx/res/css/style_dark.css
+++ b/src/qt/pivx/res/css/style_dark.css
@@ -2119,6 +2119,21 @@ QComboBox[cssClass="btn-combo"]::down-arrow {
     height: 24px;
 }
 
+QComboBox[cssClass="btn-combo-small"] {
+    background-color:#0f0b16;
+    padding:8px 16px 8px 8px;
+    font-size:14px;
+    border:1px solid #0f0b16;
+    color: #707070;
+    text-align: right;
+}
+
+QComboBox[cssClass="btn-combo-small"]::down-arrow {
+    image: url("://ic-arrow-drop-down");
+    width: 16px;
+    height: 16px;
+}
+
 QComboBox[cssClass="btn-combo-edit"] {
     background-color:#0f0b16;
     padding:10px 20px 10px 10px;

--- a/src/qt/pivx/res/css/style_dark.css
+++ b/src/qt/pivx/res/css/style_dark.css
@@ -2121,8 +2121,8 @@ QComboBox[cssClass="btn-combo"]::down-arrow {
 
 QComboBox[cssClass="btn-combo-small"] {
     background-color:#0f0b16;
-    padding:8px 16px 8px 8px;
-    font-size:14px;
+    padding:8px 14px 8px 8px;
+    font-size:13px;
     border:1px solid #0f0b16;
     color: #707070;
     text-align: right;
@@ -2130,8 +2130,8 @@ QComboBox[cssClass="btn-combo-small"] {
 
 QComboBox[cssClass="btn-combo-small"]::down-arrow {
     image: url("://ic-arrow-drop-down");
-    width: 16px;
-    height: 16px;
+    width: 15px;
+    height: 15px;
 }
 
 QComboBox[cssClass="btn-combo-edit"] {

--- a/src/qt/pivx/res/css/style_light.css
+++ b/src/qt/pivx/res/css/style_light.css
@@ -2120,6 +2120,21 @@ QComboBox[cssClass="btn-combo"]::down-arrow {
     height: 24px;
 }
 
+QComboBox[cssClass="btn-combo-small"] {
+    background-color:#ffffff;
+    padding:8px 16px 8px 8px;
+    font-size:14px;
+    border:1px solid #ffffff;
+    color: #707070;
+    text-align: right;
+}
+
+QComboBox[cssClass="btn-combo-small"]::down-arrow {
+    image: url("://ic-arrow-drop-down");
+    width: 16px;
+    height: 16px;
+}
+
 QComboBox[cssClass="btn-combo-edit"] {
     background-color:#ffffff;
     padding:10px 20px 10px 10px;

--- a/src/qt/pivx/res/css/style_light.css
+++ b/src/qt/pivx/res/css/style_light.css
@@ -2122,8 +2122,8 @@ QComboBox[cssClass="btn-combo"]::down-arrow {
 
 QComboBox[cssClass="btn-combo-small"] {
     background-color:#ffffff;
-    padding:8px 16px 8px 8px;
-    font-size:14px;
+    padding:8px 14px 8px 8px;
+    font-size:13px;
     border:1px solid #ffffff;
     color: #707070;
     text-align: right;
@@ -2131,8 +2131,8 @@ QComboBox[cssClass="btn-combo-small"] {
 
 QComboBox[cssClass="btn-combo-small"]::down-arrow {
     image: url("://ic-arrow-drop-down");
-    width: 16px;
-    height: 16px;
+    width: 15px;
+    height: 15px;
 }
 
 QComboBox[cssClass="btn-combo-edit"] {


### PR DESCRIPTION
This adds GUI controls and relative logic to sort the addresses saved in the wallet and presented to the user. 
Interested views:
- Receive --> My Addresses
- Cold Staking --> My Cold Staking Addresses
- Contacts
- Send / Delegate --> recipient dropdown

Addresses can now be sorted (ascending or descending order):
- by label (default)
- by address
- by creation date.

Closes #1038 .

---

For "receive" addresses and own "cold-staking" addresses, the controls are hidden with the list, and show up when the relative button is pressed:
<br>

![sort_addys_1b](https://user-images.githubusercontent.com/18186894/76258309-992ea500-6253-11ea-974a-9b759a020a83.gif)

---

<br>
For "contacts" the controls are visible next to the title
<br>

![sort_addys_2](https://user-images.githubusercontent.com/18186894/76258332-a3e93a00-6253-11ea-896b-745e21a71873.gif)

---

<br>
For the dropdown in the "send" widget, instead, a fixed by-label ascending order is used (adding controls for customization here would be probably useless and only make the the space overcrowded).
<br>

![sort_addys_3](https://user-images.githubusercontent.com/18186894/76258372-b3688300-6253-11ea-9483-0ff175378fb3.gif)

---
<br>


Note: currently based on top of:
- [x] #1385 

The present diff starts with the second commit.