### PR TITLE
[Refactor] zerocoin code moved from wallet.cpp to wallet_zerocoin.cpp

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -583,6 +583,9 @@ public:
     bool GetDeterministicSeed(const uint256& hashSeed, uint256& seed);
     bool AddDeterministicSeed(const uint256& seed);
 
+    // Par of the tx rescan process
+    void doZPivRescan(const CBlockIndex* pindex, const CBlock& block, std::set<uint256>& setAddedToWallet, const Consensus::Params& consensus, bool fCheckZPIV);
+
     //- ZC Mints (Only for regtest)
     std::string MintZerocoin(CAmount nValue, CWalletTx& wtxNew, std::vector<CDeterministicMint>& vDMints, const CCoinControl* coinControl = NULL);
     std::string MintZerocoinFromOutPoint(CAmount nValue, CWalletTx& wtxNew, std::vector<CDeterministicMint>& vDMints, const std::vector<COutPoint> vOutpts);


### PR DESCRIPTION
No functional changes. Quick zerocoin code move to cleanup the method a little bit. Code moved from ScanForWalletTransactions to wallet_zerocoin.cpp legacy file.