### PR TITLE
[GUI] CoinControlDialog fix SelectAll / UnselectAll

### DIFF
--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -66,8 +66,8 @@ private:
     int sortColumn;
     Qt::SortOrder sortOrder;
     bool forDelegation;
-    bool fSelectAllToggled{true};     // false when pushButtonSelectAll text is "Unselect All"
     QList<CAmount> payAmounts{};
+    unsigned int nSelectableInputs{0};
 
     QMenu* contextMenu;
     QTreeWidgetItem* contextMenuItem;
@@ -75,6 +75,7 @@ private:
     QAction* lockAction;
     QAction* unlockAction;
 
+    void updatePushButtonSelectAll(bool checked);
     void sortView(int, Qt::SortOrder);
     void inform(const QString& text);
 


### PR DESCRIPTION
Based on top of
- [x] #1611 

Only last commit is new.
This updates the flow of the toggle button SelectAll/UnselectAll in the coin control dialog (`pushButtonSelectAll`).

- use directly the checked state of the button, instead of caching it in a separate variable `fSelectAllToggled`.

- when the button is in checked ("Unselect all") state, reset it to its initial state (unchecked, with "Select all" label) if all the entries are either manually deselected, or automatically cleared after a spend)

Closes point n.3 of #1609 

