### PR TITLE
[BUG][GUI] check for available "unlocked" balance in prepareTransaction

### DIFF
--- a/src/qt/pivx/guitransactionsutils.cpp
+++ b/src/qt/pivx/guitransactionsutils.cpp
@@ -25,11 +25,11 @@ namespace GuiTransactionsUtils {
                 retStr = parent->translate("The amount to pay must be larger than 0.");
                 break;
             case WalletModel::AmountExceedsBalance:
-                retStr = parent->translate("The amount exceeds your balance.");
+                retStr = parent->translate("The amount to pay exceeds the available balance.");
                 break;
             case WalletModel::AmountWithFeeExceedsBalance:
                 retStr = parent->translate(
-                        "The total exceeds your balance when the %1 transaction fee is included.").arg(msgArg);
+                        "The total amount to pay exceeds the available balance when the %1 transaction fee is included.").arg(msgArg);
                 break;
             case WalletModel::DuplicateAddress:
                 retStr = parent->translate(

--- a/src/qt/pivx/send.cpp
+++ b/src/qt/pivx/send.cpp
@@ -134,9 +134,9 @@ void SendWidget::refreshAmounts()
         totalAmount = walletModel->getBalance(CoinControlDialog::coinControl) - total;
         ui->labelTitleTotalRemaining->setText(tr("Total remaining from the selected UTXO"));
     } else {
-        // Wallet's balance
-        totalAmount = walletModel->getBalance(nullptr, fDelegationsChecked) - total;
-        ui->labelTitleTotalRemaining->setText(tr("Total remaining"));
+        // Wallet's unlocked balance
+        totalAmount = walletModel->getUnlockedBalance(nullptr, fDelegationsChecked) - total;
+        ui->labelTitleTotalRemaining->setText(tr("Unlocked remaining"));
     }
     ui->labelAmountRemaining->setText(
             GUIUtil::formatBalance(

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -98,20 +98,27 @@ bool WalletModel::upgradeWallet(std::string& upgradeError)
     return wallet->Upgrade(upgradeError, prev_version);
 }
 
-CAmount WalletModel::getBalance(const CCoinControl* coinControl, bool fIncludeDelegated) const
+CAmount WalletModel::getBalance(const CCoinControl* coinControl, bool fIncludeDelegated, bool fUnlockedOnly) const
 {
     if (coinControl) {
         CAmount nBalance = 0;
         std::vector<COutput> vCoins;
         wallet->AvailableCoins(&vCoins, coinControl, fIncludeDelegated);
-        for (const COutput& out : vCoins)
-            if (out.fSpendable)
+        for (const COutput& out : vCoins) {
+            bool fSkip = fUnlockedOnly && isLockedCoin(out.tx->GetHash(), out.i);
+            if (out.fSpendable && !fSkip)
                 nBalance += out.tx->vout[out.i].nValue;
+        }
 
         return nBalance;
     }
 
-    return wallet->GetBalance(fIncludeDelegated);
+    return wallet->GetBalance(fIncludeDelegated) - (fUnlockedOnly ? wallet->GetLockedCoins() : CAmount(0));
+}
+
+CAmount WalletModel::getUnlockedBalance(const CCoinControl* coinControl, bool fIncludeDelegated) const
+{
+    return getBalance(coinControl, fIncludeDelegated, true);
 }
 
 CAmount WalletModel::getMinColdStakingAmount() const
@@ -471,9 +478,9 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
         return DuplicateAddress;
     }
 
-    CAmount nBalance = getBalance(coinControl, fIncludeDelegations);
+    CAmount nSpendableBalance = getUnlockedBalance(coinControl, fIncludeDelegations);
 
-    if (total > nBalance) {
+    if (total > nSpendableBalance) {
         return AmountExceedsBalance;
     }
 
@@ -513,7 +520,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
         }
 
         if (!fCreated) {
-            if ((total + nFeeRequired) > nBalance) {
+            if ((total + nFeeRequired) > nSpendableBalance) {
                 return SendCoinsReturn(AmountWithFeeExceedsBalance);
             }
 

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -151,7 +151,8 @@ public:
     bool isHDEnabled() const;
     bool upgradeWallet(std::string& upgradeError);
 
-    CAmount getBalance(const CCoinControl* coinControl = nullptr, bool fIncludeDelegated = true) const;
+    CAmount getBalance(const CCoinControl* coinControl = nullptr, bool fIncludeDelegated = true, bool fUnlockedOnly = false) const;
+    CAmount getUnlockedBalance(const CCoinControl* coinControl = nullptr, bool fIncludeDelegated = true) const;
     CAmount getUnconfirmedBalance() const;
     CAmount getImmatureBalance() const;
     CAmount getLockedBalance() const;


### PR DESCRIPTION
If the user tries to send an amount exceeding his balance, the wallet correctly returns the error related to `AmountExceedsBalance` or `AmountWithFeeExceedsBalance`.
Although, if the wallet has enough coins, but some of them are locked, the transaction preparation will fail, without giving a specific reason.
This happens because `prepareTransaction` checks the amount to send against the total wallet's balance (without excluding locked coins if any).
We fix this introducing a `getUnlockedBalance()` function in the model, and using it in `prepareTransaction`.

Similarly, in the Send Widget, the "total remaining" shows the wallet's balance (locked + unlocked), therefore the transaction might fail if the user tries to send it all, while having locked coins.
We will use the new `getUnlockedBalnce()` here too and fix the label (when there is no coin selected via coin control).
