### PR TITLE
Sapling transaction primitive data.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -135,7 +135,8 @@ LIBSAPLING_H = \
   sapling/note.hpp \
   sapling/zip32.h \
   sapling/saplingscriptpubkeyman.h \
-  sapling/proof.hpp
+  sapling/proof.hpp \
+  sapling/sapling_transaction.h
 
 .PHONY: FORCE cargo-build check-symbols check-security
 # pivx core #

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -134,7 +134,8 @@ LIBSAPLING_H = \
   sapling/address.hpp \
   sapling/note.hpp \
   sapling/zip32.h \
-  sapling/saplingscriptpubkeyman.h
+  sapling/saplingscriptpubkeyman.h \
+  sapling/proof.hpp
 
 .PHONY: FORCE cargo-build check-symbols check-security
 # pivx core #
@@ -544,7 +545,8 @@ libsapling_a_SOURCES = \
   sapling/note.cpp \
   sapling/zip32.cpp \
   sapling/crypter_sapling.cpp \
-  sapling/saplingscriptpubkeyman.cpp
+  sapling/saplingscriptpubkeyman.cpp \
+  sapling/proof.cpp
 
 if GLIBC_BACK_COMPAT
 libsapling_a_SOURCES += compat/glibc_compat.cpp

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2650,6 +2650,7 @@ void FlushStateToDisk()
 void static UpdateTip(CBlockIndex* pindexNew)
 {
     chainActive.SetTip(pindexNew);
+    g_IsSaplingActive = Params().GetConsensus().NetworkUpgradeActive(pindexNew->nHeight, Consensus::UPGRADE_V5_DUMMY);
 
     // New best block
     nTimeBestReceived = GetTime();

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -333,12 +333,24 @@ unsigned int CTransaction::GetTotalSize() const
 std::string CTransaction::ToString() const
 {
     std::string str;
-    str += strprintf("CTransaction(hash=%s, ver=%d, vin.size=%u, vout.size=%u, nLockTime=%u)\n",
-        GetHash().ToString().substr(0,10),
-        nVersion,
-        vin.size(),
-        vout.size(),
-        nLockTime);
+    if (nVersion == CTransaction::SAPLING_VERSION) {
+        str += strprintf("CTransaction(hash=%s, ver=%d, vin.size=%u, vout.size=%u, nLockTime=%u, valueBalance=%u, vShieldedSpend.size=%u, vShieldedOutput.size=%u)\n",
+                         GetHash().ToString().substr(0,10),
+                         nVersion,
+                         vin.size(),
+                         vout.size(),
+                         nLockTime,
+                         sapData->valueBalance,
+                         sapData->vShieldedSpend.size(),
+                         sapData->vShieldedOutput.size());
+    } else {
+            str += strprintf("CTransaction(hash=%s, ver=%d, vin.size=%u, vout.size=%u, nLockTime=%u)\n",
+                             GetHash().ToString().substr(0, 10),
+                             nVersion,
+                             vin.size(),
+                             vout.size(),
+                             nLockTime);
+    }
     for (unsigned int i = 0; i < vin.size(); i++)
         str += "    " + vin[i].ToString() + "\n";
     for (unsigned int i = 0; i < vout.size(); i++)

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -17,6 +17,9 @@
 
 extern bool GetTransaction(const uint256 &hash, CTransaction &txOut, uint256 &hashBlock, bool fAllowSlow);
 
+// contextual flag to guard the serialization for v5 upgrade.
+// can be removed once v5 enforcement is activated.
+std::atomic<bool> g_IsSaplingActive{false};
 
 std::string BaseOutPoint::ToStringShort() const
 {

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -17,19 +17,20 @@
 
 extern bool GetTransaction(const uint256 &hash, CTransaction &txOut, uint256 &hashBlock, bool fAllowSlow);
 
-std::string COutPoint::ToString() const
-{
-    return strprintf("COutPoint(%s, %u)", hash.ToString()/*.substr(0,10)*/, n);
-}
 
-std::string COutPoint::ToStringShort() const
+std::string BaseOutPoint::ToStringShort() const
 {
     return strprintf("%s-%u", hash.ToString().substr(0,64), n);
 }
 
-uint256 COutPoint::GetHash() const
+uint256 BaseOutPoint::GetHash() const
 {
     return Hash(BEGIN(hash), END(hash), BEGIN(n), END(n));
+}
+
+std::string COutPoint::ToString() const
+{
+    return strprintf("COutPoint(%s, %u)", hash.ToString().substr(0,10), n);
 }
 
 CTxIn::CTxIn(COutPoint prevoutIn, CScript scriptSigIn, uint32_t nSequenceIn)

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -115,7 +115,7 @@ std::string CTxOut::ToString() const
 }
 
 CMutableTransaction::CMutableTransaction() : nVersion(CTransaction::CURRENT_VERSION), nLockTime(0) {}
-CMutableTransaction::CMutableTransaction(const CTransaction& tx) : nVersion(tx.nVersion), vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime) {}
+CMutableTransaction::CMutableTransaction(const CTransaction& tx) : nVersion(tx.nVersion), vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime), sapData(tx.sapData) {}
 
 uint256 CMutableTransaction::GetHash() const
 {
@@ -149,7 +149,7 @@ size_t CTransaction::DynamicMemoryUsage() const
 
 CTransaction::CTransaction() : nVersion(CTransaction::CURRENT_VERSION), vin(), vout(), nLockTime(0) { }
 
-CTransaction::CTransaction(const CMutableTransaction &tx) : nVersion(tx.nVersion), vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime) {
+CTransaction::CTransaction(const CMutableTransaction &tx) : nVersion(tx.nVersion), vin(tx.vin), vout(tx.vout), nLockTime(tx.nLockTime), sapData(tx.sapData) {
     UpdateHash();
 }
 
@@ -159,6 +159,7 @@ CTransaction& CTransaction::operator=(const CTransaction &tx) {
     *const_cast<std::vector<CTxOut>*>(&vout) = tx.vout;
     *const_cast<unsigned int*>(&nLockTime) = tx.nLockTime;
     *const_cast<uint256*>(&hash) = tx.hash;
+    *const_cast<SaplingTxData*>(&sapData) = tx.sapData;
     return *this;
 }
 

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -33,6 +33,12 @@ std::string COutPoint::ToString() const
     return strprintf("COutPoint(%s, %u)", hash.ToString().substr(0,10), n);
 }
 
