### PR TITLE
Shutdown: remove PID file at the very end.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -263,6 +263,9 @@ void PrepareShutdown()
     }
 #endif
 
+    // Disconnect all slots
+    UnregisterAllValidationInterfaces();
+
 #ifndef WIN32
     try {
         boost::filesystem::remove(GetPidFile());
@@ -270,7 +273,6 @@ void PrepareShutdown()
         LogPrintf("%s: Unable to remove pidfile: %s\n", __func__, e.what());
     }
 #endif
-    UnregisterAllValidationInterfaces();
 }
 
 /**


### PR DESCRIPTION
Trivial change, remove the PID file once the shutdown process is completed.