### PR TITLE
[GUI] CoinControlDialog remove duplicate esc button

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -92,10 +92,7 @@ CoinControlDialog::CoinControlDialog(QWidget* parent, bool fMultisigEnabled) : Q
 
     // Buttons
     setCssProperty({ui->pushButtonSelectAll, ui->pushButtonToggleLock}, "btn-check");
-    ui->btnEsc->setProperty("cssClass", "ic-close");
     ui->pushButtonOk->setProperty("cssClass", "btn-primary");
-
-    connect(ui->btnEsc, &QPushButton::clicked, this, &CoinControlDialog::close);
 
     this->fMultisigEnabled = fMultisigEnabled;
 

--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -97,9 +97,6 @@
             <height>40</height>
            </size>
           </property>
-          <property name="styleSheet">
-           <string notr="true">padding-left:30px;</string>
-          </property>
           <property name="text">
            <string>Select PIV Outputs to Spend</string>
           </property>
@@ -123,25 +120,6 @@
            </size>
           </property>
          </spacer>
-        </item>
-        <item>
-         <widget class="QPushButton" name="btnEsc">
-          <property name="minimumSize">
-           <size>
-            <width>24</width>
-            <height>24</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>24</width>
-            <height>24</height>
-           </size>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
         </item>
        </layout>
       </item>


### PR DESCRIPTION
The coin control dialog layout was first designed to be an internal frameless dialog but then, for the size and content, ended up being a standalone dialog using the OS predetermined frame.

This PR removes the duplicate esc button.