### PR TITLE
[Refactor] Dedicated logging category for masternode pings

### DIFF
--- a/src/logging.h
+++ b/src/logging.h
@@ -61,7 +61,8 @@ namespace BCLog {
         STAKING     = (1 << 21),
         MASTERNODE  = (1 << 22),
         MNBUDGET    = (1 << 23),
-        LEGACYZC    = (1 << 24),
+        MNPING      = (1 << 24),
+        LEGACYZC    = (1 << 25),
         ALL         = ~(uint32_t)0,
     };
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -737,7 +737,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         CMasternodePing mnp;
         vRecv >> mnp;
 
-        LogPrint(BCLog::MASTERNODE, "mnp - Masternode ping, vin: %s\n", mnp.vin.prevout.hash.ToString());
+        LogPrint(BCLog::MNPING, "mnp - Masternode ping, vin: %s\n", mnp.vin.prevout.hash.ToString());
 
         if (mapSeenMasternodePing.count(mnp.GetHash())) return; //seen
         mapSeenMasternodePing.insert(std::make_pair(mnp.GetHash(), mnp));


### PR DESCRIPTION
mnping logs are very spammy. Introduce a dedicated BCLog category for them (`MNPING`), so they can be optionally turned off (whilst still keeping the `MASTERNODE` category logged).