### PR TITLE
New upgrade structure.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -461,6 +461,7 @@ set(COMMON_SOURCES
         ./src/amount.cpp
         ./src/base58.cpp
         ./src/bip38.cpp
+        ./src/consensus/upgrades.cpp
         ./src/chainparams.cpp
         ./src/coins.cpp
         ./src/key_io.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -461,6 +461,7 @@ set(COMMON_SOURCES
         ./src/amount.cpp
         ./src/base58.cpp
         ./src/bip38.cpp
+        ./src/consensus/params.cpp
         ./src/consensus/upgrades.cpp
         ./src/chainparams.cpp
         ./src/coins.cpp

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -49,6 +49,14 @@ Detailed release notes follow. This overview includes changes that affect behavi
 
 ### RPC/REST
 
+New network upgrades output
+---------------------------
+
+A new return field 'upgrades' was added to the `getblockchaininfo` RPC method.
+Showing the upcoming and active upgrades. Starting with PIVX v5.0.0 Purple Fenix
+network upgrade.
+
+
 Asm representations of scriptSig signatures now contain SIGHASH type decodes
 ----------------------------------------------------------------------------
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -229,6 +229,7 @@ libbitcoin_server_a_SOURCES = \
   blocksignature.cpp \
   chain.cpp \
   checkpoints.cpp \
+  consensus/params.cpp \
   consensus/tx_verify.cpp \
   consensus/zerocoin_verify.cpp \
   httprpc.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -106,6 +106,7 @@ BITCOIN_CORE_H = \
   consensus/tx_verify.h \
   consensus/zerocoin_verify.h \
   consensus/params.h \
+  consensus/upgrades.h \
   primitives/block.h \
   primitives/transaction.h \
   core_io.h \
@@ -388,6 +389,7 @@ libbitcoin_common_a_SOURCES = \
   base58.cpp \
   bip38.cpp \
   chainparams.cpp \
+  consensus/upgrades.cpp \
   coins.cpp \
   compressor.cpp \
   consensus/merkle.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -147,6 +147,7 @@ BITCOIN_CORE_H = \
   net.h \
   noui.h \
   policy/fees.h \
+  optional.h \
   pow.h \
   prevector.h \
   protocol.h \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -82,7 +82,8 @@ BITCOIN_TESTS =\
   test/transaction_tests.cpp \
   test/uint256_tests.cpp \
   test/univalue_tests.cpp \
-  test/util_tests.cpp
+  test/util_tests.cpp \
+  test/upgrades_tests.cpp
 
 if ENABLE_WALLET
 BITCOIN_TESTS += \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -191,6 +191,14 @@ public:
         consensus.ZC_TimeStart = 1508214600;        // October 17, 2017 4:30:00 AM
         consensus.ZC_WrappedSerialsSupply = 4131563 * COIN;   // zerocoin supply at height_last_ZC_WrappedSerials
 
+        // Network upgrades
+        consensus.vUpgrades[Consensus::BASE_NETWORK].nActivationHeight =
+                Consensus::NetworkUpgrade::ALWAYS_ACTIVE;
+        consensus.vUpgrades[Consensus::UPGRADE_TESTDUMMY].nActivationHeight =
+                Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
+        consensus.vUpgrades[Consensus::UPGRADE_PURPLE_FENIX].nActivationHeight =
+                Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
+
         /**
          * The message start string is designed to be unlikely to occur in normal data.
          * The characters are rarely used upper ASCII, not valid as UTF-8, and produce
@@ -303,6 +311,14 @@ public:
         consensus.ZC_MinStakeDepth = 200;
         consensus.ZC_TimeStart = 1501776000;
         consensus.ZC_WrappedSerialsSupply = 0;   // WrappedSerials only on main net
+
+        // Network upgrades
+        consensus.vUpgrades[Consensus::BASE_NETWORK].nActivationHeight =
+                Consensus::NetworkUpgrade::ALWAYS_ACTIVE;
+        consensus.vUpgrades[Consensus::UPGRADE_TESTDUMMY].nActivationHeight =
+                Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
+        consensus.vUpgrades[Consensus::UPGRADE_PURPLE_FENIX].nActivationHeight =
+                Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.
@@ -421,6 +437,13 @@ public:
         consensus.ZC_TimeStart = 0;                 // not implemented on regtest
         consensus.ZC_WrappedSerialsSupply = 0;
 
+        // Network upgrades
+        consensus.vUpgrades[Consensus::BASE_NETWORK].nActivationHeight =
+                Consensus::NetworkUpgrade::ALWAYS_ACTIVE;
+        consensus.vUpgrades[Consensus::UPGRADE_TESTDUMMY].nActivationHeight =
+                Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
+        consensus.vUpgrades[Consensus::UPGRADE_PURPLE_FENIX].nActivationHeight =
+                Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.
@@ -441,6 +464,12 @@ public:
     const Checkpoints::CCheckpointData& Checkpoints() const
     {
         return dataRegtest;
+    }
+
+    void UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex idx, int nActivationHeight)
+    {
+        assert(idx > Consensus::BASE_NETWORK && idx < Consensus::MAX_NETWORK_UPGRADES);
+        consensus.vUpgrades[idx].nActivationHeight = nActivationHeight;
     }
 };
 static CRegTestParams regTestParams;
@@ -482,4 +511,9 @@ bool SelectParamsFromCommandLine()
 
     SelectParams(network);
     return true;
+}
+
+void UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex idx, int nActivationHeight)
+{
+    regTestParams.UpdateNetworkUpgradeParameters(idx, nActivationHeight);
 }

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -108,4 +108,9 @@ void SelectParams(CBaseChainParams::Network network);
  */
 bool SelectParamsFromCommandLine();
 
+/**
+ * Allows modifying the network upgrade regtest parameters.
+ */
+void UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex idx, int nActivationHeight);
+
 #endif // BITCOIN_CHAINPARAMS_H

--- a/src/consensus/params.cpp
+++ b/src/consensus/params.cpp
@@ -1,0 +1,12 @@
+
+#include "consensus/params.h"
+#include "consensus/upgrades.h"
+
+namespace Consensus {
+
+bool Params::NetworkUpgradeActive(int nHeight, Consensus::UpgradeIndex idx) const
+{
+        return NetworkUpgradeState(nHeight, *this, idx) == UPGRADE_ACTIVE;
+}
+
+} // End consensus namespace

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -183,6 +183,13 @@ struct Params {
         static libzerocoin::ZerocoinParams ZCParamsDec = libzerocoin::ZerocoinParams(bnDecModulus);
         return (useModulusV1 ? &ZCParamsHex : &ZCParamsDec);
     }
+
+    /**
+     * Returns true if the given network upgrade is active as of the given block
+     * height. Caller must check that the height is >= 0 (and handle unknown
+     * heights).
+     */
+    bool NetworkUpgradeActive(int nHeight, Consensus::UpgradeIndex idx) const;
 };
 } // namespace Consensus
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -8,11 +8,70 @@
 
 #include "amount.h"
 #include "libzerocoin/Params.h"
