### PR TITLE
[Miner] Unifying the disperse coinbase tx flow + further clean up.

### DIFF
--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -532,7 +532,7 @@ void CBudgetManager::CheckAndRemove()
 
 }
 
-void CBudgetManager::FillBlockPayee(CMutableTransaction& txNew, CAmount nFees, bool fProofOfStake)
+void CBudgetManager::FillBlockPayee(CMutableTransaction& txNew, bool fProofOfStake)
 {
     LOCK(cs);
 

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -532,12 +532,10 @@ void CBudgetManager::CheckAndRemove()
 
 }
 
-void CBudgetManager::FillBlockPayee(CMutableTransaction& txNew, bool fProofOfStake)
+void CBudgetManager::FillBlockPayee(CMutableTransaction& txNew, const CBlockIndex* pindexPrev, bool fProofOfStake)
 {
-    LOCK(cs);
-
-    CBlockIndex* pindexPrev = chainActive.Tip();
     if (!pindexPrev) return;
+    LOCK(cs);
 
     int nHighestCount = 0;
     CScript payee;

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -239,7 +239,7 @@ public:
     bool PropExists(uint256 nHash);
     TrxValidationStatus IsTransactionValid(const CTransaction& txNew, int nBlockHeight);
     std::string GetRequiredPaymentsString(int nBlockHeight);
-    void FillBlockPayee(CMutableTransaction& txNew, bool fProofOfStake);
+    void FillBlockPayee(CMutableTransaction& txNew, const CBlockIndex* pindexPrev, bool fProofOfStake);
 
     void CheckOrphanVotes();
     void Clear()

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -239,7 +239,7 @@ public:
     bool PropExists(uint256 nHash);
     TrxValidationStatus IsTransactionValid(const CTransaction& txNew, int nBlockHeight);
     std::string GetRequiredPaymentsString(int nBlockHeight);
-    void FillBlockPayee(CMutableTransaction& txNew, CAmount nFees, bool fProofOfStake);
+    void FillBlockPayee(CMutableTransaction& txNew, bool fProofOfStake);
 
     void CheckOrphanVotes();
     void Clear()

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -322,15 +322,15 @@ bool IsBlockPayeeValid(const CBlock& block, int nBlockHeight)
 }
 
 
-void FillBlockPayee(CMutableTransaction& txNew, CAmount nFees, bool fProofOfStake, bool fZPIVStake)
+void FillBlockPayee(CMutableTransaction& txNew, bool fProofOfStake, bool fZPIVStake)
 {
     CBlockIndex* pindexPrev = chainActive.Tip();
     if (!pindexPrev) return;
 
     if (sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS) && budget.IsBudgetPaymentBlock(pindexPrev->nHeight + 1)) {
-        budget.FillBlockPayee(txNew, nFees, fProofOfStake);
+        budget.FillBlockPayee(txNew, fProofOfStake);
     } else {
-        masternodePayments.FillBlockPayee(txNew, nFees, fProofOfStake, fZPIVStake);
+        masternodePayments.FillBlockPayee(txNew, fProofOfStake, fZPIVStake);
     }
 }
 
@@ -343,7 +343,7 @@ std::string GetRequiredPaymentsString(int nBlockHeight)
     }
 }
 
-void CMasternodePayments::FillBlockPayee(CMutableTransaction& txNew, int64_t nFees, bool fProofOfStake, bool fZPIVStake)
+void CMasternodePayments::FillBlockPayee(CMutableTransaction& txNew, bool fProofOfStake, bool fZPIVStake)
 {
     CBlockIndex* pindexPrev = chainActive.Tip();
     if (!pindexPrev) return;

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -322,14 +322,14 @@ bool IsBlockPayeeValid(const CBlock& block, int nBlockHeight)
 }
 
 
-void FillBlockPayee(CMutableTransaction& txNew, const CBlockIndex* pindexPrev, bool fProofOfStake, bool fZPIVStake)
+void FillBlockPayee(CMutableTransaction& txNew, const CBlockIndex* pindexPrev, bool fProofOfStake)
 {
     if (!pindexPrev) return;
 
     if (sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS) && budget.IsBudgetPaymentBlock(pindexPrev->nHeight + 1)) {
         budget.FillBlockPayee(txNew, pindexPrev, fProofOfStake);
     } else {
-        masternodePayments.FillBlockPayee(txNew, pindexPrev, fProofOfStake, fZPIVStake);
+        masternodePayments.FillBlockPayee(txNew, pindexPrev, fProofOfStake);
     }
 }
 
