### PR TITLE
Abstract out CTransaction-specific signing into SignatureCreator

### DIFF
--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -13,26 +13,33 @@
 #include "uint256.h"
 #include "util.h"
 
-
-
 typedef std::vector<unsigned char> valtype;
 
-bool Sign1(const CKeyID& address, const CKeyStore& keystore, uint256 hash, int nHashType, CScript& scriptSigRet)
+TransactionSignatureCreator::TransactionSignatureCreator(const CKeyStore* keystoreIn, const CTransaction* txToIn, unsigned int nInIn, int nHashTypeIn) : BaseSignatureCreator(keystoreIn), txTo(txToIn), nIn(nInIn), nHashType(nHashTypeIn), checker(txTo, nIn) {}
+
+bool TransactionSignatureCreator::CreateSig(std::vector<unsigned char>& vchSig, const CKeyID& address, const CScript& scriptCode) const
 {
     CKey key;
-    if (!keystore.GetKey(address, key))
+    if (!keystore->GetKey(address, key))
         return false;
 
-    std::vector<unsigned char> vchSig;
+    uint256 hash = SignatureHash(scriptCode, *txTo, nIn, nHashType);
     if (!key.Sign(hash, vchSig))
         return false;
     vchSig.push_back((unsigned char)nHashType);
-    scriptSigRet << vchSig;
-
     return true;
 }
 
