### PR TITLE
[Wallet] Address book encapsulation.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1885,7 +1885,7 @@ bool AppInit2()
             LOCK(pwalletMain->cs_wallet);
             LogPrintf("setKeyPool.size() = %u\n", pwalletMain ? pwalletMain->GetKeyPoolSize() : 0);
             LogPrintf("mapWallet.size() = %u\n", pwalletMain ? pwalletMain->mapWallet.size() : 0);
-            LogPrintf("mapAddressBook.size() = %u\n", pwalletMain ? pwalletMain->mapAddressBook.size() : 0);
+            LogPrintf("mapAddressBook.size() = %u\n", pwalletMain ? pwalletMain->GetAddressBookSize() : 0);
         }
     }
 #endif

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -395,7 +395,7 @@ bool AddressTableModel::setData(const QModelIndex& index, const QVariant& value,
             }
             // Check for duplicate addresses to prevent accidental deletion of addresses, if you try
             // to paste an existing address over another address (with a different label)
-            else if (wallet->mapAddressBook.count(newAddress)) {
+            else if (wallet->HasAddressBook(newAddress)) {
                 editStatus = DUPLICATE_ADDRESS;
                 return false;
             }
@@ -483,7 +483,7 @@ QString AddressTableModel::addRow(const QString& type, const QString& label, con
         // Check for duplicate addresses
         {
             LOCK(wallet->cs_wallet);
-            if (wallet->mapAddressBook.count(DecodeDestination(strAddress))) {
+            if (wallet->HasAddressBook(DecodeDestination(strAddress))) {
                 editStatus = DUPLICATE_ADDRESS;
                 return QString();
             }

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -128,7 +128,7 @@ public:
         cachedAddressTable.clear();
         {
             LOCK(wallet->cs_wallet);
-            for (auto it = wallet->NewAddressBookIterator(); it.HasNext(); it.Next()) {
+            for (auto it = wallet->NewAddressBookIterator(); it.IsValid(); it.Next()) {
                 auto addrBookData = it.GetValue();
                 const CChainParams::Base58Type addrType =
                         AddressBook::IsColdStakingPurpose(addrBookData.purpose) ?

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -555,7 +555,7 @@ QString AddressTableModel::labelForAddress(const QString& address) const
  */
 std::string AddressTableModel::purposeForAddress(const std::string& address) const
 {
-    return wallet->purposeForAddress(DecodeDestination(address));
+    return wallet->GetPurposeForAddressBookEntry(DecodeDestination(address));
 }
 
 int AddressTableModel::lookupAddress(const QString& address) const

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -923,12 +923,10 @@ void WalletModel::listLockedCoins(std::vector<COutPoint>& vOutpts)
 void WalletModel::loadReceiveRequests(std::vector<std::string>& vReceiveRequests)
 {
     LOCK(wallet->cs_wallet);
-    auto it = wallet->NewAddressBookIterator();
-    while(it.HasNext()) {
+    for (auto it = wallet->NewAddressBookIterator(); it.IsValid(); it.Next()) {
         for (const PAIRTYPE(std::string, std::string) &item2 : it.GetValue().destdata)
             if (item2.first.size() > 2 && item2.first.substr(0, 2) == "rr") // receive request
                 vReceiveRequests.push_back(item2.second);
-        it.Next();
     }
 }
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -923,10 +923,13 @@ void WalletModel::listLockedCoins(std::vector<COutPoint>& vOutpts)
 void WalletModel::loadReceiveRequests(std::vector<std::string>& vReceiveRequests)
 {
     LOCK(wallet->cs_wallet);
-    for (const auto& item : wallet->mapAddressBook)
-        for (const PAIRTYPE(std::string, std::string) & item2 : item.second.destdata)
+    auto it = wallet->NewAddressBookIterator();
+    while(it.HasNext()) {
+        for (const PAIRTYPE(std::string, std::string) &item2 : it.GetValue().destdata)
             if (item2.first.size() > 2 && item2.first.substr(0, 2) == "rr") // receive request
                 vReceiveRequests.push_back(item2.second);
+        it.Next();
+    }
 }
 
 bool WalletModel::saveReceiveRequest(const std::string& sAddress, const int64_t nId, const std::string& sRequest)

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -392,7 +392,7 @@ public:
         UniValue detail = boost::apply_visitor(DescribeAddressVisitor(mine), dest);
         ret.pushKVs(detail);
         if (pwalletMain && pwalletMain->HasAddressBook(dest))
-            ret.push_back(Pair("account", pwalletMain->mapAddressBook[dest].name));
+            ret.push_back(Pair("account", pwalletMain->GetNameForAddressBookEntry(dest)));
 #endif
         return ret;
     }

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -391,7 +391,7 @@ public:
         ret.push_back(Pair("iswatchonly", bool(mine & ISMINE_WATCH_ONLY)));
         UniValue detail = boost::apply_visitor(DescribeAddressVisitor(mine), dest);
         ret.pushKVs(detail);
-        if (pwalletMain && pwalletMain->mapAddressBook.count(dest))
+        if (pwalletMain && pwalletMain->HasAddressBook(dest))
             ret.push_back(Pair("account", pwalletMain->mapAddressBook[dest].name));
 #endif
         return ret;

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -510,7 +510,7 @@ UniValue dumpwallet(const JSONRPCRequest& request)
                                                           CChainParams::PUBKEY_ADDRESS));
 
             file << strprintf("%s %s ", KeyIO::EncodeSecret(key), strTime);
-            if (pwalletMain->mapAddressBook.count(keyid)) {
+            if (pwalletMain->HasAddressBook(keyid)) {
                 auto entry = pwalletMain->mapAddressBook[keyid];
                 file << strprintf("label=%s", EncodeDumpString(entry.name));
             } else if (keyid == seed_id) {

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -511,8 +511,7 @@ UniValue dumpwallet(const JSONRPCRequest& request)
 
             file << strprintf("%s %s ", KeyIO::EncodeSecret(key), strTime);
             if (pwalletMain->HasAddressBook(keyid)) {
-                auto entry = pwalletMain->mapAddressBook[keyid];
-                file << strprintf("label=%s", EncodeDumpString(entry.name));
+                file << strprintf("label=%s", EncodeDumpString(pwalletMain->GetNameForAddressBookEntry(keyid)));
             } else if (keyid == seed_id) {
                 file << "hdseed=1";
             } else if (mapKeyPool.count(keyid)) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -241,9 +241,9 @@ UniValue getaddressinfo(const JSONRPCRequest& request)
     // DEPRECATED: The previous behavior of returning an array containing a JSON
     // object of `name` and `purpose` key/value pairs has been deprecated.
     UniValue labels(UniValue::VARR);
-    std::map<CTxDestination, AddressBook::CAddressBookData>::iterator mi = pwallet->mapAddressBook.find(dest);
-    if (mi != pwallet->mapAddressBook.end()) {
-        labels.push_back(AddressBookDataToJSON(mi->second, true));
+    auto addrBookData = pwallet->GetAddressBookEntry(dest);
+    if (addrBookData) {
+        labels.push_back(AddressBookDataToJSON(*addrBookData, true));
     }
     ret.pushKV("labels", std::move(labels));
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -205,7 +205,7 @@ UniValue getaddressinfo(const JSONRPCRequest& request)
     // Return label field if existing. Currently only one label can be
     // associated with an address, so the label should be equivalent to the
     // value of the name key/value pair in the labels array below.
-    if (pwallet->mapAddressBook.count(dest)) {
+    if (pwallet->HasAddressBook(dest)) {
         ret.pushKV("label", pwallet->mapAddressBook[dest].name);
         if (IsDeprecatedRPCEnabled("accounts")) {
             ret.pushKV("account", pwallet->mapAddressBook[dest].name);
@@ -2266,7 +2266,7 @@ UniValue listcoldutxos(const JSONRPCRequest& request)
             int nRequired;
             if (!ExtractDestinations(out.scriptPubKey, type, addresses, nRequired))
                 continue;
-            const bool fWhitelisted = pwalletMain->mapAddressBook.count(addresses[1]) > 0;
+            const bool fWhitelisted = pwalletMain->HasAddressBook(addresses[1]) > 0;
             if (fExcludeWhitelisted && fWhitelisted)
                 continue;
             UniValue entry(UniValue::VOBJ);
@@ -2312,7 +2312,7 @@ void ListTransactions(const CWalletTx& wtx, const std::string& strAccount, int n
             MaybePushAddress(entry, s.destination);
             entry.push_back(Pair("category", "send"));
             entry.push_back(Pair("amount", ValueFromAmount(-s.amount)));
-            if (pwalletMain->mapAddressBook.count(s.destination)) {
+            if (pwalletMain->HasAddressBook(s.destination)) {
                 entry.push_back(Pair("label", pwalletMain->mapAddressBook[s.destination].name));
             }
             entry.push_back(Pair("vout", s.vout));
@@ -2328,7 +2328,7 @@ void ListTransactions(const CWalletTx& wtx, const std::string& strAccount, int n
     if (listReceived.size() > 0 && depth >= nMinDepth) {
         for (const COutputEntry& r : listReceived) {
             std::string account;
-            if (pwalletMain->mapAddressBook.count(r.destination))
+            if (pwalletMain->HasAddressBook(r.destination))
                 account = pwalletMain->mapAddressBook[r.destination].name;
             if (fAllAccounts || (account == strAccount)) {
                 UniValue entry(UniValue::VOBJ);
@@ -2347,7 +2347,7 @@ void ListTransactions(const CWalletTx& wtx, const std::string& strAccount, int n
                     entry.push_back(Pair("category", "receive"));
                 }
                 entry.push_back(Pair("amount", ValueFromAmount(r.amount)));
-                if (pwalletMain->mapAddressBook.count(r.destination)) {
+                if (pwalletMain->HasAddressBook(r.destination)) {
                     entry.push_back(Pair("label", account));
                 }
                 entry.push_back(Pair("vout", r.vout));
@@ -2629,7 +2629,7 @@ UniValue listaccounts(const JSONRPCRequest& request)
             mapAccountBalances[strSentAccount] -= s.amount;
         if (nDepth >= nMinDepth) {
             for (const COutputEntry& r : listReceived)
-                if (pwalletMain->mapAddressBook.count(r.destination))
+                if (pwalletMain->HasAddressBook(r.destination))
                     mapAccountBalances[pwalletMain->mapAddressBook[r.destination].name] += r.amount;
                 else
                     mapAccountBalances[""] += r.amount;
@@ -3228,7 +3228,7 @@ UniValue listunspent(const JSONRPCRequest& request)
         CTxDestination address;
         if (ExtractDestination(out.tx->vout[out.i].scriptPubKey, address)) {
             entry.push_back(Pair("address", EncodeDestination(address)));
-            if (pwalletMain->mapAddressBook.count(address)) {
+            if (pwalletMain->HasAddressBook(address)) {
                 entry.push_back(Pair("label", pwalletMain->mapAddressBook[address].name));
                 if (IsDeprecatedRPCEnabled("accounts")) {
                     entry.push_back(Pair("account", pwalletMain->mapAddressBook[address].name));

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -206,9 +206,9 @@ UniValue getaddressinfo(const JSONRPCRequest& request)
     // associated with an address, so the label should be equivalent to the
     // value of the name key/value pair in the labels array below.
     if (pwallet->HasAddressBook(dest)) {
-        ret.pushKV("label", pwallet->mapAddressBook[dest].name);
+        ret.pushKV("label", pwallet->GetNameForAddressBookEntry(dest));
         if (IsDeprecatedRPCEnabled("accounts")) {
-            ret.pushKV("account", pwallet->mapAddressBook[dest].name);
+            ret.pushKV("account", pwallet->GetNameForAddressBookEntry(dest));
         }
     }
 
@@ -823,7 +823,7 @@ UniValue setlabel(const JSONRPCRequest& request)
     if (!IsValidDestination(dest))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid PIVX address");
 
-    std::string old_label = pwalletMain->mapAddressBook[dest].name;
+    std::string old_label = pwalletMain->GetNameForAddressBookEntry(dest);
     std::string label = LabelFromValue(request.params[1]);
 
     if (IsMine(*pwalletMain, dest)) {
@@ -2313,7 +2313,7 @@ void ListTransactions(const CWalletTx& wtx, const std::string& strAccount, int n
             entry.push_back(Pair("category", "send"));
             entry.push_back(Pair("amount", ValueFromAmount(-s.amount)));
             if (pwalletMain->HasAddressBook(s.destination)) {
-                entry.push_back(Pair("label", pwalletMain->mapAddressBook[s.destination].name));
+                entry.push_back(Pair("label", pwalletMain->GetNameForAddressBookEntry(s.destination)));
             }
             entry.push_back(Pair("vout", s.vout));
             entry.push_back(Pair("fee", ValueFromAmount(-nFee)));
@@ -2329,7 +2329,7 @@ void ListTransactions(const CWalletTx& wtx, const std::string& strAccount, int n
         for (const COutputEntry& r : listReceived) {
             std::string account;
             if (pwalletMain->HasAddressBook(r.destination))
-                account = pwalletMain->mapAddressBook[r.destination].name;
+                account = pwalletMain->GetNameForAddressBookEntry(r.destination);
             if (fAllAccounts || (account == strAccount)) {
                 UniValue entry(UniValue::VOBJ);
                 if (involvesWatchonly || (::IsMine(*pwalletMain, r.destination) & ISMINE_WATCH_ONLY))
@@ -2630,7 +2630,7 @@ UniValue listaccounts(const JSONRPCRequest& request)
         if (nDepth >= nMinDepth) {
             for (const COutputEntry& r : listReceived)
                 if (pwalletMain->HasAddressBook(r.destination))
-                    mapAccountBalances[pwalletMain->mapAddressBook[r.destination].name] += r.amount;
+                    mapAccountBalances[pwalletMain->GetNameForAddressBookEntry(r.destination)] += r.amount;
                 else
                     mapAccountBalances[""] += r.amount;
         }
@@ -3229,9 +3229,9 @@ UniValue listunspent(const JSONRPCRequest& request)
         if (ExtractDestination(out.tx->vout[out.i].scriptPubKey, address)) {
             entry.push_back(Pair("address", EncodeDestination(address)));
             if (pwalletMain->HasAddressBook(address)) {
-                entry.push_back(Pair("label", pwalletMain->mapAddressBook[address].name));
+                entry.push_back(Pair("label", pwalletMain->GetNameForAddressBookEntry(address)));
                 if (IsDeprecatedRPCEnabled("accounts")) {
-                    entry.push_back(Pair("account", pwalletMain->mapAddressBook[address].name));
+                    entry.push_back(Pair("account", pwalletMain->GetNameForAddressBookEntry(address)));
                 }
             }
         }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3019,6 +3019,13 @@ std::string CWallet::purposeForAddress(const CTxDestination& address) const
     return "";
 }
 
+std::string CWallet::GetNameForAddressBookEntry(const CTxDestination& address) const
+{
+    LOCK(cs_wallet);
+    auto it = mapAddressBook.find(address);
+    return it != mapAddressBook.end() ? it->second.name : "";
+}
+
 const std::string& CWallet::GetAccountName(const CScript& scriptPubKey) const
 {
     CTxDestination address;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1188,7 +1188,7 @@ bool CWallet::IsChange(const CTxOut& txout) const
             return true;
 
         LOCK(cs_wallet);
-        if (!mapAddressBook.count(address))
+        if (!HasAddressBook(address))
             return true;
     }
     return false;
@@ -3036,9 +3036,7 @@ const std::string& CWallet::GetAccountName(const CScript& scriptPubKey) const
 
 bool CWallet::HasAddressBook(const CTxDestination& address) const
 {
-    LOCK(cs_wallet); // mapAddressBook
-    std::map<CTxDestination, AddressBook::CAddressBookData>::const_iterator mi = mapAddressBook.find(address);
-    return mi != mapAddressBook.end();
+    return WITH_LOCK(cs_wallet, return mapAddressBook.count(address));
 }
 
 bool CWallet::HasDelegator(const CTxOut& out) const

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3028,6 +3028,16 @@ Optional<AddressBook::CAddressBookData> CWallet::GetAddressBookEntry(const CTxDe
     return it != mapAddressBook.end() ? Optional<AddressBook::CAddressBookData>(it->second) : nullopt;
 }
 
+void CWallet::LoadAddressBookName(const CTxDestination& dest, const std::string& strName)
+{
+    mapAddressBook[dest].name = strName;
+}
+
+void CWallet::LoadAddressBookPurpose(const CTxDestination& dest, const std::string& strPurpose)
+{
+    mapAddressBook[dest].purpose = strPurpose;
+}
+
 const std::string& CWallet::GetAccountName(const CScript& scriptPubKey) const
 {
     CTxDestination address;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2986,7 +2986,7 @@ bool CWallet::SetAddressBook(const CTxDestination& address, const std::string& s
 bool CWallet::DelAddressBook(const CTxDestination& address, const CChainParams::Base58Type addrType)
 {
     std::string strAddress =  EncodeDestination(address, addrType);
-    std::string purpose = purposeForAddress(address);
+    std::string purpose = GetPurposeForAddressBookEntry(address);
     {
         LOCK(cs_wallet); // mapAddressBook
 
@@ -3007,16 +3007,11 @@ bool CWallet::DelAddressBook(const CTxDestination& address, const CChainParams::
     return CWalletDB(strWalletFile).EraseName(strAddress);
 }
 
-std::string CWallet::purposeForAddress(const CTxDestination& address) const
+std::string CWallet::GetPurposeForAddressBookEntry(const CTxDestination& address) const
 {
-    {
-        LOCK(cs_wallet);
-        auto mi = mapAddressBook.find(address);
-        if (mi != mapAddressBook.end()) {
-            return mi->second.purpose;
-        }
-    }
-    return "";
+    LOCK(cs_wallet);
+    auto it = mapAddressBook.find(address);
+    return it != mapAddressBook.end() ? it->second.purpose : "";
 }
 
 std::string CWallet::GetNameForAddressBookEntry(const CTxDestination& address) const

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3021,6 +3021,13 @@ std::string CWallet::GetNameForAddressBookEntry(const CTxDestination& address) c
     return it != mapAddressBook.end() ? it->second.name : "";
 }
 
+Optional<AddressBook::CAddressBookData> CWallet::GetAddressBookEntry(const CTxDestination& dest) const
+{
+    LOCK(cs_wallet);
+    auto it = mapAddressBook.find(dest);
+    return it != mapAddressBook.end() ? Optional<AddressBook::CAddressBookData>(it->second) : nullopt;
+}
+
 const std::string& CWallet::GetAccountName(const CScript& scriptPubKey) const
 {
     CTxDestination address;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -637,6 +637,7 @@ public:
 
     std::string GetPurposeForAddressBookEntry(const CTxDestination& address) const;
     std::string GetNameForAddressBookEntry(const CTxDestination& address) const;
+    Optional<AddressBook::CAddressBookData> GetAddressBookEntry(const CTxDestination& address) const;
 
     const std::string& GetAccountName(const CScript& scriptPubKey) const;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -89,6 +89,7 @@ static const bool DEFAULT_DISABLE_WALLET = false;
 
 extern const char * DEFAULT_WALLET_DAT;
 
+class CAddressBookIterator;
 class CAccountingEntry;
 class CCoinControl;
 class COutput;
@@ -243,6 +244,23 @@ struct CRecipient
     {}
 };
 
+class CAddressBookIterator
+{
+public:
+    explicit CAddressBookIterator(std::map<CTxDestination, AddressBook::CAddressBookData>& _map) : map(_map), it(_map.begin()) {}
+    CTxDestination GetKey() { return it->first; }
+    AddressBook::CAddressBookData GetValue() { return it->second; }
+    bool HasNext() { return it != map.end(); }
+    bool Next() {
+        if (it == map.end()) return false;
+        it++;
+        return true;
+    }
+
+private:
+    std::map<CTxDestination, AddressBook::CAddressBookData>& map;
+    std::map<CTxDestination, AddressBook::CAddressBookData>::iterator it;
+};
 
 /**
  * A CWallet is an extension of a keystore, which also maintains a set of transactions and balances,
@@ -635,6 +653,7 @@ public:
     bool HasAddressBook(const CTxDestination& address) const;
     bool HasDelegator(const CTxOut& out) const;
 
+    CAddressBookIterator NewAddressBookIterator() { return CAddressBookIterator(mapAddressBook); }
     std::string GetPurposeForAddressBookEntry(const CTxDestination& address) const;
     std::string GetNameForAddressBookEntry(const CTxDestination& address) const;
     Optional<AddressBook::CAddressBookData> GetAddressBookEntry(const CTxDestination& address) const;
@@ -1046,7 +1065,6 @@ public:
         READWRITE(LIMITED_STRING(strComment, 65536));
     }
 };
-
 
 /**
  * DEPRECATED Account information.

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -250,11 +250,13 @@ public:
     explicit CAddressBookIterator(std::map<CTxDestination, AddressBook::CAddressBookData>& _map) : map(_map), it(_map.begin()), itEnd(_map.end()) {}
     CTxDestination GetKey() { return it->first; }
     AddressBook::CAddressBookData GetValue() { return it->second; }
-    bool HasNext() { return it != itEnd; }
+
+    bool IsValid() { return it != itEnd; }
+
     bool Next() {
-        if (!HasNext()) return false;
+        if (!IsValid()) return false;
         it++;
-        return true;
+        return IsValid();
     }
 
     void SetFilter(CTxDestination& filter)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -667,6 +667,9 @@ public:
     std::string GetNameForAddressBookEntry(const CTxDestination& address) const;
     Optional<AddressBook::CAddressBookData> GetAddressBookEntry(const CTxDestination& address) const;
 
+    void LoadAddressBookName(const CTxDestination& dest, const std::string& strName);
+    void LoadAddressBookPurpose(const CTxDestination& dest, const std::string& strPurpose);
+
     const std::string& GetAccountName(const CScript& scriptPubKey) const;
 
     bool UpdatedTransaction(const uint256& hashTx);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -316,6 +316,9 @@ private:
     // Zerocoin wallet
     CzPIVWallet* zwallet{nullptr};
 
+    //! Destination --> label/purpose mapping.
+    std::map<CTxDestination, AddressBook::CAddressBookData> mapAddressBook;
+
 public:
 
     static const CAmount DEFAULT_STAKE_SPLIT_THRESHOLD = 500 * COIN;
@@ -395,8 +398,6 @@ public:
     TxItems wtxOrdered;
 
     int64_t nOrderPosNext;
-
-    std::map<CTxDestination, AddressBook::CAddressBookData> mapAddressBook;
 
     std::set<COutPoint> setLockedCoins;
 
@@ -661,6 +662,7 @@ public:
     bool DelAddressBook(const CTxDestination& address, const CChainParams::Base58Type addrType = CChainParams::PUBKEY_ADDRESS);
     bool HasAddressBook(const CTxDestination& address) const;
     bool HasDelegator(const CTxOut& out) const;
+    int GetAddressBookSize() const { return mapAddressBook.size(); };
 
     CAddressBookIterator NewAddressBookIterator() { return CAddressBookIterator(mapAddressBook); }
     std::string GetPurposeForAddressBookEntry(const CTxDestination& address) const;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -635,7 +635,7 @@ public:
     bool HasAddressBook(const CTxDestination& address) const;
     bool HasDelegator(const CTxOut& out) const;
 
-    std::string purposeForAddress(const CTxDestination& address) const;
+    std::string GetPurposeForAddressBookEntry(const CTxDestination& address) const;
     std::string GetNameForAddressBookEntry(const CTxDestination& address) const;
 
     const std::string& GetAccountName(const CScript& scriptPubKey) const;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -247,19 +247,28 @@ struct CRecipient
 class CAddressBookIterator
 {
 public:
-    explicit CAddressBookIterator(std::map<CTxDestination, AddressBook::CAddressBookData>& _map) : map(_map), it(_map.begin()) {}
+    explicit CAddressBookIterator(std::map<CTxDestination, AddressBook::CAddressBookData>& _map) : map(_map), it(_map.begin()), itEnd(_map.end()) {}
     CTxDestination GetKey() { return it->first; }
     AddressBook::CAddressBookData GetValue() { return it->second; }
-    bool HasNext() { return it != map.end(); }
+    bool HasNext() { return it != itEnd; }
     bool Next() {
-        if (it == map.end()) return false;
+        if (!HasNext()) return false;
         it++;
         return true;
+    }
+
+    void SetFilter(CTxDestination& filter)
+    {
+        it = map.find(filter);
+        if (it != itEnd) {
+            itEnd = std::next(it);
+        }
     }
 
 private:
     std::map<CTxDestination, AddressBook::CAddressBookData>& map;
     std::map<CTxDestination, AddressBook::CAddressBookData>::iterator it;
+    std::map<CTxDestination, AddressBook::CAddressBookData>::iterator itEnd;
 };
 
 /**

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -636,6 +636,8 @@ public:
     bool HasDelegator(const CTxOut& out) const;
 
     std::string purposeForAddress(const CTxDestination& address) const;
+    std::string GetNameForAddressBookEntry(const CTxDestination& address) const;
+
     const std::string& GetAccountName(const CScript& scriptPubKey) const;
 
     bool UpdatedTransaction(const uint256& hashTx);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -510,11 +510,15 @@ bool ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue, CW
         if (strType == "name") {
             std::string strAddress;
             ssKey >> strAddress;
-            ssValue >> pwallet->mapAddressBook[DecodeDestination(strAddress)].name;
+            std::string strName;
+            ssValue >> strName;
+            pwallet->LoadAddressBookName(DecodeDestination(strAddress), strName);
         } else if (strType == "purpose") {
             std::string strAddress;
             ssKey >> strAddress;
-            ssValue >> pwallet->mapAddressBook[DecodeDestination(strAddress)].purpose;
+            std::string strPurpose;
+            ssValue >> strPurpose;
+            pwallet->LoadAddressBookPurpose(DecodeDestination(strAddress), strPurpose);
         } else if (strType == "tx") {
             uint256 hash;
             ssKey >> hash;


### PR DESCRIPTION
Essentially, have restricted `mapAddressbook` access to the wallet class only. Migrating every direct access to the correspondent getter, setter and iterator wrapper. Plus, solved a todo in `AddressTableModel::getAddressToShow` (df262e4).
 It's a preparation for the shielded addresses addressbook support.