### PR TITLE
[GUI][UX] Add accept/close keyboard controls to all dialogs

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -107,6 +107,7 @@ QT_MOC_CPP = \
   qt/pivx/moc_loadingdialog.cpp \
   qt/moc_zpivcontroldialog.cpp \
   qt/pivx/moc_pwidget.cpp \
+  qt/pivx/moc_focuseddialog.cpp \
   qt/pivx/moc_snackbar.cpp \
   qt/pivx/moc_navmenuwidget.cpp \
   qt/pivx/moc_lockunlock.cpp \
@@ -228,6 +229,7 @@ BITCOIN_QT_H = \
   qt/winshutdownmonitor.h \
   qt/zpivcontroldialog.h \
   qt/pivx/pwidget.h \
+  qt/pivx/focuseddialog.h \
   qt/pivx/guitransactionsutils.h \
   qt/pivx/snackbar.h \
   qt/pivx/navmenuwidget.h \
@@ -553,6 +555,7 @@ BITCOIN_QT_WALLET_CPP = \
   qt/pivx/loadingdialog.cpp \
   qt/zpivcontroldialog.cpp \
   qt/pivx/pwidget.cpp \
+  qt/pivx/focuseddialog.cpp \
   qt/pivx/guitransactionsutils.cpp \
   qt/pivx/snackbar.cpp \
   qt/pivx/navmenuwidget.cpp \

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -119,6 +119,7 @@ SET(QT_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/pivx/pivxgui.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/pivx/loadingdialog.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/pivx/pwidget.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/pivx/focuseddialog.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/pivx/guitransactionsutils.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/pivx/snackbar.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/pivx/navmenuwidget.cpp

--- a/src/qt/pivx/addnewcontactdialog.cpp
+++ b/src/qt/pivx/addnewcontactdialog.cpp
@@ -7,7 +7,7 @@
 #include "qt/pivx/qtutils.h"
 
 AddNewContactDialog::AddNewContactDialog(QWidget *parent) :
-    QDialog(parent),
+    FocusedDialog(parent),
     ui(new Ui::AddNewContactDialog)
 {
     ui->setupUi(this);
@@ -33,7 +33,7 @@ AddNewContactDialog::AddNewContactDialog(QWidget *parent) :
 
     connect(ui->btnEsc, &QPushButton::clicked, this, &AddNewContactDialog::close);
     connect(ui->btnCancel, &QPushButton::clicked, this, &AddNewContactDialog::close);
-    connect(ui->btnOk, &QPushButton::clicked, this, &AddNewContactDialog::ok);
+    connect(ui->btnOk, &QPushButton::clicked, this, &AddNewContactDialog::accept);
 }
 
 void AddNewContactDialog::setTexts(QString title, const char* message) {
@@ -57,9 +57,9 @@ void AddNewContactDialog::showEvent(QShowEvent *event)
     if (ui->lineEditName) ui->lineEditName->setFocus();
 }
 
-void AddNewContactDialog::ok() {
+void AddNewContactDialog::accept() {
     this->res = true;
-    accept();
+    QDialog::accept();
 }
 
 QString AddNewContactDialog::getLabel(){

--- a/src/qt/pivx/addnewcontactdialog.h
+++ b/src/qt/pivx/addnewcontactdialog.h
@@ -5,13 +5,13 @@
 #ifndef ADDNEWCONTACTDIALOG_H
 #define ADDNEWCONTACTDIALOG_H
 
-#include <QDialog>
+#include "qt/pivx/focuseddialog.h"
 
 namespace Ui {
 class AddNewContactDialog;
 }
 
-class AddNewContactDialog : public QDialog
+class AddNewContactDialog : public FocusedDialog
 {
     Q_OBJECT
 
@@ -27,7 +27,7 @@ public:
     bool res = false;
 
 public Q_SLOTS:
-    void ok();
+    void accept() override;
 private:
     Ui::AddNewContactDialog *ui;
     const char* message = nullptr;

--- a/src/qt/pivx/defaultdialog.cpp
+++ b/src/qt/pivx/defaultdialog.cpp
@@ -5,10 +5,9 @@
 #include "qt/pivx/defaultdialog.h"
 #include "qt/pivx/forms/ui_defaultdialog.h"
 #include "guiutil.h"
-#include <QKeyEvent>
 
 DefaultDialog::DefaultDialog(QWidget *parent) :
-    QDialog(parent),
+    FocusedDialog(parent),
     ui(new Ui::DefaultDialog)
 {
     ui->setupUi(this);
@@ -35,12 +34,6 @@ DefaultDialog::DefaultDialog(QWidget *parent) :
     connect(ui->btnSave, &QPushButton::clicked, this, &DefaultDialog::accept);
 }
 
-void DefaultDialog::showEvent(QShowEvent *event)
-{
-    setFocus();
-}
-
-
 void DefaultDialog::setText(const QString& title, const QString& message, const QString& okBtnText, const QString& cancelBtnText)
 {
     if (!okBtnText.isNull()) ui->btnSave->setText(okBtnText);
@@ -58,17 +51,6 @@ void DefaultDialog::accept()
 {
     this->isOk = true;
     QDialog::accept();
-}
-
-void DefaultDialog::keyPressEvent(QKeyEvent *event)
-{
-    if (event->type() == QEvent::KeyPress) {
-        QKeyEvent* ke = static_cast<QKeyEvent*>(event);
-        // Detect Enter key press
-        if (ke->key() == Qt::Key_Enter || ke->key() == Qt::Key_Return) accept();
-        // Detect Esc key press
-        if (ke->key() == Qt::Key_Escape) close();
-    }
 }
 
 DefaultDialog::~DefaultDialog()

--- a/src/qt/pivx/defaultdialog.h
+++ b/src/qt/pivx/defaultdialog.h
@@ -5,13 +5,13 @@
 #ifndef DEFAULTDIALOG_H
 #define DEFAULTDIALOG_H
 
-#include <QDialog>
+#include "qt/pivx/focuseddialog.h"
 
 namespace Ui {
 class DefaultDialog;
 }
 
-class DefaultDialog : public QDialog
+class DefaultDialog : public FocusedDialog
 {
     Q_OBJECT
 
@@ -19,7 +19,6 @@ public:
     explicit DefaultDialog(QWidget *parent = nullptr);
     ~DefaultDialog();
 
-    void showEvent(QShowEvent *event) override;
     void setText(const QString& title = "", const QString& message = "", const QString& okBtnText = "", const QString& cancelBtnText = "");
 
     bool isOk = false;
@@ -29,8 +28,6 @@ public Q_SLOTS:
 
 private:
     Ui::DefaultDialog *ui;
-protected:
-    void keyPressEvent(QKeyEvent *e) override;
 };
 
 #endif // DEFAULTDIALOG_H

--- a/src/qt/pivx/focuseddialog.cpp
+++ b/src/qt/pivx/focuseddialog.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "qt/pivx/focuseddialog.h"
+#include <QKeyEvent>
+
+FocusedDialog::FocusedDialog(QWidget *parent) :
+    QDialog(parent)
+{}
+
+void FocusedDialog::showEvent(QShowEvent *event)
+{
+    setFocus();
+}
+
+void FocusedDialog::keyPressEvent(QKeyEvent *e)
+{
+    if (e->type() == QEvent::KeyPress) {
+        QKeyEvent* ke = static_cast<QKeyEvent*>(e);
+        // Detect Enter key press
+        if (ke->key() == Qt::Key_Enter || ke->key() == Qt::Key_Return) accept();
+        // Detect Esc key press
+        if (ke->key() == Qt::Key_Escape) close();
+    }
+}
+
+FocusedDialog::~FocusedDialog()
+{}

--- a/src/qt/pivx/focuseddialog.cpp
+++ b/src/qt/pivx/focuseddialog.cpp
@@ -21,7 +21,7 @@ void FocusedDialog::keyPressEvent(QKeyEvent *e)
         // Detect Enter key press
         if (ke->key() == Qt::Key_Enter || ke->key() == Qt::Key_Return) accept();
         // Detect Esc key press
-        if (ke->key() == Qt::Key_Escape) close();
+        if (ke->key() == Qt::Key_Escape) reject();
     }
 }
 

--- a/src/qt/pivx/focuseddialog.h
+++ b/src/qt/pivx/focuseddialog.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef FOCUSEDDIALOG_H
+#define FOCUSEDDIALOG_H
+
+#include <QDialog>
+
+class FocusedDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit FocusedDialog(QWidget *parent = nullptr);
+    ~FocusedDialog();
+
+    // Sets focus on show
+    void showEvent(QShowEvent *event);
+
+protected:
+    // Detects a key press and calls accept() on ENTER and close() on ESC
+    void keyPressEvent(QKeyEvent *e);
+};
+
+#endif // FOCUSEDDIALOG_H

--- a/src/qt/pivx/focuseddialog.h
+++ b/src/qt/pivx/focuseddialog.h
@@ -19,7 +19,7 @@ public:
     void showEvent(QShowEvent *event);
 
 protected:
-    // Detects a key press and calls accept() on ENTER and close() on ESC
+    // Detects a key press and calls accept() on ENTER and reject() on ESC
     void keyPressEvent(QKeyEvent *e);
 };
 

--- a/src/qt/pivx/masternodewizarddialog.cpp
+++ b/src/qt/pivx/masternodewizarddialog.cpp
@@ -19,7 +19,7 @@
 #include <QRegularExpressionValidator>
 
 MasterNodeWizardDialog::MasterNodeWizardDialog(WalletModel *model, QWidget *parent) :
-    QDialog(parent),
+    FocusedDialog(parent),
     ui(new Ui::MasterNodeWizardDialog),
     icConfirm1(new QPushButton()),
     icConfirm3(new QPushButton()),
@@ -89,7 +89,7 @@ MasterNodeWizardDialog::MasterNodeWizardDialog(WalletModel *model, QWidget *pare
     setCssProperty(ui->pushButtonSkip, "ic-close");
 
     connect(ui->pushButtonSkip, &QPushButton::clicked, this, &MasterNodeWizardDialog::close);
-    connect(ui->btnNext, &QPushButton::clicked, this, &MasterNodeWizardDialog::onNextClicked);
+    connect(ui->btnNext, &QPushButton::clicked, this, &MasterNodeWizardDialog::accept);
     connect(ui->btnBack, &QPushButton::clicked, this, &MasterNodeWizardDialog::onBackClicked);
 }
 
@@ -98,7 +98,7 @@ void MasterNodeWizardDialog::showEvent(QShowEvent *event)
     if (ui->btnNext) ui->btnNext->setFocus();
 }
 
