### PR TITLE
[GUI][Model] Save cache BlockIndex tip in the model

### DIFF
--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -8,6 +8,7 @@
 #define BITCOIN_QT_CLIENTMODEL_H
 
 #include "uint256.h"
+#include "chain.h"
 #include <QObject>
 #include <QDateTime>
 
@@ -53,17 +54,17 @@ public:
 
     //! Return number of connections, default is in- and outbound (total)
     int getNumConnections(unsigned int flags = CONNECTIONS_ALL) const;
-    QString getMasternodeCountString() const;
-    int getNumBlocks() const;
     int getNumBlocksAtStartup();
+    QString getMasternodeCountString() const;
+
+    // from cached block index
+    int getNumBlocks() const;
+    QDateTime getLastBlockDate() const;
+    QString getLastBlockHash() const;
+    double getVerificationProgress() const;
 
     quint64 getTotalBytesRecv() const;
     quint64 getTotalBytesSent() const;
-
-    double getVerificationProgress() const;
-    QDateTime getLastBlockDate() const;
-
-    QString getLastBlockHash() const;
 
     //! Return true if core is doing initial block download
     bool inInitialBlockDownload() const;
@@ -79,7 +80,7 @@ public:
     QString formatClientStartupTime() const;
     QString dataDir() const;
 
-    void setCacheNumBlocks(int blockNum) { cachedNumBlocks = blockNum; };
+    void setCacheTip(const CBlockIndex* const tip) { cacheTip = tip; };
     void setCacheReindexing(bool reindex) { cachedReindexing = reindex; };
     void setCacheImporting(bool import) { cachedImporting = import; };
 
@@ -90,7 +91,7 @@ private:
     PeerTableModel* peerTableModel;
     BanTableModel *banTableModel;
 
-    int cachedNumBlocks;
+    const CBlockIndex* cacheTip;
     QString cachedMasternodeCountString;
     bool cachedReindexing;
     bool cachedImporting;


### PR DESCRIPTION
**Probelm**: GUI client model requires calls to `chainActive` (thus locking the main UI thread) for the following functions:
- getNumBlocks
- getLastBlockDate
- getLastBlockHash
- getVerificationProgress

**Fix**: use the `NotifyBlockTip` core signal to update a cached tip blockindex in `BlockTipChanged`, and rely on this object for the aforementioned functions.

**Note**: This should allow to complete #1047 