+std::string SaplingOutPoint::ToString() const
+{
+    return strprintf("SaplingOutPoint(%s, %u)", hash.ToString().substr(0, 10), n);
+}
+
+
 CTxIn::CTxIn(COutPoint prevoutIn, CScript scriptSigIn, uint32_t nSequenceIn)
 {
     prevout = prevoutIn;

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -2,20 +2,14 @@
 // Copyright (c) 2009-2014 The Bitcoin developers
 // Copyright (c) 2015-2020 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
-#include "primitives/block.h"
 #include "primitives/transaction.h"
 
-#include "chain.h"
 #include "hash.h"
 #include "main.h"
 #include "tinyformat.h"
 #include "utilstrencodings.h"
-#include "transaction.h"
-
-
-extern bool GetTransaction(const uint256 &hash, CTransaction &txOut, uint256 &hashBlock, bool fAllowSlow);
 
 // contextual flag to guard the serialization for v5 upgrade.
 // can be removed once v5 enforcement is activated.

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -206,7 +206,7 @@ public:
         return 3 * minRelayTxFee.GetFee(nSize);
     }
 
-    bool IsDust(CFeeRate minRelayTxFee) const
+    bool IsDust(const CFeeRate& minRelayTxFee) const
     {
         return (nValue < GetDustThreshold(minRelayTxFee));
     }
@@ -294,14 +294,14 @@ public:
 
     bool hasSaplingData() const
     {
-        return sapData != nullopt;
+        return sapData != nullopt &&
+            (!sapData->vShieldedOutput.empty() ||
+            !sapData->vShieldedSpend.empty());
     };
 
