### PR TITLE
[Miner] PoS process, calculate stakeable utxo only once.

### DIFF
--- a/src/miner.h
+++ b/src/miner.h
@@ -14,6 +14,7 @@
 class CBlock;
 class CBlockHeader;
 class CBlockIndex;
+class COutput;
 class CReserveKey;
 class CScript;
 class CWallet;
@@ -23,7 +24,7 @@ static const bool DEFAULT_PRINTPRIORITY = false;
 struct CBlockTemplate;
 
 /** Generate a new block, without valid proof-of-work */
-CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, bool fProofOfStake);
+CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, bool fProofOfStake, std::vector<COutput>* availableCoins = nullptr);
 /** Modify the extranonce in a block */
 void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& nExtraNonce);
 /** Check mined block */

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2724,14 +2724,10 @@ bool CWallet::CreateCoinStake(
         const CBlockIndex* pindexPrev,
         unsigned int nBits,
         CMutableTransaction& txNew,
-        int64_t& nTxNewTime)
+        int64_t& nTxNewTime,
+        std::vector<COutput>* availableCoins
+        )
 {
-    // Get the list of stakable utxos
-    std::vector<COutput> vCoins;
-    if (!StakeableCoins(&vCoins)) {
-        LogPrintf("%s: No coin available to stake.\n", __func__);
-        return false;
-    }
 
     const Consensus::Params& consensus = Params().GetConsensus();
 
@@ -2742,7 +2738,7 @@ bool CWallet::CreateCoinStake(
 
     // update staker status (hash)
     pStakerStatus->SetLastTip(pindexPrev);
-    pStakerStatus->SetLastCoins((int) vCoins.size());
+    pStakerStatus->SetLastCoins((int) availableCoins->size());
 
     // P2PKH block signatures were not accepted before v5 update.
     bool onlyP2PK = !consensus.NetworkUpgradeActive(pindexPrev->nHeight + 1, Consensus::UPGRADE_V5_DUMMY);
@@ -2752,7 +2748,7 @@ bool CWallet::CreateCoinStake(
     CScript scriptPubKeyKernel;
     bool fKernelFound = false;
     int nAttempts = 0;
-    for (const COutput &out : vCoins) {
+    for (const COutput &out : *availableCoins) {
         CPivStake stakeInput;
         stakeInput.SetPrevout((CTransaction) *out.tx, out.i);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -567,7 +567,12 @@ public:
     };
     CWallet::CommitResult CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey, CConnman* connman, std::string strCommand = NetMsgType::TX);
     bool AddAccountingEntry(const CAccountingEntry&, CWalletDB & pwalletdb);
-    bool CreateCoinStake(const CKeyStore& keystore, const CBlockIndex* pindexPrev, unsigned int nBits, CMutableTransaction& txNew, int64_t& nTxNewTime);
+    bool CreateCoinStake(const CKeyStore& keystore,
+                         const CBlockIndex* pindexPrev,
+                         unsigned int nBits,
+                         CMutableTransaction& txNew,
+                         int64_t& nTxNewTime,
+                         std::vector<COutput>* availableCoins);
     bool MultiSend();
     void AutoCombineDust(CConnman* connman);
 


### PR DESCRIPTION
Work on top of #1816 and part of #1817 coinstake transaction creation speedup goal. Starting on 01814d5

Improving the following situation: we are calculating the stakeable utxo twice for the same PoS block creation process (looping over the entire wallet's transactions map twice), one before calling `CreateNewBlock` in `CheckForCoins` and the second one inside the `CreateNewBlock` method when we call `CWallet::CreateCoinStake`. 
This PR fixes it adding an unique available coins vector calculated before the block creation, only once per try, in the `CheckForCoins` function and feeding `CreateNewBlock` with it.