### PR TITLE
[Qt] Convert leftover connects to Qt5 syntax

### DIFF
--- a/src/qt/pivx/loadingdialog.cpp
+++ b/src/qt/pivx/loadingdialog.cpp
@@ -53,11 +53,11 @@ void LoadingDialog::execute(Runnable *runnable, int type){
     QThread* thread = new QThread;
     Worker* worker = new Worker(runnable, type);
     worker->moveToThread(thread);
-    connect(thread, SIGNAL (started()), worker, SLOT (process()));
-    connect(worker, SIGNAL (finished()), thread, SLOT (quit()));
-    connect(worker, SIGNAL (finished()), worker, SLOT (deleteLater()));
-    connect(thread, SIGNAL (finished()), thread, SLOT (deleteLater()));
-    connect(worker, SIGNAL (finished()), this, SLOT (finished()));
+    connect(thread, &QThread::started, worker, &Worker::process);
+    connect(worker, &Worker::finished, thread, &QThread::quit);
+    connect(worker, &Worker::finished, worker, &Worker::deleteLater);
+    connect(thread, &QThread::finished, thread, &QThread::deleteLater);
+    connect(worker, &Worker::finished, this, &LoadingDialog::finished);
     thread->start();
 }
 

--- a/src/qt/pivx/pwidget.cpp
+++ b/src/qt/pivx/pwidget.cpp
@@ -90,7 +90,7 @@ bool PWidget::execute(int type)
 {
     if (task.isNull()) {
         Worker* worker = new Worker(this, type);
-        connect(worker, SIGNAL (error(QString, int)), this, SLOT (errorString(QString, int)));
+        connect(worker, &Worker::error, this, &PWidget::errorString);
 
         WorkerTask* workerTask = new WorkerTask(QPointer<Worker>(worker));
         workerTask->setAutoDelete(false);


### PR DESCRIPTION
#1049 missed a few connects that were using the old SIGNAL/SLOT syntax.
This updates them to the new syntax.