### PR TITLE
[Wallet][Bug] Fix ScriptPubKeyMan::CanGenerateKeys

### DIFF
--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -53,7 +53,7 @@ bool ScriptPubKeyMan::CanGenerateKeys()
 {
     // A wallet can generate keys if it has an HD seed (IsHDEnabled) or it is a non-HD wallet (pre FEATURE_HD)
     LOCK(wallet->cs_wallet);
-    return IsHDEnabled();
+    return IsHDEnabled() || wallet->GetVersion() < FEATURE_PRE_SPLIT_KEYPOOL;
 }
 
 bool ScriptPubKeyMan::IsHDEnabled() const
@@ -361,6 +361,9 @@ bool ScriptPubKeyMan::NewKeyPool()
  */
 bool ScriptPubKeyMan::TopUp(unsigned int kpSize)
 {
+    if (!CanGenerateKeys()) {
+        return false;
+    }
     {
         LOCK(wallet->cs_wallet);
         if (wallet->IsLocked()) return false;


### PR DESCRIPTION
Follow up to #1401 
Pre-HD wallets are still able to generate keys, as the comment in `ScriptPubKeyMan::CanGenerateKeys` clearly states. Fix the return value.

Based on top of 
- [x] #1410  

to verify that it correctly fixes the test `wallet_accounts.py` (which was failing when run with `--legacywallet` option).