### PR TITLE
[Model] Wallet interface refactor + code cleanup.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,6 +295,7 @@ set(SERVER_SOURCES
         ./src/httprpc.cpp
         ./src/httpserver.cpp
         ./src/init.cpp
+        ./src/interface/wallet.cpp
         ./src/dbwrapper.cpp
         ./src/legacy/validation_zerocoin_legacy.cpp
         ./src/main.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -121,6 +121,7 @@ BITCOIN_CORE_H = \
   httprpc.h \
   httpserver.h \
   init.h \
+  interface/wallet.h \
   invalid.h \
   invalid_outpoints.json.h \
   invalid_serials.json.h \
@@ -285,6 +286,7 @@ libbitcoin_wallet_a_SOURCES = \
   activemasternode.cpp \
   bip38.cpp \
   denomination_functions.cpp \
+  interface/wallet.cpp \
   addressbook.cpp \
   crypter.cpp \
   key_io.cpp \

--- a/src/interface/wallet.cpp
+++ b/src/interface/wallet.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2018-2020 The Bitcoin Core developers
+// Copyright (c) 2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include "interface/wallet.h"
+#include "wallet.h"
+
+namespace interfaces {
+
+    WalletBalances Wallet::getBalances() {
+        WalletBalances result;
+        result.balance = m_wallet.GetBalance();
+        result.unconfirmed_balance = m_wallet.GetUnconfirmedBalance();
+        result.immature_balance = m_wallet.GetImmatureBalance();
+        result.have_watch_only = m_wallet.HaveWatchOnly();
+        if (result.have_watch_only) {
+            result.watch_only_balance = m_wallet.GetWatchOnlyBalance();
+            result.unconfirmed_watch_only_balance = m_wallet.GetUnconfirmedWatchOnlyBalance();
+            result.immature_watch_only_balance = m_wallet.GetImmatureWatchOnlyBalance();
+        }
+        result.zerocoin_balance = m_wallet.GetZerocoinBalance(false);
+        result.unconfirmed_zerocoin_balance = m_wallet.GetUnconfirmedZerocoinBalance();
+        result.immature_zerocoin_balance = m_wallet.GetImmatureZerocoinBalance();
+        result.delegate_balance = m_wallet.GetDelegatedBalance();
+        result.coldstaked_balance = m_wallet.GetColdStakingBalance();
+        return result;
+    }
+
+} // namespace interfaces

--- a/src/interface/wallet.cpp
+++ b/src/interface/wallet.cpp
@@ -19,9 +19,6 @@ namespace interfaces {
             result.unconfirmed_watch_only_balance = m_wallet.GetUnconfirmedWatchOnlyBalance();
             result.immature_watch_only_balance = m_wallet.GetImmatureWatchOnlyBalance();
         }
-        result.zerocoin_balance = m_wallet.GetZerocoinBalance(false);
-        result.unconfirmed_zerocoin_balance = m_wallet.GetUnconfirmedZerocoinBalance();
-        result.immature_zerocoin_balance = m_wallet.GetImmatureZerocoinBalance();
         result.delegate_balance = m_wallet.GetDelegatedBalance();
         result.coldstaked_balance = m_wallet.GetColdStakingBalance();
         return result;

--- a/src/interface/wallet.h
+++ b/src/interface/wallet.h
@@ -17,9 +17,6 @@ struct WalletBalances
     CAmount balance{0};
     CAmount unconfirmed_balance{0};
     CAmount immature_balance{0};
-    CAmount zerocoin_balance{0};
-    CAmount unconfirmed_zerocoin_balance{0};
-    CAmount immature_zerocoin_balance{0};
     bool have_watch_only{false};
     CAmount watch_only_balance{0};
     CAmount unconfirmed_watch_only_balance{0};
@@ -33,9 +30,7 @@ struct WalletBalances
                immature_balance != prev.immature_balance || watch_only_balance != prev.watch_only_balance ||
                unconfirmed_watch_only_balance != prev.unconfirmed_watch_only_balance ||
                immature_watch_only_balance != prev.immature_watch_only_balance ||
-               zerocoin_balance != prev.zerocoin_balance || unconfirmed_zerocoin_balance != prev.unconfirmed_zerocoin_balance ||
-               immature_zerocoin_balance != prev.immature_zerocoin_balance || delegate_balance != prev.delegate_balance ||
-               coldstaked_balance != prev.coldstaked_balance;
+               delegate_balance != prev.delegate_balance || coldstaked_balance != prev.coldstaked_balance;
     }
 };
 

