### PR TITLE
[Travis] Bump macOS CMake target image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -238,7 +238,7 @@ jobs:
     - stage: cmake
       name: 'CMake macOS'
       os: osx
-      osx_image: xcode10.2
+      osx_image: xcode11.1
       language: cpp
       compiler:
         - clang
@@ -261,9 +261,7 @@ jobs:
             - libevent
             - qrencode
             - gmp
-#         Set 'update: true' below until TravisCI updates their macOS build images.
-#         See https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296/16
-          update: true
+          update: false
       before_install:
       install:
       before_script:


### PR DESCRIPTION
A previous bug in the TravisCI macOS images required us to force a full
homebrew update rather than rely on pre-existing package versions.
TravisCI has now updated their macOS images to fix the bug, but only for
11.x+ versions.

Further, by doing a full homebrew update, the test environment updated
to the most recent Qt 5.15 version, which we do not yet fully support (#1683 fixes this),
and was causing the build to fail.

We can go with the 11.1 image and revert to `update: false` for now,
which gives us Qt 5.14.1.