### PR TITLE
[Backport] Test LowS in standardness, removes nuisance malleability vector

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -32,7 +32,8 @@ static const unsigned int STANDARD_SCRIPT_VERIFY_FLAGS = MANDATORY_SCRIPT_VERIFY
                                                          SCRIPT_VERIFY_STRICTENC |
                                                          SCRIPT_VERIFY_MINIMALDATA |
                                                          SCRIPT_VERIFY_NULLDUMMY |
-                                                         SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS;
+                                                         SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS |
+                                                         SCRIPT_VERIFY_LOW_S;
 
 /** For convenience, standard but not mandatory verify flags. */
 static const unsigned int STANDARD_NOT_MANDATORY_VERIFY_FLAGS = STANDARD_SCRIPT_VERIFY_FLAGS & ~MANDATORY_SCRIPT_VERIFY_FLAGS;


### PR DESCRIPTION
On top of #1693 (only last commit matter for this PR).

Lot of fruitful information can be found in bitcoin#6769 .

> This adds SCRIPT_VERIFY_LOW_S to STANDARD_SCRIPT_VERIFY_FLAGS which
> will make the node require the canonical 'low-s' encoding for
> ECDSA signatures when relaying or mining.

> Absent this kind of test ECDSA is not a strong signature as given
> a valid signature {r, s} both that value and {r, -s mod n} are valid.
> These two encodings have different hashes allowing third parties a
> vector to change users txids. These attacks are avoided by picking
> a particular form as canonical and rejecting the other form(s); in
> the of the LOW_S rule, the smaller of the two possible S values is
> used.