-void MasterNodeWizardDialog::onNextClicked()
+void MasterNodeWizardDialog::accept()
 {
     switch(pos) {
         case 0:{
@@ -142,7 +142,7 @@ void MasterNodeWizardDialog::onNextClicked()
             ui->btnBack->setVisible(true);
             ui->btnBack->setVisible(true);
             isOk = createMN();
-            accept();
+            QDialog::accept();
         }
     }
     pos++;

--- a/src/qt/pivx/masternodewizarddialog.h
+++ b/src/qt/pivx/masternodewizarddialog.h
@@ -5,8 +5,8 @@
 #ifndef MASTERNODEWIZARDDIALOG_H
 #define MASTERNODEWIZARDDIALOG_H
 
-#include <QDialog>
 #include "walletmodel.h"
+#include "qt/pivx/focuseddialog.h"
 #include "qt/pivx/snackbar.h"
 #include "masternodeconfig.h"
 #include "qt/pivx/pwidget.h"
@@ -18,7 +18,7 @@ class MasterNodeWizardDialog;
 class QPushButton;
 }
 
-class MasterNodeWizardDialog : public QDialog, public PWidget::Translator
+class MasterNodeWizardDialog : public FocusedDialog, public PWidget::Translator
 {
     Q_OBJECT
 
@@ -33,7 +33,7 @@ public:
     CMasternodeConfig::CMasternodeEntry* mnEntry = nullptr;
 
 private Q_SLOTS:
-    void onNextClicked();
+    void accept() override;
     void onBackClicked();
 private:
     Ui::MasterNodeWizardDialog *ui;

--- a/src/qt/pivx/mninfodialog.cpp
+++ b/src/qt/pivx/mninfodialog.cpp
@@ -11,7 +11,7 @@
 #include <QDateTime>
 
 MnInfoDialog::MnInfoDialog(QWidget *parent) :
-    QDialog(parent),
+    FocusedDialog(parent),
     ui(new Ui::MnInfoDialog)
 {
     ui->setupUi(this);
@@ -23,7 +23,7 @@ MnInfoDialog::MnInfoDialog(QWidget *parent) :
     setCssTextBodyDialog({ui->textAmount, ui->textAddress, ui->textInputs, ui->textStatus, ui->textId, ui->textExport});
     setCssProperty({ui->pushCopy, ui->pushCopyId, ui->pushExport}, "ic-copy-big");
     setCssProperty(ui->btnEsc, "ic-close");
-    connect(ui->btnEsc, &QPushButton::clicked, this, &MnInfoDialog::closeDialog);
+    connect(ui->btnEsc, &QPushButton::clicked, this, &MnInfoDialog::close);
     connect(ui->pushCopy, &QPushButton::clicked, [this](){ copyInform(pubKey, tr("Masternode public key copied")); });
     connect(ui->pushCopyId, &QPushButton::clicked, [this](){ copyInform(txId, tr("Collateral tx id copied")); });
     connect(ui->pushExport, &QPushButton::clicked, [this](){ exportMN = true; accept(); });
@@ -57,10 +57,10 @@ void MnInfoDialog::copyInform(QString& copyStr, QString message)
     openDialog(snackBar, this);
 }
 
-void MnInfoDialog::closeDialog()
+void MnInfoDialog::close()
 {
     if (snackBar && snackBar->isVisible()) snackBar->hide();
-    close();
+    FocusedDialog::close();
 }
 
 MnInfoDialog::~MnInfoDialog()

--- a/src/qt/pivx/mninfodialog.cpp
+++ b/src/qt/pivx/mninfodialog.cpp
@@ -57,10 +57,10 @@ void MnInfoDialog::copyInform(QString& copyStr, QString message)
     openDialog(snackBar, this);
 }
 
