### PR TITLE
[GUI] Add missing QPainterPath include

### DIFF
--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -8,6 +8,7 @@
 
 #include <QColor>
 #include <QPainter>
+#include <QPainterPath>
 #include <QTimer>
 
 #include <cmath>


### PR DESCRIPTION
Qt 5.15 no longer implicitly includes QPainterPath, so explicitly
include it here.