### PR TITLE
Prepare for non-Base58 addresses [Step 3]

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -6,15 +6,15 @@
 #include "base58.h"
 
 #include "hash.h"
+#include "script/script.h"
 #include "uint256.h"
 
-#include <assert.h>
 #include <boost/variant/apply_visitor.hpp>
 #include <boost/variant/static_visitor.hpp>
+
+#include <algorithm>
+#include <assert.h>
 #include <sstream>
-#include <stdint.h>
-#include <string.h>
-#include <string>
 #include <vector>
 
 /** All alphanumeric characters except for "0", "I", "O", and "l" */
@@ -231,110 +231,64 @@ int CBase58Data::CompareTo(const CBase58Data& b58) const
 
 namespace
 {
-/** base58-encoded PIVX addresses.
- * Public-key-hash-addresses have version 0 (or 111 testnet).
- * The data vector contains RIPEMD160(SHA256(pubkey)), where pubkey is the serialized public key.
- * Script-hash-addresses have version 5 (or 196 testnet).
- * The data vector contains RIPEMD160(SHA256(cscript)), where cscript is the serialized redemption script.
- */
-class CBitcoinAddress : public CBase58Data
-{
-public:
-    bool Set(const CKeyID& id, const CChainParams::Base58Type addrType = CChainParams::PUBKEY_ADDRESS);
-    bool Set(const CScriptID& id);
-    bool Set(const CTxDestination& dest, const CChainParams::Base58Type addrType = CChainParams::PUBKEY_ADDRESS);
-    bool IsValid() const;
-    bool IsValid(const CChainParams& params) const;
-
-    CBitcoinAddress() {}
-    CBitcoinAddress(const CTxDestination& dest, const CChainParams::Base58Type addrType = CChainParams::PUBKEY_ADDRESS) { Set(dest, addrType); }
-    CBitcoinAddress(const std::string& strAddress) { SetString(strAddress); }
-    CBitcoinAddress(const char* pszAddress) { SetString(pszAddress); }
-
-    CTxDestination Get() const;
-    bool IsStakingAddress() const;
-
-
-    // Helpers
-    static const CBitcoinAddress newCSInstance(const CTxDestination& dest) {
-        return CBitcoinAddress(dest, CChainParams::STAKING_ADDRESS);
-    }
-
-    static const CBitcoinAddress newInstance(const CTxDestination& dest) {
-        return CBitcoinAddress(dest, CChainParams::PUBKEY_ADDRESS);
-    }
-};
-
-class CBitcoinAddressVisitor : public boost::static_visitor<bool>
+class DestinationEncoder : public boost::static_visitor<std::string>
 {
 private:
-    CBitcoinAddress* addr;
-    CChainParams::Base58Type type;
+    const CChainParams& m_params;
+    const CChainParams::Base58Type m_addrType;
 
 public:
-    CBitcoinAddressVisitor(CBitcoinAddress* addrIn,
-            const CChainParams::Base58Type addrType = CChainParams::PUBKEY_ADDRESS) :
-        addr(addrIn),
-        type(addrType){};
+    DestinationEncoder(const CChainParams& params, const CChainParams::Base58Type _addrType = CChainParams::PUBKEY_ADDRESS) : m_params(params), m_addrType(_addrType) {}
 
-    bool operator()(const CKeyID& id) const { return addr->Set(id, type); }
-    bool operator()(const CScriptID& id) const { return addr->Set(id); }
-    bool operator()(const CNoDestination& no) const { return false; }
+    std::string operator()(const CKeyID& id) const
+    {
+        std::vector<unsigned char> data = m_params.Base58Prefix(m_addrType);
+        data.insert(data.end(), id.begin(), id.end());
+        return EncodeBase58Check(data);
+    }
+
+    std::string operator()(const CScriptID& id) const
+    {
+        std::vector<unsigned char> data = m_params.Base58Prefix(CChainParams::SCRIPT_ADDRESS);
+        data.insert(data.end(), id.begin(), id.end());
+        return EncodeBase58Check(data);
+    }
+
+    std::string operator()(const CNoDestination& no) const { return ""; }
 };
 
+CTxDestination DecodeDestination(const std::string& str, const CChainParams& params, bool& isStaking)
+{
+    std::vector<unsigned char> data;
+    uint160 hash;
+    if (DecodeBase58Check(str, data)) {
+        // base58-encoded PIVX addresses.
+        // Public-key-hash-addresses have version 30 (or 139 testnet).
+        // The data vector contains RIPEMD160(SHA256(pubkey)), where pubkey is the serialized public key.
+        const std::vector<unsigned char>& pubkey_prefix = params.Base58Prefix(CChainParams::PUBKEY_ADDRESS);
+        if (data.size() == hash.size() + pubkey_prefix.size() && std::equal(pubkey_prefix.begin(), pubkey_prefix.end(), data.begin())) {
+            std::copy(data.begin() + pubkey_prefix.size(), data.end(), hash.begin());
+            return CKeyID(hash);
+        }
+        // Public-key-hash-coldstaking-addresses have version 63 (or 73 testnet).
+        const std::vector<unsigned char>& staking_prefix = params.Base58Prefix(CChainParams::STAKING_ADDRESS);
+        if (data.size() == hash.size() + staking_prefix.size() && std::equal(staking_prefix.begin(), staking_prefix.end(), data.begin())) {
+            isStaking = true;
+            std::copy(data.begin() + staking_prefix.size(), data.end(), hash.begin());
+            return CKeyID(hash);
+        }
+        // Script-hash-addresses have version 13 (or 19 testnet).
+        // The data vector contains RIPEMD160(SHA256(cscript)), where cscript is the serialized redemption script.
+        const std::vector<unsigned char>& script_prefix = params.Base58Prefix(CChainParams::SCRIPT_ADDRESS);
+        if (data.size() == hash.size() + script_prefix.size() && std::equal(script_prefix.begin(), script_prefix.end(), data.begin())) {
+            std::copy(data.begin() + script_prefix.size(), data.end(), hash.begin());
+            return CScriptID(hash);
+        }
+    }
+    return CNoDestination();
+}
+
 } // anon namespace