-void MnInfoDialog::close()
+void MnInfoDialog::reject()
 {
     if (snackBar && snackBar->isVisible()) snackBar->hide();
-    FocusedDialog::close();
+    QDialog::reject();
 }
 
 MnInfoDialog::~MnInfoDialog()

--- a/src/qt/pivx/mninfodialog.h
+++ b/src/qt/pivx/mninfodialog.h
@@ -27,7 +27,7 @@ public:
     void setData(QString privKey, QString name, QString address, QString txId, QString outputIndex, QString status);
 
 public Q_SLOTS:
-    void close();
+    void reject() override;
 
 private:
     Ui::MnInfoDialog *ui;

--- a/src/qt/pivx/mninfodialog.h
+++ b/src/qt/pivx/mninfodialog.h
@@ -5,7 +5,7 @@
 #ifndef MNINFODIALOG_H
 #define MNINFODIALOG_H
 
-#include <QDialog>
+#include "qt/pivx/focuseddialog.h"
 #include "qt/pivx/snackbar.h"
 
 class WalletModel;
@@ -14,7 +14,7 @@ namespace Ui {
 class MnInfoDialog;
 }
 
-class MnInfoDialog : public QDialog
+class MnInfoDialog : public FocusedDialog
 {
     Q_OBJECT
 
@@ -27,7 +27,7 @@ public:
     void setData(QString privKey, QString name, QString address, QString txId, QString outputIndex, QString status);
 
 public Q_SLOTS:
-    void closeDialog();
+    void close();
 
 private:
     Ui::MnInfoDialog *ui;

--- a/src/qt/pivx/receivedialog.cpp
+++ b/src/qt/pivx/receivedialog.cpp
@@ -9,7 +9,7 @@
 #include <QFile>
 
 ReceiveDialog::ReceiveDialog(QWidget *parent) :
-    QDialog(parent),
+    FocusedDialog(parent),
     ui(new Ui::ReceiveDialog)
 {
     ui->setupUi(this);

--- a/src/qt/pivx/receivedialog.h
+++ b/src/qt/pivx/receivedialog.h
@@ -5,7 +5,7 @@
 #ifndef RECEIVEDIALOG_H
 #define RECEIVEDIALOG_H
 
-#include <QDialog>
+#include "qt/pivx/focuseddialog.h"
 #include <QPixmap>
 
 class SendCoinsRecipient;
@@ -14,7 +14,7 @@ namespace Ui {
 class ReceiveDialog;
 }
 
-class ReceiveDialog : public QDialog
+class ReceiveDialog : public FocusedDialog
 {
     Q_OBJECT
 

--- a/src/qt/pivx/requestdialog.cpp
+++ b/src/qt/pivx/requestdialog.cpp
@@ -13,7 +13,7 @@
 #include "optionsmodel.h"
 
 RequestDialog::RequestDialog(QWidget *parent) :
-    QDialog(parent),
+    FocusedDialog(parent),
     ui(new Ui::RequestDialog)
 {
     ui->setupUi(this);
@@ -58,7 +58,7 @@ RequestDialog::RequestDialog(QWidget *parent) :
 
     connect(ui->btnCancel, &QPushButton::clicked, this, &RequestDialog::close);
     connect(ui->btnEsc, &QPushButton::clicked, this, &RequestDialog::close);
-    connect(ui->btnSave, &QPushButton::clicked, this, &RequestDialog::onNextClicked);
+    connect(ui->btnSave, &QPushButton::clicked, this, &RequestDialog::accept);
     // TODO: Change copy address for save image (the method is already implemented in other class called exportQr or something like that)
     connect(ui->btnCopyAddress, &QPushButton::clicked, this, &RequestDialog::onCopyClicked);
     connect(ui->btnCopyUrl, &QPushButton::clicked, this, &RequestDialog::onCopyUriClicked);
@@ -79,10 +79,9 @@ void RequestDialog::setPaymentRequest(bool isPaymentRequest)
     }
 }
 
-void RequestDialog::onNextClicked()
+void RequestDialog::accept()
 {
     if (walletModel) {
-
         QString labelStr = ui->lineEditLabel->text();
 
         //Amount
@@ -147,7 +146,7 @@ void RequestDialog::onCopyClicked()
     if (info) {
         GUIUtil::setClipboard(info->address);
         res = 2;
-        accept();
+        QDialog::accept();
     }
 }
 
@@ -156,7 +155,7 @@ void RequestDialog::onCopyUriClicked()
     if (info) {
         GUIUtil::setClipboard(GUIUtil::formatBitcoinURI(*info));
         res = 1;
-        accept();
+        QDialog::accept();
     }
 }
 

--- a/src/qt/pivx/requestdialog.h
+++ b/src/qt/pivx/requestdialog.h
@@ -5,10 +5,11 @@
 #ifndef REQUESTDIALOG_H
 #define REQUESTDIALOG_H
 
-#include <QDialog>
-#include <QPixmap>
-#include "walletmodel.h"
+#include "qt/pivx/focuseddialog.h"
 #include "qt/pivx/snackbar.h"
+#include "walletmodel.h"
+
+#include <QPixmap>
 
 class WalletModel;
 class PIVXGUI;
@@ -17,7 +18,7 @@ namespace Ui {
 class RequestDialog;
 }
 
-class RequestDialog : public QDialog
+class RequestDialog : public FocusedDialog
 {
     Q_OBJECT
 
@@ -31,7 +32,7 @@ public:
     int res = -1;
 
 private Q_SLOTS:
-    void onNextClicked();
+    void accept() override;
     void onCopyClicked();
     void onCopyUriClicked();
 

--- a/src/qt/pivx/sendchangeaddressdialog.cpp
+++ b/src/qt/pivx/sendchangeaddressdialog.cpp
@@ -9,7 +9,7 @@
 #include "qt/pivx/qtutils.h"
 
 SendChangeAddressDialog::SendChangeAddressDialog(QWidget* parent, WalletModel* model) :
-    QDialog(parent),
+    FocusedDialog(parent),
     walletModel(model),
     ui(new Ui::SendChangeAddressDialog)
 {
@@ -37,7 +37,7 @@ SendChangeAddressDialog::SendChangeAddressDialog(QWidget* parent, WalletModel* m
 
     connect(ui->btnEsc, &QPushButton::clicked, this, &SendChangeAddressDialog::close);
     connect(ui->btnCancel, &QPushButton::clicked, this, &SendChangeAddressDialog::reset);
-    connect(ui->btnSave, &QPushButton::clicked, this, &SendChangeAddressDialog::save);
+    connect(ui->btnSave, &QPushButton::clicked, this, &SendChangeAddressDialog::accept);
 }
 
 void SendChangeAddressDialog::setAddress(QString address)
@@ -66,13 +66,13 @@ void SendChangeAddressDialog::reset()
     close();
 }
 
-void SendChangeAddressDialog::save()
+void SendChangeAddressDialog::accept()
 {
     // validate address
     if (!walletModel->validateAddress(ui->lineEditAddress->text())) {
         inform(tr("Invalid address"));
     } else {
-        accept();
+        QDialog::accept();
     }
 }
 

--- a/src/qt/pivx/sendchangeaddressdialog.h
+++ b/src/qt/pivx/sendchangeaddressdialog.h
@@ -5,7 +5,7 @@
 #ifndef SENDCHANGEADDRESSDIALOG_H
 #define SENDCHANGEADDRESSDIALOG_H
 
-#include <QDialog>
+#include "qt/pivx/focuseddialog.h"
 #include "qt/pivx/snackbar.h"
 
 class WalletModel;
@@ -14,7 +14,7 @@ namespace Ui {
 class SendChangeAddressDialog;
 }
 
-class SendChangeAddressDialog : public QDialog
+class SendChangeAddressDialog : public FocusedDialog
 {
     Q_OBJECT
 
@@ -35,7 +35,7 @@ private:
 
 private Q_SLOTS:
     void reset();
-    void save();
+    void accept() override;
 };
 
 #endif // SENDCHANGEADDRESSDIALOG_H

--- a/src/qt/pivx/sendconfirmdialog.cpp
+++ b/src/qt/pivx/sendconfirmdialog.cpp
@@ -221,10 +221,10 @@ void TxDetailDialog::onOutputsClicked()
     }
 }
 
-void TxDetailDialog::close()
+void TxDetailDialog::reject()
 {
     if (snackBar && snackBar->isVisible()) snackBar->hide();
-    QDialog::close();
+    QDialog::reject();
 }
 
 TxDetailDialog::~TxDetailDialog()

--- a/src/qt/pivx/sendconfirmdialog.cpp
+++ b/src/qt/pivx/sendconfirmdialog.cpp
@@ -13,10 +13,9 @@
 #include "qt/pivx/qtutils.h"
 #include <QList>
 #include <QDateTime>
-#include <QKeyEvent>
 
 TxDetailDialog::TxDetailDialog(QWidget *parent, bool _isConfirmDialog, const QString& warningStr) :
-    QDialog(parent),
+    FocusedDialog(parent),
     ui(new Ui::TxDetailDialog),
     isConfirmDialog(_isConfirmDialog)
 {
@@ -68,20 +67,15 @@ TxDetailDialog::TxDetailDialog(QWidget *parent, bool _isConfirmDialog, const QSt
         ui->contentSize->setVisible(false);
 
         connect(ui->btnCancel, &QPushButton::clicked, this, &TxDetailDialog::close);
-        connect(ui->btnSave, &QPushButton::clicked, [this](){acceptTx();});
+        connect(ui->btnSave, &QPushButton::clicked, [this](){accept();});
     } else {
         ui->labelTitle->setText(tr("Transaction Details"));
         ui->containerButtons->setVisible(false);
     }
 
-    connect(ui->btnEsc, &QPushButton::clicked, this, &TxDetailDialog::closeDialog);
+    connect(ui->btnEsc, &QPushButton::clicked, this, &TxDetailDialog::close);
     connect(ui->pushInputs, &QPushButton::clicked, this, &TxDetailDialog::onInputsClicked);
     connect(ui->pushOutputs, &QPushButton::clicked, this, &TxDetailDialog::onOutputsClicked);
-}
-
-void TxDetailDialog::showEvent(QShowEvent *event)
-{
-    setFocus();
 }
 
 void TxDetailDialog::setData(WalletModel *model, const QModelIndex &index)
@@ -151,13 +145,13 @@ void TxDetailDialog::setData(WalletModel *model, WalletModelTransaction &tx)
     ui->textFee->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, txFee, false, BitcoinUnits::separatorAlways));
 }
 
