### PR TITLE
Make CBlock a vector of shared_ptr of CTransactions

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -27,7 +27,7 @@ static CBlock CreateGenesisBlock(const char* pszTimestamp, const CScript& genesi
     txNew.vout[0].scriptPubKey = genesisOutputScript;
 
     CBlock genesis;
-    genesis.vtx.push_back(txNew);
+    genesis.vtx.push_back(std::make_shared<const CTransaction>(std::move(txNew)));
     genesis.hashPrevBlock.SetNull();
     genesis.nVersion = nVersion;
     genesis.nTime    = nTime;

--- a/src/consensus/merkle.cpp
+++ b/src/consensus/merkle.cpp
@@ -156,7 +156,7 @@ uint256 BlockMerkleRoot(const CBlock& block, bool* mutated)
     std::vector<uint256> leaves;
     leaves.resize(block.vtx.size());
     for (size_t s = 0; s < block.vtx.size(); s++) {
-        leaves[s] = block.vtx[s].GetHash();
+        leaves[s] = block.vtx[s]->GetHash();
     }
     return ComputeMerkleRoot(leaves, mutated);
 }
@@ -166,7 +166,7 @@ std::vector<uint256> BlockMerkleBranch(const CBlock& block, uint32_t position)
     std::vector<uint256> leaves;
     leaves.resize(block.vtx.size());
     for (size_t s = 0; s < block.vtx.size(); s++) {
-        leaves[s] = block.vtx[s].GetHash();
+        leaves[s] = block.vtx[s]->GetHash();
     }
     return ComputeMerkleBranch(leaves, position);
 }

--- a/src/consensus/zerocoin_verify.cpp
+++ b/src/consensus/zerocoin_verify.cpp
@@ -222,7 +222,8 @@ bool RecalculatePIVSupply(int nHeightStart, bool fSkipZpiv)
 
         CAmount nValueIn = 0;
         CAmount nValueOut = 0;
