### PR TITLE
[Wallet] Fix BIP38 import crashing on empty DecKey

### DIFF
--- a/src/qt/pivx/settings/settingsbittoolwidget.cpp
+++ b/src/qt/pivx/settings/settingsbittoolwidget.cpp
@@ -73,6 +73,7 @@ SettingsBitToolWidget::SettingsBitToolWidget(PIVXGUI* _window, QWidget *parent) 
 
     ui->pushButtonImport->setText(tr("Import Address"));
     setCssProperty(ui->pushButtonImport, "btn-text-primary");
+    ui->pushButtonImport->setVisible(false);
 
     connect(ui->pushLeft, &QPushButton::clicked, [this](){onEncryptSelected(true);});
     connect(ui->pushRight,  &QPushButton::clicked, [this](){onEncryptSelected(false);});
@@ -270,6 +271,7 @@ void SettingsBitToolWidget::onClearDecrypt()
     ui->lineEditKey->clear();
     ui->lineEditDecryptResult->clear();
     ui->lineEditPassphrase->clear();
+    ui->pushButtonImport->setVisible(false);
     key = CKey();
 }
 
@@ -290,6 +292,7 @@ void SettingsBitToolWidget::onDecryptClicked()
     CPubKey pubKey = key.GetPubKey();
     CBitcoinAddress address(pubKey.GetID());
     ui->lineEditDecryptResult->setText(QString::fromStdString(address.ToString()));
+    ui->pushButtonImport->setVisible(true);
 }
 
 void SettingsBitToolWidget::importAddressFromDecKey()


### PR DESCRIPTION
**Problem:** The QT wallet crashes when hitting "Import Address" on the BIP38 Tool Decrypt mode when the "Decrypted address result" is empty.

**Cause:** Without previously decrypting, `key` is empty and `key.IsValid()` is called too late.

**Fix:** Hide `pushButtonImport` until a key has been decrypted, only when a key is decrypted; the "Import Address" button will become visible. Hitting "Clear" will also hide the button again until a new decryption has been done.

**Before decrypting:**
![image](https://user-images.githubusercontent.com/42538664/78463275-c3e50f80-76d2-11ea-89a8-c2006b5cdeae.png)

**After decrypting:**
![image](https://user-images.githubusercontent.com/42538664/78463253-8f715380-76d2-11ea-9731-4388bc50b039.png)