### PR TITLE
[GUI] Hide charts container when not USE_QTCHARTS

### DIFF
--- a/src/qt/pivx/dashboardwidget.cpp
+++ b/src/qt/pivx/dashboardwidget.cpp
@@ -42,8 +42,6 @@ DashboardWidget::DashboardWidget(PIVXGUI* parent) :
     // Containers
     setCssProperty({this, ui->left}, "container");
     ui->left->setContentsMargins(0,0,0,0);
-    setCssProperty(ui->right, "container-right");
-    ui->right->setContentsMargins(20,20,20,0);
 
     // Title
     ui->labelTitle2->setText(tr("Staking Rewards"));
@@ -86,8 +84,13 @@ DashboardWidget::DashboardWidget(PIVXGUI* parent) :
     setCssProperty(ui->pushButtonChartRight, "btn-chart-arrow-right");
 
 #ifdef USE_QTCHARTS
+    setCssProperty(ui->right, "container-right");
+    ui->right->setContentsMargins(20,20,20,0);
     connect(ui->comboBoxYears, static_cast<void (QComboBox::*)(const QString&)>(&QComboBox::currentIndexChanged),
         this, &DashboardWidget::onChartYearChanged);
+#else
+    // hide charts container if not USE_QTCHARTS
+    ui->right->setVisible(false);
 #endif // USE_QTCHARTS
 
     // Sort Transactions


### PR DESCRIPTION
QT charts are included by default (unless explicitely disabled or the library is not found). In which case, almost half of the dashboard space is basically "wasted".

![charts1](https://user-images.githubusercontent.com/18186894/78017902-45444700-734d-11ea-9d87-b181c7b85832.png)

<br>

This PR proposes to hide the charts container instead.

![charts2](https://user-images.githubusercontent.com/18186894/78017911-4a08fb00-734d-11ea-8fae-770f55eb31c1.png)
