### PR TITLE
[GUI][Bug] Notify transaction creation failure reason

### DIFF
--- a/src/qt/pivx/guitransactionsutils.cpp
+++ b/src/qt/pivx/guitransactionsutils.cpp
@@ -36,7 +36,6 @@ namespace GuiTransactionsUtils {
                         "Duplicate address found, can only send to each address once per send operation.");
                 break;
             case WalletModel::TransactionCreationFailed:
-                retStr = parent->translate("Transaction creation failed!");
                 informType = CClientUIInterface::MSG_ERROR;
                 break;
             case WalletModel::TransactionCommitFailed:

--- a/src/qt/pivx/pivxgui.cpp
+++ b/src/qt/pivx/pivxgui.cpp
@@ -620,6 +620,7 @@ bool PIVXGUI::addWallet(const QString& name, WalletModel* walletModel)
     }
 
     // Connect actions..
+    connect(walletModel, &WalletModel::message, this, &PIVXGUI::message);
     connect(masterNodesWidget, &MasterNodesWidget::message, this, &PIVXGUI::message);
     connect(coldStakingWidget, &ColdStakingWidget::message, this, &PIVXGUI::message);
     connect(topBar, &TopBar::message, this, &PIVXGUI::message);

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -527,7 +527,11 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
             if ((total + nFeeRequired) > nBalance) {
                 return SendCoinsReturn(AmountWithFeeExceedsBalance);
             }
-            Q_EMIT message(tr("Send Coins"), tr("Transaction creation failed!\n%1").arg(QString::fromStdString(strFailReason)),
+
+            Q_EMIT message(tr("Send Coins"), tr("Transaction creation failed!\n%1").arg(
+                    strFailReason == "Transaction too large" ?
+                            tr("The size of the transaction is too big.\nSelect fewer inputs with coin control.") :
+                            QString::fromStdString(strFailReason)),
                     CClientUIInterface::MSG_ERROR);
             return TransactionCreationFailed;
         }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -527,8 +527,8 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
             if ((total + nFeeRequired) > nBalance) {
                 return SendCoinsReturn(AmountWithFeeExceedsBalance);
             }
-            Q_EMIT message(tr("Send Coins"), QString::fromStdString(strFailReason),
-                CClientUIInterface::MSG_ERROR);
+            Q_EMIT message(tr("Send Coins"), tr("Transaction creation failed!\n%1").arg(QString::fromStdString(strFailReason)),
+                    CClientUIInterface::MSG_ERROR);
             return TransactionCreationFailed;
         }
 

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -360,7 +360,7 @@ Q_SIGNALS:
     void requireUnlock();
 
     // Fired when a message should be reported to the user
-    void message(const QString& title, const QString& message, unsigned int style);
+    void message(const QString& title, const QString& body, unsigned int style, bool* ret = nullptr);
 
     // Coins sent: from wallet, to recipient, in (serialized) transaction:
     void coinsSent(CWallet* wallet, SendCoinsRecipient recipient, QByteArray transaction);

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -122,7 +122,7 @@ public:
         AmountExceedsBalance,
         AmountWithFeeExceedsBalance,
         DuplicateAddress,
-        TransactionCreationFailed, // Error returned when wallet is still locked
+        TransactionCreationFailed,
         TransactionCommitFailed,
         StakingOnlyUnlocked,
         InsaneFee,


### PR DESCRIPTION
Triggered by #1619 

- first commit fixes a bug where the `WalletModel::message` signal was not connected to pwidget, therefore the message with `strFailReason` -fired by `prepareTransaction`:
https://github.com/PIVX-Project/PIVX/blob/f295ee4e4e089f76341a4f93058cfab3e974ccb9/src/qt/walletmodel.cpp#L526-L533
 was never displayed, and the user was presented only with the generic "Transaction creation failed!" -fired by `ProcessSendCoinsReturnAndInform`:
https://github.com/PIVX-Project/PIVX/blob/f295ee4e4e089f76341a4f93058cfab3e974ccb9/src/qt/pivx/guitransactionsutils.cpp#L74-L79

- second commit addresses the fact that, with the previous commit, the user is now presented with two consecutive dialogs: "Transaction too big" and "Transaction creation failed!", and merges them into one single message (which is already followed by a SnackBar with "Cannot create transaction").

- third commit adds a clearer message when `strFailReason` is "Transaction too big" (which might be frequent e.g. sweeping a big number of masternode rewards or dust outputs). Reviewers are encouraged to offer better wording.

Closes #1619