### PR TITLE
[Refactor][GUI] Set static texts in .ui files + add missing tr()

### DIFF
--- a/src/qt/pivx.cpp
+++ b/src/qt/pivx.cpp
@@ -515,7 +515,7 @@ void BitcoinApplication::shutdownResult(int retval)
 
 void BitcoinApplication::handleRunawayException(const QString& message)
 {
-    QMessageBox::critical(0, "Runaway exception", PIVXGUI::tr("A fatal error occurred. PIVX can no longer continue safely and will quit.") + QString("\n\n") + message);
+    QMessageBox::critical(0, "Runaway exception", QObject::tr("A fatal error occurred. PIVX can no longer continue safely and will quit.") + QString("\n\n") + message);
     ::exit(1);
 }
 

--- a/src/qt/pivx/addnewaddressdialog.cpp
+++ b/src/qt/pivx/addnewaddressdialog.cpp
@@ -15,18 +15,13 @@ AddNewAddressDialog::AddNewAddressDialog(QWidget *parent) :
     this->setStyleSheet(parent->styleSheet());
 
     // Container
-
     ui->frameContainer->setProperty("cssClass", "container-dialog");
 
     // Title
-
-    ui->labelTitle->setText("New Address");
     ui->labelTitle->setProperty("cssClass", "text-title-dialog");
 
     // Buttons
-
     ui->btnCancel->setProperty("cssClass", "btn-dialog-cancel");
-    ui->btnSave->setText("SAVE");
     ui->btnSave->setProperty("cssClass", "btn-primary");
 }
 

--- a/src/qt/pivx/addnewcontactdialog.cpp
+++ b/src/qt/pivx/addnewcontactdialog.cpp
@@ -14,25 +14,21 @@ AddNewContactDialog::AddNewContactDialog(QWidget *parent) :
 
     // Stylesheet
     this->setStyleSheet(parent->styleSheet());
-
     ui->frame->setProperty("cssClass", "container-dialog");
+
     // Title
-    ui->labelTitle->setText(tr("Edit Contact"));
     ui->labelTitle->setProperty("cssClass", "text-title-dialog");
 
-    ui->labelMessage->setText(tr("Set a label for the selected address"));
+    // Description
     ui->labelMessage->setProperty("cssClass", "text-main-grey");
 
     // Address
-    ui->lineEditName->setPlaceholderText(tr("Enter a name for the address (e.g Exchange)"));
     initCssEditLine(ui->lineEditName, true);
 
     // Buttons
     ui->btnEsc->setText("");
     ui->btnEsc->setProperty("cssClass", "ic-close");
-
     ui->btnCancel->setProperty("cssClass", "btn-dialog-cancel");
-    ui->btnOk->setText(tr("SAVE"));
     ui->btnOk->setProperty("cssClass", "btn-primary");
 
     connect(ui->btnEsc, &QPushButton::clicked, this, &AddNewContactDialog::close);

--- a/src/qt/pivx/addresseswidget.cpp
+++ b/src/qt/pivx/addresseswidget.cpp
@@ -78,14 +78,12 @@ AddressesWidget::AddressesWidget(PIVXGUI* parent) :
     setCssProperty(ui->listAddresses, "container");
 
     // Title
-    ui->labelTitle->setText(tr("Contacts"));
-    ui->labelSubtitle1->setText(tr("You can add a new one in the options menu to the side."));
     setCssTitleScreen(ui->labelTitle);
     setCssSubtitleScreen(ui->labelSubtitle1);
 
     // Change address option
-    ui->btnAddContact->setTitleClassAndText("btn-title-grey", "Add new contact");
-    ui->btnAddContact->setSubTitleClassAndText("text-subtitle", "Generate a new address to receive tokens.");
+    ui->btnAddContact->setTitleClassAndText("btn-title-grey", tr("Add new contact"));
+    ui->btnAddContact->setSubTitleClassAndText("text-subtitle", tr("Generate a new address to receive tokens."));
     ui->btnAddContact->setRightIconClass("ic-arrow-down");
 
     // List Addresses
@@ -108,28 +106,21 @@ AddressesWidget::AddressesWidget(PIVXGUI* parent) :
     //Empty List
     ui->emptyContainer->setVisible(false);
     setCssProperty(ui->pushImgEmpty, "img-empty-contacts");
-
-    ui->labelEmpty->setText(tr("No contacts yet"));
     setCssProperty(ui->labelEmpty, "text-empty");
 
     // Add Contact
     setCssProperty(ui->layoutNewContact, "container-options");
 
     // Name
-    ui->labelName->setText(tr("Contact name"));
     setCssProperty(ui->labelName, "text-title");
-    ui->lineEditName->setPlaceholderText(tr("e.g. John Doe"));
     setCssEditLine(ui->lineEditName, true);
 
     // Address
-    ui->labelAddress->setText(tr("Enter PIVX address"));
     setCssProperty(ui->labelAddress, "text-title");
-    ui->lineEditAddress->setPlaceholderText("e.g. D7VFR83SQbiezrW72hjc…");
     setCssEditLine(ui->lineEditAddress, true);
     ui->lineEditAddress->setValidator(new QRegExpValidator(QRegExp("^[A-Za-z0-9]+"), ui->lineEditName));
 
     // Buttons
-    ui->btnSave->setText(tr("SAVE"));
     setCssBtnPrimary(ui->btnSave);
 
     connect(ui->listAddresses, &QListView::clicked, this, &AddressesWidget::handleAddressClicked);

--- a/src/qt/pivx/addresseswidget.cpp
+++ b/src/qt/pivx/addresseswidget.cpp
@@ -33,7 +33,8 @@ public:
         return cachedRow;
     }
 
