### PR TITLE
[GUI][Bug] CoinControl payAmounts and nBytes calculation

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -33,7 +33,6 @@
 #include <QTreeWidget>
 
 QList<CAmount> CoinControlDialog::payAmounts;
-int CoinControlDialog::nSplitBlockDummy;
 CCoinControl* CoinControlDialog::coinControl = new CCoinControl();
 
 
@@ -568,13 +567,11 @@ void CoinControlDialog::updateLabels()
     // nPayAmount
     CAmount nPayAmount = 0;
     bool fDust = false;
-    CMutableTransaction txDummy;
     Q_FOREACH (const CAmount& amount, CoinControlDialog::payAmounts) {
         nPayAmount += amount;
 
         if (amount > 0) {
             CTxOut txout(amount, (CScript)std::vector<unsigned char>(24, 0));
-            txDummy.vout.push_back(txout);
             if (txout.IsDust(::minRelayTxFee))
                 fDust = true;
         }
@@ -635,7 +632,7 @@ void CoinControlDialog::updateLabels()
     // calculation
     if (nQuantity > 0) {
         // Bytes
-        nBytes = nBytesInputs + ((CoinControlDialog::payAmounts.size() > 0 ? CoinControlDialog::payAmounts.size() + std::max(1, CoinControlDialog::nSplitBlockDummy) : 2) * 34) + 10; // always assume +1 output for change here
+        nBytes = nBytesInputs + ((CoinControlDialog::payAmounts.size() > 0 ? CoinControlDialog::payAmounts.size() + 1 : 2) * 34) + 10; // always assume +1 output for change here
 
         // Priority
         double mempoolEstimatePriority = mempool.estimatePriority(nTxConfirmTarget);

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -32,7 +32,6 @@
 #include <QString>
 #include <QTreeWidget>
 
-QList<CAmount> CoinControlDialog::payAmounts;
 CCoinControl* CoinControlDialog::coinControl = new CCoinControl();
 
 
@@ -567,7 +566,7 @@ void CoinControlDialog::updateLabels()
     // nPayAmount
     CAmount nPayAmount = 0;
     bool fDust = false;
-    Q_FOREACH (const CAmount& amount, CoinControlDialog::payAmounts) {
+    Q_FOREACH (const CAmount& amount, payAmounts) {
         nPayAmount += amount;
 
         if (amount > 0) {
@@ -632,7 +631,7 @@ void CoinControlDialog::updateLabels()
     // calculation
     if (nQuantity > 0) {
         // Bytes
-        nBytes = nBytesInputs + ((CoinControlDialog::payAmounts.size() > 0 ? CoinControlDialog::payAmounts.size() + 1 : 2) * 34) + 10; // always assume +1 output for change here
+        nBytes = nBytesInputs + ((payAmounts.size() > 0 ? CoinControlDialog::payAmounts.size() + 1 : 2) * 34) + 10; // always assume +1 output for change here
 
         // Priority
         double mempoolEstimatePriority = mempool.estimatePriority(nTxConfirmTarget);
@@ -940,4 +939,14 @@ void CoinControlDialog::inform(const QString& text)
     snackBar->setText(text);
     snackBar->resize(this->width(), snackBar->height());
     openDialog(snackBar, this);
+}
+
+void CoinControlDialog::clearPayAmounts()
+{
+    payAmounts.clear();
+}
+
+void CoinControlDialog::addPayAmount(const CAmount& amount)
+{
+    payAmounts.push_back(amount);
 }

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -52,10 +52,11 @@ public:
     void updateLabels();
     void updateView();
     void refreshDialog();
+    void clearPayAmounts();
+    void addPayAmount(const CAmount& amount);
 
     static QString getPriorityLabel(double dPriority, double mempoolEstimatePriority);
 
-    static QList<CAmount> payAmounts;
     static CCoinControl* coinControl;
 
 private:
@@ -65,6 +66,7 @@ private:
     int sortColumn;
     Qt::SortOrder sortOrder;
     bool fSelectAllToggled{true};     // false when pushButtonSelectAll text is "Unselect All"
+    QList<CAmount> payAmounts{};
 
     QMenu* contextMenu;
     QTreeWidgetItem* contextMenuItem;

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -57,7 +57,6 @@ public:
 
     static QList<CAmount> payAmounts;
     static CCoinControl* coinControl;
-    static int nSplitBlockDummy;
 
 private:
     Ui::CoinControlDialog* ui;

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -44,7 +44,7 @@ class CoinControlDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit CoinControlDialog(QWidget* parent = nullptr);
+    explicit CoinControlDialog(QWidget* parent = nullptr, bool _forDelegation = false);
     ~CoinControlDialog();
 
     void setModel(WalletModel* model);
@@ -65,6 +65,7 @@ private:
     WalletModel* model;
     int sortColumn;
     Qt::SortOrder sortOrder;
+    bool forDelegation;
     bool fSelectAllToggled{true};     // false when pushButtonSelectAll text is "Unselect All"
     QList<CAmount> payAmounts{};
 

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -49,11 +49,10 @@ public:
 
     void setModel(WalletModel* model);
     void updateDialogLabels();
+    void updateLabels();
     void updateView();
     void refreshDialog();
 
-    // static because also called from sendcoinsdialog
-    static void updateLabels(WalletModel*, QDialog*);
     static QString getPriorityLabel(double dPriority, double mempoolEstimatePriority);
 
     static QList<CAmount> payAmounts;

--- a/src/qt/pivx/coldstakingwidget.cpp
+++ b/src/qt/pivx/coldstakingwidget.cpp
@@ -531,7 +531,7 @@ void ColdStakingWidget::onCoinControlClicked()
     if (isInDelegation) {
         if (walletModel->getBalance() > 0) {
             if (!coinControlDialog) {
-                coinControlDialog = new CoinControlDialog();
+                coinControlDialog = new CoinControlDialog(nullptr, true);
                 coinControlDialog->setModel(walletModel);
             } else {
                 coinControlDialog->refreshDialog();

--- a/src/qt/pivx/coldstakingwidget.cpp
+++ b/src/qt/pivx/coldstakingwidget.cpp
@@ -536,12 +536,20 @@ void ColdStakingWidget::onCoinControlClicked()
             } else {
                 coinControlDialog->refreshDialog();
             }
+            setCoinControlPayAmounts();
             coinControlDialog->exec();
             ui->btnCoinControl->setActive(CoinControlDialog::coinControl->HasSelected());
         } else {
             inform(tr("You don't have any %1 to select.").arg(CURRENCY_UNIT.c_str()));
         }
     }
+}
+
+void ColdStakingWidget::setCoinControlPayAmounts()
+{
+    if (!coinControlDialog) return;
+    coinControlDialog->clearPayAmounts();
+    coinControlDialog->addPayAmount(sendMultiRow->getAmountValue());
 }
 
 void ColdStakingWidget::onColdStakeClicked()

--- a/src/qt/pivx/coldstakingwidget.h
+++ b/src/qt/pivx/coldstakingwidget.h
@@ -122,6 +122,7 @@ private:
     void onLabelClicked(QString dialogTitle, const QModelIndex &index, const bool& isMyColdStakingAddresses);
     void updateStakingTotalLabel();
     void sortAddresses();
+    void setCoinControlPayAmounts();
 };
 
 #endif // COLDSTAKINGWIDGET_H

--- a/src/qt/pivx/send.cpp
+++ b/src/qt/pivx/send.cpp
@@ -636,6 +636,7 @@ void SendWidget::onCoinControlClicked()
             } else {
                 coinControlDialog->refreshDialog();
             }
+            setCoinControlPayAmounts();
             coinControlDialog->exec();
             ui->btnCoinControl->setActive(CoinControlDialog::coinControl->HasSelected());
             refreshAmounts();
@@ -652,6 +653,16 @@ void SendWidget::onCoinControlClicked()
         } else {
             inform(tr("You don't have any zPIV in your balance to select."));
         }
+    }
+}
+
+void SendWidget::setCoinControlPayAmounts()
+{
+    if (!coinControlDialog) return;
+    coinControlDialog->clearPayAmounts();
+    QMutableListIterator<SendMultiRow*> it(entries);
+    while (it.hasNext()) {
+        coinControlDialog->addPayAmount(it.next()->getAmountValue());
     }
 }
 

--- a/src/qt/pivx/send.h
+++ b/src/qt/pivx/send.h
@@ -103,7 +103,7 @@ private:
     void showHideCheckBoxDelegations();
     void updateEntryLabels(QList<SendCoinsRecipient> recipients);
     void setCustomFeeSelected(bool isSelected, const CAmount& customFee = DEFAULT_TRANSACTION_FEE);
-
+    void setCoinControlPayAmounts();
 };
 
 #endif // SEND_H


### PR DESCRIPTION
payAmounts were never set in CoinControlDialog, thus `nPayAmount` was always zero.
This resulted in two bugs:
- `nDust` and `nChange` were always zero, thus their labels were never used
- the nBytes calculated were wrong if the transaction had more than one output (thus the suggested fee was also wrong).

This PR removes some unused leftover, connects payAmounts (both from send and from coldstaking widgets) and fixes the tx-size calculation, considering also the cold-staking scripts (either as inputs  and/or outputs/delegations).

Fixes point n.2 of #1609 