### PR TITLE
[BUG][GUI] refresh CoinControl state in CoinControlDialog 

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -140,12 +140,6 @@ CoinControlDialog::CoinControlDialog(QWidget* parent, bool _forDelegation) : QDi
     connect(ui->pushButtonDust, &QPushButton::clicked, this, &CoinControlDialog::clipboardLowOutput);
     connect(ui->pushButtonChange, &QPushButton::clicked, this, &CoinControlDialog::clipboardChange);
 
-    if (ui->pushButtonSelectAll->isChecked()) {
-        ui->pushButtonSelectAll->setText(tr("Unselect all"));
-    } else {
-        ui->pushButtonSelectAll->setText(tr("Select all"));
-    }
-
     // toggle tree/list mode
     connect(ui->radioTreeMode, &QRadioButton::toggled, this, &CoinControlDialog::radioTreeMode);
     connect(ui->radioListMode, &QRadioButton::toggled, this, &CoinControlDialog::radioListMode);
@@ -195,6 +189,8 @@ CoinControlDialog::CoinControlDialog(QWidget* parent, bool _forDelegation) : QDi
     }
     if (settings.contains("nCoinControlSortColumn") && settings.contains("nCoinControlSortOrder"))
         sortView(settings.value("nCoinControlSortColumn").toInt(), ((Qt::SortOrder)settings.value("nCoinControlSortOrder").toInt()));
+
+    updateDialogLabels();
 }
 
 CoinControlDialog::~CoinControlDialog()

--- a/src/qt/pivx/coldstakingwidget.cpp
+++ b/src/qt/pivx/coldstakingwidget.cpp
@@ -228,6 +228,12 @@ void ColdStakingWidget::loadWalletModel()
 
 }
 
+void ColdStakingWidget::showEvent(QShowEvent *event)
+{
+    // Check coin control (as it might have been updated elsewhere)
+    ui->btnCoinControl->setActive(CoinControlDialog::coinControl->HasSelected());
+}
+
 void ColdStakingWidget::onTxArrived(const QString& hash, const bool& isCoinStake, const bool& isCSAnyType)
 {
     if (isCSAnyType) {

--- a/src/qt/pivx/coldstakingwidget.h
+++ b/src/qt/pivx/coldstakingwidget.h
@@ -51,6 +51,9 @@ public:
 public Q_SLOTS:
     void walletSynced(bool sync);
 
+protected:
+    void showEvent(QShowEvent *event) override;
+
 private Q_SLOTS:
     void changeTheme(bool isLightTheme, QString &theme) override;
     void handleAddressClicked(const QModelIndex &index);

--- a/src/qt/pivx/send.cpp
+++ b/src/qt/pivx/send.cpp
@@ -287,8 +287,11 @@ void SendWidget::showEvent(QShowEvent *event)
     CAmount cachedDelegatedBalance_new = walletModel->getDelegatedBalance();
     if (cachedDelegatedBalance != cachedDelegatedBalance_new) {
         cachedDelegatedBalance = cachedDelegatedBalance_new;
-        refreshAmounts();
     }
+
+    // Check coin control (as it might have been updated elsewhere)
+    ui->btnCoinControl->setActive(CoinControlDialog::coinControl->HasSelected());
+    refreshAmounts();
 }
 
 void SendWidget::setFocusOnLastEntry()


### PR DESCRIPTION
Triggered by @CaveSpectre11's comment [here](https://github.com/PIVX-Project/PIVX/pull/1612#pullrequestreview-408695334).

> if you want to play around, go into coin control in the send page, then out and into coin control in the delegation page, and you'll see different states (i.e. one will be highlighted like there's selections, the other won't, even though there is selected UTXOs).

Based on top of
- [x] #1612 

The SendWidget and ColdstakingWidget have two independent CoinControlDialogs which share the same CoinControl object.
This creates inconsistencies, as the coin selection is carried over from one widget to another (e.g. selecting coins in the SendWidget and then going to the ColdstakingWidget), but some feedback is not updated in the dialog:
- the toggle state of the "Select All" button is not changed
- the active state of btnCoinControl is not updated (this can be very confusing for the user, as it might seem that he has no coin selected in coincontrol, while instead he has, or vice versa).

We fix the first issue updating the dialog labels in the constructor of CoinControlDialog, and the second issue checking if coinControl has any selection (and updating btnCoinControl active state) during the show event of each widget.

