### PR TITLE
[Tests][Trivial] Remove mining in rpc_deprecated test

### DIFF
--- a/test/functional/rpc_deprecated.py
+++ b/test/functional/rpc_deprecated.py
@@ -40,9 +40,7 @@ class DeprecatedRpcTest(PivxTestFramework):
         # - setlabel
         #
         address0 = self.nodes[0].getnewaddress()
-        self.nodes[0].generate(101)
         address1 = self.nodes[1].getnewaddress()
-        self.nodes[1].generate(101)
 
         self.log.info("- getaccount")
         assert_raises_rpc_error(-32, "getaccount is deprecated", self.nodes[0].getaccount, address0)

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -94,7 +94,7 @@ BASE_SCRIPTS= [
     'wallet_dump.py',                           # ~ 83 sec
     'rpc_net.py',                               # ~ 83 sec
     'rpc_bip38.py',                             # ~ 82 sec
-    'rpc_deprecated.py',                        # ~ 82 sec
+    'rpc_deprecated.py',                        # ~ 80 sec
     'interface_bitcoin_cli.py',                 # ~ 80 sec
     'mempool_packages.py',                      # ~ 63 sec
 


### PR DESCRIPTION
No need to generate blocks for this test. We can speed it up a bit.