### PR TITLE
[Trivial] Remove leftover temporary comment

### DIFF
--- a/src/qt/pivx/dashboardwidget.h
+++ b/src/qt/pivx/dashboardwidget.h
@@ -182,7 +182,7 @@ private:
 
 private Q_SLOTS:
     void onChartRefreshed();
-    void onHideChartsChanged(bool fHide); // set as Q_SLOT to be connected with the options model in the next commit
+    void onHideChartsChanged(bool fHide);
 
 #endif
 


### PR DESCRIPTION
Trivial. No functional changes. Removes a temporary comment, leftover from #1475 