### PR TITLE
[BUG][GUI] Don't append cold-stake records twice

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -52,7 +52,6 @@ bool TransactionRecord::decomposeCoinStake(const CWallet* wallet, const CWalletT
             sub.credit = nCredit;
             sub.debit = -nDebit;
             loadHotOrColdStakeOrContract(wallet, wtx, sub);
-            parts.append(sub);
         } else {
             // PIV stake reward
             CTxDestination address;


### PR DESCRIPTION
The `TransactionRecord sub` is already appended to the `QList<TransactionRecord> parts` at the end of `decomposeCoinStake` (line 78)