### PR TITLE
[Tests] Run tests on pre-HD wallets

### DIFF
--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -361,9 +361,6 @@ bool ScriptPubKeyMan::NewKeyPool()
  */
 bool ScriptPubKeyMan::TopUp(unsigned int kpSize)
 {
-    if (!CanGenerateKeys()) {
-        return false;
-    }
     {
         LOCK(wallet->cs_wallet);
         if (wallet->IsLocked()) return false;

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -122,6 +122,8 @@ class PivxTestFramework():
                           help="Write tested RPC commands into this directory")
         parser.add_option("--configfile", dest="configfile",
                           help="Location of the test framework config file")
+        parser.add_option('--legacywallet', dest="legacywallet", default=False, action="store_true",
+                          help='create pre-HD wallets only')
         parser.add_option("--pdbonfailure", dest="pdbonfailure", default=False, action="store_true",
                           help="Attach a python debugger if test fails")
         parser.add_option("--usecli", dest="usecli", default=False, action="store_true",
@@ -248,6 +250,11 @@ class PivxTestFramework():
 
         if extra_args is None:
             extra_args = [[]] * num_nodes
+        # Check wallet version
+        if self.options.legacywallet:
+            for arg in extra_args:
+                arg.append('-legacywallet')
+            self.log.info("Running test with legacy (pre-HD) wallet")
         if binary is None:
             binary = [None] * num_nodes
         assert_equal(len(extra_args), num_nodes)

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -178,6 +178,7 @@ def main():
     parser.add_argument('--jobs', '-j', type=int, default=4, help='how many test scripts to run in parallel. Default=4.')
     parser.add_argument('--keepcache', '-k', action='store_true', help='the default behavior is to flush the cache directory on startup. --keepcache retains the cache from the previous testrun.')
     parser.add_argument('--quiet', '-q', action='store_true', help='only print dots, results summary and failure logs')
+    parser.add_argument('--legacywallet', '-w', action='store_true', help='create pre-HD wallets only')
     parser.add_argument('--tmpdirprefix', '-t', default=tempfile.gettempdir(), help="Root directory for datadirs")
     args, unknown_args = parser.parse_known_args()
 
@@ -191,6 +192,8 @@ def main():
     config.read_file(open(configfile))
 
     passon_args.append("--configfile=%s" % configfile)
+    if args.legacywallet:
+        passon_args.append("--legacywallet")
 
     # Set up logging
     logging_level = logging.INFO if args.quiet else logging.DEBUG

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -26,7 +26,11 @@ class WalletHDTest(PivxTestFramework):
         self.skip_if_no_wallet()
 
     def run_test(self):
-        # Make sure we use hd, keep masterkeyid
+        # Make sure we use hd
+        if '-legacywallet' in self.nodes[0].extra_args:
+            self.log.info("Exiting HD test for non-HD wallets")
+            return
+        # keep masterkeyid
         masterkeyid = self.nodes[1].getwalletinfo()['hdseedid']
         assert_equal(len(masterkeyid), 40)
 

--- a/test/functional/wallet_upgrade.py
+++ b/test/functional/wallet_upgrade.py
@@ -101,6 +101,10 @@ class WalletUpgradeTest (PivxTestFramework):
 
 
     def run_test(self):
+        # Make sure we use hd
+        if '-legacywallet' in self.nodes[0].extra_args:
+            self.log.info("Exiting HD upgrade test for non-HD wallets")
+            return
         self.log.info("Checking correct version")
         assert_equal(self.nodes[0].getwalletinfo()['walletversion'], 61000)
 

--- a/test/functional/wallet_upgrade.py
+++ b/test/functional/wallet_upgrade.py
@@ -76,7 +76,7 @@ class WalletUpgradeTest (PivxTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 1
 
-    def check_keys(self, addrs):
+    def check_keys(self, addrs, mined_blocks = 0):
         self.log.info("Checking old keys existence in the upgraded wallet..")
         # Now check that all of the pre upgrade addresses are still in the wallet
         for addr in addrs:
@@ -87,7 +87,7 @@ class WalletUpgradeTest (PivxTestFramework):
         self.log.info("All pre-upgrade keys found in the wallet :)")
 
         # Use all of the keys in the pre-HD keypool
-        for _ in range(0, 60):
+        for _ in range(0, 60 + mined_blocks):
             self.nodes[0].getnewaddress()
 
         self.log.info("All pre-upgrade keys should have been marked as used by now, creating new HD keys")
@@ -143,7 +143,7 @@ class WalletUpgradeTest (PivxTestFramework):
 
         self.log.info("upgrade completed, checking keys now..")
         # Now check if the upgrade went fine
-        self.check_keys(addrs)
+        self.check_keys(addrs, 1)
 
         self.log.info("Upgrade via RPC completed, all good :)")
 


### PR DESCRIPTION
This adds a startup flag `-legacywallet`, which, on first run, enables the creation of a pre-HD wallet (when a wallet.dat is already present, the flag is just ignored). This flag is available for RegTest only.

A special option `--legacywallet` is also added to the functional test_runner.
Single tests (or the entire test suite) can now be performed over legacy wallets easily, e.g.:
```
./test_runner.py -j10 --legacywallet

./wallet_basic.py --legacywallet
```

**Note 1**: Running with pre-HD wallets, the `wallet_accounts.py` test fails. It is fixed in a successive PR.

**Note 2**: Travis currently is set to run the functional test suite only on HD wallets.