### PR TITLE
[GUI] MasternodeWizard validations

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2356,3 +2356,11 @@ void DumpBanlist()
     LogPrint(BCLog::NET, "Flushed %d banned node ips/subnets to banlist.dat  %dms\n",
         banmap.size(), GetTimeMillis() - nStart);
 }
+
+// valid, reachable and routable address (except for RegTest)
+bool validateMasternodeIP(const std::string& addrStr)
+{
+    CNetAddr netAddr(addrStr.c_str());
+    return ((IsReachable(netAddr) && netAddr.IsRoutable()) ||
+            (Params().IsRegTestNet() && netAddr.IsValid()));
+}

--- a/src/net.h
+++ b/src/net.h
@@ -130,6 +130,7 @@ bool GetLocal(CService& addr, const CNetAddr* paddrPeer = NULL);
 bool IsReachable(enum Network net);
 bool IsReachable(const CNetAddr& addr);
 CAddress GetLocalAddress(const CNetAddr* paddrPeer = NULL);
+bool validateMasternodeIP(const std::string& addrStr);          // valid, reachable and routable address
 
 
 extern bool fDiscover;

--- a/src/qt/pivx/masternodewizarddialog.cpp
+++ b/src/qt/pivx/masternodewizarddialog.cpp
@@ -4,11 +4,14 @@
 
 #include "qt/pivx/masternodewizarddialog.h"
 #include "qt/pivx/forms/ui_masternodewizarddialog.h"
-#include "qt/pivx/qtutils.h"
+
+#include "activemasternode.h"
 #include "optionsmodel.h"
 #include "pairresult.h"
-#include "activemasternode.h"
+#include "qt/pivx/mnmodel.h"
 #include "qt/pivx/guitransactionsutils.h"
+#include "qt/pivx/qtutils.h"
+
 #include <QFile>
 #include <QIntValidator>
 #include <QHostAddress>
@@ -182,12 +185,11 @@ bool MasterNodeWizardDialog::createMN()
             returnStr = tr("IP or port cannot be empty");
             return false;
         }
