### PR TITLE
[CMake] Fix missing file error

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -162,7 +162,6 @@ SET(QT_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/pivx/tooltipmenu.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/pivx/addresseswidget.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/pivx/defaultdialog.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/pivx/denomgenerationdialog.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/pivx/privacywidget.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/pivx/coldstakingwidget.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/pivx/settings/settingsbackupwallet.cpp


### PR DESCRIPTION
#1443 removed the `denomgenerationdialog` files, but the `.cpp` file
reference wasn't also removed from the GUI's `CMakeLists.txt` file.