+#include "optional.h"
 #include "uint256.h"
 #include <map>
 #include <string>
 
 namespace Consensus {
+
+/**
+* Index into Params.vUpgrades and NetworkUpgradeInfo
+*
+* Being array indices, these MUST be numbered consecutively.
+*
+* The order of these indices MUST match the order of the upgrades on-chain, as
+* several functions depend on the enum being sorted.
+*/
+enum UpgradeIndex : uint32_t {
+    BASE_NETWORK,
+    UPGRADE_PURPLE_FENIX,
+    UPGRADE_TESTDUMMY,
+    // NOTE: Also add new upgrades to NetworkUpgradeInfo in upgrades.cpp
+    MAX_NETWORK_UPGRADES
+};
+
+struct NetworkUpgrade {
+    /**
+     * The first protocol version which will understand the new consensus rules
+     */
+    int nProtocolVersion;
+
+    /**
+     * Height of the first block for which the new consensus rules will be active
+     */
+    int nActivationHeight;
+
+    /**
+     * Special value for nActivationHeight indicating that the upgrade is always active.
+     * This is useful for testing, as it means tests don't need to deal with the activation
+     * process (namely, faking a chain of somewhat-arbitrary length).
+     *
+     * New blockchains that want to enable upgrade rules from the beginning can also use
+     * this value. However, additional care must be taken to ensure the genesis block
+     * satisfies the enabled rules.
+     */
+    static constexpr int ALWAYS_ACTIVE = 0;
+
+    /**
+     * Special value for nActivationHeight indicating that the upgrade will never activate.
+     * This is useful when adding upgrade code that has a testnet activation height, but
+     * should remain disabled on mainnet.
+     */
+    static constexpr int NO_ACTIVATION_HEIGHT = -1;
+
+    /**
+     * The hash of the block at height nActivationHeight, if known. This is set manually
+     * after a network upgrade activates.
+     *
+     * We use this in IsInitialBlockDownload to detect whether we are potentially being
+     * fed a fake alternate chain. We use NU activation blocks for this purpose instead of
+     * the checkpoint blocks, because network upgrades (should) have significantly more
+     * scrutiny than regular releases. nMinimumChainWork MUST be set to at least the chain
+     * work of this block, otherwise this detection will have false positives.
+     */
+    Optional<uint256> hashActivationBlock;
+};
 
 /**
  * Parameters that influence chain consensus.
@@ -66,6 +125,8 @@ struct Params {
     int64_t nPivxBadBlockTime;
     unsigned int nPivxBadBlockBits;
 
+    // Map with network updates (Starting with 'Purple Fenix')
+    NetworkUpgrade vUpgrades[MAX_NETWORK_UPGRADES];
 
     int64_t TargetTimespan(const bool fV2 = true) const { return fV2 ? nTargetTimespanV2 : nTargetTimespan; }
     uint256 ProofOfStakeLimit(const bool fV2) const { return fV2 ? posLimitV2 : posLimitV1; }

--- a/src/consensus/upgrades.cpp
+++ b/src/consensus/upgrades.cpp
@@ -1,0 +1,98 @@
+// Copyright (c) 2018 The Zcash developers
+// Copyright (c) 2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "consensus/upgrades.h"
+
+/**
+ * General information about each network upgrade.
+ * Ordered by Consensus::UpgradeIndex.
+ */
+const struct NUInfo NetworkUpgradeInfo[Consensus::MAX_NETWORK_UPGRADES] = {
+        {
+                /*.strName =*/ "Base",
+                /*.strInfo =*/ "PIVX network",
+        },
+        {
+                /*.strName =*/ "Purple Fenix",
+                /*.strInfo =*/ "PIVX network v5.0.0 update",
+        },
+        {
+                /*.strName =*/ "Test dummy",
+                /*.strInfo =*/ "Test dummy info",
+        },
+};
+
+UpgradeState NetworkUpgradeState(
+        int nHeight,
+        const Consensus::Params& params,
+        Consensus::UpgradeIndex idx)
+{
+    assert(nHeight >= 0);
+    assert(idx >= Consensus::BASE_NETWORK && idx < Consensus::MAX_NETWORK_UPGRADES);
+    auto nActivationHeight = params.vUpgrades[idx].nActivationHeight;
+
+    if (nActivationHeight == Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT) {
+        return UPGRADE_DISABLED;
+    } else if (nHeight >= nActivationHeight) {
+        // From ZIP200:
+        //
+        // ACTIVATION_HEIGHT
+        //     The block height at which the network upgrade rules will come into effect.
+        //
+        //     For removal of ambiguity, the block at height ACTIVATION_HEIGHT - 1 is
+        //     subject to the pre-upgrade consensus rules.
+        return UPGRADE_ACTIVE;
+    } else {
+        return UPGRADE_PENDING;
+    }
+}
+
+bool NetworkUpgradeActive(
+        int nHeight,
+        const Consensus::Params& params,
+        Consensus::UpgradeIndex idx)
+{
+    return NetworkUpgradeState(nHeight, params, idx) == UPGRADE_ACTIVE;
+}
+
+int CurrentEpoch(int nHeight, const Consensus::Params& params) {
+    for (auto idxInt = Consensus::MAX_NETWORK_UPGRADES - 1; idxInt >= Consensus::BASE_NETWORK; idxInt--) {
+        if (NetworkUpgradeActive(nHeight, params, Consensus::UpgradeIndex(idxInt))) {
+            return idxInt;
+        }
+    }
+    return Consensus::BASE_NETWORK;
+}
+
+bool IsActivationHeight(
+        int nHeight,
+        const Consensus::Params& params,
+        Consensus::UpgradeIndex idx)
+{
+    assert(idx >= Consensus::BASE_NETWORK && idx < Consensus::MAX_NETWORK_UPGRADES);
+
+    // Don't count BASE_NETWORK as an activation height
+    if (idx == Consensus::BASE_NETWORK) {
+        return false;
+    }
+
+    return nHeight >= 0 && nHeight == params.vUpgrades[idx].nActivationHeight;
+}
+
+bool IsActivationHeightForAnyUpgrade(
+        int nHeight,
+        const Consensus::Params& params)
+{
+    if (nHeight < 0) {
+        return false;
+    }
+
+    for (int idx = Consensus::BASE_NETWORK + 1; idx < (int) Consensus::MAX_NETWORK_UPGRADES; idx++) {
+        if (nHeight == params.vUpgrades[idx].nActivationHeight)
+            return true;
+    }
+
+    return false;
+}

--- a/src/consensus/upgrades.cpp
+++ b/src/consensus/upgrades.cpp
@@ -96,3 +96,29 @@ bool IsActivationHeightForAnyUpgrade(
 
     return false;
 }
+
+Optional<int> NextEpoch(int nHeight, const Consensus::Params& params) {
+    if (nHeight < 0) {
+        return nullopt;
+    }
+
+    // BASE_NETWORK is never pending
+    for (auto idx = Consensus::BASE_NETWORK + 1; idx < Consensus::MAX_NETWORK_UPGRADES; idx++) {
+        if (NetworkUpgradeState(nHeight, params, Consensus::UpgradeIndex(idx)) == UPGRADE_PENDING) {
+            return idx;
+        }
+    }
+
+    return nullopt;
+}
+
+Optional<int> NextActivationHeight(
+        int nHeight,
+        const Consensus::Params& params)
+{
+    auto idx = NextEpoch(nHeight, params);
+    if (idx) {
+        return params.vUpgrades[idx.get()].nActivationHeight;
+    }
+    return nullopt;
+}

--- a/src/consensus/upgrades.h
+++ b/src/consensus/upgrades.h
@@ -7,6 +7,7 @@
 #define PIVX_CONSENSUS_UPGRADES_H
 
 #include "consensus/params.h"
+#include "optional.h"
 
 enum UpgradeState {
     UPGRADE_DISABLED,
@@ -63,6 +64,20 @@ bool IsActivationHeight(
  * Returns true if the given block height is the activation height for any upgrade.
  */
 bool IsActivationHeightForAnyUpgrade(
+        int nHeight,
+        const Consensus::Params& params);
+
+/**
+ * Returns the index of the next upgrade after the given block height, or
+ * nullopt if there are no more known upgrades.
+ */
+Optional<int> NextEpoch(int nHeight, const Consensus::Params& params);
+
+/**
+ * Returns the activation height for the next upgrade after the given block height,
+ * or nullopt if there are no more known upgrades.
+ */
+Optional<int> NextActivationHeight(
         int nHeight,
         const Consensus::Params& params);
 

--- a/src/consensus/upgrades.h
+++ b/src/consensus/upgrades.h
@@ -1,0 +1,69 @@
+// Copyright (c) 2018 The Zcash developers
+// Copyright (c) 2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef PIVX_CONSENSUS_UPGRADES_H
+#define PIVX_CONSENSUS_UPGRADES_H
+
+#include "consensus/params.h"
+
+enum UpgradeState {
+    UPGRADE_DISABLED,
+    UPGRADE_PENDING,
+    UPGRADE_ACTIVE
+};
+
+struct NUInfo {
+    /** User-facing name for the upgrade */
+    std::string strName;
+    /** User-facing information string about the upgrade */
+    std::string strInfo;
+};
+
+extern const struct NUInfo NetworkUpgradeInfo[];
+
+/**
+ * Checks the state of a given network upgrade based on block height.
+ * Caller must check that the height is >= 0 (and handle unknown heights).
+ */
+UpgradeState NetworkUpgradeState(
+        int nHeight,
+        const Consensus::Params& params,
+        Consensus::UpgradeIndex idx);
+
+/**
+ * Returns true if the given network upgrade is active as of the given block
+ * height. Caller must check that the height is >= 0 (and handle unknown
+ * heights).
+ */
+bool NetworkUpgradeActive(
+        int nHeight,
+        const Consensus::Params& params,
+        Consensus::UpgradeIndex idx);
+
+/**
+ * Returns the index of the most recent upgrade as of the given block height
+ * (corresponding to the current "epoch"). Consensus::BASE_NETWORK is the
+ * default value if no upgrades are active. Caller must check that the height
+ * is >= 0 (and handle unknown heights).
+ */
+int CurrentEpoch(int nHeight, const Consensus::Params& params);
+
+/**
+ * Returns true if the given block height is the activation height for the given
+ * upgrade.
+ */
+bool IsActivationHeight(
+        int nHeight,
+        const Consensus::Params& params,
+        Consensus::UpgradeIndex upgrade);
+
+/**
+ * Returns true if the given block height is the activation height for any upgrade.
+ */
+bool IsActivationHeightForAnyUpgrade(
+        int nHeight,
+        const Consensus::Params& params);
+
+#endif // PIVX_CONSENSUS_UPGRADES_H

--- a/src/optional.h
+++ b/src/optional.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_OPTIONAL_H
+#define BITCOIN_OPTIONAL_H
+
+#include <boost/optional.hpp>
+
+//! Substitute for C++17 std::optional
+template <typename T>
+using Optional = boost::optional<T>;
+
+//! Substitute for C++17 std::nullopt
+static auto& nullopt = boost::none;
+
+#endif // BITCOIN_OPTIONAL_H

--- a/src/test/upgrades_tests.cpp
+++ b/src/test/upgrades_tests.cpp
@@ -1,0 +1,121 @@
+// Copyright (c) 2017 The Zcash Core developers
+// Copyright (c) 2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "chainparams.h"
+#include "consensus/upgrades.h"
+
+#include "test/test_pivx.h"
+
+#include <boost/test/unit_test.hpp>
+
+struct UpgradesTest : public TestingSetup {
+    UpgradesTest() {}
+    ~UpgradesTest() {
+        // Revert to default
+        UpdateNetworkUpgradeParameters(Consensus::UPGRADE_TESTDUMMY, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    }
+};
+
+BOOST_FIXTURE_TEST_SUITE(network_upgrades_tests, UpgradesTest)
+
+BOOST_AUTO_TEST_CASE(networkUpgradeStateTest)
+{
+    SelectParams(CBaseChainParams::REGTEST);
+    const Consensus::Params& params = Params().GetConsensus();
+
+    // Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT
+    BOOST_CHECK_EQUAL(
+            NetworkUpgradeState(0, params, Consensus::UPGRADE_TESTDUMMY),
+            UPGRADE_DISABLED);
+    BOOST_CHECK_EQUAL(
+            NetworkUpgradeState(1000000, params, Consensus::UPGRADE_TESTDUMMY),
+            UPGRADE_DISABLED);
+
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_TESTDUMMY, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+
+    BOOST_CHECK_EQUAL(
+            NetworkUpgradeState(0, params, Consensus::UPGRADE_TESTDUMMY),
+            UPGRADE_ACTIVE);
+    BOOST_CHECK_EQUAL(
+            NetworkUpgradeState(1000000, params, Consensus::UPGRADE_TESTDUMMY),
+            UPGRADE_ACTIVE);
+
+    int nActivationHeight = 100;
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_TESTDUMMY, nActivationHeight);
+
+    BOOST_CHECK_EQUAL(
+            NetworkUpgradeState(0, params, Consensus::UPGRADE_TESTDUMMY),
+            UPGRADE_PENDING);
+    BOOST_CHECK_EQUAL(
+            NetworkUpgradeState(nActivationHeight - 1, params, Consensus::UPGRADE_TESTDUMMY),
+            UPGRADE_PENDING);
+    BOOST_CHECK_EQUAL(
+            NetworkUpgradeState(nActivationHeight, params, Consensus::UPGRADE_TESTDUMMY),
+            UPGRADE_ACTIVE);
+    BOOST_CHECK_EQUAL(
+            NetworkUpgradeState(1000000, params, Consensus::UPGRADE_TESTDUMMY),
+            UPGRADE_ACTIVE);
+}
+
+BOOST_AUTO_TEST_CASE(IsActivationHeightTest)
+{
+    SelectParams(CBaseChainParams::REGTEST);
+    const Consensus::Params& params = Params().GetConsensus();
+
+    // Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT
+    BOOST_CHECK(!IsActivationHeight(-1, params, Consensus::UPGRADE_TESTDUMMY));
+    BOOST_CHECK(!IsActivationHeight(0, params, Consensus::UPGRADE_TESTDUMMY));
+    BOOST_CHECK(!IsActivationHeight(1, params, Consensus::UPGRADE_TESTDUMMY));
+    BOOST_CHECK(!IsActivationHeight(1000000, params, Consensus::UPGRADE_TESTDUMMY));
+
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_TESTDUMMY, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+
+    BOOST_CHECK(!IsActivationHeight(-1, params, Consensus::UPGRADE_TESTDUMMY));
+    BOOST_CHECK(IsActivationHeight(0, params, Consensus::UPGRADE_TESTDUMMY));
+    BOOST_CHECK(!IsActivationHeight(1, params, Consensus::UPGRADE_TESTDUMMY));
+    BOOST_CHECK(!IsActivationHeight(1000000, params, Consensus::UPGRADE_TESTDUMMY));
+
+    int nActivationHeight = 100;
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_TESTDUMMY, nActivationHeight);
+
+    BOOST_CHECK(!IsActivationHeight(-1, params, Consensus::UPGRADE_TESTDUMMY));
+    BOOST_CHECK(!IsActivationHeight(0, params, Consensus::UPGRADE_TESTDUMMY));
+    BOOST_CHECK(!IsActivationHeight(1, params, Consensus::UPGRADE_TESTDUMMY));
+    BOOST_CHECK(!IsActivationHeight(nActivationHeight - 1, params, Consensus::UPGRADE_TESTDUMMY));
+    BOOST_CHECK(IsActivationHeight(nActivationHeight, params, Consensus::UPGRADE_TESTDUMMY));
+    BOOST_CHECK(!IsActivationHeight(nActivationHeight + 1, params, Consensus::UPGRADE_TESTDUMMY));
+    BOOST_CHECK(!IsActivationHeight(1000000, params, Consensus::UPGRADE_TESTDUMMY));
+}
+
+BOOST_AUTO_TEST_CASE(IsActivationHeightForAnyUpgradeTest) {
+    SelectParams(CBaseChainParams::REGTEST);
+    const Consensus::Params& params = Params().GetConsensus();
+
+    // Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT
+    BOOST_CHECK(!IsActivationHeightForAnyUpgrade(-1, params));
+    BOOST_CHECK(!IsActivationHeightForAnyUpgrade(0, params));
+    BOOST_CHECK(!IsActivationHeightForAnyUpgrade(1, params));
+    BOOST_CHECK(!IsActivationHeightForAnyUpgrade(1000000, params));
+
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_TESTDUMMY, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+
+    BOOST_CHECK(!IsActivationHeightForAnyUpgrade(-1, params));
+    BOOST_CHECK(IsActivationHeightForAnyUpgrade(0, params));
+    BOOST_CHECK(!IsActivationHeightForAnyUpgrade(1, params));
+    BOOST_CHECK(!IsActivationHeightForAnyUpgrade(1000000, params));
+
+    int nActivationHeight = 100;
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_TESTDUMMY, nActivationHeight);
+
+    BOOST_CHECK(!IsActivationHeightForAnyUpgrade(-1, params));
+    BOOST_CHECK(!IsActivationHeightForAnyUpgrade(0, params));
+    BOOST_CHECK(!IsActivationHeightForAnyUpgrade(1, params));
+    BOOST_CHECK(!IsActivationHeightForAnyUpgrade(nActivationHeight - 1, params));
+    BOOST_CHECK(IsActivationHeightForAnyUpgrade(nActivationHeight, params));
+    BOOST_CHECK(!IsActivationHeightForAnyUpgrade(nActivationHeight + 1, params));
+    BOOST_CHECK(!IsActivationHeightForAnyUpgrade(1000000, params));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/upgrades_tests.cpp
+++ b/src/test/upgrades_tests.cpp
@@ -5,7 +5,7 @@
 
 #include "chainparams.h"
 #include "consensus/upgrades.h"
-
+#include "optional.h"
 #include "test/test_pivx.h"
 
 #include <boost/test/unit_test.hpp>
@@ -116,6 +116,35 @@ BOOST_AUTO_TEST_CASE(IsActivationHeightForAnyUpgradeTest) {
     BOOST_CHECK(IsActivationHeightForAnyUpgrade(nActivationHeight, params));
     BOOST_CHECK(!IsActivationHeightForAnyUpgrade(nActivationHeight + 1, params));
     BOOST_CHECK(!IsActivationHeightForAnyUpgrade(1000000, params));
+}
+
+BOOST_AUTO_TEST_CASE(NextActivationHeightTest) {
+    SelectParams(CBaseChainParams::REGTEST);
+    const Consensus::Params& params = Params().GetConsensus();
+
+    // Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT
+    BOOST_CHECK(NextActivationHeight(-1, params) == nullopt);
+    BOOST_CHECK(NextActivationHeight(0, params) == nullopt);
+    BOOST_CHECK(NextActivationHeight(1, params) == nullopt);
+    BOOST_CHECK(NextActivationHeight(1000000, params) == nullopt);
+
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_TESTDUMMY, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+
+    BOOST_CHECK(NextActivationHeight(-1, params) == nullopt);
+    BOOST_CHECK(NextActivationHeight(0, params) == nullopt);
+    BOOST_CHECK(NextActivationHeight(1, params) == nullopt);
+    BOOST_CHECK(NextActivationHeight(1000000, params) == nullopt);
+
+    int nActivationHeight = 100;
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_TESTDUMMY, nActivationHeight);
+
+    BOOST_CHECK(NextActivationHeight(-1, params) == nullopt);
+    BOOST_CHECK(NextActivationHeight(0, params) == nActivationHeight);
+    BOOST_CHECK(NextActivationHeight(1, params) == nActivationHeight);
+    BOOST_CHECK(NextActivationHeight(nActivationHeight - 1, params) == nActivationHeight);
+    BOOST_CHECK(NextActivationHeight(nActivationHeight, params) == nullopt);
+    BOOST_CHECK(NextActivationHeight(nActivationHeight + 1, params) == nullopt);
+    BOOST_CHECK(NextActivationHeight(1000000, params) == nullopt);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Custom implementation for our network of [ZIP200](https://github.com/zcash/zips/blob/master/zip-0200.rst) network upgrades structure.

This PR includes only the base structure and unit test for the upgrade mechanism, no network connection to any upgrade (only a `UPGRADE_PURPLE_FENIX` placeholder was added) nor upgrade activation hash check.

This will remove ambiguity over the many places of our code that requires the exact same check to perform the post/pre upgrade validations and actions.

Instead of using:
`If (consensus.next_update_height >= height) { //post update code }`

Now we will start using:
`if (consensus.NetworkUpgradeActive(pindex->nHeight, Consensus::UPGRADE_PURPLE_FENIX)) { //post update code }`

As well as be able to differentiate features in an specific release. Which could have different upgrade structure for testing and future upgrade + deactivation purposes.
