### PR TITLE
[Bug][Wallet] Fix insane fees

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2800,9 +2800,6 @@ CAmount CWallet::GetMinimumFee(unsigned int nTxBytes, unsigned int nConfirmTarge
 {
     // payTxFee is user-set "I want to pay this much"
     CAmount nFeeNeeded = payTxFee.GetFee(nTxBytes);
-    // user selected total at least (default=true)
-    if (fPayAtLeastCustomFee && nFeeNeeded > 0 && nFeeNeeded < payTxFee.GetFeePerK())
-        nFeeNeeded = payTxFee.GetFeePerK();
     // User didn't set: use -txconfirmtarget to estimate...
     if (nFeeNeeded == 0)
         nFeeNeeded = pool.estimateFee(nConfirmTarget).GetFee(nTxBytes);


### PR DESCRIPTION
nFeeNeeded is an absolute value (`feePerKb * txKb`), and, as explained both in GUI labels, and in the RPC help, `-payTxFee` is a value per Kb.
`CWallet::GetMinimumFee` , instead, was improperly setting `nFeeNeeded` to just `feePerKb` when a user had a custom fee set, resulting in the creation of transactions with fee much higher than expected (most transactions are well under 1Kb in size).

Closes #881 