### PR TITLE
[Tests][Refactor] Remove connect_nodes_bi

### DIFF
--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -6,7 +6,11 @@
 import os
 
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import assert_equal, wait_until, connect_nodes_bi
+from test_framework.util import (
+    assert_equal,
+    wait_until,
+    connect_nodes_bi,
+)
 
 class NotificationsTest(PivxTestFramework):
     def set_test_params(self):

--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -9,7 +9,7 @@ from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
     assert_equal,
     wait_until,
-    connect_nodes_bi,
+    connect_nodes,
 )
 
 class NotificationsTest(PivxTestFramework):
@@ -56,7 +56,7 @@ class NotificationsTest(PivxTestFramework):
         self.log.info("test -walletnotify after rescan")
         # restart node to rescan to force wallet notifications
         self.restart_node(1)
-        connect_nodes_bi(self.nodes, 0, 1)
+        connect_nodes(self.nodes[0], 1)
 
         wait_until(lambda: os.path.isfile(self.tx_filename) and os.stat(self.tx_filename).st_size >= (block_count * 65), timeout=10)
 

--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -49,7 +49,7 @@ class RESTTest (PivxTestFramework):
 
     def setup_network(self, split=False):
         super().setup_network()
-        connect_nodes_bi(self.nodes, 0, 2)
+        connect_nodes(self.nodes[0], 2)
 
     def run_test(self):
         url = urllib.parse.urlparse(self.nodes[0].url)

--- a/test/functional/mining_pos_coldStaking.py
+++ b/test/functional/mining_pos_coldStaking.py
@@ -12,8 +12,16 @@ from test_framework.mininode import network_thread_start
 from test_framework.pivx_node import PivxTestNode
 from test_framework.script import CScript, OP_CHECKSIG
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import connect_nodes_bi, p2p_port, bytes_to_hex_str, set_node_times, \
-    assert_equal, assert_greater_than, sync_blocks, sync_mempools, assert_raises_rpc_error
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    assert_raises_rpc_error,
+    p2p_port,
+    bytes_to_hex_str,
+    set_node_times,
+    sync_blocks,
+    sync_mempools,
+)
 
 # filter utxos based on first 5 bytes of scriptPubKey
 def getDelegatedUtxos(utxos):
@@ -31,15 +39,6 @@ class PIVX_ColdStakingTest(PivxTestFramework):
         # Start with PoW cache: 200 blocks
         self._initialize_chain()
         self.enable_mocktime()
-
-
-    def setup_network(self):
-        ''' Can't rely on syncing all the nodes when staking=1
-        '''
-        self.setup_nodes()
-        for i in range(self.num_nodes - 1):
-            for j in range(i+1, self.num_nodes):
-                connect_nodes_bi(self.nodes, i, j)
 
     def init_test(self):
         title = "*** Starting %s ***" % self.__class__.__name__

--- a/test/functional/mining_pos_reorg.py
+++ b/test/functional/mining_pos_reorg.py
@@ -9,7 +9,7 @@ from test_framework.util import (
     sync_blocks,
     assert_equal,
     assert_raises_rpc_error,
-    connect_nodes_bi,
+    connect_nodes,
     connect_nodes_clique,
     disconnect_nodes,
     set_node_times,
@@ -130,7 +130,7 @@ class ReorgStakeTest(PivxTestFramework):
 
         # Connect with node 2, sync and check zerocoin balance
         self.log.info("Reconnecting node 0 and node 2")
-        connect_nodes_bi(self.nodes, 0, 2)
+        connect_nodes(self.nodes[0], 2)
         sync_blocks([self.nodes[i] for i in [0, 2]])
         self.log.info("Resetting zerocoin mints on node 2")
         self.nodes[2].resetmintzerocoin(True)

--- a/test/functional/p2p_disconnect_ban.py
+++ b/test/functional/p2p_disconnect_ban.py
@@ -9,7 +9,6 @@ from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
     assert_equal,
     connect_nodes,
-    connect_nodes_bi,
     assert_raises_rpc_error,
     wait_until,
 )
