### PR TITLE
[PoS] Stake Modifier V3

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -230,7 +230,7 @@ void CBlockIndex::SetNewStakeModifier(std::vector<unsigned char>& vchSig)
 // Returns V1 stake modifier (uint64_t)
 uint64_t CBlockIndex::GetStakeModifierV1() const
 {
-    if (vStakeModifier.empty() || Params().GetConsensus().IsStakeModifierV2(nHeight))
+    if (vStakeModifier.empty() || nHeight >= Params().GetConsensus().height_start_StakeModifierV2)
         return 0;
     uint64_t nStakeModifier;
     std::memcpy(&nStakeModifier, vStakeModifier.data(), vStakeModifier.size());
@@ -240,7 +240,7 @@ uint64_t CBlockIndex::GetStakeModifierV1() const
 // Returns V2/V3 stake modifier (uint256)
 uint256 CBlockIndex::GetStakeModifier() const
 {
-    if (vStakeModifier.empty() || !Params().GetConsensus().IsStakeModifierV2(nHeight))
+    if (vStakeModifier.empty() || nHeight < Params().GetConsensus().height_start_StakeModifierV2)
         return UINT256_ZERO;
     uint256 nStakeModifier;
     std::memcpy(nStakeModifier.begin(), vStakeModifier.data(), vStakeModifier.size());

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -210,7 +210,7 @@ void CBlockIndex::SetNewStakeModifier(const uint256& prevoutId)
     // Generate Hash(prevoutId | prevModifier) - switch with genesis modifier (0) on upgrade block
     CHashWriter ss(SER_GETHASH, 0);
     ss << prevoutId;
-    ss << pprev->GetStakeModifierV2();
+    ss << pprev->GetStakeModifier();
     SetStakeModifier(ss.GetHash());
 }
 
@@ -224,8 +224,8 @@ uint64_t CBlockIndex::GetStakeModifierV1() const
     return nStakeModifier;
 }
 
