### PR TITLE
[BUG] Properly copy fCoinStake memeber between CTxInUndo and CCoins

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1721,6 +1721,7 @@ void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, CTxUndo& txund
                 CTxInUndo& undo = txundo.vprevout.back();
                 undo.nHeight = coins->nHeight;
                 undo.fCoinBase = coins->fCoinBase;
+                undo.fCoinStake = coins->fCoinStake;
                 undo.nVersion = coins->nVersion;
             }
         }
@@ -2011,6 +2012,7 @@ static bool ApplyTxInUndo(const CTxInUndo& undo, CCoinsViewCache& view, const CO
             fClean = fClean && error("%s: undo data overwriting existing transaction", __func__);
         coins->Clear();
         coins->fCoinBase = undo.fCoinBase;
+        coins->fCoinStake = undo.fCoinStake;
         coins->nHeight = undo.nHeight;
         coins->nVersion = undo.nVersion;
     } else {

--- a/src/undo.h
+++ b/src/undo.h
@@ -16,7 +16,7 @@
  *
  *  Contains the prevout's CTxOut being spent, and if this was the
  *  last output of the affected transaction, its metadata as well
- *  (coinbase or not, height, transaction version)
+ *  (coinbase/coinstake or not, height, transaction version)
  */
 class CTxInUndo
 {


### PR DESCRIPTION
The `fCoinStake` variable of the undo metadata, which  is constructed in `UpdateCoins`, is never set.
Similarly, the coins cache entry is not restoring the `fCoinStake` flag from the undo data  in `ApplyTxInUndo`.

Now, since `coins->IsCoinStake()` is checked within places like `CheckTxInputs`/`AcceptableInputs`/etc..., this could potentially lead to consensus issues in case of reorganizations.