### PR TITLE
[Core] Use std::unordered_{map,set} (C++11) instead of boost::unordered_*

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -47,8 +47,6 @@
 
 #include "libzerocoin/CoinSpend.h"
 
-#include <boost/unordered_map.hpp>
-
 class CBlockIndex;
 class CBlockTreeDB;
 class CZerocoinDB;
@@ -136,7 +134,7 @@ struct BlockHasher {
 extern CScript COINBASE_FLAGS;
 extern RecursiveMutex cs_main;
 extern CTxMemPool mempool;
-typedef boost::unordered_map<uint256, CBlockIndex*, BlockHasher> BlockMap;
+typedef std::unordered_map<uint256, CBlockIndex*, BlockHasher> BlockMap;
 extern BlockMap mapBlockIndex;
 extern uint64_t nLastBlockTx;
 extern uint64_t nLastBlockSize;

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -13,9 +13,6 @@
 #include <unordered_map>
 #include <unordered_set>
 
-#include <boost/unordered_set.hpp>
-#include <boost/unordered_map.hpp>
-
 namespace memusage
 {
 
@@ -48,8 +45,6 @@ template<typename X, typename Y> static inline size_t DynamicUsage(std::pair<X, 
 template<typename X> static size_t DynamicUsage(const std::vector<X>& v);
 template<typename X> static size_t DynamicUsage(const std::set<X>& s);
 template<typename X, typename Y> static size_t DynamicUsage(const std::map<X, Y>& m);
-template<typename X, typename Y> static size_t DynamicUsage(const boost::unordered_set<X, Y>& s);
-template<typename X, typename Y, typename Z> static size_t DynamicUsage(const boost::unordered_map<X, Y, Z>& s);
 template<typename X> static size_t DynamicUsage(const X& x);
 
 template<typename X> static size_t RecursiveDynamicUsage(const std::vector<X>& v);
@@ -171,18 +166,6 @@ struct unordered_node : private X
 private:
     void* ptr;
 };
-
-template<typename X, typename Y>
-static inline size_t DynamicUsage(const boost::unordered_set<X, Y>& s)
-{
-    return MallocUsage(sizeof(unordered_node<X>)) * s.size() + MallocUsage(sizeof(void*) * s.bucket_count());
-}
-
-template<typename X, typename Y, typename Z>
-static inline size_t DynamicUsage(const boost::unordered_map<X, Y, Z>& m)
-{
-    return MallocUsage(sizeof(unordered_node<std::pair<const X, Y> >)) * m.size() + MallocUsage(sizeof(void*) * m.bucket_count());
-}
 
 template<typename X, typename Y>
 static inline size_t DynamicUsage(const std::unordered_set<X, Y>& s)


### PR DESCRIPTION
from bitcoin/bitcoin#10548