### PR TITLE
[Build] Use syslibs for nightly snap builds

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -82,6 +82,7 @@ parts:
       #    default value is "false", to enable it, use your projects binary prefix
       OVERRIDEBINPREFIX="pivx"
       OVERRIDEDATADIR="false"
+      PARAMSDIR=".pivx-params"
       OVERRIDECONF="${OVERRIDEDATADIR}"
       COPYCONF=0    # copy example config into users data folder, 1 = enabled
       JOBS=4        # 0 means off and make will run without -j
@@ -90,6 +91,7 @@ parts:
       FIXPPCBUILD=1 # if ppc builds fail due to failed qt, apps part will return error and build will fail, 1 = enabled
       EXTRALOG=0    # prints env and all installed files at the end of current script
       RUNTESTS=1    # run make check after post install part
+      DEPENDS=0     # use the depends system instead of syslibs
       echo "-----------------------------------------------"
       echo "+++++++++++++++++++++++++++++++++++++++++++++++"
       echo "SET OVERRIDE VARIABLES IF SET" # checks OVERRIDEBINPREFIX, OVERRIDEDATADIR and OVERRIDECONF
@@ -148,17 +150,19 @@ parts:
       else
         echo "patch icons and images is disabled, skipping"
       fi
-      echo "-----------------------------------------------"
-      echo "+++++++++++++++++++++++++++++++++++++++++++++++"
-      echo "BUILD DEPENDENCIES"
-      echo "PRECOMPILE ${SNAPCRAFT_ARCH_TRIPLET} DEPENDENCIES FOR ${BINPREF}-${SNAPCRAFT_PROJECT_VERSION}" # cd to depends folder, download and precompile
-      echo "+++++++++++++++++++++++++++++++++++++++++++++++"
-      cd ${SNAPCRAFT_PART_BUILD}/depends
-      make download-linux
-      if [ $JOBS = 0 ]; then
-        make
-      else
-        make -j${JOBS} HOST=${HOST}
+      if [ $DEPENDS = 1 ]; then
+        echo "-----------------------------------------------"
+        echo "+++++++++++++++++++++++++++++++++++++++++++++++"
+        echo "BUILD DEPENDENCIES"
+        echo "PRECOMPILE ${SNAPCRAFT_ARCH_TRIPLET} DEPENDENCIES FOR ${BINPREF}-${SNAPCRAFT_PROJECT_VERSION}" # cd to depends folder, download and precompile
+        echo "+++++++++++++++++++++++++++++++++++++++++++++++"
+        cd ${SNAPCRAFT_PART_BUILD}/depends
+        make download-linux
+        if [ $JOBS = 0 ]; then
+          make HOST=${HOST}
+        else
+          make -j${JOBS} HOST=${HOST}
+        fi
       fi
       echo "-----------------------------------------------"
       echo "+++++++++++++++++++++++++++++++++++++++++++++++"
@@ -166,8 +170,15 @@ parts:
       echo "+++++++++++++++++++++++++++++++++++++++++++++++"
       cd ${SNAPCRAFT_PART_BUILD}
       echo "Configure and build ${BINPREF}"
+      if [ $RUNTESTS = 1 ]; then
+        mkdir -p ${SNAP_USER_COMMON}/${PARAMSDIR}
+      fi
       ./autogen.sh
-      ./configure --prefix=`pwd`/depends/${HOST}
+      if [ $DEPENDS = 1 ]; then
+        ./configure --prefix=`pwd`/depends/${HOST} --with-params-dir=${SNAP_USER_COMMON}/${PARAMSDIR}
+      else
+        ./configure --with-incompatible-bdb --with-params-dir=${SNAP_USER_COMMON}/${PARAMSDIR}
+      fi
       echo "-----------------------------------------------"
       echo "+++++++++++++++++++++++++++++++++++++++++++++++"
       echo "COMPILATION OF ${BINPREF}-${SNAPCRAFT_PROJECT_VERSION}" # run make to compile using -j
@@ -175,7 +186,7 @@ parts:
       if [ $JOBS = 0 ]; then
         make
       else
-        make -j${JOBS} HOST=${HOST}
+        make -j${JOBS}
       fi
       echo "-----------------------------------------------"
       echo "+++++++++++++++++++++++++++++++++++++++++++++++"
@@ -232,6 +243,7 @@ parts:
       cd ${SNAPCRAFT_PART_BUILD}
       if [ ! $SNAPCRAFT_ARCH_TRIPLET = "s390x-linux-gnu" ]; then
         if [ $RUNTESTS = 1 ]; then
+          ${SNAPCRAFT_PROJECT_DIR}/util/fetch-params.sh ${SNAP_USER_COMMON}/${PARAMSDIR}
           make check
         else
           echo "RUN TESTS disabled, skipping"
@@ -266,6 +278,26 @@ parts:
       - python3
       - help2man
       - doxygen
+      - libssl-dev
+      - libgmp-dev
+      - libevent-dev
+      - libboost-all-dev
+      - libsodium-dev
+      - cargo
+      - libminiupnpc-dev
+      - libzmq3-dev
+      - libqt5gui5
+      - libqt5core5a
+      - libqt5dbus5
+      - libqt5svg5-dev
+      - libqt5charts5-dev
+      - qttools5-dev
+      - qttools5-dev-tools
+      - libprotobuf-dev
+      - protobuf-compiler
+      - libqrencode-dev
+      - libdb-dev
+      - libdb++-dev
     stage-packages:
       - libxkbcommon0
       - ttf-ubuntu-font-family
@@ -278,6 +310,24 @@ parts:
       - locales-all
       - qtwayland5
       - ca-certificates
+      - libboost-chrono1.65.1
+      - libboost-filesystem1.65.1
+      - libboost-program-options1.65.1
+      - libboost-system1.65.1
+      - libboost-test1.65.1
+      - libboost-thread1.65.1
+      - libdb5.3++
+      - libevent-2.1-6
+      - libevent-pthreads-2.1-6
+      - libminiupnpc10
+      - libnorm1
+      - libpgm-5.2-0
+      - libprotobuf10
+      - libqrencode3
+      - libqt5charts5
+      - libqt5test5
+      - libsodium23
+      - libzmq5
     after:
       - patches
   patches:


### PR DESCRIPTION
Depends currently doesn't support non-x86_64 linux builds for the rust
dependency, so switch our nightly snap builds to use syslibs instead of
depends.

This also maintains the running of unit tests by fetching the zk params
during the build process.