### PR TITLE
[GUI][Bug] Reset custom change address

### DIFF
--- a/src/qt/pivx/send.cpp
+++ b/src/qt/pivx/send.cpp
@@ -582,27 +582,20 @@ void SendWidget::updateEntryLabels(QList<SendCoinsRecipient> recipients)
 void SendWidget::onChangeAddressClicked()
 {
     showHideOp(true);
-    SendChangeAddressDialog* dialog = new SendChangeAddressDialog(window);
+    SendChangeAddressDialog* dialog = new SendChangeAddressDialog(window, walletModel);
     if (!boost::get<CNoDestination>(&CoinControlDialog::coinControl->destChange)) {
         dialog->setAddress(QString::fromStdString(CBitcoinAddress(CoinControlDialog::coinControl->destChange).ToString()));
     }
     if (openDialogWithOpaqueBackgroundY(dialog, window, 3, 5)) {
-        if (dialog->selected) {
-            QString ret;
-            if (dialog->getAddress(walletModel, &ret)) {
-                CBitcoinAddress address(ret.toStdString());
+        CBitcoinAddress address(dialog->getAddress().toStdString());
 
-                // Ask if it's what the user really wants
-                if (!walletModel->isMine(address) &&
-                    !ask(tr("Warning!"), tr("The change address doesn't belong to this wallet.\n\nDo you want to continue?"))) {
-                    return;
-                }
-                CoinControlDialog::coinControl->destChange = address.Get();
-                ui->btnChangeAddress->setActive(true);
-            } else {
-                inform(tr("Invalid change address"));
-            }
+        // Ask if it's what the user really wants
+        if (!walletModel->isMine(address) &&
+            !ask(tr("Warning!"), tr("The change address doesn't belong to this wallet.\n\nDo you want to continue?"))) {
+            return;
         }
+        CoinControlDialog::coinControl->destChange = address.Get();
+        ui->btnChangeAddress->setActive(true);
     }
     // check if changeAddress has been reset to NoDestination (or wasn't set at all)
     if (boost::get<CNoDestination>(&CoinControlDialog::coinControl->destChange))

--- a/src/qt/pivx/send.cpp
+++ b/src/qt/pivx/send.cpp
@@ -601,10 +601,12 @@ void SendWidget::onChangeAddressClicked()
                 ui->btnChangeAddress->setActive(true);
             } else {
                 inform(tr("Invalid change address"));
-                ui->btnChangeAddress->setActive(false);
             }
         }
     }
+    // check if changeAddress has been reset to NoDestination (or wasn't set at all)
+    if (boost::get<CNoDestination>(&CoinControlDialog::coinControl->destChange))
+        ui->btnChangeAddress->setActive(false);
     dialog->deleteLater();
 }
 

--- a/src/qt/pivx/sendchangeaddressdialog.cpp
+++ b/src/qt/pivx/sendchangeaddressdialog.cpp
@@ -4,7 +4,8 @@
 
 #include "qt/pivx/sendchangeaddressdialog.h"
 #include "qt/pivx/forms/ui_sendchangeaddressdialog.h"
-#include "walletmodel.h"
+
+#include "coincontrol.h"
 #include "qt/pivx/qtutils.h"
 
 SendChangeAddressDialog::SendChangeAddressDialog(QWidget *parent) :
@@ -32,16 +33,17 @@ SendChangeAddressDialog::SendChangeAddressDialog(QWidget *parent) :
     ui->btnEsc->setProperty("cssClass", "ic-close");
 
     ui->btnCancel->setProperty("cssClass", "btn-dialog-cancel");
-    ui->btnSave->setText("SAVE");
+    ui->btnSave->setText(tr("SAVE"));
     setCssBtnPrimary(ui->btnSave);
 
     connect(ui->btnEsc, &QPushButton::clicked, this, &SendChangeAddressDialog::close);
-    connect(ui->btnCancel, &QPushButton::clicked, this, &SendChangeAddressDialog::close);
+    connect(ui->btnCancel, &QPushButton::clicked, this, &SendChangeAddressDialog::reset);
     connect(ui->btnSave, &QPushButton::clicked, [this](){ selected = true; accept(); });
 }
 
 void SendChangeAddressDialog::setAddress(QString address){
     ui->lineEditAddress->setText(address);
+    ui->btnCancel->setText(tr("RESET"));
 }
 
 bool SendChangeAddressDialog::getAddress(WalletModel *model, QString *retAddress){
@@ -56,6 +58,16 @@ bool SendChangeAddressDialog::getAddress(WalletModel *model, QString *retAddress
 void SendChangeAddressDialog::showEvent(QShowEvent *event)
 {
     if (ui->lineEditAddress) ui->lineEditAddress->setFocus();
+}
+
+void SendChangeAddressDialog::reset()
+{
+    if (!ui->lineEditAddress->text().isEmpty()) {
+        ui->lineEditAddress->clear();
+        ui->btnCancel->setText(tr("CANCEL"));
+        CoinControlDialog::coinControl->destChange = CNoDestination();
+    }
+    close();
 }
 
 SendChangeAddressDialog::~SendChangeAddressDialog(){

--- a/src/qt/pivx/sendchangeaddressdialog.h
+++ b/src/qt/pivx/sendchangeaddressdialog.h
@@ -6,6 +6,7 @@
 #define SENDCHANGEADDRESSDIALOG_H
 
 #include <QDialog>
+#include "qt/pivx/snackbar.h"
 
 class WalletModel;
 
@@ -18,20 +19,23 @@ class SendChangeAddressDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit SendChangeAddressDialog(QWidget *parent = nullptr);
+    explicit SendChangeAddressDialog(QWidget* parent, WalletModel* model);
     ~SendChangeAddressDialog();
 
     void setAddress(QString address);
-    bool getAddress(WalletModel *model, QString *retAddress);
-    bool selected = false;
+    QString getAddress() const;
 
-    void showEvent(QShowEvent *event) override;
+    void showEvent(QShowEvent* event) override;
 
 private:
+    WalletModel* walletModel;
     Ui::SendChangeAddressDialog *ui;
+    SnackBar *snackBar = nullptr;
+    void inform(const QString& text);
 
 private Q_SLOTS:
     void reset();
+    void save();
 };
 
 #endif // SENDCHANGEADDRESSDIALOG_H

--- a/src/qt/pivx/sendchangeaddressdialog.h
+++ b/src/qt/pivx/sendchangeaddressdialog.h
@@ -26,8 +26,12 @@ public:
     bool selected = false;
 
     void showEvent(QShowEvent *event) override;
+
 private:
     Ui::SendChangeAddressDialog *ui;
+
+private Q_SLOTS:
+    void reset();
 };
 
 #endif // SENDCHANGEADDRESSDIALOG_H


### PR DESCRIPTION
First commit fixes a bug where the `btnChangeAddress` in SendWidget was deactivated, despite a custom address still being saved (e.g. saving a valid address, and then trying to change it to an invalid one).

Second commit addresses a feature request: being able to reset only the change address (without resetting the whole coin control) directly from within the dialog.
With this PR, when a custom change address is set, the text of the "CANCEL" button in `SendChangeAddressDialog` is changed to "RESET" and, when clicked, resets the default change address to CNoDestination (which means that a new change address will be created during the send operation).
The upright "X" button retains its original function of just closing the dialog.
Closes #1526 