### PR TITLE
[GUI] Back port latest MacOS dock icon handler.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -550,7 +550,7 @@ case $host in
      fi
 
      AX_CHECK_LINK_FLAG([[-Wl,-headerpad_max_install_names]], [LDFLAGS="$LDFLAGS -Wl,-headerpad_max_install_names"])
-     CPPFLAGS="$CPPFLAGS -DMAC_OSX"
+     CPPFLAGS="$CPPFLAGS -DMAC_OSX -DOBJC_OLD_DISPATCH_PROTOTYPES=0"
      OBJCXXFLAGS="$CXXFLAGS"
      ;;
    *android*)

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -78,6 +78,14 @@ extern double NSAppKitVersionNumber;
 
 #define URI_SCHEME "pivx"
 
+#if defined(Q_OS_MAC)
+#pragma GCC diagnostic push
+ #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+  #include <objc/objc-runtime.h>
+ #include <CoreServices/CoreServices.h>
+#endif
+
 namespace GUIUtil
 {
 QString dateTimeStr(const QDateTime& date)
@@ -373,6 +381,27 @@ bool checkPoint(const QPoint& p, const QWidget* w)
 bool isObscured(QWidget* w)
 {
     return !(checkPoint(QPoint(0, 0), w) && checkPoint(QPoint(w->width() - 1, 0), w) && checkPoint(QPoint(0, w->height() - 1), w) && checkPoint(QPoint(w->width() - 1, w->height() - 1), w) && checkPoint(QPoint(w->width() / 2, w->height() / 2), w));
+}
+
+void bringToFront(QWidget* w)
+{
+#ifdef Q_OS_MAC
+        // Force application activation on macOS. With Qt 5.4 this is required when
+     // an action in the dock menu is triggered.
+     id app = objc_msgSend((id) objc_getClass("NSApplication"), sel_registerName("sharedApplication"));
+     objc_msgSend(app, sel_registerName("activateIgnoringOtherApps:"), YES);
+#endif
+
+    if (w) {
+        // activateWindow() (sometimes) helps with keyboard focus on Windows
+        if (w->isMinimized()) {
+            w->showNormal();
+        } else {
+            w->show();
+        }
+        w->activateWindow();
+        w->raise();
+    }
 }
 
 bool openDebugLogfile()
@@ -739,12 +768,7 @@ bool SetStartOnSystemStartup(bool fAutoStart)
 
 
 #elif defined(Q_OS_MAC)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 // based on: https://github.com/Mozketo/LaunchAtLoginController/blob/master/LaunchAtLoginController.m
-
-#include <CoreFoundation/CoreFoundation.h>
-#include <CoreServices/CoreServices.h>
 
 LSSharedFileListItemRef findStartupItemInList(LSSharedFileListRef list, CFURLRef findUrl);
 LSSharedFileListItemRef findStartupItemInList(LSSharedFileListRef list, CFURLRef findUrl)

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -80,10 +80,11 @@ extern double NSAppKitVersionNumber;
 
 #if defined(Q_OS_MAC)
 #pragma GCC diagnostic push
- #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
-  #include <objc/objc-runtime.h>
- #include <CoreServices/CoreServices.h>
+#include <CoreServices/CoreServices.h>
+
+void ForceActivation();
 #endif
 
 namespace GUIUtil
@@ -386,10 +387,7 @@ bool isObscured(QWidget* w)
 void bringToFront(QWidget* w)
 {
 #ifdef Q_OS_MAC
-        // Force application activation on macOS. With Qt 5.4 this is required when
-     // an action in the dock menu is triggered.
-     id app = objc_msgSend((id) objc_getClass("NSApplication"), sel_registerName("sharedApplication"));
-     objc_msgSend(app, sel_registerName("activateIgnoringOtherApps:"), YES);
+    ForceActivation();
 #endif
 
     if (w) {

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -127,6 +127,9 @@ QString getOpenFileName(QWidget* parent, const QString& caption, const QString& 
     */
 Qt::ConnectionType blockingGUIThreadConnection();
 
+// Activate, show and raise the widget
+void bringToFront(QWidget* w);
+
 // Determine whether a widget is hidden behind other windows
 bool isObscured(QWidget* w);
 

--- a/src/qt/macdockiconhandler.h
+++ b/src/qt/macdockiconhandler.h
@@ -9,7 +9,6 @@
 #include <QObject>
 
 QT_BEGIN_NAMESPACE
-class QIcon;
 class QMenu;
 class QWidget;
 QT_END_NAMESPACE
@@ -24,7 +23,6 @@ public:
     ~MacDockIconHandler();
 
     QMenu* dockMenu();
-    void setIcon(const QIcon& icon);
     void setMainWindow(QMainWindow* window);
     static MacDockIconHandler* instance();
     static void cleanup();

--- a/src/qt/macdockiconhandler.h
+++ b/src/qt/macdockiconhandler.h
@@ -8,11 +8,6 @@
 #include <QMainWindow>
 #include <QObject>
 
-QT_BEGIN_NAMESPACE
-class QMenu;
-class QWidget;
-QT_END_NAMESPACE
-
 /** Macintosh-specific dock icon handler.
  */
 class MacDockIconHandler : public QObject
@@ -20,9 +15,6 @@ class MacDockIconHandler : public QObject
     Q_OBJECT
 
 public:
-    ~MacDockIconHandler();
-
-    QMenu* dockMenu();
     static MacDockIconHandler* instance();
     static void cleanup();
 
@@ -31,9 +23,6 @@ Q_SIGNALS:
 
 private:
     MacDockIconHandler();
-
-    QWidget* m_dummyWidget;
-    QMenu* m_dockMenu;
 };
 
 #endif // BITCOIN_QT_MACDOCKICONHANDLER_H

--- a/src/qt/macdockiconhandler.h
+++ b/src/qt/macdockiconhandler.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2013 The Bitcoin developers
+// Copyright (c) 2011-2020 The Bitcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -23,10 +23,8 @@ public:
     ~MacDockIconHandler();
 
     QMenu* dockMenu();
-    void setMainWindow(QMainWindow* window);
     static MacDockIconHandler* instance();
     static void cleanup();
-    void handleDockIconClickEvent();
 
 Q_SIGNALS:
     void dockIconClicked();
@@ -36,7 +34,6 @@ private:
 
     QWidget* m_dummyWidget;
     QMenu* m_dockMenu;
-    QMainWindow* mainWindow;
 };
 
 #endif // BITCOIN_QT_MACDOCKICONHANDLER_H

--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -18,25 +18,18 @@ bool dockClickHandler(id self,SEL _cmd,...) {
     Q_UNUSED(self)
     Q_UNUSED(_cmd)
 
-    s_instance->handleDockIconClickEvent();
+    Q_EMIT s_instance->dockIconClicked();
 
-    // Return NO (false) to suppress the default OS X actions
+    // Return NO (false) to suppress the default macOS actions
     return false;
 }
 
 void setupDockClickHandler() {
-    Class cls = objc_getClass("NSApplication");
-    id appInst = objc_msgSend((id)cls, sel_registerName("sharedApplication"));
-
-    if (appInst != NULL) {
-        id delegate = objc_msgSend(appInst, sel_registerName("delegate"));
-        Class delClass = (Class)objc_msgSend(delegate,  sel_registerName("class"));
-        SEL shouldHandle = sel_registerName("applicationShouldHandleReopen:hasVisibleWindows:");
-        if (class_getInstanceMethod(delClass, shouldHandle))
-            class_replaceMethod(delClass, shouldHandle, (IMP)dockClickHandler, "B@:");
-        else
-            class_addMethod(delClass, shouldHandle, (IMP)dockClickHandler,"B@:");
-    }
+    id app = objc_msgSend((id)objc_getClass("NSApplication"), sel_registerName("sharedApplication"));
+    id delegate = objc_msgSend(app, sel_registerName("delegate"));
+    Class delClass = (Class)objc_msgSend(delegate, sel_registerName("class"));
+    SEL shouldHandle = sel_registerName("applicationShouldHandleReopen:hasVisibleWindows:");
+    class_replaceMethod(delClass, shouldHandle, (IMP)dockClickHandler, "B@:");
 }
 
 
@@ -47,19 +40,13 @@ MacDockIconHandler::MacDockIconHandler() : QObject()
     setupDockClickHandler();
     this->m_dummyWidget = new QWidget();
     this->m_dockMenu = new QMenu(this->m_dummyWidget);
-    this->setMainWindow(nullptr);
     this->m_dockMenu->setAsDockMenu();
     [pool release];
-}
-
-void MacDockIconHandler::setMainWindow(QMainWindow *window) {
-    this->mainWindow = window;
 }
 
 MacDockIconHandler::~MacDockIconHandler()
 {
     delete this->m_dummyWidget;
-    this->setMainWindow(NULL);
 }
 
 QMenu *MacDockIconHandler::dockMenu()
@@ -77,15 +64,4 @@ MacDockIconHandler *MacDockIconHandler::instance()
 void MacDockIconHandler::cleanup()
 {
     delete s_instance;
-}
-
-void MacDockIconHandler::handleDockIconClickEvent()
-{
-    if (this->mainWindow)
-    {
-        this->mainWindow->activateWindow();
-        this->mainWindow->show();
-    }
-
-    Q_EMIT this->dockIconClicked();
 }

--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -1,12 +1,11 @@
-// Copyright (c) 2011-2013 The Bitcoin Core developers
+// Copyright (c) 2011-2020 The Bitcoin Core developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "macdockiconhandler.h"
 
-#undef slots
-#include <objc/objc.h>
-#include <objc/message.h>
+#include <AppKit/AppKit.h>
+#include <objc/runtime.h>
 
 static MacDockIconHandler *s_instance = nullptr;
 
@@ -21,9 +20,7 @@ bool dockClickHandler(id self, SEL _cmd, ...) {
 }
 
 void setupDockClickHandler() {
-    id app = objc_msgSend((id)objc_getClass("NSApplication"), sel_registerName("sharedApplication"));
-    id delegate = objc_msgSend(app, sel_registerName("delegate"));
-    Class delClass = (Class)objc_msgSend(delegate, sel_registerName("class"));
+    Class delClass = (Class)[[[NSApplication sharedApplication] delegate] class];
     SEL shouldHandle = sel_registerName("applicationShouldHandleReopen:hasVisibleWindows:");
     class_replaceMethod(delClass, shouldHandle, (IMP)dockClickHandler, "B@:");
 }
@@ -43,4 +40,14 @@ MacDockIconHandler *MacDockIconHandler::instance()
 void MacDockIconHandler::cleanup()
 {
     delete s_instance;
+}
+
+/**
+* Force application activation on macOS. With Qt 5.5.1 this is required when
+* an action in the Dock menu is triggered.
+* TODO: Define a Qt version where it's no-longer necessary.
+*/
+void ForceActivation()
+{
+    [[NSApplication sharedApplication] activateIgnoringOtherApps:YES];
 }

--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -4,17 +4,13 @@
 
 #include "macdockiconhandler.h"
 
-#include <QMenu>
-#include <QWidget>
-
 #undef slots
-#include <Cocoa/Cocoa.h>
 #include <objc/objc.h>
 #include <objc/message.h>
 
 static MacDockIconHandler *s_instance = nullptr;
 
-bool dockClickHandler(id self,SEL _cmd,...) {
+bool dockClickHandler(id self, SEL _cmd, ...) {
     Q_UNUSED(self)
     Q_UNUSED(_cmd)
 
@@ -32,26 +28,9 @@ void setupDockClickHandler() {
     class_replaceMethod(delClass, shouldHandle, (IMP)dockClickHandler, "B@:");
 }
 
-
 MacDockIconHandler::MacDockIconHandler() : QObject()
 {
-    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-
     setupDockClickHandler();
-    this->m_dummyWidget = new QWidget();
-    this->m_dockMenu = new QMenu(this->m_dummyWidget);
-    this->m_dockMenu->setAsDockMenu();
-    [pool release];
-}
-
-MacDockIconHandler::~MacDockIconHandler()
-{
-    delete this->m_dummyWidget;
-}
-
-QMenu *MacDockIconHandler::dockMenu()
-{
-    return this->m_dockMenu;
 }
 
 MacDockIconHandler *MacDockIconHandler::instance()

--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -4,9 +4,7 @@
 
 #include "macdockiconhandler.h"
 
-#include <QImageWriter>
 #include <QMenu>
-#include <QBuffer>
 #include <QWidget>
 
 #undef slots
@@ -67,39 +65,6 @@ MacDockIconHandler::~MacDockIconHandler()
 QMenu *MacDockIconHandler::dockMenu()
 {
     return this->m_dockMenu;
-}
-
-void MacDockIconHandler::setIcon(const QIcon &icon)
-{
-    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-    NSImage *image = nil;
-    if (icon.isNull())
-        image = [[NSImage imageNamed:@"NSApplicationIcon"] retain];
-    else {
-        // generate NSImage from QIcon and use this as dock icon.
-        QSize size = icon.actualSize(QSize(128, 128));
-        QPixmap pixmap = icon.pixmap(size);
-
-        // Write image into a R/W buffer from raw pixmap, then save the image.
-        QBuffer notificationBuffer;
-        if (!pixmap.isNull() && notificationBuffer.open(QIODevice::ReadWrite)) {
-            QImageWriter writer(&notificationBuffer, "PNG");
-            if (writer.write(pixmap.toImage())) {
-                NSData* macImgData = [NSData dataWithBytes:notificationBuffer.buffer().data()
-                                             length:notificationBuffer.buffer().size()];
-                image =  [[NSImage alloc] initWithData:macImgData];
-            }
-        }
-
-        if(!image) {
-            // if testnet image could not be created, load std. app icon
-            image = [[NSImage imageNamed:@"NSApplicationIcon"] retain];
-        }
-    }
-
-    [NSApp setApplicationIconImage:image];
-    [image release];
-    [pool release];
 }
 
 MacDockIconHandler *MacDockIconHandler::instance()

--- a/src/qt/pivx/pivxgui.cpp
+++ b/src/qt/pivx/pivxgui.cpp
@@ -439,18 +439,11 @@ bool PIVXGUI::openStandardDialog(QString title, QString body, QString okBtn, QSt
 void PIVXGUI::showNormalIfMinimized(bool fToggleHidden) {
     if (!clientModel)
         return;
-    // activateWindow() (sometimes) helps with keyboard focus on Windows
-    if (isHidden()) {
-        show();
-        activateWindow();
-    } else if (isMinimized()) {
-        showNormal();
-        activateWindow();
-    } else if (GUIUtil::isObscured(this)) {
-        raise();
-        activateWindow();
-    } else if (fToggleHidden)
+    if (!isHidden() && !isMinimized() && !GUIUtil::isObscured(this) && fToggleHidden) {
         hide();
+    } else {
+        GUIUtil::bringToFront(this);
+    }
 }
 
 void PIVXGUI::toggleHidden() {

--- a/src/qt/pivx/pivxgui.cpp
+++ b/src/qt/pivx/pivxgui.cpp
@@ -71,12 +71,8 @@ PIVXGUI::PIVXGUI(const NetworkStyle* networkStyle, QWidget* parent) :
     windowTitle += " " + networkStyle->getTitleAddText();
     setWindowTitle(windowTitle);
 
-#ifndef Q_OS_MAC
     QApplication::setWindowIcon(networkStyle->getAppIcon());
     setWindowIcon(networkStyle->getAppIcon());
-#else
-    MacDockIconHandler::instance()->setIcon(networkStyle->getAppIcon());
-#endif
 
 #ifdef ENABLE_WALLET
     // Create wallet frame

--- a/src/qt/pivx/pivxgui.cpp
+++ b/src/qt/pivx/pivxgui.cpp
@@ -288,7 +288,9 @@ void PIVXGUI::createTrayIconMenu() {
     // Note: On macOS, the Dock icon is used to provide the tray's functionality.
     MacDockIconHandler* dockIconHandler = MacDockIconHandler::instance();
     connect(dockIconHandler, &MacDockIconHandler::dockIconClicked, this, &PIVXGUI::macosDockIconActivated);
-    trayIconMenu = dockIconHandler->dockMenu();
+
+    trayIconMenu = new QMenu(this);
+    trayIconMenu->setAsDockMenu();
 #endif
 
     // Configuration of the tray icon (or Dock icon) icon menu

--- a/src/qt/pivx/pivxgui.cpp
+++ b/src/qt/pivx/pivxgui.cpp
@@ -276,7 +276,7 @@ void PIVXGUI::setClientModel(ClientModel* clientModel) {
 
 void PIVXGUI::createTrayIconMenu() {
 #ifndef Q_OS_MAC
-    // return if trayIcon is unset (only on non-Mac OSes)
+    // return if trayIcon is unset (only on non-macOSes)
     if (!trayIcon)
         return;
 
@@ -285,17 +285,17 @@ void PIVXGUI::createTrayIconMenu() {
 
     connect(trayIcon, &QSystemTrayIcon::activated, this, &PIVXGUI::trayIconActivated);
 #else
-    // Note: On Mac, the dock icon is used to provide the tray's functionality.
+    // Note: On macOS, the Dock icon is used to provide the tray's functionality.
     MacDockIconHandler* dockIconHandler = MacDockIconHandler::instance();
-    dockIconHandler->setMainWindow((QMainWindow*)this);
+    connect(dockIconHandler, &MacDockIconHandler::dockIconClicked, this, &PIVXGUI::macosDockIconActivated);
     trayIconMenu = dockIconHandler->dockMenu();
 #endif
 
-    // Configuration of the tray icon (or dock icon) icon menu
+    // Configuration of the tray icon (or Dock icon) icon menu
     trayIconMenu->addAction(toggleHideAction);
     trayIconMenu->addSeparator();
 
-#ifndef Q_OS_MAC // This is built-in on Mac
+#ifndef Q_OS_MAC // This is built-in on macOS
     trayIconMenu->addSeparator();
     trayIconMenu->addAction(quitAction);
 #endif
@@ -309,6 +309,12 @@ void PIVXGUI::trayIconActivated(QSystemTrayIcon::ActivationReason reason)
         toggleHidden();
     }
 }
+#else
+void PIVXGUI::macosDockIconActivated()
+ {
+     show();
+     activateWindow();
+ }
 #endif
 
 void PIVXGUI::changeEvent(QEvent* e)

--- a/src/qt/pivx/pivxgui.h
+++ b/src/qt/pivx/pivxgui.h
@@ -176,6 +176,9 @@ private Q_SLOTS:
 #ifndef Q_OS_MAC
     /** Handle tray icon clicked */
     void trayIconActivated(QSystemTrayIcon::ActivationReason reason);
+#else
+    /** Handle macOS Dock icon clicked */
+     void macosDockIconActivated();
 #endif
 
 Q_SIGNALS:


### PR DESCRIPTION
Updating `MacDockIconHandler` to latest upstream. Fixing #1512 .

Back ported PRs:

#### gui: Add GUIUtil::bringToFront [14123](https://github.com/bitcoin/bitcoin/pull/14123):
```
The sequence show -> raise -> activateWindow is factored out to the new function GUIUtil::bringToFront where a macOS fix is added in order to fix #13829.

Also included:

simplification of BitcoinGUI::showNormalIfMinimized
```

#### qt: Replace objc_msgSend() function calls with the native Objective-C syntax [16720](https://github.com/bitcoin/bitcoin/pull/16720):

```
Changes in Xcode 11 Objective-C Runtime cause an error (#16387) during building on MacOS 10.15 Catalina.

This PR fixes this issue by replacing objc_msgSend() function calls with the native Objective-C syntax.

Refs:

changes in objc_msgSend function
OBJC_OLD_DISPATCH_PROTOTYPES macro
```