-    // Cleanup the following method when the proper Sapling parsing gets implemented.
     bool isSapling() const
     {
-        return hasSaplingData() &&
-                (!sapData.get().vShieldedOutput.empty() || !sapData.get().vShieldedSpend.empty());
+        return nVersion == SAPLING_VERSION;
     }
 
     /*
@@ -384,7 +384,7 @@ struct CMutableTransaction
         READWRITE(vout);
         READWRITE(nLockTime);
 
-        if (nVersion >= CTransaction::SAPLING_VERSION) {
+        if (nVersion == CTransaction::SAPLING_VERSION) {
             READWRITE(*const_cast<Optional<SaplingTxData>*>(&sapData));
         }
     }

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -16,9 +16,14 @@
 
 #include "sapling/sapling_transaction.h"
 
+#include <atomic>
 #include <list>
 
 class CTransaction;
+
+// contextual flag to guard the serialization for v5 upgrade.
+// can be removed once v5 enforcement is activated.
+extern std::atomic<bool> g_IsSaplingActive;
 
 /** An outpoint - a combination of a transaction hash and an index n into its vout */
 class BaseOutPoint
@@ -276,7 +281,7 @@ public:
         READWRITE(*const_cast<std::vector<CTxOut>*>(&vout));
         READWRITE(*const_cast<uint32_t*>(&nLockTime));
 
