### PR TITLE
[Core] Implement accurate memory accounting for mempool

### DIFF
--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -149,6 +149,11 @@ void CTransaction::UpdateHash() const
     *const_cast<uint256*>(&hash) = SerializeHash(*this);
 }
 
+size_t CTransaction::DynamicMemoryUsage() const
+{
+    return memusage::RecursiveDynamicUsage(vin) + memusage::RecursiveDynamicUsage(vout);
+}
+
 CTransaction::CTransaction() : nVersion(CTransaction::CURRENT_VERSION), vin(), vout(), nLockTime(0) { }
 
 CTransaction::CTransaction(const CMutableTransaction &tx) : nVersion(tx.nVersion), vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime) {

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -8,6 +8,7 @@
 #define BITCOIN_PRIMITIVES_TRANSACTION_H
 
 #include "amount.h"
+#include "memusage.h"
 #include "script/script.h"
 #include "serialize.h"
 #include "uint256.h"
@@ -54,6 +55,8 @@ public:
 
     std::string ToString() const;
     std::string ToStringShort() const;
+
+    size_t DynamicMemoryUsage() const { return 0; }
 
     uint256 GetHash();
 
@@ -109,6 +112,8 @@ public:
     }
 
     std::string ToString() const;
+
+    size_t DynamicMemoryUsage() const { return scriptSig.DynamicMemoryUsage(); }
 };
 
 /** An output of a transaction.  It contains the public key that the next input
@@ -191,6 +196,8 @@ public:
     }
 
     std::string ToString() const;
+
+    size_t DynamicMemoryUsage() const { return scriptPubKey.DynamicMemoryUsage(); }
 };
 
 struct CMutableTransaction;
@@ -297,6 +304,8 @@ public:
     unsigned int GetTotalSize() const;
 
     std::string ToString() const;
+
+    size_t DynamicMemoryUsage() const;
 };
 
 /** A mutable version of CTransaction. */

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -959,7 +959,7 @@ UniValue mempoolInfoToJSON()
     UniValue ret(UniValue::VOBJ);
     ret.push_back(Pair("size", (int64_t) mempool.size()));
     ret.push_back(Pair("bytes", (int64_t) mempool.GetTotalTxSize()));
-    //ret.push_back(Pair("usage", (int64_t) mempool.DynamicMemoryUsage()));
+    ret.push_back(Pair("usage", (int64_t) mempool.DynamicMemoryUsage()));
 
     return ret;
 }
@@ -975,6 +975,7 @@ UniValue getmempoolinfo(const UniValue& params, bool fHelp)
             "{\n"
             "  \"size\": xxxxx                (numeric) Current tx count\n"
             "  \"bytes\": xxxxx               (numeric) Sum of all tx sizes\n"
+            "  \"usage\": xxxxx               (numeric) Total memory usage for the mempool\n"
             "}\n"
 
             "\nExamples:\n" +

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -294,3 +294,8 @@ bool CScript::IsPushOnly() const
 {
     return this->IsPushOnly(begin());
 }
+
+size_t CScript::DynamicMemoryUsage() const
+{
+    return memusage::DynamicUsage(*static_cast<const CScriptBase*>(this));
+}

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "crypto/common.h"
+#include "memusage.h"
 #include "prevector.h"
 
 typedef std::vector<unsigned char> valtype;
@@ -652,6 +653,8 @@ public:
         CScriptBase::clear();
         shrink_to_fit();
     }
+
+    size_t DynamicMemoryUsage() const;
 };
 
 #endif // BITCOIN_SCRIPT_SCRIPT_H

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -43,6 +43,7 @@ private:
     CAmount nFee;         //! Cached to avoid expensive parent-transaction lookups
     size_t nTxSize;       //! ... and avoid recomputing tx size
     size_t nModSize;      //! ... and modified size for priority
+    size_t nUsageSize;    //! ... and total memory usage
     bool hasZerocoins{false}; //! ... and checking if it contains zPIV (mints/spends)
     int64_t nTime;        //! Local time when entering the mempool
     double dPriority;     //! Priority when entering the mempool
@@ -62,6 +63,7 @@ public:
     unsigned int GetHeight() const { return nHeight; }
     bool HasZerocoins() const { return hasZerocoins; }
     bool WasClearAtEntry() const { return hadNoDependencies; }
+    size_t DynamicMemoryUsage() const { return nUsageSize; }
 };
 
 
@@ -86,6 +88,7 @@ public:
         n = (uint32_t)-1;
     }
     bool IsNull() const { return (ptx == NULL && n == (uint32_t)-1); }
+    size_t DynamicMemoryUsage() const { return 0; }
 };
 
 /**
@@ -107,6 +110,7 @@ private:
 
     CFeeRate minRelayFee; //! Passed to constructor to avoid dependency on main
     uint64_t totalTxSize; //! sum of all mempool tx' byte sizes
+    uint64_t cachedInnerUsage; //! sum of dynamic memory usage of all the map elements (NOT the maps themselves)
 
 public:
     /**
@@ -203,6 +207,8 @@ public:
     /** Write/Read estimates to disk */
     bool WriteFeeEstimates(CAutoFile& fileout) const;
     bool ReadFeeEstimates(CAutoFile& filein);
+
+    size_t DynamicMemoryUsage() const;
 };
 
 /** 


### PR DESCRIPTION
Based on top of:
- [x] #1641

This continues the work of #1531 adding memory accounting for the mempool.
Backports bitcoin/bitcoin#6410.

Original description:
> This implements accurate memory usage accounting for the mempool. It is only exposed through getmempoolinfo for now, but could be used for limiting the resource requirements too (bitcoin/bitcoin#6281).