@@ -342,7 +342,7 @@ std::string GetRequiredPaymentsString(int nBlockHeight)
     }
 }
 
-void CMasternodePayments::FillBlockPayee(CMutableTransaction& txNew, const CBlockIndex* pindexPrev, bool fProofOfStake, bool fZPIVStake)
+void CMasternodePayments::FillBlockPayee(CMutableTransaction& txNew, const CBlockIndex* pindexPrev, bool fProofOfStake)
 {
     if (!pindexPrev) return;
 

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -361,10 +361,8 @@ void CMasternodePayments::FillBlockPayee(CMutableTransaction& txNew, const CBloc
         }
     }
 
-    CAmount blockValue = GetBlockValue(pindexPrev->nHeight);
-    CAmount masternodePayment = GetMasternodePayment();
-
     if (hasPayment) {
+        CAmount masternodePayment = GetMasternodePayment();
         if (fProofOfStake) {
             /**For Proof Of Stake vout[0] must be null
              * Stake reward can be split into many different outputs, so we must
@@ -397,7 +395,7 @@ void CMasternodePayments::FillBlockPayee(CMutableTransaction& txNew, const CBloc
             txNew.vout.resize(2);
             txNew.vout[1].scriptPubKey = payee;
             txNew.vout[1].nValue = masternodePayment;
-            txNew.vout[0].nValue = blockValue - masternodePayment;
+            txNew.vout[0].nValue = GetBlockValue(pindexPrev->nHeight) - masternodePayment;
         }
 
         CTxDestination address1;

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -322,15 +322,14 @@ bool IsBlockPayeeValid(const CBlock& block, int nBlockHeight)
 }
 
 
-void FillBlockPayee(CMutableTransaction& txNew, bool fProofOfStake, bool fZPIVStake)
+void FillBlockPayee(CMutableTransaction& txNew, const CBlockIndex* pindexPrev, bool fProofOfStake, bool fZPIVStake)
 {
-    CBlockIndex* pindexPrev = chainActive.Tip();
     if (!pindexPrev) return;
 
     if (sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS) && budget.IsBudgetPaymentBlock(pindexPrev->nHeight + 1)) {
-        budget.FillBlockPayee(txNew, fProofOfStake);
+        budget.FillBlockPayee(txNew, pindexPrev, fProofOfStake);
     } else {
-        masternodePayments.FillBlockPayee(txNew, fProofOfStake, fZPIVStake);
+        masternodePayments.FillBlockPayee(txNew, pindexPrev, fProofOfStake, fZPIVStake);
     }
 }
 
@@ -343,9 +342,8 @@ std::string GetRequiredPaymentsString(int nBlockHeight)
     }
 }
 
-void CMasternodePayments::FillBlockPayee(CMutableTransaction& txNew, bool fProofOfStake, bool fZPIVStake)
+void CMasternodePayments::FillBlockPayee(CMutableTransaction& txNew, const CBlockIndex* pindexPrev, bool fProofOfStake, bool fZPIVStake)
 {
-    CBlockIndex* pindexPrev = chainActive.Tip();
     if (!pindexPrev) return;
 
     bool hasPayment = true;

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -28,7 +28,7 @@ void ProcessMessageMasternodePayments(CNode* pfrom, std::string& strCommand, CDa
 bool IsBlockPayeeValid(const CBlock& block, int nBlockHeight);
 std::string GetRequiredPaymentsString(int nBlockHeight);
 bool IsBlockValueValid(const CBlock& block, CAmount nExpectedValue, CAmount nMinted);
-void FillBlockPayee(CMutableTransaction& txNew, const CBlockIndex* pindexPrev, bool fProofOfStake, bool fZPIVStake);
+void FillBlockPayee(CMutableTransaction& txNew, const CBlockIndex* pindexPrev, bool fProofOfStake);
 
 void DumpMasternodePayments();
 
@@ -279,7 +279,7 @@ public:
     int GetMinMasternodePaymentsProto();
     void ProcessMessageMasternodePayments(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
     std::string GetRequiredPaymentsString(int nBlockHeight);
-    void FillBlockPayee(CMutableTransaction& txNew, const CBlockIndex* pindexPrev, bool fProofOfStake, bool fZPIVStake);
+    void FillBlockPayee(CMutableTransaction& txNew, const CBlockIndex* pindexPrev, bool fProofOfStake);
     std::string ToString() const;
     int GetOldestBlock();
     int GetNewestBlock();

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -28,7 +28,7 @@ void ProcessMessageMasternodePayments(CNode* pfrom, std::string& strCommand, CDa
 bool IsBlockPayeeValid(const CBlock& block, int nBlockHeight);
 std::string GetRequiredPaymentsString(int nBlockHeight);
 bool IsBlockValueValid(const CBlock& block, CAmount nExpectedValue, CAmount nMinted);
-void FillBlockPayee(CMutableTransaction& txNew, bool fProofOfStake, bool fZPIVStake);
+void FillBlockPayee(CMutableTransaction& txNew, const CBlockIndex* pindexPrev, bool fProofOfStake, bool fZPIVStake);
 
 void DumpMasternodePayments();
 
@@ -279,7 +279,7 @@ public:
     int GetMinMasternodePaymentsProto();
     void ProcessMessageMasternodePayments(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
     std::string GetRequiredPaymentsString(int nBlockHeight);
-    void FillBlockPayee(CMutableTransaction& txNew, bool fProofOfStake, bool fZPIVStake);
+    void FillBlockPayee(CMutableTransaction& txNew, const CBlockIndex* pindexPrev, bool fProofOfStake, bool fZPIVStake);
     std::string ToString() const;
     int GetOldestBlock();
     int GetNewestBlock();

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -28,7 +28,7 @@ void ProcessMessageMasternodePayments(CNode* pfrom, std::string& strCommand, CDa
 bool IsBlockPayeeValid(const CBlock& block, int nBlockHeight);
 std::string GetRequiredPaymentsString(int nBlockHeight);
 bool IsBlockValueValid(const CBlock& block, CAmount nExpectedValue, CAmount nMinted);
-void FillBlockPayee(CMutableTransaction& txNew, CAmount nFees, bool fProofOfStake, bool fZPIVStake);
+void FillBlockPayee(CMutableTransaction& txNew, bool fProofOfStake, bool fZPIVStake);
 
 void DumpMasternodePayments();
 
@@ -279,7 +279,7 @@ public:
     int GetMinMasternodePaymentsProto();
     void ProcessMessageMasternodePayments(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
     std::string GetRequiredPaymentsString(int nBlockHeight);
-    void FillBlockPayee(CMutableTransaction& txNew, int64_t nFees, bool fProofOfStake, bool fZPIVStake);
+    void FillBlockPayee(CMutableTransaction& txNew, bool fProofOfStake, bool fZPIVStake);
     std::string ToString() const;
     int GetOldestBlock();
     int GetNewestBlock();

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -159,10 +159,9 @@ bool CreateCoinbaseTx(CBlock* pblock, const CScript& scriptPubKeyIn, CBlockIndex
     FillBlockPayee(txNew, pindexPrev, false);
 
     txNew.vin[0].scriptSig = CScript() << pindexPrev->nHeight + 1 << OP_0;
-    //Make payee
+    // If no payee was detected, then the whole block value goes to the first output.
     if (txNew.vout.size() == 1) {
-        CAmount blockValue = GetBlockValue(pindexPrev->nHeight);
-        txNew.vout[0].nValue = blockValue;
+        txNew.vout[0].nValue = GetBlockValue(pindexPrev->nHeight);
     }
 
     pblock->vtx.emplace_back(txNew);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -160,9 +160,7 @@ bool CreateCoinbaseTx(CBlock* pblock, const CScript& scriptPubKeyIn, CBlockIndex
 
     txNew.vin[0].scriptSig = CScript() << pindexPrev->nHeight + 1 << OP_0;
     //Make payee
-    if (txNew.vout.size() > 1) {
-        pblock->payee = txNew.vout[1].scriptPubKey;
-    } else {
+    if (txNew.vout.size() == 1) {
         CAmount blockValue = GetBlockValue(pindexPrev->nHeight);
         txNew.vout[0].nValue = blockValue;
     }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -207,7 +207,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, 
         txNew.vout[0].scriptPubKey = scriptPubKeyIn;
 
         //Masternode and general budget payments
-        FillBlockPayee(txNew, fProofOfStake, false);
+        FillBlockPayee(txNew, pindexPrev, fProofOfStake, false);
 
         txNew.vin[0].scriptSig = CScript() << nHeight << OP_0;
         //Make payee

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -182,6 +182,7 @@ bool SolveProofOfStake(CBlock* pblock, CBlockIndex* pindexPrev, CWallet* pwallet
     pblock->nTime = nTxNewTime;
     CMutableTransaction emptyTx;
     emptyTx.vin.resize(1);
+    emptyTx.vin[0].scriptSig = CScript() << pindexPrev->nHeight + 1 << OP_0;
     emptyTx.vout.resize(1);
     emptyTx.vout[0].SetEmpty();
     pblock->vtx.emplace_back(emptyTx);
@@ -446,8 +447,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, 
         pblocktemplate->vTxSigOps[0] = GetLegacySigOpCount(pblock->vtx[0]);
 
         if (fProofOfStake) {
-            unsigned int nExtraNonce = 0;
-            IncrementExtraNonce(pblock, pindexPrev, nExtraNonce);
+            pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
             LogPrintf("CPUMiner : proof-of-stake block found %s \n", pblock->GetHash().GetHex());
             if (!SignBlock(*pblock, *pwallet)) {
                 LogPrintf("%s: Signing new block with UTXO key failed \n", __func__);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -156,7 +156,7 @@ bool CreateCoinbaseTx(CBlock* pblock, const CScript& scriptPubKeyIn, CBlockIndex
     txNew.vout[0].scriptPubKey = scriptPubKeyIn;
 
     //Masternode and general budget payments
-    FillBlockPayee(txNew, pindexPrev, false, false);
+    FillBlockPayee(txNew, pindexPrev, false);
 
     txNew.vin[0].scriptSig = CScript() << pindexPrev->nHeight + 1 << OP_0;
     //Make payee

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -88,7 +88,6 @@ public:
     std::vector<unsigned char> vchBlockSig;
 
     // memory only
-    mutable CScript payee;
     mutable bool fChecked;
 
     CBlock()
@@ -117,7 +116,6 @@ public:
         CBlockHeader::SetNull();
         vtx.clear();
         fChecked = false;
-        payee = CScript();
         vchBlockSig.clear();
     }
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -624,18 +624,6 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     result.push_back(Pair("bits", strprintf("%08x", pblock->nBits)));
     result.push_back(Pair("height", (int64_t)(pindexPrev->nHeight + 1)));
     result.push_back(Pair("votes", aVotes));
-
-
-    if (pblock->payee != CScript()) {
-        CTxDestination address1;
-        ExtractDestination(pblock->payee, address1);
-        result.push_back(Pair("payee", EncodeDestination(address1).c_str()));
-        result.push_back(Pair("payee_amount", (int64_t)pblock->vtx[0].vout[1].nValue));
-    } else {
-        result.push_back(Pair("payee", ""));
-        result.push_back(Pair("payee_amount", ""));
-    }
-
     result.push_back(Pair("enforce_masternode_payments", true));
 
     return result;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2801,10 +2801,9 @@ bool CWallet::CreateCoinStake(
         }
         txNew.vout.insert(txNew.vout.end(), vout.begin(), vout.end());
 
-        CAmount nMinFee = 0;
         // Set output amount
-        int outputs = txNew.vout.size() - 1;
-        CAmount nRemaining = nCredit - nMinFee;
+        int outputs = (int) txNew.vout.size() - 1;
+        CAmount nRemaining = nCredit;
         if (outputs > 1) {
             // Split the stake across the outputs
             CAmount nShare = nRemaining / outputs;
@@ -2823,7 +2822,7 @@ bool CWallet::CreateCoinStake(
             return error("%s : exceeded coinstake size limit", __func__);
 
         // Masternode payment
-        FillBlockPayee(txNew, nMinFee, true, false);
+        FillBlockPayee(txNew, true, false);
 
         uint256 hashTxOut = txNew.GetHash();
         CTxIn in;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2822,7 +2822,7 @@ bool CWallet::CreateCoinStake(
             return error("%s : exceeded coinstake size limit", __func__);
 
         // Masternode payment
-        FillBlockPayee(txNew, true, false);
+        FillBlockPayee(txNew, pindexPrev, true, false);
 
         uint256 hashTxOut = txNew.GetHash();
         CTxIn in;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2822,7 +2822,7 @@ bool CWallet::CreateCoinStake(
             return error("%s : exceeded coinstake size limit", __func__);
 
         // Masternode payment
-        FillBlockPayee(txNew, pindexPrev, true, false);
+        FillBlockPayee(txNew, pindexPrev, true);
 
         uint256 hashTxOut = txNew.GetHash();
         CTxIn in;


### PR DESCRIPTION
Another step forward improving the miner `CreateNewBlock` function.
This time, have unified the coinbase tx creation flow that was previously dispersed over the function and having some redundant initializations/sets.
Plus, cleaned up some unused and/or unneeded fields and function arguments.

This is a preparation for #1815 work.  It will not be possible to modify any of the elements of a transaction once them are appended to a block, thus why the transaction needs (more than ever) to be crafted in one single place and not all over the sources.