### PR TITLE
[Bug] Simpler nTimeSmart computation

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -424,11 +424,15 @@ void TransactionRecord::updateStatus(const CWalletTx& wtx)
 
     // Determine transaction status
 
+    // Update time if needed
+    int64_t nTxTime = wtx.GetTxTime();
+    if (time != nTxTime) time = nTxTime;
+
     // Sort order, unrecorded transactions sort to the top
     status.sortKey = strprintf("%010d-%01d-%010u-%03d",
         (pindex ? pindex->nHeight : std::numeric_limits<int>::max()),
         (wtx.IsCoinBase() ? 1 : 0),
-        wtx.nTimeReceived,
+        time,
         idx);
 
     bool fConflicted = false;

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -22,7 +22,7 @@
 QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet* wallet, const CWalletTx& wtx)
 {
     QList<TransactionRecord> parts;
-    int64_t nTime = wtx.GetComputedTxTime();
+    int64_t nTime = wtx.GetTxTime();
     CAmount nCredit = wtx.GetCredit(ISMINE_ALL);
     CAmount nDebit = wtx.GetDebit(ISMINE_ALL);
     CAmount nNet = nCredit - nDebit;

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -102,7 +102,7 @@ public:
                 // txs are stored in order in the db, which is what should be happening)
                 sort(walletTxes.begin(), walletTxes.end(),
                         [](const CWalletTx & a, const CWalletTx & b) -> bool {
-                         return a.GetComputedTxTime() > b.GetComputedTxTime();
+                         return a.GetTxTime() > b.GetTxTime();
                      });
 
                 // Only latest ones.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1177,18 +1177,6 @@ int64_t CWalletTx::GetTxTime() const
     return n ? n : nTimeReceived;
 }
 
-int64_t CWalletTx::GetComputedTxTime() const
-{
-    LOCK(cs_main);
-    if (ContainsZerocoins()) {
-        if (IsInMainChain())
-            return mapBlockIndex.at(hashBlock)->GetBlockTime();
-        else
-            return nTimeReceived;
-    }
-    return GetTxTime();
-}
-
 int CWalletTx::GetRequestCount() const
 {
     // Returns -1 if it wasn't being tracked

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -426,7 +426,6 @@ public:
 
     std::vector<CKeyID> GetAffectedKeys(const CScript& spk);
     void GetKeyBirthTimes(std::map<CKeyID, int64_t>& mapKeyBirth) const;
-    unsigned int ComputeTimeSmart(const CWalletTx& wtx) const;
 
     /**
      * Increment the next transaction order id
@@ -910,6 +909,7 @@ public:
     bool WriteToDisk(CWalletDB *pwalletdb);
 
     int64_t GetTxTime() const;
+    void UpdateTimeSmart();
     int GetRequestCount() const;
     void RelayWalletTransaction(std::string strCommand = "tx");
     std::set<uint256> GetConflicts() const;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -769,6 +769,10 @@ public:
     std::vector<std::pair<std::string, std::string> > vOrderForm;
     unsigned int fTimeReceivedIsTxTime;
     unsigned int nTimeReceived; //! time received by this node
+    /**
+     * Stable timestamp representing the block time, for a transaction included in a block,
+     * or else the time when the transaction was received if it isn't yet part of a block.
+     */
     unsigned int nTimeSmart;
     char fFromMe;
     std::string strFromAccount;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -910,7 +910,6 @@ public:
     bool WriteToDisk(CWalletDB *pwalletdb);
 
     int64_t GetTxTime() const;
-    int64_t GetComputedTxTime() const;
     int GetRequestCount() const;
     void RelayWalletTransaction(std::string strCommand = "tx");
     std::set<uint256> GetConflicts() const;


### PR DESCRIPTION
Given the strict timestamp checks enforced with POS TimeProtocol v2 (introduced with #1002: a block cannot have a timestamp earlier than previous blocks and cannot be more than 15 seconds in the future), we don't need the complex (and error-prone) logic of the current implementation of `ComputeTimeSmart`. 
We can, instead, simply rely on the blocktime, which already ensures a proper ordering for the transactions.
This also allows us to encapsulate the function in the `CWalletTx` class (renaming it to `UpdateTimeSmart`).

We can also get rid of the additional `GetComputedTxTime` (with its additional LOCK, and main chain lookup), and just use `GetTxTime`.

Finally, update the nSmartTime when a mempool transaction is added to a block.

This should, hopefully, fix #1346 (further testing needed).