### PR TITLE
[Trivial] [GUI] Fix masternodeswidget snackbar typos

### DIFF
--- a/src/qt/pivx/masternodeswidget.cpp
+++ b/src/qt/pivx/masternodeswidget.cpp
@@ -275,7 +275,7 @@ void MasterNodesWidget::onStartAllClicked(int type)
         isLoading = true;
         if (!execute(type, std::move(pctx))) {
             isLoading = false;
-            inform(tr("Cannot perform Mastenodes start"));
+            inform(tr("Cannot perform Masternodes start"));
         }
     }
 }
@@ -338,7 +338,7 @@ void MasterNodesWidget::onInfoMNClicked()
     WalletModel::UnlockContext ctx(walletModel->requestUnlock());
     if (!ctx.isValid()) {
         // Unlock wallet was cancelled
-        inform(tr("Cannot show Mastenode information, wallet locked"));
+        inform(tr("Cannot show Masternode information, wallet locked"));
         return;
     }
     showHideOp(true);
@@ -479,7 +479,7 @@ void MasterNodesWidget::onCreateMNClicked()
     WalletModel::UnlockContext ctx(walletModel->requestUnlock());
     if (!ctx.isValid()) {
         // Unlock wallet was cancelled
-        inform(tr("Cannot create Mastenode controller, wallet locked"));
+        inform(tr("Cannot create Masternode controller, wallet locked"));
         return;
     }
 


### PR DESCRIPTION
This PR changes "Mastenode" to "Masternode", simple typo corrections in masternodeswidget.