### PR TITLE
[QA] Continuous Testing Environment for legacy pre-HD wallets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -144,6 +144,19 @@ jobs:
         BUILD_TIMEOUT=800
 
     - stage: test
+      name: 'x86_64 Linux  [GOAL: install]  [bionic]  [no GUI, no unit tests - only functional tests on legacy pre-HD wallets]'
+      env: >-
+        HOST=x86_64-unknown-linux-gnu
+        PACKAGES="python3-zmq protobuf-compiler libdbus-1-dev libharfbuzz-dev libprotobuf-dev"
+        DEP_OPTS="NO_QT=1 NO_UPNP=1 DEBUG=1 ALLOW_HOST_PACKAGES=1"
+        RUN_UNIT_TESTS=false
+        RUN_FUNCTIONAL_TESTS=true
+        TEST_RUNNER_EXTRA="--legacywallet"  # Run functional tests on pre-HD wallet
+        GOAL="install"
+        BITCOIN_CONFIG="--enable-zmq --with-gui=no --enable-glibc-back-compat --enable-reduce-exports"
+        BUILD_TIMEOUT=800
+
+    - stage: test
       name: 'x86_64 Linux  [GOAL: install]  [trusty]  [no functional tests, no depends, no GUI, only system libs]'
       env: >-
         HOST=x86_64-unknown-linux-gnu

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -150,6 +150,31 @@ EXTENDED_SCRIPTS = [
     'rpc_invalidateblock.py',
 ]
 
+LEGACY_SKIP_TESTS = [
+    # These tests are not run when the flag --legacywallet is used
+    'feature_help.py',
+    'feature_reindex.py',
+    'feature_proxy.py',
+    'feature_uacomment.py',
+    'interface_bitcoin_cli.py',
+    'interface_http.py',
+    'interface_rest.py',
+    'mempool_reorg.py',
+    'mempool_resurrect.py',
+    'mempool_spend_coinbase.py',
+    'p2p_disconnect_ban.py',
+    'p2p_time_offset.py',
+    'rpc_bip38.py',
+    'rpc_blockchain.py',
+    'rpc_budget.py',
+    'rpc_decodescript.py',
+    'rpc_net.py',
+    'rpc_signmessage.py',
+    'rpc_spork.py',
+    'wallet_hd.py',         # no HD tests for pre-HD wallets
+    'wallet_upgrade.py',    # can't upgrade to pre-HD wallet
+]
+
 # Place EXTENDED_SCRIPTS first since it has the 3 longest running tests
 ALL_SCRIPTS = EXTENDED_SCRIPTS + BASE_SCRIPTS
 
@@ -247,6 +272,10 @@ def main():
                 test_list.remove(exclude_test)
             else:
                 print("{}WARNING!{} Test '{}' not found in current test list.".format(BOLD[1], BOLD[0], exclude_test))
+
+    # If --legacywallet, remove extra test cases
+    if args.legacywallet:
+        test_list = [x for x in test_list if x not in LEGACY_SKIP_TESTS]
 
     if not test_list:
         print("No valid test scripts specified. Check that your test is in one "


### PR DESCRIPTION
Follows the discussion in #1410 .
Defines a list of tests to be skipped by the `test_runner` when running with the `--legacywallet` flag (not directly related to the wallet / key management).
Also adds a specific Travis job, to run the functional test suite on pre-HD wallets.

Note: currently based on top of 
- [x] #1411 

to make legacy tests pass.