### PR TITLE
[GUI] Hide charts at startup or at runtime

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -161,7 +161,7 @@ Detailed release notes follow. This overview includes changes that affect behavi
 
 ### P2P Protocol and Network Code
 
-The p2p alert system has been removed in [#1372](https://github.com/PIVX-Project/PIVX/pull/1372) and the 'alert' message is no longer supported.
+The p2p alert system has been removed in [PR #1372](https://github.com/PIVX-Project/PIVX/pull/1372) and the 'alert' message is no longer supported.
 
 ### GUI
 
@@ -178,12 +178,16 @@ Addresses in the dropdown of the "Send Transaction" and "Send Delegation" widget
 **Include delegations in send**: The send and cold-staking page present a checkbox ([#1391](https://github.com/PIVX-Project/PIVX/pull/1391)) to make the automatic input selection algorithm include delegated (P2CS) utxos if needed. The option is unchecked by default.
 
 
+**Staking Charts**: can now be hidden at startup (with a flag `--hidecharts`) or at runtime with a checkbox in settings --> options --> display ([PR #1475](https://github.com/PIVX-Project/PIVX/pull/1475)).
+
+
+
 ### RPC/REST
 
 ### Wallet
 
 
-__Context Lock/Unlock__ [[PR #1387]()]:<br>
+__Context Lock/Unlock__ [[PR #1387](https://github.com/PIVX-Project/PIVX/pull/1387)]:<br>
 Present the unlock dialog directly (instead of an error message), whenever an action on encrypted/locked wallet requires full unlock.<br>
 Restore the previous locking state ("locked" or "locked for staking only") when the action is completed.
 

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -197,6 +197,8 @@ void OptionsModel::setDisplayDefaultOptions(QSettings& settings, bool reset)
         settings.setValue("strThirdPartyTxUrls", "");
     strThirdPartyTxUrls = settings.value("strThirdPartyTxUrls", "").toString();
 
+    fHideCharts = GetBoolArg("-hidecharts", false);
+
     if (reset) {
         refreshDataView();
     }
@@ -287,6 +289,8 @@ QVariant OptionsModel::data(const QModelIndex& index, int role) const
             return settings.value("nDatabaseCache");
         case ThreadsScriptVerif:
             return settings.value("nThreadsScriptVerif");
+        case HideCharts:
+            return fHideCharts;
         case HideZeroBalances:
             return settings.value("fHideZeroBalances");
         case HideOrphans:
@@ -403,6 +407,10 @@ bool OptionsModel::setData(const QModelIndex& index, const QVariant& value, int 
                 settings.setValue("language", value);
                 setRestartRequired(true);
             }
+            break;
+        case HideCharts:
+            fHideCharts = value.toBool();   // memory only
+            Q_EMIT hideChartsChanged(fHideCharts);
             break;
         case HideZeroBalances:
             fHideZeroBalances = value.toBool();

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -89,11 +89,13 @@ void OptionsModel::Init()
     language = settings.value("language").toString();
 }
 
-void OptionsModel::refreshDataView(){
+void OptionsModel::refreshDataView()
+{
     Q_EMIT dataChanged(index(0), index(rowCount(QModelIndex()) - 1));
 }
 
-void OptionsModel::setMainDefaultOptions(QSettings& settings, bool reset){
+void OptionsModel::setMainDefaultOptions(QSettings& settings, bool reset)
+{
     // These are shared with the core or have a command-line parameter
     // and we want command-line parameters to overwrite the GUI settings.
     //
@@ -112,24 +114,26 @@ void OptionsModel::setMainDefaultOptions(QSettings& settings, bool reset){
     if (!SoftSetArg("-par", settings.value("nThreadsScriptVerif").toString().toStdString()))
         addOverriddenOption("-par");
 
-    if(reset){
+    if (reset) {
         refreshDataView();
     }
 }
 
-void OptionsModel::setWalletDefaultOptions(QSettings& settings, bool reset){
-    if (reset || !settings.contains("bSpendZeroConfChange"))
+void OptionsModel::setWalletDefaultOptions(QSettings& settings, bool reset)
+{
+    if (!settings.contains("bSpendZeroConfChange") || reset)
         settings.setValue("bSpendZeroConfChange", false);
     if (!SoftSetBoolArg("-spendzeroconfchange", settings.value("bSpendZeroConfChange").toBool()))
         addOverriddenOption("-spendzeroconfchange");
-    if (reset){
+    if (reset) {
         setStakeSplitThreshold(CWallet::DEFAULT_STAKE_SPLIT_THRESHOLD);
         setUseCustomFee(false);
         refreshDataView();
     }
 }
 
-void OptionsModel::setNetworkDefaultOptions(QSettings& settings, bool reset){
+void OptionsModel::setNetworkDefaultOptions(QSettings& settings, bool reset)
+{
     if (!settings.contains("fUseUPnP") || reset)
         settings.setValue("fUseUPnP", DEFAULT_UPNP);
     if (!SoftSetBoolArg("-upnp", settings.value("fUseUPnP").toBool()))
@@ -150,12 +154,13 @@ void OptionsModel::setNetworkDefaultOptions(QSettings& settings, bool reset){
     else if (!settings.value("fUseProxy").toBool() && !GetArg("-proxy", "").empty())
         addOverriddenOption("-proxy");
 
-    if(reset){
+    if (reset) {
         refreshDataView();
     }
 }
 
-void OptionsModel::setWindowDefaultOptions(QSettings& settings, bool reset){
+void OptionsModel::setWindowDefaultOptions(QSettings& settings, bool reset)
+{
     if (!settings.contains("fMinimizeToTray") || reset)
         settings.setValue("fMinimizeToTray", false);
     fMinimizeToTray = settings.value("fMinimizeToTray").toBool();
@@ -164,12 +169,13 @@ void OptionsModel::setWindowDefaultOptions(QSettings& settings, bool reset){
         settings.setValue("fMinimizeOnClose", false);
     fMinimizeOnClose = settings.value("fMinimizeOnClose").toBool();
 
-    if(reset){
+    if (reset) {
         refreshDataView();
     }
 }
 
-void OptionsModel::setDisplayDefaultOptions(QSettings& settings, bool reset){
+void OptionsModel::setDisplayDefaultOptions(QSettings& settings, bool reset)
+{
     if (!settings.contains("nDisplayUnit") || reset)
         settings.setValue("nDisplayUnit", BitcoinUnits::PIV);
     nDisplayUnit = settings.value("nDisplayUnit").toInt();
@@ -191,7 +197,7 @@ void OptionsModel::setDisplayDefaultOptions(QSettings& settings, bool reset){
         settings.setValue("strThirdPartyTxUrls", "");
     strThirdPartyTxUrls = settings.value("strThirdPartyTxUrls", "").toString();
 
-    if(reset){
+    if (reset) {
         refreshDataView();
     }
 }

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -49,6 +49,7 @@ public:
         ZeromintAddresses,   // bool
         ZeromintPercentage,  // int
         ZeromintPrefDenom,   // int
+        HideCharts,          // bool
         HideZeroBalances,    // bool
         HideOrphans,    // bool
         AnonymizePivxAmount, //int
@@ -77,6 +78,7 @@ public:
     void setCustomFeeValue(const CAmount& value);
 
     /* Explicit getters */
+    bool isHideCharts() { return fHideCharts; }
     bool getMinimizeToTray() { return fMinimizeToTray; }
     bool getMinimizeOnClose() { return fMinimizeOnClose; }
     int getDisplayUnit() { return nDisplayUnit; }
@@ -116,6 +118,7 @@ private:
     QString strThirdPartyTxUrls;
     bool fCoinControlFeatures;
     bool showColdStakingScreen;
+    bool fHideCharts;
     bool fHideZeroBalances;
     bool fHideOrphans;
     /* settings that were overriden by command-line */
@@ -133,6 +136,7 @@ Q_SIGNALS:
     void anonymizePivxAmountChanged(int);
     void coinControlFeaturesChanged(bool);
     void showHideColdStakingScreen(bool);
+    void hideChartsChanged(bool);
     void hideZeroBalancesChanged(bool);
     void hideOrphansChanged(bool);
 };

--- a/src/qt/pivx/dashboardwidget.cpp
+++ b/src/qt/pivx/dashboardwidget.cpp
@@ -221,7 +221,8 @@ void DashboardWidget::loadWalletModel()
         stakesFilter->setSourceModel(txModel);
         hasStakes = stakesFilter->rowCount() > 0;
 
-        onHideChartsChanged(GetBoolArg("-hidecharts", false));
+        onHideChartsChanged(walletModel->getOptionsModel()->isHideCharts());
+        connect(walletModel->getOptionsModel(), &OptionsModel::hideChartsChanged, this, &DashboardWidget::onHideChartsChanged);
 #endif
     }
     // update the display unit, to not use the default ("PIV")
@@ -395,10 +396,8 @@ void DashboardWidget::loadChart()
 void DashboardWidget::showHideEmptyChart(bool showEmpty, bool loading, bool forceView)
 {
     if (stakesFilter->rowCount() > SHOW_EMPTY_CHART_VIEW_THRESHOLD || forceView) {
-        if (ui->emptyContainerChart->isVisible() != showEmpty) {
-            ui->layoutChart->setVisible(!showEmpty);
-            ui->emptyContainerChart->setVisible(showEmpty);
-        }
+        ui->layoutChart->setVisible(!showEmpty);
+        ui->emptyContainerChart->setVisible(showEmpty);
     }
     // Enable/Disable sort buttons
     bool invLoading = !loading;

--- a/src/qt/pivx/dashboardwidget.cpp
+++ b/src/qt/pivx/dashboardwidget.cpp
@@ -167,8 +167,8 @@ bool hasCharts = false;
     }
 }
 
-void DashboardWidget::handleTransactionClicked(const QModelIndex &index){
-
+void DashboardWidget::handleTransactionClicked(const QModelIndex &index)
+{
     ui->listTransactions->setCurrentIndex(index);
     QModelIndex rIndex = filter->mapToSource(index);
 
@@ -184,7 +184,8 @@ void DashboardWidget::handleTransactionClicked(const QModelIndex &index){
     dialog->deleteLater();
 }
 
-void DashboardWidget::loadWalletModel(){
+void DashboardWidget::loadWalletModel()
+{
     if (walletModel && walletModel->getOptionsModel()) {
         txModel = walletModel->getTransactionTableModel();
         // Set up transaction list
@@ -199,7 +200,7 @@ void DashboardWidget::loadWalletModel(){
         ui->listTransactions->setModel(filter);
         ui->listTransactions->setModelColumn(TransactionTableModel::ToAddress);
 
-        if(txModel->size() == 0){
+        if (txModel->size() == 0) {
             ui->emptyContainer->setVisible(true);
             ui->listTransactions->setVisible(false);
             ui->comboBoxSortType->setVisible(false);
@@ -226,7 +227,8 @@ void DashboardWidget::loadWalletModel(){
     updateDisplayUnit();
 }
 
-void DashboardWidget::onTxArrived(const QString& hash, const bool& isCoinStake, const bool& isCSAnyType) {
+void DashboardWidget::onTxArrived(const QString& hash, const bool& isCoinStake, const bool& isCSAnyType)
+{
     showList();
 #ifdef USE_QTCHARTS
     if (isCoinStake) {
@@ -238,8 +240,9 @@ void DashboardWidget::onTxArrived(const QString& hash, const bool& isCoinStake, 
 #endif
 }
 
-void DashboardWidget::showList(){
-    if (filter->rowCount() == 0){
+void DashboardWidget::showList()
+{
+    if (filter->rowCount() == 0) {
         ui->emptyContainer->setVisible(true);
         ui->listTransactions->setVisible(false);
         ui->comboBoxSortType->setVisible(false);
@@ -252,7 +255,8 @@ void DashboardWidget::showList(){
     }
 }
 
-void DashboardWidget::updateDisplayUnit() {
+void DashboardWidget::updateDisplayUnit()
+{
     if (walletModel && walletModel->getOptionsModel()) {
         nDisplayUnit = walletModel->getOptionsModel()->getDisplayUnit();
         txHolder->setDisplayUnit(nDisplayUnit);
@@ -260,11 +264,12 @@ void DashboardWidget::updateDisplayUnit() {
     }
 }
 
-void DashboardWidget::onSortChanged(const QString& value){
+void DashboardWidget::onSortChanged(const QString& value)
+{
     if (!filter) return;
     int columnIndex = 0;
     Qt::SortOrder order = Qt::DescendingOrder;
-    if(!value.isNull()) {
+    if (!value.isNull()) {
         switch (ui->comboBoxSort->itemData(ui->comboBoxSort->currentIndex()).toInt()) {
             case SortTx::DATE_ASC:{
                 columnIndex = TransactionTableModel::Date;
@@ -298,7 +303,7 @@ void DashboardWidget::onSortTypeChanged(const QString& value)
     filter->setTypeFilter(filterByType);
     ui->listTransactions->update();
 
-    if (filter->rowCount() == 0){
+    if (filter->rowCount() == 0) {
         ui->emptyContainer->setVisible(true);
         ui->listTransactions->setVisible(false);
     } else {
@@ -310,7 +315,8 @@ void DashboardWidget::onSortTypeChanged(const QString& value)
     settings.setValue("transactionType", filterByType);
 }
 
-void DashboardWidget::walletSynced(bool sync){
+void DashboardWidget::walletSynced(bool sync)
+{
     if (this->isSync != sync) {
         this->isSync = sync;
         ui->layoutWarning->setVisible(!this->isSync);
@@ -320,7 +326,8 @@ void DashboardWidget::walletSynced(bool sync){
     }
 }
 
-void DashboardWidget::changeTheme(bool isLightTheme, QString& theme){
+void DashboardWidget::changeTheme(bool isLightTheme, QString& theme)
+{
     static_cast<TxViewHolder*>(this->txViewDelegate->getRowFactory())->isLightTheme = isLightTheme;
 #ifdef USE_QTCHARTS
     if (chart) this->changeChartColors();
@@ -329,7 +336,8 @@ void DashboardWidget::changeTheme(bool isLightTheme, QString& theme){
 
 #ifdef USE_QTCHARTS
 
-void DashboardWidget::tryChartRefresh() {
+void DashboardWidget::tryChartRefresh()
+{
     if (hasStakes) {
         // First check that everything was loaded properly.
         if (!chart) {
@@ -345,7 +353,8 @@ void DashboardWidget::tryChartRefresh() {
     }
 }
 
-void DashboardWidget::setChartShow(ChartShowType type) {
+void DashboardWidget::setChartShow(ChartShowType type)
+{
     this->chartShow = type;
     if (chartShow == MONTH) {
         ui->containerChartArrow->setVisible(true);
@@ -357,7 +366,8 @@ void DashboardWidget::setChartShow(ChartShowType type) {
 
 const QStringList monthsNames = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
 
-void DashboardWidget::loadChart(){
+void DashboardWidget::loadChart()
+{
     if (hasStakes) {
         if (!chart) {
             showHideEmptyChart(false, false);
@@ -379,7 +389,8 @@ void DashboardWidget::loadChart(){
     }
 }
 
-void DashboardWidget::showHideEmptyChart(bool showEmpty, bool loading, bool forceView) {
+void DashboardWidget::showHideEmptyChart(bool showEmpty, bool loading, bool forceView)
+{
     if (stakesFilter->rowCount() > SHOW_EMPTY_CHART_VIEW_THRESHOLD || forceView) {
         if (ui->emptyContainerChart->isVisible() != showEmpty) {
             ui->layoutChart->setVisible(!showEmpty);
@@ -396,7 +407,8 @@ void DashboardWidget::showHideEmptyChart(bool showEmpty, bool loading, bool forc
     ui->labelEmptyChart->setText(loading ? tr("Loading chart..") : tr("You have no staking rewards"));
 }
 
-void DashboardWidget::initChart() {
+void DashboardWidget::initChart()
+{
     chart = new QChart();
     axisX = new QBarCategoryAxis();
     axisY = new QValueAxis();
@@ -425,17 +437,18 @@ void DashboardWidget::initChart() {
     setCssProperty(ui->chartContainer, "container-chart");
 }
 
-void DashboardWidget::changeChartColors(){
+void DashboardWidget::changeChartColors()
+{
     QColor gridLineColorX;
     QColor linePenColorY;
     QColor backgroundColor;
     QColor gridY;
-    if(isLightTheme()){
+    if (isLightTheme()) {
         gridLineColorX = QColor(255,255,255);
         linePenColorY = gridLineColorX;
         backgroundColor = linePenColorY;
         axisY->setGridLineColor(QColor("#1a000000"));
-    }else{
+    } else {
         gridY = QColor("#40ffffff");
         axisY->setGridLineColor(gridY);
         gridLineColorX = QColor(15,11,22);
@@ -450,7 +463,8 @@ void DashboardWidget::changeChartColors(){
     if (set1) set1->setBorderColor(gridLineColorX);
 }
 
-void DashboardWidget::updateStakeFilter() {
+void DashboardWidget::updateStakeFilter()
+{
     if (chartShow != ALL) {
         bool filterByMonth = false;
         if (monthFilter != 0 && chartShow == MONTH) {
@@ -486,7 +500,8 @@ void DashboardWidget::updateStakeFilter() {
 }
 
 // pair PIV, zPIV
-const QMap<int, std::pair<qint64, qint64>> DashboardWidget::getAmountBy() {
+const QMap<int, std::pair<qint64, qint64>> DashboardWidget::getAmountBy()
+{
     updateStakeFilter();
     const int size = stakesFilter->rowCount();
     QMap<int, std::pair<qint64, qint64>> amountBy;
@@ -532,8 +547,8 @@ const QMap<int, std::pair<qint64, qint64>> DashboardWidget::getAmountBy() {
     return amountBy;
 }
 
-bool DashboardWidget::loadChartData(bool withMonthNames) {
-
+bool DashboardWidget::loadChartData(bool withMonthNames)
+{
     if (chartData) {
         delete chartData;
         chartData = nullptr;
@@ -577,7 +592,8 @@ bool DashboardWidget::loadChartData(bool withMonthNames) {
     return true;
 }
 
-void DashboardWidget::onChartYearChanged(const QString& yearStr) {
+void DashboardWidget::onChartYearChanged(const QString& yearStr)
+{
     if (isChartInitialized) {
         int newYear = yearStr.toInt();
         if (newYear != yearFilter) {
@@ -587,7 +603,8 @@ void DashboardWidget::onChartYearChanged(const QString& yearStr) {
     }
 }
 
-void DashboardWidget::onChartMonthChanged(const QString& monthStr) {
+void DashboardWidget::onChartMonthChanged(const QString& monthStr)
+{
     if (isChartInitialized) {
         int newMonth = ui->comboBoxMonths->currentData().toInt();
         if (newMonth != monthFilter) {
@@ -602,7 +619,8 @@ void DashboardWidget::onChartMonthChanged(const QString& monthStr) {
     }
 }
 
-bool DashboardWidget::refreshChart(){
+bool DashboardWidget::refreshChart()
+{
     if (isLoading) return false;
     isLoading = true;
     isChartMin = width() < 1300;
@@ -611,9 +629,10 @@ bool DashboardWidget::refreshChart(){
     return execute(REQUEST_LOAD_TASK);
 }
 
-void DashboardWidget::onChartRefreshed() {
+void DashboardWidget::onChartRefreshed()
+{
     if (chart) {
-        if(series){
+        if (series) {
             series->clear();
             series->detachAxis(axisX);
             series->detachAxis(axisY);
@@ -626,7 +645,7 @@ void DashboardWidget::onChartRefreshed() {
     set0->setColor(QColor(92,75,125));
     set1->setColor(QColor(176,136,255));
 
-    if(!series) {
+    if (!series) {
         series = new QBarSeries();
         chart->addSeries(series);
     }
@@ -650,7 +669,7 @@ void DashboardWidget::onChartRefreshed() {
     ui->labelAmountZpiv->setText(GUIUtil::formatBalance(chartData->totalZpiv, nDisplayUnit, true));
 
     series->append(set0);
-    if(hasZpivStakes)
+    if (hasZpivStakes)
         series->append(set1);
 
     // bar width
@@ -710,7 +729,8 @@ void DashboardWidget::onChartRefreshed() {
     isLoading = false;
 }
 
-std::pair<int, int> DashboardWidget::getChartRange(QMap<int, std::pair<qint64, qint64>> amountsBy) {
+std::pair<int, int> DashboardWidget::getChartRange(QMap<int, std::pair<qint64, qint64>> amountsBy)
+{
     switch (chartShow) {
         case YEAR:
             return std::make_pair(1, 13);
@@ -732,7 +752,8 @@ std::pair<int, int> DashboardWidget::getChartRange(QMap<int, std::pair<qint64, q
     }
 }
 
-void DashboardWidget::updateAxisX(const QStringList* args) {
+void DashboardWidget::updateAxisX(const QStringList* args)
+{
     axisX->clear();
     QStringList months;
     std::pair<int,int> range = getChartRange(chartData->amountsByCache);
@@ -744,7 +765,8 @@ void DashboardWidget::updateAxisX(const QStringList* args) {
     axisX->append(months);
 }
 
-void DashboardWidget::onChartArrowClicked(bool goLeft) {
+void DashboardWidget::onChartArrowClicked(bool goLeft)
+{
     if (goLeft) {
         dayStart--;
         if (dayStart == 0) {
@@ -760,7 +782,8 @@ void DashboardWidget::onChartArrowClicked(bool goLeft) {
     refreshChart();
 }
 
-void DashboardWidget::windowResizeEvent(QResizeEvent* event) {
+void DashboardWidget::windowResizeEvent(QResizeEvent* event)
+{
     if (hasStakes && axisX) {
         if (width() > 1300) {
             if (isChartMin) {
@@ -792,7 +815,8 @@ void DashboardWidget::windowResizeEvent(QResizeEvent* event) {
 
 #endif
 
-void DashboardWidget::run(int type) {
+void DashboardWidget::run(int type)
+{
 #ifdef USE_QTCHARTS
     if (type == REQUEST_LOAD_TASK) {
         bool withMonthNames = !isChartMin && (chartShow == YEAR);
@@ -801,11 +825,13 @@ void DashboardWidget::run(int type) {
     }
 #endif
 }
-void DashboardWidget::onError(QString error, int type) {
+void DashboardWidget::onError(QString error, int type)
+{
     inform(tr("Error loading chart: %1").arg(error));
 }
 
-void DashboardWidget::processNewTransaction(const QModelIndex& parent, int start, int /*end*/) {
+void DashboardWidget::processNewTransaction(const QModelIndex& parent, int start, int /*end*/)
+{
     // Prevent notifications-spam when initial block download is in progress
     if (!walletModel || !clientModel || clientModel->inInitialBlockDownload())
         return;
@@ -821,7 +847,8 @@ void DashboardWidget::processNewTransaction(const QModelIndex& parent, int start
     Q_EMIT incomingTransaction(date, walletModel->getOptionsModel()->getDisplayUnit(), amount, type, address);
 }
 
-DashboardWidget::~DashboardWidget(){
+DashboardWidget::~DashboardWidget()
+{
 #ifdef USE_QTCHARTS
     delete chart;
 #endif

--- a/src/qt/pivx/dashboardwidget.cpp
+++ b/src/qt/pivx/dashboardwidget.cpp
@@ -220,7 +220,8 @@ void DashboardWidget::loadWalletModel()
         stakesFilter->setOnlyStakes(true);
         stakesFilter->setSourceModel(txModel);
         hasStakes = stakesFilter->rowCount() > 0;
-        loadChart();
+
+        onHideChartsChanged(GetBoolArg("-hidecharts", false));
 #endif
     }
     // update the display unit, to not use the default ("PIV")
@@ -338,6 +339,8 @@ void DashboardWidget::changeTheme(bool isLightTheme, QString& theme)
 
 void DashboardWidget::tryChartRefresh()
 {
+    if (!fShowCharts)
+        return;
     if (hasStakes) {
         // First check that everything was loaded properly.
         if (!chart) {
@@ -811,6 +814,14 @@ void DashboardWidget::windowResizeEvent(QResizeEvent* event)
             }
         }
     }
+}
+
+void DashboardWidget::onHideChartsChanged(bool fHide)
+{
+    fShowCharts = !fHide;
+    // Hide charts if requested
+    ui->right->setVisible(fShowCharts);
+    if (fShowCharts) tryChartRefresh();
 }
 
 #endif

--- a/src/qt/pivx/dashboardwidget.h
+++ b/src/qt/pivx/dashboardwidget.h
@@ -167,6 +167,7 @@ private:
 
     ChartData* chartData = nullptr;
     bool hasStakes = false;
+    bool fShowCharts = true;
 
     void initChart();
     void showHideEmptyChart(bool show, bool loading, bool forceView = false);
@@ -181,6 +182,7 @@ private:
 
 private Q_SLOTS:
     void onChartRefreshed();
+    void onHideChartsChanged(bool fHide); // set as Q_SLOT to be connected with the options model in the next commit
 
 #endif
 

--- a/src/qt/pivx/settings/forms/settingsdisplayoptionswidget.ui
+++ b/src/qt/pivx/settings/forms/settingsdisplayoptionswidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>511</width>
-    <height>434</height>
+    <width>518</width>
+    <height>440</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -47,7 +47,7 @@
       <item>
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <property name="spacing">
-         <number>0</number>
+         <number>20</number>
         </property>
         <item>
          <layout class="QHBoxLayout" name="horizontalLayout_3">
@@ -79,22 +79,6 @@
            </layout>
           </item>
          </layout>
-        </item>
-        <item>
-         <spacer name="verticalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Fixed</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
         </item>
         <item>
          <layout class="QHBoxLayout" name="horizontalLayout_2">
@@ -137,22 +121,6 @@
          </layout>
         </item>
         <item>
-         <spacer name="verticalThreads2">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Fixed</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>10</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
          <layout class="QHBoxLayout" name="horizontalPercentagezPiv">
           <item>
            <widget class="QLabel" name="labelTitleUnit">
@@ -191,22 +159,6 @@
            </widget>
           </item>
          </layout>
-        </item>
-        <item>
-         <spacer name="verticalDenomzPiv">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Fixed</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>10</height>
-           </size>
-          </property>
-         </spacer>
         </item>
         <item>
          <layout class="QHBoxLayout" name="horizontalDenomzPiv">
@@ -249,20 +201,15 @@
          </layout>
         </item>
         <item>
-         <spacer name="verticalSpacer_4">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Minimum</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>14</height>
-           </size>
-          </property>
-         </spacer>
+         <layout class="QHBoxLayout" name="horizontalHideCharts">
+          <item>
+           <widget class="QCheckBox" name="checkBoxHideCharts">
+            <property name="text">
+             <string>Hide stake charts in the dashboard</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
         <item>
          <widget class="QPushButton" name="pushButtonSwitchBalance">
@@ -282,22 +229,6 @@
            <bool>true</bool>
           </property>
          </widget>
-        </item>
-        <item>
-         <spacer name="verticalSpacer_3">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Preferred</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>14</height>
-           </size>
-          </property>
-         </spacer>
         </item>
         <item>
          <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,1">
@@ -343,7 +274,7 @@
          </spacer>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_7">
+         <layout class="QHBoxLayout" name="horizontalReset">
           <property name="spacing">
            <number>12</number>
           </property>

--- a/src/qt/pivx/settings/settingsdisplayoptionswidget.cpp
+++ b/src/qt/pivx/settings/settingsdisplayoptionswidget.cpp
@@ -47,10 +47,15 @@ SettingsDisplayOptionsWidget::SettingsDisplayOptionsWidget(PIVXGUI* _window, QWi
     // TODO: Reconnect this option to an action. Hide it for now
     ui->labelTitleUrl->hide();
 
-    // Switch
+    // Switch (hide for now)
     ui->pushButtonSwitchBalance->setText(tr("Hide empty balances"));
     ui->pushButtonSwitchBalance->setProperty("cssClass", "btn-switch");
     ui->pushButtonSwitchBalance->setVisible(false);
+
+    // Hide checkbox if qtcharts not used
+#ifndef USE_QTCHARTS
+    ui->checkBoxHideCharts->setVisible(false);
+#endif
 
     // Combobox
     ui->comboBoxLanguage->setProperty("cssClass", "btn-combo");
@@ -142,6 +147,9 @@ void SettingsDisplayOptionsWidget::setMapper(QDataWidgetMapper *mapper)
     mapper->addMapping(ui->comboBoxLanguage, OptionsModel::Language);
     mapper->addMapping(ui->comboBoxUnit, OptionsModel::DisplayUnit);
     mapper->addMapping(ui->pushButtonSwitchBalance, OptionsModel::HideZeroBalances);
+#ifdef USE_QTCHARTS
+    mapper->addMapping(ui->checkBoxHideCharts, OptionsModel::HideCharts);
+#endif
 }
 
 void SettingsDisplayOptionsWidget::loadClientModel()

--- a/src/qt/pivx/settings/settingsdisplayoptionswidget.cpp
+++ b/src/qt/pivx/settings/settingsdisplayoptionswidget.cpp
@@ -106,7 +106,8 @@ SettingsDisplayOptionsWidget::SettingsDisplayOptionsWidget(PIVXGUI* _window, QWi
     connect(ui->pushButtonClean, &QPushButton::clicked, [this] { Q_EMIT discardSettings(); });
 }
 
-void SettingsDisplayOptionsWidget::initLanguages(){
+void SettingsDisplayOptionsWidget::initLanguages()
+{
     /* Language selector */
     QDir translations(":translations");
     QString defaultStr = QString("(") + tr("default") + QString(")");
@@ -115,18 +116,18 @@ void SettingsDisplayOptionsWidget::initLanguages(){
         QLocale locale(langStr);
 
         /** check if the locale name consists of 2 parts (language_country) */
-        if(langStr.contains("_")){
+        if (langStr.contains("_")) {
             /** display language strings as "native language - native country (locale name)", e.g. "Deutsch - Deutschland (de)" */
             ui->comboBoxLanguage->addItem(locale.nativeLanguageName() + QString(" - ") + locale.nativeCountryName() + QString(" (") + langStr + QString(")"), QVariant(langStr));
-        }
-        else{
+        } else {
             /** display language strings as "native language (locale name)", e.g. "Deutsch (de)" */
             ui->comboBoxLanguage->addItem(locale.nativeLanguageName() + QString(" (") + langStr + QString(")"), QVariant(langStr));
         }
     }
 }
 
-void SettingsDisplayOptionsWidget::onResetClicked() {
+void SettingsDisplayOptionsWidget::onResetClicked()
+{
     if (clientModel) {
         OptionsModel *optionsModel = clientModel->getOptionsModel();
         QSettings settings;
@@ -135,19 +136,22 @@ void SettingsDisplayOptionsWidget::onResetClicked() {
     }
 }
 
-void SettingsDisplayOptionsWidget::setMapper(QDataWidgetMapper *mapper){
+void SettingsDisplayOptionsWidget::setMapper(QDataWidgetMapper *mapper)
+{
     mapper->addMapping(ui->comboBoxDigits, OptionsModel::Digits);
     mapper->addMapping(ui->comboBoxLanguage, OptionsModel::Language);
     mapper->addMapping(ui->comboBoxUnit, OptionsModel::DisplayUnit);
     mapper->addMapping(ui->pushButtonSwitchBalance, OptionsModel::HideZeroBalances);
 }
 
-void SettingsDisplayOptionsWidget::loadClientModel(){
-    if(clientModel) {
+void SettingsDisplayOptionsWidget::loadClientModel()
+{
+    if (clientModel) {
         ui->comboBoxUnit->setCurrentIndex(this->clientModel->getOptionsModel()->getDisplayUnit());
     }
 }
 
-SettingsDisplayOptionsWidget::~SettingsDisplayOptionsWidget(){
+SettingsDisplayOptionsWidget::~SettingsDisplayOptionsWidget()
+{
     delete ui;
 }

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -85,6 +85,7 @@ HelpMessageDialog::HelpMessageDialog(QWidget* parent, bool about) : QDialog(pare
         strUsage += HelpMessageOpt("-min", tr("Start minimized").toStdString());
         strUsage += HelpMessageOpt("-rootcertificates=<file>", tr("Set SSL root certificates for payment request (default: -system-)").toStdString());
         strUsage += HelpMessageOpt("-splash", strprintf(tr("Show splash screen on startup (default: %u)").toStdString(), DEFAULT_SPLASHSCREEN));
+        strUsage += HelpMessageOpt("-hidecharts", strprintf(tr("Hide QT staking charts on startup (default: %u)").toStdString(), false));
         QString coreOptions = QString::fromStdString(strUsage);
         text = version + "\n" + header + "\n" + coreOptions;
 


### PR DESCRIPTION
This adds a gui-only startup flag `--hidecharts` that can be used to automatically hide the chart container at startup.

Also adds  a checkbox in display option to hide/show the charts at runtime (so a wallet could even be started without charts, and then enable them later without restarting).

![hideCharts](https://user-images.githubusercontent.com/18186894/78072201-ff17d380-739e-11ea-8471-159e2e2a11fc.gif)

<br>

NOTE: this PR might be controversial, so it has been implemented independently from #1473 (which only hides the chart when they are disabled via `configure`). If both PR are conceptually accepted, this will be rebased on top of 1473.