-void TxDetailDialog::acceptTx()
+void TxDetailDialog::accept()
 {
-    if (!isConfirmDialog)
-        throw GUIException(strprintf("%s called on non confirm dialog", __func__));
-    this->confirm = true;
-    this->sendStatus = model->sendCoins(*this->tx);
-    accept();
+    if (isConfirmDialog) {
+        this->confirm = true;
+        this->sendStatus = model->sendCoins(*this->tx);
+    }
+    QDialog::accept();
 }
 
 void TxDetailDialog::onInputsClicked()
@@ -227,25 +221,10 @@ void TxDetailDialog::onOutputsClicked()
     }
 }
 
-void TxDetailDialog::keyPressEvent(QKeyEvent *event)
-{
-    if (event->type() == QEvent::KeyPress) {
-        QKeyEvent* ke = static_cast<QKeyEvent*>(event);
-        // Detect Enter key press
-        if (ke->key() == Qt::Key_Enter || ke->key() == Qt::Key_Return) {
-            if (isConfirmDialog) acceptTx();
-            else accept();
-        }
-        // Detect Esc key press
-        if (ke->key() == Qt::Key_Escape)
-            closeDialog();
-    }
-}
-
-void TxDetailDialog::closeDialog()
+void TxDetailDialog::close()
 {
     if (snackBar && snackBar->isVisible()) snackBar->hide();
-    close();
+    QDialog::close();
 }
 
 TxDetailDialog::~TxDetailDialog()