--- a/src/interface/wallet.h
+++ b/src/interface/wallet.h
@@ -1,0 +1,55 @@
+// Copyright (c) 2018-2020 The Bitcoin Core developers
+// Copyright (c) 2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#ifndef PIVX_INTERFACES_WALLET_H
+#define PIVX_INTERFACES_WALLET_H
+
+#include <amount.h>
+#include "wallet/wallet.h"
+
+namespace interfaces {
+
+//! Collection of wallet balances.
+struct WalletBalances
+{
+    CAmount balance{0};
+    CAmount unconfirmed_balance{0};
+    CAmount immature_balance{0};
+    CAmount zerocoin_balance{0};
+    CAmount unconfirmed_zerocoin_balance{0};
+    CAmount immature_zerocoin_balance{0};
+    bool have_watch_only{false};
+    CAmount watch_only_balance{0};
+    CAmount unconfirmed_watch_only_balance{0};
+    CAmount immature_watch_only_balance{0};
+    CAmount delegate_balance{0};
+    CAmount coldstaked_balance{0};
+
+    bool balanceChanged(const WalletBalances& prev) const
+    {
+        return balance != prev.balance || unconfirmed_balance != prev.unconfirmed_balance ||
+               immature_balance != prev.immature_balance || watch_only_balance != prev.watch_only_balance ||
+               unconfirmed_watch_only_balance != prev.unconfirmed_watch_only_balance ||
+               immature_watch_only_balance != prev.immature_watch_only_balance ||
+               zerocoin_balance != prev.zerocoin_balance || unconfirmed_zerocoin_balance != prev.unconfirmed_zerocoin_balance ||
+               immature_zerocoin_balance != prev.immature_zerocoin_balance || delegate_balance != prev.delegate_balance ||
+               coldstaked_balance != prev.coldstaked_balance;
+    }
+};
+
+class Wallet {
+public:
+    explicit Wallet(CWallet& wallet) : m_wallet(wallet) { };
+    // Retrieve all the wallet balances
+    WalletBalances getBalances();
+
+private:
+    CWallet& m_wallet;
+};
+
+
+} // namespace interfaces
+
+#endif // BITCOIN_INTERFACES_WALLET_H

--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -615,17 +615,11 @@ void TopBar::updateDisplayUnit()
         int displayUnitPrev = nDisplayUnit;
         nDisplayUnit = walletModel->getOptionsModel()->getDisplayUnit();
         if (displayUnitPrev != nDisplayUnit)
-            updateBalances(walletModel->getBalance(), walletModel->getUnconfirmedBalance(), walletModel->getImmatureBalance(),
-                           walletModel->getZerocoinBalance(), walletModel->getUnconfirmedZerocoinBalance(), walletModel->getImmatureZerocoinBalance(),
-                           walletModel->getWatchBalance(), walletModel->getWatchUnconfirmedBalance(), walletModel->getWatchImmatureBalance(),
-                           walletModel->getDelegatedBalance(), walletModel->getColdStakedBalance());
+            updateBalances(walletModel->GetWalletBalances());
     }
 }
 
-void TopBar::updateBalances(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance,
-                            const CAmount& zerocoinBalance, const CAmount& unconfirmedZerocoinBalance, const CAmount& immatureZerocoinBalance,
-                            const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance,
-                            const CAmount& delegatedBalance, const CAmount& coldStakedBalance)
+void TopBar::updateBalances(const interfaces::WalletBalances& newBalance)
 {
     // Locked balance. //TODO move this to the signal properly in the future..
     CAmount nLockedBalance = 0;
@@ -635,15 +629,15 @@ void TopBar::updateBalances(const CAmount& balance, const CAmount& unconfirmedBa
     ui->labelTitle1->setText(nLockedBalance > 0 ? tr("Available (Locked included)") : tr("Available"));
 
     // PIV Total
-    QString totalPiv = GUIUtil::formatBalance(balance, nDisplayUnit);
+    QString totalPiv = GUIUtil::formatBalance(newBalance.balance, nDisplayUnit);
 
     // PIV
     // Top
     ui->labelAmountTopPiv->setText(totalPiv);
     // Expanded
     ui->labelAmountPiv->setText(totalPiv);
-    ui->labelPendingPiv->setText(GUIUtil::formatBalance(unconfirmedBalance, nDisplayUnit));
-    ui->labelImmaturePiv->setText(GUIUtil::formatBalance(immatureBalance, nDisplayUnit));
+    ui->labelPendingPiv->setText(GUIUtil::formatBalance(newBalance.unconfirmed_balance, nDisplayUnit));
+    ui->labelImmaturePiv->setText(GUIUtil::formatBalance(newBalance.immature_balance, nDisplayUnit));
 }
 
 void TopBar::resizeEvent(QResizeEvent *event)

--- a/src/qt/pivx/topbar.h
+++ b/src/qt/pivx/topbar.h
@@ -43,10 +43,7 @@ public:
     void unlockWallet();
 
 public Q_SLOTS:
-    void updateBalances(const CAmount& balance, const CAmount& unconfirmedBalance, const CAmount& immatureBalance,
-                        const CAmount& zerocoinBalance, const CAmount& unconfirmedZerocoinBalance, const CAmount& immatureZerocoinBalance,
-                        const CAmount& watchOnlyBalance, const CAmount& watchUnconfBalance, const CAmount& watchImmatureBalance,
-                        const CAmount& delegatedBalance, const CAmount& coldStakedBalance);
+    void updateBalances(const interfaces::WalletBalances& newBalance);
     void updateDisplayUnit();
 
     void setNumConnections(int count);

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -122,65 +122,19 @@ CAmount WalletModel::getMinColdStakingAmount() const
     return MIN_COLDSTAKING_AMOUNT;
 }
 