-    void init(QWidget* holder,const QModelIndex &index, bool isHovered, bool isSelected) const override{
+    void init(QWidget* holder,const QModelIndex &index, bool isHovered, bool isSelected) const override
+    {
         AddressLabelRow* row = static_cast<AddressLabelRow*>(holder);
 
         row->updateState(isLightTheme, isHovered, isSelected);
@@ -45,7 +46,8 @@ public:
         row->updateView(address, label);
     }
 
-    QColor rectColor(bool isHovered, bool isSelected) override{
+    QColor rectColor(bool isHovered, bool isSelected) override
+    {
         return getRowColor(isLightTheme, isHovered, isSelected);
     }
 
@@ -128,7 +130,8 @@ AddressesWidget::AddressesWidget(PIVXGUI* parent) :
     connect(ui->btnAddContact, &OptionButton::clicked, this, &AddressesWidget::onAddContactShowHideClicked);
 }
 
-void AddressesWidget::handleAddressClicked(const QModelIndex &index){
+void AddressesWidget::handleAddressClicked(const QModelIndex &index)
+{
     ui->listAddresses->setCurrentIndex(index);
     QRect rect = ui->listAddresses->visualRect(index);
     QPoint pos = rect.topRight();
@@ -137,13 +140,13 @@ void AddressesWidget::handleAddressClicked(const QModelIndex &index){
 
     QModelIndex rIndex = filter->mapToSource(index);
 
-    if(!this->menu){
+    if (!this->menu) {
         this->menu = new TooltipMenu(window, this);
         connect(this->menu, &TooltipMenu::message, this, &AddressesWidget::message);
         connect(this->menu, &TooltipMenu::onEditClicked, this, &AddressesWidget::onEditClicked);
         connect(this->menu, &TooltipMenu::onDeleteClicked, this, &AddressesWidget::onDeleteClicked);
         connect(this->menu, &TooltipMenu::onCopyClicked, this, &AddressesWidget::onCopyClicked);
-    }else {
+    } else {
         this->menu->hide();
     }
     this->index = rIndex;
@@ -153,7 +156,7 @@ void AddressesWidget::handleAddressClicked(const QModelIndex &index){
 
 void AddressesWidget::loadWalletModel()
 {
-    if(walletModel) {
+    if (walletModel) {
         addressTablemodel = walletModel->getAddressTableModel();
         this->filter = new AddressFilterProxyModel(QStringList({AddressTableModel::Send, AddressTableModel::ColdStakingSend}), this);
         this->filter->setSourceModel(addressTablemodel);
@@ -165,13 +168,15 @@ void AddressesWidget::loadWalletModel()
     }
 }
 
-void AddressesWidget::updateListView(){
+void AddressesWidget::updateListView()
+{
     bool empty = addressTablemodel->sizeSend() == 0;
     ui->emptyContainer->setVisible(empty);
     ui->listAddresses->setVisible(!empty);
 }
 
-void AddressesWidget::onStoreContactClicked(){
+void AddressesWidget::onStoreContactClicked()
+{
     if (walletModel) {
         QString label = ui->lineEditName->text();
         QString address = ui->lineEditAddress->text();
@@ -191,7 +196,7 @@ void AddressesWidget::onStoreContactClicked(){
 
         QString storedLabel = walletModel->getAddressTableModel()->labelForAddress(address);
 
-        if(!storedLabel.isEmpty()){
+        if (!storedLabel.isEmpty()) {
             inform(tr("Address already stored, label: %1").arg("\'"+storedLabel+"\'"));
             return;
         }
@@ -215,25 +220,27 @@ void AddressesWidget::onStoreContactClicked(){
     }
 }
 
-void AddressesWidget::onEditClicked(){
+void AddressesWidget::onEditClicked()
+{
     QString address = index.data(Qt::DisplayRole).toString();
     QString currentLabel = index.sibling(index.row(), AddressTableModel::Label).data(Qt::DisplayRole).toString();
     showHideOp(true);
     AddNewContactDialog *dialog = new AddNewContactDialog(window);
     dialog->setData(address, currentLabel);
-    if(openDialogWithOpaqueBackground(dialog, window)){
-        if(walletModel->updateAddressBookLabels(
+    if (openDialogWithOpaqueBackground(dialog, window)) {
+        if (walletModel->updateAddressBookLabels(
                 CBitcoinAddress(address.toStdString()).Get(), dialog->getLabel().toStdString(), addressTablemodel->purposeForAddress(address.toStdString()))){
             inform(tr("Contact edited"));
-        }else{
+        } else {
             inform(tr("Contact edit failed"));
         }
     }
     dialog->deleteLater();
 }
 
-void AddressesWidget::onDeleteClicked(){
-    if(walletModel) {
+void AddressesWidget::onDeleteClicked()
+{
+    if (walletModel) {
         if (ask(tr("Delete Contact"), tr("You are just about to remove the contact:\n\n%1\n\nAre you sure?").arg(index.data(Qt::DisplayRole).toString().toUtf8().constData()))
         ) {
             if (this->walletModel->getAddressTableModel()->removeRows(index.row(), 1, index)) {
@@ -246,16 +253,18 @@ void AddressesWidget::onDeleteClicked(){
     }
 }
 
-void AddressesWidget::onCopyClicked(){
+void AddressesWidget::onCopyClicked()
+{
     GUIUtil::setClipboard(index.data(Qt::DisplayRole).toString());
     inform(tr("Address copied"));
 }
 
-void AddressesWidget::onAddContactShowHideClicked(){
-    if(!ui->layoutNewContact->isVisible()){
+void AddressesWidget::onAddContactShowHideClicked()
+{
+    if (!ui->layoutNewContact->isVisible()){
         ui->btnAddContact->setRightIconClass("btn-dropdown", true);
         ui->layoutNewContact->setVisible(true);
-    }else {
+    } else {
         ui->btnAddContact->setRightIconClass("ic-arrow", true);
         ui->layoutNewContact->setVisible(false);
     }
@@ -279,10 +288,12 @@ void AddressesWidget::sortAddresses()
         this->filter->sort(sortType, sortOrder);
 }
 
-void AddressesWidget::changeTheme(bool isLightTheme, QString& theme){
+void AddressesWidget::changeTheme(bool isLightTheme, QString& theme)
+{
     static_cast<ContactsHolder*>(this->delegate->getRowFactory())->isLightTheme = isLightTheme;
 }
 
-AddressesWidget::~AddressesWidget(){
+AddressesWidget::~AddressesWidget()
+{
     delete ui;
 }

--- a/src/qt/pivx/addresslabelrow.cpp
+++ b/src/qt/pivx/addresslabelrow.cpp
@@ -14,17 +14,20 @@ AddressLabelRow::AddressLabelRow(QWidget *parent) :
     ui->lblLabel->setProperty("cssClass", "text-list-title1");
 }
 
-void AddressLabelRow::init(bool isLightTheme, bool isHover) {
+void AddressLabelRow::init(bool isLightTheme, bool isHover)
+{
     updateState(isLightTheme, isHover, false);
 }
 
-void AddressLabelRow::updateView(QString address, QString label){
+void AddressLabelRow::updateView(QString address, QString label)
+{
     ui->lblAddress->setText(address);
     ui->lblLabel->setText(label);
 }
 
-void AddressLabelRow::updateState(bool isLightTheme, bool isHovered, bool isSelected){
-    if(isLightTheme)
+void AddressLabelRow::updateState(bool isLightTheme, bool isHovered, bool isSelected)
+{
+    if (isLightTheme)
         ui->lblDivisory->setStyleSheet("background-color:#bababa");
     else
         ui->lblDivisory->setStyleSheet("background-color:#40ffffff");
@@ -32,12 +35,14 @@ void AddressLabelRow::updateState(bool isLightTheme, bool isHovered, bool isSele
      ui->btnMenu->setVisible(isHovered);
 }
 
-void AddressLabelRow::enterEvent(QEvent *) {
+void AddressLabelRow::enterEvent(QEvent *)
+{
     ui->btnMenu->setVisible(true);
     update();
 }
 
-void AddressLabelRow::leaveEvent(QEvent *) {
+void AddressLabelRow::leaveEvent(QEvent *)
+{
     ui->btnMenu->setVisible(false);
     update();
 }

--- a/src/qt/pivx/coldstakingmodel.cpp
+++ b/src/qt/pivx/coldstakingmodel.cpp
@@ -15,16 +15,19 @@ ColdStakingModel::ColdStakingModel(WalletModel* _model,
                                    QObject *parent) : QAbstractTableModel(parent), model(_model), tableModel(_tableModel), addressTableModel(_addressTableModel), cachedAmount(0){
 }
 
-void ColdStakingModel::updateCSList() {
+void ColdStakingModel::updateCSList()
+{
     refresh();
     QMetaObject::invokeMethod(this, "emitDataSetChanged", Qt::QueuedConnection);
 }
 
-void ColdStakingModel::emitDataSetChanged() {
+void ColdStakingModel::emitDataSetChanged()
+{
     Q_EMIT dataChanged(index(0, 0, QModelIndex()), index(cachedDelegations.size(), COLUMN_COUNT, QModelIndex()) );
 }
 
-void ColdStakingModel::refresh() {
+void ColdStakingModel::refresh()
+{
     cachedDelegations.clear();
     cachedAmount = 0;
     // First get all of the p2cs utxo inside the wallet
@@ -69,7 +72,8 @@ void ColdStakingModel::refresh() {
     }
 }
 
-bool ColdStakingModel::parseCSDelegation(const CTxOut& out, CSDelegation& ret, const QString& txId, const int& utxoIndex) {
+bool ColdStakingModel::parseCSDelegation(const CTxOut& out, CSDelegation& ret, const QString& txId, const int& utxoIndex)
+{
     txnouttype type;
     std::vector<CTxDestination> addresses;
     int nRequired;
@@ -109,7 +113,7 @@ int ColdStakingModel::columnCount(const QModelIndex &parent) const
 
 QVariant ColdStakingModel::data(const QModelIndex &index, int role) const
 {
-    if(!index.isValid())
+    if (!index.isValid())
             return QVariant();
 
     int row = index.row();

--- a/src/qt/pivx/coldstakingwidget.cpp
+++ b/src/qt/pivx/coldstakingwidget.cpp
@@ -46,7 +46,7 @@ public:
         QString address = index.data(Qt::DisplayRole).toString();
         QString label = index.sibling(index.row(), ColdStakingModel::OWNER_ADDRESS_LABEL).data(Qt::DisplayRole).toString();
         if (label.isEmpty()) {
-            label = "Address with no label";
+            label = QObject::tr("Address with no label");
         }
         bool isWhitelisted = index.sibling(index.row(), ColdStakingModel::IS_WHITELISTED).data(Qt::DisplayRole).toBool();
         QString amountStr = index.sibling(index.row(), ColdStakingModel::TOTAL_STACKEABLE_AMOUNT_STR).data(Qt::DisplayRole).toString();
@@ -90,40 +90,31 @@ ColdStakingWidget::ColdStakingWidget(PIVXGUI* parent) :
     fontLight.setWeight(QFont::Light);
 
     /* Title */
-    ui->labelTitle->setText(tr("Cold Staking"));
     setCssTitleScreen(ui->labelTitle);
     ui->labelTitle->setFont(fontLight);
 
     /* Button Group */
-    ui->pushLeft->setText(tr("Staker"));
-    ui->pushRight->setText(tr("Delegation"));
     setCssProperty(ui->pushLeft, "btn-check-left");
     setCssProperty(ui->pushRight, "btn-check-right");
 
     /* Subtitle */
-    ui->labelSubtitle1->setText(tr("You can delegate your PIVs, letting a hot node (24/7 online node)\nstake on your behalf, while you keep the keys securely offline."));
     setCssSubtitleScreen(ui->labelSubtitle1);
     spacerDiv = new QSpacerItem(40, 20, QSizePolicy::Maximum, QSizePolicy::Expanding);
 
     setCssProperty(ui->labelSubtitleDescription, "text-title");
-    ui->lineEditOwnerAddress->setPlaceholderText(tr("Enter owner address"));
     btnOwnerContact = ui->lineEditOwnerAddress->addAction(QIcon("://ic-contact-arrow-down"), QLineEdit::TrailingPosition);
     setCssProperty(ui->lineEditOwnerAddress, "edit-primary-multi-book");
     ui->lineEditOwnerAddress->setAttribute(Qt::WA_MacShowFocusRect, 0);
     setShadow(ui->lineEditOwnerAddress);
 
-    ui->labelSubtitle2->setText(tr("Accept PIV delegation / Delegate PIV"));
     setCssSubtitleScreen(ui->labelSubtitle2);
     ui->labelSubtitle2->setContentsMargins(0,2,0,0);
 
-    ui->pushButtonSend->setText(tr("Delegate"));
-    ui->pushButtonClear->setText(tr("Clear All"));
     setCssBtnPrimary(ui->pushButtonSend);
     setCssBtnSecondary(ui->pushButtonClear);
 
     connect(ui->pushButtonClear, &QPushButton::clicked, this, &ColdStakingWidget::clearAll);
 
-    ui->labelEditTitle->setText(tr("Cold Staking address"));
     setCssProperty(ui->labelEditTitle, "text-title");
     sendMultiRow = new SendMultiRow(this);
     sendMultiRow->setOnlyStakingAddressAccepted(true);
@@ -131,18 +122,16 @@ ColdStakingWidget::ColdStakingWidget(PIVXGUI* parent) :
     connect(sendMultiRow, &SendMultiRow::onContactsClicked, [this](){ onContactsClicked(false); });
 
     // List
-    ui->labelListHistory->setText(tr("Delegated balance history"));
     setCssProperty(ui->labelStakingTotal, "text-title-right");
     setCssProperty(ui->labelListHistory, "text-title");
     setCssProperty(ui->pushImgEmpty, "img-empty-transactions");
-    ui->labelEmpty->setText(tr("No delegations yet"));
     setCssProperty(ui->labelEmpty, "text-empty");
 
-    ui->btnCoinControl->setTitleClassAndText("btn-title-grey", "Coin Control");
-    ui->btnCoinControl->setSubTitleClassAndText("text-subtitle", "Select PIV outputs to delegate.");
+    ui->btnCoinControl->setTitleClassAndText("btn-title-grey", tr("Coin Control"));
+    ui->btnCoinControl->setSubTitleClassAndText("text-subtitle", tr("Select PIV outputs to delegate."));
 
-    ui->btnColdStaking->setTitleClassAndText("btn-title-grey", "Create Cold Staking Address");
-    ui->btnColdStaking->setSubTitleClassAndText("text-subtitle", "Creates an address to receive delegated coins\nand stake them on their owner's behalf.");
+    ui->btnColdStaking->setTitleClassAndText("btn-title-grey", tr("Create Cold Staking Address"));
+    ui->btnColdStaking->setSubTitleClassAndText("text-subtitle", tr("Creates an address to receive delegated coins\nand stake them on their owner's behalf."));
     ui->btnColdStaking->layout()->setMargin(0);
 
     connect(ui->btnCoinControl, &OptionButton::clicked, this, &ColdStakingWidget::onCoinControlClicked);
@@ -178,8 +167,8 @@ ColdStakingWidget::ColdStakingWidget(PIVXGUI* parent) :
     ui->btnMyStakingAddresses->setChecked(true);
     ui->listViewStakingAddress->setVisible(false);
 
-    ui->btnMyStakingAddresses->setTitleClassAndText("btn-title-grey", "My Cold Staking Addresses");
-    ui->btnMyStakingAddresses->setSubTitleClassAndText("text-subtitle", "List your own cold staking addresses.");
+    ui->btnMyStakingAddresses->setTitleClassAndText("btn-title-grey", tr("My Cold Staking Addresses"));
+    ui->btnMyStakingAddresses->setSubTitleClassAndText("text-subtitle", tr("List your own cold staking addresses."));
     ui->btnMyStakingAddresses->layout()->setMargin(0);
     ui->btnMyStakingAddresses->setRightIconClass("ic-arrow");
 

--- a/src/qt/pivx/dashboardwidget.cpp
+++ b/src/qt/pivx/dashboardwidget.cpp
@@ -44,16 +44,13 @@ DashboardWidget::DashboardWidget(PIVXGUI* parent) :
     ui->left->setContentsMargins(0,0,0,0);
 
     // Title
-    ui->labelTitle2->setText(tr("Staking Rewards"));
     setCssTitleScreen(ui->labelTitle);
     setCssTitleScreen(ui->labelTitle2);
 
     /* Subtitle */
-    ui->labelSubtitle->setText(tr("You can view your account's history"));
     setCssSubtitleScreen(ui->labelSubtitle);
 
     // Staking Information
-    ui->labelMessage->setText(tr("Amount of PIV and zPIV staked."));
     setCssSubtitleScreen(ui->labelMessage);
     setCssProperty(ui->labelSquarePiv, "square-chart-piv");
     setCssProperty(ui->labelSquarezPiv, "square-chart-zpiv");
@@ -65,9 +62,6 @@ DashboardWidget::DashboardWidget(PIVXGUI* parent) :
     fontBold.setWeight(QFont::Bold);
 
     setCssProperty(ui->labelChart, "legend-chart");
-
-    ui->labelAmountZpiv->setText("0 zPIV");
-    ui->labelAmountPiv->setText("0 PIV");
     setCssProperty(ui->labelAmountPiv, "text-stake-piv-disable");
     setCssProperty(ui->labelAmountZpiv, "text-stake-zpiv-disable");
 
@@ -127,18 +121,14 @@ DashboardWidget::DashboardWidget(PIVXGUI* parent) :
     //Empty List
     ui->emptyContainer->setVisible(false);
     setCssProperty(ui->pushImgEmpty, "img-empty-transactions");
-
-    ui->labelEmpty->setText(tr("No transactions yet"));
     setCssProperty(ui->labelEmpty, "text-empty");
     setCssProperty(ui->chartContainer, "container-chart");
     setCssProperty(ui->pushImgEmptyChart, "img-empty-staking-on");
 
-    ui->btnHowTo->setText(tr("How to get PIV or zPIV"));
+
     setCssBtnSecondary(ui->btnHowTo);
 
-
     setCssProperty(ui->labelEmptyChart, "text-empty");
-    ui->labelMessageEmpty->setText(tr("You can verify the staking activity in the status bar at the top right of the wallet.\nIt will start automatically as soon as the wallet has enough confirmations on any unspent balances, and the wallet has synced."));
     setCssSubtitleScreen(ui->labelMessageEmpty);
 
     // Chart State
@@ -368,7 +358,9 @@ void DashboardWidget::setChartShow(ChartShowType type)
     if (isChartInitialized) refreshChart();
 }
 
-const QStringList monthsNames = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+const QStringList monthsNames = {QObject::tr("Jan"), QObject::tr("Feb"), QObject::tr("Mar"), QObject::tr("Apr"),
+                                 QObject::tr("May"), QObject::tr("Jun"), QObject::tr("Jul"), QObject::tr("Aug"),
+                                 QObject::tr("Sep"), QObject::tr("Oct"), QObject::tr("Nov"), QObject::tr("Dec")};
 
 void DashboardWidget::loadChart()
 {

--- a/src/qt/pivx/defaultdialog.cpp
+++ b/src/qt/pivx/defaultdialog.cpp
@@ -20,11 +20,7 @@ DefaultDialog::DefaultDialog(QWidget *parent) :
     ui->frame->setProperty("cssClass", "container-dialog");
 
     // Text
-    ui->labelTitle->setText("Dialog Title");
     ui->labelTitle->setProperty("cssClass", "text-title-dialog");
-
-
-    ui->labelMessage->setText("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.");
     ui->labelMessage->setProperty("cssClass", "text-main-grey");
 
     // Buttons
@@ -32,7 +28,6 @@ DefaultDialog::DefaultDialog(QWidget *parent) :
     ui->btnEsc->setProperty("cssClass", "ic-close");
 
     ui->btnCancel->setProperty("cssClass", "btn-dialog-cancel");
-    ui->btnSave->setText("OK");
     ui->btnSave->setProperty("cssClass", "btn-primary");
 
     connect(ui->btnEsc, &QPushButton::clicked, this, &DefaultDialog::close);

--- a/src/qt/pivx/defaultdialog.cpp
+++ b/src/qt/pivx/defaultdialog.cpp
@@ -43,15 +43,15 @@ void DefaultDialog::showEvent(QShowEvent *event)
 
 void DefaultDialog::setText(const QString& title, const QString& message, const QString& okBtnText, const QString& cancelBtnText)
 {
-    if(!okBtnText.isNull()) ui->btnSave->setText(okBtnText);
-    if(!cancelBtnText.isNull()){
+    if (!okBtnText.isNull()) ui->btnSave->setText(okBtnText);
+    if (!cancelBtnText.isNull()) {
         ui->btnCancel->setVisible(true);
         ui->btnCancel->setText(cancelBtnText);
-    }else{
+    } else {
         ui->btnCancel->setVisible(false);
     }
-    if(!message.isNull()) ui->labelMessage->setText(message);
-    if(!title.isNull()) ui->labelTitle->setText(title);
+    if (!message.isNull()) ui->labelMessage->setText(message);
+    if (!title.isNull()) ui->labelTitle->setText(title);
 }
 
 void DefaultDialog::accept()

--- a/src/qt/pivx/expandablebutton.cpp
+++ b/src/qt/pivx/expandablebutton.cpp
@@ -27,7 +27,7 @@ ExpandableButton::ExpandableButton(QWidget *parent) :
 void ExpandableButton::setButtonClassStyle(const char *name, const QVariant &value, bool forceUpdate)
 {
     ui->pushButton->setProperty(name, value);
-    if(forceUpdate){
+    if (forceUpdate) {
         updateStyle(ui->pushButton);
     }
 }
@@ -40,7 +40,7 @@ void ExpandableButton::setIcon(QString path)
 void ExpandableButton::setButtonText(const QString& _text)
 {
     this->text = _text;
-    if(this->isExpanded){
+    if (this->isExpanded) {
         ui->pushButton->setText(_text);
     }
 }
@@ -90,7 +90,7 @@ void ExpandableButton::setExpanded()
 
 void ExpandableButton::enterEvent(QEvent *)
 {
-    if(!this->isAnimating){
+    if (!this->isAnimating) {
         setExpanded();
         Q_EMIT Mouse_Hover();
     }
@@ -99,7 +99,7 @@ void ExpandableButton::enterEvent(QEvent *)
 
 void ExpandableButton::leaveEvent(QEvent *)
 {
-    if(!keepExpanded){
+    if (!keepExpanded) {
         this->setSmall();
     }
     Q_EMIT Mouse_HoverLeave();

--- a/src/qt/pivx/forms/addnewaddressdialog.ui
+++ b/src/qt/pivx/forms/addnewaddressdialog.ui
@@ -50,7 +50,7 @@
       <item alignment="Qt::AlignHCenter">
        <widget class="QLabel" name="labelTitle">
         <property name="text">
-         <string>My Address</string>
+         <string>New Address</string>
         </property>
        </widget>
       </item>
@@ -190,7 +190,7 @@
            <enum>Qt::NoFocus</enum>
           </property>
           <property name="text">
-           <string>OK</string>
+           <string>SAVE</string>
           </property>
          </widget>
         </item>

--- a/src/qt/pivx/forms/addnewcontactdialog.ui
+++ b/src/qt/pivx/forms/addnewcontactdialog.ui
@@ -89,7 +89,7 @@
            <string notr="true">padding-left:24px;</string>
           </property>
           <property name="text">
-           <string>TextLabel</string>
+           <string>Edit Contact</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignCenter</set>
@@ -166,7 +166,7 @@
         <item>
          <widget class="QLabel" name="labelMessage">
           <property name="text">
-           <string>TextLabel</string>
+           <string>Set a label for the selected address</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignCenter</set>
@@ -198,7 +198,11 @@
            <number>10</number>
           </property>
           <item>
-           <widget class="QLineEdit" name="lineEditName"/>
+           <widget class="QLineEdit" name="lineEditName">
+            <property name="placeholderText">
+             <string>Enter a label for the address (e.g. Exchange)</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </item>
@@ -263,7 +267,7 @@
            <enum>Qt::NoFocus</enum>
           </property>
           <property name="text">
-           <string>OK</string>
+           <string>SAVE</string>
           </property>
          </widget>
         </item>

--- a/src/qt/pivx/forms/addresseswidget.ui
+++ b/src/qt/pivx/forms/addresseswidget.ui
@@ -68,14 +68,14 @@
             <item>
              <widget class="QLabel" name="labelTitle">
               <property name="text">
-               <string>Send</string>
+               <string>Contacts</string>
               </property>
              </widget>
             </item>
             <item alignment="Qt::AlignTop">
              <widget class="QLabel" name="labelSubtitle1">
               <property name="text">
-               <string>TextLabel</string>
+               <string>You can add a new one in the options menu to the side.</string>
               </property>
              </widget>
             </item>
@@ -279,7 +279,7 @@
                  <string notr="true"/>
                 </property>
                 <property name="text">
-                 <string>N/A</string>
+                 <string>No contacts yet</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignCenter</set>
@@ -358,7 +358,11 @@
               </widget>
              </item>
              <item>
-              <widget class="QLineEdit" name="lineEditName"/>
+              <widget class="QLineEdit" name="lineEditName">
+               <property name="placeholderText">
+                <string notr="true">e.g. John Doe</string>
+               </property>
+              </widget>
              </item>
             </layout>
            </item>
@@ -391,7 +395,11 @@
               </widget>
              </item>
              <item>
-              <widget class="QLineEdit" name="lineEditAddress"/>
+              <widget class="QLineEdit" name="lineEditAddress">
+               <property name="placeholderText">
+                <string notr="true">e.g. D8FpnBdmahyJNRsVzoKzyFHbGjcUbX43QN</string>
+               </property>
+              </widget>
              </item>
             </layout>
            </item>
@@ -441,7 +449,7 @@
                 <enum>Qt::NoFocus</enum>
                </property>
                <property name="text">
-                <string>OK</string>
+                <string>SAVE</string>
                </property>
               </widget>
              </item>

--- a/src/qt/pivx/forms/coldstakingwidget.ui
+++ b/src/qt/pivx/forms/coldstakingwidget.ui
@@ -98,7 +98,7 @@
                <item>
                 <widget class="QLabel" name="labelTitle">
                  <property name="text">
-                  <string>Title</string>
+                  <string>Cold Staking</string>
                  </property>
                 </widget>
                </item>
@@ -111,7 +111,8 @@
                   </size>
                  </property>
                  <property name="text">
-                  <string>TextLabel</string>
+                  <string>You can delegate your PIVs, letting a hot node (24/7 online node)
+stake on your behalf, while you keep the keys securely offline.</string>
                  </property>
                 </widget>
                </item>
@@ -187,7 +188,7 @@
                       <enum>Qt::NoFocus</enum>
                      </property>
                      <property name="text">
-                      <string/>
+                      <string>Staker</string>
                      </property>
                      <property name="checkable">
                       <bool>true</bool>
@@ -215,7 +216,7 @@
                       <enum>Qt::NoFocus</enum>
                      </property>
                      <property name="text">
-                      <string/>
+                      <string>Delegation</string>
                      </property>
                      <property name="checkable">
                       <bool>true</bool>
@@ -234,7 +235,7 @@
                 <item alignment="Qt::AlignTop">
                  <widget class="QLabel" name="labelSubtitle2">
                   <property name="text">
-                   <string>TextLabel</string>
+                   <string>Accept PIV delegation / Delegate PIV</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -299,7 +300,7 @@
                 <string notr="true">padding-left:20px; padding-bottom:3px;</string>
                </property>
                <property name="text">
-                <string/>
+                <string>Cold Staking address</string>
                </property>
               </widget>
              </item>
@@ -371,6 +372,9 @@
                   </property>
                   <property name="styleSheet">
                    <string notr="true"/>
+                  </property>
+                  <property name="placeholderText">
+                   <string>Enter owner address</string>
                   </property>
                  </widget>
                 </item>
@@ -453,7 +457,7 @@
                 <enum>Qt::NoFocus</enum>
                </property>
                <property name="text">
-                <string/>
+                <string>Clear All</string>
                </property>
               </widget>
              </item>
@@ -491,7 +495,7 @@
                 <enum>Qt::NoFocus</enum>
                </property>
                <property name="text">
-                <string/>
+                <string>Delegate</string>
                </property>
               </widget>
              </item>
@@ -542,7 +546,7 @@
               <item>
                <widget class="QLabel" name="labelListHistory">
                 <property name="text">
-                 <string>List of delegated balance by address</string>
+                 <string>Delegated balance history</string>
                 </property>
                </widget>
               </item>
@@ -710,7 +714,7 @@
                    <string notr="true"/>
                   </property>
                   <property name="text">
-                   <string>No balance delegated</string>
+                   <string>No delegations yet</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignCenter</set>

--- a/src/qt/pivx/forms/contactdropdownrow.ui
+++ b/src/qt/pivx/forms/contactdropdownrow.ui
@@ -67,7 +67,7 @@
            <string notr="true"/>
           </property>
           <property name="text">
-           <string>Bob Allen</string>
+           <string notr="true">Bob Allen</string>
           </property>
          </widget>
         </item>
@@ -77,7 +77,7 @@
            <string notr="true"/>
           </property>
           <property name="text">
-           <string>DN6i46dytMPVhV1JMGZFuQBh7BZZ6nNLox</string>
+           <string notr="true">DN6i46dytMPVhV1JMGZFuQBh7BZZ6nNLox</string>
           </property>
          </widget>
         </item>

--- a/src/qt/pivx/forms/csrow.ui
+++ b/src/qt/pivx/forms/csrow.ui
@@ -78,6 +78,9 @@
           <layout class="QHBoxLayout" name="horizontalLayout">
            <item>
             <widget class="QLabel" name="labelName">
+             <property name="toolTip">
+              <string notr="true"/>
+             </property>
              <property name="text">
               <string>Savings</string>
              </property>
@@ -109,6 +112,9 @@
           <layout class="QHBoxLayout" name="horizontalLayout_2">
            <item>
             <widget class="QLabel" name="labelAddress">
+             <property name="toolTip">
+              <string notr="true"/>
+             </property>
              <property name="text">
               <string>address</string>
              </property>

--- a/src/qt/pivx/forms/dashboardwidget.ui
+++ b/src/qt/pivx/forms/dashboardwidget.ui
@@ -97,7 +97,7 @@
              <item>
               <widget class="QLabel" name="labelSubtitle">
                <property name="text">
-                <string>You can see here the history of your account</string>
+                <string>View your account's history</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -258,7 +258,7 @@
                   <string notr="true"/>
                  </property>
                  <property name="text">
-                  <string>Warning</string>
+                  <string notr="true">N/A</string>
                  </property>
                  <property name="alignment">
                   <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
@@ -419,7 +419,7 @@
                <string notr="true"/>
               </property>
               <property name="text">
-               <string>No transactions</string>
+               <string>No transactions yet</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignCenter</set>
@@ -454,7 +454,7 @@
             <enum>Qt::NoFocus</enum>
            </property>
            <property name="text">
-            <string/>
+            <string>How to get PIV</string>
            </property>
           </widget>
          </item>
@@ -519,7 +519,7 @@
             <item>
              <widget class="QLabel" name="labelMessage">
               <property name="text">
-               <string>TextLabel</string>
+               <string>Amount of PIV and zPIV staked.</string>
               </property>
              </widget>
             </item>
@@ -567,7 +567,7 @@
           <item>
            <widget class="QLabel" name="labelAmountPiv">
             <property name="text">
-             <string>TextLabel</string>
+             <string notr="true">0 PIV</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignCenter</set>
@@ -577,7 +577,7 @@
           <item>
            <widget class="QLabel" name="labelAmountZpiv">
             <property name="text">
-             <string>TextLabel</string>
+             <string notr="true">0 zPIV</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignCenter</set>
@@ -694,7 +694,7 @@
                 <item>
                  <widget class="QLabel" name="labelPiv">
                   <property name="text">
-                   <string>PIV</string>
+                   <string notr="true">PIV</string>
                   </property>
                  </widget>
                 </item>
@@ -736,7 +736,7 @@
                 <item>
                  <widget class="QLabel" name="labelZpiv">
                   <property name="text">
-                   <string>zPIV</string>
+                   <string notr="true">zPIV</string>
                   </property>
                  </widget>
                 </item>
@@ -923,7 +923,7 @@ margin:0px;</string>
            </item>
            <item alignment="Qt::AlignVCenter">
             <widget class="QWidget" name="containerSort" native="true">
-             <layout class="QHBoxLayout" name="horizontalLayout_6" stretch="3,2">
+             <layout class="QHBoxLayout" name="horizontalLayout_61" stretch="3,2">
               <property name="spacing">
                <number>28</number>
               </property>
@@ -1291,7 +1291,7 @@ margin:0px;</string>
                  <string notr="true"/>
                 </property>
                 <property name="text">
-                 <string>LabelText</string>
+                 <string notr="true">N/A</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignCenter</set>
@@ -1323,7 +1323,8 @@ margin:0px;</string>
 }</string>
              </property>
              <property name="text">
-              <string>TextLabel</string>
+              <string>You can verify the staking activity in the status bar at the top right of the wallet.
+It will start automatically as soon as the wallet has enough confirmations on any unspent balances, and the wallet has synced.</string>
              </property>
              <property name="alignment">
               <set>Qt::AlignCenter</set>

--- a/src/qt/pivx/forms/defaultdialog.ui
+++ b/src/qt/pivx/forms/defaultdialog.ui
@@ -92,7 +92,7 @@
            <string notr="true">padding-left:24px;</string>
           </property>
           <property name="text">
-           <string>Transaction Details</string>
+           <string notr="true">Dialog Title</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignCenter</set>
@@ -158,7 +158,7 @@
       <item>
        <widget class="QLabel" name="labelMessage">
         <property name="text">
-         <string>Text Label</string>
+         <string notr="true">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
@@ -239,7 +239,7 @@
            <enum>Qt::NoFocus</enum>
           </property>
           <property name="text">
-           <string>SAVE</string>
+           <string>OK</string>
           </property>
          </widget>
         </item>

--- a/src/qt/pivx/forms/lockunlock.ui
+++ b/src/qt/pivx/forms/lockunlock.ui
@@ -101,7 +101,7 @@
               </size>
              </property>
              <property name="text">
-              <string/>
+              <string>Unlock Wallet</string>
              </property>
              <property name="checkable">
               <bool>true</bool>
@@ -133,7 +133,7 @@
               </size>
              </property>
              <property name="text">
-              <string/>
+              <string>Lock Wallet</string>
              </property>
              <property name="checkable">
               <bool>true</bool>
@@ -162,7 +162,7 @@
               </size>
              </property>
              <property name="text">
-              <string/>
+              <string>Staking Only</string>
              </property>
              <property name="checkable">
               <bool>true</bool>

--- a/src/qt/pivx/forms/masternodeswidget.ui
+++ b/src/qt/pivx/forms/masternodeswidget.ui
@@ -65,14 +65,15 @@
             <item>
              <widget class="QLabel" name="labelTitle">
               <property name="text">
-               <string>TextLabel</string>
+               <string>Masternodes</string>
               </property>
              </widget>
             </item>
             <item alignment="Qt::AlignTop">
              <widget class="QLabel" name="labelSubtitle1">
               <property name="text">
-               <string>TextLabel</string>
+               <string>Full nodes that incentivize node operators to perform the core consensus functions
+and vote on the treasury system receiving a periodic reward.</string>
               </property>
              </widget>
             </item>
@@ -226,7 +227,7 @@
                  <string notr="true"/>
                 </property>
                 <property name="text">
-                 <string>N/A</string>
+                 <string>No active Masternode yet</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignCenter</set>
@@ -278,7 +279,7 @@
              <enum>Qt::NoFocus</enum>
             </property>
             <property name="text">
-             <string/>
+             <string>Create Masternode Controller</string>
             </property>
            </widget>
           </item>

--- a/src/qt/pivx/forms/masternodewizarddialog.ui
+++ b/src/qt/pivx/forms/masternodewizarddialog.ui
@@ -820,7 +820,11 @@
            </spacer>
           </item>
           <item>
-           <widget class="QLineEdit" name="lineEditName"/>
+           <widget class="QLineEdit" name="lineEditName">
+            <property name="placeholderText">
+             <string notr="true">e.g. user_masternode</string>
+            </property>
+           </widget>
           </item>
           <item>
            <spacer name="verticalSpacer_1_5">
@@ -945,7 +949,11 @@
            </spacer>
           </item>
           <item>
-           <widget class="QLineEdit" name="lineEditIpAddress"/>
+           <widget class="QLineEdit" name="lineEditIpAddress">
+            <property name="placeholderText">
+             <string notr="true">e.g. 18.255.255.255</string>
+            </property>
+           </widget>
           </item>
           <item>
            <spacer name="verticalSpacer_1_8">
@@ -1055,7 +1063,7 @@
            <enum>Qt::NoFocus</enum>
           </property>
           <property name="text">
-           <string>CANCEL</string>
+           <string>BACK</string>
           </property>
          </widget>
         </item>
@@ -1077,7 +1085,7 @@
            <enum>Qt::NoFocus</enum>
           </property>
           <property name="text">
-           <string>OK</string>
+           <string>NEXT</string>
           </property>
          </widget>
         </item>

--- a/src/qt/pivx/forms/mninfodialog.ui
+++ b/src/qt/pivx/forms/mninfodialog.ui
@@ -271,7 +271,7 @@ background:transparent;
                    <item>
                     <widget class="QLabel" name="textId">
                      <property name="text">
-                      <string>492526e7fa3c810b35016...40a5df85ee227ab00b1156994</string>
+                      <string notr="true">492526e7fa3c810b35016...40a5df85ee227ab00b1156994</string>
                      </property>
                     </widget>
                    </item>
@@ -350,7 +350,7 @@ background:transparent;
                    <item>
                     <widget class="QLabel" name="textAddress">
                      <property name="text">
-                      <string>127.0.0.2:43223</string>
+                      <string notr="true">127.0.0.2:43223</string>
                      </property>
                     </widget>
                    </item>
@@ -395,7 +395,7 @@ background:transparent;
                    <item>
                     <widget class="QLabel" name="textAmount">
                      <property name="text">
-                      <string>492526e7fa3c810b35016...40a5df85ee227ab00b1156994</string>
+                      <string notr="true">492526e7fa3c810b35016...40a5df85ee227ab00b1156994</string>
                      </property>
                     </widget>
                    </item>
@@ -516,7 +516,7 @@ background:transparent;
                    <item>
                     <widget class="QLabel" name="textStatus">
                      <property name="text">
-                      <string>MISSING</string>
+                      <string notr="true">MISSING</string>
                      </property>
                     </widget>
                    </item>

--- a/src/qt/pivx/forms/myaddressrow.ui
+++ b/src/qt/pivx/forms/myaddressrow.ui
@@ -34,7 +34,7 @@
      <item>
       <widget class="QLabel" name="labelName">
        <property name="text">
-        <string>Savings</string>
+        <string notr="true">Label</string>
        </property>
       </widget>
      </item>
@@ -54,7 +54,7 @@
      <item>
       <widget class="QLabel" name="labelDate">
        <property name="text">
-        <string>Jan. 19, 2019</string>
+        <string notr="true">Date</string>
        </property>
       </widget>
      </item>
@@ -63,7 +63,7 @@
    <item>
     <widget class="QLabel" name="labelAddress">
      <property name="text">
-      <string>DN6i46dytMPVhV1JMGZFuQBh7BZZ6nNLox</string>
+      <string notr="true">DN6i46dytMPVhV1JMGZFuQBh7BZZ6nNLox</string>
      </property>
     </widget>
    </item>

--- a/src/qt/pivx/forms/navmenuwidget.ui
+++ b/src/qt/pivx/forms/navmenuwidget.ui
@@ -167,7 +167,8 @@ background-color:transparent;
              </size>
             </property>
             <property name="text">
-             <string/>
+             <string>HOME
+</string>
             </property>
             <property name="iconSize">
              <size>
@@ -195,7 +196,8 @@ background-color:transparent;
              </size>
             </property>
             <property name="text">
-             <string/>
+             <string>SEND
+</string>
             </property>
             <property name="iconSize">
              <size>
@@ -220,7 +222,8 @@ background-color:transparent;
              </size>
             </property>
             <property name="text">
-             <string/>
+             <string>RECEIVE
+</string>
             </property>
             <property name="checkable">
              <bool>true</bool>
@@ -239,7 +242,8 @@ background-color:transparent;
              </size>
             </property>
             <property name="text">
-             <string/>
+             <string>CONTACTS
+</string>
             </property>
             <property name="iconSize">
              <size>
@@ -264,7 +268,8 @@ background-color:transparent;
              </size>
             </property>
             <property name="text">
-             <string/>
+             <string>PRIVACY
+</string>
             </property>
             <property name="iconSize">
              <size>
@@ -289,7 +294,8 @@ background-color:transparent;
              </size>
             </property>
             <property name="text">
-             <string/>
+             <string>MASTER
+NODES</string>
             </property>
             <property name="iconSize">
              <size>
@@ -314,7 +320,8 @@ background-color:transparent;
              </size>
             </property>
             <property name="text">
-             <string/>
+             <string>COLD
+STAKING</string>
             </property>
             <property name="iconSize">
              <size>
@@ -339,7 +346,8 @@ background-color:transparent;
              </size>
             </property>
             <property name="text">
-             <string/>
+             <string>SETTINGS
+</string>
             </property>
             <property name="iconSize">
              <size>

--- a/src/qt/pivx/forms/optionbutton.ui
+++ b/src/qt/pivx/forms/optionbutton.ui
@@ -112,7 +112,7 @@
           <item>
            <widget class="QLabel" name="labelTitleChange">
             <property name="text">
-             <string>TextLabel</string>
+             <string notr="true">TextLabel</string>
             </property>
            </widget>
           </item>
@@ -121,7 +121,7 @@
         <item>
          <widget class="QLabel" name="labelSubtitleChange">
           <property name="text">
-           <string>TextLabel</string>
+           <string notr="true">TextLabel</string>
           </property>
          </widget>
         </item>

--- a/src/qt/pivx/forms/privacywidget.ui
+++ b/src/qt/pivx/forms/privacywidget.ui
@@ -73,7 +73,7 @@
               <item>
                <widget class="QLabel" name="labelTitle">
                 <property name="text">
-                 <string>Title</string>
+                 <string>Privacy</string>
                 </property>
                </widget>
               </item>
@@ -86,7 +86,8 @@
                  </size>
                 </property>
                 <property name="text">
-                 <string>TextLabel</string>
+                 <string>Minting zPIV anonymizes your PIV by removing any
+transaction history, making transactions untraceable</string>
                 </property>
                </widget>
               </item>
@@ -162,7 +163,7 @@
                      <enum>Qt::NoFocus</enum>
                     </property>
                     <property name="text">
-                     <string>PushButton</string>
+                     <string>Convert</string>
                     </property>
                     <property name="checkable">
                      <bool>true</bool>
@@ -190,7 +191,7 @@
                      <enum>Qt::NoFocus</enum>
                     </property>
                     <property name="text">
-                     <string>PushButton</string>
+                     <string>Mint</string>
                     </property>
                     <property name="checkable">
                      <bool>true</bool>
@@ -209,7 +210,7 @@
                <item alignment="Qt::AlignTop">
                 <widget class="QLabel" name="labelSubtitle2">
                  <property name="text">
-                  <string>TextLabel</string>
+                  <string>Mint new zPIV or convert back to PIV</string>
                  </property>
                  <property name="alignment">
                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -262,7 +263,7 @@
                  </size>
                 </property>
                 <property name="text">
-                 <string>TextLabel</string>
+                 <string notr="true">N/A</string>
                 </property>
                </widget>
               </item>
@@ -281,6 +282,9 @@
                   </property>
                   <property name="maxLength">
                    <number>8</number>
+                  </property>
+                  <property name="placeholderText">
+                   <string notr="true">0.00 PIV</string>
                   </property>
                  </widget>
                 </item>
@@ -348,7 +352,7 @@
           <item>
            <widget class="QLabel" name="labelListHistory">
             <property name="text">
-             <string>TextLabel</string>
+             <string>Last zPIV Movements</string>
             </property>
            </widget>
           </item>
@@ -492,7 +496,7 @@
                    <string notr="true"/>
                   </property>
                   <property name="text">
-                   <string>N/A</string>
+                   <string>No transactions yet</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignCenter</set>
@@ -595,14 +599,14 @@
              <item>
               <widget class="QLabel" name="labelTitleDenom1">
                <property name="text">
-                <string>TextLabel</string>
+                <string>Denom. with value 1:</string>
                </property>
               </widget>
              </item>
              <item>
               <widget class="QLabel" name="labelValueDenom1">
                <property name="text">
-                <string>TextLabel</string>
+                <string notr="true">0x1 = 0 zPIV</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -616,14 +620,14 @@
              <item>
               <widget class="QLabel" name="labelTitleDenom5">
                <property name="text">
-                <string>TextLabel</string>
+                <string>Denom. with value 5:</string>
                </property>
               </widget>
              </item>
              <item>
               <widget class="QLabel" name="labelValueDenom5">
                <property name="text">
-                <string>TextLabel</string>
+                <string notr="true">0x5 = 0 zPIV</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -637,14 +641,14 @@
              <item>
               <widget class="QLabel" name="labelTitleDenom10">
                <property name="text">
-                <string>TextLabel</string>
+                <string>Denom. with value 10:</string>
                </property>
               </widget>
              </item>
              <item>
               <widget class="QLabel" name="labelValueDenom10">
                <property name="text">
-                <string>TextLabel</string>
+                <string notr="true">0x10 = 0 zPIV</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -658,14 +662,14 @@
              <item>
               <widget class="QLabel" name="labelTitleDenom50">
                <property name="text">
-                <string>TextLabel</string>
+                <string>Denom. with value 50:</string>
                </property>
               </widget>
              </item>
              <item>
               <widget class="QLabel" name="labelValueDenom50">
                <property name="text">
-                <string>TextLabel</string>
+                <string notr="true">0x50 = 0 zPIV</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -679,14 +683,14 @@
              <item>
               <widget class="QLabel" name="labelTitleDenom100">
                <property name="text">
-                <string>TextLabel</string>
+                <string>Denom. with value 100:</string>
                </property>
               </widget>
              </item>
              <item>
               <widget class="QLabel" name="labelValueDenom100">
                <property name="text">
-                <string>TextLabel</string>
+                <string notr="true">0x100 = 0 zPIV</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -700,14 +704,14 @@
              <item>
               <widget class="QLabel" name="labelTitleDenom500">
                <property name="text">
-                <string>TextLabel</string>
+                <string>Denom. with value 500:</string>
                </property>
               </widget>
              </item>
              <item>
               <widget class="QLabel" name="labelValueDenom500">
                <property name="text">
-                <string>TextLabel</string>
+                <string notr="true">0x500 = 0 zPIV</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -721,14 +725,14 @@
              <item>
               <widget class="QLabel" name="labelTitleDenom1000">
                <property name="text">
-                <string>TextLabel</string>
+                <string>Denom. with value 1000:</string>
                </property>
               </widget>
              </item>
              <item>
               <widget class="QLabel" name="labelValueDenom1000">
                <property name="text">
-                <string>TextLabel</string>
+                <string notr="true">0x1000 = 0 zPIV</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -742,14 +746,14 @@
              <item>
               <widget class="QLabel" name="labelTitleDenom5000">
                <property name="text">
-                <string>TextLabel</string>
+                <string>Denom. with value 5000:</string>
                </property>
               </widget>
              </item>
              <item>
               <widget class="QLabel" name="labelValueDenom5000">
                <property name="text">
-                <string>TextLabel</string>
+                <string notr="true">0x5000 = 0 zPIV</string>
                </property>
                <property name="alignment">
                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/qt/pivx/forms/receivedialog.ui
+++ b/src/qt/pivx/forms/receivedialog.ui
@@ -92,7 +92,7 @@
            <string notr="true">padding-left:24px;</string>
           </property>
           <property name="text">
-           <string>Transaction Details</string>
+           <string>My Address</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignCenter</set>
@@ -196,7 +196,7 @@
       <item alignment="Qt::AlignHCenter">
        <widget class="QLabel" name="labelAddress">
         <property name="text">
-         <string>D7VFR83SQbiezrW72hjcWJtcfip5krte2Z </string>
+         <string notr="true">N/A</string>
         </property>
        </widget>
       </item>
@@ -265,7 +265,7 @@
            <enum>Qt::NoFocus</enum>
           </property>
           <property name="text">
-           <string>OK</string>
+           <string>COPY</string>
           </property>
          </widget>
         </item>

--- a/src/qt/pivx/forms/receivewidget.ui
+++ b/src/qt/pivx/forms/receivewidget.ui
@@ -71,14 +71,14 @@
             <item>
              <widget class="QLabel" name="labelTitle">
               <property name="text">
-               <string>TextLabel</string>
+               <string>Receive</string>
               </property>
              </widget>
             </item>
             <item alignment="Qt::AlignTop">
              <widget class="QLabel" name="labelSubtitle1">
               <property name="text">
-               <string>TextLabel</string>
+               <string>Scan the QR code or copy the address to receive PIV</string>
               </property>
              </widget>
             </item>
@@ -190,7 +190,7 @@
               <item>
                <widget class="QLabel" name="labelLabel">
                 <property name="text">
-                 <string>TextLabel</string>
+                 <string notr="true">N/A</string>
                 </property>
                </widget>
               </item>
@@ -210,7 +210,7 @@
               <item>
                <widget class="QLabel" name="labelDate">
                 <property name="text">
-                 <string>TextLabel</string>
+                 <string notr="true">N/A</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -235,7 +235,7 @@
               </size>
              </property>
              <property name="text">
-              <string>No address</string>
+              <string notr="true">N/A</string>
              </property>
              <property name="alignment">
               <set>Qt::AlignCenter</set>

--- a/src/qt/pivx/forms/requestdialog.ui
+++ b/src/qt/pivx/forms/requestdialog.ui
@@ -92,7 +92,7 @@
            <string notr="true">padding-left:24px;</string>
           </property>
           <property name="text">
-           <string>New Request Payment</string>
+           <string>New Payment Request</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignCenter</set>
@@ -210,7 +210,7 @@
              </size>
             </property>
             <property name="text">
-             <string>Lorem ipsum dolor sit amet, consectur cling elit, sed do </string>
+             <string>Instead of sharing only a PIVX address, you can create a payment request, bundling up more information</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignCenter</set>
@@ -288,6 +288,9 @@
                     <width>16777215</width>
                     <height>50</height>
                    </size>
+                  </property>
+                  <property name="placeholderText">
+                   <string notr="true">0.00</string>
                   </property>
                  </widget>
                 </item>
@@ -376,7 +379,7 @@
                </size>
               </property>
               <property name="text">
-               <string>TextLabel</string>
+               <string>Label</string>
               </property>
              </widget>
             </item>
@@ -393,6 +396,9 @@
                 <width>16777215</width>
                 <height>50</height>
                </size>
+              </property>
+              <property name="placeholderText">
+               <string>Enter a label for the address</string>
               </property>
              </widget>
             </item>
@@ -434,7 +440,7 @@
                </size>
               </property>
               <property name="text">
-               <string>TextLabel</string>
+               <string>Description (optional)</string>
               </property>
              </widget>
             </item>
@@ -451,6 +457,9 @@
                 <width>16777215</width>
                 <height>50</height>
                </size>
+              </property>
+              <property name="placeholderText">
+               <string>Enter description</string>
               </property>
              </widget>
             </item>
@@ -672,7 +681,7 @@
             <enum>Qt::NoFocus</enum>
            </property>
            <property name="text">
-            <string>REQUEST</string>
+            <string>GENERATE</string>
            </property>
           </widget>
          </item>

--- a/src/qt/pivx/forms/send.ui
+++ b/src/qt/pivx/forms/send.ui
@@ -81,7 +81,7 @@
             <item>
              <widget class="QLabel" name="labelSubtitle1">
               <property name="text">
-               <string>TextLabel</string>
+               <string>You can transfer public coins (PIV) or private coins (zPIV)</string>
               </property>
              </widget>
             </item>
@@ -147,7 +147,7 @@
                   <enum>Qt::NoFocus</enum>
                  </property>
                  <property name="text">
-                  <string/>
+                  <string>PIV</string>
                  </property>
                  <property name="checkable">
                   <bool>true</bool>
@@ -175,7 +175,7 @@
                   <enum>Qt::NoFocus</enum>
                  </property>
                  <property name="text">
-                  <string/>
+                  <string>zPIV</string>
                  </property>
                  <property name="checkable">
                   <bool>true</bool>
@@ -194,7 +194,7 @@
             <item>
              <widget class="QLabel" name="labelSubtitle2">
               <property name="text">
-               <string>TextLabel</string>
+               <string>Select coin type to spend</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -244,7 +244,7 @@
              <string notr="true">margin-left:8px;</string>
             </property>
             <property name="text">
-             <string>TextLabel</string>
+             <string>PIVX address or contact label</string>
             </property>
            </widget>
           </item>
@@ -267,7 +267,7 @@
           <item>
            <widget class="QLabel" name="labelSubtitleAmount">
             <property name="text">
-             <string>TextLabel</string>
+             <string>Amount</string>
             </property>
            </widget>
           </item>
@@ -401,7 +401,7 @@
              <enum>Qt::NoFocus</enum>
             </property>
             <property name="text">
-             <string>PushButton</string>
+             <string>Customize fee</string>
             </property>
            </widget>
           </item>
@@ -430,7 +430,7 @@
              <enum>Qt::RightToLeft</enum>
             </property>
             <property name="text">
-             <string>PushButton</string>
+             <string>Clear all</string>
             </property>
            </widget>
           </item>
@@ -456,7 +456,7 @@
              <enum>Qt::NoFocus</enum>
             </property>
             <property name="text">
-             <string>PushButton</string>
+             <string>Add recipient</string>
             </property>
            </widget>
           </item>
@@ -560,14 +560,14 @@
                      <item>
                       <widget class="QLabel" name="labelTitleTotalSend">
                        <property name="text">
-                        <string>TextLabel</string>
+                        <string>Total to send</string>
                        </property>
                       </widget>
                      </item>
                      <item>
                       <widget class="QLabel" name="labelAmountSend">
                        <property name="text">
-                        <string>TextLabel</string>
+                        <string notr="true">0.00 PIV</string>
                        </property>
                       </widget>
                      </item>
@@ -632,14 +632,14 @@
                      <item>
                       <widget class="QLabel" name="labelTitleTotalRemaining">
                        <property name="text">
-                        <string>TextLabel</string>
+                        <string notr="true">N/A</string>
                        </property>
                       </widget>
                      </item>
                      <item>
                       <widget class="QLabel" name="labelAmountRemaining">
                        <property name="text">
-                        <string>TextLabel</string>
+                        <string notr="true">N/A</string>
                        </property>
                       </widget>
                      </item>
@@ -796,7 +796,7 @@
              <enum>Qt::NoFocus</enum>
             </property>
             <property name="text">
-             <string>PushButton</string>
+             <string>Reset to default</string>
             </property>
            </widget>
           </item>

--- a/src/qt/pivx/forms/sendchangeaddressdialog.ui
+++ b/src/qt/pivx/forms/sendchangeaddressdialog.ui
@@ -92,7 +92,7 @@
            <string notr="true">padding-left:24px;</string>
           </property>
           <property name="text">
-           <string>Transaction Details</string>
+           <string>Custom Change Address</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignCenter</set>
@@ -164,7 +164,7 @@
          </size>
         </property>
         <property name="text">
-         <string>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim.</string>
+         <string>The remainder of the value resultant from the inputs minus the outputs value goes to the &quot;change&quot; PIVX address</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
@@ -205,6 +205,9 @@
             <width>0</width>
             <height>50</height>
            </size>
+          </property>
+          <property name="placeholderText">
+           <string notr="true">e.g. D8FpnBdmahyJNRsVzoKzyFHbGjcUbX43QN</string>
           </property>
          </widget>
         </item>
@@ -262,7 +265,7 @@
            <enum>Qt::NoFocus</enum>
           </property>
           <property name="text">
-           <string>OK</string>
+           <string>SAVE</string>
           </property>
          </widget>
         </item>

--- a/src/qt/pivx/forms/sendcustomfeedialog.ui
+++ b/src/qt/pivx/forms/sendcustomfeedialog.ui
@@ -92,7 +92,7 @@
            <string notr="true">padding-left:24px;</string>
           </property>
           <property name="text">
-           <string>Transaction Details</string>
+           <string>Customize Fee</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignCenter</set>
@@ -155,7 +155,7 @@
       <item>
        <widget class="QLabel" name="labelMessage">
         <property name="text">
-         <string>Customize the transaction fee at your to your liking, depending on the fee value your transaction will be included or not in the blockchain.</string>
+         <string>Customize the transaction fee, depending on the fee value your transaction might be included faster in the blockchain</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
@@ -278,7 +278,11 @@
             </spacer>
            </item>
            <item alignment="Qt::AlignHCenter">
-            <widget class="QLineEdit" name="lineEditCustomFee"/>
+            <widget class="QLineEdit" name="lineEditCustomFee">
+             <property name="placeholderText">
+              <string notr="true">0.000001</string>
+             </property>
+            </widget>
            </item>
            <item alignment="Qt::AlignHCenter">
             <widget class="QLabel" name="labelCustomFee">
@@ -348,7 +352,7 @@
            <enum>Qt::NoFocus</enum>
           </property>
           <property name="text">
-           <string>OK</string>
+           <string>SAVE</string>
           </property>
          </widget>
         </item>

--- a/src/qt/pivx/forms/sendmultirow.ui
+++ b/src/qt/pivx/forms/sendmultirow.ui
@@ -140,6 +140,9 @@
               <height>50</height>
              </size>
             </property>
+            <property name="placeholderText">
+             <string>Enter address</string>
+            </property>
            </widget>
           </item>
          </layout>
@@ -193,6 +196,9 @@
           </property>
           <property name="alignment">
            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+          <property name="placeholderText">
+           <string notr="true">0.00 PIV</string>
           </property>
          </widget>
         </item>
@@ -287,7 +293,7 @@ margin-left:0.05px;
 padding:0px;</string>
         </property>
         <property name="text">
-         <string>TextLabel</string>
+         <string>Address label (optional)</string>
         </property>
        </widget>
       </item>
@@ -304,6 +310,9 @@ padding:0px;</string>
           <width>16777215</width>
           <height>50</height>
          </size>
+        </property>
+        <property name="placeholderText">
+         <string>Enter label</string>
         </property>
        </widget>
       </item>

--- a/src/qt/pivx/forms/txrow.ui
+++ b/src/qt/pivx/forms/txrow.ui
@@ -110,7 +110,7 @@
               <string notr="true"/>
              </property>
              <property name="text">
-              <string>Received from Bob</string>
+              <string notr="true">N/A</string>
              </property>
              <property name="alignment">
               <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
@@ -123,7 +123,7 @@
               <string notr="true"/>
              </property>
              <property name="text">
-              <string>18/05/18</string>
+              <string notr="true">N/A</string>
              </property>
              <property name="alignment">
               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
@@ -138,7 +138,7 @@
             <string notr="true"/>
            </property>
            <property name="text">
-            <string>+0.000585 PIV</string>
+            <string notr="true">N/A</string>
            </property>
           </widget>
          </item>

--- a/src/qt/pivx/loadingdialog.cpp
+++ b/src/qt/pivx/loadingdialog.cpp
@@ -40,7 +40,6 @@ LoadingDialog::LoadingDialog(QWidget *parent) :
     ui->labelMovie->setMovie(movie);
     movie->start();
 
-    ui->labelMessage->setText(tr("Loading"));
     ui->labelMessage->setProperty("cssClass", "text-loading");
     ui->labelDots->setProperty("cssClass", "text-loading");
 }

--- a/src/qt/pivx/lockunlock.cpp
+++ b/src/qt/pivx/lockunlock.cpp
@@ -23,10 +23,6 @@ LockUnlock::LockUnlock(QWidget *parent) :
     ui->pushButtonStaking->setProperty("cssClass", "btn-check-lock-sub-menu-staking");
     ui->pushButtonStaking->setStyleSheet("padding-left: 34px;");
 
-    ui->pushButtonUnlocked->setText(tr("Unlock Wallet"));
-    ui->pushButtonLocked->setText(tr("Lock Wallet"));
-    ui->pushButtonStaking->setText(tr("Staking Only"));
-
     // Connect
     connect(ui->pushButtonUnlocked, &QPushButton::clicked, this, &LockUnlock::onUnlockClicked);
     connect(ui->pushButtonLocked, &QPushButton::clicked, this, &LockUnlock::onLockClicked);

--- a/src/qt/pivx/masternodeswidget.cpp
+++ b/src/qt/pivx/masternodeswidget.cpp
@@ -288,7 +288,7 @@ bool MasterNodesWidget::startAll(QString& failText, bool onlyMissing)
             continue;
         }
 
-        if(!mnModel->isMNCollateralMature(mnAlias)) {
+        if (!mnModel->isMNCollateralMature(mnAlias)) {
             amountOfMnFailed++;
             continue;
         }
@@ -453,7 +453,7 @@ void MasterNodesWidget::onDeleteMNClicked()
             // Unlock collateral
             bool convertOK = false;
             unsigned int indexOut = outIndex.toUInt(&convertOK);
-            if(convertOK) {
+            if (convertOK) {
                 COutPoint collateralOut(uint256(txId.toStdString()), indexOut);
                 walletModel->unlockCoin(collateralOut);
             }
@@ -464,7 +464,7 @@ void MasterNodesWidget::onDeleteMNClicked()
             mnModel->removeMn(index);
             updateListState();
         }
-    } else{
+    } else {
         inform(tr("masternode.conf file doesn't exists"));
     }
 }

--- a/src/qt/pivx/masternodeswidget.cpp
+++ b/src/qt/pivx/masternodeswidget.cpp
@@ -92,24 +92,20 @@ MasterNodesWidget::MasterNodesWidget(PIVXGUI *parent) :
     fontLight.setWeight(QFont::Light);
 
     /* Title */
-    ui->labelTitle->setText(tr("Masternodes"));
     setCssTitleScreen(ui->labelTitle);
     ui->labelTitle->setFont(fontLight);
-
-    ui->labelSubtitle1->setText(tr("Full nodes that incentivize node operators to perform the core consensus functions\nand vote on the treasury system receiving a periodic reward."));
     setCssSubtitleScreen(ui->labelSubtitle1);
 
     /* Buttons */
-    ui->pushButtonSave->setText(tr("Create Masternode Controller"));
     setCssBtnPrimary(ui->pushButtonSave);
     setCssBtnPrimary(ui->pushButtonStartAll);
     setCssBtnPrimary(ui->pushButtonStartMissing);
 
     /* Options */
-    ui->btnAbout->setTitleClassAndText("btn-title-grey", "What is a Masternode?");
-    ui->btnAbout->setSubTitleClassAndText("text-subtitle", "FAQ explaining what Masternodes are");
-    ui->btnAboutController->setTitleClassAndText("btn-title-grey", "What is a Controller?");
-    ui->btnAboutController->setSubTitleClassAndText("text-subtitle", "FAQ explaining what is a Masternode Controller");
+    ui->btnAbout->setTitleClassAndText("btn-title-grey", tr("What is a Masternode?"));
+    ui->btnAbout->setSubTitleClassAndText("text-subtitle", tr("FAQ explaining what Masternodes are"));
+    ui->btnAboutController->setTitleClassAndText("btn-title-grey", tr("What is a Controller?"));
+    ui->btnAboutController->setSubTitleClassAndText("text-subtitle", tr("FAQ explaining what is a Masternode Controller"));
 
     setCssProperty(ui->listMn, "container");
     ui->listMn->setItemDelegate(delegate);
@@ -120,7 +116,6 @@ MasterNodesWidget::MasterNodesWidget(PIVXGUI *parent) :
 
     ui->emptyContainer->setVisible(false);
     setCssProperty(ui->pushImgEmpty, "img-empty-master");
-    ui->labelEmpty->setText(tr("No active Masternode yet"));
     setCssProperty(ui->labelEmpty, "text-empty");
 
     connect(ui->pushButtonSave, &QPushButton::clicked, this, &MasterNodesWidget::onCreateMNClicked);

--- a/src/qt/pivx/masternodewizarddialog.cpp
+++ b/src/qt/pivx/masternodewizarddialog.cpp
@@ -340,7 +340,7 @@ bool MasterNodeWizardDialog::createMN()
 
                 returnStr = tr("Master node created! Wait %1 confirmations before starting it.").arg(MASTERNODE_MIN_CONFIRMATIONS);
                 return true;
-            } else{
+            } else {
                 returnStr = tr("masternode.conf file doesn't exists");
             }
         } else {

--- a/src/qt/pivx/masternodewizarddialog.cpp
+++ b/src/qt/pivx/masternodewizarddialog.cpp
@@ -53,7 +53,6 @@ MasterNodeWizardDialog::MasterNodeWizardDialog(WalletModel *model, QWidget *pare
     setCssProperty(ui->labelTitle3, "text-title-dialog");
     setCssProperty(ui->labelMessage3, "text-main-grey");
 
-    ui->lineEditName->setPlaceholderText(tr("e.g user_masternode"));
     initCssEditLine(ui->lineEditName);
     // MN alias must not contain spaces or "#" character
     QRegularExpression rx("^(?:(?![\\#\\s]).)*");
@@ -64,8 +63,6 @@ MasterNodeWizardDialog::MasterNodeWizardDialog(WalletModel *model, QWidget *pare
     setCssProperty({ui->labelSubtitleIp, ui->labelSubtitlePort}, "text-title");
     setCssSubtitleScreen(ui->labelSubtitleAddressIp);
 
-    ui->lineEditIpAddress->setPlaceholderText("e.g 18.255.255.255");
-    ui->lineEditPort->setPlaceholderText("e.g 51472");
     initCssEditLine(ui->lineEditIpAddress);
     initCssEditLine(ui->lineEditPort);
     ui->stackedWidget->setCurrentIndex(pos);
@@ -87,10 +84,8 @@ MasterNodeWizardDialog::MasterNodeWizardDialog(WalletModel *model, QWidget *pare
 
     // Connect btns
     setCssBtnPrimary(ui->btnNext);
-    ui->btnNext->setText(tr("NEXT"));
     setCssProperty(ui->btnBack , "btn-dialog-cancel");
     ui->btnBack->setVisible(false);
-    ui->btnBack->setText(tr("BACK"));
     setCssProperty(ui->pushButtonSkip, "ic-close");
 
     connect(ui->pushButtonSkip, &QPushButton::clicked, this, &MasterNodeWizardDialog::close);
@@ -216,7 +211,7 @@ bool MasterNodeWizardDialog::createMN()
         // no coincontrol, no P2CS delegations
         prepareStatus = walletModel->prepareTransaction(currentTransaction, nullptr, false);
 
-        QString returnMsg = "Unknown error";
+        QString returnMsg = tr("Unknown error");
         // process prepareStatus and on error generate message shown to user
         CClientUIInterface::MessageBoxFlags informType;
         returnMsg = GuiTransactionsUtils::ProcessSendCoinsReturn(

--- a/src/qt/pivx/mninfodialog.cpp
+++ b/src/qt/pivx/mninfodialog.cpp
@@ -24,8 +24,8 @@ MnInfoDialog::MnInfoDialog(QWidget *parent) :
     setCssProperty({ui->pushCopy, ui->pushCopyId, ui->pushExport}, "ic-copy-big");
     setCssProperty(ui->btnEsc, "ic-close");
     connect(ui->btnEsc, &QPushButton::clicked, this, &MnInfoDialog::closeDialog);
-    connect(ui->pushCopy, &QPushButton::clicked, [this](){ copyInform(pubKey, "Masternode public key copied"); });
-    connect(ui->pushCopyId, &QPushButton::clicked, [this](){ copyInform(txId, "Collateral tx id copied"); });
+    connect(ui->pushCopy, &QPushButton::clicked, [this](){ copyInform(pubKey, tr("Masternode public key copied")); });
+    connect(ui->pushCopyId, &QPushButton::clicked, [this](){ copyInform(txId, tr("Collateral tx id copied")); });
     connect(ui->pushExport, &QPushButton::clicked, [this](){ exportMN = true; accept(); });
 }
 

--- a/src/qt/pivx/mnrow.cpp
+++ b/src/qt/pivx/mnrow.cpp
@@ -21,12 +21,8 @@ void MNRow::updateView(QString address, QString label, QString status, bool wasC
 {
     ui->labelName->setText(label);
     ui->labelAddress->setText(address);
-    ui->labelDate->setText("Status: " + status);
-    if (!wasCollateralAccepted) {
-        ui->labelDate->setText("Status: Collateral tx not found");
-    } else {
-        ui->labelDate->setText("Status: " + status);
-    }
+    if (!wasCollateralAccepted) status = tr("Collateral tx not found");
+    ui->labelDate->setText(tr("Status: %1").arg(status));
 }
 
 MNRow::~MNRow()

--- a/src/qt/pivx/navmenuwidget.cpp
+++ b/src/qt/pivx/navmenuwidget.cpp
@@ -25,34 +25,21 @@ NavMenuWidget::NavMenuWidget(PIVXGUI *mainWindow, QWidget *parent) :
 
     // Buttons
     ui->btnDashboard->setProperty("name", "dash");
-    ui->btnDashboard->setText("HOME\n");
     ui->btnDashboard->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-
     ui->btnSend->setProperty("name", "send");
     ui->btnSend->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-    ui->btnSend->setText("SEND\n");
-
-    ui->btnAddress->setProperty("name", "address");
-    ui->btnAddress->setText("CONTACTS\n");
-    ui->btnAddress->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-
-    ui->btnMaster->setProperty("name", "master");
-    ui->btnMaster->setText("MASTER\r\nNODES");
-    ui->btnMaster->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-
-    ui->btnColdStaking->setProperty("name", "cold-staking");
-    ui->btnColdStaking->setText("COLD\r\nSTAKING");
-    ui->btnColdStaking->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-
-    ui->btnSettings->setProperty("name", "settings");
-    ui->btnSettings->setText("SETTINGS\n");
-    ui->btnSettings->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-
     ui->btnReceive->setProperty("name", "receive");
-    ui->btnReceive->setText("RECEIVE\n");
     ui->btnReceive->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
-
+    ui->btnAddress->setProperty("name", "address");
+    ui->btnAddress->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
     ui->btnPrivacy->setProperty("name", "privacy");
+    ui->btnPrivacy->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    ui->btnMaster->setProperty("name", "master");
+    ui->btnMaster->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    ui->btnColdStaking->setProperty("name", "cold-staking");
+    ui->btnColdStaking->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
+    ui->btnSettings->setProperty("name", "settings");
+    ui->btnSettings->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
     btns = {ui->btnDashboard, ui->btnSend, ui->btnReceive, ui->btnAddress, ui->btnPrivacy, ui->btnMaster, ui->btnColdStaking, ui->btnSettings, ui->btnColdStaking};
     onNavSelected(ui->btnDashboard, true);
 
@@ -72,8 +59,6 @@ NavMenuWidget::NavMenuWidget(PIVXGUI *mainWindow, QWidget *parent) :
 void NavMenuWidget::loadWalletModel() {
     if (walletModel) {
         if (walletModel->getZerocoinBalance() > 0) {
-            ui->btnPrivacy->setText("PRIVACY\n");
-            ui->btnPrivacy->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
             connect(ui->btnPrivacy, &QPushButton::clicked, this, &NavMenuWidget::onPrivacyClicked);
         } else {
             ui->btnPrivacy->setVisible(false);

--- a/src/qt/pivx/optionbutton.cpp
+++ b/src/qt/pivx/optionbutton.cpp
@@ -20,34 +20,41 @@ OptionButton::OptionButton(QWidget *parent) :
     setActive(false);
 }
 
-OptionButton::~OptionButton(){
+OptionButton::~OptionButton()
+{
     delete ui;
 }
 
-void OptionButton::setTitleClassAndText(QString className, QString text){
+void OptionButton::setTitleClassAndText(QString className, QString text)
+{
     ui->labelTitleChange->setText(text);
     setCssProperty(ui->labelTitleChange, className);
 }
 
-void OptionButton::setTitleText(QString text){
+void OptionButton::setTitleText(QString text)
+{
     ui->labelTitleChange->setText(text);
 }
 
-void OptionButton::setSubTitleClassAndText(QString className, QString text){
+void OptionButton::setSubTitleClassAndText(QString className, QString text)
+{
     ui->labelSubtitleChange->setText(text);
     setCssProperty(ui->labelSubtitleChange, className);
 }
 
-void OptionButton::setRightIconClass(QString className, bool forceUpdate){
+void OptionButton::setRightIconClass(QString className, bool forceUpdate)
+{
     setCssProperty(ui->labelArrow3, className);
-    if(forceUpdate) updateStyle(ui->labelArrow3);
+    if (forceUpdate) updateStyle(ui->labelArrow3);
 }
 
-void OptionButton::setRightIcon(QPixmap icon){
+void OptionButton::setRightIcon(QPixmap icon)
+{
     //ui->labelArrow3->setPixmap(icon);
 }
 
-void OptionButton::setActive(bool isActive){
+void OptionButton::setActive(bool isActive)
+{
     if (isActive) {
         ui->layoutCircle->setVisible(true);
         setCssProperty(ui->labelTitleChange, "btn-title-purple");
@@ -59,12 +66,14 @@ void OptionButton::setActive(bool isActive){
     }
 }
 
-void OptionButton::setChecked(bool checked){
+void OptionButton::setChecked(bool checked)
+{
     ui->labelArrow3->setChecked(checked);
     Q_EMIT clicked();
 }
 
-void OptionButton::mousePressEvent(QMouseEvent *qevent){
+void OptionButton::mousePressEvent(QMouseEvent *qevent)
+{
     if (qevent->button() == Qt::LeftButton){
         setChecked(!ui->labelArrow3->isChecked());
     }

--- a/src/qt/pivx/pivxgui.cpp
+++ b/src/qt/pivx/pivxgui.cpp
@@ -78,8 +78,7 @@ PIVXGUI::PIVXGUI(const NetworkStyle* networkStyle, QWidget* parent) :
 
 #ifdef ENABLE_WALLET
     // Create wallet frame
-    if(enableWallet){
-
+    if (enableWallet) {
         QFrame* centralWidget = new QFrame(this);
         this->setMinimumWidth(BASE_WINDOW_MIN_WIDTH);
         this->setMinimumHeight(BASE_WINDOW_MIN_HEIGHT);
@@ -167,7 +166,8 @@ PIVXGUI::PIVXGUI(const NetworkStyle* networkStyle, QWidget* parent) :
 
 }
 
-void PIVXGUI::createActions(const NetworkStyle* networkStyle){
+void PIVXGUI::createActions(const NetworkStyle* networkStyle)
+{
     toggleHideAction = new QAction(networkStyle->getAppIcon(), tr("&Show / Hide"), this);
     toggleHideAction->setStatusTip(tr("Show or hide the main Window"));
 
@@ -183,7 +183,8 @@ void PIVXGUI::createActions(const NetworkStyle* networkStyle){
 /**
  * Here add every event connection
  */
-void PIVXGUI::connectActions() {
+void PIVXGUI::connectActions()
+{
     QShortcut *consoleShort = new QShortcut(this);
     consoleShort->setKey(QKeySequence(SHORT_KEY + Qt::Key_C));
     connect(consoleShort, &QShortcut::activated, [this](){
@@ -206,7 +207,8 @@ void PIVXGUI::connectActions() {
 }
 
 
-void PIVXGUI::createTrayIcon(const NetworkStyle* networkStyle) {
+void PIVXGUI::createTrayIcon(const NetworkStyle* networkStyle)
+{
 #ifndef Q_OS_MAC
     trayIcon = new QSystemTrayIcon(this);
     QString toolTip = tr("PIVX Core client") + " " + networkStyle->getTitleAddText();
@@ -217,8 +219,8 @@ void PIVXGUI::createTrayIcon(const NetworkStyle* networkStyle) {
     notificator = new Notificator(QApplication::applicationName(), trayIcon, this);
 }
 
-//
-PIVXGUI::~PIVXGUI() {
+PIVXGUI::~PIVXGUI()
+{
     // Unsubscribe from notifications from core
     unsubscribeFromCoreSignals();
 
@@ -232,16 +234,17 @@ PIVXGUI::~PIVXGUI() {
 
 
 /** Get restart command-line parameters and request restart */
-void PIVXGUI::handleRestart(QStringList args){
+void PIVXGUI::handleRestart(QStringList args)
+{
     if (!ShutdownRequested())
         Q_EMIT requestedRestart(args);
 }
 
 
-void PIVXGUI::setClientModel(ClientModel* clientModel) {
+void PIVXGUI::setClientModel(ClientModel* clientModel)
+{
     this->clientModel = clientModel;
-    if(this->clientModel) {
-
+    if (this->clientModel) {
         // Create system tray menu (or setup the dock menu) that late to prevent users from calling actions,
         // while the client has not yet fully loaded
         createTrayIconMenu();
@@ -276,7 +279,8 @@ void PIVXGUI::setClientModel(ClientModel* clientModel) {
     }
 }
 
-void PIVXGUI::createTrayIconMenu() {
+void PIVXGUI::createTrayIconMenu()
+{
 #ifndef Q_OS_MAC
     // return if trayIcon is unset (only on non-macOSes)
     if (!trayIcon)
@@ -350,15 +354,17 @@ void PIVXGUI::closeEvent(QCloseEvent* event)
 }
 
 
-void PIVXGUI::messageInfo(const QString& text){
-    if(!this->snackBar) this->snackBar = new SnackBar(this, this);
+void PIVXGUI::messageInfo(const QString& text)
+{
+    if (!this->snackBar) this->snackBar = new SnackBar(this, this);
     this->snackBar->setText(text);
     this->snackBar->resize(this->width(), snackBar->height());
     openDialog(this->snackBar, this);
 }
 
 
-void PIVXGUI::message(const QString& title, const QString& message, unsigned int style, bool* ret) {
+void PIVXGUI::message(const QString& title, const QString& message, unsigned int style, bool* ret)
+{
     QString strTitle =  tr("PIVX Core"); // default title
     // Default to information icon
     int nNotifyIcon = Notificator::Information;
@@ -397,18 +403,18 @@ void PIVXGUI::message(const QString& title, const QString& message, unsigned int
         // Check for buttons, use OK as default, if none was supplied
         int r = 0;
         showNormalIfMinimized();
-        if(style & CClientUIInterface::BTN_MASK){
+        if (style & CClientUIInterface::BTN_MASK) {
             r = openStandardDialog(
                     (title.isEmpty() ? strTitle : title), message, "OK", "CANCEL"
                 );
-        }else{
+        } else {
             r = openStandardDialog((title.isEmpty() ? strTitle : title), message, "OK");
         }
         if (ret != NULL)
             *ret = r;
-    } else if(style & CClientUIInterface::MSG_INFORMATION_SNACK){
+    } else if (style & CClientUIInterface::MSG_INFORMATION_SNACK) {
         messageInfo(message);
-    }else {
+    } else {
         // Append title to "PIVX - "
         if (!msgType.isEmpty())
             strTitle += " - " + msgType;
@@ -416,7 +422,8 @@ void PIVXGUI::message(const QString& title, const QString& message, unsigned int
     }
 }
 
-bool PIVXGUI::openStandardDialog(QString title, QString body, QString okBtn, QString cancelBtn){
+bool PIVXGUI::openStandardDialog(QString title, QString body, QString okBtn, QString cancelBtn)
+{
     DefaultDialog *dialog;
     if (isVisible()) {
         showHide(true);
@@ -438,7 +445,8 @@ bool PIVXGUI::openStandardDialog(QString title, QString body, QString okBtn, QSt
 }
 
 
-void PIVXGUI::showNormalIfMinimized(bool fToggleHidden) {
+void PIVXGUI::showNormalIfMinimized(bool fToggleHidden)
+{
     if (!clientModel)
         return;
     if (!isHidden() && !isMinimized() && !GUIUtil::isObscured(this) && fToggleHidden) {
@@ -448,11 +456,13 @@ void PIVXGUI::showNormalIfMinimized(bool fToggleHidden) {
     }
 }
 
-void PIVXGUI::toggleHidden() {
+void PIVXGUI::toggleHidden()
+{
     showNormalIfMinimized(true);
 }
 
-void PIVXGUI::detectShutdown() {
+void PIVXGUI::detectShutdown()
+{
     if (ShutdownRequested()) {
         if (rpcConsole)
             rpcConsole->hide();
@@ -460,30 +470,36 @@ void PIVXGUI::detectShutdown() {
     }
 }
 
-void PIVXGUI::goToDashboard(){
-    if(stackedContainer->currentWidget() != dashboard){
+void PIVXGUI::goToDashboard()
+{
+    if (stackedContainer->currentWidget() != dashboard) {
         stackedContainer->setCurrentWidget(dashboard);
         topBar->showBottom();
     }
 }
 
-void PIVXGUI::goToSend(){
+void PIVXGUI::goToSend()
+{
     showTop(sendWidget);
 }
 
-void PIVXGUI::goToAddresses(){
+void PIVXGUI::goToAddresses()
+{
     showTop(addressesWidget);
 }
 
-void PIVXGUI::goToPrivacy(){
+void PIVXGUI::goToPrivacy()
+{
     if (privacyWidget) showTop(privacyWidget);
 }
 
-void PIVXGUI::goToMasterNodes(){
+void PIVXGUI::goToMasterNodes()
+{
     showTop(masterNodesWidget);
 }
 
-void PIVXGUI::goToColdStaking(){
+void PIVXGUI::goToColdStaking()
+{
     showTop(coldStakingWidget);
 }
 
@@ -491,18 +507,21 @@ void PIVXGUI::goToSettings(){
     showTop(settingsWidget);
 }
 
-void PIVXGUI::goToReceive(){
+void PIVXGUI::goToReceive()
+{
     showTop(receiveWidget);
 }
 
-void PIVXGUI::showTop(QWidget* view){
-    if(stackedContainer->currentWidget() != view){
+void PIVXGUI::showTop(QWidget* view)
+{
+    if (stackedContainer->currentWidget() != view) {
         stackedContainer->setCurrentWidget(view);
         topBar->showTop();
     }
 }
 
-void PIVXGUI::changeTheme(bool isLightTheme){
+void PIVXGUI::changeTheme(bool isLightTheme)
+{
 
     QString css = GUIUtil::loadStyleSheet();
     this->setStyleSheet(css);
@@ -514,7 +533,8 @@ void PIVXGUI::changeTheme(bool isLightTheme){
     updateStyle(this);
 }
 
-void PIVXGUI::resizeEvent(QResizeEvent* event){
+void PIVXGUI::resizeEvent(QResizeEvent* event)
+{
     // Parent..
     QMainWindow::resizeEvent(event);
     // background
@@ -523,19 +543,21 @@ void PIVXGUI::resizeEvent(QResizeEvent* event){
     Q_EMIT windowResizeEvent(event);
 }
 
-bool PIVXGUI::execDialog(QDialog *dialog, int xDiv, int yDiv){
+bool PIVXGUI::execDialog(QDialog *dialog, int xDiv, int yDiv)
+{
     return openDialogWithOpaqueBackgroundY(dialog, this);
 }
 
-void PIVXGUI::showHide(bool show){
-    if(!op) op = new QLabel(this);
-    if(!show){
+void PIVXGUI::showHide(bool show)
+{
+    if (!op) op = new QLabel(this);
+    if (!show) {
         op->setVisible(false);
         opEnabled = false;
-    }else{
+    } else {
         QColor bg("#000000");
         bg.setAlpha(200);
-        if(!isLightTheme()){
+        if (!isLightTheme()) {
             bg = QColor("#00000000");
             bg.setAlpha(150);
         }
@@ -554,11 +576,13 @@ void PIVXGUI::showHide(bool show){
     }
 }
 
-int PIVXGUI::getNavWidth(){
+int PIVXGUI::getNavWidth()
+{
     return this->navMenu->width();
 }
 
-void PIVXGUI::openFAQ(int section){
+void PIVXGUI::openFAQ(int section)
+{
     showHide(true);
     SettingsFaqWidget* dialog = new SettingsFaqWidget(this);
     if (section > 0) dialog->setSection(section);
@@ -571,7 +595,7 @@ void PIVXGUI::openFAQ(int section){
 bool PIVXGUI::addWallet(const QString& name, WalletModel* walletModel)
 {
     // Single wallet supported for now..
-    if(!stackedContainer || !clientModel || !walletModel)
+    if (!stackedContainer || !clientModel || !walletModel)
         return false;
 
     // set the model for every view
@@ -610,18 +634,21 @@ bool PIVXGUI::addWallet(const QString& name, WalletModel* walletModel)
     return true;
 }
 
-bool PIVXGUI::setCurrentWallet(const QString& name) {
+bool PIVXGUI::setCurrentWallet(const QString& name)
+{
     // Single wallet supported.
     return true;
 }
 
-void PIVXGUI::removeAllWallets() {
+void PIVXGUI::removeAllWallets()
+{
     // Single wallet supported.
 }
 
-void PIVXGUI::incomingTransaction(const QString& date, int unit, const CAmount& amount, const QString& type, const QString& address) {
+void PIVXGUI::incomingTransaction(const QString& date, int unit, const CAmount& amount, const QString& type, const QString& address)
+{
     // Only send notifications when not disabled
-    if(!bdisableSystemnotifications){
+    if (!bdisableSystemnotifications) {
         // On new transaction, make an info balloon
         message((amount) < 0 ? (pwalletMain->fMultiSendNotify == true ? tr("Sent MultiSend transaction") : tr("Sent transaction")) : tr("Incoming transaction"),
             tr("Date: %1\n"

--- a/src/qt/pivx/privacywidget.cpp
+++ b/src/qt/pivx/privacywidget.cpp
@@ -33,79 +33,38 @@ PrivacyWidget::PrivacyWidget(PIVXGUI* parent) :
     fontLight.setWeight(QFont::Light);
 
     /* Title */
-    ui->labelTitle->setText(tr("Privacy"));
     setCssTitleScreen(ui->labelTitle);
     ui->labelTitle->setFont(fontLight);
 
     /* Button Group */
-    ui->pushLeft->setText(tr("Convert"));
     setCssProperty(ui->pushLeft, "btn-check-left");
-    ui->pushRight->setText(tr("Mint"));
     setCssProperty(ui->pushRight, "btn-check-right");
 
     /* Subtitle */
-    ui->labelSubtitle1->setText(tr("Minting zPIV anonymizes your PIV by removing any\ntransaction history, making transactions untraceable "));
     setCssSubtitleScreen(ui->labelSubtitle1);
-
-    ui->labelSubtitle2->setText(tr("Mint new zPIV or convert back to PIV"));
     setCssSubtitleScreen(ui->labelSubtitle2);
     ui->labelSubtitle2->setContentsMargins(0,2,0,0);
     setCssProperty(ui->labelSubtitleAmount, "text-title");
 
-    ui->lineEditAmount->setPlaceholderText("0.00 PIV ");
     ui->lineEditAmount->setValidator(new QRegExpValidator(QRegExp("[0-9]+")));
     initCssEditLine(ui->lineEditAmount);
 
     /* Denom */
-    ui->labelTitleDenom1->setText("Denom. with value 1:");
-    setCssProperty(ui->labelTitleDenom1, "text-subtitle");
-    ui->labelValueDenom1->setText("0x1 = 0 zPIV");
-    setCssProperty(ui->labelValueDenom1, "text-body2");
-
-    ui->labelTitleDenom5->setText("Denom. with value 5:");
-    setCssProperty(ui->labelTitleDenom5, "text-subtitle");
-    ui->labelValueDenom5->setText("0x5 = 0 zPIV");
-    setCssProperty(ui->labelValueDenom5, "text-body2");
-
-    ui->labelTitleDenom10->setText("Denom. with value 10:");
-    setCssProperty(ui->labelTitleDenom10, "text-subtitle");
-    ui->labelValueDenom10->setText("0x10 = 0 zPIV");
-    setCssProperty(ui->labelValueDenom10, "text-body2");
-
-    ui->labelTitleDenom50->setText("Denom. with value 50:");
-    setCssProperty(ui->labelTitleDenom50, "text-subtitle");
-    ui->labelValueDenom50->setText("0x50 = 0 zPIV");
-    setCssProperty(ui->labelValueDenom50, "text-body2");
-
-    ui->labelTitleDenom100->setText("Denom. with value 100:");
-    setCssProperty(ui->labelTitleDenom100, "text-subtitle");
-    ui->labelValueDenom100->setText("0x100 = 0 zPIV");
-    setCssProperty(ui->labelValueDenom100, "text-body2");
-
-    ui->labelTitleDenom500->setText("Denom. with value 500:");
-    setCssProperty(ui->labelTitleDenom500, "text-subtitle");
-    ui->labelValueDenom500->setText("0x500 = 0 zPIV");
-    setCssProperty(ui->labelValueDenom500, "text-body2");
-
-    ui->labelTitleDenom1000->setText("Denom. with value 1000:");
-    setCssProperty(ui->labelTitleDenom1000, "text-subtitle");
-    ui->labelValueDenom1000->setText("0x1000 = 0 zPIV");
-    setCssProperty(ui->labelValueDenom1000, "text-body2");
-
-    ui->labelTitleDenom5000->setText("Denom. with value 5000:");
-    setCssProperty(ui->labelTitleDenom5000, "text-subtitle");
-    ui->labelValueDenom5000->setText("0x5000 = 0 zPIV");
-    setCssProperty(ui->labelValueDenom5000, "text-body2");
-
+    setCssProperty({ui->labelTitleDenom1, ui->labelTitleDenom5,
+                    ui->labelTitleDenom10, ui->labelTitleDenom50,
+                    ui->labelTitleDenom100, ui->labelTitleDenom500,
+                    ui->labelTitleDenom1000, ui->labelTitleDenom5000},"text-subtitle");
+    setCssProperty({ui->labelValueDenom1, ui->labelValueDenom5,
+                    ui->labelValueDenom10, ui->labelValueDenom50,
+                    ui->labelValueDenom100, ui->labelValueDenom500,
+                    ui->labelValueDenom1000, ui->labelValueDenom5000},"text-body2");
     ui->layoutDenom->setVisible(false);
 
     // List
-    ui->labelListHistory->setText(tr("Last zPIV Movements"));
     setCssProperty(ui->labelListHistory, "text-title");
 
     //ui->emptyContainer->setVisible(false);
     setCssProperty(ui->pushImgEmpty, "img-empty-privacy");
-    ui->labelEmpty->setText(tr("No transactions yet"));
     setCssProperty(ui->labelEmpty, "text-empty");
 
     // Buttons
@@ -115,18 +74,18 @@ PrivacyWidget::PrivacyWidget(PIVXGUI* parent) :
     ui->containerViewPrivacyChecks->setVisible(false);
     onMintSelected(false);
 
-    ui->btnTotalzPIV->setTitleClassAndText("btn-title-grey", "Total 0 zPIV");
-    ui->btnTotalzPIV->setSubTitleClassAndText("text-subtitle", "Show denominations of zPIV owned.");
+    ui->btnTotalzPIV->setTitleClassAndText("btn-title-grey", tr("Total 0 zPIV"));
+    ui->btnTotalzPIV->setSubTitleClassAndText("text-subtitle", tr("Show denominations of zPIV owned."));
     ui->btnTotalzPIV->setRightIconClass("ic-arrow");
 
-    ui->btnCoinControl->setTitleClassAndText("btn-title-grey", "Coin Control");
-    ui->btnCoinControl->setSubTitleClassAndText("text-subtitle", "Select PIV outputs to mint into zPIV.");
+    ui->btnCoinControl->setTitleClassAndText("btn-title-grey", tr("Coin Control"));
+    ui->btnCoinControl->setSubTitleClassAndText("text-subtitle", tr("Select PIV outputs to mint into zPIV."));
 
-    ui->btnRescanMints->setTitleClassAndText("btn-title-grey", "Rescan Mints");
-    ui->btnRescanMints->setSubTitleClassAndText("text-subtitle", "Find mints in the blockchain.");
+    ui->btnRescanMints->setTitleClassAndText("btn-title-grey", tr("Rescan Mints"));
+    ui->btnRescanMints->setSubTitleClassAndText("text-subtitle", tr("Find mints in the blockchain."));
 
-    ui->btnResetZerocoin->setTitleClassAndText("btn-title-grey", "Reset Spent zPIV");
-    ui->btnResetZerocoin->setSubTitleClassAndText("text-subtitle", "Reset zerocoin database.");
+    ui->btnResetZerocoin->setTitleClassAndText("btn-title-grey", tr("Reset Spent zPIV"));
+    ui->btnResetZerocoin->setSubTitleClassAndText("text-subtitle", tr("Reset zerocoin database."));
 
     connect(ui->btnTotalzPIV, &OptionButton::clicked, this, &PrivacyWidget::onTotalZpivClicked);
     connect(ui->btnCoinControl, &OptionButton::clicked, this, &PrivacyWidget::onCoinControlClicked);

--- a/src/qt/pivx/receivedialog.cpp
+++ b/src/qt/pivx/receivedialog.cpp
@@ -13,25 +13,20 @@ ReceiveDialog::ReceiveDialog(QWidget *parent) :
     ui(new Ui::ReceiveDialog)
 {
     ui->setupUi(this);
+
     // Stylesheet
     this->setStyleSheet(parent->styleSheet());
 
     ui->frameContainer->setProperty("cssClass", "container-dialog");
     ui->frameContainer->setContentsMargins(10,10,10,10);
 
-
     // Title
-
-    ui->labelTitle->setText("My Address");
     ui->labelTitle->setProperty("cssClass", "text-title-dialog");
 
     // Address
-
-    ui->labelAddress->setText("D7VFR83SQbiezrW72hjcWJtcfip5krte2Z");
     ui->labelAddress->setProperty("cssClass", "label-address-box");
 
     // QR image
-
     QPixmap pixmap(":/res/img/img-qr-test-big.png");
     ui->labelQrImg->setPixmap(pixmap.scaled(
                                   ui->labelQrImg->width(),
@@ -39,16 +34,12 @@ ReceiveDialog::ReceiveDialog(QWidget *parent) :
                                   Qt::KeepAspectRatio)
                               );
 
-
     // Buttons
     ui->btnEsc->setText("");
     ui->btnEsc->setProperty("cssClass", "ic-close");
-
     ui->btnCancel->setProperty("cssClass", "btn-dialog-cancel");
-    ui->btnSave->setText("COPY");
     ui->btnSave->setProperty("cssClass", "btn-primary");
     ui->btnCancel->setVisible(false);
-
 
     connect(ui->btnEsc, &QPushButton::clicked, this, &ReceiveDialog::close);
     connect(ui->btnSave, &QPushButton::clicked, this, &ReceiveDialog::onCopy);

--- a/src/qt/pivx/receivedialog.cpp
+++ b/src/qt/pivx/receivedialog.cpp
@@ -45,23 +45,25 @@ ReceiveDialog::ReceiveDialog(QWidget *parent) :
     connect(ui->btnSave, &QPushButton::clicked, this, &ReceiveDialog::onCopy);
 }
 
-void ReceiveDialog::updateQr(QString address){
-    if(!info) info = new SendCoinsRecipient();
+void ReceiveDialog::updateQr(QString address)
+{
+    if (!info) info = new SendCoinsRecipient();
     info->address = address;
     QString uri = GUIUtil::formatBitcoinURI(*info);
     ui->labelQrImg->setText("");
     ui->labelAddress->setText(address);
     QString error;
     QPixmap pixmap = encodeToQr(uri, error);
-    if(!pixmap.isNull()){
+    if (!pixmap.isNull()) {
         qrImage = &pixmap;
         ui->labelQrImg->setPixmap(qrImage->scaled(ui->labelQrImg->width(), ui->labelQrImg->height()));
-    }else{
+    } else {
         ui->labelQrImg->setText(!error.isEmpty() ? error : "Error encoding address");
     }
 }
 
-void ReceiveDialog::onCopy(){
+void ReceiveDialog::onCopy()
+{
     GUIUtil::setClipboard(info->address);
     accept();
 }

--- a/src/qt/pivx/receivewidget.cpp
+++ b/src/qt/pivx/receivewidget.cpp
@@ -41,39 +41,31 @@ ReceiveWidget::ReceiveWidget(PIVXGUI* parent) :
     ui->right->setContentsMargins(0,9,0,0);
 
     // Title
-    ui->labelTitle->setText(tr("Receive"));
-    ui->labelSubtitle1->setText(tr("Scan the QR code or copy the address to receive PIV."));
     setCssTitleScreen(ui->labelTitle);
     setCssSubtitleScreen(ui->labelSubtitle1);
 
     // Address
-    ui->labelAddress->setText(tr("No address "));
     setCssProperty(ui->labelAddress, "label-address-box");
 
-    ui->labelDate->setText("Dec. 19, 2018");
     setCssSubtitleScreen(ui->labelDate);
-    ui->labelLabel->setText("");
     setCssSubtitleScreen(ui->labelLabel);
 
     // Options
-    ui->btnMyAddresses->setTitleClassAndText("btn-title-grey", "My Addresses");
-    ui->btnMyAddresses->setSubTitleClassAndText("text-subtitle", "List your own addresses.");
+    ui->btnMyAddresses->setTitleClassAndText("btn-title-grey", tr("My Addresses"));
+    ui->btnMyAddresses->setSubTitleClassAndText("text-subtitle", tr("List your own addresses"));
     ui->btnMyAddresses->layout()->setMargin(0);
     ui->btnMyAddresses->setRightIconClass("ic-arrow");
 
-    ui->btnRequest->setTitleClassAndText("btn-title-grey", "Create Request");
-    ui->btnRequest->setSubTitleClassAndText("text-subtitle", "Request payment with a fixed amount.");
+    ui->btnRequest->setTitleClassAndText("btn-title-grey", tr("Create Request"));
+    ui->btnRequest->setSubTitleClassAndText("text-subtitle", tr("Request payment with a fixed amount"));
     ui->btnRequest->layout()->setMargin(0);
 
-    ui->pushButtonLabel->setText(tr("Add Label"));
     ui->pushButtonLabel->setLayoutDirection(Qt::RightToLeft);
     setCssProperty(ui->pushButtonLabel, "btn-secundary-label");
 
-    ui->pushButtonNewAddress->setText(tr("Generate Address"));
     ui->pushButtonNewAddress->setLayoutDirection(Qt::RightToLeft);
     setCssProperty(ui->pushButtonNewAddress, "btn-secundary-new-address");
 
-    ui->pushButtonCopy->setText(tr("Copy"));
     ui->pushButtonCopy->setLayoutDirection(Qt::RightToLeft);
     setCssProperty(ui->pushButtonCopy, "btn-secundary-copy");
 

--- a/src/qt/pivx/requestdialog.cpp
+++ b/src/qt/pivx/requestdialog.cpp
@@ -22,10 +22,7 @@ RequestDialog::RequestDialog(QWidget *parent) :
     setCssProperty(ui->frame, "container-dialog");
 
     // Text
-    ui->labelTitle->setText(tr("New Payment Request"));
     setCssProperty(ui->labelTitle, "text-title-dialog");
-
-    ui->labelMessage->setText(tr("Instead of sharing only a PIVX address, you can create a payment request, bundling up more information."));
     setCssProperty(ui->labelMessage, "text-main-grey");
 
     // Combo Coins
@@ -33,23 +30,16 @@ RequestDialog::RequestDialog(QWidget *parent) :
     setCssProperty(ui->comboContainer, "container-purple");
 
     // Label
-    ui->labelSubtitleLabel->setText(tr("Label"));
     setCssProperty(ui->labelSubtitleLabel, "text-title2-dialog");
-    ui->lineEditLabel->setPlaceholderText(tr("Enter a label for the address"));
     setCssEditLineDialog(ui->lineEditLabel, true);
 
     // Amount
-    ui->labelSubtitleAmount->setText(tr("Amount"));
     setCssProperty(ui->labelSubtitleAmount, "text-title2-dialog");
-    ui->lineEditAmount->setPlaceholderText("0.00 PIV");
     setCssEditLineDialog(ui->lineEditAmount, true);
     GUIUtil::setupAmountWidget(ui->lineEditAmount, this);
 
     // Description
-    ui->labelSubtitleDescription->setText(tr("Description (optional)"));
     setCssProperty(ui->labelSubtitleDescription, "text-title2-dialog");
-
-    ui->lineEditDescription->setPlaceholderText(tr("Enter description"));
     setCssEditLineDialog(ui->lineEditDescription, true);
 
     // Stack
@@ -62,7 +52,6 @@ RequestDialog::RequestDialog(QWidget *parent) :
     // Buttons
     setCssProperty(ui->btnEsc, "ic-close");
     setCssProperty(ui->btnCancel, "btn-dialog-cancel");
-    ui->btnSave->setText(tr("GENERATE"));
     setCssBtnPrimary(ui->btnSave);
     setCssBtnPrimary(ui->btnCopyAddress);
     setCssBtnPrimary(ui->btnCopyUrl);
@@ -104,13 +93,13 @@ void RequestDialog::onNextClicked(){
         if (!this->isPaymentRequest) {
             // Add specific checks for cold staking address creation
             if (labelStr.isEmpty()) {
-                inform("Address label cannot be empty");
+                inform(tr("Address label cannot be empty"));
                 return;
             }
         }
 
         if (value < 0 || !isValueValid) {
-            inform("Invalid amount");
+            inform(tr("Invalid amount"));
             return;
         }
 
@@ -127,10 +116,10 @@ void RequestDialog::onNextClicked(){
         PairResult r(false);
         if (this->isPaymentRequest) {
             r = walletModel->getNewAddress(address, label);
-            title = "Request for " + BitcoinUnits::format(displayUnit, value, false, BitcoinUnits::separatorAlways) + " PIV";
+            title = tr("Request for ") + BitcoinUnits::format(displayUnit, value, false, BitcoinUnits::separatorAlways) + " PIV";
         } else {
             r = walletModel->getNewStakingAddress(address, label);
-            title = "Cold Staking Address Generated";
+            title = tr("Cold Staking Address Generated");
         }
 
         if (!r.result) {

--- a/src/qt/pivx/requestdialog.cpp
+++ b/src/qt/pivx/requestdialog.cpp
@@ -64,11 +64,13 @@ RequestDialog::RequestDialog(QWidget *parent) :
     connect(ui->btnCopyUrl, &QPushButton::clicked, this, &RequestDialog::onCopyUriClicked);
 }
 
-void RequestDialog::setWalletModel(WalletModel *model){
+void RequestDialog::setWalletModel(WalletModel *model)
+{
     this->walletModel = model;
 }
 
-void RequestDialog::setPaymentRequest(bool isPaymentRequest) {
+void RequestDialog::setPaymentRequest(bool isPaymentRequest)
+{
     this->isPaymentRequest = isPaymentRequest;
     if (!this->isPaymentRequest) {
         ui->labelMessage->setText(tr("Creates an address to receive coin delegations and be able to stake them."));
@@ -77,8 +79,9 @@ void RequestDialog::setPaymentRequest(bool isPaymentRequest) {
     }
 }
 
-void RequestDialog::onNextClicked(){
-    if(walletModel) {
+void RequestDialog::onNextClicked()
+{
+    if (walletModel) {
 
         QString labelStr = ui->lineEditLabel->text();
 
@@ -139,16 +142,18 @@ void RequestDialog::onNextClicked(){
     }
 }
 
-void RequestDialog::onCopyClicked(){
-    if(info) {
+void RequestDialog::onCopyClicked()
+{
+    if (info) {
         GUIUtil::setClipboard(info->address);
         res = 2;
         accept();
     }
 }
 
-void RequestDialog::onCopyUriClicked(){
-    if(info) {
+void RequestDialog::onCopyUriClicked()
+{
+    if (info) {
         GUIUtil::setClipboard(GUIUtil::formatBitcoinURI(*info));
         res = 1;
         accept();
@@ -160,20 +165,22 @@ void RequestDialog::showEvent(QShowEvent *event)
     if (ui->lineEditAmount) ui->lineEditAmount->setFocus();
 }
 
-void RequestDialog::updateQr(QString str){
+void RequestDialog::updateQr(QString str)
+{
     QString uri = GUIUtil::formatBitcoinURI(*info);
     ui->labelQrImg->setText("");
     QString error;
     QPixmap pixmap = encodeToQr(uri, error);
-    if(!pixmap.isNull()){
+    if (!pixmap.isNull()) {
         qrImage = &pixmap;
         ui->labelQrImg->setPixmap(qrImage->scaled(ui->labelQrImg->width(), ui->labelQrImg->height()));
-    }else{
+    } else {
         ui->labelQrImg->setText(!error.isEmpty() ? error : "Error encoding address");
     }
 }
 
-void RequestDialog::inform(QString text){
+void RequestDialog::inform(QString text)
+{
     if (!snackBar)
         snackBar = new SnackBar(nullptr, this);
     snackBar->setText(text);
@@ -181,6 +188,7 @@ void RequestDialog::inform(QString text){
     openDialog(snackBar, this);
 }
 
-RequestDialog::~RequestDialog(){
+RequestDialog::~RequestDialog()
+{
     delete ui;
 }

--- a/src/qt/pivx/send.cpp
+++ b/src/qt/pivx/send.cpp
@@ -41,58 +41,38 @@ SendWidget::SendWidget(PIVXGUI* parent) :
     fontLight.setWeight(QFont::Light);
 
     /* Title */
-    ui->labelTitle->setText(tr("Send"));
     setCssProperty(ui->labelTitle, "text-title-screen");
     ui->labelTitle->setFont(fontLight);
 
     /* Button Group */
-    ui->pushLeft->setText("PIV");
     setCssProperty(ui->pushLeft, "btn-check-left");
     ui->pushLeft->setChecked(true);
-    ui->pushRight->setText("zPIV");
     setCssProperty(ui->pushRight, "btn-check-right");
 
     /* Subtitle */
-    ui->labelSubtitle1->setText(tr("You can transfer public coins (PIV) or private coins (zPIV)"));
-    setCssProperty(ui->labelSubtitle1, "text-subtitle");
+    setCssProperty({ui->labelSubtitle1, ui->labelSubtitle2}, "text-subtitle");
 
-    ui->labelSubtitle2->setText(tr("Select coin type to spend"));
-    setCssProperty(ui->labelSubtitle2, "text-subtitle");
-
-    /* Address */
-    ui->labelSubtitleAddress->setText(tr("PIVX address or contact label"));
-    setCssProperty(ui->labelSubtitleAddress, "text-title");
-
-
-    /* Amount */
-    ui->labelSubtitleAmount->setText(tr("Amount"));
-    setCssProperty(ui->labelSubtitleAmount, "text-title");
+    /* Address - Amount*/
+    setCssProperty({ui->labelSubtitleAddress, ui->labelSubtitleAmount}, "text-title");
 
     /* Buttons */
-    ui->pushButtonFee->setText(tr("Customize fee"));
     setCssBtnSecondary(ui->pushButtonFee);
-
-    ui->pushButtonClear->setText(tr("Clear all"));
     setCssProperty(ui->pushButtonClear, "btn-secundary-clear");
-
-    ui->pushButtonAddRecipient->setText(tr("Add recipient"));
     setCssProperty(ui->pushButtonAddRecipient, "btn-secundary-add");
-
     setCssBtnPrimary(ui->pushButtonSave);
-    ui->pushButtonReset->setText(tr("Reset to default"));
     setCssBtnSecondary(ui->pushButtonReset);
 
     // Coin control
-    ui->btnCoinControl->setTitleClassAndText("btn-title-grey", "Coin Control");
-    ui->btnCoinControl->setSubTitleClassAndText("text-subtitle", "Select the source of the coins.");
+    ui->btnCoinControl->setTitleClassAndText("btn-title-grey", tr("Coin Control"));
+    ui->btnCoinControl->setSubTitleClassAndText("text-subtitle", tr("Select the source of the coins"));
 
     // Change address option
-    ui->btnChangeAddress->setTitleClassAndText("btn-title-grey", "Change Address");
-    ui->btnChangeAddress->setSubTitleClassAndText("text-subtitle", "Customize the change address.");
+    ui->btnChangeAddress->setTitleClassAndText("btn-title-grey", tr("Change Address"));
+    ui->btnChangeAddress->setSubTitleClassAndText("text-subtitle", tr("Customize the change address"));
 
     // Uri
-    ui->btnUri->setTitleClassAndText("btn-title-grey", "Open URI");
-    ui->btnUri->setSubTitleClassAndText("text-subtitle", "Parse a payment request.");
+    ui->btnUri->setTitleClassAndText("btn-title-grey", tr("Open URI"));
+    ui->btnUri->setSubTitleClassAndText("text-subtitle", tr("Parse a payment request"));
 
     connect(ui->pushButtonFee, &QPushButton::clicked, this, &SendWidget::onChangeCustomFeeClicked);
     connect(ui->btnCoinControl, &OptionButton::clicked, this, &SendWidget::onCoinControlClicked);
@@ -106,15 +86,11 @@ SendWidget::SendWidget(PIVXGUI* parent) :
 
 
     // Total Send
-    ui->labelTitleTotalSend->setText(tr("Total to send"));
     setCssProperty(ui->labelTitleTotalSend, "text-title");
-
-    ui->labelAmountSend->setText("0.00 PIV");
     setCssProperty(ui->labelAmountSend, "text-body1");
 
     // Total Remaining
     setCssProperty(ui->labelTitleTotalRemaining, "text-title");
-
     setCssProperty(ui->labelAmountRemaining, "text-body1");
 
     // Icon Send

--- a/src/qt/pivx/sendchangeaddressdialog.cpp
+++ b/src/qt/pivx/sendchangeaddressdialog.cpp
@@ -23,13 +23,9 @@ SendChangeAddressDialog::SendChangeAddressDialog(QWidget* parent, WalletModel* m
     ui->frame->setProperty("cssClass", "container-dialog");
 
     // Text
-    ui->labelTitle->setText(tr("Custom Change Address"));
     ui->labelTitle->setProperty("cssClass", "text-title-dialog");
-
-    ui->labelMessage->setText(tr("The remainder of the value resultant from the inputs minus the outputs value goes to the \"change\" PIVX address"));
     ui->labelMessage->setProperty("cssClass", "text-main-grey");
 
-    ui->lineEditAddress->setPlaceholderText("Enter PIVX address (e.g D7VFR83SQbiezrW72hjc… ");
     initCssEditLine(ui->lineEditAddress, true);
 
     // Buttons
@@ -37,7 +33,6 @@ SendChangeAddressDialog::SendChangeAddressDialog(QWidget* parent, WalletModel* m
     ui->btnEsc->setProperty("cssClass", "ic-close");
 
     ui->btnCancel->setProperty("cssClass", "btn-dialog-cancel");
-    ui->btnSave->setText(tr("SAVE"));
     setCssBtnPrimary(ui->btnSave);
 
     connect(ui->btnEsc, &QPushButton::clicked, this, &SendChangeAddressDialog::close);

--- a/src/qt/pivx/sendconfirmdialog.cpp
+++ b/src/qt/pivx/sendconfirmdialog.cpp
@@ -69,7 +69,7 @@ TxDetailDialog::TxDetailDialog(QWidget *parent, bool _isConfirmDialog, const QSt
 
         connect(ui->btnCancel, &QPushButton::clicked, this, &TxDetailDialog::close);
         connect(ui->btnSave, &QPushButton::clicked, [this](){acceptTx();});
-    }else{
+    } else {
         ui->labelTitle->setText(tr("Transaction Details"));
         ui->containerButtons->setVisible(false);
     }
@@ -84,7 +84,8 @@ void TxDetailDialog::showEvent(QShowEvent *event)
     setFocus();
 }
 
-void TxDetailDialog::setData(WalletModel *model, const QModelIndex &index){
+void TxDetailDialog::setData(WalletModel *model, const QModelIndex &index)
+{
     this->model = model;
     TransactionRecord *rec = static_cast<TransactionRecord*>(index.internalPointer());
     QDateTime date = index.data(TransactionTableModel::DateRole).toDateTime();
@@ -94,7 +95,7 @@ void TxDetailDialog::setData(WalletModel *model, const QModelIndex &index){
     ui->textAmount->setText(amountText);
 
     const CWalletTx* tx = model->getTx(rec->hash);
-    if(tx) {
+    if (tx) {
         this->txHash = rec->hash;
         QString hash = QString::fromStdString(tx->GetHash().GetHex());
         ui->textId->setText(hash.left(20) + "..." + hash.right(20));
@@ -168,7 +169,7 @@ void TxDetailDialog::onInputsClicked()
         if (!inputsLoaded) {
             inputsLoaded = true;
             const CWalletTx* tx = (this->tx) ? this->tx->getTransaction() : model->getTx(this->txHash);
-            if(tx) {
+            if (tx) {
                 ui->gridInputs->setMinimumHeight(50 + (50 * tx->vin.size()));
                 int i = 1;
                 for (const CTxIn &in : tx->vin) {
@@ -243,12 +244,12 @@ void TxDetailDialog::keyPressEvent(QKeyEvent *event)
 
 void TxDetailDialog::closeDialog()
 {
-    if(snackBar && snackBar->isVisible()) snackBar->hide();
+    if (snackBar && snackBar->isVisible()) snackBar->hide();
     close();
 }
 
 TxDetailDialog::~TxDetailDialog()
 {
-    if(snackBar) delete snackBar;
+    if (snackBar) delete snackBar;
     delete ui;
 }

--- a/src/qt/pivx/sendcustomfeedialog.cpp
+++ b/src/qt/pivx/sendcustomfeedialog.cpp
@@ -25,8 +25,6 @@ SendCustomFeeDialog::SendCustomFeeDialog(PIVXGUI* parent, WalletModel* model) :
     setCssProperty(ui->frame, "container-dialog");
 
     // Text
-    ui->labelTitle->setText(tr("Customize Fee"));
-    ui->labelMessage->setText(tr("Customize the transaction fee, depending on the fee value your transaction might be included faster in the blockchain."));
     setCssProperty(ui->labelTitle, "text-title-dialog");
     setCssProperty(ui->labelMessage, "text-main-grey");
 
@@ -40,14 +38,12 @@ SendCustomFeeDialog::SendCustomFeeDialog(PIVXGUI* parent, WalletModel* model) :
 
     // Custom
     setCssProperty(ui->labelCustomFee, "label-subtitle-dialog");
-    ui->lineEditCustomFee->setPlaceholderText("0.000001");
     initCssEditLine(ui->lineEditCustomFee, true);
     GUIUtil::setupAmountWidget(ui->lineEditCustomFee, this);
 
     // Buttons
     setCssProperty(ui->btnEsc, "ic-close");
     setCssProperty(ui->btnCancel, "btn-dialog-cancel");
-    ui->btnSave->setText(tr("SAVE"));
     setCssBtnPrimary(ui->btnSave);
 
     connect(ui->btnEsc, &QPushButton::clicked, this, &SendCustomFeeDialog::close);

--- a/src/qt/pivx/sendmultirow.cpp
+++ b/src/qt/pivx/sendmultirow.cpp
@@ -19,19 +19,15 @@ SendMultiRow::SendMultiRow(PWidget *parent) :
     ui->setupUi(this);
     this->setStyleSheet(parent->styleSheet());
 
-    ui->lineEditAddress->setPlaceholderText(tr("Enter address"));
     setCssProperty(ui->lineEditAddress, "edit-primary-multi-book");
     ui->lineEditAddress->setAttribute(Qt::WA_MacShowFocusRect, 0);
     setShadow(ui->stackedAddress);
 
-    ui->lineEditAmount->setPlaceholderText("0.00 PIV ");
     initCssEditLine(ui->lineEditAmount);
     GUIUtil::setupAmountWidget(ui->lineEditAmount, this);
 
     /* Description */
-    ui->labelSubtitleDescription->setText("Address label (optional)");
     setCssProperty(ui->labelSubtitleDescription, "text-title");
-    ui->lineEditDescription->setPlaceholderText(tr("Enter label"));
     initCssEditLine(ui->lineEditDescription);
 
     // Button menu

--- a/src/qt/pivx/sendmultirow.cpp
+++ b/src/qt/pivx/sendmultirow.cpp
@@ -58,8 +58,9 @@ SendMultiRow::SendMultiRow(PWidget *parent) :
     connect(ui->btnMenu, &QPushButton::clicked, [this](){Q_EMIT onMenuClicked(this);});
 }
 
-void SendMultiRow::amountChanged(const QString& amount){
-    if(!amount.isEmpty()) {
+void SendMultiRow::amountChanged(const QString& amount)
+{
+    if (!amount.isEmpty()) {
         QString amountStr = amount;
         CAmount value = getAmountValue(amountStr);
         if (value > 0) {
@@ -73,7 +74,8 @@ void SendMultiRow::amountChanged(const QString& amount){
 /**
  * Returns -1 if the value is invalid
  */
-CAmount SendMultiRow::getAmountValue(QString amount){
+CAmount SendMultiRow::getAmountValue(QString amount)
+{
     bool isValid = false;
     CAmount value = GUIUtil::parseValue(amount, displayUnit, &isValid);
     return isValid ? value : -1;
@@ -81,7 +83,7 @@ CAmount SendMultiRow::getAmountValue(QString amount){
 
 bool SendMultiRow::addressChanged(const QString& str, bool fOnlyValidate)
 {
-    if(!str.isEmpty()) {
+    if (!str.isEmpty()) {
         QString trimmedStr = str.trimmed();
         const bool valid = walletModel->validateAddress(trimmedStr, this->onlyStakingAddressAccepted);
         if (!valid) {
@@ -94,7 +96,7 @@ bool SendMultiRow::addressChanged(const QString& str, bool fOnlyValidate)
                 QString label = walletModel->getAddressTableModel()->labelForAddress(rcp.address);
                 if (!label.isNull() && !label.isEmpty()){
                     ui->lineEditDescription->setText(label);
-                } else if(!rcp.message.isEmpty())
+                } else if (!rcp.message.isEmpty())
                     ui->lineEditDescription->setText(rcp.message);
 
                 Q_EMIT onUriParsed(rcp);
@@ -117,7 +119,8 @@ bool SendMultiRow::addressChanged(const QString& str, bool fOnlyValidate)
 }
 
 
-void SendMultiRow::loadWalletModel() {
+void SendMultiRow::loadWalletModel()
+{
     if (walletModel && walletModel->getOptionsModel()) {
         displayUnit = walletModel->getOptionsModel()->getDisplayUnit();
         connect(walletModel->getOptionsModel(), &OptionsModel::displayUnitChanged, this, &SendMultiRow::updateDisplayUnit);
@@ -125,16 +128,19 @@ void SendMultiRow::loadWalletModel() {
     clear();
 }
 
-void SendMultiRow::updateDisplayUnit(){
+void SendMultiRow::updateDisplayUnit()
+{
     // Update edit text..
     displayUnit = walletModel->getOptionsModel()->getDisplayUnit();
 }
 
-void SendMultiRow::deleteClicked() {
+void SendMultiRow::deleteClicked()
+{
     Q_EMIT removeEntry(this);
 }
 
-void SendMultiRow::clear() {
+void SendMultiRow::clear()
+{
     ui->lineEditAddress->clear();
     ui->lineEditAmount->clear();
     ui->lineEditDescription->clear();
@@ -178,7 +184,8 @@ bool SendMultiRow::validate()
     return retval;
 }
 
-SendCoinsRecipient SendMultiRow::getValue() {
+SendCoinsRecipient SendMultiRow::getValue()
+{
     // Payment request
     if (recipient.paymentRequest.IsInitialized())
         return recipient;
@@ -190,40 +197,49 @@ SendCoinsRecipient SendMultiRow::getValue() {
     return recipient;
 }
 
-QString SendMultiRow::getAddress() {
+QString SendMultiRow::getAddress()
+{
     return ui->lineEditAddress->text().trimmed();
 }
 
-CAmount SendMultiRow::getAmountValue() {
+CAmount SendMultiRow::getAmountValue()
+{
     return getAmountValue(ui->lineEditAmount->text());
 }
 
-QRect SendMultiRow::getEditLineRect(){
+QRect SendMultiRow::getEditLineRect()
+{
     return ui->lineEditAddress->rect();
 }
 
-int SendMultiRow::getEditHeight(){
+int SendMultiRow::getEditHeight()
+{
     return ui->stackedAddress->height();
 }
 
-int SendMultiRow::getEditWidth(){
+int SendMultiRow::getEditWidth()
+{
     return ui->lineEditAddress->width();
 }
 
-int SendMultiRow::getNumber(){
+int SendMultiRow::getNumber()
+{
     return number;
 }
 
-void SendMultiRow::setAddress(const QString& address) {
+void SendMultiRow::setAddress(const QString& address)
+{
     ui->lineEditAddress->setText(address);
     ui->lineEditAmount->setFocus();
 }
 
-void SendMultiRow::setAmount(const QString& amount){
+void SendMultiRow::setAmount(const QString& amount)
+{
     ui->lineEditAmount->setText(amount);
 }
 
-void SendMultiRow::setAddressAndLabelOrDescription(const QString& address, const QString& message){
+void SendMultiRow::setAddressAndLabelOrDescription(const QString& address, const QString& message)
+{
     QString label = walletModel->getAddressTableModel()->labelForAddress(address);
     if (!label.isNull() && !label.isEmpty()){
         ui->lineEditDescription->setText(label);
@@ -232,60 +248,72 @@ void SendMultiRow::setAddressAndLabelOrDescription(const QString& address, const
     setAddress(address);
 }
 
-void SendMultiRow::setLabel(const QString& label){
+void SendMultiRow::setLabel(const QString& label)
+{
     ui->lineEditDescription->setText(label);
 }
 
-bool SendMultiRow::isClear(){
+bool SendMultiRow::isClear()
+{
     return ui->lineEditAddress->text().isEmpty();
 }
 
-void SendMultiRow::setFocus(){
+void SendMultiRow::setFocus()
+{
     ui->lineEditAddress->setFocus();
 }
 
-void SendMultiRow::setOnlyStakingAddressAccepted(bool onlyStakingAddress) {
+void SendMultiRow::setOnlyStakingAddressAccepted(bool onlyStakingAddress)
+{
     this->onlyStakingAddressAccepted = onlyStakingAddress;
 }
 
 
-void SendMultiRow::setNumber(int _number){
+void SendMultiRow::setNumber(int _number)
+{
     number = _number;
     iconNumber->setText(QString::number(_number));
 }
 
-void SendMultiRow::hideLabels(){
+void SendMultiRow::hideLabels()
+{
     ui->layoutLabel->setVisible(false);
     iconNumber->setVisible(true);
 }
 
-void SendMultiRow::showLabels(){
+void SendMultiRow::showLabels()
+{
     ui->layoutLabel->setVisible(true);
     iconNumber->setVisible(false);
 }
 
-void SendMultiRow::resizeEvent(QResizeEvent *event) {
+void SendMultiRow::resizeEvent(QResizeEvent *event)
+{
     QWidget::resizeEvent(event);
 }
 
-void SendMultiRow::enterEvent(QEvent *) {
-    if(!this->isExpanded && iconNumber->isVisible()){
+void SendMultiRow::enterEvent(QEvent *)
+{
+    if (!this->isExpanded && iconNumber->isVisible()) {
         isExpanded = true;
         ui->btnMenu->setVisible(isExpanded);
     }
 }
 
-void SendMultiRow::leaveEvent(QEvent *) {
-    if(isExpanded){
+void SendMultiRow::leaveEvent(QEvent *)
+{
+    if (isExpanded) {
         isExpanded = false;
         ui->btnMenu->setVisible(isExpanded);
     }
 }
 
-int SendMultiRow::getMenuBtnWidth(){
+int SendMultiRow::getMenuBtnWidth()
+{
     return ui->btnMenu->width();
 }
 
-SendMultiRow::~SendMultiRow(){
+SendMultiRow::~SendMultiRow()
+{
     delete ui;
 }

--- a/src/qt/pivx/settings/forms/settingsbackupwallet.ui
+++ b/src/qt/pivx/settings/forms/settingsbackupwallet.ui
@@ -52,14 +52,15 @@
         <item>
          <widget class="QLabel" name="labelTitle">
           <property name="text">
-           <string>TextLabel</string>
+           <string>Backup Wallet</string>
           </property>
          </widget>
         </item>
         <item>
          <widget class="QLabel" name="labelSubtitle1">
           <property name="text">
-           <string>TextLabel</string>
+           <string>Keep your wallet safe by doing regular backups and storing your backup file externally.
+This option creates a wallet.dat file that can be used to recover your whole balance (transactions and addresses) on another device</string>
           </property>
           <property name="wordWrap">
            <bool>true</bool>
@@ -89,7 +90,7 @@
         <item>
          <widget class="QLabel" name="labelSubtitleLocation">
           <property name="text">
-           <string>TextLabel</string>
+           <string>Where</string>
           </property>
          </widget>
         </item>
@@ -111,7 +112,7 @@
            <enum>Qt::NoFocus</enum>
           </property>
           <property name="text">
-           <string/>
+           <string>Select folder...</string>
           </property>
          </widget>
         </item>
@@ -157,14 +158,15 @@
         <item>
          <widget class="QLabel" name="labelTitle_2">
           <property name="text">
-           <string>TextLabel</string>
+           <string>Change Wallet Passphrase</string>
           </property>
          </widget>
         </item>
         <item>
          <widget class="QLabel" name="labelSubtitle_2">
           <property name="text">
-           <string>TextLabel</string>
+           <string>This will decrypt the whole wallet data and encrypt it back with the new passphrase.
+Remember to write it down and store it safely, otherwise you might lose access to your funds</string>
           </property>
           <property name="wordWrap">
            <bool>true</bool>
@@ -222,7 +224,7 @@
            <enum>Qt::NoFocus</enum>
           </property>
           <property name="text">
-           <string/>
+           <string>Change Passphrase</string>
           </property>
          </widget>
         </item>

--- a/src/qt/pivx/settings/forms/settingsbittoolwidget.ui
+++ b/src/qt/pivx/settings/forms/settingsbittoolwidget.ui
@@ -62,14 +62,15 @@
             <item>
              <widget class="QLabel" name="labelTitle">
               <property name="text">
-               <string>TextLabel</string>
+               <string>BIP38 Tool</string>
               </property>
              </widget>
             </item>
             <item>
              <widget class="QLabel" name="labelSubtitle1">
               <property name="text">
-               <string>TextLabel</string>
+               <string>Encrypt your PIVX addresses (key pair actually) using BIP38 encryption.
+Using this mechanism you can share your keys without middle-man risk, only need to store your passphrase safely</string>
               </property>
               <property name="wordWrap">
                <bool>true</bool>
@@ -133,7 +134,7 @@
                 <enum>Qt::NoFocus</enum>
                </property>
                <property name="text">
-                <string/>
+                <string>Encrypt</string>
                </property>
                <property name="checkable">
                 <bool>true</bool>
@@ -161,7 +162,7 @@
                 <enum>Qt::NoFocus</enum>
                </property>
                <property name="text">
-                <string/>
+                <string>Decrypt</string>
                </property>
                <property name="checkable">
                 <bool>true</bool>
@@ -266,7 +267,7 @@
                       </size>
                      </property>
                      <property name="text">
-                      <string>TextLabel</string>
+                      <string>Encrypted key</string>
                      </property>
                     </widget>
                    </item>
@@ -283,6 +284,9 @@
                        <width>16777215</width>
                        <height>50</height>
                       </size>
+                     </property>
+                     <property name="placeholderText">
+                      <string>Enter a encrypted key</string>
                      </property>
                     </widget>
                    </item>
@@ -320,7 +324,7 @@
                     </size>
                    </property>
                    <property name="text">
-                    <string>TextLabel</string>
+                    <string>Passphrase</string>
                    </property>
                   </widget>
                  </item>
@@ -337,6 +341,9 @@
                      <width>16777215</width>
                      <height>50</height>
                     </size>
+                   </property>
+                   <property name="placeholderText">
+                    <string>Enter a passphrase</string>
                    </property>
                   </widget>
                  </item>
@@ -397,7 +404,7 @@
                      </size>
                     </property>
                     <property name="text">
-                     <string>Decrypt Address Result</string>
+                     <string>Decrypted address result</string>
                     </property>
                    </widget>
                   </item>
@@ -432,6 +439,9 @@
                          <width>16777215</width>
                          <height>50</height>
                         </size>
+                       </property>
+                       <property name="placeholderText">
+                        <string>Decrypted Address</string>
                        </property>
                       </widget>
                      </item>
@@ -535,7 +545,7 @@
                     </size>
                    </property>
                    <property name="text">
-                    <string>Clear</string>
+                    <string>CLEAR</string>
                    </property>
                   </widget>
                  </item>
@@ -570,7 +580,7 @@
                     </size>
                    </property>
                    <property name="text">
-                    <string>PushButton</string>
+                    <string>DECRYPT KEY</string>
                    </property>
                   </widget>
                  </item>
@@ -647,7 +657,7 @@
                   </size>
                  </property>
                  <property name="text">
-                  <string>TextLabel</string>
+                  <string>PIVX address</string>
                  </property>
                 </widget>
                </item>
@@ -658,6 +668,9 @@
                    <width>0</width>
                    <height>50</height>
                   </size>
+                 </property>
+                 <property name="placeholderText">
+                  <string>Enter address</string>
                  </property>
                 </widget>
                </item>
@@ -718,7 +731,7 @@
                     </size>
                    </property>
                    <property name="text">
-                    <string>TextLabel</string>
+                    <string>Passphrase</string>
                    </property>
                   </widget>
                  </item>
@@ -735,6 +748,9 @@
                      <width>16777215</width>
                      <height>50</height>
                     </size>
+                   </property>
+                   <property name="placeholderText">
+                    <string>Enter passphrase</string>
                    </property>
                   </widget>
                  </item>
@@ -801,7 +817,7 @@
                   </size>
                  </property>
                  <property name="text">
-                  <string>TextLabel</string>
+                  <string>Encrypted Key</string>
                  </property>
                 </widget>
                </item>
@@ -813,6 +829,9 @@
                    <height>50</height>
                   </size>
                  </property>
+                 <property name="placeholderText">
+                  <string>Encrypted Key</string>
+                 </property>
                 </widget>
                </item>
               </layout>
@@ -821,7 +840,7 @@
             <item>
              <widget class="QLabel" name="statusLabel_ENC">
               <property name="text">
-               <string>TextLabel</string>
+               <string notr="true">N/A</string>
               </property>
              </widget>
             </item>
@@ -874,7 +893,7 @@
                  <enum>Qt::NoFocus</enum>
                 </property>
                 <property name="text">
-                 <string>Clear</string>
+                 <string>CLEAR ALL</string>
                 </property>
                </widget>
               </item>
@@ -912,7 +931,7 @@
                  <enum>Qt::NoFocus</enum>
                 </property>
                 <property name="text">
-                 <string/>
+                 <string>ENCRYPT</string>
                 </property>
                </widget>
               </item>

--- a/src/qt/pivx/settings/forms/settingsconsolewidget.ui
+++ b/src/qt/pivx/settings/forms/settingsconsolewidget.ui
@@ -57,7 +57,7 @@
           <item>
            <widget class="QLabel" name="labelTitle">
             <property name="text">
-             <string>TextLabel</string>
+             <string>Console</string>
             </property>
            </widget>
           </item>
@@ -86,7 +86,7 @@
              <enum>Qt::NoFocus</enum>
             </property>
             <property name="text">
-             <string/>
+             <string>Open Debug File</string>
             </property>
            </widget>
           </item>
@@ -108,7 +108,7 @@
              <enum>Qt::NoFocus</enum>
             </property>
             <property name="text">
-             <string/>
+             <string>Command Line Options</string>
             </property>
            </widget>
           </item>
@@ -230,6 +230,9 @@
               <width>45</width>
               <height>45</height>
              </size>
+            </property>
+            <property name="toolTip">
+             <string>Clear history</string>
             </property>
             <property name="text">
              <string notr="true">-</string>

--- a/src/qt/pivx/settings/forms/settingsdisplayoptionswidget.ui
+++ b/src/qt/pivx/settings/forms/settingsdisplayoptionswidget.ui
@@ -62,14 +62,14 @@
             <item>
              <widget class="QLabel" name="labelTitle">
               <property name="text">
-               <string>TextLabel</string>
+               <string>Display</string>
               </property>
              </widget>
             </item>
             <item>
              <widget class="QLabel" name="labelSubtitle1">
               <property name="text">
-               <string>TextLabel</string>
+               <string>Customize the display view options</string>
               </property>
               <property name="wordWrap">
                <bool>true</bool>
@@ -85,7 +85,7 @@
           <item>
            <widget class="QLabel" name="labelTitleLanguage">
             <property name="text">
-             <string>TextLabel</string>
+             <string>Language</string>
             </property>
            </widget>
           </item>
@@ -125,7 +125,7 @@
           <item>
            <widget class="QLabel" name="labelTitleUnit">
             <property name="text">
-             <string>TextLabel</string>
+             <string>Unit to show amount</string>
             </property>
            </widget>
           </item>
@@ -165,7 +165,7 @@
           <item>
            <widget class="QLabel" name="labelTitleDigits">
             <property name="text">
-             <string>TextLabel</string>
+             <string>Decimal digits</string>
             </property>
            </widget>
           </item>
@@ -223,7 +223,7 @@
            <enum>Qt::NoFocus</enum>
           </property>
           <property name="text">
-           <string/>
+           <string>Hide empty balances</string>
           </property>
           <property name="checkable">
            <bool>true</bool>
@@ -238,7 +238,7 @@
           <item>
            <widget class="QLabel" name="labelTitleUrl">
             <property name="text">
-             <string>TextLabel</string>
+             <string>Third party transactions URLs</string>
             </property>
            </widget>
           </item>

--- a/src/qt/pivx/settings/forms/settingsfaqwidget.ui
+++ b/src/qt/pivx/settings/forms/settingsfaqwidget.ui
@@ -58,7 +58,7 @@
         <item>
          <widget class="QLabel" name="labelTitle">
           <property name="text">
-           <string>TextLabel</string>
+           <string>Frequently Asked Questions</string>
           </property>
          </widget>
         </item>
@@ -78,7 +78,7 @@
         <item>
          <widget class="QPushButton" name="pushButtonExit">
           <property name="text">
-           <string>PushButton</string>
+           <string>Exit</string>
           </property>
          </widget>
         </item>
@@ -417,7 +417,7 @@
                <item>
                 <widget class="QLabel" name="labelWebLink">
                  <property name="text">
-                  <string>TextLabel</string>
+                  <string>You can read more here</string>
                  </property>
                 </widget>
                </item>
@@ -443,7 +443,7 @@
                   <enum>Qt::NoFocus</enum>
                  </property>
                  <property name="text">
-                  <string>PushButton</string>
+                  <string>https://PIVX.org/</string>
                  </property>
                 </widget>
                </item>

--- a/src/qt/pivx/settings/forms/settingsmainoptionswidget.ui
+++ b/src/qt/pivx/settings/forms/settingsmainoptionswidget.ui
@@ -62,14 +62,14 @@
             <item>
              <widget class="QLabel" name="labelTitle">
               <property name="text">
-               <string>TextLabel</string>
+               <string>Main</string>
               </property>
              </widget>
             </item>
             <item>
              <widget class="QLabel" name="labelSubtitle1">
               <property name="text">
-               <string>TextLabel</string>
+               <string>Customize the main application options</string>
               </property>
               <property name="wordWrap">
                <bool>true</bool>
@@ -146,7 +146,7 @@
           <item>
            <widget class="QLabel" name="labelTitleSizeDb">
             <property name="text">
-             <string>TextLabel</string>
+             <string>Size of database cache</string>
             </property>
            </widget>
           </item>
@@ -196,7 +196,7 @@
           <item>
            <widget class="QLabel" name="labelTitleThreads">
             <property name="text">
-             <string>TextLabel</string>
+             <string>Number of script verification threads</string>
             </property>
            </widget>
           </item>
@@ -326,7 +326,7 @@
         <item>
          <widget class="QCheckBox" name="checkBoxMinTaskbar">
           <property name="text">
-           <string>CheckBox</string>
+           <string>Minimize to the tray instead of the taskbar</string>
           </property>
          </widget>
         </item>
@@ -349,7 +349,7 @@
         <item>
          <widget class="QCheckBox" name="checkBoxMinClose">
           <property name="text">
-           <string>CheckBox</string>
+           <string>Minimize on close</string>
           </property>
          </widget>
         </item>

--- a/src/qt/pivx/settings/forms/settingssignmessagewidgets.ui
+++ b/src/qt/pivx/settings/forms/settingssignmessagewidgets.ui
@@ -75,14 +75,14 @@
              <item>
               <widget class="QLabel" name="labelTitle">
                <property name="text">
-                <string>TextLabel</string>
+                <string>Sign/Verify Message</string>
                </property>
               </widget>
              </item>
              <item>
               <widget class="QLabel" name="labelSubtitle1">
                <property name="text">
-                <string>TextLabel</string>
+                <string notr="true">N/A</string>
                </property>
                <property name="wordWrap">
                 <bool>true</bool>
@@ -162,7 +162,7 @@
                     <enum>Qt::NoFocus</enum>
                    </property>
                    <property name="text">
-                    <string/>
+                    <string>Sign</string>
                    </property>
                    <property name="checkable">
                     <bool>true</bool>
@@ -190,7 +190,7 @@
                     <enum>Qt::NoFocus</enum>
                    </property>
                    <property name="text">
-                    <string/>
+                    <string>Verify</string>
                    </property>
                    <property name="checkable">
                     <bool>true</bool>
@@ -276,7 +276,7 @@
                </size>
               </property>
               <property name="text">
-               <string>TextLabel</string>
+               <string>PIVX address or contact label</string>
               </property>
              </widget>
             </item>
@@ -293,6 +293,9 @@
                 <width>16777215</width>
                 <height>50</height>
                </size>
+              </property>
+              <property name="placeholderText">
+               <string>Enter address</string>
               </property>
              </widget>
             </item>
@@ -335,7 +338,7 @@
               </size>
              </property>
              <property name="text">
-              <string>TextLabel</string>
+              <string>Message</string>
              </property>
             </widget>
            </item>
@@ -352,6 +355,9 @@
                <width>16777215</width>
                <height>140</height>
               </size>
+             </property>
+             <property name="placeholderText">
+              <string>Write message here...</string>
              </property>
             </widget>
            </item>
@@ -415,7 +421,7 @@
                </size>
               </property>
               <property name="text">
-               <string>TextLabel</string>
+               <string>Signature</string>
               </property>
              </widget>
             </item>
@@ -426,6 +432,9 @@
                 <width>0</width>
                 <height>50</height>
                </size>
+              </property>
+              <property name="placeholderText">
+               <string>Signature</string>
               </property>
              </widget>
             </item>
@@ -438,7 +447,7 @@
             <string notr="true">padding-top:5px;</string>
            </property>
            <property name="text">
-            <string>TextLabel</string>
+            <string notr="true">N/A</string>
            </property>
           </widget>
          </item>
@@ -491,7 +500,7 @@
               <enum>Qt::NoFocus</enum>
              </property>
              <property name="text">
-              <string>Clear</string>
+              <string>CLEAR ALL</string>
              </property>
             </widget>
            </item>
@@ -513,7 +522,7 @@
               <enum>Qt::NoFocus</enum>
              </property>
              <property name="text">
-              <string/>
+              <string>SIGN</string>
              </property>
             </widget>
            </item>

--- a/src/qt/pivx/settings/forms/settingswalletoptionswidget.ui
+++ b/src/qt/pivx/settings/forms/settingswalletoptionswidget.ui
@@ -62,14 +62,14 @@
             <item>
              <widget class="QLabel" name="labelTitle">
               <property name="text">
-               <string>TextLabel</string>
+               <string>Wallet</string>
               </property>
              </widget>
             </item>
             <item>
              <widget class="QLabel" name="labelSubtitle1">
               <property name="text">
-               <string>TextLabel</string>
+               <string>Customize the internal wallet options</string>
               </property>
               <property name="wordWrap">
                <bool>true</bool>
@@ -104,7 +104,7 @@
           <item>
            <widget class="QLabel" name="labelTitleStake">
             <property name="text">
-             <string>TextLabel</string>
+             <string>Stake split threshold</string>
             </property>
            </widget>
           </item>
@@ -131,6 +131,9 @@
             </property>
             <property name="maximum">
              <number>999999</number>
+            </property>
+            <property name="value">
+             <number>500</number>
             </property>
            </widget>
           </item>
@@ -160,7 +163,7 @@
            <item>
             <widget class="QCheckBox" name="radioButtonSpend">
              <property name="text">
-              <string>CheckBox</string>
+              <string>Spend unconfirmed change</string>
              </property>
             </widget>
            </item>
@@ -231,14 +234,14 @@
             <item>
              <widget class="QLabel" name="labelTitleNetwork">
               <property name="text">
-               <string>TextLabel</string>
+               <string>Network</string>
               </property>
              </widget>
             </item>
             <item>
              <widget class="QLabel" name="labelSubtitleNetwork">
               <property name="text">
-               <string>TextLabel</string>
+               <string>Customize the node network options</string>
               </property>
               <property name="wordWrap">
                <bool>true</bool>
@@ -289,21 +292,21 @@
            <item>
             <widget class="QCheckBox" name="checkBoxMap">
              <property name="text">
-              <string>RadioButton</string>
+              <string>Map port using UPnP</string>
              </property>
             </widget>
            </item>
            <item>
             <widget class="QCheckBox" name="checkBoxAllow">
              <property name="text">
-              <string>RadioButton</string>
+              <string>Allow incoming connections</string>
              </property>
             </widget>
            </item>
            <item>
             <widget class="QCheckBox" name="checkBoxConnect">
              <property name="text">
-              <string>RadioButton</string>
+              <string>Connect through SOCKS5 proxy (default proxy)</string>
              </property>
             </widget>
            </item>
@@ -339,7 +342,7 @@
             <item>
              <widget class="QLabel" name="labelSubtitleProxy">
               <property name="text">
-               <string>TextLabel</string>
+               <string>Proxy IP</string>
               </property>
              </widget>
             </item>
@@ -356,6 +359,9 @@
                 <width>16777215</width>
                 <height>50</height>
                </size>
+              </property>
+              <property name="placeholderText">
+               <string>Enter proxy IP</string>
               </property>
              </widget>
             </item>
@@ -382,7 +388,7 @@
             <item>
              <widget class="QLabel" name="labelSubtitlePort">
               <property name="text">
-               <string>TextLabel</string>
+               <string>Port</string>
               </property>
              </widget>
             </item>
@@ -399,6 +405,9 @@
                 <width>16777215</width>
                 <height>50</height>
                </size>
+              </property>
+              <property name="placeholderText">
+               <string>Enter port</string>
               </property>
              </widget>
             </item>
@@ -496,7 +505,7 @@
              <enum>Qt::NoFocus</enum>
             </property>
             <property name="text">
-             <string/>
+             <string>SAVE</string>
             </property>
            </widget>
           </item>

--- a/src/qt/pivx/settings/forms/settingswalletrepairwidget.ui
+++ b/src/qt/pivx/settings/forms/settingswalletrepairwidget.ui
@@ -105,14 +105,14 @@
               <item>
                <widget class="QLabel" name="labelTitle">
                 <property name="text">
-                 <string>TextLabel</string>
+                 <string>Wallet Repair</string>
                 </property>
                </widget>
               </item>
               <item>
                <widget class="QLabel" name="labelSubtitle1">
                 <property name="text">
-                 <string>TextLabel</string>
+                 <string>The buttons below will restart the wallet with command-line options to repair this wallet, fix issues with corrupt blockchain files or missing/obsolete transactions</string>
                 </property>
                 <property name="wordWrap">
                  <bool>true</bool>
@@ -167,7 +167,7 @@
                  <enum>Qt::NoFocus</enum>
                 </property>
                 <property name="text">
-                 <string/>
+                 <string>Salvage wallet</string>
                 </property>
                </widget>
               </item>
@@ -176,7 +176,7 @@
             <item>
              <widget class="QLabel" name="labelMessageSalvage">
               <property name="text">
-               <string>TextLabel</string>
+               <string>Attempt to recover private keys from a corrupt wallet.dat</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
@@ -232,7 +232,7 @@
                  <enum>Qt::NoFocus</enum>
                 </property>
                 <property name="text">
-                 <string/>
+                 <string>Rescan blockchain file</string>
                 </property>
                </widget>
               </item>
@@ -241,7 +241,7 @@
             <item>
              <widget class="QLabel" name="labelMessageRescan">
               <property name="text">
-               <string>TextLabel</string>
+               <string>Rescan the blockchain for missing wallet transactions</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
@@ -297,7 +297,7 @@
                  <enum>Qt::NoFocus</enum>
                 </property>
                 <property name="text">
-                 <string/>
+                 <string>Recover transactions 1</string>
                 </property>
                </widget>
               </item>
@@ -306,7 +306,7 @@
             <item>
              <widget class="QLabel" name="labelMessageRecover1">
               <property name="text">
-               <string>TextLabel</string>
+               <string>Recover transactions from blockchain (keep-meta-data, e.g. account owner)</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
@@ -362,7 +362,7 @@
                  <enum>Qt::NoFocus</enum>
                 </property>
                 <property name="text">
-                 <string/>
+                 <string>Recover transactions 2</string>
                 </property>
                </widget>
               </item>
@@ -371,7 +371,7 @@
             <item>
              <widget class="QLabel" name="labelMessageRecover2">
               <property name="text">
-               <string>TextLabel</string>
+               <string>Recover transactions from blockchain (drop meta-data)</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
@@ -427,7 +427,7 @@
                  <enum>Qt::NoFocus</enum>
                 </property>
                 <property name="text">
-                 <string/>
+                 <string>Upgrade wallet format</string>
                 </property>
                </widget>
               </item>
@@ -436,7 +436,7 @@
             <item>
              <widget class="QLabel" name="labelMessageUpgrade">
               <property name="text">
-               <string>TextLabel</string>
+               <string>Upgrade wallet to latest format on startup. (Note: this is NOT an update of the wallet itself)</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
@@ -492,7 +492,7 @@
                  <enum>Qt::NoFocus</enum>
                 </property>
                 <property name="text">
-                 <string/>
+                 <string>Rebuild index</string>
                 </property>
                </widget>
               </item>
@@ -501,7 +501,7 @@
             <item>
              <widget class="QLabel" name="labelMessageRebuild">
               <property name="text">
-               <string>TextLabel</string>
+               <string>Rebuild blockchain index from current blk000???.dat files</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
@@ -557,7 +557,7 @@
                  <enum>Qt::NoFocus</enum>
                 </property>
                 <property name="text">
-                 <string/>
+                 <string>Delete local blockchain</string>
                 </property>
                </widget>
               </item>
@@ -572,7 +572,7 @@
                </size>
               </property>
               <property name="text">
-               <string>TextLabel</string>
+               <string>Deletes all local blockchain folders so the wallet synchronizes from scratch</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>

--- a/src/qt/pivx/settings/settingsbackupwallet.cpp
+++ b/src/qt/pivx/settings/settingsbackupwallet.cpp
@@ -23,30 +23,19 @@ SettingsBackupWallet::SettingsBackupWallet(PIVXGUI* _window, QWidget *parent) :
     ui->left->setContentsMargins(10,10,10,10);
 
     // Title
-    ui->labelTitle->setText(tr("Backup Wallet "));
     ui->labelTitle->setProperty("cssClass", "text-title-screen");
-
-    ui->labelTitle_2->setText(tr("Change Wallet Passphrase"));
     ui->labelTitle_2->setProperty("cssClass", "text-title-screen");
     ui->labelDivider->setProperty("cssClass", "container-divider");
 
-    // Subtitle
-    ui->labelSubtitle1->setText(tr("Keep your wallet safe by doing regular backups and storing your backup file externally.\nThis option creates a wallet.dat file that can be used to recover your whole balance (transactions and addresses) on another device."));
-    ui->labelSubtitle1->setProperty("cssClass", "text-subtitle");
-
-    ui->labelSubtitle_2->setText(tr("This will decrypt the whole wallet data and encrypt it back with the new passphrase.\nRemember to write it down and store it safely, otherwise you might lose access to your funds."));
-    ui->labelSubtitle_2->setProperty("cssClass", "text-subtitle");
+    // Subtitles
+    setCssProperty({ui->labelSubtitle1, ui->labelSubtitle_2}, "text-subtitle");
 
     // Location
-    ui->labelSubtitleLocation->setText(tr("Where"));
     ui->labelSubtitleLocation->setProperty("cssClass", "text-title");
-
-    ui->pushButtonDocuments->setText(tr("Select folder..."));
     ui->pushButtonDocuments->setProperty("cssClass", "btn-edit-primary-folder");
     setShadow(ui->pushButtonDocuments);
 
     // Buttons
-    ui->pushButtonSave_2->setText(tr("Change Passphrase"));
     setCssBtnPrimary(ui->pushButtonSave_2);
 
     connect(ui->pushButtonDocuments, &QPushButton::clicked, this, &SettingsBackupWallet::selectFileOutput);

--- a/src/qt/pivx/settings/settingsbittoolwidget.cpp
+++ b/src/qt/pivx/settings/settingsbittoolwidget.cpp
@@ -32,46 +32,32 @@ SettingsBitToolWidget::SettingsBitToolWidget(PIVXGUI* _window, QWidget *parent) 
     ui->left->setContentsMargins(10,10,10,10);
 
     /* Title */
-    ui->labelTitle->setText(tr("BIP38 Tool"));
     setCssTitleScreen(ui->labelTitle);
 
     //Button Group
-    ui->pushLeft->setText(tr("Encrypt"));
     setCssProperty(ui->pushLeft, "btn-check-left");
-    ui->pushRight->setText(tr("Decrypt"));
     setCssProperty(ui->pushRight, "btn-check-right");
     ui->pushLeft->setChecked(true);
 
     // Subtitle
-    ui->labelSubtitle1->setText("Encrypt your PIVX addresses (key pair actually) using BIP38 encryption.\nUsing this mechanism you can share your keys without middle-man risk, only need to store your passphrase safely.");
     setCssSubtitleScreen(ui->labelSubtitle1);
 
     // Key
-    ui->labelSubtitleKey->setText(tr("Encrypted key"));
     setCssProperty(ui->labelSubtitleKey, "text-title");
-    ui->lineEditKey->setPlaceholderText(tr("Enter a encrypted key"));
     initCssEditLine(ui->lineEditKey);
 
     // Passphrase
-    ui->labelSubtitlePassphrase->setText(tr("Passphrase"));
     setCssProperty(ui->labelSubtitlePassphrase, "text-title");
-
-    ui->lineEditPassphrase->setPlaceholderText(tr("Enter a passphrase "));
     initCssEditLine(ui->lineEditPassphrase);
 
     // Decrypt controls
-    ui->labelSubtitleDecryptResult->setText(tr("Decrypted address result"));
     setCssProperty(ui->labelSubtitleDecryptResult, "text-title");
-    ui->lineEditDecryptResult->setPlaceholderText(tr("Decrypted Address"));
     ui->lineEditDecryptResult->setAttribute(Qt::WA_MacShowFocusRect, 0);
     ui->lineEditDecryptResult->setReadOnly(true);
     initCssEditLine(ui->lineEditDecryptResult);
 
     // Buttons
-    ui->pushButtonDecrypt->setText(tr("DECRYPT KEY"));
     setCssBtnPrimary(ui->pushButtonDecrypt);
-
-    ui->pushButtonImport->setText(tr("Import Address"));
     setCssProperty(ui->pushButtonImport, "btn-text-primary");
     ui->pushButtonImport->setVisible(false);
 
@@ -82,35 +68,24 @@ SettingsBitToolWidget::SettingsBitToolWidget(PIVXGUI* _window, QWidget *parent) 
     // Encrypt
 
     // Address
-    ui->labelSubtitleAddress->setText(tr("PIVX address"));
     setCssProperty(ui->labelSubtitleAddress, "text-title");
-
-    ui->addressIn_ENC->setPlaceholderText(tr("Enter address"));
     setCssProperty(ui->addressIn_ENC, "edit-primary-multi-book");
     ui->addressIn_ENC->setAttribute(Qt::WA_MacShowFocusRect, 0);
     setShadow(ui->addressIn_ENC);
 
     // Message
-    ui->labelSubtitleMessage->setText(tr("Passphrase"));
     setCssProperty(ui->labelSubtitleMessage, "text-title");
-
     setCssProperty(ui->passphraseIn_ENC, "edit-primary");
-    ui->passphraseIn_ENC->setPlaceholderText(tr("Enter passphrase"));
-    setCssProperty(ui->passphraseIn_ENC,"edit-primary");
     setShadow(ui->passphraseIn_ENC);
     ui->passphraseIn_ENC->setAttribute(Qt::WA_MacShowFocusRect, 0);
 
-    ui->labelSubtitleEncryptedKey->setText(tr("Encrypted Key"));
+    // Encrypted Key
     setCssProperty(ui->labelSubtitleEncryptedKey, "text-title");
-    ui->encryptedKeyOut_ENC->setPlaceholderText(tr("Encrypted key"));
     ui->encryptedKeyOut_ENC->setAttribute(Qt::WA_MacShowFocusRect, 0);
     ui->encryptedKeyOut_ENC->setReadOnly(true);
     initCssEditLine(ui->encryptedKeyOut_ENC);
 
     btnContact = ui->addressIn_ENC->addAction(QIcon("://ic-contact-arrow-down"), QLineEdit::TrailingPosition);
-    ui->pushButtonEncrypt->setText(tr("ENCRYPT"));
-    ui->pushButtonClear->setText(tr("CLEAR ALL"));
-    ui->pushButtonDecryptClear->setText(tr("CLEAR"));
     setCssBtnPrimary(ui->pushButtonEncrypt);
     setCssBtnSecondary(ui->pushButtonClear);
     setCssBtnSecondary(ui->pushButtonDecryptClear);

--- a/src/qt/pivx/settings/settingsconsolewidget.cpp
+++ b/src/qt/pivx/settings/settingsconsolewidget.cpp
@@ -250,7 +250,6 @@ SettingsConsoleWidget::SettingsConsoleWidget(PIVXGUI* _window, QWidget *parent) 
     ui->left->setContentsMargins(10,10,10,10);
 
     // Title
-    ui->labelTitle->setText(tr("Console"));
     setCssTitleScreen(ui->labelTitle);
 
     // Console container
@@ -263,14 +262,11 @@ SettingsConsoleWidget::SettingsConsoleWidget(PIVXGUI* _window, QWidget *parent) 
 
     // Buttons
     ui->pushButton->setProperty("cssClass", "ic-arrow");
-    ui->pushButtonCommandOptions->setText(tr("Command Line Options "));
-    ui->pushButtonOpenDebug->setText(tr("Open Debug File"));
     setCssBtnSecondary(ui->pushButtonOpenDebug);
     setCssBtnSecondary(ui->pushButtonClear);
     setCssBtnSecondary(ui->pushButtonCommandOptions);
 
     setShadow(ui->pushButtonClear);
-    ui->pushButtonClear->setToolTip(tr("Clear history"));
     connect(ui->pushButtonClear, &QPushButton::clicked, [this]{ clear(false); });
     connect(ui->pushButtonOpenDebug, &QPushButton::clicked, [this](){
         if(!GUIUtil::openDebugLogfile()){

--- a/src/qt/pivx/settings/settingsconsolewidget.cpp
+++ b/src/qt/pivx/settings/settingsconsolewidget.cpp
@@ -269,7 +269,7 @@ SettingsConsoleWidget::SettingsConsoleWidget(PIVXGUI* _window, QWidget *parent) 
     setShadow(ui->pushButtonClear);
     connect(ui->pushButtonClear, &QPushButton::clicked, [this]{ clear(false); });
     connect(ui->pushButtonOpenDebug, &QPushButton::clicked, [this](){
-        if(!GUIUtil::openDebugLogfile()){
+        if (!GUIUtil::openDebugLogfile()) {
             inform(tr("Cannot open debug file.\nVerify that you have installed a predetermined text editor."));
         }
     });
@@ -329,7 +329,7 @@ bool SettingsConsoleWidget::eventFilter(QObject* obj, QEvent* event)
             case Qt::Key_Return:
             case Qt::Key_Enter:
                 // forward these events to lineEdit
-                if(obj == autoCompleter->popup()) {
+                if (obj == autoCompleter->popup()) {
                     QApplication::postEvent(ui->lineEdit, new QKeyEvent(*keyevt));
                     return true;
                 }
@@ -349,7 +349,8 @@ bool SettingsConsoleWidget::eventFilter(QObject* obj, QEvent* event)
     return QWidget::eventFilter(obj, event);
 }
 
-void SettingsConsoleWidget::loadClientModel() {
+void SettingsConsoleWidget::loadClientModel()
+{
     if (clientModel){
 
         //Setup autocomplete and attach it
@@ -387,7 +388,8 @@ static QString categoryClass(int category)
     }
 }
 
-void SettingsConsoleWidget::clear(bool clearHistory){
+void SettingsConsoleWidget::clear(bool clearHistory)
+{
     ui->messagesWidget->clear();
     if (clearHistory) {
         history.clear();
@@ -531,7 +533,8 @@ void SettingsConsoleWidget::changeTheme(bool isLightTheme, QString &theme)
     updateStyle(ui->messagesWidget);
 }
 
-void SettingsConsoleWidget::onCommandsClicked() {
+void SettingsConsoleWidget::onCommandsClicked()
+{
     if (!clientModel)
         return;
 

--- a/src/qt/pivx/settings/settingsdisplayoptionswidget.cpp
+++ b/src/qt/pivx/settings/settingsdisplayoptionswidget.cpp
@@ -25,30 +25,19 @@ SettingsDisplayOptionsWidget::SettingsDisplayOptionsWidget(PIVXGUI* _window, QWi
     ui->left->setProperty("cssClass", "container");
     ui->left->setContentsMargins(10,10,10,10);
 
-    // Title
-    ui->labelTitle->setText(tr("Display"));
+    // Title - Subtitle
     setCssTitleScreen(ui->labelTitle);
-
-    // Subtitle
-    ui->labelSubtitle1->setText(tr("Customize the display view options"));
     setCssSubtitleScreen(ui->labelSubtitle1);
 
-    ui->labelTitleLanguage->setText(tr("Language"));
     ui->labelTitleLanguage->setProperty("cssClass", "text-main-settings");
-
-    ui->labelTitleUnit->setText(tr("Unit to show amount"));
     ui->labelTitleUnit->setProperty("cssClass", "text-main-settings");
-
-    ui->labelTitleDigits->setText(tr("Decimal digits"));
     ui->labelTitleDigits->setProperty("cssClass", "text-main-settings");
-
-    ui->labelTitleUrl->setText(tr("Third party transactions URLs"));
     ui->labelTitleUrl->setProperty("cssClass", "text-main-settings");
+
     // TODO: Reconnect this option to an action. Hide it for now
     ui->labelTitleUrl->hide();
 
-    // Switch (hide for now)
-    ui->pushButtonSwitchBalance->setText(tr("Hide empty balances"));
+    // Switch Balance (hide for now)
     ui->pushButtonSwitchBalance->setProperty("cssClass", "btn-switch");
     ui->pushButtonSwitchBalance->setVisible(false);
 

--- a/src/qt/pivx/settings/settingsfaqwidget.cpp
+++ b/src/qt/pivx/settings/settingsfaqwidget.cpp
@@ -107,57 +107,69 @@ SettingsFaqWidget::SettingsFaqWidget(PIVXGUI *parent) :
         connect(parent, &PIVXGUI::windowResizeEvent, this, &SettingsFaqWidget::windowResizeEvent);
 }
 
-void SettingsFaqWidget::showEvent(QShowEvent *event){
-    if(pos != 0){
+void SettingsFaqWidget::showEvent(QShowEvent *event)
+{
+    if (pos != 0) {
         QPushButton* btn = getButtons()[pos - 1];
         QMetaObject::invokeMethod(btn, "setChecked", Qt::QueuedConnection, Q_ARG(bool, true));
         QMetaObject::invokeMethod(btn, "clicked", Qt::QueuedConnection);
     }
 }
 
-void SettingsFaqWidget::setSection(int num){
+void SettingsFaqWidget::setSection(int num)
+{
     if (num < 1 || num > 10)
         return;
     pos = num;
 }
 
-void SettingsFaqWidget::onFaq1Clicked(){
+void SettingsFaqWidget::onFaq1Clicked()
+{
     ui->scrollAreaFaq->verticalScrollBar()->setValue(ui->widgetFaq1->y());
 }
 
-void SettingsFaqWidget::onFaq2Clicked(){
+void SettingsFaqWidget::onFaq2Clicked()
+{
    ui->scrollAreaFaq->verticalScrollBar()->setValue(ui->widgetFaq2->y());
 }
 
-void SettingsFaqWidget::onFaq3Clicked(){
+void SettingsFaqWidget::onFaq3Clicked()
+{
    ui->scrollAreaFaq->verticalScrollBar()->setValue(ui->widgetFaq3->y());
 }
 
-void SettingsFaqWidget::onFaq4Clicked(){
+void SettingsFaqWidget::onFaq4Clicked()
+{
     ui->scrollAreaFaq->verticalScrollBar()->setValue(ui->widgetFaq4->y());
 }
 
-void SettingsFaqWidget::onFaq5Clicked(){
+void SettingsFaqWidget::onFaq5Clicked()
+{
     ui->scrollAreaFaq->verticalScrollBar()->setValue(ui->widgetFaq5->y());
 }
 
-void SettingsFaqWidget::onFaq6Clicked(){
+void SettingsFaqWidget::onFaq6Clicked()
+{
     ui->scrollAreaFaq->verticalScrollBar()->setValue(ui->widgetFaq6->y());
 }
 
-void SettingsFaqWidget::onFaq7Clicked(){
+void SettingsFaqWidget::onFaq7Clicked()
+{
     ui->scrollAreaFaq->verticalScrollBar()->setValue(ui->widgetFaq7->y());
 }
 
-void SettingsFaqWidget::onFaq8Clicked(){
+void SettingsFaqWidget::onFaq8Clicked()
+{
     ui->scrollAreaFaq->verticalScrollBar()->setValue(ui->widgetFaq8->y());
 }
 
-void SettingsFaqWidget::onFaq9Clicked(){
+void SettingsFaqWidget::onFaq9Clicked()
+{
     ui->scrollAreaFaq->verticalScrollBar()->setValue(ui->widgetFaq9->y());
 }
 
-void SettingsFaqWidget::onFaq10Clicked(){
+void SettingsFaqWidget::onFaq10Clicked()
+{
     ui->scrollAreaFaq->verticalScrollBar()->setValue(ui->widgetFaq10->y());
 }
 
@@ -168,7 +180,8 @@ void SettingsFaqWidget::windowResizeEvent(QResizeEvent* event)
     this->move(QPoint(0, 0));
 }
 
-std::vector<QPushButton*> SettingsFaqWidget::getButtons(){
+std::vector<QPushButton*> SettingsFaqWidget::getButtons()
+{
     return {
             ui->pushButtonFaq1,
             ui->pushButtonFaq2,
@@ -183,7 +196,8 @@ std::vector<QPushButton*> SettingsFaqWidget::getButtons(){
     };
 }
 
-SettingsFaqWidget::~SettingsFaqWidget(){
+SettingsFaqWidget::~SettingsFaqWidget()
+{
     delete ui;
 }
 

--- a/src/qt/pivx/settings/settingsfaqwidget.cpp
+++ b/src/qt/pivx/settings/settingsfaqwidget.cpp
@@ -13,11 +13,8 @@ SettingsFaqWidget::SettingsFaqWidget(PIVXGUI *parent) :
     ui(new Ui::SettingsFaqWidget)
 {
     ui->setupUi(this);
-
     this->setStyleSheet(parent->styleSheet());
 
-    ui->labelTitle->setText(tr("Frequently Asked Questions"));
-    ui->labelWebLink->setText(tr("You can read more here"));
 #ifdef Q_OS_MAC
     ui->container->load("://bg-welcome");
     setCssProperty(ui->container, "container-welcome-no-image");
@@ -87,11 +84,9 @@ SettingsFaqWidget::SettingsFaqWidget(PIVXGUI *parent) :
     ui->labelContent8->setOpenExternalLinks(true);
 
     // Exit button
-    ui->pushButtonExit->setText(tr("Exit"));
     setCssProperty(ui->pushButtonExit, "btn-faq-exit");
 
     // Web Link
-    ui->pushButtonWebLink->setText("https://PIVX.org/");
     setCssProperty(ui->pushButtonWebLink, "btn-faq-web");
     setCssProperty(ui->containerButtons, "container-faq-buttons");
 

--- a/src/qt/pivx/settings/settingsinformationwidget.cpp
+++ b/src/qt/pivx/settings/settingsinformationwidget.cpp
@@ -153,7 +153,7 @@ void SettingsInformationWidget::setMasternodeCount(const QString& strMasternodes
 
 void SettingsInformationWidget::openNetworkMonitor()
 {
-    if(!rpcConsole){
+    if (!rpcConsole) {
         rpcConsole = new RPCConsole(0);
         rpcConsole->setClientModel(clientModel);
     }

--- a/src/qt/pivx/settings/settingsmainoptionswidget.cpp
+++ b/src/qt/pivx/settings/settingsmainoptionswidget.cpp
@@ -81,8 +81,9 @@ SettingsMainOptionsWidget::SettingsMainOptionsWidget(PIVXGUI* _window, QWidget *
     connect(ui->pushButtonClean, &QPushButton::clicked, [this] { Q_EMIT discardSettings(); });
 }
 
-void SettingsMainOptionsWidget::onResetClicked(){
-    if(clientModel) {
+void SettingsMainOptionsWidget::onResetClicked()
+{
+    if (clientModel) {
         if (!ask(tr("Reset Options"), tr("You are just about to reset the app\'s options to the default values.\n\nAre you sure?\n")))
             return;
         OptionsModel *optionsModel = clientModel->getOptionsModel();
@@ -96,7 +97,8 @@ void SettingsMainOptionsWidget::onResetClicked(){
     }
 }
 
-void SettingsMainOptionsWidget::setMapper(QDataWidgetMapper *mapper){
+void SettingsMainOptionsWidget::setMapper(QDataWidgetMapper *mapper)
+{
     mapper->addMapping(ui->pushSwitchStart, OptionsModel::StartAtStartup);
     mapper->addMapping(ui->threadsScriptVerif, OptionsModel::ThreadsScriptVerif);
     mapper->addMapping(ui->databaseCache, OptionsModel::DatabaseCache);
@@ -107,6 +109,7 @@ void SettingsMainOptionsWidget::setMapper(QDataWidgetMapper *mapper){
 #endif
 }
 
-SettingsMainOptionsWidget::~SettingsMainOptionsWidget(){
+SettingsMainOptionsWidget::~SettingsMainOptionsWidget()
+{
     delete ui;
 }

--- a/src/qt/pivx/settings/settingsmainoptionswidget.cpp
+++ b/src/qt/pivx/settings/settingsmainoptionswidget.cpp
@@ -45,20 +45,13 @@ SettingsMainOptionsWidget::SettingsMainOptionsWidget(PIVXGUI* _window, QWidget *
     ui->left->setContentsMargins(10,10,10,10);
     ui->labelDivider->setProperty("cssClass", "container-divider");
 
-    // Title
-    ui->labelTitle->setText(tr("Main"));
-    ui->labelSubtitle1->setText("Customize the main application options");
-
+    // Title - Subtitle
     setCssTitleScreen(ui->labelTitle);
     setCssSubtitleScreen(ui->labelSubtitle1);
     setCssTitleScreen(ui->labelTitleDown);
     setCssSubtitleScreen(ui->labelSubtitleDown);
 
-    ui->labelTitleSizeDb->setText(tr("Size of database cache"));
-    ui->labelTitleSizeDb->setProperty("cssClass", "text-main-settings");
-
-    ui->labelTitleThreads->setText(tr("Number of script verification threads"));
-    ui->labelTitleThreads->setProperty("cssClass", "text-main-settings");
+    setCssProperty({ui->labelTitleSizeDb, ui->labelTitleThreads}, "text-main-settings");
 
     // Switch
     ui->pushSwitchStart->setText(tr("Start PIVX on system login"));
@@ -72,13 +65,7 @@ SettingsMainOptionsWidget::SettingsMainOptionsWidget(PIVXGUI* _window, QWidget *
     ui->threadsScriptVerif->setAttribute(Qt::WA_MacShowFocusRect, 0);
     setShadow(ui->threadsScriptVerif);
 
-    // CheckBox
-    ui->checkBoxMinTaskbar->setText(tr("Minimize to the tray instead of the taskbar"));
-    ui->checkBoxMinClose->setText(tr("Minimize on close"));
-
     // Buttons
-    ui->pushButtonSave->setText(tr("SAVE"));
-    ui->pushButtonReset->setText(tr("Reset to default"));
     setCssBtnPrimary(ui->pushButtonSave);
     setCssBtnSecondary(ui->pushButtonReset);
     setCssBtnSecondary(ui->pushButtonClean);

--- a/src/qt/pivx/settings/settingssignmessagewidgets.cpp
+++ b/src/qt/pivx/settings/settingssignmessagewidgets.cpp
@@ -32,24 +32,16 @@ SettingsSignMessageWidgets::SettingsSignMessageWidgets(PIVXGUI* _window, QWidget
     ui->left->setContentsMargins(10,10,10,10);
 
     // Title
-    ui->labelTitle->setText(tr("Sign/Verify Message"));
     ui->labelTitle->setProperty("cssClass", "text-title-screen");
-
-    // Subtitle
     ui->labelSubtitle1->setProperty("cssClass", "text-subtitle");
 
     // Address
-    ui->labelSubtitleAddress->setText(tr("PIVX address or contact label"));
     ui->labelSubtitleAddress->setProperty("cssClass", "text-title");
-
-    ui->addressIn_SM->setPlaceholderText(tr("Enter address"));
     ui->addressIn_SM->setProperty("cssClass", "edit-primary-multi-book");
     ui->addressIn_SM->setAttribute(Qt::WA_MacShowFocusRect, 0);
     setShadow(ui->addressIn_SM);
 
     /* Button Group */
-    ui->pushSign->setText(tr("Sign"));
-    ui->pushVerify->setText(tr("Verify"));
     setCssProperty(ui->pushSign, "btn-check-right");
     setCssProperty(ui->pushVerify, "btn-check-right");
     ui->labelSubtitleSwitch->setText(tr("Select mode"));
@@ -58,17 +50,13 @@ SettingsSignMessageWidgets::SettingsSignMessageWidgets(PIVXGUI* _window, QWidget
     updateMode();
 
     // Message
-    ui->labelSubtitleMessage->setText(tr("Message"));
     ui->labelSubtitleMessage->setProperty("cssClass", "text-title");
-
-    ui->messageIn_SM->setPlaceholderText(tr("Write message"));
     ui->messageIn_SM->setProperty("cssClass","edit-primary");
     setShadow(ui->messageIn_SM);
     ui->messageIn_SM->setAttribute(Qt::WA_MacShowFocusRect, 0);
 
-    ui->labelSubtitleSignature->setText(tr("Signature"));
+    // Signature
     ui->labelSubtitleSignature->setProperty("cssClass", "text-title");
-    ui->signatureOut_SM->setPlaceholderText(tr("Signature"));
     ui->signatureOut_SM->setAttribute(Qt::WA_MacShowFocusRect, 0);
 
     initCssEditLine(ui->signatureOut_SM);
@@ -77,8 +65,6 @@ SettingsSignMessageWidgets::SettingsSignMessageWidgets(PIVXGUI* _window, QWidget
     // Buttons
     btnContact = ui->addressIn_SM->addAction(QIcon("://ic-contact-arrow-down"), QLineEdit::TrailingPosition);
 
-    ui->pushButtonSave->setText(tr("SIGN"));
-    ui->pushButtonClear->setText(tr("CLEAR ALL"));
     setCssBtnPrimary(ui->pushButtonSave);
     setCssBtnSecondary(ui->pushButtonClear);
 

--- a/src/qt/pivx/settings/settingswalletoptionswidget.cpp
+++ b/src/qt/pivx/settings/settingswalletoptionswidget.cpp
@@ -23,50 +23,31 @@ SettingsWalletOptionsWidget::SettingsWalletOptionsWidget(PIVXGUI* _window, QWidg
     ui->labelDivider->setProperty("cssClass", "container-divider");
 
     // Title
-    ui->labelTitle->setText(tr("Wallet"));
-    ui->labelSubtitle1->setText(tr("Customize the internal wallet options"));
     setCssTitleScreen(ui->labelTitle);
     setCssSubtitleScreen(ui->labelSubtitle1);
 
     // Combobox
-    ui->labelTitleStake->setText(tr("Stake split threshold:"));
     ui->labelTitleStake->setProperty("cssClass", "text-main-settings");
-
     ui->spinBoxStakeSplitThreshold->setProperty("cssClass", "btn-spin-box");
     ui->spinBoxStakeSplitThreshold->setAttribute(Qt::WA_MacShowFocusRect, 0);
     setShadow(ui->spinBoxStakeSplitThreshold);
 
     // Radio buttons
-    ui->radioButtonSpend->setText(tr("Spend unconfirmed change"));
 
     // Title
     ui->labelTitleNetwork->setText(tr("Network"));
-    ui->labelSubtitleNetwork->setText(tr("Customize the node network options"));
     setCssTitleScreen(ui->labelTitleNetwork);
     setCssSubtitleScreen(ui->labelSubtitleNetwork);
 
     // Proxy
-    ui->labelSubtitleProxy->setText(tr("Proxy IP:"));
     ui->labelSubtitleProxy->setProperty("cssClass", "text-main-settings");
-
-    ui->lineEditProxy->setPlaceholderText(tr("Enter proxy IP"));
     initCssEditLine(ui->lineEditProxy);
 
     // Port
-    ui->labelSubtitlePort->setText(tr("Port:"));
     ui->labelSubtitlePort->setProperty("cssClass", "text-main-settings");
-
-    ui->lineEditPort->setPlaceholderText("Enter port");
     initCssEditLine(ui->lineEditPort);
 
-    // Radio buttons
-    ui->checkBoxMap->setText(tr("Map port using UPnP"));
-    ui->checkBoxAllow->setText(tr("Allow incoming connections"));
-    ui->checkBoxConnect->setText(tr("Connect through SOCKS5 proxy (default proxy):"));
-
     // Buttons
-    ui->pushButtonSave->setText(tr("SAVE"));
-    ui->pushButtonReset->setText(tr("Reset to default"));
     setCssBtnPrimary(ui->pushButtonSave);
     setCssBtnSecondary(ui->pushButtonReset);
     setCssBtnSecondary(ui->pushButtonClean);

--- a/src/qt/pivx/settings/settingswalletrepairwidget.cpp
+++ b/src/qt/pivx/settings/settingswalletrepairwidget.cpp
@@ -21,55 +21,17 @@ SettingsWalletRepairWidget::SettingsWalletRepairWidget(PIVXGUI* _window, QWidget
     // Title
     ui->labelTitle->setText(tr("Wallet Repair"));
     ui->labelTitle->setProperty("cssClass", "text-title-screen");
-
-    // Subtitle
-    ui->labelSubtitle1->setText(tr("The buttons below will restart the wallet with command-line options to repair this wallet, fix issues with corrupt blockchain files or missing/obsolete transactions."));
     ui->labelSubtitle1->setProperty("cssClass", "text-subtitle");
 
     // Labels
-    ui->labelMessageSalvage->setText(tr("Attempt to recover private keys from a corrupt wallet.dat."));
-    ui->labelMessageSalvage->setProperty("cssClass", "text-main-settings");
-
-    ui->labelMessageRescan->setText(tr("Rescan the blockchain for missing wallet transactions."));
-    ui->labelMessageRescan->setProperty("cssClass", "text-main-settings");
-
-    ui->labelMessageRecover1->setText(tr("Recover transactions from blockchain (keep-meta-data, e.g. account owner)."));
-    ui->labelMessageRecover1->setProperty("cssClass", "text-main-settings");
-
-    ui->labelMessageRecover2->setText(tr("Recover transactions from blockchain (drop meta-data)."));
-    ui->labelMessageRecover2->setProperty("cssClass", "text-main-settings");
-
-    ui->labelMessageUpgrade->setText(tr("Upgrade wallet to latest format on startup. (Note: this is NOT an update of the wallet itself)"));
-    ui->labelMessageUpgrade->setProperty("cssClass", "text-main-settings");
-
-    ui->labelMessageRebuild->setText(tr("Rebuild blockchain index from current blk000???.dat files."));
-    ui->labelMessageRebuild->setProperty("cssClass", "text-main-settings");
-
-    ui->labelMessageDelete->setText(tr("Deletes all local blockchain folders so the wallet synchronizes from scratch."));
-    ui->labelMessageDelete->setProperty("cssClass", "text-main-settings");
+    setCssProperty({ui->labelMessageSalvage, ui->labelMessageRescan, ui->labelMessageRecover1,
+                    ui->labelMessageRecover2, ui->labelMessageUpgrade, ui->labelMessageRebuild,
+                    ui->labelMessageDelete}, "text-main-settings");
 
     // Buttons
-    ui->pushButtonSalvage->setText(tr("Salvage wallet"));
-    setCssBtnPrimary(ui->pushButtonSalvage);
-
-    ui->pushButtonRescan->setText(tr("Rescan blockchain file"));
-    setCssBtnPrimary(ui->pushButtonRescan);
-
-    ui->pushButtonRecover1->setText(tr("Recover transactions 1"));
-    setCssBtnPrimary(ui->pushButtonRecover1);
-
-    ui->pushButtonRecover2->setText(tr("Recover transactions 2"));
-    setCssBtnPrimary(ui->pushButtonRecover2);
-
-    ui->pushButtonUpgrade->setText(tr("Upgrade wallet format"));
-    setCssBtnPrimary(ui->pushButtonUpgrade);
-
-    ui->pushButtonRebuild->setText(tr("Rebuild index"));
-    setCssBtnPrimary(ui->pushButtonRebuild);
-
-    ui->pushButtonDelete->setText(tr("Delete local blockchain "));
-    setCssBtnPrimary(ui->pushButtonDelete);
-
+    setCssProperty({ui->pushButtonSalvage, ui->pushButtonRescan, ui->pushButtonRecover1,
+                    ui->pushButtonRecover2, ui->pushButtonUpgrade, ui->pushButtonRebuild,
+                    ui->pushButtonDelete}, "btn-primary");
 
     // Wallet Repair Buttons
     connect(ui->pushButtonSalvage, &QPushButton::clicked, this, &SettingsWalletRepairWidget::walletSalvage);

--- a/src/qt/pivx/settings/settingswidget.cpp
+++ b/src/qt/pivx/settings/settingswidget.cpp
@@ -186,7 +186,7 @@ SettingsWidget::SettingsWidget(PIVXGUI* parent) :
 
 void SettingsWidget::loadClientModel()
 {
-    if(clientModel) {
+    if (clientModel) {
         this->settingsInformationWidget->setClientModel(this->clientModel);
         this->settingsConsoleWidget->setClientModel(this->clientModel);
 
@@ -205,7 +205,8 @@ void SettingsWidget::loadClientModel()
     }
 }
 
-void SettingsWidget::loadWalletModel(){
+void SettingsWidget::loadWalletModel()
+{
     this->settingsBackupWallet->setWalletModel(this->walletModel);
     this->settingsExportCsvWidget->setWalletModel(this->walletModel);
     this->settingsSingMessageWidgets->setWalletModel(this->walletModel);
@@ -214,7 +215,8 @@ void SettingsWidget::loadWalletModel(){
     this->settingsDisplayOptionsWidget->setWalletModel(this->walletModel);
 }
 
-void SettingsWidget::onResetAction(){
+void SettingsWidget::onResetAction()
+{
     if (walletModel) {
         // confirmation dialog
         if (!ask(tr("Confirm options reset"), tr("Client restart required to activate changes.") + "<br><br>" + tr("Client will be shutdown, do you want to proceed?")))
@@ -226,8 +228,9 @@ void SettingsWidget::onResetAction(){
     }
 }
 
-void SettingsWidget::onSaveOptionsClicked(){
-    if(mapper->submit()) {
+void SettingsWidget::onSaveOptionsClicked()
+{
+    if (mapper->submit()) {
         pwalletMain->MarkDirty();
         if (this->clientModel->getOptionsModel()->isRestartRequired()) {
             bool fAcceptRestart = openStandardDialog(tr("Restart required"), tr("Your wallet needs to be restarted to apply the changes\n"), tr("Restart Now"), tr("Restart Later"));
@@ -279,87 +282,104 @@ void SettingsWidget::onFileClicked()
     selectMenu(ui->pushButtonFile);
 }
 
-void SettingsWidget::onBackupWalletClicked() {
+void SettingsWidget::onBackupWalletClicked()
+{
     ui->stackedWidgetContainer->setCurrentWidget(settingsBackupWallet);
     selectOption(ui->pushButtonFile2);
 }
 
-void SettingsWidget::onSignMessageClicked() {
+void SettingsWidget::onSignMessageClicked()
+{
     ui->stackedWidgetContainer->setCurrentWidget(settingsSingMessageWidgets);
     selectOption(ui->pushButtonConfiguration4);
 }
 
-void SettingsWidget::onConfigurationClicked() {
+void SettingsWidget::onConfigurationClicked()
+{
     selectMenu(ui->pushButtonConfiguration);
 }
 
-void SettingsWidget::onBipToolClicked() {
+void SettingsWidget::onBipToolClicked()
+{
     ui->stackedWidgetContainer->setCurrentWidget(settingsBitToolWidget);
     selectOption(ui->pushButtonConfiguration3);
 }
 
-void SettingsWidget::onMultisendClicked() {
+void SettingsWidget::onMultisendClicked()
+{
     ui->stackedWidgetContainer->setCurrentWidget(settingsMultisendWidget);
     selectOption(ui->pushButtonFile3);
 }
 
-void SettingsWidget::onExportCSVClicked() {
+void SettingsWidget::onExportCSVClicked()
+{
     ui->stackedWidgetContainer->setCurrentWidget(settingsExportCsvWidget);
     selectOption(ui->pushButtonExportCsv);
 }
 
-void SettingsWidget::onOptionsClicked() {
+void SettingsWidget::onOptionsClicked()
+{
     selectMenu(ui->pushButtonOptions);
 }
 
-void SettingsWidget::onMainOptionsClicked() {
+void SettingsWidget::onMainOptionsClicked()
+{
     ui->stackedWidgetContainer->setCurrentWidget(settingsMainOptionsWidget);
     selectOption(ui->pushButtonOptions1);
 }
 
-void SettingsWidget::onWalletOptionsClicked() {
+void SettingsWidget::onWalletOptionsClicked()
+{
     ui->stackedWidgetContainer->setCurrentWidget(settingsWalletOptionsWidget);
     selectOption(ui->pushButtonOptions2);
 }
 
-void SettingsWidget::onDisplayOptionsClicked() {
+void SettingsWidget::onDisplayOptionsClicked()
+{
     ui->stackedWidgetContainer->setCurrentWidget(settingsDisplayOptionsWidget);
     selectOption(ui->pushButtonOptions5);
 }
 
 
-void SettingsWidget::onToolsClicked() {
+void SettingsWidget::onToolsClicked()
+{
     selectMenu(ui->pushButtonTools);
 }
 
-void SettingsWidget::onInformationClicked() {
+void SettingsWidget::onInformationClicked()
+{
     ui->stackedWidgetContainer->setCurrentWidget(settingsInformationWidget);
     selectOption(ui->pushButtonTools1);
 }
 
-void SettingsWidget::showDebugConsole(){
+void SettingsWidget::showDebugConsole()
+{
     ui->pushButtonTools->setChecked(true);
     onToolsClicked();
     ui->pushButtonTools2->setChecked(true);
     onDebugConsoleClicked();
 }
 
-void SettingsWidget::onDebugConsoleClicked() {
+void SettingsWidget::onDebugConsoleClicked()
+{
     ui->stackedWidgetContainer->setCurrentWidget(settingsConsoleWidget);
     selectOption(ui->pushButtonTools2);
 }
 
-void SettingsWidget::onWalletRepairClicked() {
+void SettingsWidget::onWalletRepairClicked()
+{
     ui->stackedWidgetContainer->setCurrentWidget(settingsWalletRepairWidget);
     selectOption(ui->pushButtonTools5);
 }
 
 
-void SettingsWidget::onHelpClicked() {
+void SettingsWidget::onHelpClicked()
+{
     selectMenu(ui->pushButtonHelp);
 }
 
-void SettingsWidget::onAboutClicked() {
+void SettingsWidget::onAboutClicked()
+{
     if (!clientModel)
         return;
 
@@ -368,21 +388,24 @@ void SettingsWidget::onAboutClicked() {
 
 }
 
-void SettingsWidget::selectOption(QPushButton* option){
+void SettingsWidget::selectOption(QPushButton* option)
+{
     for (QPushButton* wid : options) {
-        if(wid) wid->setChecked(wid == option);
+        if (wid) wid->setChecked(wid == option);
     }
 }
 
-void SettingsWidget::onDiscardChanges(){
-    if(clientModel) {
+void SettingsWidget::onDiscardChanges()
+{
+    if (clientModel) {
         if (!ask(tr("Discard Unsaved Changes"), tr("You are just about to discard all of your unsaved options.\n\nAre you sure?\n")))
             return;
         clientModel->getOptionsModel()->refreshDataView();
     }
 }
 
-void SettingsWidget::setMapper(){
+void SettingsWidget::setMapper()
+{
     settingsMainOptionsWidget->setMapper(mapper);
     settingsWalletOptionsWidget->setMapper(mapper);
     settingsDisplayOptionsWidget->setMapper(mapper);
@@ -399,6 +422,7 @@ bool SettingsWidget::openStandardDialog(const QString& title, const QString& bod
     return confirmDialog->isOk;
 }
 
-SettingsWidget::~SettingsWidget(){
+SettingsWidget::~SettingsWidget()
+{
     delete ui;
 }

--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -69,36 +69,36 @@ TopBar::TopBar(PIVXGUI* _mainWindow, QWidget *parent) :
     progressBar->move(0, 34);
 
     ui->pushButtonFAQ->setButtonClassStyle("cssClass", "btn-check-faq");
-    ui->pushButtonFAQ->setButtonText("FAQ");
+    ui->pushButtonFAQ->setButtonText(tr("FAQ"));
 
     ui->pushButtonHDUpgrade->setButtonClassStyle("cssClass", "btn-check-hd-upgrade");
-    ui->pushButtonHDUpgrade->setButtonText("Upgrade to HD Wallet");
+    ui->pushButtonHDUpgrade->setButtonText(tr("Upgrade to HD Wallet"));
     ui->pushButtonHDUpgrade->setNoIconText("HD");
 
     ui->pushButtonConnection->setButtonClassStyle("cssClass", "btn-check-connect-inactive");
-    ui->pushButtonConnection->setButtonText("No Connection");
+    ui->pushButtonConnection->setButtonText(tr("No Connection"));
 
     ui->pushButtonTor->setButtonClassStyle("cssClass", "btn-check-tor-inactive");
     ui->pushButtonTor->setButtonText(tr("Tor Disabled"));
     ui->pushButtonTor->setChecked(false);
 
     ui->pushButtonStack->setButtonClassStyle("cssClass", "btn-check-stack-inactive");
-    ui->pushButtonStack->setButtonText("Staking Disabled");
+    ui->pushButtonStack->setButtonText(tr("Staking Disabled"));
 
     ui->pushButtonColdStaking->setButtonClassStyle("cssClass", "btn-check-cold-staking-inactive");
-    ui->pushButtonColdStaking->setButtonText("Cold Staking Disabled");
+    ui->pushButtonColdStaking->setButtonText(tr("Cold Staking Disabled"));
 
     ui->pushButtonSync->setButtonClassStyle("cssClass", "btn-check-sync");
-    ui->pushButtonSync->setButtonText(" %54 Synchronizing..");
+    ui->pushButtonSync->setButtonText(tr(" %54 Synchronizing.."));
 
     ui->pushButtonLock->setButtonClassStyle("cssClass", "btn-check-lock");
 
     if (isLightTheme()) {
         ui->pushButtonTheme->setButtonClassStyle("cssClass", "btn-check-theme-light");
-        ui->pushButtonTheme->setButtonText("Light Theme");
+        ui->pushButtonTheme->setButtonText(tr("Light Theme"));
     } else {
         ui->pushButtonTheme->setButtonClassStyle("cssClass", "btn-check-theme-dark");
-        ui->pushButtonTheme->setButtonText("Dark Theme");
+        ui->pushButtonTheme->setButtonText(tr("Dark Theme"));
     }
 
     setCssProperty(ui->qrContainer, "container-qr");
@@ -113,7 +113,7 @@ TopBar::TopBar(PIVXGUI* _mainWindow, QWidget *parent) :
                          Qt::KeepAspectRatio))
                 );
 
-    ui->pushButtonLock->setButtonText("Wallet Locked  ");
+    ui->pushButtonLock->setButtonText(tr("Wallet Locked "));
     ui->pushButtonLock->setButtonClassStyle("cssClass", "btn-check-status-lock");
 
 
@@ -136,10 +136,10 @@ void TopBar::onThemeClicked()
 
     if (lightTheme) {
         ui->pushButtonTheme->setButtonClassStyle("cssClass", "btn-check-theme-light",  true);
-        ui->pushButtonTheme->setButtonText("Light Theme");
+        ui->pushButtonTheme->setButtonText(tr("Light Theme"));
     } else {
         ui->pushButtonTheme->setButtonClassStyle("cssClass", "btn-check-theme-dark", true);
-        ui->pushButtonTheme->setButtonText("Dark Theme");
+        ui->pushButtonTheme->setButtonText(tr("Dark Theme"));
     }
     updateStyle(ui->pushButtonTheme);
 
@@ -230,7 +230,7 @@ void TopBar::lockDropdownClicked(const StateClicked& state)
                 if (walletModel->getEncryptionStatus() == WalletModel::Locked)
                     break;
                 walletModel->setWalletLocked(true);
-                ui->pushButtonLock->setButtonText("Wallet Locked");
+                ui->pushButtonLock->setButtonText(tr("Wallet Locked"));
                 ui->pushButtonLock->setButtonClassStyle("cssClass", "btn-check-status-lock", true);
                 // Directly update the staking status icon when the wallet is manually locked here
                 // so the feedback is instant (no need to wait for the polling timeout)
@@ -246,7 +246,7 @@ void TopBar::lockDropdownClicked(const StateClicked& state)
                 dlg->adjustSize();
                 openDialogWithOpaqueBackgroundY(dlg, window);
                 if (walletModel->getEncryptionStatus() == WalletModel::Unlocked) {
-                    ui->pushButtonLock->setButtonText("Wallet Unlocked");
+                    ui->pushButtonLock->setButtonText(tr("Wallet Unlocked"));
                     ui->pushButtonLock->setButtonClassStyle("cssClass", "btn-check-status-unlock", true);
                 }
                 dlg->deleteLater();
@@ -589,19 +589,19 @@ void TopBar::refreshStatus()
 
     switch (encStatus) {
         case WalletModel::EncryptionStatus::Unencrypted:
-            ui->pushButtonLock->setButtonText("Wallet Unencrypted");
+            ui->pushButtonLock->setButtonText(tr("Wallet Unencrypted"));
             ui->pushButtonLock->setButtonClassStyle("cssClass", "btn-check-status-unlock", true);
             break;
         case WalletModel::EncryptionStatus::Locked:
-            ui->pushButtonLock->setButtonText("Wallet Locked");
+            ui->pushButtonLock->setButtonText(tr("Wallet Locked"));
             ui->pushButtonLock->setButtonClassStyle("cssClass", "btn-check-status-lock", true);
             break;
         case WalletModel::EncryptionStatus::UnlockedForStaking:
-            ui->pushButtonLock->setButtonText("Wallet Unlocked for staking");
+            ui->pushButtonLock->setButtonText(tr("Wallet Unlocked for staking"));
             ui->pushButtonLock->setButtonClassStyle("cssClass", "btn-check-status-staking", true);
             break;
         case WalletModel::EncryptionStatus::Unlocked:
-            ui->pushButtonLock->setButtonText("Wallet Unlocked");
+            ui->pushButtonLock->setButtonText(tr("Wallet Unlocked"));
             ui->pushButtonLock->setButtonClassStyle("cssClass", "btn-check-status-unlock", true);
             break;
     }

--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -210,7 +210,7 @@ void TopBar::encryptWallet()
 
 void TopBar::unlockWallet()
 {
-    if(!walletModel)
+    if (!walletModel)
         return;
     // Unlock wallet when requested by wallet model (if unlocked or unlocked for staking only)
     if (walletModel->isWalletLocked(false))
@@ -724,6 +724,7 @@ void TopBar::run(int type)
         );
     }
 }
+
 void TopBar::onError(QString error, int type)
 {
     if (type == REQUEST_UPGRADE_WALLET) {

--- a/src/qt/pivx/txrow.cpp
+++ b/src/qt/pivx/txrow.cpp
@@ -15,41 +15,48 @@ TxRow::TxRow(QWidget *parent) :
     ui->setupUi(this);
 }
 
-void TxRow::init(bool isLightTheme) {
+void TxRow::init(bool isLightTheme)
+{
     setConfirmStatus(true);
     updateStatus(isLightTheme, false, false);
 }
 
-void TxRow::setConfirmStatus(bool isConfirm){
-    if(isConfirm){
+void TxRow::setConfirmStatus(bool isConfirm)
+{
+    if (isConfirm) {
         setCssProperty(ui->lblAddress, "text-list-body1");
         setCssProperty(ui->lblDate, "text-list-caption");
-    }else{
+    } else {
         setCssProperty(ui->lblAddress, "text-list-body-unconfirmed");
         setCssProperty(ui->lblDate,"text-list-caption-unconfirmed");
     }
 }
 
-void TxRow::updateStatus(bool isLightTheme, bool isHover, bool isSelected){
-    if(isLightTheme)
+void TxRow::updateStatus(bool isLightTheme, bool isHover, bool isSelected)
+{
+    if (isLightTheme)
         ui->lblDivisory->setStyleSheet("background-color:#bababa");
     else
         ui->lblDivisory->setStyleSheet("background-color:#40ffffff");
 }
 
-void TxRow::setDate(QDateTime date){
+void TxRow::setDate(QDateTime date)
+{
     ui->lblDate->setText(GUIUtil::dateTimeStr(date));
 }
 
-void TxRow::setLabel(QString str){
+void TxRow::setLabel(QString str)
+{
     ui->lblAddress->setText(str);
 }
 
-void TxRow::setAmount(QString str){
+void TxRow::setAmount(QString str)
+{
     ui->lblAmount->setText(str);
 }
 
-void TxRow::setType(bool isLightTheme, int type, bool isConfirmed){
+void TxRow::setType(bool isLightTheme, int type, bool isConfirmed)
+{
     QString path;
     QString css;
     bool sameIcon = false;
@@ -120,13 +127,14 @@ void TxRow::setType(bool isLightTheme, int type, bool isConfirmed){
         css = "text-list-amount-unconfirmed";
         path += "-inactive";
         setConfirmStatus(false);
-    }else{
+    } else {
         setConfirmStatus(true);
     }
     setCssProperty(ui->lblAmount, css, true);
     ui->icon->setIcon(QIcon(path));
 }
 
-TxRow::~TxRow(){
+TxRow::~TxRow()
+{
     delete ui;
 }

--- a/src/qt/pivx/txviewholder.cpp
+++ b/src/qt/pivx/txviewholder.cpp
@@ -9,13 +9,15 @@
 
 #define ADDRESS_SIZE 12
 
-QWidget* TxViewHolder::createHolder(int pos){
+QWidget* TxViewHolder::createHolder(int pos)
+{
     if (!txRow) txRow = new TxRow();
     txRow->init(isLightTheme);
     return txRow;
 }
 
-void TxViewHolder::init(QWidget* holder,const QModelIndex &index, bool isHovered, bool isSelected) const{
+void TxViewHolder::init(QWidget* holder,const QModelIndex &index, bool isHovered, bool isSelected) const
+{
     TxRow *txRow = static_cast<TxRow*>(holder);
     txRow->updateStatus(isLightTheme, isHovered, isSelected);
 
@@ -27,12 +29,12 @@ void TxViewHolder::init(QWidget* holder,const QModelIndex &index, bool isHovered
     QString label = indexType.data(Qt::DisplayRole).toString();
     int type = rIndex.data(TransactionTableModel::TypeRole).toInt();
 
-    if(type != TransactionRecord::ZerocoinMint &&
+    if (type != TransactionRecord::ZerocoinMint &&
             type !=  TransactionRecord::ZerocoinSpend_Change_zPiv &&
             type !=  TransactionRecord::StakeZPIV &&
-            type != TransactionRecord::Other){
+            type != TransactionRecord::Other) {
         QString address = rIndex.data(Qt::DisplayRole).toString();
-        if(address.length() > 20) {
+        if (address.length() > 20) {
             address = address.left(ADDRESS_SIZE) + "..." + address.right(ADDRESS_SIZE);
         }
         label += " " + address;
@@ -50,6 +52,7 @@ void TxViewHolder::init(QWidget* holder,const QModelIndex &index, bool isHovered
     txRow->setType(isLightTheme, type, !isUnconfirmed);
 }
 
-QColor TxViewHolder::rectColor(bool isHovered, bool isSelected) {
+QColor TxViewHolder::rectColor(bool isHovered, bool isSelected)
+{
     return getRowColor(isLightTheme, isHovered, isSelected);
 }

--- a/src/qt/pivx/welcomecontentwidget.cpp
+++ b/src/qt/pivx/welcomecontentwidget.cpp
@@ -71,7 +71,6 @@ WelcomeContentWidget::WelcomeContentWidget(QWidget *parent) :
     ui->labelLine2->setProperty("cssClass", "line-welcome");
     ui->labelLine3->setProperty("cssClass", "line-welcome");
 
-
     ui->groupBoxName->setProperty("cssClass", "container-welcome-box");
     ui->groupContainer->setProperty("cssClass", "container-welcome-box");
 
@@ -164,7 +163,6 @@ WelcomeContentWidget::WelcomeContentWidget(QWidget *parent) :
     connect(ui->comboBoxLanguage, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &WelcomeContentWidget::checkLanguage);
     initLanguages();
 
-
     // Resize window and move to center of desktop, disallow resizing
     QRect r(QPoint(), size());
     resize(r.size());
@@ -172,7 +170,8 @@ WelcomeContentWidget::WelcomeContentWidget(QWidget *parent) :
     move(QApplication::desktop()->screenGeometry().center() - r.center());
 }
 
-void WelcomeContentWidget::initLanguages(){
+void WelcomeContentWidget::initLanguages()
+{
     /* Language selector */
     QDir translations(":translations");
     ui->comboBoxLanguage->addItem(QString("(") + tr("default") + QString(")"), QVariant(""));
@@ -180,22 +179,23 @@ void WelcomeContentWidget::initLanguages(){
         QLocale locale(langStr);
 
         /** check if the locale name consists of 2 parts (language_country) */
-        if(langStr.contains("_")){
+        if (langStr.contains("_")) {
             /** display language strings as "native language - native country (locale name)", e.g. "Deutsch - Deutschland (de)" */
             ui->comboBoxLanguage->addItem(locale.nativeLanguageName() + QString(" - ") + locale.nativeCountryName() + QString(" (") + langStr + QString(")"), QVariant(langStr));
-        }
-        else{
+        } else {
             /** display language strings as "native language (locale name)", e.g. "Deutsch (de)" */
             ui->comboBoxLanguage->addItem(locale.nativeLanguageName() + QString(" (") + langStr + QString(")"), QVariant(langStr));
         }
     }
 }
 
-void WelcomeContentWidget::setModel(OptionsModel *model){
+void WelcomeContentWidget::setModel(OptionsModel *model)
+{
     this->model = model;
 }
 
-void WelcomeContentWidget::checkLanguage(){
+void WelcomeContentWidget::checkLanguage()
+{
     QString sel = ui->comboBoxLanguage->currentData().toString();
     QSettings settings;
     if (settings.value("language") != sel){
@@ -206,8 +206,8 @@ void WelcomeContentWidget::checkLanguage(){
     }
 }
 
-void WelcomeContentWidget::onNextClicked(){
-
+void WelcomeContentWidget::onNextClicked()
+{
     switch(pos){
         case 0:{
             ui->stackedWidget->setCurrentIndex(1);
@@ -254,7 +254,8 @@ void WelcomeContentWidget::onNextClicked(){
 
 }
 
-void WelcomeContentWidget::onBackClicked(){
+void WelcomeContentWidget::onBackClicked()
+{
     if (pos == 0) return;
     pos--;
     switch(pos){
@@ -308,7 +309,8 @@ void WelcomeContentWidget::onBackClicked(){
     }
 }
 
-void WelcomeContentWidget::onSkipClicked(){
+void WelcomeContentWidget::onSkipClicked()
+{
     isOk = true;
     accept();
 }


### PR DESCRIPTION
Set initial / static texts for widgets and dialogs in the .ui files instead of in the .cpp files, with `notr` where needed. Also add `tr()` where missing (ref: #1600).
Finally clean up styling (missing spaces, branches on newlines).