### PR TITLE
[Qt] Don't translate dummy strings in mnrow

### DIFF
--- a/src/qt/pivx/forms/mnrow.ui
+++ b/src/qt/pivx/forms/mnrow.ui
@@ -80,14 +80,14 @@
          <item>
           <widget class="QLabel" name="labelName">
            <property name="text">
-            <string>user_masternode</string>
+            <string notr="true">N/A</string>
            </property>
           </widget>
          </item>
          <item>
           <widget class="QLabel" name="labelAddress">
            <property name="text">
-            <string>Address: 88.26.164.88:51474</string>
+            <string notr="true">N/A</string>
            </property>
           </widget>
          </item>
@@ -110,7 +110,7 @@
       <item>
        <widget class="QLabel" name="labelDate">
         <property name="text">
-         <string>Jan. 19, 2019</string>
+         <string notr="true">N/A</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
These strings are placeholders, treat them as such by not sending them
to Transifex for localization.