### PR TITLE
[GUI] Explicit cast from quint32 to bool in filterAcceptsRow

### DIFF
--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -46,7 +46,7 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex& 
         return false;
     if (fHideOrphans && isOrphan(status, type))
         return false;
-    if (!(TYPE(type) & typeFilter))
+    if (!(bool)(TYPE(type) & typeFilter))
         return false;
     if (involvesWatchAddress && watchOnlyFilter == WatchOnlyFilter_No)
         return false;


### PR DESCRIPTION
This is a (hopefully definitive) fix for a strange segfault I was consistently having on testnet with the GUI wallet (during the loading of the stake charts), with the following stacktrace
```
#0  0x00007ffff58363bb in  ()
    at /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#1  0x00007ffff583b25d in  ()
    at /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#2  0x00007ffff583b932 in  ()
    at /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#3  0x00007ffff583bca9 in  ()
    at /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#4  0x00007ffff583c50a in QSortFilterProxyModel::invalidateFilter() ()
    at /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#5  0x00005555556aa809 in DashboardWidget::updateStakeFilter() (this=this@entry=0x5555577817d0) at qt/pivx/dashboardwidget.cpp:480
#6  0x00005555556ac736 in DashboardWidget::getAmountBy() (this=this@entry=0x5555577817d0) at qt/pivx/dashboardwidget.cpp:503
#7  0x00005555556ad1a1 in DashboardWidget::loadChartData(bool) (this=this@entry=0x5555577817d0, withMonthNames=false)
    at qt/pivx/dashboardwidget.cpp:556
#8  0x00005555556ad703 in DashboardWidget::run(int) (this=0x5555577817d0, type=<optimized out>) at qt/pivx/dashboardwidget.cpp:812
#9  0x00005555557641d4 in Worker::process() (this=0x5555576314c0)
    at qt/pivx/loadingdialog.cpp:12
#10 0x00007ffff56932b2 in  () at /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#11 0x00007ffff569617d in  () at /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#12 0x00007ffff4ae36db in start_thread (arg=0x7ffe61ffb700) at pthread_create.c:463
#13 0x00007ffff2c9e88f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

Explicit the cast to bool when checking the transaction type in `TransactionFilterProxy::filterAcceptsRow`.