### PR TITLE
[Bug] Fix min depth requirement for stake inputs in AvailableCoins

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1946,7 +1946,7 @@ bool CWallet::AvailableCoins(
             if (nDepth == 0 && !pcoin->InMempool()) continue;
 
             // Check min depth requirement for stake inputs
-            if (nCoinType == STAKEABLE_COINS && nDepth < Params().GetConsensus().nStakeMinDepth - 1) continue;
+            if (nCoinType == STAKEABLE_COINS && nDepth < Params().GetConsensus().nStakeMinDepth) continue;
 
             for (unsigned int i = 0; i < pcoin->vout.size(); i++) {
                 bool found = false;


### PR DESCRIPTION
If `nDepth` is equal to `nStakeMinDepth - 1` then the coin is not skipped in `AvailableCoins` and gets included in the list of stakeable utxos.
This utxo won't be able to stake though, as it will fail `ContextCheck` in `Stake()` (logging an error), thus it shouldn't have been included in the first place.