@@ -100,7 +99,7 @@ class DisconnectBanTest(PivxTestFramework):
         assert not [node for node in self.nodes[0].getpeerinfo() if node['addr'] == address1]
 
         self.log.info("disconnectnode: successfully reconnect node")
-        connect_nodes_bi(self.nodes, 0, 1)  # reconnect the node
+        connect_nodes(self.nodes[0], 1)  # reconnect the node
         assert_equal(len(self.nodes[0].getpeerinfo()), 2)
         assert [node for node in self.nodes[0].getpeerinfo() if node['addr'] == address1]
 

--- a/test/functional/p2p_disconnect_ban.py
+++ b/test/functional/p2p_disconnect_ban.py
@@ -8,8 +8,9 @@ import time
 from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_raises_rpc_error,
+    connect_nodes,
     connect_nodes_bi,
+    assert_raises_rpc_error,
     wait_until,
 )
 
@@ -18,6 +19,10 @@ class DisconnectBanTest(PivxTestFramework):
         self.num_nodes = 2
 
     def run_test(self):
+        self.log.info("Connect nodes both way")
+        connect_nodes(self.nodes[0], 1)
+        connect_nodes(self.nodes[1], 0)
+
         self.log.info("Test setban and listbanned RPCs")
 
         self.log.info("setban: successfully ban single IP address")
@@ -74,7 +79,9 @@ class DisconnectBanTest(PivxTestFramework):
 
         # Clear ban lists
         self.nodes[1].clearbanned()
-        connect_nodes_bi(self.nodes, 0, 1)
+        self.log.info("Connect nodes both way")
+        connect_nodes(self.nodes[0], 1)
+        connect_nodes(self.nodes[1], 0)
 
         self.log.info("Test disconnectnode RPCs")
 

--- a/test/functional/p2p_time_offset.py
+++ b/test/functional/p2p_time_offset.py
@@ -8,9 +8,13 @@ import time
 from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
     assert_equal,
-    connect_nodes_bi,
-    set_node_times
+    connect_nodes,
+    set_node_times,
 )
+
+def connect_nodes_bi(nodes, a, b):
+    connect_nodes(nodes[a], b)
+    connect_nodes(nodes[b], a)
 
 class TimeOffsetTest(PivxTestFramework):
     def set_test_params(self):

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -4,7 +4,15 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    assert_fee_amount,
+    assert_greater_than,
+    count_bytes,
+    connect_nodes,
+    Decimal,
+    JSONRPCException,
+)
 
 
 def get_unspent(listunspent, amount):
@@ -22,12 +30,12 @@ class RawTransactionsTest(PivxTestFramework):
         self.num_nodes = 4
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+        self.nodes = self.start_nodes()
 
-        connect_nodes_bi(self.nodes,0,1)
-        connect_nodes_bi(self.nodes,1,2)
-        connect_nodes_bi(self.nodes,0,2)
-        connect_nodes_bi(self.nodes,0,3)
+        connect_nodes(self.nodes[0], 1)
+        connect_nodes(self.nodes[1], 2)
+        connect_nodes(self.nodes[0], 2)
+        connect_nodes(self.nodes[0], 3)
 
         self.is_network_split=False
         self.sync_all()
@@ -469,18 +477,18 @@ class RawTransactionsTest(PivxTestFramework):
         # locked wallet test
         self.nodes[1].encryptwallet("test")
         self.nodes.pop(1)
-        stop_nodes(self.nodes)
+        self.stop_nodes()
 
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir)
+        self.nodes = self.start_nodes()
         # This test is not meant to test fee estimation and we'd like
         # to be sure all txs are sent at a consistent desired feerate
         for node in self.nodes:
             node.settxfee(min_relay_tx_fee)
 
