### PR TITLE
[GUI] Show topbar "Locked Included" label on delegations.

### DIFF
--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -604,7 +604,7 @@ void TopBar::updateBalances(const CAmount& balance, const CAmount& unconfirmedBa
     if (walletModel) {
         nLockedBalance = walletModel->getLockedBalance();
     }
-    ui->labelTitle1->setText(nLockedBalance > 0 ? tr("Available (Locked included)") : tr("Available"));
+    ui->labelTitle1->setText(nLockedBalance + delegatedBalance > 0 ? tr("Available (Locked included)") : tr("Available"));
 
     // PIV Total
     CAmount pivAvailableBalance = balance;


### PR DESCRIPTION
Simple enough, if there are delegations in the wallet, show the "Locked included" description in the topbar's available balance label (Same as it's happening with the locked collateral).