-        if (nVersion == CTransaction::SAPLING_VERSION) {
+        if (g_IsSaplingActive && nVersion == CTransaction::SAPLING_VERSION) {
             READWRITE(*const_cast<Optional<SaplingTxData>*>(&sapData));
         }
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -18,14 +18,14 @@
 class CTransaction;
 
 /** An outpoint - a combination of a transaction hash and an index n into its vout */
-class COutPoint
+class BaseOutPoint
 {
 public:
     uint256 hash;
     uint32_t n;
 
-    COutPoint() { SetNull(); }
-    COutPoint(uint256 hashIn, uint32_t nIn) { hash = hashIn; n = nIn; }
+    BaseOutPoint() { SetNull(); }
+    BaseOutPoint(uint256 hashIn, uint32_t nIn) { hash = hashIn; n = nIn; }
 
     ADD_SERIALIZE_METHODS;
 
@@ -38,17 +38,17 @@ public:
     void SetNull() { hash.SetNull(); n = (uint32_t) -1; }
     bool IsNull() const { return (hash.IsNull() && n == (uint32_t) -1); }
 
-    friend bool operator<(const COutPoint& a, const COutPoint& b)
+    friend bool operator<(const BaseOutPoint& a, const BaseOutPoint& b)
     {
         return (a.hash < b.hash || (a.hash == b.hash && a.n < b.n));
     }
 
-    friend bool operator==(const COutPoint& a, const COutPoint& b)
+    friend bool operator==(const BaseOutPoint& a, const BaseOutPoint& b)
     {
         return (a.hash == b.hash && a.n == b.n);
     }
 
-    friend bool operator!=(const COutPoint& a, const COutPoint& b)
+    friend bool operator!=(const BaseOutPoint& a, const BaseOutPoint& b)
     {
         return !(a == b);
     }
@@ -60,6 +60,15 @@ public:
 
     uint256 GetHash() const;
 
+};
+
+/** An outpoint - a combination of a transaction hash and an index n into its vout */
+class COutPoint : public BaseOutPoint
+{
+public:
+    COutPoint() : BaseOutPoint() {};
+    COutPoint(uint256 hashIn, uint32_t nIn) : BaseOutPoint(hashIn, nIn) {};
+    std::string ToString() const;
 };
 
 /** An input of a transaction.  It contains the location of the previous

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -291,10 +291,20 @@ public:
         return hash;
     }
 
+    /*
+     * Context for the two methods below:
+     * We can think of the Sapling shielded part of the transaction as an input
+     * or output according to whether valueBalance - the sum of shielded input
+     * values minus the sum of shielded output values - is positive or negative.
+     */
+
     // Return sum of txouts.
     CAmount GetValueOut() const;
     // GetValueIn() is a method on CCoinsViewCache, because
     // inputs must be known to compute value in.
+
+    // Return sum of (positive valueBalance or zero) and JoinSplit vpub_new
+    CAmount GetShieldedValueIn() const;
 
     // Compute priority, given priority of inputs and (optionally) tx size
     double ComputePriority(double dPriorityInputs, unsigned int nTxSize=0) const;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -2,7 +2,7 @@
 // Copyright (c) 2009-2014 The Bitcoin developers
 // Copyright (c) 2015-2020 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 #ifndef BITCOIN_PRIMITIVES_TRANSACTION_H
 #define BITCOIN_PRIMITIVES_TRANSACTION_H

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -275,7 +275,7 @@ public:
         READWRITE(*const_cast<std::vector<CTxOut>*>(&vout));
         READWRITE(*const_cast<uint32_t*>(&nLockTime));
 
-        if (nVersion >= CTransaction::SAPLING_VERSION) {
+        if (nVersion == CTransaction::SAPLING_VERSION) {
             READWRITE(*const_cast<SaplingTxData*>(&sapData));
         }
 

--- a/src/sapling/proof.cpp
+++ b/src/sapling/proof.cpp
@@ -1,0 +1,13 @@
+#include "sapling/proof.hpp"
+
+namespace libzcash {
+
+ProofVerifier ProofVerifier::Strict() {
+    return ProofVerifier(true);
+}
+
+ProofVerifier ProofVerifier::Disabled() {
+    return ProofVerifier(false);
+}
+
+}

--- a/src/sapling/proof.hpp
+++ b/src/sapling/proof.hpp
@@ -1,0 +1,246 @@
+// Copyright (c) 2016-2020 The ZCash developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef ZC_PROOF_H_
+#define ZC_PROOF_H_
+
+#include "serialize.h"
+#include "blob_uint256.h"
+
+namespace libzcash {
+
+const unsigned char G1_PREFIX_MASK = 0x02;
+const unsigned char G2_PREFIX_MASK = 0x0a;
+
+// Element in the base field
+class Fq {
+private:
+    base_blob<256> data;
+public:
+    Fq() : data() { }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(data);
+    }
+
+    friend bool operator==(const Fq& a, const Fq& b)
+    {
+        return (
+            a.data == b.data
+        );
+    }
+
+    friend bool operator!=(const Fq& a, const Fq& b)
+    {
+        return !(a == b);
+    }
+};
+
+// Element in the extension field
+class Fq2 {
+private:
+    base_blob<512> data;
+public:
+    Fq2() : data() { }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(data);
+    }
+
+    friend bool operator==(const Fq2& a, const Fq2& b)
+    {
+        return (
+            a.data == b.data
+        );
+    }
+
+    friend bool operator!=(const Fq2& a, const Fq2& b)
+    {
+        return !(a == b);
+    }
+};
+
+// Compressed point in G1
+class CompressedG1 {
+private:
+    bool y_lsb;
+    Fq x;
+
+public:
+    CompressedG1() : y_lsb(false), x() { }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        unsigned char leadingByte = G1_PREFIX_MASK;
+
+        if (y_lsb) {
+            leadingByte |= 1;
+        }
+
+        READWRITE(leadingByte);
+
+        if ((leadingByte & (~1)) != G1_PREFIX_MASK) {
+            throw std::ios_base::failure("lead byte of G1 point not recognized");
+        }
+
+        y_lsb = leadingByte & 1;
+
+        READWRITE(x);
+    }
+
+    friend bool operator==(const CompressedG1& a, const CompressedG1& b)
+    {
+        return (
+            a.y_lsb == b.y_lsb &&
+            a.x == b.x
+        );
+    }
+
+    friend bool operator!=(const CompressedG1& a, const CompressedG1& b)
+    {
+        return !(a == b);
+    }
+};
+
+// Compressed point in G2
+class CompressedG2 {
+private:
+    bool y_gt;
+    Fq2 x;
+
+public:
+    CompressedG2() : y_gt(false), x() { }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        unsigned char leadingByte = G2_PREFIX_MASK;
+
+        if (y_gt) {
+            leadingByte |= 1;
+        }
+
+        READWRITE(leadingByte);
+
+        if ((leadingByte & (~1)) != G2_PREFIX_MASK) {
+            throw std::ios_base::failure("lead byte of G2 point not recognized");
+        }
+
+        y_gt = leadingByte & 1;
+
+        READWRITE(x);
+    }
+
+    friend bool operator==(const CompressedG2& a, const CompressedG2& b)
+    {
+        return (
+            a.y_gt == b.y_gt &&
+            a.x == b.x
+        );
+    }
+
+    friend bool operator!=(const CompressedG2& a, const CompressedG2& b)
+    {
+        return !(a == b);
+    }
+};
+
+// Compressed zkSNARK proof
+class PHGRProof {
+private:
+    CompressedG1 g_A;
+    CompressedG1 g_A_prime;
+    CompressedG2 g_B;
+    CompressedG1 g_B_prime;
+    CompressedG1 g_C;
+    CompressedG1 g_C_prime;
+    CompressedG1 g_K;
+    CompressedG1 g_H;
+
+public:
+    PHGRProof() : g_A(), g_A_prime(), g_B(), g_B_prime(), g_C(), g_C_prime(), g_K(), g_H() { }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(g_A);
+        READWRITE(g_A_prime);
+        READWRITE(g_B);
+        READWRITE(g_B_prime);
+        READWRITE(g_C);
+        READWRITE(g_C_prime);
+        READWRITE(g_K);
+        READWRITE(g_H);
+    }
+
+    friend bool operator==(const PHGRProof& a, const PHGRProof& b)
+    {
+        return (
+            a.g_A == b.g_A &&
+            a.g_A_prime == b.g_A_prime &&
+            a.g_B == b.g_B &&
+            a.g_B_prime == b.g_B_prime &&
+            a.g_C == b.g_C &&
+            a.g_C_prime == b.g_C_prime &&
+            a.g_K == b.g_K &&
+            a.g_H == b.g_H
+        );
+    }
+
+    friend bool operator!=(const PHGRProof& a, const PHGRProof& b)
+    {
+        return !(a == b);
+    }
+};
+
+void initialize_curve_params();
+
+class ProofVerifier {
+private:
+    bool perform_verification;
+
+    ProofVerifier(bool perform_verification) : perform_verification(perform_verification) { }
+
+public:
+    // ProofVerifier should never be copied
+    ProofVerifier(const ProofVerifier&) = delete;
+    ProofVerifier& operator=(const ProofVerifier&) = delete;
+    ProofVerifier(ProofVerifier&&);
+    ProofVerifier& operator=(ProofVerifier&&);
+
+    // Creates a verification context that strictly verifies
+    // all proofs using libsnark's API.
+    static ProofVerifier Strict();
+
+    // Creates a verification context that performs no
+    // verification, used when avoiding duplicate effort
+    // such as during reindexing.
+    static ProofVerifier Disabled();
+
+    template <typename VerificationKey,
+              typename ProcessedVerificationKey,
+              typename PrimaryInput,
+              typename Proof
+              >
+    bool check(
+        const VerificationKey& vk,
+        const ProcessedVerificationKey& pvk,
+        const PrimaryInput& pi,
+        const Proof& p
+    );
+};
+
+}
+
+#endif // ZC_PROOF_H_