-        connect_nodes_bi(self.nodes,0,1)
-        connect_nodes_bi(self.nodes,1,2)
-        connect_nodes_bi(self.nodes,0,2)
-        connect_nodes_bi(self.nodes,0,3)
+        connect_nodes(self.nodes[0], 1)
+        connect_nodes(self.nodes[1], 2)
+        connect_nodes(self.nodes[0], 2)
+        connect_nodes(self.nodes[0], 3)
         self.is_network_split=False
         self.sync_all()
 

--- a/test/functional/rpc_invalidateblock.py
+++ b/test/functional/rpc_invalidateblock.py
@@ -27,7 +27,7 @@ class InvalidateTest(PivxTestFramework):
         assert(self.nodes[1].getblockcount() == 6)
 
         self.log.info("Connect nodes to force a reorg")
-        connect_nodes_bi(self.nodes,0,1)
+        connect_nodes(self.nodes[0], 1)
         sync_blocks(self.nodes[0:2])
         assert(self.nodes[0].getblockcount() == 6)
         badhash = self.nodes[1].getblockhash(2)
@@ -40,7 +40,7 @@ class InvalidateTest(PivxTestFramework):
             raise AssertionError("Wrong tip for node0, hash %s, height %d"%(newhash,newheight))
 
         self.log.info("Make sure we won't reorg to a lower work chain:")
-        connect_nodes_bi(self.nodes,1,2)
+        connect_nodes(self.nodes[1], 2)
         self.log.info("Sync node 2 to node 1 so both have 6 blocks")
         sync_blocks(self.nodes[1:3])
         assert(self.nodes[2].getblockcount() == 6)

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -35,7 +35,6 @@ class NetTest(PivxTestFramework):
         #self._test_getpeerinfo()
 
     def _test_connection_count(self):
-        # connect_nodes_bi connects each node to the other
         assert_equal(self.nodes[0].getconnectioncount(), 2)
 
     def _test_getnettotals(self):

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -12,7 +12,7 @@ from test_framework.util import (
     assert_equal,
     assert_greater_than_or_equal,
     assert_raises_rpc_error,
-    connect_nodes_bi,
+    connect_nodes,
     disconnect_nodes,
     p2p_port,
     wait_until,
@@ -24,6 +24,10 @@ class NetTest(PivxTestFramework):
         self.num_nodes = 2
 
     def run_test(self):
+        self.log.info("Connect nodes both way")
+        connect_nodes(self.nodes[0], 1)
+        connect_nodes(self.nodes[1], 0)
+
         self._test_connection_count()
         self._test_getnettotals()
         self._test_getnetworkinginfo()
@@ -68,7 +72,9 @@ class NetTest(PivxTestFramework):
         # Wait a bit for all sockets to close
         wait_until(lambda: self.nodes[0].getnetworkinfo()['connections'] == 0, timeout=3)
 
-        connect_nodes_bi(self.nodes, 0, 1)
+        self.log.info("Connect nodes both way")
+        connect_nodes(self.nodes[0], 1)
+        connect_nodes(self.nodes[1], 0)
         assert_equal(self.nodes[0].getnetworkinfo()['connections'], 2)
 
     def _test_getaddednodeinfo(self):

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -16,7 +16,7 @@ from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
-    connect_nodes_bi,
+    connect_nodes,
     Decimal,
 )
 
@@ -47,7 +47,7 @@ class RawTransactionsTest(PivxTestFramework):
 
     def setup_network(self, split=False):
         super().setup_network()
