### PR TITLE
Tip lock handling in tier two.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -109,6 +109,7 @@ BITCOIN_CORE_H = \
   primitives/block.h \
   primitives/transaction.h \
   core_io.h \
+  dsnotificationinterface.h \
   crypter.h \
   pairresult.h \
   addressbook.h \
@@ -272,6 +273,7 @@ libbitcoin_wallet_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_wallet_a_SOURCES = \
   activemasternode.cpp \
   bip38.cpp \
+  dsnotificationinterface.cpp \
   denomination_functions.cpp \
   addressbook.cpp \
   crypter.cpp \

--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2015 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "dsnotificationinterface.h"
+#include "masternode-budget.h"
+#include "masternode-payments.h"
+#include "masternode-sync.h"
+
+CDSNotificationInterface::CDSNotificationInterface()
+{
+}
+
+CDSNotificationInterface::~CDSNotificationInterface()
+{
+}
+
+void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindex)
+{
+    masternodePayments.UpdatedBlockTip(pindex);
+    budget.UpdatedBlockTip(pindex);
+    masternodeSync.UpdatedBlockTip(pindex);
+}

--- a/src/dsnotificationinterface.h
+++ b/src/dsnotificationinterface.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_DSNOTIFICATIONINTERFACE_H
+#define BITCOIN_DSNOTIFICATIONINTERFACE_H
+
+#include "validationinterface.h"
+
+class CDSNotificationInterface : public CValidationInterface
+{
+public:
+    // virtual CDSNotificationInterface();
+    CDSNotificationInterface();
+    virtual ~CDSNotificationInterface();
+
+protected:
+    // CValidationInterface
+    void UpdatedBlockTip(const CBlockIndex *pindex);
+
+private:
+};
+
+#endif // BITCOIN_DSNOTIFICATIONINTERFACE_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4281,12 +4281,14 @@ bool ProcessNewBlock(CValidationState& state, CNode* pfrom, CBlock* pblock, CDis
     if (!ActivateBestChain(state, pblock, checked))
         return error("%s : ActivateBestChain failed", __func__);
 