-// Returns V2 stake modifier (uint256)
-uint256 CBlockIndex::GetStakeModifierV2() const
+// Returns V2/V3 stake modifier (uint256)
+uint256 CBlockIndex::GetStakeModifier() const
 {
     if (vStakeModifier.empty() || !Params().GetConsensus().IsStakeModifierV2(nHeight))
         return UINT256_ZERO;

--- a/src/chain.h
+++ b/src/chain.h
@@ -260,7 +260,7 @@ public:
     void SetStakeModifier(const uint256& nStakeModifier);
     void SetNewStakeModifier(const uint256& prevoutId);     // generates and sets new v2 modifier
     uint64_t GetStakeModifierV1() const;
-    uint256 GetStakeModifierV2() const;
+    uint256 GetStakeModifier() const;
 
     //! Check whether this block index entry is valid up to the passed validity level.
     bool IsValid(enum BlockStatus nUpTo = BLOCK_VALID_TRANSACTIONS) const;

--- a/src/chain.h
+++ b/src/chain.h
@@ -257,9 +257,10 @@ public:
     bool SetStakeEntropyBit(unsigned int nEntropyBit);
     bool GeneratedStakeModifier() const { return (nFlags & BLOCK_STAKE_MODIFIER); }
     void SetStakeModifier(const uint64_t nStakeModifier, bool fGeneratedStakeModifier);
+    void SetNewStakeModifier();                             // generates and sets new v1 modifier
     void SetStakeModifier(const uint256& nStakeModifier);
-    void SetNewStakeModifier(const uint256& prevoutId);             // generates and sets new v2 modifier
-    void SetNewStakeModifier(std::vector<unsigned char>& vchSig);    // generates and sets new v3 modifier
+    void SetNewStakeModifier(const uint256& prevoutId);     // generates and sets new v2 modifier
+    void SetNewStakeModifier(const CTxOut& txout);          // generates and sets new v3 modifier
     uint64_t GetStakeModifierV1() const;
     uint256 GetStakeModifier() const;
 

--- a/src/chain.h
+++ b/src/chain.h
@@ -341,7 +341,7 @@ public:
             READWRITE(nMint);
             READWRITE(nMoneySupply);
             READWRITE(nFlags);
-            if (!Params().GetConsensus().IsStakeModifierV2(nHeight)) {
+            if (nHeight < Params().GetConsensus().height_start_StakeModifierV2) {
                 uint64_t nStakeModifier = 0;
                 READWRITE(nStakeModifier);
                 this->SetStakeModifier(nStakeModifier, this->GeneratedStakeModifier());

--- a/src/chain.h
+++ b/src/chain.h
@@ -258,7 +258,8 @@ public:
     bool GeneratedStakeModifier() const { return (nFlags & BLOCK_STAKE_MODIFIER); }
     void SetStakeModifier(const uint64_t nStakeModifier, bool fGeneratedStakeModifier);
     void SetStakeModifier(const uint256& nStakeModifier);
-    void SetNewStakeModifier(const uint256& prevoutId);     // generates and sets new v2 modifier
+    void SetNewStakeModifier(const uint256& prevoutId);             // generates and sets new v2 modifier
+    void SetNewStakeModifier(std::vector<unsigned char>& vchSig);    // generates and sets new v3 modifier
     uint64_t GetStakeModifierV1() const;
     uint256 GetStakeModifier() const;
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -87,7 +87,7 @@ static Checkpoints::MapCheckpoints mapCheckpoints =
     boost::assign::map_list_of
     (259201, uint256S("1c9121bf9329a6234bfd1ea2d91515f19cd96990725265253f4b164283ade5dd"))
     (424998, uint256S("f31e381eedb0ed3ed65fcc98cc71f36012bee32e8efd017c4f9fb0620fd35f6b"))
-    (616764, uint256S("29dd0bd1c59484f290896687b4ffb6a49afa5c498caf61967c69a541f8191557")) //first block to use modifierV2
+    (616764, uint256S("29dd0bd1c59484f290896687b4ffb6a49afa5c498caf61967c69a541f8191557")) //first block to use new modifierV1
     (623933, uint256S("c7aafa648a0f1450157dc93bd4d7448913a85b7448f803b4ab970d91fc2a7da7"))
     (791150, uint256S("8e76f462e4e82d1bd21cb72e1ce1567d4ddda2390f26074ffd1f5d9c270e5e50"))
     (795000, uint256S("4423cceeb9fd574137a18733416275a70fdf95283cc79ad976ca399aa424a443"))
@@ -96,8 +96,8 @@ static Checkpoints::MapCheckpoints mapCheckpoints =
     (863805, uint256S("a755bd9a22b63c70d3db474f4b2b61a1f86c835b290a081bb3ec1ba2103eb4cb"))
     (867733, uint256S("03b26296bf693de5782c76843d2fb649cb66d4b05550c6a79c047ff7e1c3ae15"))
     (879650, uint256S("227e1d2b738b6cd83c46d1d64617934ec899d77cee34336a56e61b71acd10bb2"))
-    (895400, uint256S("7796a0274a608fac12d400198174e50beda992c1d522e52e5b95b884bc1beac6"))//block that serial# range is enforced
-    (895991, uint256S("d53013ed7ea5c325b9696c95e07667d6858f8ff7ee13fecfa90827bf3c9ae316"))//network split here
+    (895400, uint256S("7796a0274a608fac12d400198174e50beda992c1d522e52e5b95b884bc1beac6"))  //block that serial# range is enforced
+    (895991, uint256S("d53013ed7ea5c325b9696c95e07667d6858f8ff7ee13fecfa90827bf3c9ae316"))  //network split here
     (908000, uint256S("202708f8c289b676fceb832a079ff6b308a28608339acbf7584de533619d014d"))
     (1142400, uint256S("98aff9d605bf123247f98b1e3a02567eb5799d208d78ec30fb89737b1c1f79c5"))
     (1679090, uint256S("f747ce055ba1b12e1f2e842bd480bc647210799359cb2e553ab292065e3419d6")) //!< First block with a "wrapped" serial spend
@@ -105,6 +105,7 @@ static Checkpoints::MapCheckpoints mapCheckpoints =
     (1778954, uint256S("0d3241268264a2908d6babf00d9cd1ffb83d93d7bb4e428820127fe227c2029c")) //!< Network split here
     (1788528, uint256S("ea9243ff8fc079fdd7a04f11fac415de4d98e1bb0dc38db6f79f8f8bbfdbe496")) //!< Network split here
     (2153200, uint256S("14e477e597d24549cac5e59d97d32155e6ec2861c1003b42d0566f9bf39b65d5")); //!< First v7 block
+
 static const Checkpoints::CCheckpointData data = {
     &mapCheckpoints,
     1578332625, // * UNIX timestamp of last checkpoint block
@@ -183,6 +184,7 @@ public:
         consensus.height_start_MessSignaturesV2 = 2153200;  // height_start_TimeProtoV2
         consensus.height_start_StakeModifierNewSelection = 615800;
         consensus.height_start_StakeModifierV2 = 1967000;   // Block v6: 0ef2556e40f3b9f6e02ce611b832e0bbfe7734a8ea751c7b555310ee49b61456
+        consensus.height_start_StakeModifierV3 = 1519000;   // Block V8
         consensus.height_start_TimeProtoV2 = 2153200;       // Block v7: 14e477e597d24549cac5e59d97d32155e6ec2861c1003b42d0566f9bf39b65d5
         consensus.height_start_ZC = 863787;                 // Block v4: 5b2482eca24caf2a46bb22e0545db7b7037282733faa3a42ec20542509999a64
         consensus.height_start_ZC_InvalidSerials = 891737;
@@ -298,6 +300,7 @@ public:
         consensus.height_start_MessSignaturesV2 = 1347000;      // height_start_TimeProtoV2
         consensus.height_start_StakeModifierNewSelection = 51197;
         consensus.height_start_StakeModifierV2 = 1214000;       // Block v6: 1822577176173752aea33d1f60607cefe9e0b1c54ebaa77eb40201a385506199
+        consensus.height_start_StakeModifierV3 = 999999999;     // Block V8
         consensus.height_start_TimeProtoV2 = 1347000;           // Block v7: 30c173ffc09a13f288bf6e828216107037ce5b79536b1cebd750a014f4939882
         consensus.height_start_ZC = 201576;                     // Block v4: 258c489f42f03cb97db2255e47938da4083eee4e242853c2d48bae2b1d0110a6
         consensus.height_start_ZC_InvalidSerials = 999999999;
@@ -420,6 +423,7 @@ public:
         consensus.height_start_MessSignaturesV2 = 1;
         consensus.height_start_StakeModifierNewSelection = 0;
         consensus.height_start_StakeModifierV2 = 251;       // start with modifier V2 on regtest
+        consensus.height_start_StakeModifierV3 = 311; // Block V8  (after last accum checkpoint)
         consensus.height_start_TimeProtoV2 = 999999999;
         consensus.height_start_ZC = 300;
         consensus.height_start_ZC_InvalidSerials = 999999999;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -55,6 +55,7 @@ struct Params {
     int height_start_MessSignaturesV2;
     int height_start_StakeModifierNewSelection;
     int height_start_StakeModifierV2;               // Blocks v6 start
+    int height_start_StakeModifierV3;               // Blocks v8 start
     int height_start_TimeProtoV2;                   // Blocks v7 start
     int height_start_ZC;                            // Blocks v4 start
     int height_start_ZC_InvalidSerials;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -74,7 +74,6 @@ struct Params {
     bool MoneyRange(const CAmount& nValue) const { return (nValue >= 0 && nValue <= nMaxMoneyOut); }
     bool IsMessSigV2(const int nHeight) const { return nHeight >= height_start_MessSignaturesV2; }
     bool IsTimeProtocolV2(const int nHeight) const { return nHeight >= height_start_TimeProtoV2; }
-    bool IsStakeModifierV2(const int nHeight) const { return nHeight >= height_start_StakeModifierV2; }
 
     int FutureBlockTimeDrift(const int nHeight) const
     {
@@ -96,7 +95,7 @@ struct Params {
             const int utxoFromBlockHeight, const uint32_t utxoFromBlockTime) const
     {
         // before stake modifier V2, we require the utxo to be nStakeMinAge old
-        if (!IsStakeModifierV2(contextHeight))
+        if (contextHeight < height_start_StakeModifierV2)
             return (utxoFromBlockTime + nStakeMinAge <= contextTime);
         // with stake modifier V2+, we require the utxo to be nStakeMinDepth deep in the chain
         return (contextHeight - utxoFromBlockHeight >= nStakeMinDepth);

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -159,3 +159,33 @@ bool CheckTransaction(const CTransaction& tx, bool fZerocoinActive, bool fReject
 
     return true;
 }
+
+bool CheckStakeModifierSig(const CTransaction& tx, const CTxOut& stakePrevout,
+                           const uint256& prevModifier, std::string& strErrorRet)
+{
+    if (!tx.IsCoinStake()) {
+        strErrorRet = "Called on non-coinstake transaction";
+        return false;
+    }
+    std::vector<unsigned char> vchSig;
+    if (!tx.vout[0].GetStakeModifierSig(vchSig)) {
+        strErrorRet = "Failed to get modifier signature from coinstake";
+        return false;
+    }
+    CKeyID keyID;
+    if (!stakePrevout.GetKeyIDFromUTXO(keyID)) {
+        strErrorRet = "Failed to get coinstake prevout keyID";
+        return false;
+    }
+    CPubKey pubkeyFromSig;
+    if(!pubkeyFromSig.RecoverCompact(prevModifier, vchSig)) {
+        strErrorRet = "Error recovering public key from stake modifier signature.";
+        return false;
+    }
+    if(pubkeyFromSig.GetID() != keyID) {
+        strErrorRet = "Stake modifier signature fails";
+        return false;
+    }
+    // All good
+    return true;
+}

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -5,6 +5,9 @@
 #ifndef BITCOIN_CONSENSUS_TX_VERIFY_H
 #define BITCOIN_CONSENSUS_TX_VERIFY_H
 
+#include "primitives/transaction.h"
+#include "uint256.h"
+
 #include <stdint.h>
 #include <vector>
 
@@ -17,7 +20,7 @@ class CValidationState;
 
 /** Context-independent validity checks */
 bool CheckTransaction(const CTransaction& tx, bool fZerocoinActive, bool fRejectBadUTXO, CValidationState& state, bool fFakeSerialAttack = false, bool fColdStakingActive=false);
-
+bool CheckStakeModifierSig(const CTransaction& tx, const CTxOut& stakePrevout, const uint256& prevModifier, std::string& strErrorRet);
 /**
  * Count ECDSA signature operations the old-fashioned (pre-0.6) way
  * @return number of sigops this transaction's outputs will produce when spent

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -33,12 +33,15 @@ CStakeKernel::CStakeKernel(const CBlockIndex* const pindexPrev, CStakeInput* sta
     nBits(nBits),
     stakeValue(stakeInput->GetValue())
 {
-    if (!Params().GetConsensus().IsStakeModifierV2(pindexPrev->nHeight + 1)) { // Modifier v1
+    // Set kernel stake modifier
+    if (pindexPrev->nHeight + 1 < Params().GetConsensus().height_start_StakeModifierV2) {
         uint64_t nStakeModifier = 0;
         if (!GetOldStakeModifier(stakeInput, nStakeModifier))
             LogPrintf("%s : ERROR: Failed to get kernel stake modifier\n", __func__);
+        // Modifier v1
         stakeModifier << nStakeModifier;
-    } else { // Modifier v2
+    } else {
+        // Modifier v2 / v3
         stakeModifier << pindexPrev->GetStakeModifier();
     }
     CBlockIndex* pindexFrom = stakeInput->GetIndexFrom();

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -5,10 +5,10 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <boost/assign/list_of.hpp>
-
-#include "db.h"
 #include "kernel.h"
+
+#include "consensus/tx_verify.h"
+#include "db.h"
 #include "legacy/stakemodifier.h"
 #include "script/interpreter.h"
 #include "util.h"
@@ -16,6 +16,8 @@
 #include "utilmoneystr.h"
 #include "zpivchain.h"
 #include "zpiv/zpos.h"
+
+#include <boost/assign/list_of.hpp>
 
 /**
  * CStakeKernel Constructor
@@ -146,6 +148,7 @@ bool Stake(const CBlockIndex* pindexPrev, CStakeInput* stakeInput, unsigned int 
  */
 bool CheckProofOfStake(const CBlock& block, std::string& strError, const CBlockIndex* pindexPrev)
 {
+    const int nHeight = pindexPrev->nHeight + 1;
     // Initialize stake input
     std::unique_ptr<CStakeInput> stakeInput;
     if (!LoadStakeInput(block, pindexPrev, stakeInput)) {
@@ -154,26 +157,9 @@ bool CheckProofOfStake(const CBlock& block, std::string& strError, const CBlockI
     }
 
     // Stake input contextual checks
-    if (!stakeInput->ContextCheck(pindexPrev->nHeight + 1, block.nTime)) {
+    if (!stakeInput->ContextCheck(nHeight, block.nTime)) {
         strError = "stake input failing contextual checks";
         return false;
-    }
-
-    // Verify signature
-    if (!stakeInput->IsZPIV()) {
-        CTransaction txPrev;
-        if (!stakeInput->GetTxFrom(txPrev)) {
-            strError = "unable to get txPrev for coinstake";
-            return false;
-        }
-        const CTransaction& tx = block.vtx[1];
-        const CTxIn& txin = tx.vin[0];
-        ScriptError serror;
-        if (!VerifyScript(txin.scriptSig, txPrev.vout[txin.prevout.n].scriptPubKey, STANDARD_SCRIPT_VERIFY_FLAGS,
-                 TransactionSignatureChecker(&tx, 0), &serror)) {
-            strError = strprintf("signature fails: %s", serror ? ScriptErrorString(serror) : "");
-            return false;
-        }
     }
 
     // Verify Proof Of Stake
@@ -181,6 +167,36 @@ bool CheckProofOfStake(const CBlock& block, std::string& strError, const CBlockI
     if (!stakeKernel.CheckKernelHash()) {
         strError = "kernel hash check fails";
         return false;
+    }
+
+    // zPoS disabled (ContextCheck) before blocks V8, and the tx input signature is in CoinSpend
+    if (stakeInput->IsZPIV()) return true;
+
+    // Verify tx input signature
+    CTxOut stakePrevout;
+    if (!stakeInput->GetTxOutFrom(stakePrevout)) {
+        strError = "unable to get stake prevout for coinstake";
+        return false;
+    }
+    const CTransaction& tx = block.vtx[1];
+    const CTxIn& txin = tx.vin[0];
+    ScriptError serror;
+    if (!VerifyScript(txin.scriptSig, stakePrevout.scriptPubKey, STANDARD_SCRIPT_VERIFY_FLAGS,
+             TransactionSignatureChecker(&tx, 0), &serror)) {
+        strError = strprintf("signature fails: %s", serror ? ScriptErrorString(serror) : "");
+        return false;
+    }
+
+    // Verify modifier signature (from block V8+)
+    if (block.nVersion >= 8) {
+        if (nHeight < Params().GetConsensus().height_start_StakeModifierV3) {
+            strError = strprintf("Block version %d arrived too early (height %d)", block.nVersion, nHeight);
+            return false;
+        }
+        if (!CheckStakeModifierSig(tx, stakePrevout, pindexPrev->GetStakeModifier(), strError)) {
+            strError = strprintf("modifier signature fails: %s", strError);
+            return false;
+        }
     }
 
     // All good

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -37,7 +37,7 @@ CStakeKernel::CStakeKernel(const CBlockIndex* const pindexPrev, CStakeInput* sta
             LogPrintf("%s : ERROR: Failed to get kernel stake modifier\n", __func__);
         stakeModifier << nStakeModifier;
     } else { // Modifier v2
-        stakeModifier << pindexPrev->GetStakeModifierV2();
+        stakeModifier << pindexPrev->GetStakeModifier();
     }
     CBlockIndex* pindexFrom = stakeInput->GetIndexFrom();
     nTimeBlockFrom = pindexFrom->nTime;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -127,7 +127,10 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, 
 
     // Make sure to create the correct block version
     const Consensus::Params& consensus = Params().GetConsensus();
-    pblock->nVersion = 7;       //!> Removes accumulator checkpoints
+
+    //!> Block v7: Removes accumulator checkpoints
+    //!> Block v8: Introduces stake modifier V3
+    pblock->nVersion = (nHeight >= consensus.height_start_StakeModifierV3 ? 8 : 7);
     // -regtest only: allow overriding block.nVersion with
     // -blockversion=N to test forking scenarios
     if (Params().IsRegTestNet()) {

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -23,7 +23,7 @@ class CBlockHeader
 {
 public:
     // header
-    static const int32_t CURRENT_VERSION=7;     //!> Version 7 removes nAccumulatorCheckpoint from serialization
+    static const int32_t CURRENT_VERSION=8;     //!> Version 8 introduces stake modifier V3
     int32_t nVersion;
     uint256 hashPrevBlock;
     uint256 hashMerkleRoot;

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -99,6 +99,11 @@ bool CTxOut::IsZerocoinMint() const
     return scriptPubKey.IsZerocoinMint();
 }
 
+bool CTxOut::IsStakeModifierSig() const
+{
+    return scriptPubKey.IsStakeModifierSig();
+}
+
 CAmount CTxOut::GetZerocoinMinted() const
 {
     if (!IsZerocoinMint())
@@ -188,12 +193,14 @@ bool CTransaction::IsCoinStake() const
     if (vin.empty())
         return false;
 
-    // ppcoin: the coin stake transaction is marked with the first output empty
     bool fAllowNull = vin[0].IsZerocoinSpend();
     if (vin[0].prevout.IsNull() && !fAllowNull)
         return false;
 
-    return (vout.size() >= 2 && vout[0].IsEmpty());
+    // coinstake transactions are marked with the first output, which can either be
+    // empty or with a script publishing the modifier signature (via OP_STAKEMODIFIER)
+    return (vout.size() >= 2 &&
+                    (vout[0].IsEmpty() || vout[0].IsStakeModifierSig()));
 }
 
 bool CTransaction::CheckColdStake(const CScript& script) const

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -121,6 +121,15 @@ bool CTxOut::IsStakeModifierSig() const
     return scriptPubKey.IsStakeModifierSig();
 }
 
+bool CTxOut::GetStakeModifierSig(std::vector<unsigned char>& vchSig) const
+{
+    if (!IsStakeModifierSig())
+        return false;
+
+    vchSig = std::vector<unsigned char>(scriptPubKey.begin()+2, scriptPubKey.end());
+    return true;
+}
+
 CAmount CTxOut::GetZerocoinMinted() const
 {
     if (!IsZerocoinMint())

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -94,6 +94,23 @@ uint256 CTxOut::GetHash() const
     return SerializeHash(*this);
 }
 
+bool CTxOut::GetKeyIDFromUTXO(CKeyID& keyIDRet) const
+{
+    std::vector<valtype> vSolutions;
+    txnouttype whichType;
+    if (scriptPubKey.empty() || !Solver(scriptPubKey, whichType, vSolutions))
+        return false;
+    if (whichType == TX_PUBKEY) {
+        keyIDRet = CPubKey(vSolutions[0]).GetID();
+        return true;
+    }
+    if (whichType == TX_PUBKEYHASH || whichType == TX_COLDSTAKE) {
+        keyIDRet = CKeyID(uint160(vSolutions[0]));
+        return true;
+    }
+    return false;
+}
+
 bool CTxOut::IsZerocoinMint() const
 {
     return scriptPubKey.IsZerocoinMint();

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -176,6 +176,7 @@ public:
     }
 
     bool IsStakeModifierSig() const;
+    bool GetStakeModifierSig(std::vector<unsigned char>& vchSig) const;
 
     bool IsZerocoinMint() const;
     CAmount GetZerocoinMinted() const;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -174,6 +174,8 @@ public:
         return (nValue < 3*minRelayTxFee.GetFee(nSize));
     }
 
+    bool IsStakeModifierSig() const;
+
     bool IsZerocoinMint() const;
     CAmount GetZerocoinMinted() const;
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -160,6 +160,7 @@ public:
     }
 
     uint256 GetHash() const;
+    bool GetKeyIDFromUTXO(CKeyID& keyIDRet) const;
 
     bool IsDust(CFeeRate minRelayTxFee) const
     {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -151,7 +151,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Cannot get proof of stake hash");
 
         std::string stakeModifier = (Params().GetConsensus().IsStakeModifierV2(blockindex->nHeight) ?
-                                     blockindex->GetStakeModifierV2().GetHex() :
+                                     blockindex->GetStakeModifier().GetHex() :
                                      strprintf("%016x", blockindex->GetStakeModifierV1()));
         result.push_back(Pair("stakeModifier", stakeModifier));
         result.push_back(Pair("hashProofOfStake", hashProofOfStakeRet.GetHex()));

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -150,7 +150,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
         if (!GetStakeKernelHash(hashProofOfStakeRet, block, blockindex->pprev))
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Cannot get proof of stake hash");
 
-        std::string stakeModifier = (Params().GetConsensus().IsStakeModifierV2(blockindex->nHeight) ?
+        std::string stakeModifier = (blockindex->nHeight >= Params().GetConsensus().height_start_StakeModifierV2 ?
                                      blockindex->GetStakeModifier().GetHex() :
                                      strprintf("%016x", blockindex->GetStakeModifierV1()));
         result.push_back(Pair("stakeModifier", stakeModifier));

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -445,6 +445,12 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
                 }
                 break;
 
+                case OP_STAKEMODIFIER:
+                {
+                    return set_error(serror, SCRIPT_ERR_OP_STAKEMODIFIER);
+                }
+                break;
+
 
                 //
                 // Stack ops

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -269,6 +269,11 @@ bool CScript::StartsWithOpcode(const opcodetype opcode) const
     return (!this->empty() && this->at(0) == opcode);
 }
 
+bool CScript::IsStakeModifierSig() const
+{
+    return StartsWithOpcode(OP_STAKEMODIFIER);
+}
+
 bool CScript::IsZerocoinMint() const
 {
     return StartsWithOpcode(OP_ZEROCOINMINT);

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -271,7 +271,9 @@ bool CScript::StartsWithOpcode(const opcodetype opcode) const
 
 bool CScript::IsStakeModifierSig() const
 {
-    return StartsWithOpcode(OP_STAKEMODIFIER);
+    // opcode + len + compact signature <= 1 + 1 + 65 bytes
+    return (StartsWithOpcode(OP_STAKEMODIFIER) && this->size() > 2 &&
+            this->size() <= 67 && this->at(1) == (int)this->size() - 2);
 }
 
 bool CScript::IsZerocoinMint() const

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -155,8 +155,9 @@ const char* GetOpName(opcodetype opcode)
     case OP_ZEROCOINSPEND          : return "OP_ZEROCOINSPEND";
     case OP_ZEROCOINPUBLICSPEND    : return "OP_ZEROCOINPUBLICSPEND";
 
-    // cold staking
+    // staking / cold staking
     case OP_CHECKCOLDSTAKEVERIFY   : return "OP_CHECKCOLDSTAKEVERIFY";
+    case OP_STAKEMODIFIER          : return "OP_STAKEMODIFIER";
 
     case OP_INVALIDOPCODE          : return "OP_INVALIDOPCODE";
 

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -179,6 +179,9 @@ enum opcodetype
     // cold staking
     OP_CHECKCOLDSTAKEVERIFY = 0xd1,
 
+    // v3 stake modifier
+    OP_STAKEMODIFIER = 0xd2,
+
     // template matching params
     OP_SMALLINTEGER = 0xfa,
     OP_PUBKEYS = 0xfb,

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -619,6 +619,7 @@ public:
     bool IsPayToScriptHash() const;
     bool IsPayToColdStaking() const;
     bool StartsWithOpcode(const opcodetype opcode) const;
+    bool IsStakeModifierSig() const;
     bool IsZerocoinMint() const;
     bool IsZerocoinSpend() const;
     bool IsZerocoinPublicSpend() const;

--- a/src/script/script_error.cpp
+++ b/src/script/script_error.cpp
@@ -48,6 +48,8 @@ const char* ScriptErrorString(const ScriptError serror)
             return "Operation not valid with the current altstack size";
         case SCRIPT_ERR_OP_RETURN:
             return "OP_RETURN was encountered";
+        case SCRIPT_ERR_OP_STAKEMODIFIER:
+            return "Attempted to use OP_STAKEMODIFIER";
         case SCRIPT_ERR_UNBALANCED_CONDITIONAL:
             return "Invalid OP_IF construction";
         case SCRIPT_ERR_NEGATIVE_LOCKTIME:

--- a/src/script/script_error.h
+++ b/src/script/script_error.h
@@ -13,6 +13,7 @@ typedef enum ScriptError_t
     SCRIPT_ERR_UNKNOWN_ERROR,
     SCRIPT_ERR_EVAL_FALSE,
     SCRIPT_ERR_OP_RETURN,
+    SCRIPT_ERR_OP_STAKEMODIFIER,
 
     /* Max sizes */
     SCRIPT_ERR_SCRIPT_SIZE,

--- a/src/stakeinput.cpp
+++ b/src/stakeinput.cpp
@@ -50,6 +50,14 @@ bool CPivStake::GetTxFrom(CTransaction& tx) const
     return true;
 }
 
+bool CPivStake::GetTxOutFrom(CTxOut& out) const
+{
+    if (txFrom.IsNull() || nPosition >= txFrom.vout.size())
+        return false;
+    out = txFrom.vout[nPosition];
+    return true;
+}
+
 bool CPivStake::CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut)
 {
     txIn = CTxIn(txFrom.GetHash(), nPosition);

--- a/src/stakeinput.h
+++ b/src/stakeinput.h
@@ -24,6 +24,7 @@ public:
     virtual CBlockIndex* GetIndexFrom() = 0;
     virtual bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = UINT256_ZERO) = 0;
     virtual bool GetTxFrom(CTransaction& tx) const = 0;
+    virtual bool GetTxOutFrom(CTxOut& out) const = 0;
     virtual CAmount GetValue() const = 0;
     virtual bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) = 0;
     virtual bool IsZPIV() const = 0;
@@ -46,6 +47,7 @@ public:
 
     CBlockIndex* GetIndexFrom() override;
     bool GetTxFrom(CTransaction& tx) const override;
+    bool GetTxOutFrom(CTxOut& out) const override;
     CAmount GetValue() const override;
     CDataStream GetUniqueness() const override;
     bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = UINT256_ZERO) override;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2618,7 +2618,7 @@ bool CWallet::CreateCoinStake(
         if (pindexPrev->nHeight + 1 >= consensus.height_start_StakeModifierV3) {
             CTxOut stakePrevout;
             if (!stakeInput->GetTxOutFrom(stakePrevout) ||
-                    !SignCoinStakeModifier(pindexPrev->GetStakeModifierV2(), stakePrevout, txNew))
+                    !SignCoinStakeModifier(pindexPrev->GetStakeModifier(), stakePrevout, txNew))
                 return error("%s: failed to sign coinstake modifier", __func__);
         }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2518,7 +2518,6 @@ bool CWallet::CreateTransaction(CScript scriptPubKey, const CAmount& nValue, CWa
     return CreateTransaction(vecSend, wtxNew, reservekey, nFeeRet, strFailReason, coinControl, coin_type, useIX, nFeePay, fIncludeDelegated);
 }
 
-// ppcoin: create coin stake transaction
 bool CWallet::CreateCoinStake(
         const CKeyStore& keystore,
         const CBlockIndex* pindexPrev,
@@ -2541,6 +2540,8 @@ bool CWallet::CreateCoinStake(
         input->SetPrevout((CTransaction) *out.tx, out.i);
         listInputs.emplace_back(std::move(input));
     }
+
+    const Consensus::Params& consensus = Params().GetConsensus();
 
     // Mark coin stake transaction
     txNew.vin.clear();
@@ -2613,12 +2614,20 @@ bool CWallet::CreateCoinStake(
         // put the remaining on the last output (which all into the first if only one output)
         txNew.vout[outputs].nValue += nRemaining;
 
+        // Coinstake marker (for blocks V8+)
+        if (pindexPrev->nHeight + 1 >= consensus.height_start_StakeModifierV3) {
+            CTxOut stakePrevout;
+            if (!stakeInput->GetTxOutFrom(stakePrevout) ||
+                    !SignCoinStakeModifier(pindexPrev->GetStakeModifierV2(), stakePrevout, txNew))
+                return error("%s: failed to sign coinstake modifier", __func__);
+        }
+
         // Limit size
         unsigned int nBytes = ::GetSerializeSize(txNew, SER_NETWORK, PROTOCOL_VERSION);
         if (nBytes >= DEFAULT_BLOCK_MAX_SIZE / 5)
             return error("CreateCoinStake : exceeded coinstake size limit");
 
-        //Masternode payment
+        // Masternode payment
         FillBlockPayee(txNew, nMinFee, true, false);
 
         uint256 hashTxOut = txNew.GetHash();
@@ -2652,7 +2661,7 @@ bool CWallet::CreateCoinStake(
             if (!out.IsZerocoinMint())
                 continue;
 
-            libzerocoin::PublicCoin pubcoin(Params().GetConsensus().Zerocoin_Params(false));
+            libzerocoin::PublicCoin pubcoin(consensus.Zerocoin_Params(false));
             CValidationState state;
             if (!TxOutToPublicCoin(out, pubcoin, state))
                 return error("%s: extracting pubcoin from txout failed", __func__);
@@ -2670,6 +2679,30 @@ bool CWallet::CreateCoinStake(
     }
 
     // Successfully generated coinstake
+    return true;
+}
+
+// Signs a previous modifier with the key of the stake input. publish signature in
+// coinstake (vout[0] with OP_STAKEMODIFIER)
+bool CWallet::SignCoinStakeModifier(const uint256& prevModifier, const CTxOut& stakePrevout, CMutableTransaction& coinstake)
+{
+    // tx needs at least two outputs
+    if (coinstake.vout.size() < 2)
+        return error("%s : called on non-coinstake transaction (vout size: %d)",
+                __func__, coinstake.vout.size());
+    CKeyID keyID;
+    if (!stakePrevout.GetKeyIDFromUTXO(keyID))
+        return error("%s : failed to get keyID from coinstake prevout", __func__);
+    CKey key;
+    if (!GetKey(keyID, key))
+        return error("%s : failed to find key in keystore", __func__);
+    std::vector<unsigned char> vchSigRet;
+    if (!key.SignCompact(prevModifier, vchSigRet))
+        return error("%s : failed to sign previous modifier", __func__);
+    // Add modifier signature to first output
+    coinstake.vout[0].scriptPubKey = CScript() << OP_STAKEMODIFIER << vchSigRet;
+    LogPrintf("%s : Modifier (%s) signed with coinstake key. Signature=%s\n",
+            __func__, prevModifier.GetHex(), EncodeBase64(&vchSigRet[0], vchSigRet.size()));
     return true;
 }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -464,6 +464,7 @@ public:
     bool AddAccountingEntry(const CAccountingEntry&, CWalletDB & pwalletdb);
     int GenerateObfuscationOutputs(int nTotalValue, std::vector<CTxOut>& vout);
     bool CreateCoinStake(const CKeyStore& keystore, const CBlockIndex* pindexPrev, unsigned int nBits, CMutableTransaction& txNew, int64_t& nTxNewTime);
+    bool SignCoinStakeModifier(const uint256& prevModifier, const CTxOut& stakePrevout, CMutableTransaction& coinstake);
     bool MultiSend();
     void AutoCombineDust();
 

--- a/src/zpiv/zpos.h
+++ b/src/zpiv/zpos.h
@@ -29,6 +29,7 @@ public:
     bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = UINT256_ZERO) override { return false; /* creation disabled */}
     bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) override { return false; /* creation disabled */}
     bool GetTxFrom(CTransaction& tx) const override { return false; /* not available */ }
+    bool GetTxOutFrom(CTxOut& out) const override { return false; /* not available */ }
     virtual bool ContextCheck(int nHeight, uint32_t nTime) override;
 };
 

--- a/test/functional/mining_pos_reorg.py
+++ b/test/functional/mining_pos_reorg.py
@@ -106,10 +106,7 @@ class ReorgStakeTest(PivxTestFramework):
         set_node_times(self.nodes, block_time_0)
         last_block = self.nodes[0].getblock(self.nodes[0].getbestblockhash())
         assert(len(last_block["tx"]) > 1)                                       # a PoS block has at least two txes
-        coinstake_txid = last_block["tx"][1]
-        coinstake_tx = self.nodes[0].getrawtransaction(coinstake_txid, True)
-        assert(coinstake_tx["vout"][0]["scriptPubKey"]["hex"] == "")            # first output of coinstake is empty
-        stakeinput = coinstake_tx["vin"][0]
+        stakeinput = self.nodes[0].getrawtransaction(last_block["tx"][1], True)["vin"][0]
 
         # The stake input was unspent 1 block ago, now it's not
         res, utxo = findUtxoInList(stakeinput["txid"], stakeinput["vout"], initial_unspent_0)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -638,7 +638,7 @@ class PivxTestFramework():
             for i in [2, 3]:
                 assert (self.nodes[i].lockunspent(True, [{"txid": res[i-2]['txid'], "vout": 8}]))
 
-            # Verify height and balances
+            # Verify height, version and balances
             self.test_PoS_chain_balances()
 
             # Shut nodes down, and clean up cache directories:
@@ -700,6 +700,8 @@ class PivxTestFramework():
             assert_equal(self.nodes[i].getblockcount(), 330)
             if i > 0:
                 assert_equal(self.nodes[i].getbestblockhash(), best_block)
+        # Verify version of last block
+        assert_equal(self.nodes[0].getblock(best_block, True)["version"], 8)
 
         # balance is mature pow blocks rewards minus stake inputs (spent)
         w_info = [self.nodes[i].getwalletinfo() for i in range(num_nodes)]


### PR DESCRIPTION
New stake modifier protocol (v3) proposed as hard fork.
Instead of using a chain of hashes, we propose to switch to a chain of *signatures*. 
So the new modifier, instead of being the hash of the previous modifier, combined with the txId of the coinstake input, becomes the hash of a signature, performed with the key of the coinstake prevout, over the previous modifier.

This makes the modifier completely unpredictable, thus offering a much better protection against grinding.

The flow is fairly simple: the staker, after finding a valid kernel, signs the modifier used, and publishes the signature (prefixed by a new opcode `OP_STAKEMODIFIER`) in the first output of the coinstake transaction. All peers then verify the signature during the proof of stake checks. The hash of this signature is  saved in the block index, and becomes the modifier to be used for the successive block's kernel.

Note: the new modifier is enforced bumping the block version (to V8). 
Testnet activation height is set at block `1519000`, while Mainnet uses a placeholder for now.
RegTest is activated at block 311 (so v8 blocks are already produced during the PoS cache).