### PR TITLE
[Util] Buffer log messages and explicitly open logs

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1063,8 +1063,8 @@ bool AppInit2()
 #endif
     if (GetBoolArg("-shrinkdebugfile", logCategories != BCLog::NONE))
         ShrinkDebugFile();
-    LogPrintf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
-    LogPrintf("PIVX version %s (%s)\n", FormatFullVersion(), CLIENT_DATE);
+    if (fPrintToDebugLog)
+        OpenDebugLog();
 #ifdef ENABLE_WALLET
     LogPrintf("Using BerkeleyDB version %s\n", DbEnv::version(0, 0, 0));
 #endif

--- a/src/util.h
+++ b/src/util.h
@@ -153,6 +153,7 @@ void ReadConfigFile(std::map<std::string, std::string>& mapSettingsRet, std::map
 boost::filesystem::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif
 boost::filesystem::path GetTempPath();
+void OpenDebugLog();
 void ShrinkDebugFile();
 void runCommand(std::string strCommand);
 


### PR DESCRIPTION
implemented on top of
- [x] #1449 
- [x] #1437
- [x] #1439 

Backports bitcoin#6149

> Prevents stomping on debug logs in datadirs that are locked by other
instances and lost parameter interaction messages that can get wiped by
ShrinkDebugFile().
The log is now opened explicitly and all emitted messages are buffered
until this open occurs.  The version message and log cut have also been
moved to the earliest possible sensible location.