### PR TITLE
[BUG][GUI] Fix MasternodeWidget StartAll

### DIFF
--- a/src/qt/pivx/loadingdialog.h
+++ b/src/qt/pivx/loadingdialog.h
@@ -24,6 +24,7 @@ public:
     ~Worker(){
         runnable = nullptr;
     }
+    virtual void clean() {};
 public Q_SLOTS:
     void process();
 Q_SIGNALS:
@@ -45,10 +46,18 @@ public:
         Worker::Worker(runnable, type),
         pctx(std::move(_pctx))
     {}
+    void clean() override
+    {
+        if (pctx) pctx.reset();
+    }
+    void setContext(std::unique_ptr<WalletModel::UnlockContext> _pctx)
+    {
+        clean();
+        pctx = std::move(_pctx);
+    }
 private:
     std::unique_ptr<WalletModel::UnlockContext> pctx{nullptr};
 };
-
 
 class LoadingDialog : public QDialog
 {

--- a/src/qt/pivx/loadingdialog.h
+++ b/src/qt/pivx/loadingdialog.h
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <QTimer>
 #include "qt/pivx/prunnable.h"
+#include "qt/walletmodel.h"
 
 namespace Ui {
 class LoadingDialog;
@@ -34,6 +35,21 @@ private:
     int type;
 };
 
+/*
+ * Worker that keeps track of the wallet unlock context
+ */
+class WalletWorker : public Worker {
+    Q_OBJECT
+public:
+    WalletWorker(Runnable* runnable, int type, std::unique_ptr<WalletModel::UnlockContext> _pctx):
+        Worker::Worker(runnable, type),
+        pctx(std::move(_pctx))
+    {}
+private:
+    std::unique_ptr<WalletModel::UnlockContext> pctx{nullptr};
+};
+
+
 class LoadingDialog : public QDialog
 {
     Q_OBJECT
@@ -42,8 +58,7 @@ public:
     explicit LoadingDialog(QWidget *parent = nullptr);
     ~LoadingDialog();
 
-
-    void execute(Runnable *runnable, int type);
+    void execute(Runnable *runnable, int type, std::unique_ptr<WalletModel::UnlockContext> pctx = nullptr);
 
 public Q_SLOTS:
     void finished();

--- a/src/qt/pivx/masternodeswidget.cpp
+++ b/src/qt/pivx/masternodeswidget.cpp
@@ -5,7 +5,6 @@
 #include "qt/pivx/masternodeswidget.h"
 #include "qt/pivx/forms/ui_masternodeswidget.h"
 
-#include "qt/pivx/loadingdialog.h"
 #include "qt/pivx/qtutils.h"
 #include "qt/pivx/mnrow.h"
 #include "qt/pivx/mninfodialog.h"
@@ -274,10 +273,10 @@ void MasterNodesWidget::onStartAllClicked(int type)
             return;
         }
         isLoading = true;
-        // Action performed on a separate thread
-        LoadingDialog *dialog = new LoadingDialog(window);
-        dialog->execute(this, type, std::move(pctx));
-        openDialogWithOpaqueBackgroundFullScreen(dialog, window);
+        if (!execute(type, std::move(pctx))) {
+            isLoading = false;
+            inform(tr("Cannot perform Mastenodes start"));
+        }
     }
 }
 

--- a/src/qt/pivx/masternodeswidget.h
+++ b/src/qt/pivx/masternodeswidget.h
@@ -5,13 +5,16 @@
 #ifndef MASTERNODESWIDGET_H
 #define MASTERNODESWIDGET_H
 
-#include <QWidget>
 #include "qt/pivx/pwidget.h"
 #include "qt/pivx/furabstractlistitemdelegate.h"
 #include "qt/pivx/mnmodel.h"
 #include "qt/pivx/tooltipmenu.h"
-#include <QTimer>
+#include "walletmodel.h"
+
 #include <atomic>
+
+#include <QTimer>
+#include <QWidget>
 
 class PIVXGUI;
 
@@ -60,6 +63,9 @@ private:
     QTimer *timer = nullptr;
 
     std::atomic<bool> isLoading;
+
+    // pointer to global unlock context (for async unlock/relock)
+    WalletModel::UnlockContext* pctx = nullptr;
 
     bool checkMNsNetwork();
     void startAlias(QString strAlias);

--- a/src/qt/pivx/masternodeswidget.h
+++ b/src/qt/pivx/masternodeswidget.h
@@ -64,9 +64,6 @@ private:
 
     std::atomic<bool> isLoading;
 
-    // pointer to global unlock context (for async unlock/relock)
-    WalletModel::UnlockContext* pctx = nullptr;
-
     bool checkMNsNetwork();
     void startAlias(QString strAlias);
     bool startAll(QString& failedMN, bool onlyMissing);

--- a/src/qt/pivx/pwidget.h
+++ b/src/qt/pivx/pwidget.h
@@ -9,6 +9,7 @@
 #include <QWidget>
 #include <QString>
 #include "qt/pivx/prunnable.h"
+#include "walletmodel.h"
 
 class PIVXGUI;
 class ClientModel;
@@ -63,7 +64,7 @@ protected:
     virtual void loadWalletModel();
 
     void showHideOp(bool show);
-    bool execute(int type);
+    bool execute(int type, std::unique_ptr<WalletModel::UnlockContext> pctx = nullptr);
     void warn(const QString& title, const QString& message);
     bool ask(const QString& title, const QString& message);
     void showDialog(QDialog *dialog, int xDiv = 3, int yDiv = 5);

--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -519,6 +519,7 @@ void TopBar::showUpgradeDialog()
             tr("Upgrading to HD wallet will improve\nthe wallet's reliability and security.\n\n\n"
                     "NOTE: after the upgrade, a new \nbackup will be created.\n"))) {
 
+        if (pctx) delete pctx;
         pctx = new WalletModel::UnlockContext(walletModel->requestUnlock());
         if (!pctx->isValid()) {
             warn(tr("Upgrade Wallet"), tr("Wallet unlock cancelled"));

--- a/src/qt/pivx/topbar.h
+++ b/src/qt/pivx/topbar.h
@@ -82,9 +82,6 @@ private:
     QTimer* timerStakingIcon = nullptr;
     bool isInitializing = true;
 
-    // pointer to global unlock context (for async unlock/relock)
-    WalletModel::UnlockContext* pctx = nullptr;
-
     void updateTorIcon();
 };
 

--- a/src/qt/pivx/topbar.h
+++ b/src/qt/pivx/topbar.h
@@ -82,7 +82,7 @@ private:
     QTimer* timerStakingIcon = nullptr;
     bool isInitializing = true;
 
-    // pointer to global unlock context (for multithread unlock/relock)
+    // pointer to global unlock context (for async unlock/relock)
     WalletModel::UnlockContext* pctx = nullptr;
 
     void updateTorIcon();


### PR DESCRIPTION
**Problem**: startAll fails when the wallet is locked.

**Cause**: startAll is executed as async background task, thus the lock context is lost (and the wallet is re-locked) when the execution gets to `startMN()`

**Fix**: use a global unlock context pointer (as we did with the upgrade to HD flow).