--- a/src/sapling/sapling_transaction.h
+++ b/src/sapling/sapling_transaction.h
@@ -1,0 +1,152 @@
+// Copyright (c) 2016-2020 The ZCash developers
+// Copyright (c) 2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef PIVX_SAPLING_TRANSACTION_H
+#define PIVX_SAPLING_TRANSACTION_H
+
+#include "serialize.h"
+#include "streams.h"
+#include "uint256.h"
+#include "consensus/consensus.h"
+
+#include "sapling/noteencryption.hpp"
+#include "sapling/sapling.h"
+#include "sapling/proof.hpp"
+
+#include <boost/variant.hpp>
+
+// These constants are defined in the protocol § 7.1:
+// https://zips.z.cash/protocol/protocol.pdf#txnencoding
+#define OUTPUTDESCRIPTION_SIZE 948
+#define SPENDDESCRIPTION_SIZE 384
+
+namespace libzcash {
+    static constexpr size_t GROTH_PROOF_SIZE = (
+            48 + // π_A
+            96 + // π_B
+            48); // π_C
+
+    typedef std::array<unsigned char, GROTH_PROOF_SIZE> GrothProof;
+}
+
+/**
+ * A shielded input to a transaction. It contains data that describes a Spend transfer.
+ */
+class SpendDescription
+{
+public:
+    typedef std::array<unsigned char, 64> spend_auth_sig_t;
+
+    uint256 cv;                    //!< A value commitment to the value of the input note.
+    uint256 anchor;                //!< A Merkle root of the Sapling note commitment tree at some block height in the past.
+    uint256 nullifier;             //!< The nullifier of the input note.
+    uint256 rk;                    //!< The randomized public key for spendAuthSig.
+    libzcash::GrothProof zkproof;  //!< A zero-knowledge proof using the spend circuit.
+    spend_auth_sig_t spendAuthSig; //!< A signature authorizing this spend.
+
+    SpendDescription() { }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(cv);
+        READWRITE(anchor);
+        READWRITE(nullifier);
+        READWRITE(rk);
+        READWRITE(zkproof);
+        READWRITE(spendAuthSig);
+    }
+
+    friend bool operator==(const SpendDescription& a, const SpendDescription& b)
+    {
+        return (
+                a.cv == b.cv &&
+                a.anchor == b.anchor &&
+                a.nullifier == b.nullifier &&
+                a.rk == b.rk &&
+                a.zkproof == b.zkproof &&
+                a.spendAuthSig == b.spendAuthSig
+        );
+    }
+
+    friend bool operator!=(const SpendDescription& a, const SpendDescription& b)
+    {
+        return !(a == b);
+    }
+};
+
+/**
+ * A shielded output to a transaction. It contains data that describes an Output transfer.
+ */
+class OutputDescription
+{
+public:
+    uint256 cv;                     //!< A value commitment to the value of the output note.
+    uint256 cmu;                     //!< The u-coordinate of the note commitment for the output note.
+    uint256 ephemeralKey;           //!< A Jubjub public key.
+    libzcash::SaplingEncCiphertext encCiphertext; //!< A ciphertext component for the encrypted output note.
+    libzcash::SaplingOutCiphertext outCiphertext; //!< A ciphertext component for the encrypted output note.
+    libzcash::GrothProof zkproof;   //!< A zero-knowledge proof using the output circuit.
+
+    OutputDescription() { }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(cv);
+        READWRITE(cmu);
+        READWRITE(ephemeralKey);
+        READWRITE(encCiphertext);
+        READWRITE(outCiphertext);
+        READWRITE(zkproof);
+    }
+
+    friend bool operator==(const OutputDescription& a, const OutputDescription& b)
+    {
+        return (
+                a.cv == b.cv &&
+                a.cmu == b.cmu &&
+                a.ephemeralKey == b.ephemeralKey &&
+                a.encCiphertext == b.encCiphertext &&
+                a.outCiphertext == b.outCiphertext &&
+                a.zkproof == b.zkproof
+        );
+    }
+
+    friend bool operator!=(const OutputDescription& a, const OutputDescription& b)
+    {
+        return !(a == b);
+    }
+};
+
+class SaplingTxData
+{
+public:
+    typedef std::array<unsigned char, 64> binding_sig_t;
+
+    CAmount valueBalance{0};
+    std::vector<SpendDescription> vShieldedSpend;
+    std::vector<OutputDescription> vShieldedOutput;
+    binding_sig_t bindingSig = {{0}};
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
+    {
+        READWRITE(*const_cast<CAmount*>(&valueBalance));
+        READWRITE(*const_cast<std::vector<SpendDescription>*>(&vShieldedSpend));
+        READWRITE(*const_cast<std::vector<OutputDescription>*>(&vShieldedOutput));
+        READWRITE(*const_cast<binding_sig_t*>(&bindingSig));
+    }
+
+    explicit SaplingTxData() : valueBalance(0), vShieldedSpend(), vShieldedOutput() { }
+    explicit SaplingTxData(const SaplingTxData& from) : valueBalance(from.valueBalance), vShieldedSpend(from.vShieldedSpend), vShieldedOutput(from.vShieldedOutput), bindingSig(from.bindingSig) {}
+};
+
+
+#endif //PIVX_SAPLING_TRANSACTION_H

