### PR TITLE
[Build] allow for empty RUST_TARGET in offline builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1207,6 +1207,11 @@ case $host in
     ;;
 esac
 
+if test -z "$RUST_TARGET"; then
+  AC_MSG_WARN([RUST_TARGET not set, assuming native build])
+fi
+AM_CONDITIONAL([HAVE_RUST_TARGET], [test -n "$RUST_TARGET"])
+
 # Additional Zcash flags
 AX_CHECK_COMPILE_FLAG([-fno-strict-aliasing],[CXXFLAGS="$CXXFLAGS -fno-strict-aliasing"])
 AX_CHECK_COMPILE_FLAG([-Wno-builtin-declaration-mismatch],[CXXFLAGS="$CXXFLAGS -Wno-builtin-declaration-mismatch"],,[[$CXXFLAG_WERROR]])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -63,7 +63,10 @@ $(CARGO_CONFIGURED):
 
 else
 # Enable dependency vendoring
-RUST_BUILD_OPTS += --locked --offline --target $(RUST_TARGET)
+RUST_BUILD_OPTS += --locked --offline
+if HAVE_RUST_TARGET
+RUST_BUILD_OPTS += --target $(RUST_TARGET)
+endif
 
 CARGO_CONFIGURED = $(top_srcdir)/.cargo/.configured-for-offline
 $(CARGO_CONFIGURED): $(top_srcdir)/.cargo/config.offline


### PR DESCRIPTION
The RUST_TARGET variable only applies when cross-compiling. Build
systems like launchpad and copr don't cross compile, but also need
pre-vendored rust sources as they don't allow network access during the
build stage. In this situation, the RUST_TARGET variable is empty.

This will fix our nightly PPA builds on Launchpad, and is supported by
additional changes in my `pivx-packaging` repo, as well as a new
`rust-vendored-sources` repo, both hosted on launchpad.

A separate PR will
be made to fix our nightly Snap builds, which will either entail re-working
how those builds are done, or rewrite the `rust.mk` descriptor.