### PR TITLE
[Trivial] Remove spammy log in CheckSignature

### DIFF
--- a/src/messagesigner.cpp
+++ b/src/messagesigner.cpp
@@ -128,16 +128,11 @@ bool CSignedMessage::CheckSignature(const CPubKey& pubKey) const
 
     if (nMessVersion == MessageVersion::MESS_VER_HASH) {
         uint256 hash = GetSignatureHash();
-        if(!CHashSigner::VerifyHash(hash, pubKey, vchSig, strError))
-            return error("%s : VerifyHash failed: %s", __func__, strError);
-
-    } else {
-        std::string strMessage = GetStrMessage();
-        if(!CMessageSigner::VerifyMessage(pubKey, vchSig, strMessage, strError))
-            return error("%s : VerifyMessage failed: %s", __func__, strError);
+        return CHashSigner::VerifyHash(hash, pubKey, vchSig, strError);
     }
 
-    return true;
+    std::string strMessage = GetStrMessage();
+    return CMessageSigner::VerifyMessage(pubKey, vchSig, strMessage, strError);
 }
 
 bool CSignedMessage::CheckSignature() const


### PR DESCRIPTION
Remove extra logs in `CSignedMessage::CheckSignature`.
This method is inherited by all classes extending `CSignedMessage` and its log does not give useful information to the verifier at all (it's not even clear what is the class in question). Might just be of some help when signing (`VerifyHash` is called from within `CSignedMessage::Sign` too).
All relevant logs for verifiers are already provided by the caller - e.g. 
```cpp
if (!mess.CheckSignature()) { /* log something */ }
```