+    /*
     if (!fLiteMode) {
         if (masternodeSync.RequestedMasternodeAssets > MASTERNODE_SYNC_LIST) {
             masternodePayments.ProcessBlock(GetHeight() + 10);
             budget.NewBlock();
         }
     }
+     */
 
     if (pwalletMain) {
         /* disable multisend

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -516,8 +516,10 @@ void CBudgetManager::FillBlockPayee(CMutableTransaction& txNew, CAmount nFees, b
 {
     LOCK(cs);
 
-    if(!pCurrentBlockIndex) return;
-    int nHeight = pCurrentBlockIndex->nHeight;
+    AssertLockHeld(cs_main);
+    CBlockIndex* tip = chainActive.Tip();
+    if(!tip) return;
+    int nHeight = tip->nHeight;
 
     int nHighestCount = 0;
     CScript payee;

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -181,6 +181,9 @@ private:
     // XX42    std::map<uint256, CTransaction> mapCollateral;
     std::map<uint256, uint256> mapCollateralTxids;
 
+    // Keep track of current block index
+    const CBlockIndex *pCurrentBlockIndex;
+
 public:
     // critical section to protect the inner data structures
     mutable RecursiveMutex cs;
@@ -275,6 +278,8 @@ public:
         READWRITE(mapProposals);
         READWRITE(mapFinalizedBudgets);
     }
+
+    void UpdatedBlockTip(const CBlockIndex *pindex);
 };
 
 
@@ -332,7 +337,7 @@ public:
     double GetScore();
     bool HasMinimumRequiredSupport();
 
-    bool IsValid(std::string& strError, bool fCheckCollateral = true);
+    bool IsValid(const CBlockIndex* pindex, std::string& strError, bool fCheckCollateral=true);
 
     std::string GetName() { return strBudgetName; }
     std::string GetProposals();
@@ -486,7 +491,7 @@ public:
     bool HasMinimumRequiredSupport();
     std::pair<std::string, std::string> GetVotes();
 
-    bool IsValid(std::string& strError, bool fCheckCollateral = true);
+    bool IsValid(const CBlockIndex* pindex, std::string& strError, bool fCheckCollateral = true);
 
     bool IsEstablished();
     bool IsPassing(const CBlockIndex* pindexPrev, int nBlockStartBudget, int nBlockEndBudget, int mnCount);
@@ -497,9 +502,9 @@ public:
     int GetBlockEnd() { return nBlockEnd; }
     CScript GetPayee() { return address; }
     int GetTotalPaymentCount();
-    int GetRemainingPaymentCount();
+    int GetRemainingPaymentCount(const CBlockIndex* pindex);
     int GetBlockStartCycle();
-    int GetBlockCurrentCycle();
+    int GetBlockCurrentCycle(const CBlockIndex* pindex);
     int GetBlockEndCycle();
     double GetRatio();
     int GetYeas() const;

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -325,6 +325,7 @@ bool IsBlockPayeeValid(const CBlock& block, int nBlockHeight)
 
 void FillBlockPayee(CMutableTransaction& txNew, CAmount nFees, bool fProofOfStake, bool fZPIVStake)
 {
+    AssertLockHeld(cs_main);
     CBlockIndex* pindexPrev = chainActive.Tip();
     if(!pindexPrev) return;
 
@@ -346,8 +347,10 @@ std::string GetRequiredPaymentsString(int nBlockHeight)
 
 void CMasternodePayments::FillBlockPayee(CMutableTransaction& txNew, int64_t nFees, bool fProofOfStake, bool fZPIVStake)
 {
-    if(!pCurrentBlockIndex) return;
-    int tipHeight = pCurrentBlockIndex->nHeight;
+    AssertLockHeld(cs_main);
+    CBlockIndex* tip = chainActive.Tip();
+    if(!tip) return;
+    int tipHeight = tip->nHeight;
 
     bool hasPayment = true;
     CScript payee;

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -227,16 +227,19 @@ void DumpMasternodePayments()
 
 bool IsBlockValueValid(const CBlock& block, CAmount nExpectedValue, CAmount nMinted)
 {
-    CBlockIndex* pindexPrev = chainActive.Tip();
-    if (pindexPrev == NULL) return true;
-
     int nHeight = 0;
-    if (pindexPrev->GetBlockHash() == block.hashPrevBlock) {
-        nHeight = pindexPrev->nHeight + 1;
-    } else { //out of order
-        BlockMap::iterator mi = mapBlockIndex.find(block.hashPrevBlock);
-        if (mi != mapBlockIndex.end() && (*mi).second)
-            nHeight = (*mi).second->nHeight + 1;
+    {
+        LOCK(cs_main);
+        CBlockIndex* tip = chainActive.Tip();
+        if(!tip) return true; // No chain
+
+        if (tip->GetBlockHash() == block.hashPrevBlock) {
+            nHeight = tip->nHeight + 1;
+        } else { //out of order
+            BlockMap::iterator mi = mapBlockIndex.find(block.hashPrevBlock);
+            if (mi != mapBlockIndex.end() && (*mi).second)
+                nHeight = (*mi).second->nHeight + 1;
+        }
     }
 
     if (nHeight == 0) {

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -231,6 +231,8 @@ class CMasternodePayments
 private:
     int nSyncedFromPeer;
     int nLastBlockHeight;
+    // Keep track of current block index
+    const CBlockIndex *pCurrentBlockIndex;
 
 public:
     std::map<uint256, CMasternodePaymentWinner> mapMasternodePayeeVotes;
@@ -292,6 +294,8 @@ public:
         READWRITE(mapMasternodePayeeVotes);
         READWRITE(mapMasternodeBlocks);
     }
+
+    void UpdatedBlockTip(const CBlockIndex *pindex);
 };
 
 

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -63,16 +63,9 @@ bool CMasternodeSync::IsBlockchainSynced()
 
     if (fImporting || fReindex) return false;
 
-    int64_t blockTime = 0;
-    {
-        TRY_LOCK(cs_main, lockMain);
-        if (!lockMain) return false;
-        CBlockIndex *pindex = chainActive.Tip();
-        if (pindex == nullptr) return false;
-        blockTime = pindex->nTime;
-    }
+    if(!pCurrentBlockIndex) return false;
 
-    if (blockTime + 60 * 60 < lastProcess)
+    if (pCurrentBlockIndex->nTime + 60 * 60 < lastProcess)
         return false;
 
     fBlockchainSynced = true;
@@ -259,6 +252,8 @@ void CMasternodeSync::Process()
 
     if (tick++ % MASTERNODE_SYNC_TIMEOUT != 0) return;
 
+    if(!pCurrentBlockIndex) return;
+
     if (IsSynced()) {
         /*
             Resync if we lose all masternodes from sleep/wake or failure to sync originally
@@ -419,4 +414,9 @@ void CMasternodeSync::Process()
             }
         }
     }
+}
+
+void CMasternodeSync::UpdatedBlockTip(const CBlockIndex *pindex)
+{
+    pCurrentBlockIndex = pindex;
 }

--- a/src/masternode-sync.h
+++ b/src/masternode-sync.h
@@ -62,6 +62,9 @@ public:
     // Time when current masternode asset sync started
     int64_t nAssetSyncStarted;
 
+    // Keep track of current block index
+    const CBlockIndex *pCurrentBlockIndex;
+
     CMasternodeSync();
 
     void AddedMasternodeList(uint256 hash);
@@ -81,6 +84,8 @@ public:
     bool IsMasternodeListSynced();
     bool IsBlockchainSynced();
     void ClearFulfilledRequest();
+
+    void UpdatedBlockTip(const CBlockIndex *pindex);
 };
 
 #endif

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -251,6 +251,7 @@ public:
 
     int GetMasternodeInputAge()
     {
+        LOCK(cs_main);
         if (chainActive.Tip() == NULL) return 0;
 
         if (cacheInputAge == 0) {

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -262,9 +262,6 @@ void WalletModel::emitBalanceChanged()
 
 void WalletModel::checkBalanceChanged()
 {
-    TRY_LOCK(cs_main, lockMain);
-    if (!lockMain) return;
-
     CAmount newBalance = getBalance();
     CAmount newUnconfirmedBalance = getUnconfirmedBalance();
     CAmount newImmatureBalance = getImmatureBalance();

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -150,8 +150,11 @@ UniValue getmasternodecount (const UniValue& params, bool fHelp)
     int nCount = 0;
     int ipv4 = 0, ipv6 = 0, onion = 0;
 
-    if (chainActive.Tip())
-        mnodeman.GetNextMasternodeInQueueForPayment(chainActive.Tip()->nHeight, true, nCount);
+    {
+        LOCK(cs_main);
+        if (chainActive.Tip())
+            mnodeman.GetNextMasternodeInQueueForPayment(chainActive.Tip()->nHeight, true, nCount);
+    }
 
     mnodeman.CountNetworks(ActiveProtocol(), ipv4, ipv6, onion);
 
@@ -700,8 +703,9 @@ UniValue getmasternodescores (const UniValue& params, bool fHelp)
     }
     UniValue obj(UniValue::VOBJ);
 
+    int tipHeight = WITH_LOCK(cs_main, { return chainActive.Tip()->nHeight; });
     std::vector<CMasternode> vMasternodes = mnodeman.GetFullMasternodeVector();
-    for (int nHeight = chainActive.Tip()->nHeight - nLast; nHeight < chainActive.Tip()->nHeight + 20; nHeight++) {
+    for (int nHeight = tipHeight - nLast; nHeight < tipHeight + 20; nHeight++) {
         uint256 nHigh;
         CMasternode* pBestMasternode = NULL;
         for (CMasternode& mn : vMasternodes) {

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -6,6 +6,7 @@
 #include "init.h"
 #include "consensus/merkle.h"
 #include "main.h"
+#include "masternode-payments.h"
 #include "miner.h"
 #include "pubkey.h"
 #include "uint256.h"
@@ -63,6 +64,9 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
 
     LOCK(cs_main);
     Checkpoints::fEnabled = false;
+
+    // force UpdatedBlockTip to initialize pCurrentBlockIndex
+    mnpayments.UpdatedBlockTip(chainActive.Tip());
 
     // Simple block creation, nothing special yet:
     BOOST_CHECK(pblocktemplate = CreateNewBlock(scriptPubKey, pwalletMain, false));


### PR DESCRIPTION
This is coming from [#710](https://github.com/dashpay/dash/pull/710) + adapted to our sources.

Can be taken as a good performance improvement for 4.2 over the tier two `cs_main` lock usage (without make radical changes). 
5.0 will need to have major changes in this area.

* First commit removes an unneeded `cs_main` lock.
* Second commit add some guards to `chainActive` over the tier two sources.
* Third commit introduces a new interface and a `CBlockIndex* currentTip` member on each of the tier two objects to not have to re request the tip, locking `cs_main`, on every validation/action.

-- Needs proper testing --