### PR TITLE
[GUI] Less GUI locks, IBD state cached.

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -158,7 +158,7 @@ void ClientModel::updateAlert()
 
 bool ClientModel::inInitialBlockDownload() const
 {
-    return IsInitialBlockDownload();
+    return cachedInitialSync;
 }
 
 enum BlockSource ClientModel::getBlockSource() const
@@ -243,6 +243,7 @@ static void BlockTipChanged(ClientModel *clientmodel, bool initialSync, const CB
         clientmodel->setCacheTip(pIndex);
         clientmodel->setCacheImporting(fImporting);
         clientmodel->setCacheReindexing(fReindex);
+        clientmodel->setCacheInitialSync(initialSync);
         Q_EMIT clientmodel->numBlocksChanged(pIndex->nHeight);
         nLastBlockTipUpdateNotification = now;
     }

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -80,9 +80,10 @@ public:
     QString formatClientStartupTime() const;
     QString dataDir() const;
 
-    void setCacheTip(const CBlockIndex* const tip) { cacheTip = tip; };
-    void setCacheReindexing(bool reindex) { cachedReindexing = reindex; };
-    void setCacheImporting(bool import) { cachedImporting = import; };
+    void setCacheTip(const CBlockIndex* const tip) { cacheTip = tip; }
+    void setCacheReindexing(bool reindex) { cachedReindexing = reindex; }
+    void setCacheImporting(bool import) { cachedImporting = import; }
+    void setCacheInitialSync(bool _initialSync) { cachedInitialSync = _initialSync; }
 
     bool getTorInfo(std::string& ip_port) const;
 
@@ -95,6 +96,7 @@ private:
     QString cachedMasternodeCountString;
     bool cachedReindexing;
     bool cachedImporting;
+    bool cachedInitialSync;
 
     int numBlocksAtStartup;
 

--- a/src/qt/pivx/dashboardwidget.cpp
+++ b/src/qt/pivx/dashboardwidget.cpp
@@ -213,12 +213,8 @@ void DashboardWidget::loadWalletModel(){
         // chart filter
         stakesFilter = new TransactionFilterProxy();
         stakesFilter->setDynamicSortFilter(true);
-        stakesFilter->setSortCaseSensitivity(Qt::CaseInsensitive);
-        stakesFilter->setFilterCaseSensitivity(Qt::CaseInsensitive);
-        stakesFilter->setSortRole(Qt::EditRole);
         stakesFilter->setOnlyStakes(true);
         stakesFilter->setSourceModel(txModel);
-        stakesFilter->sort(TransactionTableModel::Date, Qt::AscendingOrder);
         hasStakes = stakesFilter->rowCount() > 0;
         loadChart();
 #endif


### PR DESCRIPTION
We were locking `cs_main`, calling `IsInitialBlockDownload` on every new row inserted in the transaction table model.

This PR caches the IBD state and updates it on every new block from the back-end without lock `cs_main` at all.