### PR TITLE
[Masternodes] Missing cs main locks in CalculateScore and GetMasternodeInputAge

### DIFF
--- a/src/masternode.h
+++ b/src/masternode.h
@@ -251,14 +251,20 @@ public:
 
     int GetMasternodeInputAge()
     {
-        if (chainActive.Tip() == NULL) return 0;
+        int tipHeight;
+        {
+            LOCK(cs_main);
+            CBlockIndex *pindex = chainActive.Tip();
+            if (!pindex) return 0;
+            tipHeight = pindex->nHeight;
+        }
 
         if (cacheInputAge == 0) {
             cacheInputAge = GetInputAge(vin);
-            cacheInputAgeBlock = chainActive.Tip()->nHeight;
+            cacheInputAgeBlock = tipHeight;
         }
 
-        return cacheInputAge + (chainActive.Tip()->nHeight - cacheInputAgeBlock);
+        return cacheInputAge + (tipHeight - cacheInputAgeBlock);
     }
 
     std::string Status()


### PR DESCRIPTION
In `CalculateScore`, `GetMasternodeInputAge` and `GetBlockHash` we had `chainActive` accessed without cs_main being held. This PR fixes it.
No functional changes. Can be added to 4.2.1 back ports list as well.