### PR TITLE
[Wallet] Initialize zwalletMain to prevent memory access violations.

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -608,8 +608,8 @@ public:
     std::map<libzerocoin::CoinDenomination, CAmount> GetMyZerocoinDistribution() const;
 
     // zPIV wallet
-    CzPIVWallet* zwalletMain;
-    std::unique_ptr<CzPIVTracker> zpivTracker;
+    CzPIVWallet* zwalletMain{nullptr};
+    std::unique_ptr<CzPIVTracker> zpivTracker{nullptr};
     void setZWallet(CzPIVWallet* zwallet);
     CzPIVWallet* getZWallet();
     bool IsMyZerocoinSpend(const CBigNum& bnSerial) const;


### PR DESCRIPTION
Simple enough, last fix needed for CWallet usage in unit test.

Initializing zwalletMain to null to prevent memory access violations if it's not being set.