### PR TITLE
[Validation] Reduce cs_main locks during ConnectTip/SyncWithWallets

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2438,7 +2438,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                         CWalletTx wtx(pwalletMain, tx);
                         wtx.nTimeReceived = pindex->GetBlockTime();
                         wtx.SetMerkleBranch(block);
-                        pwalletMain->AddToWallet(wtx, nullptr);
+                        pwalletMain->AddToWallet(wtx);
                         setAddedTx.insert(pSpend.second);
                     }
                 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2433,11 +2433,13 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                     continue;
 
                 //Search block for matching tx, turn into wtx, set merkle branch, add to wallet
-                for (const CTransaction& tx : block.vtx) {
+                int posInBlock = 0;
+                for (posInBlock = 0; posInBlock < (int)block.vtx.size(); posInBlock++) {
+                    auto& tx = block.vtx[posInBlock];
                     if (tx.GetHash() == pSpend.second) {
                         CWalletTx wtx(pwalletMain, tx);
                         wtx.nTimeReceived = pindex->GetBlockTime();
-                        wtx.SetMerkleBranch(block);
+                        wtx.SetMerkleBranch(pindex, posInBlock);
                         pwalletMain->AddToWallet(wtx);
                         setAddedTx.insert(pSpend.second);
                     }
@@ -2708,7 +2710,7 @@ bool static DisconnectTip(CValidationState& state)
     // Let wallets know transactions went from 1-confirmed to
     // 0-confirmed or conflicted:
     for (const CTransaction& tx : block.vtx) {
-        SyncWithWallets(tx, NULL);
+        SyncWithWallets(tx, pindexDelete->pprev);
     }
     return true;
 }
@@ -2723,7 +2725,7 @@ static int64_t nTimePostConnect = 0;
  * Connect a new block to chainActive. pblock is either NULL or a pointer to a CBlock
  * corresponding to pindexNew, to bypass loading it again from disk.
  */
-bool static ConnectTip(CValidationState& state, CBlockIndex* pindexNew, const CBlock* pblock, bool fAlreadyChecked)
+bool static ConnectTip(CValidationState& state, CBlockIndex* pindexNew, const CBlock* pblock, bool fAlreadyChecked, std::list<CTransaction> &txConflicted, std::vector<std::tuple<CTransaction,CBlockIndex*,int>> &txChanged)
 {
     assert(pindexNew->pprev == chainActive.Tip());
 
@@ -2773,18 +2775,12 @@ bool static ConnectTip(CValidationState& state, CBlockIndex* pindexNew, const CB
     LogPrint(BCLog::BENCH, "  - Writing chainstate: %.2fms [%.2fs]\n", (nTime5 - nTime4) * 0.001, nTimeChainState * 0.000001);
 
     // Remove conflicting transactions from the mempool.
-    std::list<CTransaction> txConflicted;
     mempool.removeForBlock(pblock->vtx, pindexNew->nHeight, txConflicted, !IsInitialBlockDownload());
     // Update chainActive & related variables.
     UpdateTip(pindexNew);
-    // Tell wallet about transactions that went from mempool
-    // to conflicted:
-    for (const CTransaction& tx : txConflicted) {
-        SyncWithWallets(tx, NULL);
-    }
-    // ... and about transactions that got confirmed:
-    for (const CTransaction& tx : pblock->vtx) {
-        SyncWithWallets(tx, pblock);
+
+    for(unsigned int i=0; i < pblock->vtx.size(); i++) {
+        txChanged.push_back(std::make_tuple(pblock->vtx[i], pindexNew, i));
     }
 
     int64_t nTime6 = GetTimeMicros();
@@ -2915,7 +2911,7 @@ static void PruneBlockIndexCandidates()
  * Try to make some progress towards making pindexMostWork the active block.
  * pblock is either NULL or a pointer to a CBlock corresponding to pindexMostWork.
  */
-static bool ActivateBestChainStep(CValidationState& state, CBlockIndex* pindexMostWork, const CBlock* pblock, bool fAlreadyChecked)
+static bool ActivateBestChainStep(CValidationState& state, CBlockIndex* pindexMostWork, const CBlock* pblock, bool fAlreadyChecked, std::list<CTransaction>& txConflicted, std::vector<std::tuple<CTransaction,CBlockIndex*,int>>& txChanged)
 {
     AssertLockHeld(cs_main);
     if (pblock == NULL)
@@ -2951,7 +2947,7 @@ static bool ActivateBestChainStep(CValidationState& state, CBlockIndex* pindexMo
 
         // Connect new blocks.
         BOOST_REVERSE_FOREACH (CBlockIndex* pindexConnect, vpindexToConnect) {
-            if (!ConnectTip(state, pindexConnect, pindexConnect == pindexMostWork ? pblock : NULL, fAlreadyChecked)) {
+            if (!ConnectTip(state, pindexConnect, pindexConnect == pindexMostWork ? pblock : NULL, fAlreadyChecked, txConflicted, txChanged)) {
                 if (state.IsInvalid()) {
                     // The block violates a consensus rule.
                     if (!state.CorruptionPossible())
@@ -3009,6 +3005,8 @@ bool ActivateBestChain(CValidationState& state, const CBlock* pblock, bool fAlre
         boost::this_thread::interruption_point();
 
         const CBlockIndex *pindexFork;
+        std::list<CTransaction> txConflicted;
+        std::vector<std::tuple<CTransaction,CBlockIndex*,int>> txChanged;
         bool fInitialDownload;
         while (true) {
             TRY_LOCK(cs_main, lockMain);
@@ -3024,7 +3022,7 @@ bool ActivateBestChain(CValidationState& state, const CBlock* pblock, bool fAlre
             if (pindexMostWork == NULL || pindexMostWork == chainActive.Tip())
                 return true;
 
-            if (!ActivateBestChainStep(state, pindexMostWork, pblock && pblock->GetHash() == pindexMostWork->GetBlockHash() ? pblock : NULL, fAlreadyChecked))
+            if (!ActivateBestChainStep(state, pindexMostWork, pblock && pblock->GetHash() == pindexMostWork->GetBlockHash() ? pblock : NULL, fAlreadyChecked, txConflicted, txChanged))
                 return false;
 
             pindexNewTip = chainActive.Tip();
@@ -3035,6 +3033,17 @@ bool ActivateBestChain(CValidationState& state, const CBlock* pblock, bool fAlre
 
         // When we reach this point, we switched to a new tip (stored in pindexNewTip).
         // Notifications/callbacks that can run without cs_main
+
+        // throw all transactions though the signal-interface
+        // while _not_ holding the cs_main lock
+        for (const CTransaction &tx : txConflicted) {
+            SyncWithWallets(tx, pindexNewTip);
+        }
+        // ... and about transactions that got confirmed:
+        for(unsigned int i = 0; i < txChanged.size(); i++) {
+            SyncWithWallets(std::get<0>(txChanged[i]), std::get<1>(txChanged[i]), std::get<2>(txChanged[i]));
+        }
+
         // Always notify the UI if a new block tip was connected
         if (pindexFork != pindexNewTip) {
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2780,7 +2780,7 @@ bool static ConnectTip(CValidationState& state, CBlockIndex* pindexNew, const CB
     UpdateTip(pindexNew);
 
     for(unsigned int i=0; i < pblock->vtx.size(); i++) {
-        txChanged.push_back(std::make_tuple(pblock->vtx[i], pindexNew, i));
+        txChanged.emplace_back(pblock->vtx[i], pindexNew, i);
     }
 
     int64_t nTime6 = GetTimeMicros();
@@ -3001,12 +3001,15 @@ bool ActivateBestChain(CValidationState& state, const CBlock* pblock, bool fAlre
 
     CBlockIndex* pindexNewTip = nullptr;
     CBlockIndex* pindexMostWork = nullptr;
+    std::vector<std::tuple<CTransaction,CBlockIndex*,int>> txChanged;
+    if (pblock)
+        txChanged.reserve(pblock->vtx.size());
     do {
+        txChanged.clear();
         boost::this_thread::interruption_point();
 
         const CBlockIndex *pindexFork;
         std::list<CTransaction> txConflicted;
-        std::vector<std::tuple<CTransaction,CBlockIndex*,int>> txChanged;
         bool fInitialDownload;
         while (true) {
             TRY_LOCK(cs_main, lockMain);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1098,7 +1098,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
             return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "mempool full");
     }
 
-    SyncWithWallets(tx, nullptr);
+    GetMainSignals().SyncTransaction(tx, nullptr, CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK);
 
     return true;
 }
@@ -2710,7 +2710,7 @@ bool static DisconnectTip(CValidationState& state)
     // Let wallets know transactions went from 1-confirmed to
     // 0-confirmed or conflicted:
     for (const CTransaction& tx : block.vtx) {
-        SyncWithWallets(tx, pindexDelete->pprev);
+        GetMainSignals().SyncTransaction(tx, pindexDelete->pprev, CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK);
     }
     return true;
 }
@@ -3040,11 +3040,11 @@ bool ActivateBestChain(CValidationState& state, const CBlock* pblock, bool fAlre
         // throw all transactions though the signal-interface
         // while _not_ holding the cs_main lock
         for (const CTransaction &tx : txConflicted) {
-            SyncWithWallets(tx, pindexNewTip);
+            GetMainSignals().SyncTransaction(tx, pindexNewTip, CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK);
         }
         // ... and about transactions that got confirmed:
         for(unsigned int i = 0; i < txChanged.size(); i++) {
-            SyncWithWallets(std::get<0>(txChanged[i]), std::get<1>(txChanged[i]), std::get<2>(txChanged[i]));
+            GetMainSignals().SyncTransaction(std::get<0>(txChanged[i]), std::get<1>(txChanged[i]), std::get<2>(txChanged[i]));
         }
 
         // Always notify the UI if a new block tip was connected

--- a/src/test/accounting_tests.cpp
+++ b/src/test/accounting_tests.cpp
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(acc_orderupgrade)
     pwalletMain->AddAccountingEntry(ae, walletdb);
 
     wtx.mapValue["comment"] = "z";
-    pwalletMain->AddToWallet(wtx, &walletdb);
+    pwalletMain->AddToWallet(wtx);
     vpwtx.push_back(&pwalletMain->mapWallet[wtx.GetHash()]);
     vpwtx[0]->nTimeReceived = (unsigned int)1333333335;
     vpwtx[0]->nOrderPos = -1;
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(acc_orderupgrade)
         --tx.nLockTime;  // Just to change the hash :)
         *static_cast<CTransaction*>(&wtx) = CTransaction(tx);
     }
-    pwalletMain->AddToWallet(wtx, &walletdb);
+    pwalletMain->AddToWallet(wtx);
     vpwtx.push_back(&pwalletMain->mapWallet[wtx.GetHash()]);
     vpwtx[1]->nTimeReceived = (unsigned int)1333333336;
 
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(acc_orderupgrade)
         --tx.nLockTime;  // Just to change the hash :)
         *static_cast<CTransaction*>(&wtx) = CTransaction(tx);
     }
-    pwalletMain->AddToWallet(wtx, &walletdb);
+    pwalletMain->AddToWallet(wtx);
     vpwtx.push_back(&pwalletMain->mapWallet[wtx.GetHash()]);
     vpwtx[2]->nTimeReceived = (unsigned int)1333333329;
     vpwtx[2]->nOrderPos = -1;

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -16,7 +16,7 @@ CMainSignals& GetMainSignals()
 void RegisterValidationInterface(CValidationInterface* pwalletIn) {
 // XX42 g_signals.EraseTransaction.connect(boost::bind(&CValidationInterface::EraseFromWallet, pwalletIn, _1));
     g_signals.UpdatedBlockTip.connect(boost::bind(&CValidationInterface::UpdatedBlockTip, pwalletIn, _1));
-    g_signals.SyncTransaction.connect(boost::bind(&CValidationInterface::SyncTransaction, pwalletIn, _1, _2));
+    g_signals.SyncTransaction.connect(boost::bind(&CValidationInterface::SyncTransaction, pwalletIn, _1, _2, _3));
     g_signals.NotifyTransactionLock.connect(boost::bind(&CValidationInterface::NotifyTransactionLock, pwalletIn, _1));
     g_signals.UpdatedTransaction.connect(boost::bind(&CValidationInterface::UpdatedTransaction, pwalletIn, _1));
     g_signals.SetBestChain.connect(boost::bind(&CValidationInterface::SetBestChain, pwalletIn, _1));
@@ -36,7 +36,7 @@ void UnregisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.SetBestChain.disconnect(boost::bind(&CValidationInterface::SetBestChain, pwalletIn, _1));
     g_signals.UpdatedTransaction.disconnect(boost::bind(&CValidationInterface::UpdatedTransaction, pwalletIn, _1));
     g_signals.NotifyTransactionLock.disconnect(boost::bind(&CValidationInterface::NotifyTransactionLock, pwalletIn, _1));
-    g_signals.SyncTransaction.disconnect(boost::bind(&CValidationInterface::SyncTransaction, pwalletIn, _1, _2));
+    g_signals.SyncTransaction.disconnect(boost::bind(&CValidationInterface::SyncTransaction, pwalletIn, _1, _2, _3));
     g_signals.UpdatedBlockTip.disconnect(boost::bind(&CValidationInterface::UpdatedBlockTip, pwalletIn, _1));
 // XX42    g_signals.EraseTransaction.disconnect(boost::bind(&CValidationInterface::EraseFromWallet, pwalletIn, _1));
 }
@@ -55,6 +55,6 @@ void UnregisterAllValidationInterfaces() {
 // XX42    g_signals.EraseTransaction.disconnect_all_slots();
 }
 
-void SyncWithWallets(const CTransaction &tx, const CBlock *pblock = NULL) {
-    g_signals.SyncTransaction(tx, pblock);
+void SyncWithWallets(const CTransaction &tx, const CBlockIndex *pindex, int posInBlock) {
+    g_signals.SyncTransaction(tx, pindex, posInBlock);
 }

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -54,7 +54,3 @@ void UnregisterAllValidationInterfaces() {
     g_signals.UpdatedBlockTip.disconnect_all_slots();
 // XX42    g_signals.EraseTransaction.disconnect_all_slots();
 }
-
-void SyncWithWallets(const CTransaction &tx, const CBlockIndex *pindex, int posInBlock) {
-    g_signals.SyncTransaction(tx, pindex, posInBlock);
-}

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -28,13 +28,13 @@ void UnregisterValidationInterface(CValidationInterface* pwalletIn);
 /** Unregister all wallets from core */
 void UnregisterAllValidationInterfaces();
 /** Push an updated transaction to all registered wallets */
-void SyncWithWallets(const CTransaction& tx, const CBlock* pblock);
+void SyncWithWallets(const CTransaction& tx, const CBlockIndex *pindex, int posInBlock = -1);
 
 class CValidationInterface {
 protected:
 // XX42    virtual void EraseFromWallet(const uint256& hash){};
     virtual void UpdatedBlockTip(const CBlockIndex *pindex) {}
-    virtual void SyncTransaction(const CTransaction &tx, const CBlock *pblock) {}
+    virtual void SyncTransaction(const CTransaction &tx, const CBlockIndex *pindex, int posInBlock) {}
     virtual void NotifyTransactionLock(const CTransaction &tx) {}
     virtual void SetBestChain(const CBlockLocator &locator) {}
     virtual bool UpdatedTransaction(const uint256 &hash) { return false;}
@@ -54,7 +54,7 @@ struct CMainSignals {
     /** Notifies listeners of updated block chain tip */
     boost::signals2::signal<void (const CBlockIndex *)> UpdatedBlockTip;
     /** Notifies listeners of updated transaction data (transaction, and optionally the block it is found in. */
-    boost::signals2::signal<void (const CTransaction &, const CBlock *)> SyncTransaction;
+    boost::signals2::signal<void (const CTransaction &, const CBlockIndex *pindex, int posInBlock)> SyncTransaction;
     /** Notifies listeners of an updated transaction lock without new data. */
     boost::signals2::signal<void (const CTransaction &)> NotifyTransactionLock;
     /** Notifies listeners of an updated transaction without new data (for now: a coinbase potentially becoming visible). */

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -27,8 +27,6 @@ void RegisterValidationInterface(CValidationInterface* pwalletIn);
 void UnregisterValidationInterface(CValidationInterface* pwalletIn);
 /** Unregister all wallets from core */
 void UnregisterAllValidationInterfaces();
-/** Push an updated transaction to all registered wallets */
-void SyncWithWallets(const CTransaction& tx, const CBlockIndex *pindex, int posInBlock = -1);
 
 class CValidationInterface {
 protected:
@@ -53,6 +51,8 @@ struct CMainSignals {
 // XX42    boost::signals2::signal<void(const uint256&)> EraseTransaction;
     /** Notifies listeners of updated block chain tip */
     boost::signals2::signal<void (const CBlockIndex *)> UpdatedBlockTip;
+    /** A posInBlock value for SyncTransaction which indicates the transaction was conflicted, disconnected, or not in a block */
+    static const int SYNC_TRANSACTION_NOT_IN_BLOCK = -1;
     /** Notifies listeners of updated transaction data (transaction, and optionally the block it is found in. */
     boost::signals2::signal<void (const CTransaction &, const CBlockIndex *pindex, int posInBlock)> SyncTransaction;
     /** Notifies listeners of an updated transaction lock without new data. */

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -906,18 +906,18 @@ bool CWallet::LoadToWallet(const CWalletTx& wtxIn)
  * pblock is optional, but should be provided if the transaction is known to be in a block.
  * If fUpdate is true, existing transactions will be updated.
  */
-bool CWallet::AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pblock, bool fUpdate)
+bool CWallet::AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlockIndex* pIndex, int posInBlock, bool fUpdate)
 {
     {
         AssertLockHeld(cs_wallet);
 
-        if (pblock && !tx.HasZerocoinSpendInputs() && !tx.IsCoinBase()) {
+        if (posInBlock != -1 && !tx.HasZerocoinSpendInputs() && !tx.IsCoinBase()) {
             for (const CTxIn& txin : tx.vin) {
                 std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range = mapTxSpends.equal_range(txin.prevout);
                 while (range.first != range.second) {
                     if (range.first->second != tx.GetHash()) {
-                        LogPrintf("Transaction %s (in block %s) conflicts with wallet transaction %s (both spend %s:%i)\n", tx.GetHash().ToString(), pblock->GetHash().ToString(), range.first->second.ToString(), range.first->first.hash.ToString(), range.first->first.n);
-                        MarkConflicted(pblock->GetHash(), range.first->second);
+                        LogPrintf("Transaction %s (in block %s) conflicts with wallet transaction %s (both spend %s:%i)\n", tx.GetHash().ToString(), pIndex->GetBlockHash().ToString(), range.first->second.ToString(), range.first->first.hash.ToString(), range.first->first.n);
+                        MarkConflicted(pIndex->GetBlockHash(), range.first->second);
                     }
                     range.first++;
                 }
@@ -941,8 +941,8 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pbl
 
             CWalletTx wtx(this, tx);
             // Get merkle branch if transaction was found in a block
-            if (pblock)
-                wtx.SetMerkleBranch(*pblock);
+            if (posInBlock != -1)
+                wtx.SetMerkleBranch(pIndex, posInBlock);
 
             return AddToWallet(wtx, false);
         }
@@ -1067,10 +1067,10 @@ void CWallet::MarkConflicted(const uint256& hashBlock, const uint256& hashTx)
     }
 }
 
-void CWallet::SyncTransaction(const CTransaction& tx, const CBlock* pblock)
+void CWallet::SyncTransaction(const CTransaction& tx, const CBlockIndex *pindex, int posInBlock)
 {
     LOCK(cs_wallet);
-    if (!AddToWalletIfInvolvingMe(tx, pblock, true))
+    if (!AddToWalletIfInvolvingMe(tx, pindex, posInBlock, true))
         return; // Not one of ours
 
     // If a transaction changes 'conflicted' state, that changes the balance
@@ -1635,8 +1635,9 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate, b
 
             CBlock block;
             ReadBlockFromDisk(block, pindex);
-            for (CTransaction& tx : block.vtx) {
-                if (AddToWalletIfInvolvingMe(tx, &block, fUpdate))
+            int posInBlock;
+            for (posInBlock = 0; posInBlock < (int)block.vtx.size(); posInBlock++) {
+                if (AddToWalletIfInvolvingMe(block.vtx[posInBlock], pindex, posInBlock, fUpdate))
                     ret++;
             }
 
@@ -3831,22 +3832,15 @@ CWalletKey::CWalletKey(int64_t nExpires)
     nTimeExpires = nExpires;
 }
 
-void CMerkleTx::SetMerkleBranch(const CBlock& block)
+void CMerkleTx::SetMerkleBranch(const CBlockIndex* pindex, int posInBlock)
 {
     CBlock blockTmp;
 
     // Update the tx's hashBlock
-    hashBlock = block.GetHash();
+    hashBlock = pindex->GetBlockHash();
 
-    // Locate the transaction
-    for (nIndex = 0; nIndex < (int)block.vtx.size(); nIndex++)
-        if (block.vtx[nIndex] == *(CTransaction*)this)
-            break;
-    if (nIndex == (int)block.vtx.size()) {
-        nIndex = -1;
-        LogPrintf("ERROR: SetMerkleBranch() : couldn't find tx in block\n");
-        return;
-    }
+    // set the position of the transaction in the block
+    nIndex = posInBlock;
 }
 
 int CMerkleTx::GetDepthInMainChain(bool enableIX) const

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2947,11 +2947,6 @@ CWallet::CommitResult CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey&
         LOCK2(cs_main, cs_wallet);
         LogPrintf("%s:\n%s", __func__, wtxNew.ToString());
         {
-            // This is only to keep the database open to defeat the auto-flush for the
-            // duration of this scope.  This is the only place where this optimization
-            // maybe makes sense; please don't do it anywhere else.
-            CWalletDB* pwalletdb = fFileBacked ? new CWalletDB(strWalletFile, "r+") : NULL;
-
             // Take key pair from key pool so it won't be used again
             reservekey.KeepKey();
 
@@ -2972,9 +2967,6 @@ CWallet::CommitResult CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey&
                     updated_hashes.insert(txin.prevout.hash);
                 }
             }
-
-            if (fFileBacked)
-                delete pwalletdb;
         }
 
         res.hashTx = wtxNew.GetHash();

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3834,8 +3834,6 @@ CWalletKey::CWalletKey(int64_t nExpires)
 
 void CMerkleTx::SetMerkleBranch(const CBlockIndex* pindex, int posInBlock)
 {
-    CBlock blockTmp;
-
     // Update the tx's hashBlock
     hashBlock = pindex->GetBlockHash();
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -435,7 +435,7 @@ public:
 
     bool GetLabelDestination(CTxDestination& dest, const std::string& label, bool bForceNew = false);
     void MarkDirty();
-    bool AddToWallet(const CWalletTx& wtxIn, CWalletDB* pwalletdb = nullptr);
+    bool AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose = true);
     bool LoadToWallet(const CWalletTx& wtxIn);
     void SyncTransaction(const CTransaction& tx, const CBlock* pblock);
     bool AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pblock, bool fUpdate);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -437,8 +437,8 @@ public:
     void MarkDirty();
     bool AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose = true);
     bool LoadToWallet(const CWalletTx& wtxIn);
-    void SyncTransaction(const CTransaction& tx, const CBlock* pblock);
-    bool AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pblock, bool fUpdate);
+    void SyncTransaction(const CTransaction& tx, const CBlockIndex *pindex, int posInBlock);
+    bool AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlockIndex* pIndex, int posInBlock, bool fUpdate);
     void EraseFromWallet(const uint256& hash);
 
     /**
@@ -762,8 +762,7 @@ public:
         READWRITE(nIndex);
     }
 
-    void SetMerkleBranch(const CBlock& block);
-
+    void SetMerkleBranch(const CBlockIndex* pIndex, int posInBlock);
 
     /**
      * Return depth of transaction in blockchain:

--- a/src/wallet/wallet_zerocoin.cpp
+++ b/src/wallet/wallet_zerocoin.cpp
@@ -101,7 +101,6 @@ void CWallet::doZPivRescan(const CBlockIndex* pindex, const CBlock& block,
     if (fCheckZPIV && consensus.NetworkUpgradeActive(pindex->nHeight, Consensus::UPGRADE_ZC)) {
         std::list<CZerocoinMint> listMints;
         BlockToZerocoinMintList(block, listMints, true);
-        CWalletDB walletdb(strWalletFile);
 
         for (auto& m : listMints) {
             if (IsMyMint(m.GetValue())) {
@@ -117,7 +116,7 @@ void CWallet::doZPivRescan(const CBlockIndex* pindex, const CBlock& block,
                         CWalletTx wtx(this, tx);
                         wtx.nTimeReceived = block.GetBlockTime();
                         wtx.SetMerkleBranch(block);
-                        AddToWallet(wtx, &walletdb);
+                        AddToWallet(wtx);
                         setAddedToWallet.insert(txid);
                     }
                 }
@@ -137,7 +136,7 @@ void CWallet::doZPivRescan(const CBlockIndex* pindex, const CBlock& block,
                         wtx.SetMerkleBranch(blockSpend);
 
                     wtx.nTimeReceived = pindexSpend->nTime;
-                    AddToWallet(wtx, &walletdb);
+                    AddToWallet(wtx);
                     setAddedToWallet.emplace(txidSpend);
                 }
             }

--- a/src/wallet/wallet_zerocoin.cpp
+++ b/src/wallet/wallet_zerocoin.cpp
@@ -102,20 +102,23 @@ void CWallet::doZPivRescan(const CBlockIndex* pindex, const CBlock& block,
         std::list<CZerocoinMint> listMints;
         BlockToZerocoinMintList(block, listMints, true);
 
+        int posInBlock = 0;
         for (auto& m : listMints) {
             if (IsMyMint(m.GetValue())) {
                 LogPrint(BCLog::LEGACYZC, "%s: found mint\n", __func__);
                 UpdateMint(m.GetValue(), pindex->nHeight, m.GetTxHash(), m.GetDenomination());
 
                 // Add the transaction to the wallet
-                for (auto& tx : block.vtx) {
+                posInBlock = 0;
+                for (posInBlock = 0; posInBlock < (int)block.vtx.size(); posInBlock++) {
+                    auto& tx = block.vtx[posInBlock];
                     uint256 txid = tx.GetHash();
                     if (setAddedToWallet.count(txid) || mapWallet.count(txid))
                         continue;
                     if (txid == m.GetTxHash()) {
                         CWalletTx wtx(this, tx);
                         wtx.nTimeReceived = block.GetBlockTime();
-                        wtx.SetMerkleBranch(block);
+                        wtx.SetMerkleBranch(pindex, posInBlock);
                         AddToWallet(wtx);
                         setAddedToWallet.insert(txid);
                     }
@@ -132,8 +135,14 @@ void CWallet::doZPivRescan(const CBlockIndex* pindex, const CBlock& block,
                     CWalletTx wtx(this, txSpend);
                     CBlockIndex* pindexSpend = chainActive[nHeightSpend];
                     CBlock blockSpend;
-                    if (ReadBlockFromDisk(blockSpend, pindexSpend))
-                        wtx.SetMerkleBranch(blockSpend);
+                    if (ReadBlockFromDisk(blockSpend, pindexSpend)) {
+                        posInBlock = 0;
+                        for (posInBlock = 0; posInBlock < (int)blockSpend.vtx.size(); posInBlock++) {
+                            auto &tx = blockSpend.vtx[posInBlock];
+                            if (tx.GetHash() == txidSpend)
+                                wtx.SetMerkleBranch(pindexSpend, posInBlock);
+                        }
+                    }
 
                     wtx.nTimeReceived = pindexSpend->nTime;
                     AddToWallet(wtx);

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -143,7 +143,7 @@ void CZMQNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindex)
     }
 }
 
-void CZMQNotificationInterface::SyncTransaction(const CTransaction &tx, const CBlock *pblock)
+void CZMQNotificationInterface::SyncTransaction(const CTransaction& tx, const CBlockIndex* pindex, int posInBlock)
 {
     for (std::list<CZMQAbstractNotifier*>::iterator i = notifiers.begin(); i!=notifiers.end(); )
     {

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -24,7 +24,7 @@ protected:
     void Shutdown();
 
     // CValidationInterface
-    void SyncTransaction(const CTransaction &tx, const CBlock *pblock);
+    void SyncTransaction(const CTransaction& tx, const CBlockIndex *pindex, int posInBlock);
     void UpdatedBlockTip(const CBlockIndex *pindex);
     void NotifyTransactionLock(const CTransaction &tx);
 

--- a/src/zpiv/zpivwallet.cpp
+++ b/src/zpiv/zpivwallet.cpp
@@ -261,8 +261,15 @@ void CzPIVWallet::SyncWithChain(bool fGenerateMintPool)
                 if (!setAddedTx.count(txHash)) {
                     CBlock block;
                     CWalletTx wtx(wallet, tx);
-                    if (pindex && ReadBlockFromDisk(block, pindex))
-                        wtx.SetMerkleBranch(block);
+                    if (pindex && ReadBlockFromDisk(block, pindex)) {
+                        int posInBlock;
+                        for (posInBlock = 0; posInBlock < (int)block.vtx.size(); posInBlock++) {
+                            if (wtx.GetHash() == txHash) {
+                                wtx.SetMerkleBranch(pindex, posInBlock);
+                                break;
+                            }
+                        }
+                    }
 
                     //Fill out wtx so that a transaction record can be created
                     wtx.nTimeReceived = pindex->GetBlockTime();
@@ -318,8 +325,15 @@ bool CzPIVWallet::SetMintSeen(const CBigNum& bnValue, const int& nHeight, const 
         CWalletTx wtx(wallet, txSpend);
         CBlockIndex* pindex = chainActive[nHeightTx];
         CBlock block;
-        if (ReadBlockFromDisk(block, pindex))
-            wtx.SetMerkleBranch(block);
+        if (ReadBlockFromDisk(block, pindex)) {
+            int posInBlock;
+            for (posInBlock = 0; posInBlock < (int) block.vtx.size(); posInBlock++) {
+                if (wtx.GetHash() == txidSpend) {
+                    wtx.SetMerkleBranch(pindex, posInBlock);
+                    break;
+                }
+            }
+        }
 
         wtx.nTimeReceived = pindex->nTime;
         wallet->AddToWallet(wtx);

--- a/src/zpiv/zpivwallet.cpp
+++ b/src/zpiv/zpivwallet.cpp
@@ -183,7 +183,6 @@ void CzPIVWallet::SyncWithChain(bool fGenerateMintPool)
 {
     uint32_t nLastCountUsed = 0;
     bool found = true;
-    CWalletDB walletdb(wallet->strWalletFile);
 
     std::set<uint256> setAddedTx;
     while (found) {
@@ -267,7 +266,7 @@ void CzPIVWallet::SyncWithChain(bool fGenerateMintPool)
 
                     //Fill out wtx so that a transaction record can be created
                     wtx.nTimeReceived = pindex->GetBlockTime();
-                    wallet->AddToWallet(wtx, &walletdb);
+                    wallet->AddToWallet(wtx);
                     setAddedTx.insert(txHash);
                 }
 
@@ -323,8 +322,7 @@ bool CzPIVWallet::SetMintSeen(const CBigNum& bnValue, const int& nHeight, const 
             wtx.SetMerkleBranch(block);
 
         wtx.nTimeReceived = pindex->nTime;
-        CWalletDB walletdb(wallet->strWalletFile);
-        wallet->AddToWallet(wtx, &walletdb);
+        wallet->AddToWallet(wtx);
     }
 
     // Add to zpivTracker which also adds to database

--- a/src/zpivchain.cpp
+++ b/src/zpivchain.cpp
@@ -435,14 +435,16 @@ bool UpdateZPIVSupplyConnect(const CBlock& block, CBlockIndex* pindex, bool fJus
                 if (pwalletMain->IsMyMint(m.GetValue())) {
                     pwalletMain->UpdateMint(m.GetValue(), pindex->nHeight, m.GetTxHash(), m.GetDenomination());
                     // Add the transaction to the wallet
-                    for (auto& tx : block.vtx) {
+                    int posInBlock = 0;
+                    for (posInBlock = 0; posInBlock < (int)block.vtx.size(); posInBlock++) {
+                        auto& tx = block.vtx[posInBlock];
                         uint256 txid = tx.GetHash();
                         if (setAddedToWallet.count(txid))
                             continue;
                         if (txid == m.GetTxHash()) {
                             CWalletTx wtx(pwalletMain, tx);
                             wtx.nTimeReceived = block.GetBlockTime();
-                            wtx.SetMerkleBranch(block);
+                            wtx.SetMerkleBranch(pindex, posInBlock);
                             pwalletMain->AddToWallet(wtx);
                             setAddedToWallet.insert(txid);
                         }

--- a/src/zpivchain.cpp
+++ b/src/zpivchain.cpp
@@ -443,7 +443,7 @@ bool UpdateZPIVSupplyConnect(const CBlock& block, CBlockIndex* pindex, bool fJus
                             CWalletTx wtx(pwalletMain, tx);
                             wtx.nTimeReceived = block.GetBlockTime();
                             wtx.SetMerkleBranch(block);
-                            pwalletMain->AddToWallet(wtx, nullptr);
+                            pwalletMain->AddToWallet(wtx);
                             setAddedToWallet.insert(txid);
                         }
                     }


### PR DESCRIPTION
Work done on top of #1717 .

Essentially an improvement over `SyncWithWallets` & `SyncTransaction` flow to run without locking `cs_main`.
(made as less modifications as possible over the zpiv wallet/chain files, no real need to improve that code.. most of it will disappear soon)

It's an adapted version of bitcoin#7946.

