### PR TITLE
[GUI] TopBar navigation (sync/peers)

### DIFF
--- a/src/qt/pivx/pivxgui.cpp
+++ b/src/qt/pivx/pivxgui.cpp
@@ -502,6 +502,13 @@ void PIVXGUI::goToSettings(){
     showTop(settingsWidget);
 }
 
+void PIVXGUI::goToSettingsInfo()
+{
+    navMenu->selectSettings();
+    settingsWidget->showInformation();
+    goToSettings();
+}
+
 void PIVXGUI::goToReceive()
 {
     showTop(receiveWidget);

--- a/src/qt/pivx/pivxgui.cpp
+++ b/src/qt/pivx/pivxgui.cpp
@@ -514,6 +514,11 @@ void PIVXGUI::goToReceive()
     showTop(receiveWidget);
 }
 
+void PIVXGUI::openNetworkMonitor()
+{
+    settingsWidget->openNetworkMonitor();
+}
+
 void PIVXGUI::showTop(QWidget* view)
 {
     if (stackedContainer->currentWidget() != view) {

--- a/src/qt/pivx/pivxgui.h
+++ b/src/qt/pivx/pivxgui.h
@@ -68,6 +68,7 @@ public Q_SLOTS:
     void goToMasterNodes();
     void goToColdStaking();
     void goToSettings();
+    void goToSettingsInfo();
 
     void connectActions();
 

--- a/src/qt/pivx/pivxgui.h
+++ b/src/qt/pivx/pivxgui.h
@@ -69,6 +69,7 @@ public Q_SLOTS:
     void goToColdStaking();
     void goToSettings();
     void goToSettingsInfo();
+    void openNetworkMonitor();
 
     void connectActions();
 

--- a/src/qt/pivx/settings/settingsinformationwidget.h
+++ b/src/qt/pivx/settings/settingsinformationwidget.h
@@ -27,6 +27,8 @@ private Q_SLOTS:
     void setNumConnections(int count);
     void setNumBlocks(int count);
     void setMasternodeCount(const QString& strMasternodes);
+
+public Q_SLOTS:
     void openNetworkMonitor();
 
 private:

--- a/src/qt/pivx/settings/settingswidget.cpp
+++ b/src/qt/pivx/settings/settingswidget.cpp
@@ -367,6 +367,14 @@ void SettingsWidget::showDebugConsole()
     onDebugConsoleClicked();
 }
 
+void SettingsWidget::showInformation()
+{
+    ui->pushButtonTools->setChecked(true);
+    onToolsClicked();
+    ui->pushButtonTools1->setChecked(true);
+    onInformationClicked();
+}
+
 void SettingsWidget::onDebugConsoleClicked()
 {
     ui->stackedWidgetContainer->setCurrentWidget(settingsConsoleWidget);

--- a/src/qt/pivx/settings/settingswidget.cpp
+++ b/src/qt/pivx/settings/settingswidget.cpp
@@ -403,6 +403,11 @@ void SettingsWidget::onAboutClicked()
 
 }
 
+void SettingsWidget::openNetworkMonitor()
+{
+    settingsInformationWidget->openNetworkMonitor();
+}
+
 void SettingsWidget::selectOption(QPushButton* option)
 {
     for (QPushButton* wid : options) {

--- a/src/qt/pivx/settings/settingswidget.h
+++ b/src/qt/pivx/settings/settingswidget.h
@@ -41,6 +41,7 @@ public:
     void loadWalletModel() override;
     void setMapper();
     void showDebugConsole();
+    void showInformation();
 
 Q_SIGNALS:
     /** Get restart command-line parameters and handle restart */
@@ -75,7 +76,6 @@ private Q_SLOTS:
     // Help
     void onHelpClicked();
     void onAboutClicked();
-
     void onResetAction();
     void onSaveOptionsClicked();
 

--- a/src/qt/pivx/settings/settingswidget.h
+++ b/src/qt/pivx/settings/settingswidget.h
@@ -42,6 +42,7 @@ public:
     void setMapper();
     void showDebugConsole();
     void showInformation();
+    void openNetworkMonitor();
 
 Q_SIGNALS:
     /** Get restart command-line parameters and handle restart */

--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -126,6 +126,7 @@ TopBar::TopBar(PIVXGUI* _mainWindow, QWidget *parent) :
     connect(ui->pushButtonSync, &ExpandableButton::Mouse_HoverLeave, this, &TopBar::refreshProgressBarSize);
     connect(ui->pushButtonSync, &ExpandableButton::Mouse_Hover, this, &TopBar::refreshProgressBarSize);
     connect(ui->pushButtonSync, &ExpandableButton::Mouse_Pressed, [this](){window->goToSettingsInfo();});
+    connect(ui->pushButtonConnection, &ExpandableButton::Mouse_Pressed, [this](){window->openNetworkMonitor();});
 }
 
 void TopBar::onThemeClicked()

--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -125,6 +125,7 @@ TopBar::TopBar(PIVXGUI* _mainWindow, QWidget *parent) :
     connect(ui->pushButtonColdStaking, &ExpandableButton::Mouse_Pressed, this, &TopBar::onColdStakingClicked);
     connect(ui->pushButtonSync, &ExpandableButton::Mouse_HoverLeave, this, &TopBar::refreshProgressBarSize);
     connect(ui->pushButtonSync, &ExpandableButton::Mouse_Hover, this, &TopBar::refreshProgressBarSize);
+    connect(ui->pushButtonSync, &ExpandableButton::Mouse_Pressed, [this](){window->goToSettingsInfo();});
 }
 
 void TopBar::onThemeClicked()
@@ -145,7 +146,6 @@ void TopBar::onThemeClicked()
 
     Q_EMIT themeChanged(lightTheme);
 }
-
 
 void TopBar::onBtnLockClicked()
 {


### PR DESCRIPTION
Adds two features for easier navigation:
- go directly to the information panel (showing latest block num and hash) when clicking on the "sync" (double arrow) button of the top bar
- open directly the network monitor when clicking on the network button of the top bar.

Closes #1685 