### PR TITLE
uint256 to arith_uint256 migration (Second step).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -495,6 +495,8 @@ set(UTIL_SOURCES
         ./src/random.cpp
         ./src/rpc/protocol.cpp
         ./src/sync.cpp
+        ./src/blob_uint256.cpp
+        ./src/arith_uint256.cpp
         ./src/uint256.cpp
         ./src/util/threadnames.cpp
         ./src/util.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -176,6 +176,7 @@ BITCOIN_CORE_H = \
   txmempool.h \
   guiinterface.h \
   uint256.h \
+  blob_uint256.h \
   undo.h \
   util/memory.h \
   util.h \
@@ -420,6 +421,7 @@ libbitcoin_util_a_SOURCES = \
   support/cleanse.cpp \
   sync.cpp \
   uint256.cpp \
+  blob_uint256.cpp \
   util.cpp \
   utilmoneystr.cpp \
   util/threadnames.cpp \
@@ -525,6 +527,7 @@ libbitcoinconsensus_la_SOURCES = \
   script/interpreter.cpp \
   script/bitcoinconsensus.cpp \
   uint256.cpp \
+  blob_uint256.cpp \
   utilstrencodings.cpp
 
 if GLIBC_BACK_COMPAT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -80,6 +80,7 @@ BITCOIN_CORE_H = \
   activemasternode.h \
   addrman.h \
   allocators.h \
+  arith_uint256.h \
   amount.h \
   base58.h \
   bip38.h \
@@ -176,6 +177,7 @@ BITCOIN_CORE_H = \
   txmempool.h \
   guiinterface.h \
   uint256.h \
+  uint512.h \
   blob_uint256.h \
   undo.h \
   util/memory.h \
@@ -410,6 +412,7 @@ libbitcoin_common_a_SOURCES = \
 libbitcoin_util_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 libbitcoin_util_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_util_a_SOURCES = \
+  arith_uint256.cpp \
   allocators.cpp \
   chainparamsbase.cpp \
   clientversion.cpp \
@@ -513,6 +516,7 @@ pivx_tx_LDADD += $(BOOST_LIBS) $(CRYPTO_LIBS)
 if BUILD_BITCOIN_LIBS
 include_HEADERS = script/bitcoinconsensus.h
 libbitcoinconsensus_la_SOURCES = \
+  arith_uint256.cpp \
   allocators.cpp \
   primitives/transaction.cpp \
   crypto/hmac_sha512.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -27,7 +27,8 @@ BITCOIN_TEST_SUITE = \
   test/test_pivx.cpp
 # test_pivx binary #
 BITCOIN_TESTS =\
-  test/zerocoin_denomination_tests.cpp\
+  test/arith_uint256_tests.cpp \
+  test/zerocoin_denomination_tests.cpp \
   test/zerocoin_transactions_tests.cpp \
   test/zerocoin_bignum_tests.cpp \
   test/addrman_tests.cpp \

--- a/src/arith_uint256.cpp
+++ b/src/arith_uint256.cpp
@@ -202,6 +202,15 @@ std::string base_uint<BITS>::ToString() const
 }
 
 template <unsigned int BITS>