--- a/src/qt/pivx/sendconfirmdialog.h
+++ b/src/qt/pivx/sendconfirmdialog.h
@@ -37,7 +37,7 @@ public:
 
 public Q_SLOTS:
     void accept() override;
-    void close();
+    void reject() override;
     void onInputsClicked();
     void onOutputsClicked();
 

--- a/src/qt/pivx/sendconfirmdialog.h
+++ b/src/qt/pivx/sendconfirmdialog.h
@@ -5,8 +5,8 @@
 #ifndef SENDCONFIRMDIALOG_H
 #define SENDCONFIRMDIALOG_H
 
-#include <QDialog>
 #include "walletmodeltransaction.h"
+#include "qt/pivx/focuseddialog.h"
 #include "qt/pivx/snackbar.h"
 
 class WalletModelTransaction;
@@ -20,7 +20,7 @@ QT_BEGIN_NAMESPACE
 class QModelIndex;
 QT_END_NAMESPACE
 
-class TxDetailDialog : public QDialog
+class TxDetailDialog : public FocusedDialog
 {
     Q_OBJECT
 
@@ -28,7 +28,6 @@ public:
     explicit TxDetailDialog(QWidget *parent = nullptr, bool isConfirmDialog = true, const QString& warningStr = QString());
     ~TxDetailDialog();
 
-    void showEvent(QShowEvent *event) override;
     bool isConfirm() { return this->confirm;}
     WalletModel::SendCoinsReturn getStatus() { return this->sendStatus;}
 
@@ -37,10 +36,10 @@ public:
     void setDisplayUnit(int unit){this->nDisplayUnit = unit;};
 
 public Q_SLOTS:
-    void acceptTx();
+    void accept() override;
+    void close();
     void onInputsClicked();
     void onOutputsClicked();
-    void closeDialog();
 
 private:
     Ui::TxDetailDialog *ui;
@@ -55,9 +54,6 @@ private:
 
     bool inputsLoaded = false;
     bool outputsLoaded = false;
-
-protected:
-    void keyPressEvent(QKeyEvent *e) override;
 };
 
 #endif // SENDCONFIRMDIALOG_H