-CAmount WalletModel::getUnconfirmedBalance() const
-{
-    return wallet->GetUnconfirmedBalance();
-}
-
-CAmount WalletModel::getImmatureBalance() const
-{
-    return wallet->GetImmatureBalance();
-}
-
 CAmount WalletModel::getLockedBalance() const
 {
     return wallet->GetLockedCoins();
 }
-
-CAmount WalletModel::getZerocoinBalance() const
-{
-    return wallet->GetZerocoinBalance(false);
-}
-
-CAmount WalletModel::getUnconfirmedZerocoinBalance() const
-{
-    return wallet->GetUnconfirmedZerocoinBalance();
-}
-
-CAmount WalletModel::getImmatureZerocoinBalance() const
-{
-    return wallet->GetImmatureZerocoinBalance();
-}
-
 
 bool WalletModel::haveWatchOnly() const
 {
     return fHaveWatchOnly;
 }
 
-CAmount WalletModel::getWatchBalance() const
-{
-    return wallet->GetWatchOnlyBalance();
-}
-
-CAmount WalletModel::getWatchUnconfirmedBalance() const
-{
-    return wallet->GetUnconfirmedWatchOnlyBalance();
-}
-
-CAmount WalletModel::getWatchImmatureBalance() const
-{
-    return wallet->GetImmatureWatchOnlyBalance();
-}
-
 CAmount WalletModel::getDelegatedBalance() const
 {
     return wallet->GetDelegatedBalance();
-}
-
-CAmount WalletModel::getColdStakedBalance() const
-{
-    return wallet->GetColdStakingBalance();
 }
 
 bool WalletModel::isColdStaking() const

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -167,10 +167,6 @@ public:
     EncryptionStatus getEncryptionStatus() const;
     bool isWalletUnlocked() const;
     bool isWalletLocked(bool fFullUnlocked = true) const;
-    CKey generateNewKey() const; //for temporary paper wallet key generation
-    bool setAddressBook(const CTxDestination& address, const std::string& strName, const std::string& strPurpose);
-    void encryptKey(const CKey key, const std::string& pwd, const std::string& slt, std::vector<unsigned char>& crypted);
-    void decryptKey(const std::vector<unsigned char>& crypted, const std::string& slt, const std::string& pwd, CKey& key);
     void emitBalanceChanged(); // Force update of UI-elements even when no values have changed
 
     // Check address for validity

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -158,19 +158,9 @@ public:
 
     CAmount getBalance(const CCoinControl* coinControl = nullptr, bool fIncludeDelegated = true, bool fUnlockedOnly = false) const;
     CAmount getUnlockedBalance(const CCoinControl* coinControl = nullptr, bool fIncludeDelegated = true) const;
-    CAmount getUnconfirmedBalance() const;
-    CAmount getImmatureBalance() const;
     CAmount getLockedBalance() const;
-    CAmount getZerocoinBalance() const;
-    CAmount getUnconfirmedZerocoinBalance() const;
-    CAmount getImmatureZerocoinBalance() const;
     bool haveWatchOnly() const;
-    CAmount getWatchBalance() const;
-    CAmount getWatchUnconfirmedBalance() const;
-    CAmount getWatchImmatureBalance() const;
-
     CAmount getDelegatedBalance() const;
-    CAmount getColdStakedBalance() const;
 
     bool isColdStaking() const;
 


### PR DESCRIPTION
This is motivated by the different types of balances that we currently have (and the new ones that are coming).

1) Refactor: Back ported and adapted the `WalletBalances` wrapper class.
2) Cleanup: Removed the not used balance getters from `walletModel` + some not implemented methods that we had.
3) Cleanup: Removed the zerocoin balance related fields from the GUI, we are not showing it anymore and the GUI was still calculating + caching them. 