### PR TITLE
[Trivial][GUI] Fix capsLabel color (make it text-warning)

### DIFF
--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -59,6 +59,7 @@ AskPassphraseDialog::AskPassphraseDialog(Mode mode, QWidget* parent, WalletModel
     ui->passLabel3->setText("Repeat passphrase");
     ui->passLabel3->setProperty("cssClass", "text-title");
 
+    setCssProperty(ui->capsLabel, "text-warning-small");
     ui->capsLabel->setVisible(false);
 
     ui->passEdit1->setMinimumSize(ui->passEdit1->sizeHint());

--- a/src/qt/pivx/res/css/style_dark.css
+++ b/src/qt/pivx/res/css/style_dark.css
@@ -1749,9 +1749,9 @@ HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH*/
     font-size:16px;
 }
 
-*[cssClass="text-violet-warning"] {
-    color: #877B9F;;
-    font-size:13px;
+*[cssClass="text-warning-small"] {
+    color: #f84444;
+    font-size:14px;
 }
 
 *[cssClass="ic-warning"] {

--- a/src/qt/pivx/res/css/style_light.css
+++ b/src/qt/pivx/res/css/style_light.css
@@ -1749,9 +1749,9 @@ HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH*/
     font-size:16px;
 }
 
-*[cssClass="text-violet-warning"] {
-    color: #877B9F;;
-    font-size:13px;
+*[cssClass="text-warning-small"] {
+    color: #f84444;
+    font-size:14px;
 }
 
 *[cssClass="ic-warning"] {


### PR DESCRIPTION
Ref: https://github.com/PIVX-Project/PIVX/pull/1428#issuecomment-600925968

Caps-lock warning is black.
Assign text-warning css to make it clearly visible (and instantly recognizable as warning) in both themes.