### PR TITLE
[GUI][Trivial] ColdStakingWidget: fix containerSend margins

### DIFF
--- a/src/qt/pivx/forms/coldstakingwidget.ui
+++ b/src/qt/pivx/forms/coldstakingwidget.ui
@@ -55,10 +55,10 @@
            <number>0</number>
           </property>
           <property name="leftMargin">
-           <number>20</number>
+           <number>0</number>
           </property>
           <property name="rightMargin">
-           <number>20</number>
+           <number>0</number>
           </property>
           <item>
            <widget class="QWidget" name="containerTitle" native="true">
@@ -79,13 +79,13 @@
               <number>0</number>
              </property>
              <property name="leftMargin">
-              <number>0</number>
+              <number>20</number>
              </property>
              <property name="topMargin">
               <number>0</number>
              </property>
              <property name="rightMargin">
-              <number>0</number>
+              <number>20</number>
              </property>
              <property name="bottomMargin">
               <number>0</number>


### PR DESCRIPTION
Cold staking widget: set containerSend margins to zero to keep consistency with send widget.
Closes #1444 

Before:
![cswidg1](https://user-images.githubusercontent.com/18186894/78084802-778b8e00-73b9-11ea-95ca-90a05a5eb710.png)

<br>

After:
![cswidg2](https://user-images.githubusercontent.com/18186894/78084809-7bb7ab80-73b9-11ea-9eb5-a317113d3074.png)
