### PR TITLE
[Init] Add `-debuglogfile` option

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -150,6 +150,12 @@ E.g. `logging "[\"all\"]" "[\"http\"]""`
 Details about each new command can be found below.
 
 
+Changed command-line options
+-----------------------------
+
+- `-debuglogfile=<file>` can be used to specify an alternative debug logging file. This can be an absolute path or a path relative to the data directory
+
+
 *version* Change log
 ==============
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -383,6 +383,7 @@ std::string HelpMessage(HelpMessageMode mode)
 #endif
     }
     strUsage += HelpMessageOpt("-datadir=<dir>", _("Specify data directory"));
+    strUsage += HelpMessageOpt("-debuglogfile=<file>", strprintf(_("Specify location of debug log file: this can be an absolute path or a path relative to the data directory (default: %s)"), DEFAULT_DEBUGLOGFILE));
     strUsage += HelpMessageOpt("-dbcache=<n>", strprintf(_("Set database cache size in megabytes (%d to %d, default: %d)"), nMinDbCache, nMaxDbCache, nDefaultDbCache));
     strUsage += HelpMessageOpt("-loadblock=<file>", _("Imports blocks from external blk000??.dat file") + " " + _("on startup"));
     strUsage += HelpMessageOpt("-maxreorg=<n>", strprintf(_("Set the Maximum reorg depth (default: %u)"), DEFAULT_MAX_REORG_DEPTH));
@@ -1063,8 +1064,9 @@ bool AppInit2()
 #endif
     if (GetBoolArg("-shrinkdebugfile", logCategories != BCLog::NONE))
         ShrinkDebugFile();
-    if (fPrintToDebugLog)
-        OpenDebugLog();
+    if (fPrintToDebugLog && !OpenDebugLog()) {
+        return UIError(strprintf("Could not open debug log file %s", GetDebugLogPath().string()));
+    }
 #ifdef ENABLE_WALLET
     LogPrintf("Using BerkeleyDB version %s\n", DbEnv::version(0, 0, 0));
 #endif

--- a/src/util.h
+++ b/src/util.h
@@ -32,6 +32,8 @@
 #include <boost/thread/exceptions.hpp>
 #include <boost/thread/condition_variable.hpp> // for boost::thread_interrupted
 
+extern const char * const DEFAULT_DEBUGLOGFILE;
+
 //PIVX only features
 
 extern bool fMasterNode;
