### PR TITLE
[Tools] logprint-scanner for error() and strprintf()

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -399,12 +399,10 @@ public:
 
     std::string ToString() const
     {
-        std::string str = "CDiskBlockIndex(";
-        str += CBlockIndex::ToString();
-        str += strprintf("\n                hashBlock=%s, hashPrev=%s)",
-            GetBlockHash().ToString(),
-            hashPrev.ToString());
-        return str;
+        return strprintf("CDiskBlockIndex(%s\n                hashBlock=%s, hashPrev=%s)",
+                CBlockIndex::ToString(),
+                GetBlockHash().ToString(),
+                hashPrev.ToString());
     }
 };
 

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -97,7 +97,7 @@ bool LoadStakeInput(const CBlock& block, const CBlockIndex* pindexPrev, std::uni
     } else {
         // check that is the actual parent block
         if (block.hashPrevBlock != pindexPrev->GetBlockHash())
-            return error("%s : previous block mismatch");
+            return error("%s : previous block mismatch", __func__);
     }
 
     // Check that this is a PoS block

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -954,7 +954,7 @@ static std::string FormatStateMessage(const CValidationState &state)
 {
     return strprintf("%s%s (code %i)",
         state.GetRejectReason(),
-        state.GetDebugMessage().empty() ? "" : ", " + state.GetDebugMessage(),
+        (state.GetDebugMessage().empty() ? "" : ", " + state.GetDebugMessage()),
         state.GetRejectCode());
 }
 
@@ -3546,7 +3546,7 @@ bool CheckColdStakeFreeOutput(const CTransaction& tx, const int nHeight)
         if (budget.IsBudgetPaymentBlock(nHeight)) {
             // if superblocks are not enabled, reject
             if (!sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS))
-                return error("%s: superblocks are not enabled");
+                return error("%s: superblocks are not enabled", __func__);
             return true;
         }
 

--- a/src/stakeinput.cpp
+++ b/src/stakeinput.cpp
@@ -13,7 +13,7 @@
 bool CPivStake::InitFromTxIn(const CTxIn& txin)
 {
     if (txin.IsZerocoinSpend())
-        return error("%s: unable to initialize CPivStake from zerocoin spend");
+        return error("%s: unable to initialize CPivStake from zerocoin spend", __func__);
 
     // Find the previous transaction in database
     uint256 hashBlock;
@@ -155,7 +155,7 @@ bool CPivStake::ContextCheck(int nHeight, uint32_t nTime)
     // Get Stake input block time/height
     CBlockIndex* pindexFrom = GetIndexFrom();
     if (!pindexFrom)
-        return error("%s: unable to get previous index for stake input");
+        return error("%s: unable to get previous index for stake input", __func__);
     const int nHeightBlockFrom = pindexFrom->nHeight;
     const uint32_t nTimeBlockFrom = pindexFrom->nTime;
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -880,11 +880,10 @@ UniValue CreateColdStakeDelegation(const UniValue& params, CWalletTx& wtxNew, CR
         // Check that the owner address belongs to this wallet, or fForceExternalAddr is true
         bool fForceExternalAddr = params.size() > 3 && !params[3].isNull() ? params[3].get_bool() : false;
         if (!fForceExternalAddr && !pwalletMain->HaveKey(ownerKey)) {
-            std::string errMsg = strprintf("The provided owneraddress \"%s\" is not present in this wallet.\n"
-                    "Set 'fExternalOwner' argument to true, in order to force the stake delegation to an external owner address.\n"
+            std::string errMsg = strprintf("The provided owneraddress \"%s\" is not present in this wallet.\n", params[2].get_str());
+            errMsg += "Set 'fExternalOwner' argument to true, in order to force the stake delegation to an external owner address.\n"
                     "e.g. delegatestake stakingaddress amount owneraddress true.\n"
-                    "WARNING: Only the owner of the key to owneraddress will be allowed to spend these coins after the delegation.",
-                    params[2].get_str());
+                    "WARNING: Only the owner of the key to owneraddress will be allowed to spend these coins after the delegation.";
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, errMsg);
         }
         ownerAddressStr = params[2].get_str();

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2666,7 +2666,7 @@ bool CWallet::CreateCoinStake(
         // Limit size
         unsigned int nBytes = ::GetSerializeSize(txNew, SER_NETWORK, PROTOCOL_VERSION);
         if (nBytes >= DEFAULT_BLOCK_MAX_SIZE / 5)
-            return error("CreateCoinStake : exceeded coinstake size limit");
+            return error("%s : exceeded coinstake size limit", __func__);
 
         // Masternode payment
         FillBlockPayee(txNew, nMinFee, true, false);

--- a/src/zpiv/zpos.cpp
+++ b/src/zpiv/zpos.cpp
@@ -24,7 +24,7 @@ bool CLegacyZPivStake::InitFromTxIn(const CTxIn& txin)
 {
     // Construct the stakeinput object
     if (!txin.IsZerocoinSpend())
-        return error("%s: unable to initialize CLegacyZPivStake from non zc-spend");
+        return error("%s: unable to initialize CLegacyZPivStake from non zc-spend", __func__);
 
     // Check spend type
     libzerocoin::CoinSpend spend = TxInToZerocoinSpend(txin);


### PR DESCRIPTION
The wallet crashes if the number of format arguments passed to `error()` or `strprintf()` does not match the number of specifiers.
The script `logprint-scanner.py` checks this only for `LogPrint()` and `LogPrintf()` lines (but not for `error()`, which indirectly uses `LogPrintf`).
This PR adds the checks to the script and fixes the few offending instances found.