### PR TITLE
[Build] Set complete cpp/cxx flags for bench_pivx binary

### DIFF
--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -15,7 +15,8 @@ bench_bench_pivx_SOURCES = \
   bench/perf.h \
   bench/prevector_destructor.cpp
 
-bench_bench_pivx_CPPFLAGS = $(BITCOIN_INCLUDES) $(EVENT_CLFAGS) $(EVENT_PTHREADS_CFLAGS) -I$(builddir)/bench/
+bench_bench_pivx_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(EVENT_CFLAGS) $(EVENT_PTHREADS_CFLAGS) -I$(builddir)/bench/
+bench_bench_pivx_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 bench_bench_pivx_LDADD = \
   $(LIBBITCOIN_SERVER) \
   $(LIBBITCOIN_COMMON) \


### PR DESCRIPTION
Follows suit with the rest of our binary targets and prevents a
relocation error when linking on some architectures.