### PR TITLE
[Net] Fix resource leak in ReadBinaryFile

### DIFF
--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -378,8 +378,10 @@ static std::pair<bool,std::string> ReadBinaryFile(const std::string &filename, s
     while ((n=fread(buffer, 1, sizeof(buffer), f)) > 0) {
         // Check for reading errors so we don't return any data if we couldn't
         // read the entire file (or up to maxsize)
-        if (ferror(f))
+        if (ferror(f)) {
+            fclose(f);
             return std::make_pair(false,"");
+        }
         retval.append(buffer, buffer+n);
         if (retval.size() > maxsize)
             break;


### PR DESCRIPTION
Straightforward fix. Coming from upstream [10587](https://github.com/bitcoin/bitcoin/pull/10587)
```
Potential file descriptor leak introduced in commit 0b6f40d via PR #10408 
(submitted 2017-05-16, merged 2017-05-18).
```