### PR TITLE
[QT] Add password mismatch warnings

### DIFF
--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -272,7 +272,7 @@ bool AskPassphraseDialog::event(QEvent* event)
             fCapsLock = !fCapsLock;
         }
 
-        getWarnings();
+        updateWarningsLabel();
 
         // Detect Enter key press
         if ((ke->key() == Qt::Key_Enter || ke->key() == Qt::Key_Return) && ui->pushButtonOk->isEnabled()) {
@@ -303,7 +303,7 @@ bool AskPassphraseDialog::eventFilter(QObject* object, QEvent* event)
             }
         }
     }
-    getWarnings();
+    updateWarningsLabel();
 
     return QDialog::eventFilter(object, event);
 }
@@ -320,7 +320,7 @@ bool AskPassphraseDialog::openStandardDialog(QString title, QString body, QStrin
     return ret;
 }
 
-void AskPassphraseDialog::getWarnings()
+void AskPassphraseDialog::updateWarningsLabel()
 {
     // Merge warning labels together if there's two warnings
     bool validPassphrases = false;

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -59,8 +59,8 @@ AskPassphraseDialog::AskPassphraseDialog(Mode mode, QWidget* parent, WalletModel
     ui->passLabel3->setText("Repeat passphrase");
     ui->passLabel3->setProperty("cssClass", "text-title");
 
-    setCssProperty(ui->capsLabel, "text-warning-small");
-    ui->capsLabel->setVisible(false);
+    setCssProperty(ui->passWarningLabel, "text-warning-small");
+    ui->passWarningLabel->setVisible(false);
 
     ui->passEdit1->setMinimumSize(ui->passEdit1->sizeHint());
     ui->passEdit2->setMinimumSize(ui->passEdit2->sizeHint());
@@ -189,16 +189,11 @@ void AskPassphraseDialog::accept()
                 tr("ENCRYPT"), tr("CANCEL")
         );
         if (ret) {
-            if (newpass1 == newpass2) {
-                newpassCache = newpass1;
-                PIVXGUI* window = static_cast<PIVXGUI*>(parentWidget());
-                LoadingDialog *dialog = new LoadingDialog(window);
-                dialog->execute(this, 1);
-                openDialogWithOpaqueBackgroundFullScreen(dialog, window);
-            } else {
-                QMessageBox::critical(this, tr("Wallet encryption failed"),
-                    tr("The supplied passphrases do not match."));
-            }
+            newpassCache = newpass1;
+            PIVXGUI* window = static_cast<PIVXGUI*>(parentWidget());
+            LoadingDialog *dialog = new LoadingDialog(window);
+            dialog->execute(this, 1);
+            openDialogWithOpaqueBackgroundFullScreen(dialog, window);
         } else {
             QDialog::reject(); // Cancelled
         }
@@ -251,7 +246,8 @@ void AskPassphraseDialog::textChanged()
     bool acceptable = false;
     switch (mode) {
     case Mode::Encrypt: // New passphrase x2
-        acceptable = !ui->passEdit2->text().isEmpty() && !ui->passEdit3->text().isEmpty();
+        acceptable = !ui->passEdit2->text().isEmpty() && !ui->passEdit3->text().isEmpty() && // Passphrases are not empty
+                     ui->passEdit2->text() == ui->passEdit3->text();                         // Passphrases match eachother
         break;
     case Mode::UnlockAnonymize: // Old passphrase x1
     case Mode::Unlock:          // Old passphrase x1
@@ -259,7 +255,9 @@ void AskPassphraseDialog::textChanged()
         acceptable = !ui->passEdit1->text().isEmpty();
         break;
     case Mode::ChangePass: // Old passphrase x1, new passphrase x2
-        acceptable = !ui->passEdit1->text().isEmpty() && !ui->passEdit2->text().isEmpty() && !ui->passEdit3->text().isEmpty();
+        acceptable = !ui->passEdit2->text().isEmpty() && !ui->passEdit3->text().isEmpty() && // New passphrases are not empty
+                     ui->passEdit2->text() == ui->passEdit3->text() &&                       // New passphrases match eachother
+                     !ui->passEdit1->text().isEmpty();                                       // Old passphrase is not empty
         break;
     }
     ui->pushButtonOk->setEnabled(acceptable);
@@ -272,9 +270,10 @@ bool AskPassphraseDialog::event(QEvent* event)
         // Detect Caps Lock key press.
         if (ke->key() == Qt::Key_CapsLock) {
             fCapsLock = !fCapsLock;
-            ui->capsLabel->setVisible(fCapsLock);
-            fCapsLock ? ui->capsLabel->setText(tr("WARNING: The Caps Lock key is on!")) : ui->capsLabel->clear();
         }
+
+        getWarnings();
+
         // Detect Enter key press
         if ((ke->key() == Qt::Key_Enter || ke->key() == Qt::Key_Return) && ui->pushButtonOk->isEnabled()) {
             accept();
@@ -299,15 +298,13 @@ bool AskPassphraseDialog::eventFilter(QObject* object, QEvent* event)
             bool fShift = (ke->modifiers() & Qt::ShiftModifier) != 0;
             if ((fShift && *psz >= 'a' && *psz <= 'z') || (!fShift && *psz >= 'A' && *psz <= 'Z')) {
                 fCapsLock = true;
-                ui->capsLabel->setText(tr("WARNING: The Caps Lock key is on!"));
-                ui->capsLabel->setVisible(true);
             } else if (psz->isLetter()) {
                 fCapsLock = false;
-                ui->capsLabel->clear();
-                ui->capsLabel->setVisible(false);
             }
         }
     }
