### PR TITLE
[GUI] Fix dashboard txs list blinking issue

### DIFF
--- a/src/qt/pivx/dashboardwidget.cpp
+++ b/src/qt/pivx/dashboardwidget.cpp
@@ -108,8 +108,6 @@ DashboardWidget::DashboardWidget(PIVXGUI* parent) :
     ui->listTransactions->setMinimumHeight(NUM_ITEMS * (DECORATION_SIZE + 2));
     ui->listTransactions->setAttribute(Qt::WA_MacShowFocusRect, false);
     ui->listTransactions->setSelectionBehavior(QAbstractItemView::SelectRows);
-    ui->listTransactions->setLayoutMode(QListView::LayoutMode::Batched);
-    ui->listTransactions->setBatchSize(50);
     ui->listTransactions->setUniformItemSizes(true);
 
     // Sync Warning


### PR DESCRIPTION
The batch processing mode of the QListView is the cause of the list blinking on every update.

Seems that internally, QT fires up a screen region update that it's not calculated properly when the batch mode is enabled. Forcing to update the whole view even when there is no visual change for the rows that are being shown.

So, have moved the layout mode back to SinglePass, it solves the issue for now. We should check in the future if this has been solved in a newer QT version.