### PR TITLE
[Wallet] Do not try to resend transactions if the node is importing or in IBD

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6197,7 +6197,7 @@ bool SendMessages(CNode* pto)
         // Resend wallet transactions that haven't gotten in a block yet
         // Except during reindex, importing and IBD, when old wallet
         // transactions become unconfirmed and spams other nodes.
-        if (!fReindex /*&& !fImporting && !IsInitialBlockDownload()*/) {
+        if (!fReindex && !fImporting && !IsInitialBlockDownload()) {
             GetMainSignals().Broadcast();
         }
 


### PR DESCRIPTION
As the title says, the wallet shouldn't resend transactions if the node is importing or in IBD state. The node doesn't know the real status until it's synced.