### PR TITLE
[Bug] Fix g_best_block initialization in ABC

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1832,6 +1832,14 @@ bool AppInit2()
     CValidationState state;
     if (!ActivateBestChain(state))
         strErrors << "Failed to connect best block";
+    // update g_best_block if needed
+    {
+        LOCK(g_best_block_mutex);
+        if (g_best_block.IsNull() && chainActive.Tip()) {
+            g_best_block = chainActive.Tip()->GetBlockHash();
+            g_best_block_cv.notify_all();
+        }
+    }
 
     std::vector<boost::filesystem::path> vImportFiles;
     if (mapArgs.count("-loadblock")) {


### PR DESCRIPTION
`g_best_block` holds a cached best block hash.
This is updated during `ActivateBestChain` (in `UpdateTip`).

**Problem**: at startup, the object is not initialized until a new block arrives (`ActivateBestChainStep` is not called) thus `g_best_block != chainActive.Tip()->GetBlockHash()` so, if the client stakes before receiving a new block, that stake gets orphaned.
In case of segregated devnet with just one staker, it is impossible to move the chain at all.