### PR TITLE
[QA][Bug] Shorter wallet_basic.py functional test

### DIFF
--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -28,10 +28,10 @@ def assert_fee_amount(fee, tx_size, fee_per_kB):
     """Assert the fee was in range"""
     target_fee = round(tx_size * fee_per_kB / 1000, 8)
     if fee < target_fee:
-        raise AssertionError("Fee of %s BTC too low! (Should be %s BTC)" % (str(fee), str(target_fee)))
+        raise AssertionError("Fee of %s PIV too low! (Should be %s PIV)" % (str(fee), str(target_fee)))
     # allow the wallet's estimation to be at most 2 bytes off
     if fee > (tx_size + 20) * fee_per_kB / 1000:
-        raise AssertionError("Fee of %s BTC too high! (Should be %s BTC)" % (str(fee), str(target_fee)))
+        raise AssertionError("Fee of %s PIV too high! (Should be %s PIV)" % (str(fee), str(target_fee)))
 
 def assert_equal(thing1, thing2, *args):
     if thing1 != thing2 or any(thing1 != arg for arg in args):

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -56,10 +56,11 @@ BASE_SCRIPTS= [
     # Scripts that are run by the travis build process.
 
     # Longest test should go first, to favor running tests in parallel
-    'wallet_basic.py',                          # ~ 833 sec
+    'wallet_basic.py',                          # ~ 498 sec
     'wallet_backup.py',                         # ~ 477 sec
 
     # vv Tests less than 5m vv
+    'wallet_zapwallettxes.py',                  # ~ 300 sec
     'p2p_time_offset.py',                       # ~ 267 sec
     'mining_pos_coldStaking.py',                # ~ 215 sec
     'mining_pos_reorg.py',                      # ~ 212 sec
@@ -68,7 +69,6 @@ BASE_SCRIPTS= [
     'wallet_zerocoin_publicspends.py',          # ~ 202 sec
     'feature_logging.py',                       # ~ 200 sec
     'rpc_rawtransaction.py',                    # ~ 193 sec
-    'wallet_zapwallettxes.py',                  # ~ 180 sec
     'wallet_keypool_topup.py',                  # ~ 174 sec
     'wallet_txn_doublespend.py --mineblock',    # ~ 157 sec
     'wallet_txn_clone.py --mineblock',          # ~ 157 sec

--- a/test/functional/wallet_zapwallettxes.py
+++ b/test/functional/wallet_zapwallettxes.py
@@ -18,7 +18,7 @@ from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
-    wait_until,
+    sync_mempools,
 )
 
 class ZapWalletTXesTest (PivxTestFramework):
@@ -40,31 +40,43 @@ class ZapWalletTXesTest (PivxTestFramework):
         self.sync_all()
         self.nodes[0].generate(1)
         self.sync_all()
+        balance_nodes = [self.nodes[i].getbalance() for i in range(self.num_nodes)]
 
         # This transaction will not be confirmed
         txid2 = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 20)
+        sync_mempools(self.nodes, wait=.1)
 
         # Confirmed and unconfirmed transactions are now in the wallet.
         assert_equal(self.nodes[0].gettransaction(txid1)['txid'], txid1)
         assert_equal(self.nodes[0].gettransaction(txid2)['txid'], txid2)
 
+        # Exercise balance rpcs
+        assert_equal(self.nodes[1].getwalletinfo()["unconfirmed_balance"], 20)
+        assert_equal(self.nodes[1].getunconfirmedbalance(), 20)
+
         # Stop-start node0. Both confirmed and unconfirmed transactions remain in the wallet.
         self.stop_node(0)
         self.start_node(0)
-
         assert_equal(self.nodes[0].gettransaction(txid1)['txid'], txid1)
         assert_equal(self.nodes[0].gettransaction(txid2)['txid'], txid2)
 
-        # Stop node0 and restart with zapwallettxes and persistmempool. The unconfirmed
+        # Stop nodes and restart with zapwallettxes and persistmempool. The unconfirmed
         # transaction is zapped from the wallet, but is re-added when the mempool is reloaded.
-        self.stop_node(0)
-        self.start_node(0, ["-zapwallettxes=2"])
+        # original balances are restored
+        for i in range(1, 3):
+            self.log.info("Restarting with --zapwallettxes=%d" % i)
+            self.stop_nodes()
+            self.start_node(0, ["-zapwallettxes=%d" % i])
+            self.start_node(1, ["-zapwallettxes=%d" % i])
 
-        # tx1 is still be available because it was confirmed
-        assert_equal(self.nodes[0].gettransaction(txid1)['txid'], txid1)
+            # tx1 is still be available because it was confirmed
+            assert_equal(self.nodes[0].gettransaction(txid1)['txid'], txid1)
 
-        # This will raise an exception because the unconfirmed transaction has been zapped
-        assert_raises_rpc_error(-5, 'Invalid or non-wallet transaction id', self.nodes[0].gettransaction, txid2)
+            # This will raise an exception because the unconfirmed transaction has been zapped
+            assert_raises_rpc_error(-5, 'Invalid or non-wallet transaction id', self.nodes[0].gettransaction, txid2)
+
+            # Check (confirmed) balances
+            assert_equal(balance_nodes, [self.nodes[i].getbalance() for i in range(self.num_nodes)])
 
 if __name__ == '__main__':
     ZapWalletTXesTest().main()


### PR DESCRIPTION
Our current `wallet_basic.py` test takes quite some time.
Most of the preparations, though, are unnecessary, as we don't have the feature supposed to be checked (e.g. "subtract fee from amount", or fee collected by the miner or list zero value tx as available coins).
Also restore the check for the correct fee amount, previously commented, with `assert_fee_amount`.
Finally moves the `--zapwallettxes` checks to its test. This makes wallet_basic much faster (498 seconds vs 833) and wallet_zapwallettxes slower (but, at least, it can be run in parallel with the other, making the overall test_runner runtime shorter).

Note: This also fixes a bug in the previous version of the test, highlighted by #1575 (the fee was fixed at the value taken from the first tx sent).