### PR TITLE
[GUI] Split "Delegators" address type in the table model

### DIFF
--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -22,7 +22,8 @@
 const QString AddressTableModel::Send = "S";
 const QString AddressTableModel::Receive = "R";
 const QString AddressTableModel::Zerocoin = "X";
-const QString AddressTableModel::Delegators = "D";
+const QString AddressTableModel::Delegator = "D";
+const QString AddressTableModel::Delegable = "E";
 const QString AddressTableModel::ColdStaking = "C";
 const QString AddressTableModel::ColdStakingSend = "T";
 
@@ -31,7 +32,8 @@ struct AddressTableEntry {
         Sending,
         Receiving,
         Zerocoin,
-        Delegators,
+        Delegator,
+        Delegable,
         ColdStaking,
         ColdStakingSend,
         Hidden /* QSortFilterProxyModel will filter these out */
@@ -72,9 +74,10 @@ static AddressTableEntry::Type translateTransactionType(const QString& strPurpos
         addressType = AddressTableEntry::Sending;
     else if (strPurpose ==  QString::fromStdString(AddressBook::AddressBookPurpose::RECEIVE))
         addressType = AddressTableEntry::Receiving;
-    else if (strPurpose == QString::fromStdString(AddressBook::AddressBookPurpose::DELEGATOR)
-            || strPurpose == QString::fromStdString(AddressBook::AddressBookPurpose::DELEGABLE))
-        addressType = AddressTableEntry::Delegators;
+    else if (strPurpose == QString::fromStdString(AddressBook::AddressBookPurpose::DELEGATOR))
+        addressType = AddressTableEntry::Delegator;
+    else if (strPurpose == QString::fromStdString(AddressBook::AddressBookPurpose::DELEGABLE))
+        addressType = AddressTableEntry::Delegable;
     else if (strPurpose == QString::fromStdString(AddressBook::AddressBookPurpose::COLD_STAKING))
         addressType = AddressTableEntry::ColdStaking;
     else if (strPurpose == QString::fromStdString(AddressBook::AddressBookPurpose::COLD_STAKING_SEND))
@@ -91,8 +94,10 @@ static QString translateTypeToString(AddressTableEntry::Type type)
             return QObject::tr("Contact");
         case AddressTableEntry::Receiving:
             return QObject::tr("Receiving");
-        case AddressTableEntry::Delegators:
+        case AddressTableEntry::Delegator:
             return QObject::tr("Delegator");
+        case AddressTableEntry::Delegable:
+            return QObject::tr("Delegable");
         case AddressTableEntry::ColdStaking:
             return QObject::tr("Cold Staking");
         case AddressTableEntry::ColdStakingSend:
@@ -341,8 +346,10 @@ QVariant AddressTableModel::data(const QModelIndex& index, int role) const
                 return Send;
             case AddressTableEntry::Receiving:
                 return Receive;
-            case AddressTableEntry::Delegators:
-                return Delegators;
+            case AddressTableEntry::Delegator:
+                return Delegator;
+            case AddressTableEntry::Delegable:
+                return Delegable;
             case AddressTableEntry::ColdStaking:
                 return ColdStaking;
             case AddressTableEntry::ColdStakingSend:

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -33,7 +33,7 @@ public:
     };
 
     enum RoleIndex {
-        TypeRole = Qt::UserRole /**< Type of address (#Send, #Receive, #ColdStaking, #ColdStakingSend, #Delegators) */
+        TypeRole = Qt::UserRole /**< Type of address (#Send, #Receive, #ColdStaking, #ColdStakingSend, #Delegator, #Delegable) */
     };
 
     /** Return status of edit/insert operation */
@@ -49,7 +49,8 @@ public:
     static const QString Send;    /**< Specifies send address */
     static const QString Receive; /**< Specifies receive address */
     static const QString Zerocoin; /**< Specifies stealth address */
-    static const QString Delegators; /**< Specifies cold staking addresses which delegated tokens to this wallet */
+    static const QString Delegator; /**< Specifies cold staking addresses which delegated tokens to this wallet and ARE being staked */
+    static const QString Delegable; /**< Specifies cold staking addresses which delegated tokens to this wallet*/
     static const QString ColdStaking; /**< Specifies cold staking own addresses */
     static const QString ColdStakingSend; /**< Specifies send cold staking addresses (simil 'contacts')*/
 

--- a/src/qt/pivx/qtutils.cpp
+++ b/src/qt/pivx/qtutils.cpp
@@ -136,7 +136,8 @@ void setFilterAddressBook(QComboBox* filter, SortEdit* lineEdit)
     filter->addItem(QObject::tr("Receiving"), AddressTableModel::Receive);
     filter->addItem(QObject::tr("Contacts"), AddressTableModel::Send);
     filter->addItem(QObject::tr("Cold Staking"), AddressTableModel::ColdStaking);
-    filter->addItem(QObject::tr("Delegators"), AddressTableModel::Delegators);
+    filter->addItem(QObject::tr("Delegator"), AddressTableModel::Delegator);
+    filter->addItem(QObject::tr("Delegable"), AddressTableModel::Delegable);
     filter->addItem(QObject::tr("Staking Contacts"), AddressTableModel::ColdStakingSend);
 }
 


### PR DESCRIPTION
PR dividing the "Delegators" address type in table model in "Delegable" and "Delegator" as it's divided in the back end.

This will enable the different addresses type exports.