### PR TITLE
[GUI] cs widget: minor usability improvements

### DIFF
--- a/src/qt/pivx/coldstakingwidget.cpp
+++ b/src/qt/pivx/coldstakingwidget.cpp
@@ -106,6 +106,7 @@ ColdStakingWidget::ColdStakingWidget(PIVXGUI* parent) :
     setCssProperty(ui->lineEditOwnerAddress, "edit-primary-multi-book");
     ui->lineEditOwnerAddress->setAttribute(Qt::WA_MacShowFocusRect, 0);
     setShadow(ui->lineEditOwnerAddress);
+    connect(ui->lineEditOwnerAddress, &QLineEdit::textChanged, this, &ColdStakingWidget::onOwnerAddressChanged);
 
     setCssSubtitleScreen(ui->labelSubtitle2);
     ui->labelSubtitle2->setContentsMargins(0,2,0,0);
@@ -772,6 +773,14 @@ void ColdStakingWidget::onMyStakingAddressesClicked()
         ui->sortWidget->setVisible(false);
         ui->rightContainer->addItem(spacerDiv);
     }
+}
+
+void ColdStakingWidget::onOwnerAddressChanged()
+{
+    const bool isValid = ui->lineEditOwnerAddress->text().isEmpty() || (
+            walletModel && walletModel->validateAddress(ui->lineEditOwnerAddress->text()));
+
+    setCssProperty(ui->lineEditOwnerAddress, isValid ? "edit-primary-multi-book" : "edit-primary-multi-book-error", true);
 }
 
 void ColdStakingWidget::changeTheme(bool isLightTheme, QString& theme)

--- a/src/qt/pivx/coldstakingwidget.cpp
+++ b/src/qt/pivx/coldstakingwidget.cpp
@@ -414,13 +414,6 @@ void ColdStakingWidget::onSendClicked()
     if (!walletModel || !walletModel->getOptionsModel())
         return;
 
-    WalletModel::UnlockContext ctx(walletModel->requestUnlock());
-    if (!ctx.isValid()) {
-        // Unlock wallet was cancelled
-        inform(tr("Cannot send delegation, wallet locked"));
-        return;
-    }
-
     if (!walletModel->isColdStakingNetworkelyEnabled()) {
         inform(tr("Cold staking is networkely disabled"));
         return;
@@ -451,25 +444,27 @@ void ColdStakingWidget::onSendClicked()
 
 
     bool isStakingAddressFromThisWallet = walletModel->isMine(dest.address);
-    bool isOwnerAddressFromThisWallet = isOwnerEmpty;
+    bool isOwnerAddressFromThisWallet = isOwnerEmpty || walletModel->isMine(inputOwner);
 
-    if (!isOwnerAddressFromThisWallet) {
-        isOwnerAddressFromThisWallet = walletModel->isMine(inputOwner);
-
-        // Warn the user if the owner address is not from this wallet
-        if (!isOwnerAddressFromThisWallet &&
-            !ask(tr("ALERT!"),
-                    tr("Delegating to an external owner address!\n\n"
-                       "The delegated coins will NOT be spendable by this wallet.\nSpending these coins will need to be done from the wallet or\ndevice containing the owner address.\n\n"
-                       "Do you wish to proceed?"))
-            ) {
-                return;
-        }
+    // Warn the user if the owner address is not from this wallet
+    if (!isOwnerAddressFromThisWallet && !ask(tr("ALERT!"),
+                tr("Delegating to an external owner address!\n\n"
+                   "The delegated coins will NOT be spendable by this wallet.\nSpending these coins will need to be done from the wallet or\ndevice containing the owner address.\n\n"
+                   "Do you wish to proceed?"))) {
+            return;
     }
 
     // Don't try to delegate the balance if both addresses are from this wallet
     if (isStakingAddressFromThisWallet && isOwnerAddressFromThisWallet) {
         inform(tr("Staking address corresponds to this wallet, change it to an external node"));
+        return;
+    }
+
+    // Unlock wallet
+    WalletModel::UnlockContext ctx(walletModel->requestUnlock());
+    if (!ctx.isValid()) {
+        // Unlock wallet was cancelled
+        inform(tr("Cannot send delegation, wallet locked"));
         return;
     }
 

--- a/src/qt/pivx/coldstakingwidget.h
+++ b/src/qt/pivx/coldstakingwidget.h
@@ -72,6 +72,7 @@ private Q_SLOTS:
     void clearAll();
     void onLabelClicked();
     void onMyStakingAddressesClicked();
+    void onOwnerAddressChanged();
     void onDelegationsRefreshed();
     void onSortChanged(int idx);
     void onSortOrderChanged(int idx);

--- a/src/qt/pivx/sendconfirmdialog.cpp
+++ b/src/qt/pivx/sendconfirmdialog.cpp
@@ -128,7 +128,10 @@ void TxDetailDialog::setData(WalletModel *model, WalletModelTransaction &tx)
     ui->textAmount->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, totalAmount, false, BitcoinUnits::separatorAlways) + " (Fee included)");
     int nRecipients = tx.getRecipients().size();
     if (nRecipients == 1) {
-        SendCoinsRecipient recipient = tx.getRecipients().at(0);
+        const SendCoinsRecipient& recipient = tx.getRecipients().at(0);
+        if (recipient.isP2CS) {
+            ui->labelSend->setText(tr("Delegating to"));
+        }
         if (recipient.label.isEmpty()) { // If there is no label, then do not show the blank space.
             ui->textSendLabel->setText(recipient.address);
             ui->textSend->setVisible(false);


### PR DESCRIPTION
Three simple fixes to the cold staking widget:

1. give immediate feedback (with red outline) when the owner address is not valid (same as we have with SendMultiRow objects, e.g. the staker address in this widget). Closes #1596 

2. on send: try to unlock the wallet only when all validity checks are passing.

3. since the address shown on the confirmation dialog is the staker, change the label "Sending to" in "Delegating to".