### PR TITLE
[BUG][GUI] Restore message() connection for ColdStakingWidget

### DIFF
--- a/src/qt/pivx/pivxgui.cpp
+++ b/src/qt/pivx/pivxgui.cpp
@@ -607,6 +607,7 @@ bool PIVXGUI::addWallet(const QString& name, WalletModel* walletModel)
     // Connect actions..
     connect(walletModel, &WalletModel::message, this, &PIVXGUI::message);
     connect(masterNodesWidget, &MasterNodesWidget::message, this, &PIVXGUI::message);
+    connect(coldStakingWidget, &ColdStakingWidget::message, this, &PIVXGUI::message);
     connect(topBar, &TopBar::message, this, &PIVXGUI::message);
     connect(sendWidget, &SendWidget::message,this, &PIVXGUI::message);
     connect(receiveWidget, &ReceiveWidget::message,this, &PIVXGUI::message);


### PR DESCRIPTION
For some mysterious reason that completely eludes me, I removed this by accident in 4863f402eb8b2ab40b0099c0ca0ea0efbd910182.
Let's put it back in.