+std::string base_uint<BITS>::ToStringReverseEndian() const
+{
+    char psz[sizeof(pn) * 2 + 1];
+    for (unsigned int i = 0; i < sizeof(pn); i++)
+        sprintf(psz + i * 2, "%02x", ((unsigned char*)pn)[i]);
+    return std::string(psz, psz + sizeof(pn) * 2);
+}
+
+template <unsigned int BITS>
 unsigned int base_uint<BITS>::bits() const
 {
     for (int pos = WIDTH - 1; pos >= 0; pos--) {
@@ -249,6 +258,15 @@ template std::string base_uint<256>::ToString() const;
 template void base_uint<256>::SetHex(const char*);
 template void base_uint<256>::SetHex(const std::string&);
 template unsigned int base_uint<256>::bits() const;
+template std::string base_uint<256>::ToStringReverseEndian() const;
+
+// Explicit instantiations for base_uint<512>
+template base_uint<512>::base_uint(const std::string&);
+template base_uint<512>& base_uint<512>::operator<<=(unsigned int);
+template base_uint<512>& base_uint<512>::operator>>=(unsigned int);
+template std::string base_uint<512>::GetHex() const;
+template std::string base_uint<512>::ToString() const;
+template std::string base_uint<512>::ToStringReverseEndian() const;
 
 // This implementation directly uses shifts instead of going
 // through an intermediate MPI representation.
@@ -355,35 +373,4 @@ uint64_t arith_uint256::GetHash(const arith_uint256& salt) const
     HashFinal(a, b, c);
 
     return ((((uint64_t)b) << 32) | c);
-}
-
-blob_uint256 ArithToUint256(const arith_uint256 &a)
-{
-    blob_uint256 b;
-    for(int x=0; x<a.WIDTH; ++x)
-        WriteLE32(b.begin() + x*4, a.pn[x]);
-    return b;
-}
-arith_uint256 UintToArith256(const blob_uint256 &a)
-{
-    arith_uint256 b;
-    for(int x=0; x<b.WIDTH; ++x)
-        b.pn[x] = ReadLE32(a.begin() + x*4);
-    return b;
-}
-
-blob_uint512 ArithToUint512(const arith_uint512 &a)
-{
-    blob_uint512 b;
-    for(int x=0; x<a.WIDTH; ++x)
-        WriteLE32(b.begin() + x*4, a.pn[x]);
-    return b;
-}
-
-arith_uint512 UintToArith512(const blob_uint512 &a)
-{
-    arith_uint512 b;
-    for(int x=0; x<b.WIDTH; ++x)
-        b.pn[x] = ReadLE32(a.begin() + x*4);
-    return b;
 }

--- a/src/arith_uint256.cpp
+++ b/src/arith_uint256.cpp
@@ -1,0 +1,389 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "arith_uint256.h"
+
+#include "crypto/common.h"
+#include "utilstrencodings.h"
+
+#include <stdio.h>
+#include <string.h>
+
+template <unsigned int BITS>
+base_uint<BITS>::base_uint(const std::string& str)
+{
+    SetHex(str);
+}
+
+template <unsigned int BITS>
+base_uint<BITS>::base_uint(const std::vector<unsigned char>& vch)
+{
+    if (vch.size() != sizeof(pn))
+        throw uint_error("Converting vector of wrong size to base_uint");
+    memcpy(pn, &vch[0], sizeof(pn));
+}
+
+template <unsigned int BITS>
+base_uint<BITS>& base_uint<BITS>::operator<<=(unsigned int shift)
+{
+    base_uint<BITS> a(*this);
+    for (int i = 0; i < WIDTH; i++)
+        pn[i] = 0;
+    int k = shift / 32;
+    shift = shift % 32;
+    for (int i = 0; i < WIDTH; i++) {
+        if (i + k + 1 < WIDTH && shift != 0)
+            pn[i + k + 1] |= (a.pn[i] >> (32 - shift));
+        if (i + k < WIDTH)
+            pn[i + k] |= (a.pn[i] << shift);
+    }
+    return *this;
+}
+
+template <unsigned int BITS>
+base_uint<BITS>& base_uint<BITS>::operator>>=(unsigned int shift)
+{
+    base_uint<BITS> a(*this);
+    for (int i = 0; i < WIDTH; i++)
+        pn[i] = 0;
+    int k = shift / 32;
+    shift = shift % 32;
+    for (int i = 0; i < WIDTH; i++) {
+        if (i - k - 1 >= 0 && shift != 0)
+            pn[i - k - 1] |= (a.pn[i] << (32 - shift));
+        if (i - k >= 0)
+            pn[i - k] |= (a.pn[i] >> shift);
+    }
+    return *this;
+}
+
+template <unsigned int BITS>
+base_uint<BITS>& base_uint<BITS>::operator*=(uint32_t b32)
+{
+    uint64_t carry = 0;
+    for (int i = 0; i < WIDTH; i++) {
+        uint64_t n = carry + (uint64_t)b32 * pn[i];
+        pn[i] = n & 0xffffffff;
+        carry = n >> 32;
+    }
+    return *this;
+}
+
+template <unsigned int BITS>
+base_uint<BITS>& base_uint<BITS>::operator*=(const base_uint& b)
+{
+    base_uint<BITS> a = *this;
+    *this = 0;
+    for (int j = 0; j < WIDTH; j++) {
+        uint64_t carry = 0;
+        for (int i = 0; i + j < WIDTH; i++) {
+            uint64_t n = carry + pn[i + j] + (uint64_t)a.pn[j] * b.pn[i];
+            pn[i + j] = n & 0xffffffff;
+            carry = n >> 32;
+        }
+    }
+    return *this;
+}
+
+template <unsigned int BITS>
+base_uint<BITS>& base_uint<BITS>::operator/=(const base_uint& b)
+{
+    base_uint<BITS> div = b;     // make a copy, so we can shift.
+    base_uint<BITS> num = *this; // make a copy, so we can subtract.
+    *this = 0;                   // the quotient.
+    int num_bits = num.bits();
+    int div_bits = div.bits();
+    if (div_bits == 0)
+        throw uint_error("Division by zero");
+    if (div_bits > num_bits) // the result is certainly 0.
+        return *this;
+    int shift = num_bits - div_bits;
+    div <<= shift; // shift so that div and num align.
+    while (shift >= 0) {
+        if (num >= div) {
+            num -= div;
+            pn[shift / 32] |= (1 << (shift & 31)); // set a bit of the result.
+        }
+        div >>= 1; // shift back.
+        shift--;
+    }
+    // num now contains the remainder of the division.
+    return *this;
+}
+
+template <unsigned int BITS>
+int base_uint<BITS>::CompareTo(const base_uint<BITS>& b) const
+{
+    for (int i = WIDTH - 1; i >= 0; i--) {
+        if (pn[i] < b.pn[i])
+            return -1;
+        if (pn[i] > b.pn[i])
+            return 1;
+    }
+    return 0;
+}
+
+template <unsigned int BITS>
+bool base_uint<BITS>::EqualTo(uint64_t b) const
+{
+    for (int i = WIDTH - 1; i >= 2; i--) {
+        if (pn[i])
+            return false;
+    }
+    if (pn[1] != (b >> 32))
+        return false;
+    if (pn[0] != (b & 0xfffffffful))
+        return false;
+    return true;
+}
+
+template <unsigned int BITS>
+double base_uint<BITS>::getdouble() const
+{
+    double ret = 0.0;
+    double fact = 1.0;
+    for (int i = 0; i < WIDTH; i++) {
+        ret += fact * pn[i];
+        fact *= 4294967296.0;
+    }
+    return ret;
+}
+
+template <unsigned int BITS>
+std::string base_uint<BITS>::GetHex() const
+{
+    char psz[sizeof(pn) * 2 + 1];
+    for (unsigned int i = 0; i < sizeof(pn); i++)
+        sprintf(psz + i * 2, "%02x", ((unsigned char*)pn)[sizeof(pn) - i - 1]);
+    return std::string(psz, psz + sizeof(pn) * 2);
+}
+
+template <unsigned int BITS>
+void base_uint<BITS>::SetHex(const char* psz)
+{
+    memset(pn, 0, sizeof(pn));
+
+    // skip leading spaces
+    while (isspace(*psz))
+        psz++;
+
+    // skip 0x
+    if (psz[0] == '0' && tolower(psz[1]) == 'x')
+        psz += 2;
+
+    // hex string to uint
+    const char* pbegin = psz;
+    while (::HexDigit(*psz) != -1)
+        psz++;
+    psz--;
+    unsigned char* p1 = (unsigned char*)pn;
+    unsigned char* pend = p1 + WIDTH * 4;
+    while (psz >= pbegin && p1 < pend) {
+        *p1 = ::HexDigit(*psz--);
+        if (psz >= pbegin) {
+            *p1 |= ((unsigned char)::HexDigit(*psz--) << 4);
+            p1++;
+        }
+    }
+}
+
+template <unsigned int BITS>
+void base_uint<BITS>::SetHex(const std::string& str)
+{
+    SetHex(str.c_str());
+}
+
+template <unsigned int BITS>
+std::string base_uint<BITS>::ToString() const
+{
+    return (GetHex());
+}
+
+template <unsigned int BITS>
+unsigned int base_uint<BITS>::bits() const
+{
+    for (int pos = WIDTH - 1; pos >= 0; pos--) {
+        if (pn[pos]) {
+            for (int bits = 31; bits > 0; bits--) {
+                if (pn[pos] & 1 << bits)
+                    return 32 * pos + bits + 1;
+            }
+            return 32 * pos + 1;
+        }
+    }
+    return 0;
+}
+
+// Explicit instantiations for base_uint<160>
+template base_uint<160>::base_uint(const std::string&);
+template base_uint<160>::base_uint(const std::vector<unsigned char>&);
+template base_uint<160>& base_uint<160>::operator<<=(unsigned int);
+template base_uint<160>& base_uint<160>::operator>>=(unsigned int);
+template base_uint<160>& base_uint<160>::operator*=(uint32_t b32);
+template base_uint<160>& base_uint<160>::operator*=(const base_uint<160>& b);
+template base_uint<160>& base_uint<160>::operator/=(const base_uint<160>& b);
+template int base_uint<160>::CompareTo(const base_uint<160>&) const;
+template bool base_uint<160>::EqualTo(uint64_t) const;
+template double base_uint<160>::getdouble() const;
+template std::string base_uint<160>::GetHex() const;
+template std::string base_uint<160>::ToString() const;
+template void base_uint<160>::SetHex(const char*);
+template void base_uint<160>::SetHex(const std::string&);
+template unsigned int base_uint<160>::bits() const;
+
+// Explicit instantiations for base_uint<256>
+template base_uint<256>::base_uint(const std::string&);
+template base_uint<256>::base_uint(const std::vector<unsigned char>&);
+template base_uint<256>& base_uint<256>::operator<<=(unsigned int);
+template base_uint<256>& base_uint<256>::operator>>=(unsigned int);
+template base_uint<256>& base_uint<256>::operator*=(uint32_t b32);
+template base_uint<256>& base_uint<256>::operator*=(const base_uint<256>& b);
+template base_uint<256>& base_uint<256>::operator/=(const base_uint<256>& b);
+template int base_uint<256>::CompareTo(const base_uint<256>&) const;
+template bool base_uint<256>::EqualTo(uint64_t) const;
+template double base_uint<256>::getdouble() const;
+template std::string base_uint<256>::GetHex() const;
+template std::string base_uint<256>::ToString() const;
+template void base_uint<256>::SetHex(const char*);
+template void base_uint<256>::SetHex(const std::string&);
+template unsigned int base_uint<256>::bits() const;
+
+// This implementation directly uses shifts instead of going
+// through an intermediate MPI representation.
+arith_uint256& arith_uint256::SetCompact(uint32_t nCompact, bool* pfNegative, bool* pfOverflow)
+{
+    int nSize = nCompact >> 24;
+    uint32_t nWord = nCompact & 0x007fffff;
+    if (nSize <= 3) {
+        nWord >>= 8 * (3 - nSize);
+        *this = nWord;
+    } else {
+        *this = nWord;
+        *this <<= 8 * (nSize - 3);
+    }
+    if (pfNegative)
+        *pfNegative = nWord != 0 && (nCompact & 0x00800000) != 0;
+    if (pfOverflow)
+        *pfOverflow = nWord != 0 && ((nSize > 34) ||
+                                     (nWord > 0xff && nSize > 33) ||
+                                     (nWord > 0xffff && nSize > 32));
+    return *this;
+}
+
+uint32_t arith_uint256::GetCompact(bool fNegative) const
+{
+    int nSize = (bits() + 7) / 8;
+    uint32_t nCompact = 0;
+    if (nSize <= 3) {
+        nCompact = GetLow64() << 8 * (3 - nSize);
+    } else {
+        arith_uint256 bn = *this >> 8 * (nSize - 3);
+        nCompact = bn.GetLow64();
+    }
+    // The 0x00800000 bit denotes the sign.
+    // Thus, if it is already set, divide the mantissa by 256 and increase the exponent.
+    if (nCompact & 0x00800000) {
+        nCompact >>= 8;
+        nSize++;
+    }
+    assert((nCompact & ~0x007fffff) == 0);
+    assert(nSize < 256);
+    nCompact |= nSize << 24;
+    nCompact |= (fNegative && (nCompact & 0x007fffff) ? 0x00800000 : 0);
+    return nCompact;
+}
+
+static void inline HashMix(uint32_t& a, uint32_t& b, uint32_t& c)
+{
+    // Taken from lookup3, by Bob Jenkins.
+    a -= c;
+    a ^= ((c << 4) | (c >> 28));
+    c += b;
+    b -= a;
+    b ^= ((a << 6) | (a >> 26));
+    a += c;
+    c -= b;
+    c ^= ((b << 8) | (b >> 24));
+    b += a;
+    a -= c;
+    a ^= ((c << 16) | (c >> 16));
+    c += b;
+    b -= a;
+    b ^= ((a << 19) | (a >> 13));
+    a += c;
+    c -= b;
+    c ^= ((b << 4) | (b >> 28));
+    b += a;
+}
+
+static void inline HashFinal(uint32_t& a, uint32_t& b, uint32_t& c)
+{
+    // Taken from lookup3, by Bob Jenkins.
+    c ^= b;
+    c -= ((b << 14) | (b >> 18));
+    a ^= c;
+    a -= ((c << 11) | (c >> 21));
+    b ^= a;
+    b -= ((a << 25) | (a >> 7));
+    c ^= b;
+    c -= ((b << 16) | (b >> 16));
+    a ^= c;
+    a -= ((c << 4) | (c >> 28));
+    b ^= a;
+    b -= ((a << 14) | (a >> 18));
+    c ^= b;
+    c -= ((b << 24) | (b >> 8));
+}
+
+uint64_t arith_uint256::GetHash(const arith_uint256& salt) const
+{
+    uint32_t a, b, c;
+    a = b = c = 0xdeadbeef + (WIDTH << 2);
+
+    a += pn[0] ^ salt.pn[0];
+    b += pn[1] ^ salt.pn[1];
+    c += pn[2] ^ salt.pn[2];
+    HashMix(a, b, c);
+    a += pn[3] ^ salt.pn[3];
+    b += pn[4] ^ salt.pn[4];
+    c += pn[5] ^ salt.pn[5];
+    HashMix(a, b, c);
+    a += pn[6] ^ salt.pn[6];
+    b += pn[7] ^ salt.pn[7];
+    HashFinal(a, b, c);
+
+    return ((((uint64_t)b) << 32) | c);
+}
+
+blob_uint256 ArithToUint256(const arith_uint256 &a)
+{
+    blob_uint256 b;
+    for(int x=0; x<a.WIDTH; ++x)
+        WriteLE32(b.begin() + x*4, a.pn[x]);
+    return b;
+}
+arith_uint256 UintToArith256(const blob_uint256 &a)
+{
+    arith_uint256 b;
+    for(int x=0; x<b.WIDTH; ++x)
+        b.pn[x] = ReadLE32(a.begin() + x*4);
+    return b;
+}
+
+blob_uint512 ArithToUint512(const arith_uint512 &a)
+{
+    blob_uint512 b;
+    for(int x=0; x<a.WIDTH; ++x)
+        WriteLE32(b.begin() + x*4, a.pn[x]);
+    return b;
+}
+
+arith_uint512 UintToArith512(const blob_uint512 &a)
+{
+    arith_uint512 b;
+    for(int x=0; x<b.WIDTH; ++x)
+        b.pn[x] = ReadLE32(a.begin() + x*4);
+    return b;
+}

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -1,0 +1,379 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_ARITH_UINT256_H
+#define BITCOIN_ARITH_UINT256_H
+
+#include "blob_uint256.h"
+#include "uint512.h"
+#include <assert.h>
+#include <cstring>
+#include <stdexcept>
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+class blob_uint512;
+class blob_uint256;
+
+class uint_error : public std::runtime_error {
+public:
+    explicit uint_error(const std::string& str) : std::runtime_error(str) {}
+};
+
+/** Template base class for unsigned big integers. */
+template<unsigned int BITS>
+class base_uint
+{
+public:
+    enum { WIDTH=BITS/32 };
+    uint32_t pn[WIDTH];
+
+    base_uint()
+    {
+        for (int i = 0; i < WIDTH; i++)
+            pn[i] = 0;
+    }
+
+    base_uint(const base_uint& b)
+    {
+        for (int i = 0; i < WIDTH; i++)
+            pn[i] = b.pn[i];
+    }
+
+    base_uint& operator=(const base_uint& b)
+    {
+        for (int i = 0; i < WIDTH; i++)
+            pn[i] = b.pn[i];
+        return *this;
+    }
+
+    base_uint(uint64_t b)
+    {
+        pn[0] = (unsigned int)b;
+        pn[1] = (unsigned int)(b >> 32);
+        for (int i = 2; i < WIDTH; i++)
+            pn[i] = 0;
+    }
+
+    explicit base_uint(const std::string& str);
+    explicit base_uint(const std::vector<unsigned char>& vch);
+
+    bool operator!() const
+    {
+        for (int i = 0; i < WIDTH; i++)
+            if (pn[i] != 0)
+                return false;
+        return true;
+    }
+
+    const base_uint operator~() const
+    {
+        base_uint ret;
+        for (int i = 0; i < WIDTH; i++)
+            ret.pn[i] = ~pn[i];
+        return ret;
+    }
+
+    const base_uint operator-() const
+    {
+        base_uint ret;
+        for (int i = 0; i < WIDTH; i++)
+            ret.pn[i] = ~pn[i];
+        ret++;
+        return ret;
+    }
+
+    double getdouble() const;
+
+    base_uint& operator=(uint64_t b)
+    {
+        pn[0] = (unsigned int)b;
+        pn[1] = (unsigned int)(b >> 32);
+        for (int i = 2; i < WIDTH; i++)
+            pn[i] = 0;
+        return *this;
+    }
+
+    base_uint& operator^=(const base_uint& b)
+    {
+        for (int i = 0; i < WIDTH; i++)
+            pn[i] ^= b.pn[i];
+        return *this;
+    }
+
+    base_uint& operator&=(const base_uint& b)
+    {
+        for (int i = 0; i < WIDTH; i++)
+            pn[i] &= b.pn[i];
+        return *this;
+    }
+
+    base_uint& operator|=(const base_uint& b)
+    {
+        for (int i = 0; i < WIDTH; i++)
+            pn[i] |= b.pn[i];
+        return *this;
+    }
+
+    base_uint& operator^=(uint64_t b)
+    {
+        pn[0] ^= (unsigned int)b;
+        pn[1] ^= (unsigned int)(b >> 32);
+        return *this;
+    }
+
+    base_uint& operator|=(uint64_t b)
+    {
+        pn[0] |= (unsigned int)b;
+        pn[1] |= (unsigned int)(b >> 32);
+        return *this;
+    }
+
+    base_uint& operator<<=(unsigned int shift);
+    base_uint& operator>>=(unsigned int shift);
+
+    base_uint& operator+=(const base_uint& b)
+    {
+        uint64_t carry = 0;
+        for (int i = 0; i < WIDTH; i++)
+        {
+            uint64_t n = carry + pn[i] + b.pn[i];
+            pn[i] = n & 0xffffffff;
+            carry = n >> 32;
+        }
+        return *this;
+    }
+
+    base_uint& operator-=(const base_uint& b)
+    {
+        *this += -b;
+        return *this;
+    }
+
+    base_uint& operator+=(uint64_t b64)
+    {
+        base_uint b;
+        b = b64;
+        *this += b;
+        return *this;
+    }
+
+    base_uint& operator-=(uint64_t b64)
+    {
+        base_uint b;
+        b = b64;
+        *this += -b;
+        return *this;
+    }
+
+    base_uint& operator*=(uint32_t b32);
+    base_uint& operator*=(const base_uint& b);
+    base_uint& operator/=(const base_uint& b);
+
+    base_uint& operator++()
+    {
+        // prefix operator
+        int i = 0;
+        while (++pn[i] == 0 && i < WIDTH-1)
+            i++;
+        return *this;
+    }
+
+    const base_uint operator++(int)
+    {
+        // postfix operator
+        const base_uint ret = *this;
+        ++(*this);
+        return ret;
+    }
+
+    base_uint& operator--()
+    {
+        // prefix operator
+        int i = 0;
+        while (--pn[i] == (uint32_t)-1 && i < WIDTH-1)
+            i++;
+        return *this;
+    }
+
+    const base_uint operator--(int)
+    {
+        // postfix operator
+        const base_uint ret = *this;
+        --(*this);
+        return ret;
+    }
+
+    int CompareTo(const base_uint& b) const;
+    bool EqualTo(uint64_t b) const;
+
+    friend inline const base_uint operator+(const base_uint& a, const base_uint& b) { return base_uint(a) += b; }
+    friend inline const base_uint operator-(const base_uint& a, const base_uint& b) { return base_uint(a) -= b; }
+    friend inline const base_uint operator*(const base_uint& a, const base_uint& b) { return base_uint(a) *= b; }
+    friend inline const base_uint operator/(const base_uint& a, const base_uint& b) { return base_uint(a) /= b; }
+    friend inline const base_uint operator|(const base_uint& a, const base_uint& b) { return base_uint(a) |= b; }
+    friend inline const base_uint operator&(const base_uint& a, const base_uint& b) { return base_uint(a) &= b; }
+    friend inline const base_uint operator^(const base_uint& a, const base_uint& b) { return base_uint(a) ^= b; }
+    friend inline const base_uint operator>>(const base_uint& a, int shift) { return base_uint(a) >>= shift; }
+    friend inline const base_uint operator<<(const base_uint& a, int shift) { return base_uint(a) <<= shift; }
+    friend inline const base_uint operator*(const base_uint& a, uint32_t b) { return base_uint(a) *= b; }
+    friend inline bool operator==(const base_uint& a, const base_uint& b) { return memcmp(a.pn, b.pn, sizeof(a.pn)) == 0; }
+    friend inline bool operator!=(const base_uint& a, const base_uint& b) { return memcmp(a.pn, b.pn, sizeof(a.pn)) != 0; }
+    friend inline bool operator>(const base_uint& a, const base_uint& b) { return a.CompareTo(b) > 0; }
+    friend inline bool operator<(const base_uint& a, const base_uint& b) { return a.CompareTo(b) < 0; }
+    friend inline bool operator>=(const base_uint& a, const base_uint& b) { return a.CompareTo(b) >= 0; }
+    friend inline bool operator<=(const base_uint& a, const base_uint& b) { return a.CompareTo(b) <= 0; }
+    friend inline bool operator==(const base_uint& a, uint64_t b) { return a.EqualTo(b); }
+    friend inline bool operator!=(const base_uint& a, uint64_t b) { return !a.EqualTo(b); }
+
+    std::string GetHex() const;
+    void SetHex(const char* psz);
+    void SetHex(const std::string& str);
+    std::string ToString() const;
+
+    unsigned char* begin()
+    {
+        return (unsigned char*)&pn[0];
+    }
+
+    unsigned char* end()
+    {
+        return (unsigned char*)&pn[WIDTH];
+    }
+
+    const unsigned char* begin() const
+    {
+        return (unsigned char*)&pn[0];
+    }
+
+    const unsigned char* end() const
+    {
+        return (unsigned char*)&pn[WIDTH];
+    }
+
+    unsigned int size() const
+    {
+        return sizeof(pn);
+    }
+
+    /**
+     * Returns the position of the highest bit set plus one, or zero if the
+     * value is zero.
+     */
+    unsigned int bits() const;
+
+    uint64_t GetLow64() const
+    {
+        assert(WIDTH >= 2);
+        return pn[0] | (uint64_t)pn[1] << 32;
+    }
+
+    unsigned int GetSerializeSize(int nType, int nVersion) const
+    {
+        return sizeof(pn);
+    }
+
+    template<typename Stream>
+    void Serialize(Stream& s, int nType, int nVersion) const
+    {
+        s.write((char*)pn, sizeof(pn));
+    }
+
+    template<typename Stream>
+    void Unserialize(Stream& s, int nType, int nVersion)
+    {
+        s.read((char*)pn, sizeof(pn));
+    }
+
+    // Temporary for migration to blob160/256
+    uint64_t GetCheapHash() const
+    {
+        return GetLow64();
+    }
+    void SetNull()
+    {
+        memset(pn, 0, sizeof(pn));
+    }
+    bool IsNull() const
+    {
+        for (int i = 0; i < WIDTH; i++)
+            if (pn[i] != 0)
+                return false;
+        return true;
+    }
+};
+
+/** 160-bit unsigned big integer. */
+class arith_uint160 : public base_uint<160> {
+public:
+    arith_uint160() {}
+    arith_uint160(const base_uint<160>& b) : base_uint<160>(b) {}
+    arith_uint160(uint64_t b) : base_uint<160>(b) {}
+    explicit arith_uint160(const std::string& str) : base_uint<160>(str) {}
+    explicit arith_uint160(const std::vector<unsigned char>& vch) : base_uint<160>(vch) {}
+};
+
+/** 256-bit unsigned big integer. */
+class arith_uint256 : public base_uint<256> {
+public:
+    arith_uint256() {}
+    arith_uint256(const base_uint<256>& b) : base_uint<256>(b) {}
+    arith_uint256(uint64_t b) : base_uint<256>(b) {}
+    explicit arith_uint256(const std::string& str) : base_uint<256>(str) {}
+    explicit arith_uint256(const std::vector<unsigned char>& vch) : base_uint<256>(vch) {}
+
+    /**
+     * The "compact" format is a representation of a whole
+     * number N using an unsigned 32bit number similar to a
+     * floating point format.
+     * The most significant 8 bits are the unsigned exponent of base 256.
+     * This exponent can be thought of as "number of bytes of N".
+     * The lower 23 bits are the mantissa.
+     * Bit number 24 (0x800000) represents the sign of N.
+     * N = (-1^sign) * mantissa * 256^(exponent-3)
+     *
+     * Satoshi's original implementation used BN_bn2mpi() and BN_mpi2bn().
+     * MPI uses the most significant bit of the first byte as sign.
+     * Thus 0x1234560000 is compact (0x05123456)
+     * and  0xc0de000000 is compact (0x0600c0de)
+     *
+     * Bitcoin only uses this "compact" format for encoding difficulty
+     * targets, which are unsigned 256bit quantities.  Thus, all the
+     * complexities of the sign bit and using base 256 are probably an
+     * implementation accident.
+     */
+    arith_uint256& SetCompact(uint32_t nCompact, bool *pfNegative = NULL, bool *pfOverflow = NULL);
+    uint32_t GetCompact(bool fNegative = false) const;
+
+    uint64_t GetHash(const arith_uint256& salt) const;
+
+    uint32_t Get32(int n = 0) const { return pn[2 * n]; }
+};
+
+/** 512-bit unsigned big integer. */
+class arith_uint512 : public base_uint<512> {
+public:
+    arith_uint512() {}
+    arith_uint512(const base_uint<512>& b) : base_uint<512>(b) {}
+    arith_uint512(uint64_t b) : base_uint<512>(b) {}
+    explicit arith_uint512(const std::string& str) : base_uint<512>(str) {}
+    explicit arith_uint512(const std::vector<unsigned char>& vch) : base_uint<512>(vch) {}
+
+    uint64_t GetHash(const arith_uint256& salt) const;
+
+    friend arith_uint512 UintToArith512(const blob_uint512 &a);
+    friend blob_uint512 ArithToUint512(const arith_uint512 &a);
+
+};
+
+blob_uint256 ArithToUint256(const arith_uint256 &);
+arith_uint256 UintToArith256(const blob_uint256 &);
+blob_uint512 ArithToUint512(const arith_uint512 &);
+arith_uint512 UintToArith512(const blob_uint512 &);
+
+const arith_uint256 ARITH_UINT256_ZERO = arith_uint256();
+
+#endif // BITCOIN_UINT256_H

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -17,6 +17,8 @@
 
 class blob_uint512;
 class blob_uint256;
+class uint256;
+class uint512;
 
 class uint_error : public std::runtime_error {
 public:
@@ -233,6 +235,7 @@ public:
     void SetHex(const char* psz);
     void SetHex(const std::string& str);
     std::string ToString() const;
+    std::string ToStringReverseEndian() const;
 
     unsigned char* begin()
     {
@@ -259,6 +262,15 @@ public:
         return sizeof(pn);
     }
 
+    uint64_t Get64(int n = 0) const
+    {
+        return pn[2 * n] | (uint64_t)pn[2 * n + 1] << 32;
+    }
+
+    uint32_t Get32(int n = 0) const
+    {
+        return pn[2 * n];
+    }
     /**
      * Returns the position of the highest bit set plus one, or zero if the
      * value is zero.
@@ -304,6 +316,14 @@ public:
                 return false;
         return true;
     }
+
+    friend class uint160;
+    friend class uint256;
+    friend class uint512;
+
+    friend class arith_uint160;
+    friend class arith_uint256;
+    friend class arith_uint512;
 };
 
 /** 160-bit unsigned big integer. */
@@ -364,15 +384,14 @@ public:
 
     uint64_t GetHash(const arith_uint256& salt) const;
 
-    friend arith_uint512 UintToArith512(const blob_uint512 &a);
-    friend blob_uint512 ArithToUint512(const arith_uint512 &a);
+    //friend arith_uint512 UintToArith512(const blob_uint512 &a);
+    //friend blob_uint512 ArithToUint512(const arith_uint512 &a);
 
 };
 
-blob_uint256 ArithToUint256(const arith_uint256 &);
-arith_uint256 UintToArith256(const blob_uint256 &);
-blob_uint512 ArithToUint512(const arith_uint512 &);
-arith_uint512 UintToArith512(const blob_uint512 &);
+/** Old classes definitions */
+
+/** End classes definitions */
 
 const arith_uint256 ARITH_UINT256_ZERO = arith_uint256();
 

--- a/src/blob_uint256.cpp
+++ b/src/blob_uint256.cpp
@@ -1,0 +1,146 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "blob_uint256.h"
+
+#include "utilstrencodings.h"
+
+#include <stdio.h>
+#include <string.h>
+
+template <unsigned int BITS>
+base_blob<BITS>::base_blob(const std::vector<unsigned char>& vch)
+{
+    assert(vch.size() == sizeof(data));
+    memcpy(data, &vch[0], sizeof(data));
+}
+
+template <unsigned int BITS>
+std::string base_blob<BITS>::GetHex() const
+{
+    char psz[sizeof(data) * 2 + 1];
+    for (unsigned int i = 0; i < sizeof(data); i++)
+        sprintf(psz + i * 2, "%02x", data[sizeof(data) - i - 1]);
+    return std::string(psz, psz + sizeof(data) * 2);
+}
+
+template <unsigned int BITS>
+void base_blob<BITS>::SetHex(const char* psz)
+{
+    memset(data, 0, sizeof(data));
+
+    // skip leading spaces
+    while (isspace(*psz))
+        psz++;
+
+    // skip 0x
+    if (psz[0] == '0' && tolower(psz[1]) == 'x')
+        psz += 2;
+
+    // hex string to uint
+    const char* pbegin = psz;
+    while (::HexDigit(*psz) != -1)
+        psz++;
+    psz--;
+    unsigned char* p1 = (unsigned char*)data;
+    unsigned char* pend = p1 + WIDTH * 4;
+    while (psz >= pbegin && p1 < pend) {
+        *p1 = ::HexDigit(*psz--);
+        if (psz >= pbegin) {
+            *p1 |= ((unsigned char)::HexDigit(*psz--) << 4);
+            p1++;
+        }
+    }
+}
+
+template <unsigned int BITS>
+void base_blob<BITS>::SetHex(const std::string& str)
+{
+    SetHex(str.c_str());
+}
+
+template <unsigned int BITS>
+std::string base_blob<BITS>::ToString() const
+{
+    return GetHex();
+}
+
+// Explicit instantiations for base_blob<160>
+template base_blob<160>::base_blob(const std::vector<unsigned char>&);
+template std::string base_blob<160>::GetHex() const;
+template std::string base_blob<160>::ToString() const;
+template void base_blob<160>::SetHex(const char*);
+template void base_blob<160>::SetHex(const std::string&);
+
+// Explicit instantiations for base_blob<256>
+template base_blob<256>::base_blob(const std::vector<unsigned char>&);
+template std::string base_blob<256>::GetHex() const;
+template std::string base_blob<256>::ToString() const;
+template void base_blob<256>::SetHex(const char*);
+template void base_blob<256>::SetHex(const std::string&);
+
+static void inline HashMix(uint32_t& a, uint32_t& b, uint32_t& c)
+{
+    // Taken from lookup3, by Bob Jenkins.
+    a -= c;
+    a ^= ((c << 4) | (c >> 28));
+    c += b;
+    b -= a;
+    b ^= ((a << 6) | (a >> 26));
+    a += c;
+    c -= b;
+    c ^= ((b << 8) | (b >> 24));
+    b += a;
+    a -= c;
+    a ^= ((c << 16) | (c >> 16));
+    c += b;
+    b -= a;
+    b ^= ((a << 19) | (a >> 13));
+    a += c;
+    c -= b;
+    c ^= ((b << 4) | (b >> 28));
+    b += a;
+}
+
+static void inline HashFinal(uint32_t& a, uint32_t& b, uint32_t& c)
+{
+    // Taken from lookup3, by Bob Jenkins.
+    c ^= b;
+    c -= ((b << 14) | (b >> 18));
+    a ^= c;
+    a -= ((c << 11) | (c >> 21));
+    b ^= a;
+    b -= ((a << 25) | (a >> 7));
+    c ^= b;
+    c -= ((b << 16) | (b >> 16));
+    a ^= c;
+    a -= ((c << 4) | (c >> 28));
+    b ^= a;
+    b -= ((a << 14) | (a >> 18));
+    c ^= b;
+    c -= ((b << 24) | (b >> 8));
+}
+
+uint64_t uint256::GetHash(const uint256& salt) const
+{
+    uint32_t a, b, c;
+    const uint32_t *pn = (const uint32_t*)data;
+    const uint32_t *salt_pn = (const uint32_t*)salt.data;
+    a = b = c = 0xdeadbeef + (WIDTH << 2);
+
+    a += pn[0] ^ salt_pn[0];
+    b += pn[1] ^ salt_pn[1];
+    c += pn[2] ^ salt_pn[2];
+    HashMix(a, b, c);
+    a += pn[3] ^ salt_pn[3];
+    b += pn[4] ^ salt_pn[4];
+    c += pn[5] ^ salt_pn[5];
+    HashMix(a, b, c);
+    a += pn[6] ^ salt_pn[6];
+    b += pn[7] ^ salt_pn[7];
+    HashFinal(a, b, c);
+
+    return ((((uint64_t)b) << 32) | c);
+}

--- a/src/blob_uint256.cpp
+++ b/src/blob_uint256.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php .
 
 #include "blob_uint256.h"
 
@@ -45,7 +45,7 @@ void base_blob<BITS>::SetHex(const char* psz)
         psz++;
     psz--;
     unsigned char* p1 = (unsigned char*)data;
-    unsigned char* pend = p1 + WIDTH * 4;
+    unsigned char* pend = p1 + WIDTH;
     while (psz >= pbegin && p1 < pend) {
         *p1 = ::HexDigit(*psz--);
         if (psz >= pbegin) {
@@ -128,7 +128,7 @@ uint64_t blob_uint256::GetHash(const blob_uint256& salt) const
     uint32_t a, b, c;
     const uint32_t *pn = (const uint32_t*)data;
     const uint32_t *salt_pn = (const uint32_t*)salt.data;
-    a = b = c = 0xdeadbeef + (WIDTH << 2);
+    a = b = c = 0xdeadbeef + WIDTH;
 
     a += pn[0] ^ salt_pn[0];
     b += pn[1] ^ salt_pn[1];

--- a/src/blob_uint256.cpp
+++ b/src/blob_uint256.cpp
@@ -123,7 +123,7 @@ static void inline HashFinal(uint32_t& a, uint32_t& b, uint32_t& c)
     c -= ((b << 24) | (b >> 8));
 }
 
-uint64_t uint256::GetHash(const uint256& salt) const
+uint64_t blob_uint256::GetHash(const blob_uint256& salt) const
 {
     uint32_t a, b, c;
     const uint32_t *pn = (const uint32_t*)data;

--- a/src/blob_uint256.h
+++ b/src/blob_uint256.h
@@ -1,0 +1,164 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin developers
+// Copyright (c) 2014-2015 The Dash developers
+// Copyright (c) 2015-2018 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef PIVX_BLOB_UINT256_H
+#define PIVX_BLOB_UINT256_H
+
+#include <assert.h>
+#include <cstring>
+#include <stdexcept>
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+/** Template base class for fixed-sized opaque blobs. */
+template<unsigned int BITS>
+class base_blob
+{
+protected:
+    enum { WIDTH=BITS/8 };
+    uint8_t data[WIDTH];
+
+public:
+
+    base_blob()
+    {
+        SetNull();
+    }
+
+    explicit base_blob(const std::vector<unsigned char>& vch);
+
+    bool IsNull() const
+    {
+        for (int i = 0; i < WIDTH; i++)
+            if (data[i] != 0)
+                return false;
+        return true;
+    }
+
+    void SetNull()
+    {
+        memset(data, 0, sizeof(data));
+    }
+
+    friend inline bool operator==(const base_blob& a, const base_blob& b) { return memcmp(a.data, b.data, sizeof(a.data)) == 0; }
+    friend inline bool operator!=(const base_blob& a, const base_blob& b) { return memcmp(a.data, b.data, sizeof(a.data)) != 0; }
+    friend inline bool operator<(const base_blob& a, const base_blob& b) { return memcmp(a.data, b.data, sizeof(a.data)) < 0; }
+
+    std::string GetHex() const;
+    void SetHex(const char* psz);
+    void SetHex(const std::string& str);
+    std::string ToString() const;
+
+    unsigned char* begin()
+    {
+        return &data[0];
+    }
+
+    unsigned char* end()
+    {
+        return &data[WIDTH];
+    }
+
+    const unsigned char* begin() const
+    {
+        return &data[0];
+    }
+
+    const unsigned char* end() const
+    {
+        return &data[WIDTH];
+    }
+
+    unsigned int size() const
+    {
+        return sizeof(data);
+    }
+
+    unsigned int GetSerializeSize(int nType, int nVersion) const
+    {
+        return sizeof(data);
+    }
+
+    template<typename Stream>
+    void Serialize(Stream& s, int nType, int nVersion) const
+    {
+        s.write((char*)data, sizeof(data));
+    }
+
+    template<typename Stream>
+    void Unserialize(Stream& s, int nType, int nVersion)
+    {
+        s.read((char*)data, sizeof(data));
+    }
+};
+
+/** 160-bit opaque blob.
+ * @note This type is called uint160 for historical reasons only. It is an opaque
+ * blob of 160 bits and has no integer operations.
+ */
+class uint160 : public base_blob<160> {
+public:
+    uint160() {}
+    uint160(const base_blob<160>& b) : base_blob<160>(b) {}
+    explicit uint160(const std::vector<unsigned char>& vch) : base_blob<160>(vch) {}
+};
+
+/** 256-bit opaque blob.
+ * @note This type is called uint256 for historical reasons only. It is an
+ * opaque blob of 256 bits and has no integer operations. Use arith_uint256 if
+ * those are required.
+ */
+class uint256 : public base_blob<256> {
+public:
+    uint256() {}
+    uint256(const base_blob<256>& b) : base_blob<256>(b) {}
+    explicit uint256(const std::vector<unsigned char>& vch) : base_blob<256>(vch) {}
+
+    /** A cheap hash function that just returns 64 bits from the result, it can be
+     * used when the contents are considered uniformly random. It is not appropriate
+     * when the value can easily be influenced from outside as e.g. a network adversary could
+     * provide values to trigger worst-case behavior.
+     * @note The result of this function is not stable between little and big endian.
+     */
+    uint64_t GetCheapHash() const
+    {
+        uint64_t result;
+        memcpy((void*)&result, (void*)data, 8);
+        return result;
+    }
+
+    /** A more secure, salted hash function.
+     * @note This hash is not stable between little and big endian.
+     */
+    uint64_t GetHash(const uint256& salt) const;
+};
+
+/* uint256 from const char *.
+ * This is a separate function because the constructor uint256(const char*) can result
+ * in dangerously catching uint256(0).
+ */
+inline uint256 uint256S(const char *str)
+{
+    uint256 rv;
+    rv.SetHex(str);
+    return rv;
+}
+/* uint256 from std::string.
+ * This is a separate function because the constructor uint256(const std::string &str) can result
+ * in dangerously catching uint256(0) via std::string(const char*).
+ */
+inline uint256 uint256S(const std::string& str)
+{
+    return blob_uint256S(str.c_str());
+}
+
+/** constant uint256 instances */
+const uint256 UINT256_ZERO = uint256();
+const uint256 UINT256_ONE = uint256S("0000000000000000000000000000000000000000000000000000000000000001");
+
+#endif // PIVX_BLOB_UINT256_H

--- a/src/blob_uint256.h
+++ b/src/blob_uint256.h
@@ -19,11 +19,10 @@
 template<unsigned int BITS>
 class base_blob
 {
-protected:
+public:
+    // todo: make this protected
     enum { WIDTH=BITS/8 };
     uint8_t data[WIDTH];
-
-public:
 
     base_blob()
     {
@@ -101,11 +100,11 @@ public:
  * @note This type is called uint160 for historical reasons only. It is an opaque
  * blob of 160 bits and has no integer operations.
  */
-class uint160 : public base_blob<160> {
+class blob_uint160 : public base_blob<160> {
 public:
-    uint160() {}
-    uint160(const base_blob<160>& b) : base_blob<160>(b) {}
-    explicit uint160(const std::vector<unsigned char>& vch) : base_blob<160>(vch) {}
+    blob_uint160() {}
+    blob_uint160(const base_blob<160>& b) : base_blob<160>(b) {}
+    explicit blob_uint160(const std::vector<unsigned char>& vch) : base_blob<160>(vch) {}
 };
 
 /** 256-bit opaque blob.
@@ -113,11 +112,11 @@ public:
  * opaque blob of 256 bits and has no integer operations. Use arith_uint256 if
  * those are required.
  */
-class uint256 : public base_blob<256> {
+class blob_uint256 : public base_blob<256> {
 public:
-    uint256() {}
-    uint256(const base_blob<256>& b) : base_blob<256>(b) {}
-    explicit uint256(const std::vector<unsigned char>& vch) : base_blob<256>(vch) {}
+    blob_uint256() {}
+    blob_uint256(const base_blob<256>& b) : base_blob<256>(b) {}
+    explicit blob_uint256(const std::vector<unsigned char>& vch) : base_blob<256>(vch) {}
 
     /** A cheap hash function that just returns 64 bits from the result, it can be
      * used when the contents are considered uniformly random. It is not appropriate
@@ -135,16 +134,16 @@ public:
     /** A more secure, salted hash function.
      * @note This hash is not stable between little and big endian.
      */
-    uint64_t GetHash(const uint256& salt) const;
+    uint64_t GetHash(const blob_uint256& salt) const;
 };
 
 /* uint256 from const char *.
  * This is a separate function because the constructor uint256(const char*) can result
  * in dangerously catching uint256(0).
  */
-inline uint256 uint256S(const char *str)
+inline blob_uint256 blob_uint256S(const char *str)
 {
-    uint256 rv;
+    blob_uint256 rv;
     rv.SetHex(str);
     return rv;
 }
@@ -152,13 +151,13 @@ inline uint256 uint256S(const char *str)
  * This is a separate function because the constructor uint256(const std::string &str) can result
  * in dangerously catching uint256(0) via std::string(const char*).
  */
-inline uint256 uint256S(const std::string& str)
+inline blob_uint256 blob_uint256S(const std::string& str)
 {
     return blob_uint256S(str.c_str());
 }
 
 /** constant uint256 instances */
-const uint256 UINT256_ZERO = uint256();
-const uint256 UINT256_ONE = uint256S("0000000000000000000000000000000000000000000000000000000000000001");
+const blob_uint256 BLOB_UINT256_ZERO = blob_uint256();
+const blob_uint256 BLOB_UINT256_ONE = blob_uint256S("0000000000000000000000000000000000000000000000000000000000000001");
 
 #endif // PIVX_BLOB_UINT256_H

--- a/src/test/arith_uint256_tests.cpp
+++ b/src/test/arith_uint256_tests.cpp
@@ -28,32 +28,39 @@ const unsigned char R1Array[] =
     "\x22\x81\xaa\xb5\x33\xf0\x08\x32\xd5\x56\xb1\xf9\xea\xe5\x1d\x7d";
 const char R1ArrayHex[] = "7D1DE5EAF9B156D53208F033B5AA8122D2d2355d5e12292b121156cfdb4a529c";
 const double R1Ldouble = 0.4887374590559308955; // R1L equals roughly R1Ldouble * 2^256
-const arith_uint256 R1L = arith_uint256V(std::vector<unsigned char>(R1Array,R1Array+32));
+const double R1Sdouble = 0.7096329412477836074;
+const arith_uint256 R1L = arith_uint256(std::vector<unsigned char>(R1Array,R1Array+32));
+const arith_uint160 R1S = arith_uint160(std::vector<unsigned char>(R1Array,R1Array+20));
 const uint64_t R1LLow64 = 0x121156cfdb4a529cULL;
 
 const unsigned char R2Array[] =
     "\x70\x32\x1d\x7c\x47\xa5\x6b\x40\x26\x7e\x0a\xc3\xa6\x9c\xb6\xbf"
     "\x13\x30\x47\xa3\x19\x2d\xda\x71\x49\x13\x72\xf0\xb4\xca\x81\xd7";
-const arith_uint256 R2L = arith_uint256V(std::vector<unsigned char>(R2Array,R2Array+32));
+const arith_uint256 R2L = arith_uint256(std::vector<unsigned char>(R2Array,R2Array+32));
+const arith_uint160 R2S = arith_uint160(std::vector<unsigned char>(R2Array,R2Array+20));
 
 const char R1LplusR2L[] = "549FB09FEA236A1EA3E31D4D58F1B1369288D204211CA751527CFC175767850C";
 
 const unsigned char ZeroArray[] =
     "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
     "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
-const arith_uint256 ZeroL = arith_uint256V(std::vector<unsigned char>(ZeroArray,ZeroArray+32));
+const arith_uint256 ZeroL = arith_uint256(std::vector<unsigned char>(ZeroArray,ZeroArray+32));
+const arith_uint160 ZeroS = arith_uint160(std::vector<unsigned char>(ZeroArray,ZeroArray+20));
 
 const unsigned char OneArray[] =
     "\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
     "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
-const arith_uint256 OneL = arith_uint256V(std::vector<unsigned char>(OneArray,OneArray+32));
+const arith_uint256 OneL = arith_uint256(std::vector<unsigned char>(OneArray,OneArray+32));
+const arith_uint160 OneS = arith_uint160(std::vector<unsigned char>(OneArray,OneArray+20));
 
 const unsigned char MaxArray[] =
     "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
     "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff";
-const arith_uint256 MaxL = arith_uint256V(std::vector<unsigned char>(MaxArray,MaxArray+32));
+const arith_uint256 MaxL = arith_uint256(std::vector<unsigned char>(MaxArray,MaxArray+32));
+const arith_uint160 MaxS = arith_uint160(std::vector<unsigned char>(MaxArray,MaxArray+20));
 
 const arith_uint256 HalfL = (OneL << 255);
+const arith_uint160 HalfS = (OneS << 159);
 std::string ArrayToString(const unsigned char A[], unsigned int width)
 {
     std::stringstream Stream;
@@ -68,21 +75,28 @@ std::string ArrayToString(const unsigned char A[], unsigned int width)
 BOOST_AUTO_TEST_CASE( basics ) // constructors, equality, inequality
 {
     BOOST_CHECK(1 == 0+1);
-    // constructor arith_uint256(std::vector<char>):
+    // constructor arith_uint256(vector<char>):
     BOOST_CHECK(R1L.ToString() == ArrayToString(R1Array,32));
+    BOOST_CHECK(R1S.ToString() == ArrayToString(R1Array,20));
     BOOST_CHECK(R2L.ToString() == ArrayToString(R2Array,32));
+    BOOST_CHECK(R2S.ToString() == ArrayToString(R2Array,20));
     BOOST_CHECK(ZeroL.ToString() == ArrayToString(ZeroArray,32));
+    BOOST_CHECK(ZeroS.ToString() == ArrayToString(ZeroArray,20));
     BOOST_CHECK(OneL.ToString() == ArrayToString(OneArray,32));
+    BOOST_CHECK(OneS.ToString() == ArrayToString(OneArray,20));
     BOOST_CHECK(MaxL.ToString() == ArrayToString(MaxArray,32));
+    BOOST_CHECK(MaxS.ToString() == ArrayToString(MaxArray,20));
     BOOST_CHECK(OneL.ToString() != ArrayToString(ZeroArray,32));
+    BOOST_CHECK(OneS.ToString() != ArrayToString(ZeroArray,20));
 
     // == and !=
-    BOOST_CHECK(R1L != R2L);
-    BOOST_CHECK(ZeroL != OneL);
-    BOOST_CHECK(OneL != ZeroL);
-    BOOST_CHECK(MaxL != ZeroL);
-    BOOST_CHECK(~MaxL == ZeroL);
+    BOOST_CHECK(R1L != R2L && R1S != R2S);
+    BOOST_CHECK(ZeroL != OneL && ZeroS != OneS);
+    BOOST_CHECK(OneL != ZeroL && OneS != ZeroS);
+    BOOST_CHECK(MaxL != ZeroL && MaxS != ZeroS);
+    BOOST_CHECK(~MaxL == ZeroL && ~MaxS == ZeroS);
     BOOST_CHECK( ((R1L ^ R2L) ^ R1L) == R2L);
+    BOOST_CHECK( ((R1S ^ R2S) ^ R1S) == R2S);
 
     uint64_t Tmp64 = 0xc4dab720d9c7acaaULL;
     for (unsigned int i = 0; i < 256; ++i)
@@ -93,6 +107,15 @@ BOOST_AUTO_TEST_CASE( basics ) // constructors, equality, inequality
         BOOST_CHECK(((arith_uint256(Tmp64) ^ (OneL << i) ) != Tmp64 ));
     }
     BOOST_CHECK(ZeroL == (OneL << 256));
+
+    for (unsigned int i = 0; i < 160; ++i)
+    {
+        BOOST_CHECK(ZeroS != (OneS << i));
+        BOOST_CHECK((OneS << i) != ZeroS);
+        BOOST_CHECK(R1S != (R1S ^ (OneS << i)));
+        BOOST_CHECK(((arith_uint160(Tmp64) ^ (OneS << i) ) != Tmp64 ));
+    }
+    BOOST_CHECK(ZeroS == (OneS << 256));
 
     // String Constructor and Copy Constructor
     BOOST_CHECK(arith_uint256("0x"+R1L.ToString()) == R1L);
@@ -109,11 +132,30 @@ BOOST_AUTO_TEST_CASE( basics ) // constructors, equality, inequality
     BOOST_CHECK(arith_uint256(ZeroL) == ZeroL);
     BOOST_CHECK(arith_uint256(OneL) == OneL);
 
+    BOOST_CHECK(arith_uint160("0x"+R1S.ToString()) == R1S);
+    BOOST_CHECK(arith_uint160("0x"+R2S.ToString()) == R2S);
+    BOOST_CHECK(arith_uint160("0x"+ZeroS.ToString()) == ZeroS);
+    BOOST_CHECK(arith_uint160("0x"+OneS.ToString()) == OneS);
+    BOOST_CHECK(arith_uint160("0x"+MaxS.ToString()) == MaxS);
+    BOOST_CHECK(arith_uint160(R1S.ToString()) == R1S);
+    BOOST_CHECK(arith_uint160("   0x"+R1S.ToString()+"   ") == R1S);
+    BOOST_CHECK(arith_uint160("") == ZeroS);
+    BOOST_CHECK(R1S == arith_uint160(R1ArrayHex));
+
+    BOOST_CHECK(arith_uint160(R1S) == R1S);
+    BOOST_CHECK((arith_uint160(R1S^R2S)^R2S) == R1S);
+    BOOST_CHECK(arith_uint160(ZeroS) == ZeroS);
+    BOOST_CHECK(arith_uint160(OneS) == OneS);
+
     // uint64_t constructor
     BOOST_CHECK( (R1L & arith_uint256("0xffffffffffffffff")) == arith_uint256(R1LLow64));
     BOOST_CHECK(ZeroL == arith_uint256(0));
     BOOST_CHECK(OneL == arith_uint256(1));
-    BOOST_CHECK(arith_uint256("0xffffffffffffffff") == arith_uint256(0xffffffffffffffffULL));
+    BOOST_CHECK(arith_uint256("0xffffffffffffffff") = arith_uint256(0xffffffffffffffffULL));
+    BOOST_CHECK( (R1S & arith_uint160("0xffffffffffffffff")) == arith_uint160(R1LLow64));
+    BOOST_CHECK(ZeroS == arith_uint160(0));
+    BOOST_CHECK(OneS == arith_uint160(1));
+    BOOST_CHECK(arith_uint160("0xffffffffffffffff") = arith_uint160(0xffffffffffffffffULL));
 
     // Assignment (from base_uint)
     arith_uint256 tmpL = ~ZeroL; BOOST_CHECK(tmpL == ~ZeroL);
@@ -121,6 +163,17 @@ BOOST_AUTO_TEST_CASE( basics ) // constructors, equality, inequality
     tmpL = ~R1L; BOOST_CHECK(tmpL == ~R1L);
     tmpL = ~R2L; BOOST_CHECK(tmpL == ~R2L);
     tmpL = ~MaxL; BOOST_CHECK(tmpL == ~MaxL);
+    arith_uint160 tmpS = ~ZeroS; BOOST_CHECK(tmpS == ~ZeroS);
+    tmpS = ~OneS; BOOST_CHECK(tmpS == ~OneS);
+    tmpS = ~R1S; BOOST_CHECK(tmpS == ~R1S);
+    tmpS = ~R2S; BOOST_CHECK(tmpS == ~R2S);
+    tmpS = ~MaxS; BOOST_CHECK(tmpS == ~MaxS);
+
+    // Wrong length must throw exception.
+    BOOST_CHECK_THROW(arith_uint256(std::vector<unsigned char>(OneArray,OneArray+31)), uint_error);
+    BOOST_CHECK_THROW(arith_uint256(std::vector<unsigned char>(OneArray,OneArray+20)), uint_error);
+    BOOST_CHECK_THROW(arith_uint160(std::vector<unsigned char>(OneArray,OneArray+32)), uint_error);
+    BOOST_CHECK_THROW(arith_uint160(std::vector<unsigned char>(OneArray,OneArray+19)), uint_error);
 }
 
 void shiftArrayRight(unsigned char* to, const unsigned char* from, unsigned int arrayLength, unsigned int bitsToShift)
@@ -160,7 +213,7 @@ BOOST_AUTO_TEST_CASE( shifts ) { // "<<"  ">>"  "<<="  ">>="
     for (unsigned int i = 0; i < 256; ++i)
     {
         shiftArrayLeft(TmpArray, OneArray, 32, i);
-        BOOST_CHECK(arith_uint256V(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (OneL << i));
+        BOOST_CHECK(arith_uint256(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (OneL << i));
         TmpL = OneL; TmpL <<= i;
         BOOST_CHECK(TmpL == (OneL << i));
         BOOST_CHECK((HalfL >> (255-i)) == (OneL << i));
@@ -168,22 +221,22 @@ BOOST_AUTO_TEST_CASE( shifts ) { // "<<"  ">>"  "<<="  ">>="
         BOOST_CHECK(TmpL == (OneL << i));
 
         shiftArrayLeft(TmpArray, R1Array, 32, i);
-        BOOST_CHECK(arith_uint256V(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (R1L << i));
+        BOOST_CHECK(arith_uint256(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (R1L << i));
         TmpL = R1L; TmpL <<= i;
         BOOST_CHECK(TmpL == (R1L << i));
 
         shiftArrayRight(TmpArray, R1Array, 32, i);
-        BOOST_CHECK(arith_uint256V(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (R1L >> i));
+        BOOST_CHECK(arith_uint256(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (R1L >> i));
         TmpL = R1L; TmpL >>= i;
         BOOST_CHECK(TmpL == (R1L >> i));
 
         shiftArrayLeft(TmpArray, MaxArray, 32, i);
-        BOOST_CHECK(arith_uint256V(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (MaxL << i));
+        BOOST_CHECK(arith_uint256(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (MaxL << i));
         TmpL = MaxL; TmpL <<= i;
         BOOST_CHECK(TmpL == (MaxL << i));
 
         shiftArrayRight(TmpArray, MaxArray, 32, i);
-        BOOST_CHECK(arith_uint256V(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (MaxL >> i));
+        BOOST_CHECK(arith_uint256(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (MaxL >> i));
         TmpL = MaxL; TmpL >>= i;
         BOOST_CHECK(TmpL == (MaxL >> i));
     }
@@ -195,27 +248,74 @@ BOOST_AUTO_TEST_CASE( shifts ) { // "<<"  ">>"  "<<="  ">>="
     for (unsigned int i = 128; i < 256; ++i) {
         BOOST_CHECK((c1L << i) == (c2L << (i-128)));
     }
+
+    arith_uint160 TmpS;
+    for (unsigned int i = 0; i < 160; ++i)
+    {
+        shiftArrayLeft(TmpArray, OneArray, 20, i);
+        BOOST_CHECK(arith_uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (OneS << i));
+        TmpS = OneS; TmpS <<= i;
+        BOOST_CHECK(TmpS == (OneS << i));
+        BOOST_CHECK((HalfS >> (159-i)) == (OneS << i));
+        TmpS = HalfS; TmpS >>= (159-i);
+        BOOST_CHECK(TmpS == (OneS << i));
+
+        shiftArrayLeft(TmpArray, R1Array, 20, i);
+        BOOST_CHECK(arith_uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (R1S << i));
+        TmpS = R1S; TmpS <<= i;
+        BOOST_CHECK(TmpS == (R1S << i));
+
+        shiftArrayRight(TmpArray, R1Array, 20, i);
+        BOOST_CHECK(arith_uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (R1S >> i));
+        TmpS = R1S; TmpS >>= i;
+        BOOST_CHECK(TmpS == (R1S >> i));
+
+        shiftArrayLeft(TmpArray, MaxArray, 20, i);
+        BOOST_CHECK(arith_uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (MaxS << i));
+        TmpS = MaxS; TmpS <<= i;
+        BOOST_CHECK(TmpS == (MaxS << i));
+
+        shiftArrayRight(TmpArray, MaxArray, 20, i);
+        BOOST_CHECK(arith_uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (MaxS >> i));
+        TmpS = MaxS; TmpS >>= i;
+        BOOST_CHECK(TmpS == (MaxS >> i));
+    }
+    arith_uint160 c1S = arith_uint160(0x0123456789abcdefULL);
+    arith_uint160 c2S = c1S << 80;
+    for (unsigned int i = 0; i < 80; ++i) {
+        BOOST_CHECK((c1S << i) == (c2S >> (80-i)));
+    }
+    for (unsigned int i = 80; i < 160; ++i) {
+        BOOST_CHECK((c1S << i) == (c2S << (i-80)));
+    }
 }
 
 BOOST_AUTO_TEST_CASE( unaryOperators ) // !    ~    -
 {
-    BOOST_CHECK(!ZeroL);
-    BOOST_CHECK(!(!OneL));
+    BOOST_CHECK(!ZeroL);  BOOST_CHECK(!ZeroS);
+    BOOST_CHECK(!(!OneL));BOOST_CHECK(!(!OneS));
     for (unsigned int i = 0; i < 256; ++i)
         BOOST_CHECK(!(!(OneL<<i)));
-    BOOST_CHECK(!(!R1L));
-    BOOST_CHECK(!(!MaxL));
+    for (unsigned int i = 0; i < 160; ++i)
+        BOOST_CHECK(!(!(OneS<<i)));
+    BOOST_CHECK(!(!R1L));BOOST_CHECK(!(!R1S));
+    BOOST_CHECK(!(!R2S));BOOST_CHECK(!(!R2S));
+    BOOST_CHECK(!(!MaxL));BOOST_CHECK(!(!MaxS));
 
-    BOOST_CHECK(~ZeroL == MaxL);
+    BOOST_CHECK(~ZeroL == MaxL); BOOST_CHECK(~ZeroS == MaxS);
 
     unsigned char TmpArray[32];
     for (unsigned int i = 0; i < 32; ++i) { TmpArray[i] = ~R1Array[i]; }
-    BOOST_CHECK(arith_uint256V(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (~R1L));
+    BOOST_CHECK(arith_uint256(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (~R1L));
+    BOOST_CHECK(arith_uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (~R1S));
 
-    BOOST_CHECK(-ZeroL == ZeroL);
+    BOOST_CHECK(-ZeroL == ZeroL); BOOST_CHECK(-ZeroS == ZeroS);
     BOOST_CHECK(-R1L == (~R1L)+1);
+    BOOST_CHECK(-R1S == (~R1S)+1);
     for (unsigned int i = 0; i < 256; ++i)
         BOOST_CHECK(-(OneL<<i) == (MaxL << i));
+    for (unsigned int i = 0; i < 160; ++i)
+        BOOST_CHECK(-(OneS<<i) == (MaxS << i));
 }
 
 
@@ -223,10 +323,13 @@ BOOST_AUTO_TEST_CASE( unaryOperators ) // !    ~    -
 // element of Aarray and Barray, and then converting the result into a arith_uint256.
 #define CHECKBITWISEOPERATOR(_A_,_B_,_OP_)                              \
     for (unsigned int i = 0; i < 32; ++i) { TmpArray[i] = _A_##Array[i] _OP_ _B_##Array[i]; } \
-    BOOST_CHECK(arith_uint256V(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (_A_##L _OP_ _B_##L));
+    BOOST_CHECK(arith_uint256(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (_A_##L _OP_ _B_##L)); \
+    for (unsigned int i = 0; i < 20; ++i) { TmpArray[i] = _A_##Array[i] _OP_ _B_##Array[i]; } \
+    BOOST_CHECK(arith_uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (_A_##S _OP_ _B_##S));
 
 #define CHECKASSIGNMENTOPERATOR(_A_,_B_,_OP_)                           \
-    TmpL = _A_##L; TmpL _OP_##= _B_##L; BOOST_CHECK(TmpL == (_A_##L _OP_ _B_##L));
+    TmpL = _A_##L; TmpL _OP_##= _B_##L; BOOST_CHECK(TmpL == (_A_##L _OP_ _B_##L)); \
+    TmpS = _A_##S; TmpS _OP_##= _B_##S; BOOST_CHECK(TmpS == (_A_##S _OP_ _B_##S));
 
 BOOST_AUTO_TEST_CASE( bitwiseOperators )
 {
@@ -249,6 +352,7 @@ BOOST_AUTO_TEST_CASE( bitwiseOperators )
     CHECKBITWISEOPERATOR(Max,R1,&)
 
     arith_uint256 TmpL;
+    arith_uint160 TmpS;
     CHECKASSIGNMENTOPERATOR(R1,R2,|)
     CHECKASSIGNMENTOPERATOR(R1,R2,^)
     CHECKASSIGNMENTOPERATOR(R1,R2,&)
@@ -267,9 +371,13 @@ BOOST_AUTO_TEST_CASE( bitwiseOperators )
 
     uint64_t Tmp64 = 0xe1db685c9a0b47a2ULL;
     TmpL = R1L; TmpL |= Tmp64;  BOOST_CHECK(TmpL == (R1L | arith_uint256(Tmp64)));
+    TmpS = R1S; TmpS |= Tmp64;  BOOST_CHECK(TmpS == (R1S | arith_uint160(Tmp64)));
     TmpL = R1L; TmpL |= 0; BOOST_CHECK(TmpL == R1L);
+    TmpS = R1S; TmpS |= 0; BOOST_CHECK(TmpS == R1S);
     TmpL ^= 0; BOOST_CHECK(TmpL == R1L);
+    TmpS ^= 0; BOOST_CHECK(TmpS == R1S);
     TmpL ^= Tmp64;  BOOST_CHECK(TmpL == (R1L ^ arith_uint256(Tmp64)));
+    TmpS ^= Tmp64;  BOOST_CHECK(TmpS == (R1S ^ arith_uint160(Tmp64)));
 }
 
 BOOST_AUTO_TEST_CASE( comparison ) // <= >= < >
@@ -283,6 +391,16 @@ BOOST_AUTO_TEST_CASE( comparison ) // <= >= < >
         BOOST_CHECK( TmpL >= R1L ); BOOST_CHECK( (TmpL == R1L) != (TmpL > R1L)); BOOST_CHECK( (TmpL == R1L) || !( TmpL <= R1L));
         BOOST_CHECK( R1L <= TmpL ); BOOST_CHECK( (R1L == TmpL) != (R1L < TmpL)); BOOST_CHECK( (TmpL == R1L) || !( R1L >= TmpL));
         BOOST_CHECK(! (TmpL < R1L)); BOOST_CHECK(! (R1L > TmpL));
+    }
+    arith_uint160 TmpS;
+    for (unsigned int i = 0; i < 160; ++i) {
+        TmpS= OneS<< i;
+        BOOST_CHECK( TmpS >= ZeroS && TmpS > ZeroS && ZeroS < TmpS && ZeroS <= TmpS);
+        BOOST_CHECK( TmpS >= 0 && TmpS > 0 && 0 < TmpS && 0 <= TmpS);
+        TmpS |= R1S;
+        BOOST_CHECK( TmpS >= R1S ); BOOST_CHECK( (TmpS == R1S) != (TmpS > R1S)); BOOST_CHECK( (TmpS == R1S) || !( TmpS <= R1S));
+        BOOST_CHECK( R1S <= TmpS ); BOOST_CHECK( (R1S == TmpS) != (R1S < TmpS)); BOOST_CHECK( (TmpS == R1S) || !( R1S >= TmpS));
+        BOOST_CHECK(! (TmpS < R1S)); BOOST_CHECK(! (R1S > TmpS));
     }
 }
 
@@ -328,6 +446,49 @@ BOOST_AUTO_TEST_CASE( plusMinus )
     }
     TmpL = R1L;
     BOOST_CHECK(--TmpL == R1L-1);
+
+    // 160-bit; copy-pasted
+    arith_uint160 TmpS = 0;
+    BOOST_CHECK(R1S+R2S == arith_uint160(R1LplusR2L));
+    TmpS += R1S;
+    BOOST_CHECK(TmpS == R1S);
+    TmpS += R2S;
+    BOOST_CHECK(TmpS == R1S + R2S);
+    BOOST_CHECK(OneS+MaxS == ZeroS);
+    BOOST_CHECK(MaxS+OneS == ZeroS);
+    for (unsigned int i = 1; i < 160; ++i) {
+        BOOST_CHECK( (MaxS >> i) + OneS == (HalfS >> (i-1)) );
+        BOOST_CHECK( OneS + (MaxS >> i) == (HalfS >> (i-1)) );
+        TmpS = (MaxS>>i); TmpS += OneS;
+        BOOST_CHECK( TmpS == (HalfS >> (i-1)) );
+        TmpS = (MaxS>>i); TmpS += 1;
+        BOOST_CHECK( TmpS == (HalfS >> (i-1)) );
+        TmpS = (MaxS>>i);
+        BOOST_CHECK( TmpS++ == (MaxS>>i) );
+        BOOST_CHECK( TmpS == (HalfS >> (i-1)));
+    }
+    BOOST_CHECK(arith_uint160(0xbedc77e27940a7ULL) + 0xee8d836fce66fbULL == arith_uint160(0xbedc77e27940a7ULL + 0xee8d836fce66fbULL));
+    TmpS = arith_uint160(0xbedc77e27940a7ULL); TmpS += 0xee8d836fce66fbULL;
+    BOOST_CHECK(TmpS == arith_uint160(0xbedc77e27940a7ULL+0xee8d836fce66fbULL));
+    TmpS -= 0xee8d836fce66fbULL;  BOOST_CHECK(TmpS == 0xbedc77e27940a7ULL);
+    TmpS = R1S;
+    BOOST_CHECK(++TmpS == R1S+1);
+
+    BOOST_CHECK(R1S -(-R2S) == R1S+R2S);
+    BOOST_CHECK(R1S -(-OneS) == R1S+OneS);
+    BOOST_CHECK(R1S - OneS == R1S+(-OneS));
+    for (unsigned int i = 1; i < 160; ++i) {
+        BOOST_CHECK((MaxS>>i) - (-OneS)  == (HalfS >> (i-1)));
+        BOOST_CHECK((HalfS >> (i-1)) - OneS == (MaxS>>i));
+        TmpS = (HalfS >> (i-1));
+        BOOST_CHECK(TmpS-- == (HalfS >> (i-1)));
+        BOOST_CHECK(TmpS == (MaxS >> i));
+        TmpS = (HalfS >> (i-1));
+        BOOST_CHECK(--TmpS == (MaxS >> i));
+    }
+    TmpS = R1S;
+    BOOST_CHECK(--TmpS == R1S-1);
+
 }
 
 BOOST_AUTO_TEST_CASE( multiply )
@@ -343,12 +504,28 @@ BOOST_AUTO_TEST_CASE( multiply )
     BOOST_CHECK((R2L * OneL) == R2L);
     BOOST_CHECK((R2L * MaxL) == -R2L);
 
+    BOOST_CHECK((R1S * R1S).ToString() == "a7761bf30d5237e9873f9bff3642a732c4d84f10");
+    BOOST_CHECK((R1S * R2S).ToString() == "ba51c008df851987d9dd323f0e5de07760529c40");
+    BOOST_CHECK((R1S * ZeroS) == ZeroS);
+    BOOST_CHECK((R1S * OneS) == R1S);
+    BOOST_CHECK((R1S * MaxS) == -R1S);
+    BOOST_CHECK((R2S * R1S) == (R1S * R2S));
+    BOOST_CHECK((R2S * R2S).ToString() == "c28bb2b45a1d85ab7996ccd3e102a650f74ff100");
+    BOOST_CHECK((R2S * ZeroS) == ZeroS);
+    BOOST_CHECK((R2S * OneS) == R2S);
+    BOOST_CHECK((R2S * MaxS) == -R2S);
+
     BOOST_CHECK(MaxL * MaxL == OneL);
+    BOOST_CHECK(MaxS * MaxS == OneS);
 
     BOOST_CHECK((R1L * 0) == 0);
     BOOST_CHECK((R1L * 1) == R1L);
     BOOST_CHECK((R1L * 3).ToString() == "7759b1c0ed14047f961ad09b20ff83687876a0181a367b813634046f91def7d4");
     BOOST_CHECK((R2L * 0x87654321UL).ToString() == "23f7816e30c4ae2017257b7a0fa64d60402f5234d46e746b61c960d09a26d070");
+    BOOST_CHECK((R1S * 0) == 0);
+    BOOST_CHECK((R1S * 1) == R1S);
+    BOOST_CHECK((R1S * 7).ToString() == "f7a987f3c3bf758d927f202d7e795faeff084244");
+    BOOST_CHECK((R2S * 0xFFFFFFFFUL).ToString() == "1c6f6c930353e17f7d6127213bb18d2883e2cd90");
 }
 
 BOOST_AUTO_TEST_CASE( divide )
@@ -367,6 +544,21 @@ BOOST_AUTO_TEST_CASE( divide )
     BOOST_CHECK(R2L / MaxL == ZeroL);
     BOOST_CHECK(MaxL / R2L == 1);
     BOOST_CHECK_THROW(R2L / ZeroL, uint_error);
+
+    arith_uint160 D1S("D3C5EDCDEA54EB92679F0A4B4");
+    arith_uint160 D2S("13037");
+    BOOST_CHECK((R1S / D1S).ToString() == "0000000000000000000000000db9af3beade6c02");
+    BOOST_CHECK((R1S / D2S).ToString() == "000098dfb6cc40ca592bf74366794f298ada205c");
+    BOOST_CHECK(R1S / OneS == R1S);
+    BOOST_CHECK(R1S / MaxS == ZeroS);
+    BOOST_CHECK(MaxS / R1S == 1);
+    BOOST_CHECK_THROW(R1S / ZeroS, uint_error);
+    BOOST_CHECK((R2S / D1S).ToString() == "0000000000000000000000000c5608e781182047");
+    BOOST_CHECK((R2S / D2S).ToString() == "00008966751b7187c3c67c1fda5cea7db2c1c069");
+    BOOST_CHECK(R2S / OneS == R2S);
+    BOOST_CHECK(R2S / MaxS == ZeroS);
+    BOOST_CHECK(MaxS / R2S == 1);
+    BOOST_CHECK_THROW(R2S / ZeroS, uint_error);
 }
 
 
@@ -375,7 +567,7 @@ bool almostEqual(double d1, double d2)
     return fabs(d1-d2) <= 4*fabs(d1)*std::numeric_limits<double>::epsilon();
 }
 
-BOOST_AUTO_TEST_CASE( methods ) // GetHex SetHex size() GetLow64 GetSerializeSize, Serialize, Unserialize
+BOOST_AUTO_TEST_CASE( methods ) // GetHex SetHex begin() end() size() GetLow64 GetSerializeSize, Serialize, Unserialize
 {
     BOOST_CHECK(R1L.GetHex() == R1L.ToString());
     BOOST_CHECK(R2L.GetHex() == R2L.ToString());
@@ -388,25 +580,107 @@ BOOST_AUTO_TEST_CASE( methods ) // GetHex SetHex size() GetLow64 GetSerializeSiz
     TmpL.SetHex(HalfL.ToString()); BOOST_CHECK(TmpL == HalfL);
 
     TmpL.SetHex(R1L.ToString());
+    BOOST_CHECK(memcmp(R1L.begin(), R1Array, 32)==0);
+    BOOST_CHECK(memcmp(TmpL.begin(), R1Array, 32)==0);
+    BOOST_CHECK(memcmp(R2L.begin(), R2Array, 32)==0);
+    BOOST_CHECK(memcmp(ZeroL.begin(), ZeroArray, 32)==0);
+    BOOST_CHECK(memcmp(OneL.begin(), OneArray, 32)==0);
     BOOST_CHECK(R1L.size() == 32);
     BOOST_CHECK(R2L.size() == 32);
     BOOST_CHECK(ZeroL.size() == 32);
     BOOST_CHECK(MaxL.size() == 32);
+    BOOST_CHECK(R1L.begin() + 32 == R1L.end());
+    BOOST_CHECK(R2L.begin() + 32 == R2L.end());
+    BOOST_CHECK(OneL.begin() + 32 == OneL.end());
+    BOOST_CHECK(MaxL.begin() + 32 == MaxL.end());
+    BOOST_CHECK(TmpL.begin() + 32 == TmpL.end());
     BOOST_CHECK(R1L.GetLow64()  == R1LLow64);
     BOOST_CHECK(HalfL.GetLow64() ==0x0000000000000000ULL);
     BOOST_CHECK(OneL.GetLow64() ==0x0000000000000001ULL);
+    BOOST_CHECK(R1L.GetSerializeSize(0,PROTOCOL_VERSION) == 32);
+    BOOST_CHECK(ZeroL.GetSerializeSize(0,PROTOCOL_VERSION) == 32);
+
+    std::stringstream ss;
+    R1L.Serialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(ss.str() == std::string(R1Array,R1Array+32));
+    TmpL.Unserialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(R1L == TmpL);
+    ss.str("");
+    ZeroL.Serialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(ss.str() == std::string(ZeroArray,ZeroArray+32));
+    TmpL.Unserialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(ZeroL == TmpL);
+    ss.str("");
+    MaxL.Serialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(ss.str() == std::string(MaxArray,MaxArray+32));
+    TmpL.Unserialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(MaxL == TmpL);
+    ss.str("");
+
+    BOOST_CHECK(R1S.GetHex() == R1S.ToString());
+    BOOST_CHECK(R2S.GetHex() == R2S.ToString());
+    BOOST_CHECK(OneS.GetHex() == OneS.ToString());
+    BOOST_CHECK(MaxS.GetHex() == MaxS.ToString());
+    arith_uint160 TmpS(R1S);
+    BOOST_CHECK(TmpS == R1S);
+    TmpS.SetHex(R2S.ToString());   BOOST_CHECK(TmpS == R2S);
+    TmpS.SetHex(ZeroS.ToString()); BOOST_CHECK(TmpS == 0);
+    TmpS.SetHex(HalfS.ToString()); BOOST_CHECK(TmpS == HalfS);
+
+    TmpS.SetHex(R1S.ToString());
+    BOOST_CHECK(memcmp(R1S.begin(), R1Array, 20)==0);
+    BOOST_CHECK(memcmp(TmpS.begin(), R1Array, 20)==0);
+    BOOST_CHECK(memcmp(R2S.begin(), R2Array, 20)==0);
+    BOOST_CHECK(memcmp(ZeroS.begin(), ZeroArray, 20)==0);
+    BOOST_CHECK(memcmp(OneS.begin(), OneArray, 20)==0);
+    BOOST_CHECK(R1S.size() == 20);
+    BOOST_CHECK(R2S.size() == 20);
+    BOOST_CHECK(ZeroS.size() == 20);
+    BOOST_CHECK(MaxS.size() == 20);
+    BOOST_CHECK(R1S.begin() + 20 == R1S.end());
+    BOOST_CHECK(R2S.begin() + 20 == R2S.end());
+    BOOST_CHECK(OneS.begin() + 20 == OneS.end());
+    BOOST_CHECK(MaxS.begin() + 20 == MaxS.end());
+    BOOST_CHECK(TmpS.begin() + 20 == TmpS.end());
+    BOOST_CHECK(R1S.GetLow64()  == R1LLow64);
+    BOOST_CHECK(HalfS.GetLow64() ==0x0000000000000000ULL);
+    BOOST_CHECK(OneS.GetLow64() ==0x0000000000000001ULL);
+    BOOST_CHECK(R1S.GetSerializeSize(0,PROTOCOL_VERSION) == 20);
+    BOOST_CHECK(ZeroS.GetSerializeSize(0,PROTOCOL_VERSION) == 20);
+
+    R1S.Serialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(ss.str() == std::string(R1Array,R1Array+20));
+    TmpS.Unserialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(R1S == TmpS);
+    ss.str("");
+    ZeroS.Serialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(ss.str() == std::string(ZeroArray,ZeroArray+20));
+    TmpS.Unserialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(ZeroS == TmpS);
+    ss.str("");
+    MaxS.Serialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(ss.str() == std::string(MaxArray,MaxArray+20));
+    TmpS.Unserialize(ss,0,PROTOCOL_VERSION);
+    BOOST_CHECK(MaxS == TmpS);
+    ss.str("");
 
     for (unsigned int i = 0; i < 255; ++i)
     {
         BOOST_CHECK((OneL << i).getdouble() == ldexp(1.0,i));
+        if (i < 160) BOOST_CHECK((OneS << i).getdouble() == ldexp(1.0,i));
     }
     BOOST_CHECK(ZeroL.getdouble() == 0.0);
+    BOOST_CHECK(ZeroS.getdouble() == 0.0);
     for (int i = 256; i > 53; --i)
         BOOST_CHECK(almostEqual((R1L>>(256-i)).getdouble(), ldexp(R1Ldouble,i)));
+    for (int i = 160; i > 53; --i)
+        BOOST_CHECK(almostEqual((R1S>>(160-i)).getdouble(), ldexp(R1Sdouble,i)));
     uint64_t R1L64part = (R1L>>192).GetLow64();
+    uint64_t R1S64part = (R1S>>96).GetLow64();
     for (int i = 53; i > 0; --i) // doubles can store all integers in {0,...,2^54-1} exactly
     {
         BOOST_CHECK((R1L>>(256-i)).getdouble() == (double)(R1L64part >> (64-i)));
+        BOOST_CHECK((R1S>>(160-i)).getdouble() == (double)(R1S64part >> (64-i)));
     }
 }
 
@@ -542,20 +816,23 @@ BOOST_AUTO_TEST_CASE(bignum_SetCompact)
 BOOST_AUTO_TEST_CASE( getmaxcoverage ) // some more tests just to get 100% coverage
 {
     // ~R1L give a base_uint<256>
-    BOOST_CHECK((~~R1L >> 10) == (R1L >> 10));
-    BOOST_CHECK((~~R1L << 10) == (R1L << 10));
-    BOOST_CHECK(!(~~R1L < R1L));
-    BOOST_CHECK(~~R1L <= R1L);
-    BOOST_CHECK(!(~~R1L > R1L));
-    BOOST_CHECK(~~R1L >= R1L);
-    BOOST_CHECK(!(R1L < ~~R1L));
-    BOOST_CHECK(R1L <= ~~R1L);
-    BOOST_CHECK(!(R1L > ~~R1L));
-    BOOST_CHECK(R1L >= ~~R1L);
+    BOOST_CHECK((~~R1L >> 10) == (R1L >> 10)); BOOST_CHECK((~~R1S >> 10) == (R1S >> 10));
+    BOOST_CHECK((~~R1L << 10) == (R1L << 10)); BOOST_CHECK((~~R1S << 10) == (R1S << 10));
+    BOOST_CHECK(!(~~R1L < R1L)); BOOST_CHECK(!(~~R1S < R1S));
+    BOOST_CHECK(~~R1L <= R1L); BOOST_CHECK(~~R1S <= R1S);
+    BOOST_CHECK(!(~~R1L > R1L)); BOOST_CHECK(!(~~R1S > R1S));
+    BOOST_CHECK(~~R1L >= R1L); BOOST_CHECK(~~R1S >= R1S);
+    BOOST_CHECK(!(R1L < ~~R1L)); BOOST_CHECK(!(R1S < ~~R1S));
+    BOOST_CHECK(R1L <= ~~R1L); BOOST_CHECK(R1S <= ~~R1S);
+    BOOST_CHECK(!(R1L > ~~R1L)); BOOST_CHECK(!(R1S > ~~R1S));
+    BOOST_CHECK(R1L >= ~~R1L); BOOST_CHECK(R1S >= ~~R1S);
 
     BOOST_CHECK(~~R1L + R2L == R1L + ~~R2L);
+    BOOST_CHECK(~~R1S + R2S == R1S + ~~R2S);
     BOOST_CHECK(~~R1L - R2L == R1L - ~~R2L);
+    BOOST_CHECK(~~R1S - R2S == R1S - ~~R2S);
     BOOST_CHECK(~R1L != R1L); BOOST_CHECK(R1L != ~R1L);
+    BOOST_CHECK(~R1S != R1S); BOOST_CHECK(R1S != ~R1S);
     unsigned char TmpArray[32];
     CHECKBITWISEOPERATOR(~R1,R2,|)
     CHECKBITWISEOPERATOR(~R1,R2,^)

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -5,268 +5,9 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "uint256.h"
+#include "crypto/common.h"
 
-#include "utilstrencodings.h"
-
-#include <stdio.h>
-#include <string.h>
-
-template <unsigned int BITS>
-base_uint<BITS>::base_uint(const std::string& str)
-{
-    SetHex(str);
-}
-
-template <unsigned int BITS>
-base_uint<BITS>::base_uint(const std::vector<unsigned char>& vch)
-{
-    if (vch.size() != sizeof(pn))
-        throw uint_error("Converting vector of wrong size to base_uint");
-    memcpy(pn, &vch[0], sizeof(pn));
-}
-
-template <unsigned int BITS>
-base_uint<BITS>& base_uint<BITS>::operator<<=(unsigned int shift)
-{
-    base_uint<BITS> a(*this);
-    for (int i = 0; i < WIDTH; i++)
-        pn[i] = 0;
-    int k = shift / 32;
-    shift = shift % 32;
-    for (int i = 0; i < WIDTH; i++) {
-        if (i + k + 1 < WIDTH && shift != 0)
-            pn[i + k + 1] |= (a.pn[i] >> (32 - shift));
-        if (i + k < WIDTH)
-            pn[i + k] |= (a.pn[i] << shift);
-    }
-    return *this;
-}
-
-template <unsigned int BITS>
-base_uint<BITS>& base_uint<BITS>::operator>>=(unsigned int shift)
-{
-    base_uint<BITS> a(*this);
-    for (int i = 0; i < WIDTH; i++)
-        pn[i] = 0;
-    int k = shift / 32;
-    shift = shift % 32;
-    for (int i = 0; i < WIDTH; i++) {
-        if (i - k - 1 >= 0 && shift != 0)
-            pn[i - k - 1] |= (a.pn[i] << (32 - shift));
-        if (i - k >= 0)
-            pn[i - k] |= (a.pn[i] >> shift);
-    }
-    return *this;
-}
-
-template <unsigned int BITS>
-base_uint<BITS>& base_uint<BITS>::operator*=(uint32_t b32)
-{
-    uint64_t carry = 0;
-    for (int i = 0; i < WIDTH; i++) {
-        uint64_t n = carry + (uint64_t)b32 * pn[i];
-        pn[i] = n & 0xffffffff;
-        carry = n >> 32;
-    }
-    return *this;
-}
-
-template <unsigned int BITS>
-base_uint<BITS>& base_uint<BITS>::operator*=(const base_uint& b)
-{
-    base_uint<BITS> a = *this;
-    *this = 0;
-    for (int j = 0; j < WIDTH; j++) {
-        uint64_t carry = 0;
-        for (int i = 0; i + j < WIDTH; i++) {
-            uint64_t n = carry + pn[i + j] + (uint64_t)a.pn[j] * b.pn[i];
-            pn[i + j] = n & 0xffffffff;
-            carry = n >> 32;
-        }
-    }
-    return *this;
-}
-
-template <unsigned int BITS>
-base_uint<BITS>& base_uint<BITS>::operator/=(const base_uint& b)
-{
-    base_uint<BITS> div = b;     // make a copy, so we can shift.
-    base_uint<BITS> num = *this; // make a copy, so we can subtract.
-    *this = 0;                   // the quotient.
-    int num_bits = num.bits();
-    int div_bits = div.bits();
-    if (div_bits == 0)
-        throw uint_error("Division by zero");
-    if (div_bits > num_bits) // the result is certainly 0.
-        return *this;
-    int shift = num_bits - div_bits;
-    div <<= shift; // shift so that div and nun align.
-    while (shift >= 0) {
-        if (num >= div) {
-            num -= div;
-            pn[shift / 32] |= (1 << (shift & 31)); // set a bit of the result.
-        }
-        div >>= 1; // shift back.
-        shift--;
-    }
-    // num now contains the remainder of the division.
-    return *this;
-}
-
-template <unsigned int BITS>
-int base_uint<BITS>::CompareTo(const base_uint<BITS>& b) const
-{
-    for (int i = WIDTH - 1; i >= 0; i--) {
-        if (pn[i] < b.pn[i])
-            return -1;
-        if (pn[i] > b.pn[i])
-            return 1;
-    }
-    return 0;
-}
-
-template <unsigned int BITS>
-bool base_uint<BITS>::EqualTo(uint64_t b) const
-{
-    for (int i = WIDTH - 1; i >= 2; i--) {
-        if (pn[i])
-            return false;
-    }
-    if (pn[1] != (b >> 32))
-        return false;
-    if (pn[0] != (b & 0xfffffffful))
-        return false;
-    return true;
-}
-
-template <unsigned int BITS>
-double base_uint<BITS>::getdouble() const
-{
-    double ret = 0.0;
-    double fact = 1.0;
-    for (int i = 0; i < WIDTH; i++) {
-        ret += fact * pn[i];
-        fact *= 4294967296.0;
-    }
-    return ret;
-}
-
-template <unsigned int BITS>
-std::string base_uint<BITS>::GetHex() const
-{
-    char psz[sizeof(pn) * 2 + 1];
-    for (unsigned int i = 0; i < sizeof(pn); i++)
-        sprintf(psz + i * 2, "%02x", ((unsigned char*)pn)[sizeof(pn) - i - 1]);
-    return std::string(psz, psz + sizeof(pn) * 2);
-}
-
-template <unsigned int BITS>
-void base_uint<BITS>::SetHex(const char* psz)
-{
-    memset(pn, 0, sizeof(pn));
-
-    // skip leading spaces
-    while (isspace(*psz))
-        psz++;
-
-    // skip 0x
-    if (psz[0] == '0' && tolower(psz[1]) == 'x')
-        psz += 2;
-
-    // hex string to uint
-    const char* pbegin = psz;
-    while (::HexDigit(*psz) != -1)
-        psz++;
-    psz--;
-    unsigned char* p1 = (unsigned char*)pn;
-    unsigned char* pend = p1 + WIDTH * 4;
-    while (psz >= pbegin && p1 < pend) {
-        *p1 = ::HexDigit(*psz--);
-        if (psz >= pbegin) {
-            *p1 |= ((unsigned char)::HexDigit(*psz--) << 4);
-            p1++;
-        }
-    }
-}
-
-template <unsigned int BITS>
-void base_uint<BITS>::SetHex(const std::string& str)
-{
-    SetHex(str.c_str());
-}
-
-template <unsigned int BITS>
-std::string base_uint<BITS>::ToString() const
-{
-    return (GetHex());
-}
-
-template <unsigned int BITS>
-std::string base_uint<BITS>::ToStringReverseEndian() const
-{
-    char psz[sizeof(pn) * 2 + 1];
-    for (unsigned int i = 0; i < sizeof(pn); i++)
-        sprintf(psz + i * 2, "%02x", ((unsigned char*)pn)[i]);
-    return std::string(psz, psz + sizeof(pn) * 2);
-}
-
-template <unsigned int BITS>
-unsigned int base_uint<BITS>::bits() const
-{
-    for (int pos = WIDTH - 1; pos >= 0; pos--) {
-        if (pn[pos]) {
-            for (int bits = 31; bits > 0; bits--) {
-                if (pn[pos] & 1 << bits)
-                    return 32 * pos + bits + 1;
-            }
-            return 32 * pos + 1;
-        }
-    }
-    return 0;
-}
-
-// Explicit instantiations for base_uint<160>
-template base_uint<160>::base_uint(const std::string&);
-template base_uint<160>::base_uint(const std::vector<unsigned char>&);
-template base_uint<160>& base_uint<160>::operator<<=(unsigned int);
-template base_uint<160>& base_uint<160>::operator>>=(unsigned int);
-template base_uint<160>& base_uint<160>::operator*=(uint32_t b32);
-template base_uint<160>& base_uint<160>::operator*=(const base_uint<160>& b);
-template base_uint<160>& base_uint<160>::operator/=(const base_uint<160>& b);
-template int base_uint<160>::CompareTo(const base_uint<160>&) const;
-template bool base_uint<160>::EqualTo(uint64_t) const;
-template double base_uint<160>::getdouble() const;
-template std::string base_uint<160>::GetHex() const;
-template std::string base_uint<160>::ToString() const;
-template void base_uint<160>::SetHex(const char*);
-template void base_uint<160>::SetHex(const std::string&);
-template unsigned int base_uint<160>::bits() const;
-
-// Explicit instantiations for base_uint<256>
-template base_uint<256>::base_uint(const std::string&);
-template base_uint<256>::base_uint(const std::vector<unsigned char>&);
-template base_uint<256>& base_uint<256>::operator<<=(unsigned int);
-template base_uint<256>& base_uint<256>::operator>>=(unsigned int);
-template base_uint<256>& base_uint<256>::operator*=(uint32_t b32);
-template base_uint<256>& base_uint<256>::operator*=(const base_uint<256>& b);
-template base_uint<256>& base_uint<256>::operator/=(const base_uint<256>& b);
-template int base_uint<256>::CompareTo(const base_uint<256>&) const;
-template bool base_uint<256>::EqualTo(uint64_t) const;
-template double base_uint<256>::getdouble() const;
-template std::string base_uint<256>::GetHex() const;
-template std::string base_uint<256>::ToString() const;
-template void base_uint<256>::SetHex(const char*);
-template void base_uint<256>::SetHex(const std::string&);
-template unsigned int base_uint<256>::bits() const;
-template std::string base_uint<256>::ToStringReverseEndian() const;
-
-// Explicit instantiations for base_uint<512>
-template base_uint<512>::base_uint(const std::string&);
-template base_uint<512>& base_uint<512>::operator<<=(unsigned int);
-template base_uint<512>& base_uint<512>::operator>>=(unsigned int);
-template std::string base_uint<512>::GetHex() const;
-template std::string base_uint<512>::ToString() const;
-template std::string base_uint<512>::ToStringReverseEndian() const;
+/** Old classes definitions **/
 
 // This implementation directly uses shifts instead of going
 // through an intermediate MPI representation.
@@ -285,8 +26,8 @@ uint256& uint256::SetCompact(uint32_t nCompact, bool* pfNegative, bool* pfOverfl
         *pfNegative = nWord != 0 && (nCompact & 0x00800000) != 0;
     if (pfOverflow)
         *pfOverflow = nWord != 0 && ((nSize > 34) ||
-                                        (nWord > 0xff && nSize > 33) ||
-                                        (nWord > 0xffff && nSize > 32));
+                                     (nWord > 0xff && nSize > 33) ||
+                                     (nWord > 0xffff && nSize > 32));
     return *this;
 }
 
@@ -373,4 +114,35 @@ uint64_t uint256::GetHash(const uint256& salt) const
     HashFinal(a, b, c);
 
     return ((((uint64_t)b) << 32) | c);
+}
+
+uint256 ArithToUint256(const arith_uint256 &a)
+{
+    uint256 b;
+    for(int x=0; x<a.WIDTH; ++x)
+        WriteLE32(b.begin() + x*4, a.pn[x]);
+    return b;
+}
+arith_uint256 UintToArith256(const uint256 &a)
+{
+    arith_uint256 b;
+    for(int x=0; x<b.WIDTH; ++x)
+        b.pn[x] = ReadLE32(a.begin() + x*4);
+    return b;
+}
+
+uint512 ArithToUint512(const arith_uint512 &a)
+{
+    uint512 b;
+    for(int x=0; x<a.WIDTH; ++x)
+        WriteLE32(b.begin() + x*4, a.pn[x]);
+    return b;
+}
+
+arith_uint512 UintToArith512(const uint512 &a)
+{
+    arith_uint512 b;
+    for(int x=0; x<b.WIDTH; ++x)
+        b.pn[x] = ReadLE32(a.begin() + x*4);
+    return b;
 }

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -8,6 +8,7 @@
 #ifndef PIVX_UINT256_H
 #define PIVX_UINT256_H
 
+#include "arith_uint256.h"
 #include <assert.h>
 #include <cstring>
 #include <stdexcept>
@@ -15,312 +16,11 @@
 #include <string>
 #include <vector>
 
-class uint_error : public std::runtime_error
-{
-public:
-    explicit uint_error(const std::string& str) : std::runtime_error(str) {}
-};
-
-/** Template base class for unsigned big integers. */
-template <unsigned int BITS>
-class base_uint
-{
-protected:
-    enum { WIDTH = BITS / 32 };
-    uint32_t pn[WIDTH];
-
-public:
-    base_uint()
-    {
-        for (int i = 0; i < WIDTH; i++)
-            pn[i] = 0;
-    }
-
-    base_uint(const base_uint& b)
-    {
-        for (int i = 0; i < WIDTH; i++)
-            pn[i] = b.pn[i];
-    }
-
-
-    bool IsNull() const
-    {
-        for (int i = 0; i < WIDTH; i++)
-            if (pn[i] != 0)
-                return false;
-        return true;
-    }
-
-    void SetNull()
-    {
-        memset(pn, 0, sizeof(pn));
-    }
-
-
-    base_uint& operator=(const base_uint& b)
-    {
-        for (int i = 0; i < WIDTH; i++)
-            pn[i] = b.pn[i];
-        return *this;
-    }
-
-    base_uint(uint64_t b)
-    {
-        pn[0] = (unsigned int)b;
-        pn[1] = (unsigned int)(b >> 32);
-        for (int i = 2; i < WIDTH; i++)
-            pn[i] = 0;
-    }
-
-    explicit base_uint(const std::string& str);
-    explicit base_uint(const std::vector<unsigned char>& vch);
-
-    bool operator!() const
-    {
-        for (int i = 0; i < WIDTH; i++)
-            if (pn[i] != 0)
-                return false;
-        return true;
-    }
-
-    const base_uint operator~() const
-    {
-        base_uint ret;
-        for (int i = 0; i < WIDTH; i++)
-            ret.pn[i] = ~pn[i];
-        return ret;
-    }
-
-    const base_uint operator-() const
-    {
-        base_uint ret;
-        for (int i = 0; i < WIDTH; i++)
-            ret.pn[i] = ~pn[i];
-        ret++;
-        return ret;
-    }
-
-    double getdouble() const;
-
-    base_uint& operator=(uint64_t b)
-    {
-        pn[0] = (unsigned int)b;
-        pn[1] = (unsigned int)(b >> 32);
-        for (int i = 2; i < WIDTH; i++)
-            pn[i] = 0;
-        return *this;
-    }
-
-    base_uint& operator^=(const base_uint& b)
-    {
-        for (int i = 0; i < WIDTH; i++)
-            pn[i] ^= b.pn[i];
-        return *this;
-    }
-
-    base_uint& operator&=(const base_uint& b)
-    {
-        for (int i = 0; i < WIDTH; i++)
-            pn[i] &= b.pn[i];
-        return *this;
-    }
-
-    base_uint& operator|=(const base_uint& b)
-    {
-        for (int i = 0; i < WIDTH; i++)
-            pn[i] |= b.pn[i];
-        return *this;
-    }
-
-    base_uint& operator^=(uint64_t b)
-    {
-        pn[0] ^= (unsigned int)b;
-        pn[1] ^= (unsigned int)(b >> 32);
-        return *this;
-    }
-
-    base_uint& operator|=(uint64_t b)
-    {
-        pn[0] |= (unsigned int)b;
-        pn[1] |= (unsigned int)(b >> 32);
-        return *this;
-    }
-
-    base_uint& operator<<=(unsigned int shift);
-    base_uint& operator>>=(unsigned int shift);
-
-    base_uint& operator+=(const base_uint& b)
-    {
-        uint64_t carry = 0;
-        for (int i = 0; i < WIDTH; i++) {
-            uint64_t n = carry + pn[i] + b.pn[i];
-            pn[i] = n & 0xffffffff;
-            carry = n >> 32;
-        }
-        return *this;
-    }
-
-    base_uint& operator-=(const base_uint& b)
-    {
-        *this += -b;
-        return *this;
-    }
-
-    base_uint& operator+=(uint64_t b64)
-    {
-        base_uint b;
-        b = b64;
-        *this += b;
-        return *this;
-    }
-
-    base_uint& operator-=(uint64_t b64)
-    {
-        base_uint b;
-        b = b64;
-        *this += -b;
-        return *this;
-    }
-
-    base_uint& operator*=(uint32_t b32);
-    base_uint& operator*=(const base_uint& b);
-    base_uint& operator/=(const base_uint& b);
-
-    base_uint& operator++()
-    {
-        // prefix operator
-        int i = 0;
-        while (++pn[i] == 0 && i < WIDTH - 1)
-            i++;
-        return *this;
-    }
-
-    const base_uint operator++(int)
-    {
-        // postfix operator
-        const base_uint ret = *this;
-        ++(*this);
-        return ret;
-    }
-
-    base_uint& operator--()
-    {
-        // prefix operator
-        int i = 0;
-        while (--pn[i] == (uint32_t)-1 && i < WIDTH - 1)
-            i++;
-        return *this;
-    }
-
-    const base_uint operator--(int)
-    {
-        // postfix operator
-        const base_uint ret = *this;
-        --(*this);
-        return ret;
-    }
-
-    int CompareTo(const base_uint& b) const;
-    bool EqualTo(uint64_t b) const;
-
-    friend inline const base_uint operator+(const base_uint& a, const base_uint& b) { return base_uint(a) += b; }
-    friend inline const base_uint operator-(const base_uint& a, const base_uint& b) { return base_uint(a) -= b; }
-    friend inline const base_uint operator*(const base_uint& a, const base_uint& b) { return base_uint(a) *= b; }
-    friend inline const base_uint operator/(const base_uint& a, const base_uint& b) { return base_uint(a) /= b; }
-    friend inline const base_uint operator|(const base_uint& a, const base_uint& b) { return base_uint(a) |= b; }
-    friend inline const base_uint operator&(const base_uint& a, const base_uint& b) { return base_uint(a) &= b; }
-    friend inline const base_uint operator^(const base_uint& a, const base_uint& b) { return base_uint(a) ^= b; }
-    friend inline const base_uint operator>>(const base_uint& a, int shift) { return base_uint(a) >>= shift; }
-    friend inline const base_uint operator<<(const base_uint& a, int shift) { return base_uint(a) <<= shift; }
-    friend inline const base_uint operator*(const base_uint& a, uint32_t b) { return base_uint(a) *= b; }
-    friend inline bool operator==(const base_uint& a, const base_uint& b) { return memcmp(a.pn, b.pn, sizeof(a.pn)) == 0; }
-    friend inline bool operator!=(const base_uint& a, const base_uint& b) { return memcmp(a.pn, b.pn, sizeof(a.pn)) != 0; }
-    friend inline bool operator>(const base_uint& a, const base_uint& b) { return a.CompareTo(b) > 0; }
-    friend inline bool operator<(const base_uint& a, const base_uint& b) { return a.CompareTo(b) < 0; }
-    friend inline bool operator>=(const base_uint& a, const base_uint& b) { return a.CompareTo(b) >= 0; }
-    friend inline bool operator<=(const base_uint& a, const base_uint& b) { return a.CompareTo(b) <= 0; }
-    friend inline bool operator==(const base_uint& a, uint64_t b) { return a.EqualTo(b); }
-    friend inline bool operator!=(const base_uint& a, uint64_t b) { return !a.EqualTo(b); }
-
-    std::string GetHex() const;
-    void SetHex(const char* psz);
-    void SetHex(const std::string& str);
-    std::string ToString() const;
-    std::string ToStringReverseEndian() const;
-
-    unsigned char* begin()
-    {
-        return (unsigned char*)&pn[0];
-    }
-
-    unsigned char* end()
-    {
-        return (unsigned char*)&pn[WIDTH];
-    }
-
-    const unsigned char* begin() const
-    {
-        return (unsigned char*)&pn[0];
-    }
-
-    const unsigned char* end() const
-    {
-        return (unsigned char*)&pn[WIDTH];
-    }
-
-    unsigned int size() const
-    {
-        return sizeof(pn);
-    }
-
-    uint64_t Get64(int n = 0) const
-    {
-        return pn[2 * n] | (uint64_t)pn[2 * n + 1] << 32;
-    }
-
-    uint32_t Get32(int n = 0) const
-    {
-        return pn[2 * n];
-    }
-    /**
-     * Returns the position of the highest bit set plus one, or zero if the
-     * value is zero.
-     */
-    unsigned int bits() const;
-
-    uint64_t GetLow64() const
-    {
-        assert(WIDTH >= 2);
-        return pn[0] | (uint64_t)pn[1] << 32;
-    }
-
-    unsigned int GetSerializeSize(int nType, int nVersion) const
-    {
-        return sizeof(pn);
-    }
-
-    template <typename Stream>
-    void Serialize(Stream& s, int nType, int nVersion) const
-    {
-        s.write((char*)pn, sizeof(pn));
-    }
-
-    template <typename Stream>
-    void Unserialize(Stream& s, int nType, int nVersion)
-    {
-        s.read((char*)pn, sizeof(pn));
-    }
-
-    // Temporary for migration to opaque uint160/256
-    uint64_t GetCheapHash() const
-    {
-        return GetLow64();
-    }
-
-    friend class uint160;
-    friend class uint256;
-    friend class uint512;
-};
+//
+// This is a migration file class, as soon as we move every
+// uint256 field used, invalidly, as a number to the proper arith_uint256, this will be replaced
+// with the blob_uint256 file.
+//
 
 /** 160-bit unsigned big integer. */
 class uint160 : public base_uint<160>
@@ -352,20 +52,43 @@ public:
      * The lower 23 bits are the mantissa.
      * Bit number 24 (0x800000) represents the sign of N.
      * N = (-1^sign) * mantissa * 256^(exponent-3)
-     * 
+     *
      * Satoshi's original implementation used BN_bn2mpi() and BN_mpi2bn().
      * MPI uses the most significant bit of the first byte as sign.
      * Thus 0x1234560000 is compact (0x05123456)
      * and  0xc0de000000 is compact (0x0600c0de)
-     * 
+     *
      * Bitcoin only uses this "compact" format for encoding difficulty
      * targets, which are unsigned 256bit quantities.  Thus, all the
      * complexities of the sign bit and using base 256 are probably an
      * implementation accident.
      */
-    uint256& SetCompact(uint32_t nCompact, bool* pfNegative = NULL, bool* pfOverflow = NULL);
+    uint256& SetCompact(uint32_t nCompact, bool* pfNegative = nullptr, bool* pfOverflow = nullptr);
     uint32_t GetCompact(bool fNegative = false) const;
     uint64_t GetHash(const uint256& salt) const;
+};
+
+/** 512-bit unsigned big integer. */
+class uint512 : public base_uint<512>
+{
+public:
+    uint512() {}
+    uint512(const base_uint<512>& b) : base_uint<512>(b) {}
+    uint512(uint64_t b) : base_uint<512>(b) {}
+    explicit uint512(const std::string& str) : base_uint<512>(str) {}
+    explicit uint512(const std::vector<unsigned char>& vch) : base_uint<512>(vch) {}
+
+    uint256 trim256() const
+    {
+        uint256 ret;
+        for (unsigned int i = 0; i < uint256::WIDTH; i++) {
+            ret.pn[i] = pn[i];
+        }
+        return ret;
+    }
+
+    friend arith_uint512 UintToArith512(const uint512 &a);
+    friend uint512 ArithToUint512(const arith_uint512 &a);
 };
 
 /* uint256 from const char *.
@@ -389,32 +112,17 @@ inline uint256 uint256S(const std::string& str)
     return rv;
 }
 
-/** 512-bit unsigned big integer. */
-class uint512 : public base_uint<512>
-{
-public:
-    uint512() {}
-    uint512(const base_uint<512>& b) : base_uint<512>(b) {}
-    uint512(uint64_t b) : base_uint<512>(b) {}
-    explicit uint512(const std::string& str) : base_uint<512>(str) {}
-    explicit uint512(const std::vector<unsigned char>& vch) : base_uint<512>(vch) {}
-
-    uint256 trim256() const
-    {
-        uint256 ret;
-        for (unsigned int i = 0; i < uint256::WIDTH; i++) {
-            ret.pn[i] = pn[i];
-        }
-        return ret;
-    }
-};
-
 inline uint512 uint512S(const std::string& str)
 {
     uint512 rv;
     rv.SetHex(str);
     return rv;
 }
+
+uint256 ArithToUint256(const arith_uint256 &);
+arith_uint256 UintToArith256(const uint256 &);
+uint512 ArithToUint512(const arith_uint512 &);
+arith_uint512 UintToArith512(const uint512 &);
 
 /** constant uint256 instances */
 const uint256 UINT256_ZERO = uint256();

--- a/src/uint512.h
+++ b/src/uint512.h
@@ -6,27 +6,24 @@
 #define PIVX_UINT512_H
 
 #include "arith_uint256.h"
-#include "uint256.h"
+#include "blob_uint256.h"
 
 /** 512-bit unsigned big integer. */
-class uint512 : public base_blob<512>
+class blob_uint512 : public base_blob<512>
 {
 public:
-    uint512() {}
-    uint512(const base_blob<512>& b) : base_blob<512>(b) {}
-    //explicit uint512(const std::vector<unsigned char>& vch) : base_uint<512>(vch) {}
-    explicit uint512(const std::vector<unsigned char>& vch) : base_blob<512>(vch) {}
-    //explicit uint512(const std::string& str) : base_blob<512>(str) {}
+    blob_uint512() {}
+    blob_uint512(const base_blob<512>& b) : base_blob<512>(b) {}
+    explicit blob_uint512(const std::vector<unsigned char>& vch) : base_blob<512>(vch) {}
 
-    uint256 trim256() const
+    blob_uint256 trim256() const
     {
         std::vector<unsigned char> vch;
         const unsigned char* p = this->begin();
         for (unsigned int i = 0; i < 32; i++) {
             vch.push_back(*p++);
         }
-        uint256 retval(vch);
-        return retval;
+        return blob_uint256(vch);
     }
 };
 
@@ -35,9 +32,9 @@ public:
  * This is a separate function because the constructor uint256(const char*) can result
  * in dangerously catching UINT256_ZERO.
  */
-inline uint512 uint512S(const char* str)
+inline blob_uint512 blob_uint512S(const char* str)
 {
-    uint512 rv;
+    blob_uint512 rv;
     rv.SetHex(str);
     return rv;
 }


### PR DESCRIPTION
This is part of the large effort of making the uint256 file an opaque blob object and not treat every uint256 as an arith_uint256 anymore (same for the uint160 and uint512). Work coded on top of #1395, this is the second step.

As we cannot do it all at once, i opted to do the migration in steps. 
The amount of changes needed is really extensive and the risk of damage the synchronization process -and other areas as well- is high, this will need changes on the MNs, budget and zerocoin library sources which are using the uint256 object purely as a number.

This step is doing the following changes:

1) Creating blob_uint256 files (opaque blob version of the uint256 files -- this is the future uint256 files that will be refactored once all of the fields that are using it as a number in our sources get migrated to use the new arith_uint256 classes).

2) Creating arith_uint256 files.

3) Cleaning shared code between the uint256 file and the arith_uint256 classes and only leaving in uint256 the old classes that needs to be checked and migrated -- if them are using the uint256 as a number and not as an opaque blob object -- (following the explanation in point 1).

4) Updating, cleaning and connecting the arith_uint256 unit test (including arith_uint160 and arith_uint256 checks and validations).