-
-bool CBitcoinAddress::Set(const CKeyID& id, const CChainParams::Base58Type addrType)
-{
-    SetData(Params().Base58Prefix(addrType), &id, 20);
-    return true;
-}
-
-bool CBitcoinAddress::Set(const CScriptID& id)
-{
-    SetData(Params().Base58Prefix(CChainParams::SCRIPT_ADDRESS), &id, 20);
-    return true;
-}
-
-bool CBitcoinAddress::Set(const CTxDestination& dest, const CChainParams::Base58Type addrType)
-{
-    return boost::apply_visitor(CBitcoinAddressVisitor(this, addrType), dest);
-}
-
-bool CBitcoinAddress::IsValid() const
-{
-    return IsValid(Params());
-}
-
-bool CBitcoinAddress::IsValid(const CChainParams& params) const
-{
-    bool fCorrectSize = vchData.size() == 20;
-    bool fKnownVersion = vchVersion == params.Base58Prefix(CChainParams::PUBKEY_ADDRESS) ||
-                         vchVersion == params.Base58Prefix(CChainParams::SCRIPT_ADDRESS) ||
-                         vchVersion == params.Base58Prefix(CChainParams::STAKING_ADDRESS);
-    return fCorrectSize && fKnownVersion;
-}
-
-CTxDestination CBitcoinAddress::Get() const
-{
-    if (!IsValid())
-        return CNoDestination();
-    uint160 id;
-    memcpy(&id, &vchData[0], 20);
-    if (vchVersion == Params().Base58Prefix(CChainParams::PUBKEY_ADDRESS) ||
-            vchVersion == Params().Base58Prefix(CChainParams::STAKING_ADDRESS))
-        return CKeyID(id);
-    else if (vchVersion == Params().Base58Prefix(CChainParams::SCRIPT_ADDRESS))
-        return CScriptID(id);
-    else
-        return CNoDestination();
-}
-
-bool CBitcoinAddress::IsStakingAddress() const
-{
-    bool fCorrectSize = vchData.size() == 20;
-    return fCorrectSize && vchVersion == Params().Base58Prefix(CChainParams::STAKING_ADDRESS);
-}
 
 CKey DecodeSecret(const std::string& str)
 {
@@ -365,13 +319,6 @@ std::string EncodeSecret(const CKey& key)
     return ret;
 }
 