@@ -161,7 +163,8 @@ void ReadConfigFile(std::map<std::string, std::string>& mapSettingsRet, std::map
 boost::filesystem::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif
 boost::filesystem::path GetTempPath();
-void OpenDebugLog();
+boost::filesystem::path GetDebugLogPath();
+bool OpenDebugLog();
 void ShrinkDebugFile();
 void runCommand(std::string strCommand);
 

--- a/test/functional/feature_logging.py
+++ b/test/functional/feature_logging.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Copyright (c) 20200 The PIVX Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test debug logging."""
+
+import os
+
+from test_framework.test_framework import PivxTestFramework
+
+class LoggingTest(PivxTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def run_test(self):
+        # test default log file name
+        assert os.path.isfile(os.path.join(self.nodes[0].datadir, "regtest", "debug.log"))
+        self.log.info("Default filename ok")
+
+        # test alternative log file name in datadir
+        self.restart_node(0, ["-debuglogfile=foo.log"])
+        assert os.path.isfile(os.path.join(self.nodes[0].datadir, "regtest", "foo.log"))
+        self.log.info("Alternative filename ok")
+
+        # test alternative log file name outside datadir
+        tempname = os.path.join(self.options.tmpdir, "foo.log")
+        self.restart_node(0, ["-debuglogfile=%s" % tempname])
+        assert os.path.isfile(tempname)
+        self.log.info("Alternative filename outside datadir ok")
+
+        # check that invalid log (relative) will cause error
+        self.stop_node(0)
+        self.assert_start_raises_init_error(0, ["-debuglogfile=ssdksjdf/sdasdfa/sdfsdfsfd"],
+                                                "Error: Could not open debug log file")
+        self.log.info("Invalid relative filename throws")
+
+        # check that invalid log (absolute) will cause error
+        self.stop_node(0)
+        invalidname = os.path.join(self.options.tmpdir, "foo/foo.log")
+        self.assert_start_raises_init_error(0, ["-debuglogfile=%s" % invalidname],
+                                               "Error: Could not open debug log file")
+        self.log.info("Invalid absolute filename throws")
+
+
+if __name__ == '__main__':
+    LoggingTest().main()

--- a/test/functional/feature_logging.py
+++ b/test/functional/feature_logging.py
@@ -31,17 +31,34 @@ class LoggingTest(PivxTestFramework):
         self.log.info("Alternative filename outside datadir ok")
 
         # check that invalid log (relative) will cause error
+        invdir = os.path.join(self.nodes[0].datadir, "regtest", "foo")
+        invalidname = os.path.join("foo", "foo.log")
         self.stop_node(0)
-        self.assert_start_raises_init_error(0, ["-debuglogfile=ssdksjdf/sdasdfa/sdfsdfsfd"],
+        self.assert_start_raises_init_error(0, ["-debuglogfile=%s" % (invalidname)],
                                                 "Error: Could not open debug log file")
+        assert not os.path.isfile(os.path.join(invdir, "foo.log"))
         self.log.info("Invalid relative filename throws")
+
+        # check that a previously invalid log (relative) works after path exists
+        os.mkdir(invdir)
+        self.start_node(0, ["-debuglogfile=%s" % (invalidname)])
+        assert os.path.isfile(os.path.join(invdir, "foo.log"))
+        self.log.info("Relative filename ok when path exists")
 
         # check that invalid log (absolute) will cause error
         self.stop_node(0)
-        invalidname = os.path.join(self.options.tmpdir, "foo/foo.log")
+        invdir = os.path.join(self.options.tmpdir, "foo")
+        invalidname = os.path.join(invdir, "foo.log")
         self.assert_start_raises_init_error(0, ["-debuglogfile=%s" % invalidname],
                                                "Error: Could not open debug log file")
+        assert not os.path.isfile(os.path.join(invdir, "foo.log"))
         self.log.info("Invalid absolute filename throws")
+
+        # check that a previously invalid log (relative) works after path exists
+        os.mkdir(invdir)
+        self.start_node(0, ["-debuglogfile=%s" % (invalidname)])
+        assert os.path.isfile(os.path.join(invdir, "foo.log"))
+        self.log.info("Absolute filename ok when path exists")
 
 
 if __name__ == '__main__':

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -66,10 +66,10 @@ BASE_SCRIPTS= [
     'wallet_abandonconflict.py',                # ~ 212 sec
     'wallet_hd.py',                             # ~ 210 sec
     'wallet_zerocoin_publicspends.py',          # ~ 202 sec
+    'feature_logging.py',                       # ~ 200 sec
     'rpc_rawtransaction.py',                    # ~ 193 sec
     'wallet_zapwallettxes.py',                  # ~ 180 sec
     'wallet_keypool_topup.py',                  # ~ 174 sec
-    'feature_logging.py',                       # ~ 166 sec
     'wallet_txn_doublespend.py --mineblock',    # ~ 157 sec
     'wallet_txn_clone.py --mineblock',          # ~ 157 sec
     'rpc_spork.py',                             # ~ 156 sec

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -69,6 +69,7 @@ BASE_SCRIPTS= [
     'rpc_rawtransaction.py',                    # ~ 193 sec
     'wallet_zapwallettxes.py',                  # ~ 180 sec
     'wallet_keypool_topup.py',                  # ~ 174 sec
+    'feature_logging.py',                       # ~ 166 sec
     'wallet_txn_doublespend.py --mineblock',    # ~ 157 sec
     'wallet_txn_clone.py --mineblock',          # ~ 157 sec
     'rpc_spork.py',                             # ~ 156 sec
@@ -153,6 +154,7 @@ EXTENDED_SCRIPTS = [
 LEGACY_SKIP_TESTS = [
     # These tests are not run when the flag --legacywallet is used
     'feature_help.py',
+    'feature_logging.py',
     'feature_reindex.py',
     'feature_proxy.py',
     'feature_uacomment.py',


### PR DESCRIPTION
Implemented on top of
- [x] #1449
- [x] #1437
- [x] #1439 
- [x] #1450
- [x] #1451 

Only last 4 commits are relevant to this PR.
Backports bitcoin#11781

> This patch adds an option to configure the name and/or directory of the debug log file.</br></br>
The user can specify either a relative path, in which case the path is relative to the (network specific) data directory. They can also specify an absolute path to put the log anywhere else in the file system.

Functional test included.