### PR TITLE
CBlockUndo WriteTodisk & ReadFromDisk moved to standalone functions.

### DIFF
--- a/src/undo.h
+++ b/src/undo.h
@@ -82,9 +82,6 @@ public:
     {
         READWRITE(vtxundo);
     }
-
-    bool WriteToDisk(CDiskBlockPos& pos, const uint256& hashBlock);
-    bool ReadFromDisk(const CDiskBlockPos& pos, const uint256& hashBlock);
 };
 
 #endif // BITCOIN_UNDO_H


### PR DESCRIPTION
No functional changes. Small refactor in main.cpp going into upstream direction. 

CBlockUndo::WriteTodisk & CBlockUndo::ReadFromDisk moved out of the class to standalone functions.