### PR TITLE
[Wallet] Acquire cs_main lock before cs_wallet during wallet initialization

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3042,13 +3042,14 @@ CAmount CWallet::GetMinimumFee(unsigned int nTxBytes, unsigned int nConfirmTarge
 
 DBErrors CWallet::LoadWallet(bool& fFirstRunRet)
 {
+    LOCK2(cs_main, cs_wallet);
+
     if (!fFileBacked)
         return DB_LOAD_OK;
 
     DBErrors nLoadWalletRet = CWalletDB(strWalletFile, "cr+").LoadWallet(this);
     if (nLoadWalletRet == DB_NEED_REWRITE) {
         if (CDB::Rewrite(strWalletFile, "\x04pool")) {
-            LOCK(cs_wallet);
             // TODO: Implement spk_man->RewriteDB().
             m_spk_man->set_pre_split_keypool.clear();
             // Note: can't top-up keypool here, because wallet is locked.


### PR DESCRIPTION
Fixing
```
2020-08-01 09:53:49 POTENTIAL DEADLOCK DETECTED
2020-08-01 09:53:49 Previous lock order was:
2020-08-01 09:53:49  (1) cs_main wallet/wallet.cpp:1617 (in thread )
2020-08-01 09:53:49  (2) cs_wallet wallet/wallet.cpp:1617 (in thread )
2020-08-01 09:53:49 Current lock order is:
2020-08-01 09:53:49  (2) pwallet->cs_wallet wallet/walletdb.cpp:708 (in thread )
2020-08-01 09:53:49  (1) cs_main wallet/wallet.cpp:1013 (in thread )
```

(backports bitcoin/bitcoin#11126)

> `CWallet::MarkConflicted` may acquire the `cs_main` lock after `CWalletDB::LoadWallet` acquires the `cs_wallet` lock during wallet initialization. (`CWalletDB::LoadWallet` calls `ReadKeyValue` which calls `CWallet::LoadToWallet` which calls `CWallet::MarkConflicted`). 
> This is the opposite order that `cs_main` and `cs_wallet` locks are acquired in the rest of the code, and so leads to POTENTIAL DEADLOCK DETECTED errors if bitcoin is built with -DDEBUG_LOCKORDER.
>
> This commit changes `CWallet::LoadWallet` (which calls `CWalletDB::LoadWallet`) to acquire both locks in the standard order. 