### PR TITLE
sporks: remove unneeded chainActive access.

### DIFF
--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -4,7 +4,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "main.h"
-#include "masternode-budget.h"
 #include "messagesigner.h"
 #include "net.h"
 #include "spork.h"
@@ -76,14 +75,6 @@ void CSporkManager::ProcessSpork(CNode* pfrom, std::string& strCommand, CDataStr
 {
     if (fLiteMode) return; // disable all masternode related functionality
 
-    int nChainHeight = 0;
-    {
-        LOCK(cs_main);
-        if (chainActive.Tip() == nullptr)
-            return;
-        nChainHeight = chainActive.Height();
-    }
-
     if (strCommand == NetMsgType::SPORK) {
         CSporkMessage spork;
         vRecv >> spork;
@@ -120,13 +111,13 @@ void CSporkManager::ProcessSpork(CNode* pfrom, std::string& strCommand, CDataStr
                     return;
                 } else {
                     // update active spork
-                    LogPrintf("%s : got updated spork %d (%s) with value %d (signed at %d) - block %d \n", __func__,
-                            spork.nSporkID, sporkName, spork.nValue, spork.nTimeSigned, nChainHeight);
+                    LogPrintf("%s : got updated spork %d (%s) with value %d (signed at %d) \n", __func__,
+                            spork.nSporkID, sporkName, spork.nValue, spork.nTimeSigned);
                 }
             } else {
                 // spork is not active
-                LogPrintf("%s : got new spork %d (%s) with value %d (signed at %d) - block %d \n", __func__,
-                        spork.nSporkID, sporkName, spork.nValue, spork.nTimeSigned, nChainHeight);
+                LogPrintf("%s : got new spork %d (%s) with value %d (signed at %d) \n", __func__,
+                        spork.nSporkID, sporkName, spork.nValue, spork.nTimeSigned);
             }
         }
 


### PR DESCRIPTION
Removed a not needed `ChainActive` access in `ProcessSpork`. One `cs_main` lock less.