### PR TITLE
[GUI] Return early in pollBalanceChanged

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -238,7 +238,14 @@ void WalletModel::pollBalanceChanged()
     if (!lockWallet)
         return;
 
-    int chainHeight = chainActive.Height();
+    // Don't continue processing if the chain tip time is less than the first
+    // key creation time as there is no need to iterate over the transaction
+    // table model in this case.
+    auto tip = chainActive.Tip();
+    if (tip->GetBlockTime() < getCreationTime())
+        return;
+
+    int chainHeight = tip->nHeight;
     if (fForceCheckBalanceChanged || chainHeight != cachedNumBlocks) {
         fForceCheckBalanceChanged = false;
 


### PR DESCRIPTION
When syncing or reindexing with a pre-existing wallet, there is no need
to do any updating of the transaction table model data when the chain's
tip time is prior to the wallet's creation time.

This offers a scaling performance boost as the number of transactions
a wallet has increases. For context, here are some sync time comparisons:

Current `master`:
```
Time to sync to Nov 27 2019: ~4 hours
```

This PR:
```
Time to sync to Nov 27 2019: ~1 hour 30 minutes
```

The wallet is a testnet wallet created on Nov 27 2019, and has roughly
96k transactions since then. Sync time from wallet creation timestamp
to the current block height remain unchanged here.

Note: wallets that have **imported** a watch-only address, a private key,
or set a different HD seed will not benefit from this change as those
wallets have their creation time set to a static value of `1`