### PR TITLE
[GUI][Model] Remove zerocoin methods.

### DIFF
--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -177,9 +177,6 @@ public:
     void decryptKey(const std::vector<unsigned char>& crypted, const std::string& slt, const std::string& pwd, CKey& key);
     void emitBalanceChanged(); // Force update of UI-elements even when no values have changed
 
-    // return minted zPIV
-    bool getMint(const uint256& hashSerial, CZerocoinMint& mint);
-
     // Check address for validity
     bool validateAddress(const QString& address);
     // Check address for validity and type (whether cold staking address or not)
@@ -203,29 +200,6 @@ public:
 
     // Send coins to a list of recipients
     SendCoinsReturn sendCoins(WalletModelTransaction& transaction);
-    // Mint zPIV
-    bool mintCoins(CAmount value, CCoinControl* coinControl, std::string &strError);
-
-    bool createZpivSpend(
-            CWalletTx &wtxNew,
-            std::vector<CZerocoinMint> &vMintsSelected,
-            CZerocoinSpendReceipt &receipt,
-            std::list<std::pair<CTxDestination, CAmount>> outputs,
-            std::string changeAddress = ""
-    );
-
-    bool sendZpiv(
-            std::vector<CZerocoinMint> &vMintsSelected,
-            CZerocoinSpendReceipt &receipt,
-            std::list<std::pair<CTxDestination, CAmount>> outputs,
-            std::string changeAddress = ""
-    );
-
-    bool convertBackZpiv(
-            CAmount value,
-            std::vector<CZerocoinMint> &vMintsSelected,
-            CZerocoinSpendReceipt &receipt
-    );
 
     // Wallet encryption
     bool setWalletEncrypted(bool encrypted, const SecureString& passphrase);
@@ -297,14 +271,9 @@ public:
     void unlockCoin(COutPoint& output);
     void listLockedCoins(std::vector<COutPoint>& vOutpts);
 
-    void listZerocoinMints(std::set<CMintMeta>& setMints, bool fUnusedOnly = false, bool fMaturedOnly = false, bool fUpdateStatus = false, bool fWrongSeed = false);
-
     std::string GetUniqueWalletBackupName();
     void loadReceiveRequests(std::vector<std::string>& vReceiveRequests);
     bool saveReceiveRequest(const std::string& sAddress, const int64_t nId, const std::string& sRequest);
-
-    std::string resetMintZerocoin();
-    std::string resetSpentZerocoin();
 
 private:
     CWallet* wallet;
@@ -379,8 +348,6 @@ public Q_SLOTS:
     void updateTransaction();
     /* New, updated or removed address book entry */
     void updateAddressBook(const QString& address, const QString& label, bool isMine, const QString& purpose, int status);
-    /* Zerocoin update */
-    void updateAddressBook(const QString &pubCoin, const QString &isUsed, int status);
     /* Watch-only added */
     void updateWatchOnlyFlag(bool fHaveWatchonly);
     /* Current, immature or unconfirmed balance might have changed - emit 'balanceChanged' if so */


### PR DESCRIPTION
#1549 dropped zerocoin support in the GUI, this is a follow up removing the now unused methods and signal connections from the wallet model .