### PR TITLE
[RPC] Upgrade to HD wallet.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1689,10 +1689,12 @@ bool AppInit2()
             }
         }
 
-        // Upgrade to HD if explicit upgrade was requested.
-        std::string upgradeError;
-        if (!pwalletMain->Upgrade(upgradeError, prev_version)) {
-            strErrors << upgradeError << "\n";
+        // Upgrade to HD only if explicit upgrade was requested
+        if (GetBoolArg("-upgradewallet", false)) {
+            std::string upgradeError;
+            if (!pwalletMain->Upgrade(upgradeError, prev_version)) {
+                strErrors << upgradeError << "\n";
+            }
         }
 
         if (fFirstRun) {

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -404,6 +404,7 @@ static const CRPCCommand vRPCCommands[] =
         {"wallet", "getbalance", &getbalance, false, false, true},
         {"wallet", "getcoldstakingbalance", &getcoldstakingbalance, false, false, true},
         {"wallet", "getdelegatedbalance", &getdelegatedbalance, false, false, true},
+        {"wallet", "upgradewallet", &upgradewallet, true, false, true},
         {"wallet", "sethdseed", &sethdseed, true, false, true},
         {"wallet", "getaddressinfo", &getaddressinfo, true, false, true},
         {"wallet", "getnewaddress", &getnewaddress, true, false, true},

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -179,6 +179,8 @@ extern std::string HelpExampleCli(std::string methodname, std::string args);
 extern std::string HelpExampleRpc(std::string methodname, std::string args);
 
 extern void EnsureWalletIsUnlocked(bool fAllowAnonOnly = false);
+// Ensure the wallet's existence.
+extern void EnsureWallet();
 extern UniValue DoZpivSpend(const CAmount nAmount, std::vector<CZerocoinMint>& vMintsSelected, std::string address_str);
 
 extern UniValue getconnectioncount(const UniValue& params, bool fHelp); // in rpc/net.cpp
@@ -216,6 +218,7 @@ extern UniValue delegatestake(const UniValue& params, bool fHelp); // in rpcwall
 extern UniValue rawdelegatestake(const UniValue& params, bool fHelp);
 extern UniValue delegatoradd(const UniValue& params, bool fHelp);
 extern UniValue delegatorremove(const UniValue& params, bool fHelp);
+extern UniValue upgradewallet(const UniValue& params, bool fHelp);
 extern UniValue sethdseed(const UniValue& params, bool fHelp);
 extern UniValue getaddressinfo(const UniValue& params, bool fHelp);
 extern UniValue getnewaddress(const UniValue& params, bool fHelp);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1518,19 +1518,13 @@ bool CWalletTx::WriteToDisk(CWalletDB *pwalletdb)
 
 bool CWallet::Upgrade(std::string& error, const int& prevVersion)
 {
-    // Upgrade to HD if explicit upgrade
-    if (GetBoolArg("-upgradewallet", false)) {
-        LOCK(cs_wallet);
-
-        // Do not upgrade versions if we are already in the last one
-        if (prevVersion >= FEATURE_PRE_SPLIT_KEYPOOL) {
-            error = strprintf(_("Cannot upgrade to HD wallet (already running HD support). Version: %d"), prevVersion);
-            return false;
-        }
-
-        return m_spk_man->Upgrade(prevVersion, error);
+    LOCK(cs_wallet);
+    // Do not upgrade versions if we are already in the last one
+    if (prevVersion >= FEATURE_PRE_SPLIT_KEYPOOL) {
+        error = strprintf(_("Cannot upgrade to HD wallet (already running HD support). Version: %d"), prevVersion);
+        return false;
     }
-    return true;
+    return m_spk_man->Upgrade(prevVersion, error);
 }
 
 /**


### PR DESCRIPTION
The rationality behind this work is that locked wallets, as them are encrypted, are not able to upgrade to HD wallet. The keystore and thereby keys are not available to perform any action at initialization time.

This PR solves it adding a new JSON-RPC command `upgradewallet` to be able to upgrade the wallet at runtime, requesting the wallet passphrase if it's needed.

A functional test verifying the new command was included inside the `wallet_upgrade.py` test.

