### PR TITLE
[Scripts] Only fetch translations for high-completion locals

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,7 @@
+[main]
+host = https://www.transifex.com
+
+[pivx-project-translations.qt-translation-40x]
+file_filter = src/qt/locale/pivx_<lang>.ts
+source_file = src/qt/locale/pivx_en.ts
+source_lang = en

--- a/contrib/devtools/update-translations.py
+++ b/contrib/devtools/update-translations.py
@@ -29,6 +29,8 @@ SOURCE_LANG = 'pivx_en.ts'
 LOCALE_DIR = 'src/qt/locale'
 # Minimum number of messages for translation to be considered at all
 MIN_NUM_MESSAGES = 10
+# Minimum completion percentage required to download from transifex
+MINIMUM_PERC = 80
 # Path to git
 GIT = os.getenv("GIT", "git")
 
@@ -50,7 +52,7 @@ def remove_current_translations():
         os.remove(name + '.orig')
 
 def fetch_all_translations():
-    if subprocess.call([TX, 'pull', '-f', '-a']):
+    if subprocess.call([TX, 'pull', '-f', '-a', '--minimum-perc=%s' % MINIMUM_PERC]):
         print('Error while fetching translations', file=sys.stderr)
         sys.exit(1)
 

--- a/contrib/devtools/update-translations.py
+++ b/contrib/devtools/update-translations.py
@@ -14,6 +14,7 @@ It will do the following automatically:
 - update git for added translations
 - update build system
 '''
+import argparse
 import subprocess
 import re
 import sys
@@ -51,8 +52,11 @@ def remove_current_translations():
     for (_,name) in all_ts_files('.orig'):
         os.remove(name + '.orig')
 
-def fetch_all_translations():
-    if subprocess.call([TX, 'pull', '-f', '-a', '--minimum-perc=%s' % MINIMUM_PERC]):
+def fetch_all_translations(fAll = False):
+    call_list = [TX, 'pull', '-f', '-a']
+    if not fAll:
+        call_list.append('--minimum-perc=%s' % MINIMUM_PERC)
+    if subprocess.call(call_list):
         print('Error while fetching translations', file=sys.stderr)
         sys.exit(1)
 
@@ -250,9 +254,17 @@ def update_build_systems():
 
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(add_help=False,
+                                     usage='%(prog)s [update-translations.py options] [flags]',
+                                     description=__doc__,
+                                     epilog='',
+                                     formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument('--ignore_completion', '-i', action='store_true', help='fetch all translations, even those not reaching the completion threshold')
+    args, unknown_args = parser.parse_known_args()
+
     check_at_repository_root()
     remove_current_translations()
-    fetch_all_translations()
+    fetch_all_translations(args.ignore_completion)
     postprocess_translations()
     update_git()
     update_build_systems()


### PR DESCRIPTION
This restricts the fetching of translations from Transifex during the
translation process to only fetch the translations that meet a defined
minimum completion threshold percentage.

In order to allow testers/self-compilers to see partial translations in-wallet,
a runtime override flag has been added to the `update-translations.py`
script; `--ignore_completion`

Also, finally add the public configuration file for the `tx` CLI tool

Closes #1432