### PR TITLE
[GUI] Recognize key event for clearing console

### DIFF
--- a/src/qt/pivx/settings/settingsconsolewidget.cpp
+++ b/src/qt/pivx/settings/settingsconsolewidget.cpp
@@ -345,6 +345,8 @@ bool SettingsConsoleWidget::eventFilter(QObject* obj, QEvent* event)
                     QApplication::postEvent(ui->lineEdit, new QKeyEvent(*keyevt));
                     return true;
                 }
+                if (mod == Qt::ControlModifier && key == Qt::Key_L)
+                    clear(false);
         }
     }
     return QWidget::eventFilter(obj, event);


### PR DESCRIPTION
Alternative to #1585 that leaves the wording unchanged, but adds key-combo recognition to the settingsconsolewidget the clear the history as how the initial help text describes.

Adjust the settingsconsolewidget event filter to explicitly recognize
the key combo for clearing the console.

fixes #1213 which was actually not adequately resolved in #1499