### PR TITLE
[P2P] Improve AlreadyHave

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4901,12 +4901,14 @@ bool static AlreadyHave(const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
             hashRecentRejectsChainTip = chainActive.Tip()->GetBlockHash();
             recentRejects->reset();
         }
-
+        // Use pcoinsTip->HaveCoinsInCache as a quick approximation to exclude
+        // requesting or processing some txs which have already been included in a block
         return recentRejects->contains(inv.hash) ||
                mempool.exists(inv.hash) ||
                mapOrphanTransactions.count(inv.hash) ||
-               pcoinsTip->HaveCoins(inv.hash);
+               pcoinsTip->HaveCoinsInCache(inv.hash);
     }
+
     case MSG_BLOCK:
         return mapBlockIndex.count(inv.hash);
     case MSG_TXLOCK_REQUEST:


### PR DESCRIPTION
Based on top of:
- [x] #1799

Only last commit is new.
Now that we have implemented `HaveCoinsInCache`, we can use it to speed up `AlreadyHave`, by avoiding unnecessary database access for unknown transactions.
(backported from bitcoin/bitcoin#7874)