--- a/src/qt/pivx/sendcustomfeedialog.cpp
+++ b/src/qt/pivx/sendcustomfeedialog.cpp
@@ -12,7 +12,7 @@
 #include <QComboBox>
 
 SendCustomFeeDialog::SendCustomFeeDialog(PIVXGUI* parent, WalletModel* model) :
-    QDialog(parent),
+    FocusedDialog(parent),
     ui(new Ui::SendCustomFeeDialog),
     walletModel(model)
 {
@@ -60,6 +60,7 @@ SendCustomFeeDialog::SendCustomFeeDialog(PIVXGUI* parent, WalletModel* model) :
 
 void SendCustomFeeDialog::showEvent(QShowEvent* event)
 {
+    FocusedDialog::showEvent(event);
     updateFee();
     if (walletModel->hasWalletCustomFee()) {
         ui->checkBoxCustom->setChecked(true);

--- a/src/qt/pivx/sendcustomfeedialog.h
+++ b/src/qt/pivx/sendcustomfeedialog.h
@@ -5,8 +5,8 @@
 #ifndef SENDCUSTOMFEEDIALOG_H
 #define SENDCUSTOMFEEDIALOG_H
 
-#include <QDialog>
 #include "amount.h"
+#include "qt/pivx/focuseddialog.h"
 #include "qt/pivx/snackbar.h"
 
 class PIVXGUI;
@@ -16,7 +16,7 @@ namespace Ui {
 class SendCustomFeeDialog;
 }
 
-class SendCustomFeeDialog : public QDialog
+class SendCustomFeeDialog : public FocusedDialog
 {
     Q_OBJECT
 


### PR DESCRIPTION
This creates a generic extension of QDialog, named `FocusedDialog`, with the property of having the focus on show and filtering key press events to call `accept()` with ENTER/RETURN and `close()` with ESC (ref: #1392).
Removes code duplication in `DefaultDialog` and `TxDetailDialog` by making them child classes of FocusedDialog.
Also add this ability to other dialogs as well:
- `AddNewContactDialog` (closes #1606)
- `MasterNodeWizardDialog`
- `MnInfoDialog`
- `ReceiveDialog`
- `RequestDialog`
- `SendChangeAddressDialog`
- `SendCustomFeeDialog`
