### PR TITLE
[GUI] Update MNs count every 40 seconds.

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -50,7 +50,7 @@ ClientModel::ClientModel(OptionsModel* optionsModel, QObject* parent) : QObject(
     pollMnTimer = new QTimer(this);
     connect(pollMnTimer, &QTimer::timeout, this, &ClientModel::updateMnTimer);
     // no need to update as frequent as data for balances/txes/blocks
-    pollMnTimer->start(MODEL_UPDATE_DELAY * 4);
+    pollMnTimer->start(MODEL_UPDATE_DELAY * 40);
 
     subscribeToCoreSignals();
 }


### PR DESCRIPTION
Previously, we were updating the MNs cached count in the GUI every 4 seconds and there is absolutely no need to try to lock the important `cs_main` for a number so rarely used like the masternodes count. 40 seconds looks more like a decent time to check for MNs updates.

Maybe we should discuss in the future if we really want to continue polling for this number. Could move it to a signal but still, it's a rarely used number. Thinking that it would be just fine to update it when the user request it and done.