### PR TITLE
Remove unused MultiSigScriptSet typedef and member

### DIFF
--- a/src/keystore.h
+++ b/src/keystore.h
@@ -51,7 +51,6 @@ public:
 typedef std::map<CKeyID, CKey> KeyMap;
 typedef std::map<CScriptID, CScript> ScriptMap;
 typedef std::set<CScript> WatchOnlySet;
-typedef std::set<CScript> MultiSigScriptSet;
 
 /** Basic key store, that keeps keys in an address->secret map */
 class CBasicKeyStore : public CKeyStore
@@ -60,7 +59,6 @@ protected:
     KeyMap mapKeys;
     ScriptMap mapScripts;
     WatchOnlySet setWatchOnly;
-    MultiSigScriptSet setMultiSig;
 
 public:
     bool AddKeyPubKey(const CKey& key, const CPubKey& pubkey);


### PR DESCRIPTION
multisig GUI functionality was removed on a previous PR. This member and typedef is not being used anymore