-bool SignN(const std::vector<valtype>& multisigdata, const CKeyStore& keystore, uint256 hash, int nHashType, CScript& scriptSigRet)
+static bool Sign1(const CKeyID& address, const BaseSignatureCreator& creator, const CScript& scriptCode, CScript& scriptSigRet)
+{
+    std::vector<unsigned char> vchSig;
+    if (!creator.CreateSig(vchSig, address, scriptCode))
+        return false;
+    scriptSigRet << vchSig;
+    return true;
+}
+
+static bool SignN(const std::vector<valtype>& multisigdata, const BaseSignatureCreator& creator, const CScript& scriptCode, CScript& scriptSigRet)
 {
     int nSigned = 0;
     int nRequired = multisigdata.front()[0];
@@ -40,70 +47,55 @@ bool SignN(const std::vector<valtype>& multisigdata, const CKeyStore& keystore, 
     {
         const valtype& pubkey = multisigdata[i];
         CKeyID keyID = CPubKey(pubkey).GetID();
-        if (Sign1(keyID, keystore, hash, nHashType, scriptSigRet))
+        if (Sign1(keyID, creator, scriptCode, scriptSigRet))
             ++nSigned;
     }
     return nSigned==nRequired;
 }
 
 /**
- * Sign scriptPubKey with private keys stored in keystore, given transaction hash and hash type.
+ * Sign scriptPubKey using signature made with creator.
  * Signatures are returned in scriptSigRet (or returns false if scriptPubKey can't be signed),
  * unless whichTypeRet is TX_SCRIPTHASH, in which case scriptSigRet is the redemption script.
  * Returns false if scriptPubKey could not be completely satisfied.
  */
-bool Solver(const CKeyStore& keystore, const CScript& scriptPubKey, uint256 hash, int nHashType,
+static bool SignStep(const BaseSignatureCreator& creator, const CScript& scriptPubKey,
                   CScript& scriptSigRet, txnouttype& whichTypeRet, bool fColdStake = false)
 {
     scriptSigRet.clear();
 
     std::vector<valtype> vSolutions;
     if (!Solver(scriptPubKey, whichTypeRet, vSolutions))
-    {
-        LogPrintf("*** solver solver failed \n");
         return false;
-    }
 
     CKeyID keyID;
     switch (whichTypeRet)
     {
     case TX_NONSTANDARD:
     case TX_NULL_DATA:
-    {
-        LogPrintf("*** null data \n");
         return false;
-    }
     case TX_ZEROCOINMINT:
         return false;
     case TX_PUBKEY:
         keyID = CPubKey(vSolutions[0]).GetID();
-        if(!Sign1(keyID, keystore, hash, nHashType, scriptSigRet))
-        {
-            LogPrintf("*** Sign1 failed \n");
-            return false;
-        }
-        return true;
+        return Sign1(keyID, creator, scriptPubKey, scriptSigRet);
     case TX_PUBKEYHASH:
         keyID = CKeyID(uint160(vSolutions[0]));
-        if (!Sign1(keyID, keystore, hash, nHashType, scriptSigRet))
-        {
-            LogPrintf("*** solver failed to sign \n");
+        if (!Sign1(keyID, creator, scriptPubKey, scriptSigRet))
             return false;
-        }
         else
         {
             CPubKey vch;
-            if (!keystore.GetPubKey(keyID, vch))
-                return error("%s : Unable to get public key from keyID", __func__);
+            creator.KeyStore().GetPubKey(keyID, vch);
             scriptSigRet << ToByteVector(vch);
         }
         return true;
     case TX_SCRIPTHASH:
-        return keystore.GetCScript(uint160(vSolutions[0]), scriptSigRet);
+        return creator.KeyStore().GetCScript(uint160(vSolutions[0]), scriptSigRet);
 
     case TX_MULTISIG:
         scriptSigRet << OP_0; // workaround CHECKMULTISIG bug
-        return (SignN(vSolutions, keystore, hash, nHashType, scriptSigRet));
+        return (SignN(vSolutions, creator, scriptPubKey, scriptSigRet));
 
     case TX_COLDSTAKE:
         if (fColdStake) {
@@ -113,11 +105,11 @@ bool Solver(const CKeyStore& keystore, const CScript& scriptPubKey, uint256 hash
             // sign with the owner key
             keyID = CKeyID(uint160(vSolutions[1]));
         }
-        if (!Sign1(keyID, keystore, hash, nHashType, scriptSigRet))
+        if (!Sign1(keyID, creator, scriptPubKey, scriptSigRet))
             return error("*** %s: failed to sign with the %s key.",
                     __func__, fColdStake ? "cold staker" : "owner");
         CPubKey vch;
-        if (!keystore.GetPubKey(keyID, vch))
+        if (!creator.KeyStore().GetPubKey(keyID, vch))
             return error("%s : Unable to get public key from keyID", __func__);
         scriptSigRet << (fColdStake ? (int)OP_TRUE : OP_FALSE) << ToByteVector(vch);
         return true;
@@ -126,17 +118,10 @@ bool Solver(const CKeyStore& keystore, const CScript& scriptPubKey, uint256 hash
     return false;
 }
 
-bool SignSignature(const CKeyStore &keystore, const CScript& fromPubKey, CMutableTransaction& txTo, unsigned int nIn, int nHashType, bool fColdStake)
+bool ProduceSignature(const BaseSignatureCreator& creator, const CScript& fromPubKey, CScript& scriptSig, bool fColdStake)
 {
-    assert(nIn < txTo.vin.size());
-    CTxIn& txin = txTo.vin[nIn];
-
-    // Leave out the signature from the hash, since a signature can't sign itself.
-    // The checksig op will also drop the signatures from its hash.
-    uint256 hash = SignatureHash(fromPubKey, txTo, nIn, nHashType);
-
     txnouttype whichType;
-    if (!Solver(keystore, fromPubKey, hash, nHashType, txin.scriptSig, whichType, fColdStake))
+    if (!SignStep(creator, fromPubKey, scriptSig, whichType, fColdStake))
         return false;
 
     if (whichType == TX_SCRIPTHASH)
@@ -144,21 +129,29 @@ bool SignSignature(const CKeyStore &keystore, const CScript& fromPubKey, CMutabl
         // Solver returns the subscript that need to be evaluated;
         // the final scriptSig is the signatures from that
         // and then the serialized subscript:
-        CScript subscript = txin.scriptSig;
-
-        // Recompute txn hash using subscript in place of scriptPubKey:
-        uint256 hash2 = SignatureHash(subscript, txTo, nIn, nHashType);
+        CScript subscript = scriptSig;
 
         txnouttype subType;
         bool fSolved =
-            Solver(keystore, subscript, hash2, nHashType, txin.scriptSig, subType) && subType != TX_SCRIPTHASH;
+            SignStep(creator, subscript, scriptSig, subType, fColdStake) && subType != TX_SCRIPTHASH;
         // Append serialized subscript whether or not it is completely signed:
-        txin.scriptSig << valtype(subscript.begin(), subscript.end());
+        scriptSig << valtype(subscript.begin(), subscript.end());
         if (!fSolved) return false;
     }
 
     // Test solution
-    return VerifyScript(txin.scriptSig, fromPubKey, STANDARD_SCRIPT_VERIFY_FLAGS, MutableTransactionSignatureChecker(&txTo, nIn));
+    return VerifyScript(scriptSig, fromPubKey, STANDARD_SCRIPT_VERIFY_FLAGS, creator.Checker());
+}
+
+bool SignSignature(const CKeyStore &keystore, const CScript& fromPubKey, CMutableTransaction& txTo, unsigned int nIn, int nHashType, bool fColdStake)
+{
+    assert(nIn < txTo.vin.size());
+    CTxIn& txin = txTo.vin[nIn];
+
+    CTransaction txToConst(txTo);
+    TransactionSignatureCreator creator(&keystore, &txToConst, nIn, nHashType);
+
+    return ProduceSignature(creator, fromPubKey, txin.scriptSig, fColdStake);
 }
 
 bool SignSignature(const CKeyStore &keystore, const CTransaction& txFrom, CMutableTransaction& txTo, unsigned int nIn, int nHashType, bool fColdStake)
@@ -179,7 +172,7 @@ static CScript PushAll(const std::vector<valtype>& values)
     return result;
 }
 
-static CScript CombineMultisig(const CScript& scriptPubKey, const CTransaction& txTo, unsigned int nIn,
+static CScript CombineMultisig(const CScript& scriptPubKey, const BaseSignatureChecker& checker,
                                const std::vector<valtype>& vSolutions,
                                const std::vector<valtype>& sigs1, const std::vector<valtype>& sigs2)
 {
@@ -209,7 +202,7 @@ static CScript CombineMultisig(const CScript& scriptPubKey, const CTransaction& 
             if (sigs.count(pubkey))
                 continue; // Already got a sig for this pubkey
 
-            if (TransactionSignatureChecker(&txTo, nIn).CheckSig(sig, pubkey, scriptPubKey))
+            if (checker.CheckSig(sig, pubkey, scriptPubKey))
             {
                 sigs[pubkey] = sig;
                 break;
@@ -234,7 +227,7 @@ static CScript CombineMultisig(const CScript& scriptPubKey, const CTransaction& 
     return result;
 }
 
-static CScript CombineSignatures(const CScript& scriptPubKey, const CTransaction& txTo, unsigned int nIn,
+static CScript CombineSignatures(const CScript& scriptPubKey, const BaseSignatureChecker& checker,
                                  const txnouttype txType, const std::vector<valtype>& vSolutions,
                                  std::vector<valtype>& sigs1, std::vector<valtype>& sigs2)
 {
@@ -270,18 +263,25 @@ static CScript CombineSignatures(const CScript& scriptPubKey, const CTransaction
             Solver(pubKey2, txType2, vSolutions2);
             sigs1.pop_back();
             sigs2.pop_back();
-            CScript result = CombineSignatures(pubKey2, txTo, nIn, txType2, vSolutions2, sigs1, sigs2);
+            CScript result = CombineSignatures(pubKey2, checker, txType2, vSolutions2, sigs1, sigs2);
             result << spk;
             return result;
         }
     case TX_MULTISIG:
-        return CombineMultisig(scriptPubKey, txTo, nIn, vSolutions, sigs1, sigs2);
+        return CombineMultisig(scriptPubKey, checker, vSolutions, sigs1, sigs2);
     }
 
     return CScript();
 }
 
 CScript CombineSignatures(const CScript& scriptPubKey, const CTransaction& txTo, unsigned int nIn,
+                          const CScript& scriptSig1, const CScript& scriptSig2)
+{
+    TransactionSignatureChecker checker(&txTo, nIn);
+    return CombineSignatures(scriptPubKey, checker, scriptSig1, scriptSig2);
+}
+
+CScript CombineSignatures(const CScript& scriptPubKey, const BaseSignatureChecker& checker,
                           const CScript& scriptSig1, const CScript& scriptSig2)
 {
     txnouttype txType;
@@ -293,5 +293,5 @@ CScript CombineSignatures(const CScript& scriptPubKey, const CTransaction& txTo,
     std::vector<valtype> stack2;
     EvalScript(stack2, scriptSig2, SCRIPT_VERIFY_STRICTENC, BaseSignatureChecker());
 
-    return CombineSignatures(scriptPubKey, txTo, nIn, txType, vSolutions, stack1, stack2);
+    return CombineSignatures(scriptPubKey, checker, txType, vSolutions, stack1, stack2);
 }

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -8,24 +8,53 @@
 #define BITCOIN_SCRIPT_SIGN_H
 
 #include "script/interpreter.h"
-#include "key.h"
-#include "keystore.h"
-#include "script/standard.h"
 
+class CKeyID;
 class CKeyStore;
 class CScript;
 class CTransaction;
 
 struct CMutableTransaction;
 
-bool Sign1(const CKeyID& address, const CKeyStore& keystore, uint256 hash, int nHashType, CScript& scriptSigRet);
+/** Virtual base class for signature creators. */
+class BaseSignatureCreator {
+protected:
+    const CKeyStore* keystore;
+
+public:
+    BaseSignatureCreator(const CKeyStore* keystoreIn) : keystore(keystoreIn) {}
+    const CKeyStore& KeyStore() const { return *keystore; };
+    virtual ~BaseSignatureCreator() {}
+    virtual const BaseSignatureChecker& Checker() const =0;
+
+    /** Create a singular (non-script) signature. */
+    virtual bool CreateSig(std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode) const =0;
+};
+
+/** A signature creator for transactions. */
+class TransactionSignatureCreator : public BaseSignatureCreator {
+    const CTransaction* txTo;
+    unsigned int nIn;
+    int nHashType;
+    const TransactionSignatureChecker checker;
+
+public:
+    TransactionSignatureCreator(const CKeyStore* keystoreIn, const CTransaction* txToIn, unsigned int nInIn, int nHashTypeIn=SIGHASH_ALL);
+    const BaseSignatureChecker& Checker() const { return checker; }
+    bool CreateSig(std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode) const;
+};
+
+/** Produce a script signature using a generic signature creator. */
+bool ProduceSignature(const BaseSignatureCreator& creator, const CScript& scriptPubKey, CScript& scriptSig, bool fColdStake);
+
+/** Produce a script signature for a transaction. */
 bool SignSignature(const CKeyStore& keystore, const CScript& fromPubKey, CMutableTransaction& txTo, unsigned int nIn, int nHashType=SIGHASH_ALL, bool fColdStake = false);
 bool SignSignature(const CKeyStore& keystore, const CTransaction& txFrom, CMutableTransaction& txTo, unsigned int nIn, int nHashType=SIGHASH_ALL, bool fColdStake = false);
 
-/**
- * Given two sets of signatures for scriptPubKey, possibly with OP_0 placeholders,
- * combine them intelligently and return the result.
- */
+/** Combine two script signatures using a generic signature checker, intelligently, possibly with OP_0 placeholders. */
+CScript CombineSignatures(const CScript& scriptPubKey, const BaseSignatureChecker& checker, const CScript& scriptSig1, const CScript& scriptSig2);
+
+/** Combine two script signatures on transactions. */
 CScript CombineSignatures(const CScript& scriptPubKey, const CTransaction& txTo, unsigned int nIn, const CScript& scriptSig1, const CScript& scriptSig2);
 
 #endif // BITCOIN_SCRIPT_SIGN_H


### PR DESCRIPTION
Coming from upstream@[5208](https://github.com/bitcoin/bitcoin/pull/5208)

> Build an abstraction class BaseSignatureCreator that doesn't depend on the data type being signed, and a SignatureCreator specific to CTransaction's. Instead of doing the abstraction at the hash compution level, do it at the signature creation level, which means a slight bit more code duplication, but less code changes.
> 
> Full disclosure: this is useful for sidechains-related work.