-        for (const CTransaction& tx : block.vtx) {
+        for (const auto& txIn : block.vtx) {
+            const CTransaction& tx = *txIn;
             for (unsigned int i = 0; i < tx.vin.size(); i++) {
                 if (tx.IsCoinBase())
                     break;

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -106,7 +106,7 @@ bool LoadStakeInput(const CBlock& block, const CBlockIndex* pindexPrev, std::uni
         return error("called on non PoS block");
 
     // Construct the stakeinput object
-    const CTxIn& txin = block.vtx[1].vin[0];
+    const CTxIn& txin = block.vtx[1]->vin[0];
     stake = txin.IsZerocoinSpend() ?
             std::unique_ptr<CStakeInput>(new CLegacyZPivStake()) :
             std::unique_ptr<CStakeInput>(new CPivStake());
@@ -181,11 +181,11 @@ bool CheckProofOfStake(const CBlock& block, std::string& strError, const CBlockI
         strError = "unable to get stake prevout for coinstake";
         return false;
     }
-    const CTransaction& tx = block.vtx[1];
-    const CTxIn& txin = tx.vin[0];
+    const auto& tx = block.vtx[1];
+    const CTxIn& txin = tx->vin[0];
     ScriptError serror;
     if (!VerifyScript(txin.scriptSig, stakePrevout.scriptPubKey, STANDARD_SCRIPT_VERIFY_FLAGS,
-             TransactionSignatureChecker(&tx, 0, stakePrevout.nValue), &serror)) {
+             TransactionSignatureChecker(tx.get(), 0, stakePrevout.nValue), &serror)) {
         strError = strprintf("signature fails: %s", serror ? ScriptErrorString(serror) : "");
         return false;
     }

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -259,7 +259,7 @@ bool IsBlockPayeeValid(const CBlock& block, int nBlockHeight)
     }
 
     const bool isPoSActive = Params().GetConsensus().NetworkUpgradeActive(nBlockHeight, Consensus::UPGRADE_POS);
-    const CTransaction& txNew = (isPoSActive ? block.vtx[1] : block.vtx[0]);
+    const CTransaction& txNew = *(isPoSActive ? block.vtx[1] : block.vtx[0]);
 
     //check if it's a budget block
     if (sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS)) {

--- a/src/merkleblock.cpp
+++ b/src/merkleblock.cpp
@@ -23,8 +23,8 @@ CMerkleBlock::CMerkleBlock(const CBlock& block, CBloomFilter& filter)
     vHashes.reserve(block.vtx.size());
 
     for (unsigned int i = 0; i < block.vtx.size(); i++) {
-        const uint256& hash = block.vtx[i].GetHash();
-        if (filter.IsRelevantAndUpdate(block.vtx[i])) {
+        const uint256& hash = block.vtx[i]->GetHash();
+        if (filter.IsRelevantAndUpdate(*block.vtx[i])) {
             vMatch.push_back(true);
             vMatchedTxn.emplace_back(i, hash);
         } else

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -45,7 +45,7 @@ std::string CBlock::ToString() const
         vtx.size());
     for (unsigned int i = 0; i < vtx.size(); i++)
     {
-        s << "  " << vtx[i].ToString() << "\n";
+        s << "  " << vtx[i]->ToString() << "\n";
     }
     return s.str();
 }

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -82,7 +82,7 @@ class CBlock : public CBlockHeader
 {
 public:
     // network and disk
-    std::vector<CTransaction> vtx;
+    std::vector<std::shared_ptr<const CTransaction>> vtx;
 
     // ppcoin: block signature - signed by one of the coin base txout[N]'s owner
     std::vector<unsigned char> vchBlockSig;
@@ -107,8 +107,8 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(*(CBlockHeader*)this);
         READWRITE(vtx);
-	if(vtx.size() > 1 && vtx[1].IsCoinStake())
-		READWRITE(vchBlockSig);
+        if(vtx.size() > 1 && vtx[1]->IsCoinStake())
+            READWRITE(vchBlockSig);
     }
 
     void SetNull()
@@ -135,7 +135,7 @@ public:
 
     bool IsProofOfStake() const
     {
-        return (vtx.size() > 1 && vtx[1].IsCoinStake());
+        return (vtx.size() > 1 && vtx[1]->IsCoinStake());
     }
 
     bool IsProofOfWork() const

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -152,6 +152,10 @@ CTransaction::CTransaction(const CMutableTransaction &tx) : nVersion(tx.nVersion
     UpdateHash();
 }
 
+CTransaction::CTransaction(CMutableTransaction &&tx) : nVersion(tx.nVersion), vin(std::move(tx.vin)), vout(std::move(tx.vout)), wit(std::move(tx.wit)), nLockTime(tx.nLockTime) {
+    UpdateHash();
+}
+
 CTransaction& CTransaction::operator=(const CTransaction &tx) {
     *const_cast<int*>(&nVersion) = tx.nVersion;
     *const_cast<std::vector<CTxIn>*>(&vin) = tx.vin;

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -152,7 +152,7 @@ CTransaction::CTransaction(const CMutableTransaction &tx) : nVersion(tx.nVersion
     UpdateHash();
 }
 
-CTransaction::CTransaction(CMutableTransaction &&tx) : nVersion(tx.nVersion), vin(std::move(tx.vin)), vout(std::move(tx.vout)), wit(std::move(tx.wit)), nLockTime(tx.nLockTime) {
+CTransaction::CTransaction(CMutableTransaction &&tx) : nVersion(tx.nVersion), vin(std::move(tx.vin)), vout(std::move(tx.vout)), nLockTime(tx.nLockTime) {
     UpdateHash();
 }
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -239,6 +239,7 @@ public:
 
     /** Convert a CMutableTransaction into a CTransaction. */
     CTransaction(const CMutableTransaction &tx);
+    CTransaction(CMutableTransaction &&tx);
 
     CTransaction& operator=(const CTransaction& tx);
 
@@ -253,6 +254,9 @@ public:
         if (ser_action.ForRead())
             UpdateHash();
     }
+
+    template <typename Stream>
+    CTransaction(deserialize_type, Stream& s) : CTransaction(CMutableTransaction(deserialize, s)) {}
 
     bool IsNull() const {
         return vin.empty() && vout.empty();
@@ -330,6 +334,11 @@ struct CMutableTransaction
         READWRITE(vin);
         READWRITE(vout);
         READWRITE(nLockTime);
+    }
+
+    template <typename Stream>
+    CMutableTransaction(deserialize_type, Stream& s) {
+        Unserialize(s);
     }
 
     /** Compute the hash of this CMutableTransaction. This is computed on the

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -119,7 +119,8 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     result.push_back(Pair("merkleroot", block.hashMerkleRoot.GetHex()));
     result.push_back(Pair("acc_checkpoint", block.nAccumulatorCheckpoint.GetHex()));
     UniValue txs(UniValue::VARR);
-    for (const CTransaction& tx : block.vtx) {
+    for (const auto& txIn : block.vtx) {
+        const CTransaction& tx = *txIn;
         if (txDetails) {
             UniValue objTx(UniValue::VOBJ);
             TxToJSON(tx, UINT256_ZERO, objTx);
@@ -1306,7 +1307,8 @@ UniValue getserials(const JSONRPCRequest& request) {
                 throw JSONRPCError(RPC_INTERNAL_ERROR, "Can't read block from disk");
 
         // loop through each tx in the block
-        for (const CTransaction& tx : block.vtx) {
+        for (const auto& txIn : block.vtx) {
+            const CTransaction& tx = *txIn;
             std::string txid = tx.GetHash().GetHex();
             // collect the destination (first output) if fVerbose
             std::string spentTo = "";
@@ -1466,7 +1468,8 @@ UniValue getblockindexstats(const JSONRPCRequest& request) {
         nTxCount = block.IsProofOfStake() ? nTxCount + ntx - 2 : nTxCount + ntx - 1;
 
         // loop through each tx in block and save size and fee
-        for (const CTransaction& tx : block.vtx) {
+        for (const auto& txIn : block.vtx) {
+            const CTransaction& tx = *txIn;
             if (tx.IsCoinBase() || (tx.IsCoinStake() && !tx.HasZerocoinSpendInputs()))
                 continue;
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -575,8 +575,9 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     UniValue transactions(UniValue::VARR);
     std::map<uint256, int64_t> setTxIndex;
     int i = 0;
-    for (CTransaction& tx : pblock->vtx) {
-        uint256 txHash = tx.GetHash();
+    for (const auto& txIn : pblock->vtx) {
+        const CTransaction& tx = *txIn;
+        const uint256& txHash = tx.GetHash();
         setTxIndex[txHash] = i++;
 
         if (tx.IsCoinBase())
@@ -622,7 +623,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     result.push_back(Pair("previousblockhash", pblock->hashPrevBlock.GetHex()));
     result.push_back(Pair("transactions", transactions));
     result.push_back(Pair("coinbaseaux", aux));
-    result.push_back(Pair("coinbasevalue", (int64_t)pblock->vtx[0].GetValueOut()));
+    result.push_back(Pair("coinbasevalue", (int64_t)pblock->vtx[0]->GetValueOut()));
     result.push_back(Pair("longpollid", chainActive.Tip()->GetBlockHash().GetHex() + i64tostr(nTransactionsUpdatedLast)));
     result.push_back(Pair("target", hashTarget.GetHex()));
     result.push_back(Pair("mintime", (int64_t)pindexPrev->GetMedianTimePast() + 1));
@@ -683,7 +684,7 @@ UniValue submitblock(const JSONRPCRequest& request)
     if (!DecodeHexBlk(block, request.params[0].get_str()))
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Block decode failed");
 
-    if (block.vtx.empty() || !block.vtx[0].IsCoinBase()) {
+    if (block.vtx.empty() || !block.vtx[0]->IsCoinBase()) {
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Block does not start with a coinbase");
     }
 

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -13,6 +13,7 @@
 #include <ios>
 #include <limits>
 #include <map>
+#include <memory>
 #include <set>
 #include <stdint.h>
 #include <string.h>
@@ -28,6 +29,20 @@
 
 
 static const unsigned int MAX_SIZE = 0x02000000;
+
+/**
+ * Dummy data type to identify deserializing constructors.
+ *
+ * By convention, a constructor of a type T with signature
+ *
+ *   template <typename Stream> T::T(deserialize_type, Stream& s)
+ *
+ * is a deserializing constructor, which builds the type by
+ * deserializing it from s. If T contains const fields, this
+ * is likely the only way to do so.
+ */
+struct deserialize_type {};
+constexpr deserialize_type deserialize {};
 
 /**
  * Used to bypass the rule against non-const reference to temporary
@@ -607,6 +622,19 @@ template<typename Stream, typename K, typename T, typename Pred, typename A> voi
 template<typename Stream, typename K, typename Pred, typename A> void Serialize(Stream& os, const std::set<K, Pred, A>& m);
 template<typename Stream, typename K, typename Pred, typename A> void Unserialize(Stream& is, std::set<K, Pred, A>& m);
 
+/**
+ * shared_ptr
+ */
+template<typename Stream, typename T> void Serialize(Stream& os, const std::shared_ptr<const T>& p);
+template<typename Stream, typename T> void Unserialize(Stream& os, std::shared_ptr<const T>& p);
+
+/**
+ * unique_ptr
+ */
+template<typename Stream, typename T> void Serialize(Stream& os, const std::unique_ptr<const T>& p);
+template<typename Stream, typename T> void Unserialize(Stream& os, std::unique_ptr<const T>& p);
+
+
 
 /**
  * If none of the specialized versions above matched, default to calling member function.
@@ -846,6 +874,41 @@ void Unserialize(Stream& is, std::set<K, Pred, A>& m)
         it = m.insert(it, key);
     }
 }
+
+
+
+/**
+ * unique_ptr
+ */
+template<typename Stream, typename T> void
+Serialize(Stream& os, const std::unique_ptr<const T>& p)
+{
+    Serialize(os, *p);
+}
+
+template<typename Stream, typename T>
+void Unserialize(Stream& is, std::unique_ptr<const T>& p)
+{
+    p.reset(new T(deserialize, is));
+}
+
+
+
+/**
+ * shared_ptr
+ */
+template<typename Stream, typename T> void
+Serialize(Stream& os, const std::shared_ptr<const T>& p)
+{
+    Serialize(os, *p);
+}
+
+template<typename Stream, typename T>
+void Unserialize(Stream& is, std::shared_ptr<const T>& p)
+{
+    p = std::make_shared<const T>(deserialize, is);
+}
+
 
 
 /**

--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -62,8 +62,8 @@ CBlock CreateDummyBlockWithSignature(CKey stakingKey, BlockSignatureType type, b
 
     // Now the block.
     CBlock block;
-    block.vtx.emplace_back(); // dummy first tx
-    block.vtx.emplace_back(txCoinStake);
+    block.vtx.emplace_back(std::make_shared<const CTransaction>(CTransaction())); // dummy first tx
+    block.vtx.emplace_back(std::make_shared<const CTransaction>(txCoinStake));
     SignBlockWithKey(block, stakingKey);
 
     return block;

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -443,7 +443,7 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     pool.addUnchecked(tx5.GetHash(), entry.Fee(1000LL).FromTx(tx5, &pool));
     pool.addUnchecked(tx7.GetHash(), entry.Fee(9000LL).FromTx(tx7, &pool));
 
-    std::vector<CTransaction> vtx;
+    std::vector<std::shared_ptr<const CTransaction>> vtx;
     std::list<CTransaction> conflicts;
     SetMockTime(42);
     SetMockTime(42 + CTxMemPool::ROLLING_FEE_HALFLIFE);

--- a/src/test/merkle_tests.cpp
+++ b/src/test/merkle_tests.cpp
@@ -15,8 +15,8 @@ static uint256 BlockBuildMerkleTree(const CBlock& block, bool* fMutated, std::ve
 {
     vMerkleTree.clear();
     vMerkleTree.reserve(block.vtx.size() * 2 + 16); // Safe upper bound for the number of total nodes.
-    for (std::vector<CTransaction>::const_iterator it(block.vtx.begin()); it != block.vtx.end(); ++it)
-        vMerkleTree.push_back(it->GetHash());
+    for (std::vector<std::shared_ptr<const CTransaction>>::const_iterator it(block.vtx.begin()); it != block.vtx.end(); ++it)
+        vMerkleTree.push_back((*it)->GetHash());
     int j = 0;
     bool mutated = false;
     for (int nSize = block.vtx.size(); nSize > 1; nSize = (nSize + 1) / 2)
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(merkle_test)
             for (int j = 0; j < ntx; j++) {
                 CMutableTransaction mtx;
                 mtx.nLockTime = j;
-                block.vtx[j] = mtx;
+                block.vtx[j] = std::make_shared<const CTransaction>(mtx);
             }
             // Compute the root of the block before mutating it.
             bool unmutatedMutated = false;
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(merkle_test)
                     std::vector<uint256> newBranch = BlockMerkleBranch(block, mtx);
                     std::vector<uint256> oldBranch = BlockGetMerkleBranch(block, merkleTree, mtx);
                     BOOST_CHECK(oldBranch == newBranch);
-                    BOOST_CHECK(ComputeMerkleRootFromBranch(block.vtx[mtx].GetHash(), newBranch, mtx) == oldRoot);
+                    BOOST_CHECK(ComputeMerkleRootFromBranch(block.vtx[mtx]->GetHash(), newBranch, mtx) == oldRoot);
                 }
             }
         }

--- a/src/test/pmt_tests.cpp
+++ b/src/test/pmt_tests.cpp
@@ -42,14 +42,14 @@ BOOST_AUTO_TEST_CASE(pmt_test1)
         for (unsigned int j=0; j<nTx; j++) {
             CMutableTransaction tx;
             tx.nLockTime = rand(); // actual transaction data doesn't matter; just make the nLockTime's unique
-            block.vtx.emplace_back(tx);
+            block.vtx.emplace_back(std::make_shared<const CTransaction>(tx));
         }
 
         // calculate actual merkle root and height
         uint256 merkleRoot1 = BlockMerkleRoot(block);
         std::vector<uint256> vTxid(nTx, UINT256_ZERO);
         for (unsigned int j=0; j<nTx; j++)
-            vTxid[j] = block.vtx[j].GetHash();
+            vTxid[j] = block.vtx[j]->GetHash();
         int nHeight = 1, nTx_ = nTx;
         while (nTx_ > 1) {
             nTx_ = (nTx_+1)/2;

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
     CFeeRate baseRate(basefee, ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION));
 
     // Create a fake block
-    std::vector<CTransaction> block;
+    std::vector<std::shared_ptr<const CTransaction>> block;
     int blocknum = 0;
 
     // Loop through 200 blocks
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
             while (txHashes[9-h].size()) {
                 CTransaction btx;
                 if (mpool.lookup(txHashes[9-h].back(), btx))
-                    block.push_back(btx);
+                    block.push_back(std::make_shared<const CTransaction>(btx));
                 txHashes[9-h].pop_back();
             }
         }
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
         while(txHashes[j].size()) {
             CTransaction btx;
             if (mpool.lookup(txHashes[j].back(), btx))
-                block.push_back(btx);
+                block.push_back(std::make_shared<const CTransaction>(btx));
             txHashes[j].pop_back();
         }
     }
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
                 mpool.addUnchecked(hash, entry.Fee(feeV[j]).Time(GetTime()).Priority(0).Height(blocknum).FromTx(tx, &mpool));
                 CTransaction btx;
                 if (mpool.lookup(hash, btx))
-                    block.push_back(btx);
+                    block.push_back(std::make_shared<const CTransaction>(btx));
             }
         }
         mpool.removeForBlock(block, ++blocknum, dummyConflicted);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -542,21 +542,21 @@ void CTxMemPool::removeConflicts(const CTransaction& tx, std::list<CTransaction>
 /**
  * Called when a block is connected. Removes from mempool and updates the miner fee estimator.
  */
-void CTxMemPool::removeForBlock(const std::vector<CTransaction>& vtx, unsigned int nBlockHeight, std::list<CTransaction>& conflicts, bool fCurrentEstimate)
+void CTxMemPool::removeForBlock(const std::vector<std::shared_ptr<const CTransaction>>& vtx, unsigned int nBlockHeight, std::list<CTransaction>& conflicts, bool fCurrentEstimate)
 {
     LOCK(cs);
     std::vector<CTxMemPoolEntry> entries;
-    for (const CTransaction& tx : vtx) {
-        uint256 hash = tx.GetHash();
+    for (const auto& tx : vtx) {
+        uint256 hash = tx->GetHash();
         indexed_transaction_set::iterator i = mapTx.find(hash);
         if (i != mapTx.end())
             entries.push_back(*i);
     }
-    for (const CTransaction& tx : vtx) {
+    for (const auto& tx : vtx) {
         std::list<CTransaction> dummy;
-        remove(tx, dummy, false);
-        removeConflicts(tx, conflicts);
-        ClearPrioritisation(tx.GetHash());
+        remove(*tx, dummy, false);
+        removeConflicts(*tx, conflicts);
+        ClearPrioritisation(tx->GetHash());
     }
     // After the txs in the new block have been removed from the mempool, update policy estimates
     minerPolicyEstimator->processBlock(nBlockHeight, entries, fCurrentEstimate);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -478,7 +478,7 @@ public:
     void remove(const CTransaction& tx, std::list<CTransaction>& removed, bool fRecursive = false);
     void removeForReorg(const CCoinsViewCache* pcoins, unsigned int nMemPoolHeight, int flags);
     void removeConflicts(const CTransaction& tx, std::list<CTransaction>& removed);
-    void removeForBlock(const std::vector<CTransaction>& vtx, unsigned int nBlockHeight, std::list<CTransaction>& conflicts, bool fCurrentEstimate = true);
+    void removeForBlock(const std::vector<std::shared_ptr<const CTransaction>>& vtx, unsigned int nBlockHeight, std::list<CTransaction>& conflicts, bool fCurrentEstimate = true);
     void clear();
     void _clear();  // lock-free
     void queryHashes(std::vector<uint256>& vtxid);

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -320,7 +320,7 @@ void removeTxFromMempool(CWalletTx& wtx)
 CBlockIndex* SimpleFakeMine(CWalletTx& wtx, CBlockIndex* pprev = nullptr)
 {
     CBlock block;
-    block.vtx.push_back(wtx);
+    block.vtx.emplace_back(std::make_shared<const CTransaction>(wtx));
     block.hashMerkleRoot = BlockMerkleRoot(block);
     if (pprev) block.hashPrevBlock = pprev->GetBlockHash();
     CBlockIndex* fakeIndex = new CBlockIndex(block);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1513,7 +1513,7 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate, b
             ReadBlockFromDisk(block, pindex);
             int posInBlock;
             for (posInBlock = 0; posInBlock < (int)block.vtx.size(); posInBlock++) {
-                if (AddToWalletIfInvolvingMe(block.vtx[posInBlock], pindex, posInBlock, fUpdate))
+                if (AddToWalletIfInvolvingMe(*block.vtx[posInBlock], pindex, posInBlock, fUpdate))
                     ret++;
             }
 

--- a/src/wallet/wallet_zerocoin.cpp
+++ b/src/wallet/wallet_zerocoin.cpp
@@ -111,7 +111,7 @@ void CWallet::doZPivRescan(const CBlockIndex* pindex, const CBlock& block,
                 // Add the transaction to the wallet
                 posInBlock = 0;
                 for (posInBlock = 0; posInBlock < (int)block.vtx.size(); posInBlock++) {
-                    auto& tx = block.vtx[posInBlock];
+                    const auto& tx = *(block.vtx[posInBlock]);
                     uint256 txid = tx.GetHash();
                     if (setAddedToWallet.count(txid) || mapWallet.count(txid))
                         continue;
@@ -139,7 +139,7 @@ void CWallet::doZPivRescan(const CBlockIndex* pindex, const CBlock& block,
                         posInBlock = 0;
                         for (posInBlock = 0; posInBlock < (int)blockSpend.vtx.size(); posInBlock++) {
                             auto &tx = blockSpend.vtx[posInBlock];
-                            if (tx.GetHash() == txidSpend)
+                            if (tx->GetHash() == txidSpend)
                                 wtx.SetMerkleBranch(pindexSpend, posInBlock);
                         }
                     }

--- a/src/zpivchain.cpp
+++ b/src/zpivchain.cpp
@@ -20,7 +20,8 @@ std::map<libzerocoin::CoinDenomination, int64_t> mapZerocoinSupply;
 
 bool BlockToMintValueVector(const CBlock& block, const libzerocoin::CoinDenomination denom, std::vector<CBigNum>& vValues)
 {
-    for (const CTransaction& tx : block.vtx) {
+    for (const auto& txIn : block.vtx) {
+        const CTransaction& tx = *txIn;
         if(!tx.HasZerocoinMintOutputs())
             continue;
 
@@ -45,7 +46,8 @@ bool BlockToMintValueVector(const CBlock& block, const libzerocoin::CoinDenomina
 
 bool BlockToPubcoinList(const CBlock& block, std::list<libzerocoin::PublicCoin>& listPubcoins, bool fFilterInvalid)
 {
-    for (const CTransaction& tx : block.vtx) {
+    for (const auto& txIn : block.vtx) {
+        const CTransaction& tx = *txIn;
         if(!tx.HasZerocoinMintOutputs())
             continue;
 
@@ -87,7 +89,8 @@ bool BlockToPubcoinList(const CBlock& block, std::list<libzerocoin::PublicCoin>&
 //return a list of zerocoin mints contained in a specific block
 bool BlockToZerocoinMintList(const CBlock& block, std::list<CZerocoinMint>& vMints, bool fFilterInvalid)
 {
-    for (const CTransaction& tx : block.vtx) {
+    for (const auto& txIn : block.vtx) {
+        const CTransaction& tx = *txIn;
         if(!tx.HasZerocoinMintOutputs())
             continue;
 
@@ -279,7 +282,8 @@ std::string ReindexZerocoinDB()
         // update supply
         UpdateZPIVSupplyConnect(block, pindex, true);
 
-        for (const CTransaction& tx : block.vtx) {
+        for (const auto& txIn : block.vtx) {
+            const CTransaction& tx = *txIn;
             for (unsigned int i = 0; i < tx.vin.size(); i++) {
                 if (tx.IsCoinBase())
                     break;
@@ -379,7 +383,8 @@ bool TxOutToPublicCoin(const CTxOut& txout, libzerocoin::PublicCoin& pubCoin, CV
 std::list<libzerocoin::CoinDenomination> ZerocoinSpendListFromBlock(const CBlock& block, bool fFilterInvalid)
 {
     std::list<libzerocoin::CoinDenomination> vSpends;
-    for (const CTransaction& tx : block.vtx) {
+    for (const auto& txIn : block.vtx) {
+        const CTransaction& tx = *txIn;
         if (!tx.HasZerocoinSpendInputs())
             continue;
 
@@ -437,8 +442,8 @@ bool UpdateZPIVSupplyConnect(const CBlock& block, CBlockIndex* pindex, bool fJus
                     // Add the transaction to the wallet
                     int posInBlock = 0;
                     for (posInBlock = 0; posInBlock < (int)block.vtx.size(); posInBlock++) {
-                        auto& tx = block.vtx[posInBlock];
-                        uint256 txid = tx.GetHash();
+                        auto& tx = *block.vtx[posInBlock];
+                        const uint256& txid = tx.GetHash();
                         if (setAddedToWallet.count(txid))
                             continue;
                         if (txid == m.GetTxHash()) {


### PR DESCRIPTION
Inspired on #9125 (with many more adaptations), preparation for #8580. Ant work 🐜 

Establishing the bases for the work, we will need to continue migrating `CTransaction` to `std::shared_ptr<const CTransaction>` where is possible. Example bitcoin#8126 (can find more in #1726 list).

TODO: 
* back port final `CTransactionRef` implementation commit.

EDIT:
This is now depending on #1816 .