### PR TITLE
[RPC] Add logging RPC

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -141,7 +141,11 @@ The following commands have been removed from the RPC interface:
 ### Newly introduced commands
 
 The following new commands have been added to the RPC interface:
-- `...`
+- `logging` <br>Gets and sets the logging configuration.<br>
+When called without an argument, returns the list of categories that are currently being debug logged.<br>
+When called with arguments, adds or removes categories from debug logging.<br>
+E.g. `logging "[\"all\"]" "[\"http\"]""`
+
 
 Details about each new command can be found below.
 

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -389,14 +389,13 @@ bool InitHTTPServer()
 
     // Redirect libevent's logging to our own log
     event_set_log_callback(&libevent_log_cb);
-#if LIBEVENT_VERSION_NUMBER >= 0x02010100
-    // If -debug=libevent, set full libevent debugging.
-    // Otherwise, disable all libevent debugging.
-    if (LogAcceptCategory(BCLog::LIBEVENT))
-        event_enable_debug_logging(EVENT_DBG_ALL);
-    else
-        event_enable_debug_logging(EVENT_DBG_NONE);
-#endif
+    // Update libevent's log handling. Returns false if our version of
+    // libevent doesn't support debug logging, in which case we should
+    // clear the BCLog::LIBEVENT flag.
+    if (!UpdateHTTPServerLogging(logCategories & BCLog::LIBEVENT)) {
+        logCategories &= ~BCLog::LIBEVENT;
+    }
+
 #ifdef WIN32
     evthread_use_windows_threads();
 #else
@@ -437,6 +436,20 @@ bool InitHTTPServer()
     eventBase = base;
     eventHTTP = http;
     return true;
+}
+
+bool UpdateHTTPServerLogging(bool enable) {
+#if LIBEVENT_VERSION_NUMBER >= 0x02010100
+    if (enable) {
+        event_enable_debug_logging(EVENT_DBG_ALL);
+    } else {
+        event_enable_debug_logging(EVENT_DBG_NONE);
+    }
+    return true;
+#else
+    // Can't update libevent logging if version < 02010100
+    return false;
+#endif
 }
 
 std::thread threadHTTP;

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -32,6 +32,10 @@ void InterruptHTTPServer();
 /** Stop HTTP server */
 void StopHTTPServer();
 
+/** Change logging level for libevent. Removes BCLog::LIBEVENT from logCategories if
+ * libevent doesn't support debug logging.*/
+bool UpdateHTTPServerLogging(bool enable);
+
 /** Handler for requests to a certain HTTP path */
 typedef std::function<void(HTTPRequest* req, const std::string &)> HTTPRequestHandler;
 /** Register handler for prefix.

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -90,6 +90,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
         {"listunspent", 1},
         {"listunspent", 2},
         {"listunspent", 3},
+        {"logging", 0},
+        {"logging", 1},
         {"getblock", 1},
         {"getblockheader", 1},
         {"gettransaction", 1},

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -348,6 +348,7 @@ static const CRPCCommand vRPCCommands[] =
 
         /* Utility functions */
         {"util", "createmultisig", &createmultisig, true, true, false},
+        {"util", "logging", &logging, true, false, false},
         {"util", "validateaddress", &validateaddress, true, false, false}, /* uses wallet if enabled */
         {"util", "verifymessage", &verifymessage, true, false, false},
         {"util", "estimatefee", &estimatefee, true, true, false},

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -350,6 +350,7 @@ extern UniValue mnfinalbudget(const UniValue& params, bool fHelp);
 extern UniValue checkbudgets(const UniValue& params, bool fHelp);
 
 extern UniValue getinfo(const UniValue& params, bool fHelp); // in rpc/misc.cpp
+extern UniValue logging(const UniValue& params, bool fHelp);
 extern UniValue mnsync(const UniValue& params, bool fHelp);
 extern UniValue spork(const UniValue& params, bool fHelp);
 extern UniValue validateaddress(const UniValue& params, bool fHelp);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -112,7 +112,7 @@ bool fLogTimestamps = false;
 bool fLogIPs = false;
 volatile bool fReopenDebugLog = false;
 
-/** Log categories bitfield. Leveldb/libevent need special handling if their flags are changed at runtime. */
+/** Log categories bitfield. libevent needs special handling if their flags are changed at runtime. */
 std::atomic<uint32_t> logCategories(0);
 
 
@@ -317,6 +317,21 @@ static std::string LogTimestampStr(const std::string &str, bool *fStartedNewLine
         *fStartedNewLine = false;
 
     return strStamped;
+}
+
+std::vector<CLogCategoryActive> ListActiveLogCategories()
+{
+    std::vector<CLogCategoryActive> ret;
+    for (unsigned int i = 0; i < ARRAYLEN(LogCategories); i++) {
+        // Omit the special cases.
+        if (LogCategories[i].flag != BCLog::NONE && LogCategories[i].flag != BCLog::ALL) {
+            CLogCategoryActive catActive;
+            catActive.category = LogCategories[i].category;
+            catActive.active = LogAcceptCategory(LogCategories[i].flag);
+            ret.push_back(catActive);
+        }
+    }
+    return ret;
 }
 
 int LogPrintStr(const std::string& str)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -112,9 +112,8 @@ bool fLogTimestamps = false;
 bool fLogIPs = false;
 volatile bool fReopenDebugLog = false;
 
-/** Log categories bitfield. libevent needs special handling if their flags are changed at runtime. */
+/** Log categories bitfield. */
 std::atomic<uint32_t> logCategories(0);
-
 
 /** Init OpenSSL library multithreading support */
 static RecursiveMutex** ppmutexOpenSSL;

--- a/src/util.h
+++ b/src/util.h
@@ -57,6 +57,12 @@ extern volatile bool fReopenDebugLog;
 void SetupEnvironment();
 bool SetupNetworking();
 
+struct CLogCategoryActive
+{
+    std::string category;
+    bool active;
+};
+
 namespace BCLog {
     enum LogFlags : uint32_t {
         NONE        = 0,
@@ -95,8 +101,10 @@ static inline bool LogAcceptCategory(uint32_t category)
     return (logCategories.load(std::memory_order_relaxed) & category) != 0;
 }
 
-/** Returns a string with the supported log categories */
+/** Returns a string with the log categories. */
 std::string ListLogCategories();
+/** Returns a vector of the active log categories. */
+std::vector<CLogCategoryActive> ListActiveLogCategories();
 /** Return true if str parses as a log category and set the flags in f */
 bool GetLogCategory(uint32_t *f, const std::string *str);
 /** Send a string to the log output */


### PR DESCRIPTION
Implemented on top of:
- [x] #1449 
- [x] #1437
- [x] #1439 
- [x] #1450 

Backports bitcoin#10150

> Adds an RPC to get/set active logging categories.
First commit allows all categories except libevent to be reconfigured during runtime.
Second commit modifies InitHTTPServer() to allow leveldb logging to be reconfigured during runtime.