### PR TITLE
[GUI][Bug] Don't clear address label during send address validation

### DIFF
--- a/src/qt/pivx/send.cpp
+++ b/src/qt/pivx/send.cpp
@@ -727,7 +727,8 @@ void SendWidget::onContactsClicked(SendMultiRow* entry)
         menuContacts->setWalletModel(walletModel, AddressTableModel::Send);
         connect(menuContacts, &ContactsDropdown::contactSelected, [this](QString address, QString label) {
             if (focusedEntry) {
-                focusedEntry->setLabel(label);
+                if (label != "(no label)")
+                    focusedEntry->setLabel(label);
                 focusedEntry->setAddress(address);
             }
         });

--- a/src/qt/pivx/sendmultirow.h
+++ b/src/qt/pivx/sendmultirow.h
@@ -73,7 +73,7 @@ protected:
 
 private Q_SLOTS:
     void amountChanged(const QString&);
-    bool addressChanged(const QString&);
+    bool addressChanged(const QString&, bool fOnlyValidate = false);
     void deleteClicked();
     //void on_payTo_textChanged(const QString& address);
     //void on_addressBookButton_clicked();


### PR DESCRIPTION
The current sending flow clears and/or overwrites the user-supplied
address label multiple times, including when doing final address
validation after clicking the send button. This results in the entered
label never being used.

This stops the default clear and the overzealous replacing/setting of
the label text.