### PR TITLE
[GUI][Bug] Fix max decimals in sendcustomfeedialog

### DIFF
--- a/src/qt/pivx/forms/sendcustomfeedialog.ui
+++ b/src/qt/pivx/forms/sendcustomfeedialog.ui
@@ -283,7 +283,7 @@
            <item alignment="Qt::AlignHCenter">
             <widget class="QLabel" name="labelCustomFee">
              <property name="text">
-              <string>Per kilobyte</string>
+              <string>PIV/kilobyte</string>
              </property>
             </widget>
            </item>

--- a/src/qt/pivx/sendcustomfeedialog.cpp
+++ b/src/qt/pivx/sendcustomfeedialog.cpp
@@ -37,8 +37,9 @@ SendCustomFeeDialog::SendCustomFeeDialog(QWidget *parent) :
 
     // Custom
     setCssProperty(ui->labelCustomFee, "label-subtitle-dialog");
-    ui->lineEditCustomFee->setPlaceholderText("0.000001 PIV");
+    ui->lineEditCustomFee->setPlaceholderText("0.000001");
     initCssEditLine(ui->lineEditCustomFee, true);
+    GUIUtil::setupAmountWidget(ui->lineEditCustomFee, this);
 
     // Buttons
     setCssProperty(ui->btnEsc, "ic-close");


### PR DESCRIPTION
Custom Fee is expressed in PIV/kB.
Thus can only have at max 8 decimals.
Closes #1397 