### PR TITLE
[Backport] Preemptively catch a few potential bugs

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -474,6 +474,11 @@ public:
 private:
     CCoinsMap::iterator FetchCoins(const uint256& txid);
     CCoinsMap::const_iterator FetchCoins(const uint256& txid) const;
+
+    /**
+      * By making the copy constructor private, we prevent accidentally using it when one intends to create a cache on top of a base cache.
+      */
+    CCoinsViewCache(const CCoinsViewCache &);
 };
 
 #endif // BITCOIN_COINS_H


### PR DESCRIPTION
This causes CCoinsViewCache(CCoinsViewCache) to fail at compile-time rather than copy an existing cache (most likely the caller intends to sub-cache it)

It also makes ConnectBlock's fJustCheck work correctly for the genesis block, just in case it gets in there somehow.

Coming from upstream@[5580](https://github.com/bitcoin/bitcoin/pull/5580)