### PR TITLE
[Trivial][GUI] Add more room to contacts dropdown

### DIFF
--- a/src/qt/pivx/coldstakingwidget.cpp
+++ b/src/qt/pivx/coldstakingwidget.cpp
@@ -339,7 +339,7 @@ void ColdStakingWidget::onContactsClicked()
     ui->vContainerOwner->getContentsMargins(&margin2, nullptr, nullptr, nullptr);
     pos.setX(pos.x() + margin1 + margin2);
 
-    height = (contactsSize <= 2) ? height * ( 2 * (contactsSize + 1 )) : height * 4;
+    height = (contactsSize <= 2) ? height * ( 2 * (contactsSize + 1 )) : height * 6;
 
     if (!menuContacts) {
         menuContacts = new ContactsDropdown(

--- a/src/qt/pivx/send.cpp
+++ b/src/qt/pivx/send.cpp
@@ -714,7 +714,7 @@ void SendWidget::onContactsClicked(SendMultiRow* entry)
         return;
     }
 
-    int height = (contactsSize <= 2) ? entry->getEditHeight() * ( 2 * (contactsSize + 1 )) : entry->getEditHeight() * 4;
+    int height = (contactsSize <= 2) ? entry->getEditHeight() * ( 2 * (contactsSize + 1 )) : entry->getEditHeight() * 6;
     int width = entry->getEditWidth();
 
     if (!menuContacts) {


### PR DESCRIPTION
Make contacts dropdown a little bit higher, so at least 4 addresses fit

![contacts_dropdown_1](https://user-images.githubusercontent.com/18186894/76907704-35395b80-68a7-11ea-948f-0a0fde5964c6.png)

---
![contacts_dropdown_2](https://user-images.githubusercontent.com/18186894/76907712-39657900-68a7-11ea-8114-6c66d270fdb0.png)

---
Closes #1416 