### PR TITLE
[BUG][GUI] Non-static coinControl object in CoinControlDialogs

### DIFF
--- a/src/base58.h
+++ b/src/base58.h
@@ -214,7 +214,7 @@ public:
 
     std::string ToString()
     {
-        if (boost::get<CNoDestination>(&dest)) {
+        if (!IsValidDestination(dest)) {
             // Invalid address
             return "";
         }

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -32,8 +32,6 @@
 #include <QString>
 #include <QTreeWidget>
 
-CCoinControl* CoinControlDialog::coinControl = new CCoinControl();
-
 
 bool CCoinControlWidgetItem::operator<(const QTreeWidgetItem &other) const {
     int column = treeWidget()->sortColumn();
@@ -48,6 +46,7 @@ CoinControlDialog::CoinControlDialog(QWidget* parent, bool _forDelegation) : QDi
                                                         model(0),
                                                         forDelegation(_forDelegation)
 {
+    coinControl = new CCoinControl();
     ui->setupUi(this);
 
     /* Open CSS when configured */
@@ -205,6 +204,7 @@ CoinControlDialog::~CoinControlDialog()
     settings.setValue("nCoinControlSortOrder", (int)sortOrder);
 
     delete ui;
+    delete coinControl;
 }
 
 void CoinControlDialog::setModel(WalletModel* model)

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -57,7 +57,7 @@ public:
 
     static QString getPriorityLabel(double dPriority, double mempoolEstimatePriority);
 
-    static CCoinControl* coinControl;
+    CCoinControl* coinControl;
 
 private:
     Ui::CoinControlDialog* ui;

--- a/src/qt/pivx/coldstakingwidget.cpp
+++ b/src/qt/pivx/coldstakingwidget.cpp
@@ -197,11 +197,14 @@ ColdStakingWidget::ColdStakingWidget(PIVXGUI* parent) :
     connect(ui->listView, &QListView::clicked, this, &ColdStakingWidget::handleAddressClicked);
     connect(ui->listViewStakingAddress, &QListView::clicked, this, &ColdStakingWidget::handleMyColdAddressClicked);
     connect(ui->btnMyStakingAddresses, &OptionButton::clicked, this, &ColdStakingWidget::onMyStakingAddressesClicked);
+
+    coinControlDialog = new CoinControlDialog(nullptr, true);
 }
 
 void ColdStakingWidget::loadWalletModel()
 {
     if (walletModel) {
+        coinControlDialog->setModel(walletModel);
         sendMultiRow->setWalletModel(walletModel);
         txModel = walletModel->getTransactionTableModel();
         csModel = new ColdStakingModel(walletModel, txModel, walletModel->getAddressTableModel(), this);
@@ -474,7 +477,7 @@ void ColdStakingWidget::onSendClicked()
 
     // Prepare transaction for getting txFee earlier (exlude delegated coins)
     WalletModelTransaction currentTransaction(recipients);
-    WalletModel::SendCoinsReturn prepareStatus = walletModel->prepareTransaction(currentTransaction, CoinControlDialog::coinControl, false);
+    WalletModel::SendCoinsReturn prepareStatus = walletModel->prepareTransaction(currentTransaction, coinControlDialog->coinControl, false);
 
     // process prepareStatus and on error generate message shown to user
     GuiTransactionsUtils::ProcessSendCoinsReturnAndInform(
@@ -520,8 +523,8 @@ void ColdStakingWidget::clearAll()
 {
     if (sendMultiRow) sendMultiRow->clear();
     ui->lineEditOwnerAddress->clear();
-    if (CoinControlDialog::coinControl) {
-        CoinControlDialog::coinControl->SetNull();
+    if (coinControlDialog->coinControl) {
+        coinControlDialog->coinControl->SetNull();
         ui->btnCoinControl->setActive(false);
     }
 }
@@ -530,15 +533,10 @@ void ColdStakingWidget::onCoinControlClicked()
 {
     if (isInDelegation) {
         if (walletModel->getBalance() > 0) {
-            if (!coinControlDialog) {
-                coinControlDialog = new CoinControlDialog(nullptr, true);
-                coinControlDialog->setModel(walletModel);
-            } else {
-                coinControlDialog->refreshDialog();
-            }
+            coinControlDialog->refreshDialog();
             setCoinControlPayAmounts();
             coinControlDialog->exec();
-            ui->btnCoinControl->setActive(CoinControlDialog::coinControl->HasSelected());
+            ui->btnCoinControl->setActive(coinControlDialog->coinControl->HasSelected());
         } else {
             inform(tr("You don't have any %1 to select.").arg(CURRENCY_UNIT.c_str()));
         }
@@ -834,4 +832,5 @@ ColdStakingWidget::~ColdStakingWidget()
     ui->rightContainer->removeItem(spacerDiv);
     delete spacerDiv;
     delete ui;
+    delete coinControlDialog;
 }

--- a/src/qt/pivx/send.cpp
+++ b/src/qt/pivx/send.cpp
@@ -446,14 +446,14 @@ void SendWidget::onChangeAddressClicked()
 {
     showHideOp(true);
     SendChangeAddressDialog* dialog = new SendChangeAddressDialog(window, walletModel);
-    if (!boost::get<CNoDestination>(&coinControlDialog->coinControl->destChange)) {
+    if (IsValidDestination(coinControlDialog->coinControl->destChange)) {
         dialog->setAddress(QString::fromStdString(EncodeDestination(coinControlDialog->coinControl->destChange)));
     }
 
     CTxDestination destChange = (openDialogWithOpaqueBackgroundY(dialog, window, 3, 5) ?
                                  dialog->getDestination() : CNoDestination());
 
-    if (boost::get<CNoDestination>(&destChange)) {
+    if (!IsValidDestination(destChange)) {
         // no change address set
         ui->btnChangeAddress->setActive(false);
     } else {

--- a/src/qt/pivx/sendchangeaddressdialog.h
+++ b/src/qt/pivx/sendchangeaddressdialog.h
@@ -5,6 +5,7 @@
 #ifndef SENDCHANGEADDRESSDIALOG_H
 #define SENDCHANGEADDRESSDIALOG_H
 
+#include "script/standard.h"
 #include "qt/pivx/focuseddialog.h"
 #include "qt/pivx/snackbar.h"
 
@@ -23,7 +24,7 @@ public:
     ~SendChangeAddressDialog();
 
     void setAddress(QString address);
-    QString getAddress() const;
+    CTxDestination getDestination() const;
 
     void showEvent(QShowEvent* event) override;
 
@@ -31,6 +32,8 @@ private:
     WalletModel* walletModel;
     Ui::SendChangeAddressDialog *ui;
     SnackBar *snackBar = nullptr;
+    CTxDestination dest;
+
     void inform(const QString& text);
 
 private Q_SLOTS:

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -414,7 +414,7 @@ UniValue delegatoradd(const UniValue& params, bool fHelp)
 
     bool isStakingAddress = false;
     CTxDestination dest = DecodeDestination(params[0].get_str(), isStakingAddress);
-    if (boost::get<CNoDestination>(&dest) || isStakingAddress)
+    if (!IsValidDestination(dest) || isStakingAddress)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid PIVX address");
 
     const std::string strLabel = (params.size() > 1 ? params[1].get_str() : "");
@@ -446,7 +446,7 @@ UniValue delegatorremove(const UniValue& params, bool fHelp)
 
     bool isStakingAddress = false;
     CTxDestination dest = DecodeDestination(params[0].get_str(), isStakingAddress);
-    if (boost::get<CNoDestination>(&dest) || isStakingAddress)
+    if (!IsValidDestination(dest) || isStakingAddress)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid PIVX address");
 
     CKeyID keyID = *boost::get<CKeyID>(&dest);
@@ -872,7 +872,7 @@ UniValue CreateColdStakeDelegation(const UniValue& params, CWalletTx& wtxNew, CR
         // Address provided
         bool isStaking = false;
         CTxDestination dest = DecodeDestination(params[2].get_str(), isStaking);
-        if (boost::get<CNoDestination>(&dest) || isStaking)
+        if (!IsValidDestination(dest) || isStaking)
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid PIVX spending address");
         ownerKey = *boost::get<CKeyID>(&dest);
         if (!ownerKey)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2451,7 +2451,7 @@ bool CWallet::CreateTransaction(const std::vector<std::pair<CScript, CAmount> >&
                     bool combineChange = false;
 
                     // coin control: send change to custom address
-                    if (coinControl && !boost::get<CNoDestination>(&coinControl->destChange)) {
+                    if (coinControl && IsValidDestination(coinControl->destChange)) {
                         scriptChange = GetScriptForDestination(coinControl->destChange);
 
                         std::vector<CTxOut>::iterator it = txNew.vout.begin();
@@ -3319,7 +3319,7 @@ void CWallet::GetKeyBirthTimes(std::map<CKeyID, int64_t>& mapKeyBirth) const
 
 bool CWallet::AddDestData(const CTxDestination& dest, const std::string& key, const std::string& value)
 {
-    if (boost::get<CNoDestination>(&dest))
+    if (!IsValidDestination(dest))
         return false;
 
     mapAddressBook[dest].destdata.insert(std::make_pair(key, value));


### PR DESCRIPTION
This is an alternative to #1691 .

Instead of fixing the the issue by checking for edits to `coinControl` in the show event of the dialogs, make `coinControl` a class variable of `CoinControlDialog`, so each dialog instance has its own independent object, and there are no inconsistencies.