+    getWarnings();
+
     return QDialog::eventFilter(object, event);
 }
 
@@ -321,6 +318,26 @@ bool AskPassphraseDialog::openStandardDialog(QString title, QString body, QStrin
     bool ret = confirmDialog->isOk;
     confirmDialog->deleteLater();
     return ret;
+}
+
+void AskPassphraseDialog::getWarnings()
+{
+    // Merge warning labels together if there's two warnings
+    bool validPassphrases = false;
+    validPassphrases = ui->passEdit2->text() == ui->passEdit3->text();
+    QString warningStr = "";
+    if (fCapsLock || !validPassphrases) warningStr += tr("WARNING:") + "<br>";
+    if (fCapsLock) warningStr += "* " + tr("The caps lock key is on!");
+    if (fCapsLock && !validPassphrases) warningStr += "<br>";
+    if (!validPassphrases) warningStr += "* " + tr("Passphrases do not match!");
+
+    if (warningStr.isEmpty()) {
+        ui->passWarningLabel->clear();
+        ui->passWarningLabel->setVisible(false);
+    } else {
+        ui->passWarningLabel->setText(warningStr);
+        ui->passWarningLabel->setVisible(true);
+    }
 }
 
 void AskPassphraseDialog::warningMessage()

--- a/src/qt/askpassphrasedialog.h
+++ b/src/qt/askpassphrasedialog.h
@@ -66,7 +66,7 @@ private:
     bool fCapsLock;
     SecureString newpassCache = "";
 
-    void getWarnings();
+    void updateWarningsLabel();
     void run(int type) override;
     void onError(QString error, int type) override;
     QCheckBox *btnWatch;

--- a/src/qt/askpassphrasedialog.h
+++ b/src/qt/askpassphrasedialog.h
@@ -66,6 +66,7 @@ private:
     bool fCapsLock;
     SecureString newpassCache = "";
 
+    void getWarnings();
     void run(int type) override;
     void onError(QString error, int type) override;
     QCheckBox *btnWatch;

--- a/src/qt/forms/askpassphrasedialog.ui
+++ b/src/qt/forms/askpassphrasedialog.ui
@@ -305,7 +305,7 @@
          </spacer>
         </item>
         <item>
-         <widget class="QLabel" name="capsLabel">
+         <widget class="QLabel" name="passWarningLabel">
           <property name="font">
            <font>
             <weight>75</weight>
@@ -316,7 +316,7 @@
            <string/>
           </property>
           <property name="alignment">
-           <set>Qt::AlignCenter</set>
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
This closes #1605 by adding a warning message & deactivating the "OK" button when the two passphrase fields do not match eachother.

![image](https://user-images.githubusercontent.com/42538664/81461042-1b2e4200-91a1-11ea-8dab-c7262b2de864.png)

As this warning is in the same area as the caps lock warning, the two have been merged into a single "passWarningLabel" which "stacks" warnings ontop of eachother, so both warnings can be shown independently, or both at once.

![image](https://user-images.githubusercontent.com/42538664/81461053-2b462180-91a1-11ea-840f-40c983e7c85d.png)

This PR ensures a user cannot proceed via the "OK" button until:
1. The new passphrase fields are not empty.
2. The new passphrase fields share identical texts.
3. (If changing password only) The **old** passphrase field is not empty.