### PR TITLE
[GUI] Fix settings language combobox initialization.

### DIFF
--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -88,6 +88,7 @@ public:
     bool getProxySettings(QNetworkProxy& proxy) const;
     bool getCoinControlFeatures() { return fCoinControlFeatures; }
     const QString& getOverriddenByCommandLine() { return strOverriddenByCommandLine; }
+    const QString& getLang() { return language; }
 
     /* Restart flag helper */
     void setRestartRequired(bool fRequired);

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -134,11 +134,6 @@ private:
 
 Q_SIGNALS:
     void displayUnitChanged(int unit);
-    void zeromintEnableChanged(bool);
-    void zeromintAddressesChanged(bool);
-    void zeromintPercentageChanged(int);
-    void preferredDenomChanged(int);
-    void anonymizePivxAmountChanged(int);
     void coinControlFeaturesChanged(bool);
     void showHideColdStakingScreen(bool);
     void hideChartsChanged(bool);

--- a/src/qt/pivx/settings/settingsdisplayoptionswidget.cpp
+++ b/src/qt/pivx/settings/settingsdisplayoptionswidget.cpp
@@ -94,7 +94,6 @@ SettingsDisplayOptionsWidget::SettingsDisplayOptionsWidget(PIVXGUI* _window, QWi
     setCssBtnSecondary(ui->pushButtonReset);
     setCssBtnSecondary(ui->pushButtonClean);
 
-    initLanguages();
     connect(ui->pushButtonSave, &QPushButton::clicked, [this] { Q_EMIT saveSettings(); });
     connect(ui->pushButtonReset, &QPushButton::clicked, this, &SettingsDisplayOptionsWidget::onResetClicked);
     connect(ui->pushButtonClean, &QPushButton::clicked, [this] { Q_EMIT discardSettings(); });
@@ -102,11 +101,15 @@ SettingsDisplayOptionsWidget::SettingsDisplayOptionsWidget(PIVXGUI* _window, QWi
 
 void SettingsDisplayOptionsWidget::initLanguages()
 {
+    const QString& selectedLang = this->clientModel->getOptionsModel()->getLang();
     /* Language selector */
     QDir translations(":translations");
     QString defaultStr = QString("(") + tr("default") + QString(")");
     ui->comboBoxLanguage->addItem(defaultStr, QVariant(""));
-    Q_FOREACH (const QString& langStr, translations.entryList()) {
+    QStringList list = translations.entryList();
+    int selectedIndex = 0;
+    for (int i = 0; i < list.size(); ++i) {
+        const QString& langStr = list[i];
         QLocale locale(langStr);
 
         /** check if the locale name consists of 2 parts (language_country) */
@@ -117,7 +120,12 @@ void SettingsDisplayOptionsWidget::initLanguages()
             /** display language strings as "native language (locale name)", e.g. "Deutsch (de)" */
             ui->comboBoxLanguage->addItem(locale.nativeLanguageName() + QString(" (") + langStr + QString(")"), QVariant(langStr));
         }
+        // Save selected index
+        if (langStr == selectedLang) {
+            selectedIndex = i + 1;
+        }
     }
+    ui->comboBoxLanguage->setCurrentIndex(selectedIndex);
 }
 
 void SettingsDisplayOptionsWidget::onResetClicked()
@@ -145,6 +153,7 @@ void SettingsDisplayOptionsWidget::loadClientModel()
 {
     if (clientModel) {
         ui->comboBoxUnit->setCurrentIndex(this->clientModel->getOptionsModel()->getDisplayUnit());
+        initLanguages();
     }
 }
 

--- a/src/qt/pivx/settings/settingswidget.cpp
+++ b/src/qt/pivx/settings/settingswidget.cpp
@@ -192,15 +192,13 @@ void SettingsWidget::loadClientModel()
 
         OptionsModel *optionsModel = this->clientModel->getOptionsModel();
         if (optionsModel) {
+            settingsDisplayOptionsWidget->setClientModel(clientModel);
+            settingsMainOptionsWidget->setClientModel(clientModel);
+            settingsWalletOptionsWidget->setClientModel(clientModel);
+
             mapper->setModel(optionsModel);
             setMapper();
             mapper->toFirst();
-            settingsMainOptionsWidget->setClientModel(clientModel);
-            settingsDisplayOptionsWidget->setClientModel(clientModel);
-            settingsWalletOptionsWidget->setClientModel(clientModel);
-            /* keep consistency for action triggered elsewhere */
-
-            // TODO: Connect show restart needed and apply changes.
         }
     }
 }


### PR DESCRIPTION
Fixes #1627 + including a small cleanup.

The selected item in the languages combobox was not being initialized with the stored value.