### PR TITLE
[GUI] Don't log to console by default.

### DIFF
--- a/src/qt/pivx.cpp
+++ b/src/qt/pivx.cpp
@@ -420,6 +420,10 @@ void BitcoinApplication::startThread()
 
 void BitcoinApplication::parameterSetup()
 {
+    // Default printtoconsole to false for the GUI. GUI programs should not
+    // print to the console unnecessarily.
+    SoftSetBoolArg("-printtoconsole", false);
+
     InitLogging();
     InitParameterInteraction();
 }


### PR DESCRIPTION
Default `-printtoconsole` to false for the GUI. 

GUI programs should not print to the console unnecessarily. For example, when launched by the
window manager, the output might end up in the X session log file, resulting in duplicate logging. On Windows, it is pointless as well because pivx-qt isn't a console application.

Coming from upstream@[13055](https://github.com/bitcoin/bitcoin/pull/13055)