### PR TITLE
[GUI][Model] Fix staking address validation

### DIFF
--- a/src/qt/pivx/sendmultirow.cpp
+++ b/src/qt/pivx/sendmultirow.cpp
@@ -88,7 +88,7 @@ bool SendMultiRow::addressChanged(const QString& str)
     ui->lineEditDescription->clear();
     if(!str.isEmpty()) {
         QString trimmedStr = str.trimmed();
-        bool valid = (this->onlyStakingAddressAccepted) ? walletModel->validateStakingAddress(trimmedStr) : walletModel->validateAddress(trimmedStr);
+        const bool valid = walletModel->validateAddress(trimmedStr, this->onlyStakingAddressAccepted);
         if (!valid) {
             // check URI
             SendCoinsRecipient rcp;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -360,19 +360,10 @@ bool WalletModel::validateAddress(const QString& address)
     return addressParsed.IsValid();
 }
 
-bool WalletModel::validateStakingAddress(const QString& address)
+bool WalletModel::validateAddress(const QString& address, bool fStaking)
 {
-    if (validateAddress(address)) {
-        // check for staking only addresses
-        QChar firstLetter = address.at(0).toLower();
-        if (isTestNetwork() && firstLetter == 'w')
-            return true;
-
-        // mainnet check
-        if (firstLetter == 's')
-            return true;
-    }
-    return false;
+    CBitcoinAddress addressParsed(address.toStdString());
+    return (addressParsed.IsValid() && fStaking == addressParsed.IsStakingAddress());
 }
 
 bool WalletModel::updateAddressBookLabels(const CTxDestination& dest, const std::string& strName, const std::string& strPurpose)

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -183,7 +183,8 @@ public:
 
     // Check address for validity
     bool validateAddress(const QString& address);
-    bool validateStakingAddress(const QString& address);
+    // Check address for validity and type (whether cold staking address or not)
+    bool validateAddress(const QString& address, bool fStaking);
 
     // Return status record for SendCoins, contains error id + information
     struct SendCoinsReturn {


### PR DESCRIPTION
**Problem**: `validateStakingAddress` uses a naive validation based on the first letter, and is currently broken on regtest (as `IsTestNetwork` was updated in https://github.com/PIVX-Project/PIVX/commit/2be6f7b271d82efaab87707141ac7e7c61d90b85 to be false on RegTestNet).

**Fix**: introduce a boolean argument in `validateAddress` (which already uses a full `CBitcoinAddress` validation) to properly check staking addresses as well.