### PR TITLE
[Qt] Fixup filter dropdown localizations

### DIFF
--- a/src/qt/pivx/qtutils.cpp
+++ b/src/qt/pivx/qtutils.cpp
@@ -4,24 +4,25 @@
 
 #include "qt/pivx/qtutils.h"
 
-#include "qt/pivx/snackbar.h"
-#include "qrencode.h"
 #include "guiconstants.h"
+#include "qrencode.h"
+#include "qt/pivx/snackbar.h"
 
 #include <QFile>
-#include <QStyle>
-#include <QListView>
 #include <QGraphicsDropShadowEffect>
+#include <QListView>
+#include <QStyle>
 
 Qt::Modifier SHORT_KEY
 #ifdef Q_OS_MAC
-        = Qt::CTRL;
+    = Qt::CTRL;
 #else
-        = Qt::ALT;
+    = Qt::ALT;
 #endif
 
 // Open dialog at the bottom
-bool openDialog(QDialog *widget, QWidget *gui){
+bool openDialog(QDialog* widget, QWidget* gui)
+{
     widget->setWindowFlags(Qt::CustomizeWindowHint);
     widget->setAttribute(Qt::WA_TranslucentBackground, true);
     QPropertyAnimation* animation = new QPropertyAnimation(widget, "pos");
@@ -35,7 +36,8 @@ bool openDialog(QDialog *widget, QWidget *gui){
     return widget->exec();
 }
 
-void closeDialog(QDialog *widget, PIVXGUI *gui){
+void closeDialog(QDialog* widget, PIVXGUI* gui)
+{
     widget->setWindowFlags(Qt::CustomizeWindowHint);
     widget->setAttribute(Qt::WA_TranslucentBackground, true);
     QPropertyAnimation* animation = new QPropertyAnimation(widget, "pos");
@@ -46,22 +48,24 @@ void closeDialog(QDialog *widget, PIVXGUI *gui){
     animation->start(QAbstractAnimation::DeleteWhenStopped);
 }
 
-void openDialogFullScreen(QWidget *parent, QWidget * dialog){
+void openDialogFullScreen(QWidget* parent, QWidget* dialog)
+{
     dialog->setWindowFlags(Qt::CustomizeWindowHint);
     dialog->move(0, 0);
     dialog->show();
     dialog->activateWindow();
-    dialog->resize(parent->width(),parent->height());
+    dialog->resize(parent->width(), parent->height());
 }
 
-bool openDialogWithOpaqueBackgroundY(QDialog *widget, PIVXGUI *gui, double posX, int posY){
+bool openDialogWithOpaqueBackgroundY(QDialog* widget, PIVXGUI* gui, double posX, int posY)
+{
     widget->setWindowFlags(Qt::CustomizeWindowHint);
     widget->setAttribute(Qt::WA_TranslucentBackground, true);
     QPropertyAnimation* animation = new QPropertyAnimation(widget, "pos");
     animation->setDuration(300);
-    int xPos = gui->width() / posX ;
+    int xPos = gui->width() / posX;
     animation->setStartValue(QPoint(xPos, gui->height()));
-    animation->setEndValue(QPoint(xPos, gui->height() / posY));//- (gui->height()) / posY  ));
+    animation->setEndValue(QPoint(xPos, gui->height() / posY)); //- (gui->height()) / posY  ));
     animation->setEasingCurve(QEasingCurve::OutQuad);
     animation->start(QAbstractAnimation::DeleteWhenStopped);
     widget->activateWindow();
@@ -70,16 +74,18 @@ bool openDialogWithOpaqueBackgroundY(QDialog *widget, PIVXGUI *gui, double posX,
     return res;
 }
 
-bool openDialogWithOpaqueBackground(QDialog *widget, PIVXGUI *gui, double posX){
+bool openDialogWithOpaqueBackground(QDialog* widget, PIVXGUI* gui, double posX)
+{
     return openDialogWithOpaqueBackgroundY(widget, gui, posX, 5);
 }
 
-bool openDialogWithOpaqueBackgroundFullScreen(QDialog *widget, PIVXGUI *gui){
+bool openDialogWithOpaqueBackgroundFullScreen(QDialog* widget, PIVXGUI* gui)
+{
     widget->setWindowFlags(Qt::CustomizeWindowHint);
     widget->setAttribute(Qt::WA_TranslucentBackground, true);
 
     widget->activateWindow();
-    widget->resize(gui->width(),gui->height());
+    widget->resize(gui->width(), gui->height());
 
     QPropertyAnimation* animation = new QPropertyAnimation(widget, "pos");
     animation->setDuration(300);
@@ -94,7 +100,8 @@ bool openDialogWithOpaqueBackgroundFullScreen(QDialog *widget, PIVXGUI *gui){
     return res;
 }
 
-QPixmap encodeToQr(QString str, QString &errorStr, QColor qrColor){
+QPixmap encodeToQr(QString str, QString& errorStr, QColor qrColor)
+{
     if (!str.isEmpty()) {
         // limit URI length
         if (str.length() > MAX_URI_LENGTH) {
@@ -122,7 +129,8 @@ QPixmap encodeToQr(QString str, QString &errorStr, QColor qrColor){
     return QPixmap();
 }
 
-void setFilterAddressBook(QComboBox* filter, SortEdit* lineEdit) {
+void setFilterAddressBook(QComboBox* filter, SortEdit* lineEdit)
+{
     initComboBox(filter, lineEdit);
     filter->addItem("All", "");
     filter->addItem("Receiving", AddressTableModel::Receive);
@@ -132,7 +140,8 @@ void setFilterAddressBook(QComboBox* filter, SortEdit* lineEdit) {
     filter->addItem("Staking Contacts", AddressTableModel::ColdStakingSend);
 }
 
-void setSortTx(QComboBox* filter, SortEdit* lineEdit) {
+void setSortTx(QComboBox* filter, SortEdit* lineEdit)
+{
     // Sort Transactions
     initComboBox(filter, lineEdit);
     filter->addItem("Date desc", SortTx::DATE_DESC);
@@ -141,7 +150,8 @@ void setSortTx(QComboBox* filter, SortEdit* lineEdit) {
     filter->addItem("Amount asc", SortTx::AMOUNT_DESC);
 }
 
-void setSortTxTypeFilter(QComboBox* filter, SortEdit* lineEditType) {
+void setSortTxTypeFilter(QComboBox* filter, SortEdit* lineEditType)
+{
     initComboBox(filter, lineEditType);
     filter->addItem(filter->tr("All"), TransactionFilterProxy::ALL_TYPES);
     filter->addItem(filter->tr("Received"), TransactionFilterProxy::TYPE(TransactionRecord::RecvWithAddress) | TransactionFilterProxy::TYPE(TransactionRecord::RecvFromOther));
@@ -156,16 +166,18 @@ void setSortTxTypeFilter(QComboBox* filter, SortEdit* lineEditType) {
     filter->addItem(filter->tr("Delegations"), TransactionFilterProxy::TYPE(TransactionRecord::P2CSDelegation));
 }
 
-void setupSettings(QSettings *settings){
-    if(!settings->contains("lightTheme")){
+void setupSettings(QSettings* settings)
+{
+    if (!settings->contains("lightTheme")) {
         settings->setValue("lightTheme", true);
     }
 }
 
-QSettings *settings = nullptr;
+QSettings* settings = nullptr;
 
-QSettings* getSettings(){
-    if(!settings){
+QSettings* getSettings()
+{
+    if (!settings) {
         settings = new QSettings();
         // Setup initial values if them are not there
         setupSettings(settings);
@@ -174,12 +186,14 @@ QSettings* getSettings(){
     return settings;
 }
 
-bool isLightTheme(){
+bool isLightTheme()
+{
     return getSettings()->value("lightTheme", true).toBool();
 }
 
-void setTheme(bool isLight){
-    QSettings* settings =  getSettings();
+void setTheme(bool isLight)
+{
+    QSettings* settings = getSettings();
     settings->setValue("theme", isLight ? "default" : "default-dark");
     settings->setValue("lightTheme", isLight);
 }
@@ -187,28 +201,30 @@ void setTheme(bool isLight){
 
 // Style
 
-void updateStyle(QWidget* widget){
+void updateStyle(QWidget* widget)
+{
     widget->style()->unpolish(widget);
     widget->style()->polish(widget);
     widget->update();
 }
 
 
-QColor getRowColor(bool isLightTheme, bool isHovered, bool isSelected){
-    if(isLightTheme){
+QColor getRowColor(bool isLightTheme, bool isHovered, bool isSelected)
+{
+    if (isLightTheme) {
         if (isSelected) {
             return QColor("#25b088ff");
-        }else if(isHovered){
+        } else if (isHovered) {
             return QColor("#25bababa");
-        } else{
+        } else {
             return QColor("#ffffff");
         }
-    }else{
+    } else {
         if (isSelected) {
             return QColor("#25b088ff");
-        }else if(isHovered){
+        } else if (isHovered) {
             return QColor("#25bababa");
-        } else{
+        } else {
             return QColor("#0f0b16");
         }
     }
@@ -242,22 +258,28 @@ void fillAddressSortControls(SortEdit* seType, SortEdit* seOrder, QComboBox* box
     boxOrder->setCurrentIndex(0);
 }
 
-void initCssEditLine(QLineEdit *edit, bool isDialog){
-    if (isDialog) setCssEditLineDialog(edit, true, false);
-    else setCssEditLine(edit, true, false);
+void initCssEditLine(QLineEdit* edit, bool isDialog)
+{
+    if (isDialog)
+        setCssEditLineDialog(edit, true, false);
+    else
+        setCssEditLine(edit, true, false);
     setShadow(edit);
     edit->setAttribute(Qt::WA_MacShowFocusRect, 0);
 }
 
-void setCssEditLine(QLineEdit *edit, bool isValid, bool forceUpdate){
+void setCssEditLine(QLineEdit* edit, bool isValid, bool forceUpdate)
+{
     setCssProperty(edit, isValid ? "edit-primary" : "edit-primary-error", forceUpdate);
 }
 
-void setCssEditLineDialog(QLineEdit *edit, bool isValid, bool forceUpdate){
+void setCssEditLineDialog(QLineEdit* edit, bool isValid, bool forceUpdate)
+{
     setCssProperty(edit, isValid ? "edit-primary-dialog" : "edit-primary-dialog-error", forceUpdate);
 }
 
-void setShadow(QWidget *edit){
+void setShadow(QWidget* edit)
+{
     QGraphicsDropShadowEffect* shadowEffect = new QGraphicsDropShadowEffect();
     shadowEffect->setColor(QColor(0, 0, 0, 22));
     shadowEffect->setXOffset(0);
@@ -266,44 +288,60 @@ void setShadow(QWidget *edit){
     edit->setGraphicsEffect(shadowEffect);
 }
 
-void setCssBtnPrimary(QPushButton *btn, bool forceUpdate){
+void setCssBtnPrimary(QPushButton* btn, bool forceUpdate)
+{
     setCssProperty(btn, "btn-primary", forceUpdate);
 }
 
-void setCssBtnSecondary(QPushButton *btn, bool forceUpdate){
+void setCssBtnSecondary(QPushButton* btn, bool forceUpdate)
+{
     setCssProperty(btn, "btn-secundary", forceUpdate);
 }
 
-void setCssTextBodyDialog(std::initializer_list<QWidget*> args){
-    Q_FOREACH (QWidget* w, args) { setCssTextBodyDialog(w); }
+void setCssTextBodyDialog(std::initializer_list<QWidget*> args)
+{
+    Q_FOREACH (QWidget* w, args) {
+        setCssTextBodyDialog(w);
+    }
 }
 
-void setCssTextBodyDialog(QWidget* widget) {
+void setCssTextBodyDialog(QWidget* widget)
+{
     setCssProperty(widget, "text-body1-dialog", false);
 }
 
-void setCssTitleScreen(QLabel* label) {
+void setCssTitleScreen(QLabel* label)
+{
     setCssProperty(label, "text-title-screen", false);
 }
 
-void setCssSubtitleScreen(QWidget* wid) {
+void setCssSubtitleScreen(QWidget* wid)
+{
     setCssProperty(wid, "text-subtitle", false);
 }
 
-void setCssProperty(std::initializer_list<QWidget*> args, QString value){
-    Q_FOREACH (QWidget* w, args) { setCssProperty(w, value); }
+void setCssProperty(std::initializer_list<QWidget*> args, QString value)
+{
+    Q_FOREACH (QWidget* w, args) {
+        setCssProperty(w, value);
+    }
 }
 
-void setCssProperty(QWidget *wid, QString value, bool forceUpdate){
+void setCssProperty(QWidget* wid, QString value, bool forceUpdate)
+{
     wid->setProperty("cssClass", value);
     forceUpdateStyle(wid, forceUpdate);
 }
 
-void forceUpdateStyle(QWidget *widget, bool forceUpdate){
-    if(forceUpdate)
+void forceUpdateStyle(QWidget* widget, bool forceUpdate)
+{
+    if (forceUpdate)
         updateStyle(widget);
 }
 
-void forceUpdateStyle(std::initializer_list<QWidget*> args){
-    Q_FOREACH (QWidget* w, args) { forceUpdateStyle(w, true); }
+void forceUpdateStyle(std::initializer_list<QWidget*> args)
+{
+    Q_FOREACH (QWidget* w, args) {
+        forceUpdateStyle(w, true);
+    }
 }

--- a/src/qt/pivx/qtutils.cpp
+++ b/src/qt/pivx/qtutils.cpp
@@ -153,17 +153,17 @@ void setSortTx(QComboBox* filter, SortEdit* lineEdit)
 void setSortTxTypeFilter(QComboBox* filter, SortEdit* lineEditType)
 {
     initComboBox(filter, lineEditType);
-    filter->addItem(filter->tr("All"), TransactionFilterProxy::ALL_TYPES);
-    filter->addItem(filter->tr("Received"), TransactionFilterProxy::TYPE(TransactionRecord::RecvWithAddress) | TransactionFilterProxy::TYPE(TransactionRecord::RecvFromOther));
-    filter->addItem(filter->tr("Sent"), TransactionFilterProxy::TYPE(TransactionRecord::SendToAddress) | TransactionFilterProxy::TYPE(TransactionRecord::SendToOther));
-    filter->addItem(filter->tr("Mined"), TransactionFilterProxy::TYPE(TransactionRecord::Generated));
-    filter->addItem(filter->tr("Minted"), TransactionFilterProxy::TYPE(TransactionRecord::StakeMint));
-    filter->addItem(filter->tr("MN reward"), TransactionFilterProxy::TYPE(TransactionRecord::MNReward));
-    filter->addItem(filter->tr("To yourself"), TransactionFilterProxy::TYPE(TransactionRecord::SendToSelf));
-    filter->addItem(filter->tr("Cold stakes"), TransactionFilterProxy::TYPE(TransactionRecord::StakeDelegated));
-    filter->addItem(filter->tr("Hot stakes"), TransactionFilterProxy::TYPE(TransactionRecord::StakeHot));
-    filter->addItem(filter->tr("Delegated"), TransactionFilterProxy::TYPE(TransactionRecord::P2CSDelegationSent) | TransactionFilterProxy::TYPE(TransactionRecord::P2CSDelegationSentOwner));
-    filter->addItem(filter->tr("Delegations"), TransactionFilterProxy::TYPE(TransactionRecord::P2CSDelegation));
+    filter->addItem(QObject::tr("All"), TransactionFilterProxy::ALL_TYPES);
+    filter->addItem(QObject::tr("Received"), TransactionFilterProxy::TYPE(TransactionRecord::RecvWithAddress) | TransactionFilterProxy::TYPE(TransactionRecord::RecvFromOther));
+    filter->addItem(QObject::tr("Sent"), TransactionFilterProxy::TYPE(TransactionRecord::SendToAddress) | TransactionFilterProxy::TYPE(TransactionRecord::SendToOther));
+    filter->addItem(QObject::tr("Mined"), TransactionFilterProxy::TYPE(TransactionRecord::Generated));
+    filter->addItem(QObject::tr("Minted"), TransactionFilterProxy::TYPE(TransactionRecord::StakeMint));
+    filter->addItem(QObject::tr("MN reward"), TransactionFilterProxy::TYPE(TransactionRecord::MNReward));
+    filter->addItem(QObject::tr("To yourself"), TransactionFilterProxy::TYPE(TransactionRecord::SendToSelf));
+    filter->addItem(QObject::tr("Cold stakes"), TransactionFilterProxy::TYPE(TransactionRecord::StakeDelegated));
+    filter->addItem(QObject::tr("Hot stakes"), TransactionFilterProxy::TYPE(TransactionRecord::StakeHot));
+    filter->addItem(QObject::tr("Delegated"), TransactionFilterProxy::TYPE(TransactionRecord::P2CSDelegationSent) | TransactionFilterProxy::TYPE(TransactionRecord::P2CSDelegationSentOwner));
+    filter->addItem(QObject::tr("Delegations"), TransactionFilterProxy::TYPE(TransactionRecord::P2CSDelegation));
 }
 
 void setupSettings(QSettings* settings)

--- a/src/qt/pivx/qtutils.cpp
+++ b/src/qt/pivx/qtutils.cpp
@@ -132,22 +132,22 @@ QPixmap encodeToQr(QString str, QString& errorStr, QColor qrColor)
 void setFilterAddressBook(QComboBox* filter, SortEdit* lineEdit)
 {
     initComboBox(filter, lineEdit);
-    filter->addItem("All", "");
-    filter->addItem("Receiving", AddressTableModel::Receive);
-    filter->addItem("Contacts", AddressTableModel::Send);
-    filter->addItem("Cold Staking", AddressTableModel::ColdStaking);
-    filter->addItem("Delegators", AddressTableModel::Delegators);
-    filter->addItem("Staking Contacts", AddressTableModel::ColdStakingSend);
+    filter->addItem(QObject::tr("All"), "");
+    filter->addItem(QObject::tr("Receiving"), AddressTableModel::Receive);
+    filter->addItem(QObject::tr("Contacts"), AddressTableModel::Send);
+    filter->addItem(QObject::tr("Cold Staking"), AddressTableModel::ColdStaking);
+    filter->addItem(QObject::tr("Delegators"), AddressTableModel::Delegators);
+    filter->addItem(QObject::tr("Staking Contacts"), AddressTableModel::ColdStakingSend);
 }
 
 void setSortTx(QComboBox* filter, SortEdit* lineEdit)
 {
     // Sort Transactions
     initComboBox(filter, lineEdit);
-    filter->addItem("Date desc", SortTx::DATE_DESC);
-    filter->addItem("Date asc", SortTx::DATE_ASC);
-    filter->addItem("Amount desc", SortTx::AMOUNT_ASC);
-    filter->addItem("Amount asc", SortTx::AMOUNT_DESC);
+    filter->addItem(QObject::tr("Date desc"), SortTx::DATE_DESC);
+    filter->addItem(QObject::tr("Date asc"), SortTx::DATE_ASC);
+    filter->addItem(QObject::tr("Amount desc"), SortTx::AMOUNT_ASC);
+    filter->addItem(QObject::tr("Amount asc"), SortTx::AMOUNT_DESC);
 }
 
 void setSortTxTypeFilter(QComboBox* filter, SortEdit* lineEditType)

--- a/src/qt/pivx/qtutils.h
+++ b/src/qt/pivx/qtutils.h
@@ -5,19 +5,21 @@
 #ifndef QTUTILS_H
 #define QTUTILS_H
 
-#include <QWidget>
-#include <QDialog>
-#include <QPropertyAnimation>
+#include "qt/pivx/pivxgui.h"
+
 #include <QAbstractAnimation>
-#include <QPoint>
-#include <QString>
 #include <QColor>
 #include <QComboBox>
-#include <QSettings>
+#include <QDialog>
 #include <QPixmap>
+#include <QPoint>
+#include <QPropertyAnimation>
+#include <QSettings>
 #include <QStandardPaths>
+#include <QString>
+#include <QWidget>
+
 #include <initializer_list>
-#include "qt/pivx/pivxgui.h"
 
 // Repair parameters
 const QString SALVAGEWALLET("-salvagewallet");
@@ -30,15 +32,15 @@ const QString RESYNC("-resync");
 
 extern Qt::Modifier SHORT_KEY;
 
-bool openDialog(QDialog *widget, QWidget *gui);
-void closeDialog(QDialog *widget, PIVXGUI *gui);
-void openDialogFullScreen(QWidget *parent, QWidget * dialog);
-bool openDialogWithOpaqueBackgroundY(QDialog *widget, PIVXGUI *gui, double posX = 3, int posY = 5);
-bool openDialogWithOpaqueBackground(QDialog *widget, PIVXGUI *gui, double posX = 3);
-bool openDialogWithOpaqueBackgroundFullScreen(QDialog *widget, PIVXGUI *gui);
+bool openDialog(QDialog* widget, QWidget* gui);
+void closeDialog(QDialog* widget, PIVXGUI* gui);
+void openDialogFullScreen(QWidget* parent, QWidget* dialog);
+bool openDialogWithOpaqueBackgroundY(QDialog* widget, PIVXGUI* gui, double posX = 3, int posY = 5);
+bool openDialogWithOpaqueBackground(QDialog* widget, PIVXGUI* gui, double posX = 3);
+bool openDialogWithOpaqueBackgroundFullScreen(QDialog* widget, PIVXGUI* gui);
 
 //
-QPixmap encodeToQr(QString str, QString &errorStr, QColor qrColor = Qt::black);
+QPixmap encodeToQr(QString str, QString& errorStr, QColor qrColor = Qt::black);
 
 // Helpers
 void updateStyle(QWidget* widget);
@@ -51,27 +53,27 @@ void setSortTxTypeFilter(QComboBox* filter, SortEdit* lineEdit);
 
 // Settings
 QSettings* getSettings();
-void setupSettings(QSettings *settings);
+void setupSettings(QSettings* settings);
 
 bool isLightTheme();
 void setTheme(bool isLight);
 
 void initComboBox(QComboBox* combo, QLineEdit* lineEdit = nullptr, QString cssClass = "btn-combo");
 void fillAddressSortControls(SortEdit* seType, SortEdit* seOrder, QComboBox* boxType, QComboBox* boxOrder);
-void initCssEditLine(QLineEdit *edit, bool isDialog = false);
-void setCssEditLine(QLineEdit *edit, bool isValid, bool forceUpdate = false);
-void setCssEditLineDialog(QLineEdit *edit, bool isValid, bool forceUpdate = false);
-void setShadow(QWidget *edit);
+void initCssEditLine(QLineEdit* edit, bool isDialog = false);
+void setCssEditLine(QLineEdit* edit, bool isValid, bool forceUpdate = false);
+void setCssEditLineDialog(QLineEdit* edit, bool isValid, bool forceUpdate = false);
+void setShadow(QWidget* edit);
 
-void setCssBtnPrimary(QPushButton *btn, bool forceUpdate = false);
-void setCssBtnSecondary(QPushButton *btn, bool forceUpdate = false);
+void setCssBtnPrimary(QPushButton* btn, bool forceUpdate = false);
+void setCssBtnSecondary(QPushButton* btn, bool forceUpdate = false);
 void setCssTitleScreen(QLabel* label);
 void setCssSubtitleScreen(QWidget* wid);
 void setCssTextBodyDialog(std::initializer_list<QWidget*> args);
 void setCssTextBodyDialog(QWidget* widget);
 void setCssProperty(std::initializer_list<QWidget*> args, QString value);
-void setCssProperty(QWidget *wid, QString value, bool forceUpdate = false);
-void forceUpdateStyle(QWidget *widget, bool forceUpdate);
+void setCssProperty(QWidget* wid, QString value, bool forceUpdate = false);
+void forceUpdateStyle(QWidget* widget, bool forceUpdate);
 void forceUpdateStyle(std::initializer_list<QWidget*> args);
 
 #endif // QTUTILS_H


### PR DESCRIPTION
The address type filter dropdown items and the sorting method dropdown items weren't available for localization.

Additionally, the transaction type filter dropdown items were using a call method that isn't supported by Qt's linquist utility program (which we use to generate the updated localization source file as part of `make translate`).

Finally, the file was not in compliance with our coding style guidelines, so the first commit is a reformat-only commit which can be duplicated by running the following command on `master`:
```bash
clang-format -i src/qt/pivx/qtutils.*
```
(minor blank-line changes were made afterwards in the header include section of `qtutils.h`)