### PR TITLE
[Trivial][GUI] Rename clear history and remove clsKey

### DIFF
--- a/src/qt/pivx/settings/forms/settingsconsolewidget.ui
+++ b/src/qt/pivx/settings/forms/settingsconsolewidget.ui
@@ -227,12 +227,12 @@
             </property>
             <property name="maximumSize">
              <size>
-              <width>45</width>
+              <width>135</width>
               <height>45</height>
              </size>
             </property>
             <property name="text">
-             <string notr="true">-</string>
+             <string notr="true">Clear History</string>
             </property>
            </widget>
           </item>

--- a/src/qt/pivx/settings/settingsconsolewidget.cpp
+++ b/src/qt/pivx/settings/settingsconsolewidget.cpp
@@ -412,14 +412,8 @@ void SettingsConsoleWidget::clear(bool clearHistory){
     QString theme;
     changeTheme(isLightTheme(), theme);
 
-#ifdef Q_OS_MAC
-    QString clsKey = "(⌘)-L";
-#else
-    QString clsKey = "Ctrl-L";
-#endif
-
     message(CMD_REPLY, (tr("Welcome to the PIVX RPC console.") + "<br>" +
-                        tr("Use up and down arrows to navigate history, and %1 to clear screen.").arg("<b>"+clsKey+"</b>") + "<br>" +
+                        tr("Use up and down arrows to navigate history.") + "<br>" +
                         tr("Type <b>help</b> for an overview of available commands.") +
                         "<br><span class=\"secwarning\"><br>" +
                         tr("WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.") +

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -620,14 +620,8 @@ void RPCConsole::clear()
         ".secwarning { color: red; }"
         "b { color: #006060; } ");
 
-#ifdef Q_OS_MAC
-    QString clsKey = "(⌘)-L";
-#else
-    QString clsKey = "Ctrl-L";
-#endif
-
     message(CMD_REPLY, (tr("Welcome to the PIVX RPC console.") + "<br>" +
-                        tr("Use up and down arrows to navigate history, and %1 to clear screen.").arg("<b>"+clsKey+"</b>") + "<br>" +
+                        tr("Use up and down arrows to navigate history.") + "<br>" +
                         tr("Type <b>help</b> for an overview of available commands.") +
                         "<br><span class=\"secwarning\"><br>" +
                         tr("WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.") +


### PR DESCRIPTION
Upon the creation of PR #1499 it needed some tidying up in my opinion.
Removal of the message at the top of console mentioning the usage of Ctrl + L to clear screen.
Removes related #ifdefs 
Final outlook:
![ClearHistory1](https://user-images.githubusercontent.com/45834289/80720736-f3651d00-8ac2-11ea-9031-233959bf6b20.png)