-CTxDestination DestinationFor(const CKeyID& keyID, const CChainParams::Base58Type addrType)
-{
-    CBitcoinAddress addr(keyID, addrType);
-    if (!addr.IsValid()) throw std::runtime_error("Error, trying to decode an invalid keyID");
-    return addr.Get();
-}
-
 std::string EncodeDestination(const CTxDestination& dest, bool isStaking)
 {
     return EncodeDestination(dest, isStaking ? CChainParams::STAKING_ADDRESS : CChainParams::PUBKEY_ADDRESS);
@@ -379,36 +326,32 @@ std::string EncodeDestination(const CTxDestination& dest, bool isStaking)
 
 std::string EncodeDestination(const CTxDestination& dest, const CChainParams::Base58Type addrType)
 {
-    CBitcoinAddress addr(dest, addrType);
-    if (!addr.IsValid()) return "";
-    return addr.ToString();
+    return boost::apply_visitor(DestinationEncoder(Params(), addrType), dest);
 }
 
 CTxDestination DecodeDestination(const std::string& str)
 {
-    return CBitcoinAddress(str).Get();
+    bool isStaking;
+    return DecodeDestination(str, Params(), isStaking);
 }
 
 CTxDestination DecodeDestination(const std::string& str, bool& isStaking)
 {
-    CBitcoinAddress addr(str);
-    isStaking = addr.IsStakingAddress();
-    return addr.Get();
+    return DecodeDestination(str, Params(), isStaking);
 }
 
 bool IsValidDestinationString(const std::string& str, bool fStaking, const CChainParams& params)
 {
-    return IsValidDestinationString(str, fStaking);
+    bool isStaking = false;
+    return IsValidDestination(DecodeDestination(str, params, isStaking)) && (isStaking == fStaking);
 }
 
 bool IsValidDestinationString(const std::string& str)
 {
-    CBitcoinAddress address(str);
-    return address.IsValid();
+    return IsValidDestinationString(str, false, Params());
 }
 
 bool IsValidDestinationString(const std::string& str, bool isStaking)
 {
-    CBitcoinAddress address(str);
-    return address.IsValid() && (address.IsStakingAddress() == isStaking);
+    return IsValidDestinationString(str, isStaking, Params());
 }

--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -346,11 +346,6 @@ bool IsValidDestinationString(const std::string& str, bool fStaking, const CChai
     return IsValidDestination(DecodeDestination(str, params, isStaking)) && (isStaking == fStaking);
 }
 
-bool IsValidDestinationString(const std::string& str)
-{
-    return IsValidDestinationString(str, false, Params());
-}
-
 bool IsValidDestinationString(const std::string& str, bool isStaking)
 {
     return IsValidDestinationString(str, isStaking, Params());

--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -231,6 +231,42 @@ int CBase58Data::CompareTo(const CBase58Data& b58) const
 
 namespace
 {
+/** base58-encoded PIVX addresses.
+ * Public-key-hash-addresses have version 0 (or 111 testnet).
+ * The data vector contains RIPEMD160(SHA256(pubkey)), where pubkey is the serialized public key.
+ * Script-hash-addresses have version 5 (or 196 testnet).
+ * The data vector contains RIPEMD160(SHA256(cscript)), where cscript is the serialized redemption script.
+ */
+class CBitcoinAddress : public CBase58Data
+{
+public:
+    bool Set(const CKeyID& id, const CChainParams::Base58Type addrType = CChainParams::PUBKEY_ADDRESS);
+    bool Set(const CScriptID& id);
+    bool Set(const CTxDestination& dest, const CChainParams::Base58Type addrType = CChainParams::PUBKEY_ADDRESS);
+    bool IsValid() const;
+    bool IsValid(const CChainParams& params) const;
+
+    CBitcoinAddress() {}
+    CBitcoinAddress(const CTxDestination& dest, const CChainParams::Base58Type addrType = CChainParams::PUBKEY_ADDRESS) { Set(dest, addrType); }
+    CBitcoinAddress(const std::string& strAddress) { SetString(strAddress); }
+    CBitcoinAddress(const char* pszAddress) { SetString(pszAddress); }
+
+    CTxDestination Get() const;
+    bool GetKeyID(CKeyID& keyID) const;
+    bool IsScript() const;
+    bool IsStakingAddress() const;
+
+
+    // Helpers
+    static const CBitcoinAddress newCSInstance(const CTxDestination& dest) {
+        return CBitcoinAddress(dest, CChainParams::STAKING_ADDRESS);
+    }
+
+    static const CBitcoinAddress newInstance(const CTxDestination& dest) {
+        return CBitcoinAddress(dest, CChainParams::PUBKEY_ADDRESS);
+    }
+};
+
 class CBitcoinAddressVisitor : public boost::static_visitor<bool>
 {
 private:

--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -252,8 +252,6 @@ public:
     CBitcoinAddress(const char* pszAddress) { SetString(pszAddress); }
 
     CTxDestination Get() const;
-    bool GetKeyID(CKeyID& keyID) const;
-    bool IsScript() const;
     bool IsStakingAddress() const;
 
 
@@ -330,24 +328,6 @@ CTxDestination CBitcoinAddress::Get() const
         return CScriptID(id);
     else
         return CNoDestination();
-}
-
-bool CBitcoinAddress::GetKeyID(CKeyID& keyID) const
-{
-    if (!IsValid() ||
-            (vchVersion != Params().Base58Prefix(CChainParams::PUBKEY_ADDRESS) &&
-            vchVersion != Params().Base58Prefix(CChainParams::STAKING_ADDRESS)))
-        return false;
-    uint160 id;
-    memcpy(&id, &vchData[0], 20);
-    keyID = CKeyID(id);
-    return true;
-}
-
-bool CBitcoinAddress::IsScript() const
-{
-    bool fCorrectSize = vchData.size() == 20;
-    return fCorrectSize && vchVersion == Params().Base58Prefix(CChainParams::SCRIPT_ADDRESS);
 }
 
 bool CBitcoinAddress::IsStakingAddress() const

--- a/src/base58.h
+++ b/src/base58.h
@@ -18,7 +18,6 @@
 #include "chainparams.h"
 #include "key.h"
 #include "pubkey.h"
-#include "script/script.h"
 #include "script/standard.h"
 
 #include <string>
@@ -141,7 +140,6 @@ typedef CBitcoinExtKeyBase<CExtKey, BIP32_EXTKEY_SIZE, CChainParams::EXT_SECRET_
 typedef CBitcoinExtKeyBase<CExtPubKey, BIP32_EXTKEY_SIZE, CChainParams::EXT_PUBLIC_KEY> CBitcoinExtPubKey;
 
 
-CTxDestination DestinationFor(const CKeyID& keyID, const CChainParams::Base58Type addrType);
 std::string EncodeDestination(const CTxDestination& dest, bool isStaking);
 std::string EncodeDestination(const CTxDestination& dest, const CChainParams::Base58Type addrType = CChainParams::PUBKEY_ADDRESS);
 // DecodeDestinationisStaking flag is set to true when the string arg is from an staking address

--- a/src/base58.h
+++ b/src/base58.h
@@ -101,42 +101,6 @@ public:
     bool operator>(const CBase58Data& b58) const { return CompareTo(b58) > 0; }
 };
 
-/** base58-encoded PIVX addresses.
- * Public-key-hash-addresses have version 0 (or 111 testnet).
- * The data vector contains RIPEMD160(SHA256(pubkey)), where pubkey is the serialized public key.
- * Script-hash-addresses have version 5 (or 196 testnet).
- * The data vector contains RIPEMD160(SHA256(cscript)), where cscript is the serialized redemption script.
- */
-class CBitcoinAddress : public CBase58Data
-{
-public:
-    bool Set(const CKeyID& id, const CChainParams::Base58Type addrType = CChainParams::PUBKEY_ADDRESS);
-    bool Set(const CScriptID& id);
-    bool Set(const CTxDestination& dest, const CChainParams::Base58Type addrType = CChainParams::PUBKEY_ADDRESS);
-    bool IsValid() const;
-    bool IsValid(const CChainParams& params) const;
-
-    CBitcoinAddress() {}
-    CBitcoinAddress(const CTxDestination& dest, const CChainParams::Base58Type addrType = CChainParams::PUBKEY_ADDRESS) { Set(dest, addrType); }
-    CBitcoinAddress(const std::string& strAddress) { SetString(strAddress); }
-    CBitcoinAddress(const char* pszAddress) { SetString(pszAddress); }
-
-    CTxDestination Get() const;
-    bool GetKeyID(CKeyID& keyID) const;
-    bool IsScript() const;
-    bool IsStakingAddress() const;
-
-
-    // Helpers
-    static const CBitcoinAddress newCSInstance(const CTxDestination& dest) {
-        return CBitcoinAddress(dest, CChainParams::STAKING_ADDRESS);
-    }
-
-    static const CBitcoinAddress newInstance(const CTxDestination& dest) {
-        return CBitcoinAddress(dest, CChainParams::PUBKEY_ADDRESS);
-    }
-};
-
 CKey DecodeSecret(const std::string& str);
 std::string EncodeSecret(const CKey& key);
 

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -383,7 +383,7 @@ void PaymentServer::handleURIOrFile(const QString& s)
         {
             SendCoinsRecipient recipient;
             if (GUIUtil::parseBitcoinURI(s, &recipient)) {
-                if (!IsValidDestinationString(recipient.address.toStdString())) {
+                if (!IsValidDestinationString(recipient.address.toStdString(), false, Params())) {
                     Q_EMIT message(tr("URI handling"), tr("Invalid payment address %1").arg(recipient.address),
                         CClientUIInterface::MSG_ERROR);
                 } else

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -193,11 +193,9 @@ void PaymentServer::ipcParseCommandLine(int argc, char* argv[])
 
             SendCoinsRecipient r;
             if (GUIUtil::parseBitcoinURI(arg, &r) && !r.address.isEmpty()) {
-                CBitcoinAddress address(r.address.toStdString());
-
-                if (address.IsValid(Params(CBaseChainParams::MAIN))) {
+                if (IsValidDestinationString(r.address.toStdString(), false, Params(CBaseChainParams::MAIN))) {
                     SelectParams(CBaseChainParams::MAIN);
-                } else if (address.IsValid(Params(CBaseChainParams::TESTNET))) {
+                } else if (IsValidDestinationString(r.address.toStdString(), false, Params(CBaseChainParams::TESTNET))) {
                     SelectParams(CBaseChainParams::TESTNET);
                 }
             }
@@ -385,8 +383,7 @@ void PaymentServer::handleURIOrFile(const QString& s)
         {
             SendCoinsRecipient recipient;
             if (GUIUtil::parseBitcoinURI(s, &recipient)) {
-                CBitcoinAddress address(recipient.address.toStdString());
-                if (!address.IsValid()) {
+                if (!IsValidDestinationString(recipient.address.toStdString())) {
                     Q_EMIT message(tr("URI handling"), tr("Invalid payment address %1").arg(recipient.address),
                         CClientUIInterface::MSG_ERROR);
                 } else
@@ -505,7 +502,7 @@ bool PaymentServer::processPaymentRequest(PaymentRequestPlus& request, SendCoins
         CTxDestination dest;
         if (ExtractDestination(sendingTo.first, dest)) {
             // Append destination address
-            addresses.append(QString::fromStdString(CBitcoinAddress(dest).ToString()));
+            addresses.append(QString::fromStdString(EncodeDestination(dest)));
         } else if (!recipient.authenticatedMerchant.isEmpty()) {
             // Insecure payments to custom pivx addresses are not supported
             // (there is no good way to tell the user where they are paying in a way

--- a/src/qt/pivx/settings/settingsmultisendwidget.cpp
+++ b/src/qt/pivx/settings/settingsmultisendwidget.cpp
@@ -337,7 +337,7 @@ void SettingsMultisendWidget::activate()
         strRet = tr("Unable to activate MultiSend, no available recipients");
     else if (!(ui->checkBoxStake->isChecked() || ui->checkBoxRewards->isChecked())) {
         strRet = tr("Unable to activate MultiSend\nCheck one or both of the check boxes to send on stake and/or masternode rewards");
-    } else if (IsValidDestinationString(pwalletMain->vMultiSend[0].first)) {
+    } else if (IsValidDestinationString(pwalletMain->vMultiSend[0].first, false, Params())) {
         pwalletMain->fMultiSendStake = ui->checkBoxStake->isChecked();
         pwalletMain->fMultiSendMasternodeReward = ui->checkBoxRewards->isChecked();
 

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -263,12 +263,12 @@ public:
     bool whitelistAddressFromColdStaking(const QString &addressStr);
     bool blacklistAddressFromColdStaking(const QString &address);
     bool updateAddressBookPurpose(const QString &addressStr, const std::string& purpose);
-    std::string getLabelForAddress(const CBitcoinAddress& address);
-    bool getKeyId(const CBitcoinAddress& address, CKeyID& keyID);
+    std::string getLabelForAddress(const CTxDestination& address);
+    bool getKeyId(const CTxDestination& address, CKeyID& keyID);
 
     bool isMine(const CTxDestination& address);
     bool isMine(const QString& addressStr);
-    bool isUsed(CBitcoinAddress address);
+    bool isUsed(CTxDestination address);
     void getOutputs(const std::vector<COutPoint>& vOutpoints, std::vector<COutput>& vOutputs);
     bool getMNCollateralCandidate(COutPoint& outPoint);
     bool isSpent(const COutPoint& outpoint) const;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1238,7 +1238,7 @@ UniValue getserials(const UniValue& params, bool fHelp) {
                     if (!ExtractDestinations(tx.vout[0].scriptPubKey, type, addresses, nRequired)) {
                         spentTo = strprintf("type: %d", GetTxnOutputType(type));
                     } else {
-                        spentTo = CBitcoinAddress(addresses[0]).ToString();
+                        spentTo = EncodeDestination(addresses[0]);
                     }
                 }
             }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -132,7 +132,7 @@ PairResult CWallet::getNewAddress(CTxDestination& ret, const std::string address
     if (!SetAddressBook(keyID, addressLabel, purpose))
         throw std::runtime_error("CWallet::getNewAddress() : SetAddressBook failed");
 
-    ret = DestinationFor(keyID, addrType);
+    ret = CTxDestination(keyID);
     return PairResult(true);
 }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -362,7 +362,7 @@ public:
     //! >> Available coins (P2CS)
     void GetAvailableP2CSCoins(std::vector<COutput>& vCoins) const;
 
-    std::map<CBitcoinAddress, std::vector<COutput> > AvailableCoinsByAddress(bool fConfirmed = true, CAmount maxCoinValue = 0);
+    std::map<CTxDestination, std::vector<COutput> > AvailableCoinsByAddress(bool fConfirmed = true, CAmount maxCoinValue = 0);
 
     /// Get 10000 PIV output and keys which can be used for the Masternode
     bool GetMasternodeVinAndKeys(CTxIn& txinRet, CPubKey& pubKeyRet, CKey& keyRet, std::string strTxHash = "", std::string strOutputIndex = "");
@@ -383,7 +383,7 @@ public:
     PairResult getNewAddress(CTxDestination& ret, std::string label);
     PairResult getNewStakingAddress(CTxDestination& ret, std::string label);
     int64_t GetKeyCreationTime(CPubKey pubkey);
-    int64_t GetKeyCreationTime(const CBitcoinAddress& address);
+    int64_t GetKeyCreationTime(const CTxDestination& address);
 
     //! Adds a key to the store, and saves it to disk.
     bool AddKeyPubKey(const CKey& key, const CPubKey& pubkey);
@@ -529,7 +529,7 @@ public:
     bool GetBudgetSystemCollateralTX(CWalletTx& tx, uint256 hash, bool useIX);
     bool GetBudgetFinalizationCollateralTX(CWalletTx& tx, uint256 hash, bool useIX); // Only used for budget finalization
 
-    bool IsUsed(const CBitcoinAddress address) const;
+    bool IsUsed(const CTxDestination address) const;
 
     isminetype IsMine(const CTxIn& txin) const;
     CAmount GetDebit(const CTxIn& txin, const isminefilter& filter) const;
@@ -548,7 +548,7 @@ public:
     DBErrors LoadWallet(bool& fFirstRunRet);
     DBErrors ZapWalletTx(std::vector<CWalletTx>& vWtx);
 
-    static CBitcoinAddress ParseIntoAddress(const CTxDestination& dest, const std::string& purpose);
+    static std::string ParseIntoAddress(const CTxDestination& dest, const std::string& purpose);
 
     bool SetAddressBook(const CTxDestination& address, const std::string& strName, const std::string& purpose);
     bool DelAddressBook(const CTxDestination& address, const CChainParams::Base58Type addrType = CChainParams::PUBKEY_ADDRESS);
@@ -618,7 +618,7 @@ public:
             const CCoinControl* coinControl = NULL);
 
     // - ZC PublicSpends
-    bool SpendZerocoin(CAmount nAmount, CWalletTx& wtxNew, CZerocoinSpendReceipt& receipt, std::vector<CZerocoinMint>& vMintsSelected, std::list<std::pair<CTxDestination,CAmount>> addressesTo, CBitcoinAddress* changeAddress = nullptr);
+    bool SpendZerocoin(CAmount nAmount, CWalletTx& wtxNew, CZerocoinSpendReceipt& receipt, std::vector<CZerocoinMint>& vMintsSelected, std::list<std::pair<CTxDestination,CAmount>> addressesTo, CTxDestination* changeAddress = nullptr);
     bool MintsToInputVectorPublicSpend(std::map<CBigNum, CZerocoinMint>& mapMintsSelected, const uint256& hashTxOut, std::vector<CTxIn>& vin, CZerocoinSpendReceipt& receipt, libzerocoin::SpendType spendType, CBlockIndex* pindexCheckpoint = nullptr);
     bool CreateZCPublicSpendTransaction(
             CAmount nValue,
@@ -628,7 +628,7 @@ public:
             std::vector<CZerocoinMint>& vSelectedMints,
             std::vector<CDeterministicMint>& vNewMints,
             std::list<std::pair<CTxDestination,CAmount>> addressesTo,
-            CBitcoinAddress* changeAddress = nullptr);
+            CTxDestination* changeAddress = nullptr);
 
     // - ZC Balances
     CAmount GetZerocoinBalance(bool fMatureOnly) const;

--- a/src/wallet/wallet_zerocoin.cpp
+++ b/src/wallet/wallet_zerocoin.cpp
@@ -293,7 +293,7 @@ bool CWallet::CreateZerocoinMintTransaction(const CAmount nValue,
 // - ZC PublicSpends
 
 bool CWallet::SpendZerocoin(CAmount nAmount, CWalletTx& wtxNew, CZerocoinSpendReceipt& receipt, std::vector<CZerocoinMint>& vMintsSelected,
-        std::list<std::pair<CTxDestination, CAmount>> addressesTo, CBitcoinAddress* changeAddress)
+        std::list<std::pair<CTxDestination, CAmount>> addressesTo, CTxDestination* changeAddress)
 {
     // Default: assume something goes wrong. Depending on the problem this gets more specific below
     int nStatus = ZPIV_SPEND_ERROR;
@@ -454,7 +454,7 @@ bool CWallet::CreateZCPublicSpendTransaction(
         std::vector<CZerocoinMint>& vSelectedMints,
         std::vector<CDeterministicMint>& vNewMints,
         std::list<std::pair<CTxDestination,CAmount>> addressesTo,
-        CBitcoinAddress* changeAddress)
+        CTxDestination * changeAddress)
 {
     // Check available funds
     int nStatus = ZPIV_TRX_FUNDS_PROBLEMS;
@@ -622,7 +622,7 @@ bool CWallet::CreateZCPublicSpendTransaction(
                 CScript scriptChange;
                 // Change address
                 if(changeAddress){
-                    scriptChange = GetScriptForDestination(changeAddress->Get());
+                    scriptChange = GetScriptForDestination(*changeAddress);
                 } else {
                     // Reserve a new key pair from key pool
                     CPubKey vchPubKey;


### PR DESCRIPTION
Finished the complete removal of the base58 address class from the sources, migrated to the destination wrapper.

Plus includes bitcoin#11117 - last commit - and bitcoin#11259 as an extra.