### PR TITLE
[BUG] Prevent StartAll from starting mns with immature collateral

### DIFF
--- a/src/qt/pivx/masternodeswidget.cpp
+++ b/src/qt/pivx/masternodeswidget.cpp
@@ -269,7 +269,8 @@ void MasterNodesWidget::onStartAllClicked(int type)
         inform(tr("Cannot perform Mastenodes start, wallet locked"));
         return;
     }
-    if (!checkMNsNetwork()) return;
+    if (!Params().IsRegTestNet() && !checkMNsNetwork()) return;     // skip on RegNet: so we can test even if tier two not synced
+
     if (isLoading) {
         inform(tr("Background task is being executed, please wait"));
     } else {
@@ -291,6 +292,11 @@ bool MasterNodesWidget::startAll(QString& failText, bool onlyMissing)
         if (onlyMissing && !mnModel->isMNInactive(mnAlias)) {
             if (!mnModel->isMNActive(mnAlias))
                 amountOfMnFailed++;
+            continue;
+        }
+
+        if(!mnModel->isMNCollateralMature(mnAlias)) {
+            amountOfMnFailed++;
             continue;
         }
 

--- a/src/qt/pivx/mnmodel.cpp
+++ b/src/qt/pivx/mnmodel.cpp
@@ -174,6 +174,13 @@ bool MNModel::isMNActive(QString mnAlias)
     return activeState == CMasternode::MASTERNODE_PRE_ENABLED || activeState == CMasternode::MASTERNODE_ENABLED;
 }
 
+bool MNModel::isMNCollateralMature(QString mnAlias)
+{
+    QMap<QString, std::pair<QString, CMasternode*>>::const_iterator it = nodes.find(mnAlias);
+    if (it != nodes.end()) return collateralTxAccepted.value(it.value().second->vin.prevout.hash.GetHex());
+    throw std::runtime_error(std::string("Masternode alias not found"));
+}
+
 bool MNModel::isMNsNetworkSynced()
 {
     return masternodeSync.IsSynced();

--- a/src/qt/pivx/mnmodel.h
+++ b/src/qt/pivx/mnmodel.h
@@ -49,6 +49,8 @@ public:
     bool isMNInactive(QString mnAlias);
     // Masternode is active if it's in PRE_ENABLED OR ENABLED state
     bool isMNActive(QString mnAlias);
+    // Masternode collateral has enough confirmations
+    bool isMNCollateralMature(QString mnAlias);
 
 
 private:


### PR DESCRIPTION
Extends the fix of #1389 (point 2) also to `startAll` (not only `startAlias`).

Additional ref: https://github.com/PIVX-Project/PIVX/issues/1226