--- a/src/sapling/sapling_transaction.h
+++ b/src/sapling/sapling_transaction.h
@@ -51,7 +51,7 @@ public:
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+    inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(cv);
         READWRITE(anchor);
         READWRITE(nullifier);
@@ -96,7 +96,7 @@ public:
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+    inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(cv);
         READWRITE(cmu);
         READWRITE(ephemeralKey);
@@ -136,7 +136,7 @@ public:
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion)
+    inline void SerializationOp(Stream& s, Operation ser_action)
     {
         READWRITE(*const_cast<CAmount*>(&valueBalance));
         READWRITE(*const_cast<std::vector<SpendDescription>*>(&vShieldedSpend));

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1125,6 +1125,7 @@ uint256 GetOutputsHash(const CTransaction& txTo) {
 }
 
 uint256 GetShieldedSpendsHash(const CTransaction& txTo) {
+    assert(txTo.sapData);
     CBLAKE2bWriter ss(SER_GETHASH, 0, PIVX_SHIELDED_SPENDS_HASH_PERSONALIZATION);
     auto sapData = txTo.sapData;
     for (const auto& n : sapData->vShieldedSpend) {
@@ -1138,6 +1139,7 @@ uint256 GetShieldedSpendsHash(const CTransaction& txTo) {
 }
 
 uint256 GetShieldedOutputsHash(const CTransaction& txTo) {
+    assert(txTo.sapData);
     CBLAKE2bWriter ss(SER_GETHASH, 0, PIVX_SHIELDED_OUTPUTS_HASH_PERSONALIZATION);
     auto sapData = txTo.sapData;
     for (const auto& n : sapData->vShieldedOutput) {

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1166,7 +1166,8 @@ uint256 SignatureHash(const CScript& scriptCode, const CTransaction& txTo, unsig
         return UINT256_ONE;
     }
 
-    if (sigversion == SIGVERSION_WITNESS_V0) {
+    // currently: sigversion_sapling is disabled everywhere.
+    if (sigversion == SIGVERSION_SAPLING) {
 
         uint256 hashPrevouts;
         uint256 hashSequence;

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -19,6 +19,9 @@ class CScript;
 class CTransaction;
 class uint256;
 
+/** Special case nIn for signing Sapling txs. */
+const unsigned int NOT_AN_INPUT = UINT_MAX;
+
 /** Signature hash types/flags */
 enum
 {

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -88,7 +88,7 @@ bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, unsigned i
 
 struct PrecomputedTransactionData
 {
-    uint256 hashPrevouts, hashSequence, hashOutputs;
+    uint256 hashPrevouts, hashSequence, hashOutputs, hashShieldedSpends, hashShieldedOutputs;
 
     PrecomputedTransactionData(const CTransaction& tx);
 };

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -99,7 +99,7 @@ struct PrecomputedTransactionData
 enum SigVersion
 {
     SIGVERSION_BASE = 0,
-    SIGVERSION_WITNESS_V0 = 1,
+    SIGVERSION_SAPLING = 1,
 };
 
 uint256 SignatureHash(const CScript &scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType, const CAmount& amount, SigVersion sigversion, const PrecomputedTransactionData* cache = nullptr);

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -12,6 +12,7 @@
 #include <assert.h>
 #include <ios>
 #include <limits>
+#include <list>
 #include <map>
 #include <set>
 #include <stdint.h>
@@ -697,6 +698,43 @@ void Unserialize(Stream& is, std::basic_string<C>& str)
         is.read((char*)&str[0], nSize * sizeof(str[0]));
 }
 
+/**
+  * list
+  */
+template<typename T, typename A> unsigned int GetSerializeSize(const std::list<T, A>& m, int nType, int nVersion);
+template<typename Stream, typename T, typename A> void Serialize(Stream& os, const std::list<T, A>& m, int nType, int nVersion);
+template<typename Stream, typename T, typename A> void Unserialize(Stream& is, std::list<T, A>& m, int nType, int nVersion);
+
+template<typename T, typename A>
+unsigned int GetSerializeSize(const std::list<T, A>& l, int nType, int nVersion)
+{
+    unsigned int nSize = GetSizeOfCompactSize(l.size());
+    for (typename std::list<T, A>::const_iterator it = l.begin(); it != l.end(); ++it)
+        nSize += GetSerializeSize((*it), nType, nVersion);
+    return nSize;
+}
+
+template<typename Stream, typename T, typename A>
+void Serialize(Stream& os, const std::list<T, A>& l, int nType, int nVersion)
+{
+    WriteCompactSize(os, l.size());
+    for (typename std::list<T, A>::const_iterator it = l.begin(); it != l.end(); ++it)
+        Serialize(os, (*it), nType, nVersion);
+}
+
+template<typename Stream, typename T, typename A>
+void Unserialize(Stream& is, std::list<T, A>& l, int nType, int nVersion)
+{
+    l.clear();
+    unsigned int nSize = ReadCompactSize(is);
+    typename std::list<T, A>::iterator it = l.begin();
+    for (unsigned int i = 0; i < nSize; i++)
+    {
+        T item;
+        Unserialize(is, item, nType, nVersion);
+        l.push_back(item);
+    }
+}
 
 
 /**


### PR DESCRIPTION
Work coming from #1798. Decoupled commits related to the Sapling transaction primitive data and the new signature hash to make the review a little bit easier there. Plus, squashed some of them.

List of commits taken from #1798:

Primitive data:

* Add serialization for primitive boost::optional<T>. —> 659cc558
* Transaction: Implement BaseOutPoint class.  —> f17b23c7
* Backport zkSNARK compression. —> 5dbc3c9
* Basic Sapling transaction primitive data --> c49594f
* Add serialization for std:list objects. —> 7cc57f7
* sapling_transaction.h migrated to the new serialization —> dbb618f6
* Fix sighash_tests —> e1e33163 
* Transaction GetShieldedValueIn & GetValueOut back port —> 0fbe0236
* BugFix in GetShieldedValueIn —> 57ee1bc6
* Missing SaplingOutPoint::ToString() method implemented —> e1fe5bf7
* Transaction: add sapling data to toString —> 26ce38b5
* make SaplingTxData Optional in transaction primitive  — PARTIALLY  —> c3b1aedc
* Cleaning compiler warnings — PARTIALLY —> 644c381f
* transaction: fix sapling version to 2. —> 8fc595f5
* Transaction: GetDustThreshold method implemented. —> dadf199c.
* Transaction:hasSaplingData check is enough checking for vShieldedOutput and vShieldedSpend emptiness. —> 57d3236f

Signature hash:

* Introduce SignatureHash personalization updates —> 550217f7
* Enable sigversion for Sapling transactions. —> c04abe1d 
* Sapling signature hash (Custom version of ZIP 243) —> eac206e9
* Not try to serialize empty fields in Sapling signature hash  --->  ce5a467
