### PR TITLE
NU custom activation height startup arg.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -468,8 +468,7 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_V3_4].nActivationHeight          = 251;
         consensus.vUpgrades[Consensus::UPGRADE_V4_0].nActivationHeight          =
                 Consensus::NetworkUpgrade::ALWAYS_ACTIVE;
-        consensus.vUpgrades[Consensus::UPGRADE_V5_DUMMY].nActivationHeight =
-                Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
+        consensus.vUpgrades[Consensus::UPGRADE_V5_DUMMY].nActivationHeight       = 300;
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -25,7 +25,6 @@ namespace Consensus {
 */
 enum UpgradeIndex : uint32_t {
     BASE_NETWORK,
-    UPGRADE_TESTDUMMY,
     UPGRADE_POS,
     UPGRADE_POS_V2,
     UPGRADE_ZC,
@@ -35,6 +34,7 @@ enum UpgradeIndex : uint32_t {
     UPGRADE_V3_4,
     UPGRADE_V4_0,
     UPGRADE_V5_DUMMY,
+    UPGRADE_TESTDUMMY,
     // NOTE: Also add new upgrades to NetworkUpgradeInfo in upgrades.cpp
     MAX_NETWORK_UPGRADES
 };

--- a/src/consensus/upgrades.cpp
+++ b/src/consensus/upgrades.cpp
@@ -8,6 +8,9 @@
 /**
  * General information about each network upgrade.
  * Ordered by Consensus::UpgradeIndex.
+ *
+ * If the upgrade name has many words, use the '_' character to divide them.
+ * We are using it in the -nuparams startup arg and input it with spaces is just ugly.
  */
 const struct NUInfo NetworkUpgradeInfo[Consensus::MAX_NETWORK_UPGRADES] = {
         {
@@ -19,7 +22,7 @@ const struct NUInfo NetworkUpgradeInfo[Consensus::MAX_NETWORK_UPGRADES] = {
                 /*.strInfo =*/ "Proof of Stake Consensus activation",
         },
         {
-                /*.strName =*/ "PoS v2",
+                /*.strName =*/ "PoS_v2",
                 /*.strInfo =*/ "New selection for stake modifier",
         },
         {
@@ -27,7 +30,7 @@ const struct NUInfo NetworkUpgradeInfo[Consensus::MAX_NETWORK_UPGRADES] = {
                 /*.strInfo =*/ "ZeroCoin protocol activation - start block v4",
         },
         {
-                /*.strName =*/ "Zerocoin v2",
+                /*.strName =*/ "Zerocoin_v2",
                 /*.strInfo =*/ "new zerocoin serials and zPOS start",
         },
         {
@@ -35,23 +38,23 @@ const struct NUInfo NetworkUpgradeInfo[Consensus::MAX_NETWORK_UPGRADES] = {
                 /*.strInfo =*/ "CLTV (BIP65) activation - start block v5",
         },
         {
-                /*.strName =*/ "Zerocoin Public",
+                /*.strName =*/ "Zerocoin_Public",
                 /*.strInfo =*/ "activation of zerocoin public spends (spend v3)",
         },
         {
-                /*.strName =*/ "PIVX v3.4",
+                /*.strName =*/ "PIVX_v3.4",
                 /*.strInfo =*/ "new 256-bit stake modifier - start block v6",
         },
         {
-                /*.strName =*/ "PIVX v4.0",
+                /*.strName =*/ "PIVX_v4.0",
                 /*.strInfo =*/ "new message sigs - start block v7 - time protocol - zc spend v4",
         },
         {
-                /*.strName =*/ "v5 dummy",
+                /*.strName =*/ "v5_dummy",
                 /*.strInfo =*/ "Placeholder for future PIVX version 5.0 upgrade",
         },
         {
-                /*.strName =*/ "Test dummy",
+                /*.strName =*/ "Test_dummy",
                 /*.strInfo =*/ "Test dummy info",
         },
 };

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -929,8 +929,6 @@ bool InitNUParams()
                     found = true;
                     LogPrintf("Setting network upgrade activation parameters for %s to height=%d\n", vDeploymentParams[0], nActivationHeight);
                     break;
-                } else {
-                    UIError(vDeploymentParams[0]);
                 }
             }
             if (!found) {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -799,8 +799,10 @@ void NetworkUpgradeDescPushBack(
     // hidden. This is used when network upgrade implementations are merged
     // without specifying the activation height.
     if (consensusParams.vUpgrades[idx].nActivationHeight != Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT) {
+        std::string name = NetworkUpgradeInfo[idx].strName;
+        std::replace(name.begin(), name.end(), '_', ' '); // Beautify the name
         networkUpgrades.push_back(Pair(
-                NetworkUpgradeInfo[idx].strName,
+                name,
                 NetworkUpgradeDesc(consensusParams, idx, height)));
     }
 }


### PR DESCRIPTION
Few commits decoupled from the Sapling branch.

Included here:

1) Fixing an upgrade index issue (last commit).

2) Added the 'nuparams' startup arg to customize the regtest network upgrade activation height (Used in the functional tests).