### PR TITLE
[GUI] SendMultiRow: clear address label when address is changed

### DIFF
--- a/src/qt/pivx/sendmultirow.cpp
+++ b/src/qt/pivx/sendmultirow.cpp
@@ -83,7 +83,9 @@ CAmount SendMultiRow::getAmountValue(QString amount){
     return isValid ? value : -1;
 }
 
-bool SendMultiRow::addressChanged(const QString& str){
+bool SendMultiRow::addressChanged(const QString& str)
+{
+    ui->lineEditDescription->clear();
     if(!str.isEmpty()) {
         QString trimmedStr = str.trimmed();
         bool valid = (this->onlyStakingAddressAccepted) ? walletModel->validateStakingAddress(trimmedStr) : walletModel->validateAddress(trimmedStr);


### PR DESCRIPTION
In the send tab, when there is only one recipient, the address label is automatically loaded by the wallet if the user enters a known address in the recipient field.

**Problem:** If the user overwrites the recipient entry, inserting a new address, and this address is not found in the addressbook (or even simply deletes the previous inserted address), then the label does not change, and keeps displaying the one fetched earlier (the label of the __previous__ address).
This of course could lead to issues of users sending to a different recipient than intended.

**Fix:** Trivial. clear the label whenever the address is changed (before updating it if the address inserted is labeled in the addressbook).
