### PR TITLE
[Consensus] CheckColdStakeFreeOutput when mnsync not complete

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3675,7 +3675,7 @@ bool CheckColdStakeFreeOutput(const CTransaction& tx, const int nHeight)
             CAmount amtIn = txPrev.vout[tx.vin[0].prevout.n].nValue + GetBlockValue(nHeight - 1);
             CAmount amtOut = 0;
             for (unsigned int i = 1; i < outs-1; i++) amtOut += tx.vout[i].nValue;
-            if (amtOut < amtIn)
+            if (amtOut != amtIn)
                 return error("%s: non-free outputs value %d less than required %d", __func__, amtOut, amtIn);
             return true;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3661,13 +3661,34 @@ bool CheckColdStakeFreeOutput(const CTransaction& tx, const int nHeight)
         if (lastOut.nValue == 3 * COIN)
             return true;
 
-        if (budget.IsBudgetPaymentBlock(nHeight)) {
-            // if this is a budget payment, check that SPORK_9 and SPORK_13 are active (if spork list synced)
-            return (!masternodeSync.IsSporkListSynced() ||
-                    (sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS) &&
-                    sporkManager.IsSporkActive(SPORK_9_MASTERNODE_BUDGET_ENFORCEMENT)));
+        // This could be a budget block.
+        if (Params().IsRegTestNet())
+            return false;
+
+        // if mnsync is incomplete, we cannot verify if this is a budget block.
+        // so we check that the staker is not transferring value to the free output
+        if (!masternodeSync.IsSynced()) {
+            // First try finding the previous transaction in database
+            CTransaction txPrev; uint256 hashBlock;
+            if (!GetTransaction(tx.vin[0].prevout.hash, txPrev, hashBlock, true))
+                return error("%s : read txPrev failed: %s",  __func__, tx.vin[0].prevout.hash.GetHex());
+            CAmount amtIn = txPrev.vout[tx.vin[0].prevout.n].nValue + GetBlockValue(nHeight - 1);
+            CAmount amtOut = 0;
+            for (unsigned int i = 1; i < outs-1; i++) amtOut += tx.vout[i].nValue;
+            if (amtOut < amtIn)
+                return error("%s: non-free outputs value %d less than required %d", __func__, amtOut, amtIn);
+            return true;
         }
 
+        // Check that this is indeed a superblock.
+        if (budget.IsBudgetPaymentBlock(nHeight)) {
+            // if superblocks are not enabled, reject
+            if (!sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS))
+                return error("%s: superblocks are not enabled");
+            return true;
+        }
+
+        // wrong free output
         return error("%s: Wrong cold staking outputs: vout[%d].scriptPubKey (%s) != vout[%d].scriptPubKey (%s) - value: %s",
                 __func__, outs-1, HexStr(lastOut.scriptPubKey), outs-2, HexStr(tx.vout[outs-2].scriptPubKey), FormatMoney(lastOut.nValue).c_str());
     }


### PR DESCRIPTION
Follow up to #1331 for the same bug.

**Problem:** if the finalized budgets and the masternode list are not synchronized, the output returned from `IsBudgetPaymentBlock` is unreliable.

For the moment we fix it by checking that the sum of the stake input value and block reward is at least equal to the sum of the values of non-free outputs.

A better approach, for the future, would be probably to outright prevent any call to `CheckBlock` when `IsInitialBlockDownload` is false but mnSync is not fully completed yet.