-        // TODO: Validate IP address..
-        int portInt = portStr.toInt();
-        if (portInt <= 0 && portInt > 999999) {
-            returnStr = tr("Invalid port number");
+        if (!MNModel::validateMNIP(addressStr)) {
+            returnStr = tr("Invalid IP address");
             return false;
         }
+
         // ip + port
         std::string ipAddress = addressStr.toStdString();
         std::string port = portStr.toStdString();

--- a/src/qt/pivx/masternodewizarddialog.cpp
+++ b/src/qt/pivx/masternodewizarddialog.cpp
@@ -12,6 +12,8 @@
 #include <QFile>
 #include <QIntValidator>
 #include <QHostAddress>
+#include <QRegularExpression>
+#include <QRegularExpressionValidator>
 
 MasterNodeWizardDialog::MasterNodeWizardDialog(WalletModel *model, QWidget *parent) :
     QDialog(parent),
@@ -50,7 +52,9 @@ MasterNodeWizardDialog::MasterNodeWizardDialog(WalletModel *model, QWidget *pare
 
     ui->lineEditName->setPlaceholderText(tr("e.g user_masternode"));
     initCssEditLine(ui->lineEditName);
-    ui->lineEditName->setValidator(new QRegExpValidator(QRegExp("^[A-Za-z0-9]+"), ui->lineEditName));
+    // MN alias must not contain spaces or "#" character
+    QRegularExpression rx("^(?:(?![\\#\\s]).)*");
+    ui->lineEditName->setValidator(new QRegularExpressionValidator(rx, ui->lineEditName));
 
     // Frame 4
     setCssProperty(ui->labelTitle4, "text-title-dialog");
@@ -62,12 +66,10 @@ MasterNodeWizardDialog::MasterNodeWizardDialog(WalletModel *model, QWidget *pare
     initCssEditLine(ui->lineEditIpAddress);
     initCssEditLine(ui->lineEditPort);
     ui->stackedWidget->setCurrentIndex(pos);
-    ui->lineEditPort->setValidator(new QIntValidator(0, 9999999, ui->lineEditPort));
+    ui->lineEditPort->setEnabled(false);    // use default port number
     if (walletModel->isRegTestNetwork()) {
-        ui->lineEditPort->setEnabled(false);
         ui->lineEditPort->setText("51476");
     } else if (walletModel->isTestNetwork()) {
-        ui->lineEditPort->setEnabled(false);
         ui->lineEditPort->setText("51474");
     } else {
         ui->lineEditPort->setText("51472");

--- a/src/qt/pivx/mnmodel.cpp
+++ b/src/qt/pivx/mnmodel.cpp
@@ -3,9 +3,11 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "qt/pivx/mnmodel.h"
+
+#include "activemasternode.h"
 #include "masternode-sync.h"
 #include "masternodeman.h"
-#include "activemasternode.h"
+#include "net.h"        // for validateMasternodeIP
 #include "sync.h"
 #include "uint256.h"
 #include "wallet/wallet.h"
@@ -184,4 +186,9 @@ bool MNModel::isMNCollateralMature(QString mnAlias)
 bool MNModel::isMNsNetworkSynced()
 {
     return masternodeSync.IsSynced();
+}
+
+bool MNModel::validateMNIP(const QString& addrStr)
+{
+    return validateMasternodeIP(addrStr.toStdString());
 }

--- a/src/qt/pivx/mnmodel.h
+++ b/src/qt/pivx/mnmodel.h
@@ -51,6 +51,8 @@ public:
     bool isMNActive(QString mnAlias);
     // Masternode collateral has enough confirmations
     bool isMNCollateralMature(QString mnAlias);
+    // Validate string representing a masternode IP address
+    static bool validateMNIP(const QString& addrStr);
 
 
 private:

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -235,4 +235,29 @@ BOOST_AUTO_TEST_CASE(subnet_test)
     BOOST_CHECK_EQUAL(subnet.ToString(), "1:2:3:4:5:6:7:8/ffff:ffff:ffff:fffe:ffff:ffff:ffff:ff0f");
 }
 
+BOOST_AUTO_TEST_CASE(validate_test)
+{
+    std::list<std::string> validIPv4 = {"11.12.13.14", "50.168.168.150", "72.31.250.250"};
+    std::list<std::string> validIPv6 = {"1111:2222:3333:4444:5555:6666::8888", "2001:0002:6c::430", "2002:cb0a:3cdd:1::1"};
+    std::list<std::string> validTor = {"5wyqrzbvrdsumnok.onion", "FD87:D87E:EB43:edb1:8e4:3588:e546:35ca"};
+
+    for (const std::string& ipStr : validIPv4)
+        BOOST_CHECK_MESSAGE(validateMasternodeIP(ipStr), ipStr);
+    for (const std::string& ipStr : validIPv6)
+        BOOST_CHECK_MESSAGE(validateMasternodeIP(ipStr), ipStr);
+    for (const std::string& ipStr : validTor)
+        BOOST_CHECK_MESSAGE(validateMasternodeIP(ipStr), ipStr);
+
+    std::list<std::string> invalidIPv4 = {"11.12.13.14.15", "11.12.13.330", "30.168.1.255.1", "192.168.1.1", "255.255.255.255"};
+    std::list<std::string> invalidIPv6 = {"1111:2222:3333:4444:5555:6666:7777:8888:9999", "2002:cb0a:3cdd::1::1", "1111:2222:3333:::5555:6666:7777:8888"};
+    std::list<std::string> invalidTor = {"5wyqrzbvrdsumnok.noonion"};
+
+    for (const std::string& ipStr : invalidIPv4)
+        BOOST_CHECK_MESSAGE(!validateMasternodeIP(ipStr), ipStr);
+    for (const std::string& ipStr : invalidIPv6)
+        BOOST_CHECK_MESSAGE(!validateMasternodeIP(ipStr), ipStr);
+    for (const std::string& ipStr : invalidTor)
+        BOOST_CHECK_MESSAGE(!validateMasternodeIP(ipStr), ipStr);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
First commit fixes the masternode alias: right now only letters and digits are allowed, but special characters (except spaces and hash marks) should be allowed too. It also replaces deprecated `QRegExp` with `QRegularExpression` (as per #1124) and fixes the port number to the default.
Closes #1471 

Second commit introduces validation for masternode IP addresses: they should be valid IPv4, IPv6 or .onion addresses and, if not on regtest, they should be reachable and routable. A unit test for the new `validateMasternodeIP` function is added to netbase_tests.
Also removes the validation for the port, since it's fixed to network-default.
