### PR TITLE
[Travis] Lower the build timeout for the functional tests job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -143,7 +143,7 @@ jobs:
         #TEST_RUNNER_EXTRA="--coverage --extended"  # Run extended tests so that coverage does not fail, but exclude the very slow dbcrash
         GOAL="install"
         BITCOIN_CONFIG="--enable-zmq --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports --disable-online-rust --with-params-dir=$PARAMS_DIR"
-        BUILD_TIMEOUT=800
+        BUILD_TIMEOUT=540
 
     - stage: test
       name: 'x86_64 Linux  [GOAL: install]  [bionic]  [no GUI, no unit tests - only functional tests on legacy pre-HD wallets]'


### PR DESCRIPTION
in order to increase the time reserved for executing the tests.

Currently the 8th travis job fails, and saves a cache of the binaries, at the end of the build phase, if it took more than 14 minutes.
This leaves at least 36 minutes to run the functional test suite, which is not enough anymore.
Lower the build timeout to 9 minutes, so we have at least 41 minutes for the tests. We'll need to restart that job more often, but we'll see less timeouts.