### PR TITLE
[Wallet] AvailableCoins remove duplicated watchonly config argument.

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2079,8 +2079,7 @@ bool CWallet::AvailableCoins(std::vector<COutput>* pCoins,      // --> populates
                              AvailableCoinsType nCoinType,      // Default: ALL_COINS
                              bool fOnlyConfirmed,               // Default: true
                              bool fIncludeZeroValue,            // Default: false
-                             bool fUseIX,                       // Default: false
-                             int nWatchonlyConfig               // Default: 1
+                             bool fUseIX                       // Default: false
                              ) const
 {
     if (pCoins) pCoins->clear();
@@ -2117,8 +2116,7 @@ bool CWallet::AvailableCoins(std::vector<COutput>* pCoins,      // --> populates
 
                 isminetype mine = IsMine(pcoin->vout[i]);
                 if (  (mine == ISMINE_NO) ||
-                      (mine == ISMINE_SPENDABLE && nWatchonlyConfig == 2) ||
-                      (mine == ISMINE_WATCH_ONLY && nWatchonlyConfig == 1) ||
+                      (mine == ISMINE_WATCH_ONLY && coinControl && !coinControl->fAllowWatchOnly) ||
                       (IsLockedCoin((*it).first, i) && nCoinType != ONLY_10000) ||
                       (pcoin->vout[i].nValue <= 0 && !fIncludeZeroValue) ||
                       (fCoinsSelected && !coinControl->fAllowOtherInputs && !coinControl->IsSelected(COutPoint((*it).first, i)))

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -351,8 +351,7 @@ public:
                         AvailableCoinsType nCoinType    = ALL_COINS,
                         bool fOnlyConfirmed             = true,
                         bool fIncludeZeroValue          = false,
-                        bool fUseIX                     = false,
-                        int nWatchonlyConfig            = 1
+                        bool fUseIX                     = false
                         ) const;
     //! >> Available coins (spending)
     bool SelectCoinsToSpend(const std::vector<COutput>& vAvailableCoins, const CAmount& nTargetValue, std::set<std::pair<const CWalletTx*, unsigned int> >& setCoinsRet, CAmount& nValueRet, const CCoinControl* coinControl = nullptr) const;

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -147,7 +147,7 @@ class WalletTest(PivxTestFramework):
         assert(self.nodes[1].validateaddress(address_to_import)["iswatchonly"])
 
         # 4. Check that the unspents after import are not spendable
-        listunspent = self.nodes[1].listunspent(1, 9999999, [], 3)
+        listunspent = self.nodes[1].listunspent(1, 9999999, [], 2)
         assert_array_result(listunspent,
                            {"address": address_to_import},
                            {"spendable": False})


### PR DESCRIPTION
Cleaning a duplicate watch only filtering configuration from `CWallet::AvailableCoins`. The same configuration can be found in `CCoinControl` object, `fAllowWatchOnly` member.

It has mostly non-functional changes and only duplicated code cleanup. The only functional change exception is in `listunspent` rpc command.
`listunspent` command will not be able anymore to retrieve only the watch only utxo. watch only utxo can be added or not to the utxo set with a custom configuration (same as before).