### PR TITLE
[Wallet] Abandon tx in CommitTransaction if ATMP fails

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -950,7 +950,7 @@ CAmount GetMinRelayFee(const CTransaction& tx, const CTxMemPool& pool, unsigned 
 }
 
 /** Convert CValidationState to a human-readable message for logging */
-static std::string FormatStateMessage(const CValidationState &state)
+std::string FormatStateMessage(const CValidationState &state)
 {
     return strprintf("%s%s (code %i)",
         state.GetRejectReason(),

--- a/src/main.h
+++ b/src/main.h
@@ -253,6 +253,9 @@ bool AcceptableInputs(CTxMemPool& pool, CValidationState& state, const CTransact
 int GetInputAge(CTxIn& vin);
 int GetIXConfirmations(uint256 nTXHash);
 
+/** Convert CValidationState to a human-readable message for logging */
+std::string FormatStateMessage(const CValidationState &state);
+
 struct CNodeStateStats {
     int nMisbehavior;
     int nSyncHeight;

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -213,7 +213,9 @@ void CBudgetManager::SubmitFinalBudget()
         // Get our change address
         CReserveKey reservekey(pwalletMain);
         // Send the tx to the network. Do NOT use SwiftTx, locking might need too much time to propagate, especially for testnet
-        pwalletMain->CommitTransaction(wtx, reservekey, "NO-ix");
+        const CWallet::CommitResult& res = pwalletMain->CommitTransaction(wtx, reservekey, "NO-ix");
+        if (res.status != CWallet::CommitStatus::OK)
+            return;
         tx = (CTransaction)wtx;
         txidCollateral = tx.GetHash();
         mapCollateralTxids.insert(std::make_pair(tempBudget.GetHash(), txidCollateral));

--- a/src/qt/pivx/guitransactionsutils.cpp
+++ b/src/qt/pivx/guitransactionsutils.cpp
@@ -15,8 +15,8 @@ namespace GuiTransactionsUtils {
         QString retStr;
         informType = CClientUIInterface::MSG_WARNING;
         // This comment is specific to SendCoinsDialog usage of WalletModel::SendCoinsReturn.
-        // WalletModel::TransactionCommitFailed is used only in WalletModel::sendCoins()
-        // all others are used only in WalletModel::prepareTransaction()
+        // WalletModel::TransactionCheckFailed and WalletModel::TransactionCommitFailed
+        // are used only in WalletModel::sendCoins(). All others are used only in WalletModel::prepareTransaction()
         switch (sendCoinsReturn.status) {
             case WalletModel::InvalidAddress:
                 retStr = parent->translate("The recipient address is not valid, please recheck.");
@@ -38,9 +38,12 @@ namespace GuiTransactionsUtils {
             case WalletModel::TransactionCreationFailed:
                 informType = CClientUIInterface::MSG_ERROR;
                 break;
+            case WalletModel::TransactionCheckFailed:
+                retStr = parent->translate("The transaction is not valid!");
+                informType = CClientUIInterface::MSG_ERROR;
+                break;
             case WalletModel::TransactionCommitFailed:
-                retStr = parent->translate(
-                        "The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.");
+                retStr = QString::fromStdString(sendCoinsReturn.commitRes.ToString());
                 informType = CClientUIInterface::MSG_ERROR;
                 break;
             case WalletModel::StakingOnlyUnlocked:

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -122,6 +122,7 @@ public:
         AmountWithFeeExceedsBalance,
         DuplicateAddress,
         TransactionCreationFailed,
+        TransactionCheckFailed,
         TransactionCommitFailed,
         StakingOnlyUnlocked,
         InsaneFee,
@@ -185,7 +186,12 @@ public:
     // Return status record for SendCoins, contains error id + information
     struct SendCoinsReturn {
         SendCoinsReturn(StatusCode status = OK) : status(status) {}
+        SendCoinsReturn(CWallet::CommitResult _commitRes) : commitRes(_commitRes)
+        {
+            status = (_commitRes.status == CWallet::CommitStatus::OK ? OK : TransactionCommitFailed);
+        }
         StatusCode status;
+        CWallet::CommitResult commitRes;
     };
 
     void setWalletDefaultFee(CAmount fee = DEFAULT_TRANSACTION_FEE);

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -155,7 +155,9 @@ UniValue preparebudget(const UniValue& params, bool fHelp)
     // make our change address
     CReserveKey reservekey(pwalletMain);
     //send the tx to the network
-    pwalletMain->CommitTransaction(wtx, reservekey, useIX ? NetMsgType::IX : NetMsgType::TX);
+    const CWallet::CommitResult& res = pwalletMain->CommitTransaction(wtx, reservekey, useIX ? NetMsgType::IX : NetMsgType::TX);
+    if (res.status != CWallet::CommitStatus::OK)
+        throw JSONRPCError(RPC_WALLET_ERROR, res.ToString());
 
     return wtx.GetHash().ToString();
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -473,7 +473,24 @@ public:
         CAmount nFeePay = 0,
         bool fIncludeDelegated = false);
     bool CreateTransaction(CScript scriptPubKey, const CAmount& nValue, CWalletTx& wtxNew, CReserveKey& reservekey, CAmount& nFeeRet, std::string& strFailReason, const CCoinControl* coinControl = NULL, AvailableCoinsType coin_type = ALL_COINS, bool useIX = false, CAmount nFeePay = 0, bool fIncludeDelegated = false);
-    bool CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey, std::string strCommand = NetMsgType::TX);
+
+    // enumeration for CommitResult (return status of CommitTransaction)
+    enum CommitStatus
+    {
+        OK,
+        Abandoned,              // Failed to accept to memory pool. Successfully removed from the wallet.
+        NotAccepted,            // Failed to accept to memory pool. Unable to abandon.
+    };
+    struct CommitResult
+    {
+        CommitResult(): status(CommitStatus::NotAccepted) {}
+        CWallet::CommitStatus status;
+        CValidationState state;
+        uint256 hashTx = UINT256_ZERO;
+        // converts CommitResult in human-readable format
+        std::string ToString() const;
+    };
+    CWallet::CommitResult CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey, std::string strCommand = NetMsgType::TX);
     bool AddAccountingEntry(const CAccountingEntry&, CWalletDB & pwalletdb);
     bool CreateCoinStake(const CKeyStore& keystore, const CBlockIndex* pindexPrev, unsigned int nBits, CMutableTransaction& txNew, int64_t& nTxNewTime);
     bool MultiSend();

--- a/src/wallet/wallet_zerocoin.cpp
+++ b/src/wallet/wallet_zerocoin.cpp
@@ -136,8 +136,9 @@ std::string CWallet::MintZerocoin(CAmount nValue, CWalletTx& wtxNew, std::vector
     }
 
     //commit the transaction to the network
-    if (!CommitTransaction(wtxNew, reservekey)) {
-        return _("Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.");
+    const CWallet::CommitResult& res = CommitTransaction(wtxNew, reservekey);
+    if (res.status != CWallet::CommitStatus::OK) {
+        return res.ToString();
     } else {
         //update mints with full transaction hash and then database them
         CWalletDB walletdb(strWalletFile);
@@ -319,7 +320,8 @@ bool CWallet::SpendZerocoin(CAmount nAmount, CWalletTx& wtxNew, CZerocoinSpendRe
 
 
     CWalletDB walletdb(strWalletFile);
-    if (!CommitTransaction(wtxNew, reserveKey)) {
+    const CWallet::CommitResult& res = CommitTransaction(wtxNew, reserveKey);
+    if (res.status != CWallet::CommitStatus::OK) {
         LogPrintf("%s: failed to commit\n", __func__);
         nStatus = ZPIV_COMMIT_FAILED;
 

--- a/test/functional/mining_pos_coldStaking.py
+++ b/test/functional/mining_pos_coldStaking.py
@@ -129,7 +129,7 @@ class PIVX_ColdStakingTest(PivxTestFramework):
         # Check that SPORK 17 is disabled
         assert (not self.isColdStakingEnforced())
         self.log.info("Creating a stake-delegation tx before cold staking enforcement...")
-        assert_raises_rpc_error(-4, "The transaction was rejected!",
+        assert_raises_rpc_error(-4, "Failed to accept tx in the memory pool (reason: cold-stake-inactive (code 16))\nTransaction canceled.",
                                 self.nodes[0].delegatestake, staker_address, INPUT_VALUE, owner_address, False, False, True)
         self.log.info("Good. Cold Staking NOT ACTIVE yet.")
 


### PR DESCRIPTION
This is an alternative to #1664.
It takes the opposite approach. 
When ATMP fails in `CommitTransaction`, instead of just returning the txid (hoping that the failure is not permanent) try to directly abandon the transaction. 
Save the result of these operations in a new struct `CWallet::CommitResult`, and use it to give a detailed feedback to the user (via log lines, JSON-RPC errors and GUI dialogs).

Based on top of:
- [x] #1670 

This PR also cherry-picks 5f122633020ce5d9f78c73394cda576a8657a3ac from bitcoin/bitcoin#6898, in order to use `FormatStateMessage` outside of main.