-        connect_nodes_bi(self.nodes,0,2)
+        connect_nodes(self.nodes[0], 2)
 
     def run_test(self):
 

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -13,7 +13,12 @@ Test the following RPCs:
 """
 
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+    connect_nodes_bi,
+    Decimal,
+)
 
 
 class multidict(dict):

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -45,7 +45,7 @@ from .util import (
     assert_equal,
     assert_greater_than,
     check_json_precision,
-    connect_nodes_bi,
+    connect_nodes,
     connect_nodes_clique,
     disconnect_nodes,
     DEFAULT_FEE,
@@ -227,8 +227,18 @@ class PivxTestFramework():
         # Connect the nodes as a "chain".  This allows us
         # to split the network between nodes 1 and 2 to get
         # two halves that can work on competing chains.
+        #
+        # Topology looks like this:
+        # node0 <-- node1 <-- node2 <-- node3
+        #
+        # If all nodes are in IBD (clean chain from genesis), node0 is assumed to be the source of blocks (miner). To
+        # ensure block propagation, all nodes will establish outgoing connections toward node0.
+        # See fPreferredDownload in net_processing.
+        #
+        # If further outbound connections are needed, they can be added at the beginning of the test with e.g.
+        # connect_nodes(self.nodes[1], 2)
         for i in range(self.num_nodes - 1):
-            connect_nodes_bi(self.nodes, i, i + 1)
+            connect_nodes(self.nodes[i + 1], i)
         self.sync_all()
 
     def setup_nodes(self):

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -364,7 +364,7 @@ class PivxTestFramework():
         """
         Join the (previously split) network halves together.
         """
-        connect_nodes_bi(self.nodes, 1, 2)
+        connect_nodes(self.nodes[1], 2)
         self.sync_all()
 
     def sync_all(self, node_groups=None):

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -361,15 +361,12 @@ def connect_nodes(from_connection, node_num):
     # with transaction relaying
     wait_until(lambda:  all(peer['version'] != 0 for peer in from_connection.getpeerinfo()))
 
-def connect_nodes_bi(nodes, a, b):
-    connect_nodes(nodes[a], b)
-    connect_nodes(nodes[b], a)
-
 def connect_nodes_clique(nodes):
     l = len(nodes)
     for a in range(l):
         for b in range(a, l):
-            connect_nodes_bi(nodes, a, b)
+            connect_nodes(nodes[a], b)
+            connect_nodes(nodes[b], a)
 
 def sync_blocks(rpc_connections, *, wait=1, timeout=60):
     """

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -57,30 +57,31 @@ BASE_SCRIPTS= [
 
     # Longest test should go first, to favor running tests in parallel
     'wallet_basic.py',                          # ~ 833 sec
-    'wallet_backup.py',                         # ~ 459 sec
-    'mining_pos_reorg.py',                      # ~ 305 sec
+    'wallet_backup.py',                         # ~ 477 sec
 
     # vv Tests less than 5m vv
-    'mining_pos_coldStaking.py',                # ~ 289 sec
-    'wallet_zerocoin_publicspends.py',          # ~ 270 sec
-    'p2p_time_offset.py',                       # ~ 263 sec
-    'wallet_abandonconflict.py',                # ~ 208 sec
-    'wallet_hd.py',                             # ~ 205 sec
-    'rpc_rawtransaction.py',                    # ~ 190 sec
-    'wallet_zapwallettxes.py',                  # ~ 172 sec
-    'wallet_keypool_topup.py',                  # ~ 167 sec
+    'p2p_time_offset.py',                       # ~ 267 sec
+    'mining_pos_coldStaking.py',                # ~ 215 sec
+    'mining_pos_reorg.py',                      # ~ 212 sec
+    'wallet_abandonconflict.py',                # ~ 212 sec
+    'wallet_hd.py',                             # ~ 210 sec
+    'wallet_zerocoin_publicspends.py',          # ~ 202 sec
+    'rpc_rawtransaction.py',                    # ~ 193 sec
+    'wallet_zapwallettxes.py',                  # ~ 180 sec
+    'wallet_keypool_topup.py',                  # ~ 174 sec
     'wallet_txn_doublespend.py --mineblock',    # ~ 157 sec
     'wallet_txn_clone.py --mineblock',          # ~ 157 sec
+    'rpc_spork.py',                             # ~ 156 sec
     'interface_rest.py',                        # ~ 154 sec
-    'rpc_spork.py',                             # ~ 149 sec
     'feature_proxy.py',                         # ~ 143 sec
     'feature_uacomment.py',                     # ~ 130 sec
-    'mining_pos_fakestake.py',                  # ~ 123 sec
+    'wallet_upgrade.py',                        # ~ 124 sec
     'wallet_import_stakingaddress.py',          # ~ 123 sec
 
     # vv Tests less than 2m vv
     'p2p_disconnect_ban.py',                    # ~ 118 sec
     'wallet_listreceivedby.py',                 # ~ 117 sec
+    'mining_pos_fakestake.py',                  # ~ 113 sec
     'feature_reindex.py',                       # ~ 110 sec
     'interface_http.py',                        # ~ 105 sec
     'rpc_listtransactions.py',                  # ~ 97 sec
@@ -93,16 +94,15 @@ BASE_SCRIPTS= [
     'interface_bitcoin_cli.py',                 # ~ 80 sec
 
     # vv Tests less than 60s vv
-    'wallet_accounts.py',                       # ~ 55 sec
+    'wallet_accounts.py',                       # ~ 57 sec
+    'rpc_signmessage.py',                       # ~ 54 sec
     'mempool_resurrect.py',                     # ~ 51 sec
-    'wallet_upgrade.py',                        # ~ 50 sec
     'rpc_budget.py',                            # ~ 50 sec
     'mempool_spend_coinbase.py',                # ~ 50 sec
     'rpc_signrawtransaction.py',                # ~ 50 sec
     'rpc_decodescript.py',                      # ~ 50 sec
     'rpc_blockchain.py',                        # ~ 50 sec
     'wallet_disable.py',                        # ~ 50 sec
-    'rpc_signmessage.py',                       # ~ 50 sec
     'feature_help.py',                          # ~ 30 sec
 
     # Don't append tests at the end to avoid merge conflicts

--- a/test/functional/wallet_abandonconflict.py
+++ b/test/functional/wallet_abandonconflict.py
@@ -5,8 +5,14 @@
 
 
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import *
-import urllib.parse
+from test_framework.util import (
+    assert_equal,
+    connect_nodes,
+    Decimal,
+    disconnect_nodes,
+    sync_blocks,
+    sync_mempools
+)
 
 class AbandonConflictTest(PivxTestFramework):
     def set_test_params(self):
@@ -31,8 +37,8 @@ class AbandonConflictTest(PivxTestFramework):
         assert(balance - newbalance < Decimal("0.001")) #no more than fees lost
         balance = newbalance
 
-        url = urllib.parse.urlparse(self.nodes[1].url)
-        self.nodes[0].disconnectnode(url.hostname+":"+str(p2p_port(1)))
+        # Disconnect nodes so node0's transactions don't get into node1's mempool
+        disconnect_nodes(self.nodes[0], 1)
 
         # Identify the 10btc outputs
         nA = next(i for i, vout in enumerate(self.nodes[0].getrawtransaction(txA, 1)["vout"]) if vout["value"] == 10)

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -4,7 +4,17 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the wallet."""
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_array_result,
+    assert_equal,
+    assert_fee_amount,
+    assert_raises_rpc_error,
+    connect_nodes,
+    Decimal,
+    sync_blocks,
+    sync_mempools,
+    wait_until,
+)
 
 class WalletTest(PivxTestFramework):
     def set_test_params(self):
@@ -16,9 +26,9 @@ class WalletTest(PivxTestFramework):
         self.start_node(0)
         self.start_node(1)
         self.start_node(2)
-        connect_nodes_bi(self.nodes,0,1)
-        connect_nodes_bi(self.nodes,1,2)
-        connect_nodes_bi(self.nodes,0,2)
+        connect_nodes(self.nodes[0], 1)
+        connect_nodes(self.nodes[1], 2)
+        connect_nodes(self.nodes[0], 2)
         self.sync_all([self.nodes[0:3]])
 
     def check_fee_amount(self, curr_balance, balance_with_fee, fee_per_byte, tx_size):
@@ -164,7 +174,7 @@ class WalletTest(PivxTestFramework):
         sync_mempools(self.nodes[0:2])
 
         self.start_node(3)
-        connect_nodes_bi(self.nodes, 0, 3)
+        connect_nodes(self.nodes[0], 3)
         sync_blocks(self.nodes)
 
         # Exercise balance rpcs

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -42,7 +42,7 @@ class BumpFeeTest(PivxTestFramework):
         self.start_node(1)
         self.nodes[1].walletpassphrase(WALLET_PASSPHRASE, WALLET_PASSPHRASE_TIMEOUT)
 
-        connect_nodes_bi(self.nodes, 0, 1)
+        connect_nodes(self.nodes[0], 1)
         self.sync_all()
 
         peer_node, rbf_node = self.nodes

--- a/test/functional/wallet_keypool_topup.py
+++ b/test/functional/wallet_keypool_topup.py
@@ -15,7 +15,7 @@ import shutil
 from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
     assert_equal,
-    connect_nodes_bi,
+    connect_nodes,
     sync_blocks,
 )
 
@@ -36,7 +36,7 @@ class KeypoolRestoreTest(PivxTestFramework):
 
         shutil.copyfile(self.tmpdir + "/node1/regtest/wallet.dat", self.tmpdir + "/wallet.bak")
         self.start_node(1, self.extra_args[1])
-        connect_nodes_bi(self.nodes, 0, 1)
+        connect_nodes(self.nodes[0], 1)
 
         self.log.info("Generate keys for wallet")
 
@@ -62,7 +62,7 @@ class KeypoolRestoreTest(PivxTestFramework):
         self.log.info("Verify keypool is restored and balance is correct")
 
         self.start_node(1, self.extra_args[1])
-        connect_nodes_bi(self.nodes, 0, 1)
+        connect_nodes(self.nodes[0], 1)
         self.sync_all()
 
         # wallet was not backupped after emptying the key pool.

--- a/test/functional/wallet_listsinceblock.py
+++ b/test/functional/wallet_listsinceblock.py
@@ -5,7 +5,12 @@
 """Test the listsincelast RPC."""
 
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import assert_equal, assert_array_result, assert_raises_rpc_error
+from test_framework.util import (
+    assert_equal,
+    assert_array_result,
+    assert_raises_rpc_error,
+    connect_nodes,
+)
 
 class ListSinceBlockTest (PivxTestFramework):
     def set_test_params(self):
@@ -13,6 +18,9 @@ class ListSinceBlockTest (PivxTestFramework):
         self.setup_clean_chain = True
 
     def run_test(self):
+        # All nodes are in IBD from genesis, so they'll need the miner (node2) to be an outbound connection, or have
+        # only one connection. (See fPreferredDownload in net_processing)
+        connect_nodes(self.nodes[1], 2)
         self.nodes[2].generate(101)
         self.sync_all()
 


### PR DESCRIPTION
Mostly from upstream bitcoin#16898

> By default all test nodes are connected in a chain. However, instead of just a single connection between each pair of nodes, we end up with up to four connections for a "middle" node (two outbound, two inbound, from each side).
>
> This is generally redundant (tx and block relay should succeed with just a single connection) and confusing. For example, test timeouts after a call to sync_ may be racy and hard to reproduce. On top of that, the test debug.logs are hard to read because txs and block invs may be relayed on the same connection multiple times.
>
> Fix this by inlining connect_nodes_bi in the two tests that need it, and then replace it with a single connect_nodes in all other tests.
>
> Historic background:
>
> connect_nodes_bi has been introduced as a (temporary?) workaround for bug #5113 and #5138, which has long been fixed in #5157 and #5662.