### PR TITLE
[Trivial][GUI] Minor letter change to uppercase

### DIFF
--- a/src/qt/pivx/settings/settingsmultisendwidget.cpp
+++ b/src/qt/pivx/settings/settingsmultisendwidget.cpp
@@ -158,7 +158,7 @@ SettingsMultisendWidget::SettingsMultisendWidget(PWidget *parent) :
     ui->left->setContentsMargins(10,10,10,10);
 
     // Title
-    ui->labelTitle->setText("Multisend");
+    ui->labelTitle->setText("MultiSend");
     setCssTitleScreen(ui->labelTitle);
 
     ui->labelSubtitle1->setText(tr("MultiSend allows you to automatically send up to 100% of your stake or masternode reward to a list of other PIVX addresses after it matures."));


### PR DESCRIPTION
`Multisend` -> `MultiSend` in title in order to keep consistency.

**EDIT:** Not to open new PR, this would be good to be changed here as well then:
![multisendBug2](https://user-images.githubusercontent.com/57232689/80266826-4479a900-869e-11ea-8240-c3a9b54affc5.jpg)

![multisendBug3](https://user-images.githubusercontent.com/57232689/80267449-4c871800-86a1-11ea-9a70-9d2b9fa6183d.jpg)
