### PR TITLE
[GUI][Trivial] Fix button size in welcomecontentwidget

### DIFF
--- a/src/qt/pivx/forms/welcomecontentwidget.ui
+++ b/src/qt/pivx/forms/welcomecontentwidget.ui
@@ -267,7 +267,7 @@
                  </property>
                  <property name="maximumSize">
                   <size>
-                   <width>16777215</width>
+                   <width>140</width>
                    <height>1</height>
                   </size>
                  </property>
@@ -353,7 +353,7 @@
                  </property>
                  <property name="maximumSize">
                   <size>
-                   <width>16777215</width>
+                   <width>140</width>
                    <height>1</height>
                   </size>
                  </property>
@@ -439,7 +439,7 @@
                  </property>
                  <property name="maximumSize">
                   <size>
-                   <width>16777215</width>
+                   <width>160</width>
                    <height>1</height>
                   </size>
                  </property>
@@ -715,7 +715,7 @@
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
-                      <width>40</width>
+                      <width>20</width>
                       <height>20</height>
                      </size>
                     </property>
@@ -725,7 +725,7 @@
                    <widget class="QPushButton" name="pushName4">
                     <property name="minimumSize">
                      <size>
-                      <width>110</width>
+                      <width>150</width>
                       <height>0</height>
                      </size>
                     </property>
@@ -759,7 +759,7 @@
                     </property>
                     <property name="sizeHint" stdset="0">
                      <size>
-                      <width>96</width>
+                      <width>76</width>
                       <height>20</height>
                      </size>
                     </property>


### PR DESCRIPTION
Trivial fix for last button which was cropping out part of the text "Masternode".

Linux:
![welcomecontentwidget_linux](https://user-images.githubusercontent.com/18186894/76882379-db22a100-687a-11ea-8f56-4a757bc00508.png)

Closes #1419 

