### PR TITLE
[GUI] Start masternodes polling timer only when is needed.

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -49,8 +49,6 @@ ClientModel::ClientModel(OptionsModel* optionsModel, QObject* parent) : QObject(
 
     pollMnTimer = new QTimer(this);
     connect(pollMnTimer, &QTimer::timeout, this, &ClientModel::updateMnTimer);
-    // no need to update as frequent as data for balances/txes/blocks
-    pollMnTimer->start(MODEL_UPDATE_DELAY * 40);
 
     subscribeToCoreSignals();
 }
@@ -147,6 +145,21 @@ void ClientModel::updateMnTimer()
         cachedMasternodeCountString = newMasternodeCountString;
 
         Q_EMIT strMasternodesChanged(cachedMasternodeCountString);
+    }
+}
+
+void ClientModel::startMasternodesTimer()
+{
+    if (!pollMnTimer->isActive()) {
+        // no need to update as frequent as data for balances/txes/blocks
+        pollMnTimer->start(MODEL_UPDATE_DELAY * 40);
+    }
+}
+
+void ClientModel::stopMasternodesTimer()
+{
+    if (pollMnTimer->isActive()) {
+        pollMnTimer->stop();
     }
 }
 

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -86,6 +86,10 @@ public:
 
     bool getTorInfo(std::string& ip_port) const;
 
+    // Start/Stop the masternode polling timer
+    void startMasternodesTimer();
+    void stopMasternodesTimer();
+
 private:
     QString getMasternodeCountString() const;
     OptionsModel* optionsModel;

--- a/src/qt/pivx/settings/settingsinformationwidget.cpp
+++ b/src/qt/pivx/settings/settingsinformationwidget.cpp
@@ -160,6 +160,21 @@ void SettingsInformationWidget::openNetworkMonitor()
     rpcConsole->showNetwork();
 }
 
+void SettingsInformationWidget::showEvent(QShowEvent *event)
+{
+    QWidget::showEvent(event);
+    if (clientModel) {
+        clientModel->startMasternodesTimer();
+    }
+}
+
+void SettingsInformationWidget::hideEvent(QHideEvent *event) {
+    QWidget::hideEvent(event);
+    if (clientModel) {
+        clientModel->stopMasternodesTimer();
+    }
+}
+
 SettingsInformationWidget::~SettingsInformationWidget()
 {
     delete ui;

--- a/src/qt/pivx/settings/settingsinformationwidget.h
+++ b/src/qt/pivx/settings/settingsinformationwidget.h
@@ -27,6 +27,8 @@ private Q_SLOTS:
     void setNumConnections(int count);
     void setNumBlocks(int count);
     void setMasternodeCount(const QString& strMasternodes);
+    void showEvent(QShowEvent* event) override;
+    void hideEvent(QHideEvent* event) override;
 
 public Q_SLOTS:
     void openNetworkMonitor();

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -948,6 +948,7 @@ void RPCConsole::showEvent(QShowEvent* event)
 
     // start PeerTableModel auto refresh
     clientModel->getPeerTableModel()->startAutoRefresh();
+    clientModel->startMasternodesTimer();
 }
 
 void RPCConsole::hideEvent(QHideEvent* event)
@@ -959,6 +960,7 @@ void RPCConsole::hideEvent(QHideEvent* event)
 
     // stop PeerTableModel auto refresh
     clientModel->getPeerTableModel()->stopAutoRefresh();
+    clientModel->stopMasternodesTimer();
 }
 
 void RPCConsole::showBackups()
@@ -1049,3 +1051,4 @@ void RPCConsole::showOrHideBanTableIfRequired()
     ui->banlistWidget->setVisible(visible);
     ui->banHeading->setVisible(visible);
 }
+


### PR DESCRIPTION
The masternodes polling was starting when the clientModel object is generated, locking `cs_main` every certain amount of time without care on whether the information is being presented or not.
 This PR changes it, the polling timer will only be started when the information is needed on the screen and stopped when the user leaves such screen.