### PR TITLE
[GUI] Fix text cut-off in sendchangeaddressdialog

### DIFF
--- a/src/qt/pivx/forms/sendchangeaddressdialog.ui
+++ b/src/qt/pivx/forms/sendchangeaddressdialog.ui
@@ -160,7 +160,7 @@
         <property name="minimumSize">
          <size>
           <width>0</width>
-          <height>50</height>
+          <height>70</height>
          </size>
         </property>
         <property name="text">


### PR DESCRIPTION
The text in the Change Address dialog is cut-off, this PR simply increases the minimum height of labelMessage to give the text enough room without clipping.

**Before:**

![image](https://user-images.githubusercontent.com/42538664/78942361-7c36fd00-7ab1-11ea-812b-9fae7df3d6e7.png)

**After:**

![image](https://user-images.githubusercontent.com/42538664/78942432-a38dca00-7ab1-11ea-8c55-898b57b7b207.png)
