### PR TITLE
[Refactor] Masternode Budget first refactoring and cleanup

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1749,7 +1749,8 @@ bool AppInit2()
     uiInterface.InitMessage(_("Loading budget cache..."));
 
     CBudgetDB budgetdb;
-    CBudgetDB::ReadResult readResult2 = budgetdb.Read(budget);
+    const bool fDryRun = (WITH_LOCK(cs_main, return chainActive.Height(); ) <= 0);
+    CBudgetDB::ReadResult readResult2 = budgetdb.Read(budget, fDryRun);
 
     if (readResult2 == CBudgetDB::FileError)
         LogPrintf("Missing budget cache - budget.dat, will try to recreate\n");

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1749,8 +1749,11 @@ bool AppInit2()
     uiInterface.InitMessage(_("Loading budget cache..."));
 
     CBudgetDB budgetdb;
-    const bool fDryRun = (WITH_LOCK(cs_main, return chainActive.Height(); ) <= 0);
+    int nChainHeight = WITH_LOCK(cs_main, return chainActive.Height(); );
+    const bool fDryRun = (nChainHeight <= 0);
     CBudgetDB::ReadResult readResult2 = budgetdb.Read(budget, fDryRun);
+    if (nChainHeight > 0)
+        budget.SetBestHeight(nChainHeight);
 
     if (readResult2 == CBudgetDB::FileError)
         LogPrintf("Missing budget cache - budget.dat, will try to recreate\n");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4948,25 +4948,25 @@ bool static AlreadyHave(const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
         }
         return false;
     case MSG_BUDGET_VOTE:
-        if (budget.mapSeenMasternodeBudgetVotes.count(inv.hash)) {
+        if (budget.HaveSeenProposalVote(inv.hash)) {
             masternodeSync.AddedBudgetItem(inv.hash);
             return true;
         }
         return false;
     case MSG_BUDGET_PROPOSAL:
-        if (budget.mapSeenMasternodeBudgetProposals.count(inv.hash)) {
+        if (budget.HaveSeenProposal(inv.hash)) {
             masternodeSync.AddedBudgetItem(inv.hash);
             return true;
         }
         return false;
     case MSG_BUDGET_FINALIZED_VOTE:
-        if (budget.mapSeenFinalizedBudgetVotes.count(inv.hash)) {
+        if (budget.HaveSeenFinalizedBudgetVote(inv.hash)) {
             masternodeSync.AddedBudgetItem(inv.hash);
             return true;
         }
         return false;
     case MSG_BUDGET_FINALIZED:
-        if (budget.mapSeenFinalizedBudgets.count(inv.hash)) {
+        if (budget.HaveSeenFinalizedBudget(inv.hash)) {
             masternodeSync.AddedBudgetItem(inv.hash);
             return true;
         }
@@ -5163,41 +5163,29 @@ void static ProcessGetData(CNode* pfrom, CConnman& connman, std::atomic<bool>& i
                     }
                 }
                 if (!pushed && inv.type == MSG_BUDGET_VOTE) {
-                    if (budget.mapSeenMasternodeBudgetVotes.count(inv.hash)) {
-                        CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-                        ss.reserve(1000);
-                        ss << budget.mapSeenMasternodeBudgetVotes[inv.hash];
-                        connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::BUDGETVOTE, ss));
+                    if (budget.HaveSeenProposalVote(inv.hash)) {
+                        connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::BUDGETVOTE, budget.GetProposalVoteSerialized(inv.hash)));
                         pushed = true;
                     }
                 }
 
                 if (!pushed && inv.type == MSG_BUDGET_PROPOSAL) {
-                    if (budget.mapSeenMasternodeBudgetProposals.count(inv.hash)) {
-                        CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-                        ss.reserve(1000);
-                        ss << budget.mapSeenMasternodeBudgetProposals[inv.hash];
-                        connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::BUDGETPROPOSAL, ss));
+                    if (budget.HaveSeenProposal(inv.hash)) {
+                        connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::BUDGETPROPOSAL, budget.GetProposalSerialized(inv.hash)));
                         pushed = true;
                     }
                 }
 
                 if (!pushed && inv.type == MSG_BUDGET_FINALIZED_VOTE) {
-                    if (budget.mapSeenFinalizedBudgetVotes.count(inv.hash)) {
-                        CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-                        ss.reserve(1000);
-                        ss << budget.mapSeenFinalizedBudgetVotes[inv.hash];
-                        connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::FINALBUDGETVOTE, ss));
+                    if (budget.HaveSeenFinalizedBudgetVote(inv.hash)) {
+                        connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::FINALBUDGETVOTE, budget.GetFinalizedBudgetVoteSerialized(inv.hash)));
                         pushed = true;
                     }
                 }
 
                 if (!pushed && inv.type == MSG_BUDGET_FINALIZED) {
-                    if (budget.mapSeenFinalizedBudgets.count(inv.hash)) {
-                        CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-                        ss.reserve(1000);
-                        ss << budget.mapSeenFinalizedBudgets[inv.hash];
-                        connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::FINALBUDGET, ss));
+                    if (budget.HaveSeenFinalizedBudget(inv.hash)) {
+                        connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::FINALBUDGET, budget.GetFinalizedBudgetSerialized(inv.hash)));
                         pushed = true;
                     }
                 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3044,7 +3044,7 @@ static bool ActivateBestChainStep(CValidationState& state, CBlockIndex* pindexMo
  * or an activated best chain. pblock is either NULL or a pointer to a block
  * that is already loaded (to avoid loading it again from disk).
  */
-bool ActivateBestChain(CValidationState& state, const CBlock* pblock, bool fAlreadyChecked, CConnman* connman)
+bool ActivateBestChain(CValidationState& state, const CBlock* pblock, bool fAlreadyChecked, CConnman* connman, CBudgetManager* pbudget)
 {
     // Note that while we're often called here from ProcessNewBlock, this is
     // far from a guarantee. Things in the P2P/RPC will often end up calling
@@ -3101,6 +3101,8 @@ bool ActivateBestChain(CValidationState& state, const CBlock* pblock, bool fAlre
         // Notifications/callbacks that can run without cs_main
         if(connman)
             connman->SetBestHeight(pindexNewTip->nHeight);
+        if(pbudget)
+            pbudget->SetBestHeight(pindexNewTip->nHeight);
 
         // Always notify the UI if a new block tip was connected
         if (pindexFork != pindexNewTip) {
@@ -4221,7 +4223,7 @@ bool ProcessNewBlock(CValidationState& state, CNode* pfrom, const CBlock* pblock
         }
     }
 
-    if (!ActivateBestChain(state, pblock, checked, connman))
+    if (!ActivateBestChain(state, pblock, checked, connman, &budget))
         return error("%s : ActivateBestChain failed", __func__);
 
     if (!fLiteMode) {

--- a/src/main.h
+++ b/src/main.h
@@ -49,6 +49,7 @@
 
 class CBlockIndex;
 class CBlockTreeDB;
+class CBudgetManager;
 class CZerocoinDB;
 class CSporkDB;
 class CBloomFilter;
@@ -244,7 +245,7 @@ double ConvertBitsToDouble(unsigned int nBits);
 int64_t GetMasternodePayment();
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader* pblock, bool fProofOfStake);
 
-bool ActivateBestChain(CValidationState& state, const CBlock* pblock = NULL, bool fAlreadyChecked = false, CConnman* connman = NULL);
+bool ActivateBestChain(CValidationState& state, const CBlock* pblock = NULL, bool fAlreadyChecked = false, CConnman* connman = nullptr, CBudgetManager* pbudget = nullptr);
 CAmount GetBlockValue(int nHeight);
 
 /** Create a new block index entry for a given block hash */

--- a/src/main.h
+++ b/src/main.h
@@ -245,7 +245,7 @@ double ConvertBitsToDouble(unsigned int nBits);
 int64_t GetMasternodePayment();
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader* pblock, bool fProofOfStake);
 
-bool ActivateBestChain(CValidationState& state, const CBlock* pblock = NULL, bool fAlreadyChecked = false, CConnman* connman = nullptr, CBudgetManager* pbudget = nullptr);
+bool ActivateBestChain(CValidationState& state, const CBlock* pblock = NULL, bool fAlreadyChecked = false, CConnman* connman = nullptr);
 CAmount GetBlockValue(int nHeight);
 
 /** Create a new block index entry for a given block hash */

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -1659,42 +1659,14 @@ double CBudgetProposal::GetRatio()
     return ((double)(yeas) / (double)(yeas + nays));
 }
 
-int CBudgetProposal::GetYeas() const
+int CBudgetProposal::GetVoteCount(CBudgetVote::VoteDirection vd) const
 {
     int ret = 0;
-
-    std::map<uint256, CBudgetVote>::const_iterator it = mapVotes.begin();
-    while (it != mapVotes.end()) {
-        if ((*it).second.GetDirection() == CBudgetVote::VOTE_YES && (*it).second.IsValid()) ret++;
-        ++it;
+    for (const auto& it : mapVotes) {
+        const CBudgetVote& vote = it.second;
+        if (vote.GetDirection() == vd && vote.IsValid())
+            ret++;
     }
-
-    return ret;
-}
-
-int CBudgetProposal::GetNays() const
-{
-    int ret = 0;
-
-    std::map<uint256, CBudgetVote>::const_iterator it = mapVotes.begin();
-    while (it != mapVotes.end()) {
-        if ((*it).second.GetDirection() == CBudgetVote::VOTE_NO && (*it).second.IsValid()) ret++;
-        ++it;
-    }
-
-    return ret;
-}
-
-int CBudgetProposal::GetAbstains() const
-{
-    int ret = 0;
-
-    std::map<uint256, CBudgetVote>::const_iterator it = mapVotes.begin();
-    while (it != mapVotes.end()) {
-        if ((*it).second.GetDirection() == CBudgetVote::VOTE_ABSTAIN && (*it).second.IsValid()) ret++;
-        ++it;
-    }
-
     return ret;
 }
 

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -1245,8 +1245,7 @@ void CBudgetManager::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
     }
 }
 
-//mark that a full sync is needed
-void CBudgetManager::ResetSync()
+void CBudgetManager::SetSynced(bool synced)
 {
     LOCK(cs);
 
@@ -1254,7 +1253,7 @@ void CBudgetManager::ResetSync()
         CBudgetProposal* pbudgetProposal = FindProposal(it.first);
         if (pbudgetProposal && pbudgetProposal->fValid) {
             //mark votes
-            pbudgetProposal->SetSynced(false);
+            pbudgetProposal->SetSynced(synced);
         }
     }
 
@@ -1262,32 +1261,7 @@ void CBudgetManager::ResetSync()
         CFinalizedBudget* pfinalizedBudget = FindFinalizedBudget(it.first);
         if (pfinalizedBudget && pfinalizedBudget->fValid) {
             //mark votes
-            pfinalizedBudget->SetSynced(false);
-        }
-    }
-}
-
-void CBudgetManager::MarkSynced()
-{
-    LOCK(cs);
-
-    /*
-        Mark that we've sent all valid items
-    */
-
-    for (const auto& it: mapSeenMasternodeBudgetProposals) {
-        CBudgetProposal* pbudgetProposal = FindProposal(it.first);
-        if (pbudgetProposal && pbudgetProposal->fValid) {
-            //mark votes
-            pbudgetProposal->SetSynced(true);
-        }
-    }
-
-    for (const auto& it: mapSeenFinalizedBudgets) {
-        CFinalizedBudget* pfinalizedBudget = FindFinalizedBudget(it.first);
-        if (pfinalizedBudget && pfinalizedBudget->fValid) {
-            //mark votes
-            pfinalizedBudget->SetSynced(true);
+            pfinalizedBudget->SetSynced(synced);
         }
     }
 }

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -1245,12 +1245,6 @@ void CBudgetManager::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
     }
 }
 
-bool CBudgetManager::PropExists(const uint256& nHash)
-{
-    if (mapProposals.count(nHash)) return true;
-    return false;
-}
-
 //mark that a full sync is needed
 void CBudgetManager::ResetSync()
 {
@@ -2039,6 +2033,7 @@ std::string CFinalizedBudget::GetStatus()
 
     return retBadHashes + retBadPayeeOrAmount;
 }
+
 
 bool CFinalizedBudget::IsValid(std::string& strError, bool fCheckCollateral)
 {

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -599,15 +599,13 @@ CFinalizedBudget* CBudgetManager::FindFinalizedBudget(const uint256& nHash)
     return NULL;
 }
 
-// !TODO: return const pointer
-CBudgetProposal* CBudgetManager::FindProposal(const std::string& strProposalName)
+const CBudgetProposal* CBudgetManager::FindProposalByName(const std::string& strProposalName) const
 {
-    //find the prop with the highest yes count
     int nYesCount = 0;
-    CBudgetProposal* pbudgetProposal = nullptr;
+    const CBudgetProposal* pbudgetProposal = nullptr;
 
-    for (auto& it: mapProposals) {
-        CBudgetProposal& proposal = it.second;
+    for (const auto& it: mapProposals) {
+        const CBudgetProposal& proposal = it.second;
         if (proposal.GetName() == strProposalName && proposal.GetYeas() > nYesCount) {
             pbudgetProposal = &proposal;
             nYesCount = pbudgetProposal->GetYeas();
@@ -1484,7 +1482,7 @@ bool CBudgetProposal::IsValid(std::string& strError, bool fCheckCollateral)
     return true;
 }
 
-bool CBudgetProposal::IsEstablished()
+bool CBudgetProposal::IsEstablished() const
 {
     return nTime < GetAdjustedTime() - Params().GetConsensus().nProposalEstablishmentTime;
 }

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -895,8 +895,10 @@ bool CBudgetManager::AddAndRelayProposalVote(const CBudgetVote& vote, std::strin
     return false;
 }
 
-void CBudgetManager::NewBlock()
+void CBudgetManager::NewBlock(int height)
 {
+    SetBestHeight(height);
+
     if (masternodeSync.RequestedMasternodeAssets <= MASTERNODE_SYNC_BUDGET) return;
 
     if (strBudgetMode == "suggest") { //suggest the budget we see

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -2165,6 +2165,29 @@ TrxValidationStatus CFinalizedBudget::IsTransactionValid(const CTransaction& txN
     return transactionStatus;
 }
 
+bool CFinalizedBudget::GetBudgetPaymentByBlock(int64_t nBlockHeight, CTxBudgetPayment& payment) const
+{
+    LOCK(cs);
+
+    int i = nBlockHeight - GetBlockStart();
+    if (i < 0) return false;
+    if (i > (int)vecBudgetPayments.size() - 1) return false;
+    payment = vecBudgetPayments[i];
+    return true;
+}
+
+bool CFinalizedBudget::GetPayeeAndAmount(int64_t nBlockHeight, CScript& payee, CAmount& nAmount) const
+{
+    LOCK(cs);
+
+    int i = nBlockHeight - GetBlockStart();
+    if (i < 0) return false;
+    if (i > (int)vecBudgetPayments.size() - 1) return false;
+    payee = vecBudgetPayments[i].payee;
+    nAmount = vecBudgetPayments[i].nAmount;
+    return true;
+}
+
 void CFinalizedBudget::SubmitVote()
 {
     // function called only from initialized masternodes

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -578,14 +578,15 @@ CFinalizedBudget* CBudgetManager::FindFinalizedBudget(const uint256& nHash)
 
 const CBudgetProposal* CBudgetManager::FindProposalByName(const std::string& strProposalName) const
 {
-    int nYesCount = 0;
+    int64_t nYesCountMax = std::numeric_limits<int64_t>::min();
     const CBudgetProposal* pbudgetProposal = nullptr;
 
     for (const auto& it: mapProposals) {
         const CBudgetProposal& proposal = it.second;
-        if (proposal.GetName() == strProposalName && proposal.GetYeas() > nYesCount) {
+        int64_t nYesCount = proposal.GetYeas() - proposal.GetNays();
+        if (proposal.GetName() == strProposalName && nYesCount > nYesCountMax) {
             pbudgetProposal = &proposal;
-            nYesCount = pbudgetProposal->GetYeas();
+            nYesCountMax = nYesCount;
         }
     }
 

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -714,15 +714,13 @@ std::vector<CBudgetProposal*> CBudgetManager::GetAllProposals()
 
     std::vector<CBudgetProposal*> vBudgetProposalRet;
 
-    std::map<uint256, CBudgetProposal>::iterator it = mapProposals.begin();
-    while (it != mapProposals.end()) {
-        (*it).second.CleanAndRemove();
-
-        CBudgetProposal* pbudgetProposal = &((*it).second);
+    for (auto& it: mapProposals) {
+        CBudgetProposal* pbudgetProposal = &(it.second);
+        pbudgetProposal->CleanAndRemove();
         vBudgetProposalRet.push_back(pbudgetProposal);
-
-        ++it;
     }
+
+    std::sort(vBudgetProposalRet.begin(), vBudgetProposalRet.end(), CBudgetProposal::PtrHigherYes);
 
     return vBudgetProposalRet;
 }

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -1649,8 +1649,8 @@ double CBudgetProposal::GetRatio()
     std::map<uint256, CBudgetVote>::iterator it = mapVotes.begin();
 
     while (it != mapVotes.end()) {
-        if ((*it).second.GetDirection() == VOTE_YES) yeas++;
-        if ((*it).second.GetDirection() == VOTE_NO) nays++;
+        if ((*it).second.GetDirection() == CBudgetVote::VOTE_YES) yeas++;
+        if ((*it).second.GetDirection() == CBudgetVote::VOTE_NO) nays++;
         ++it;
     }
 
@@ -1665,7 +1665,7 @@ int CBudgetProposal::GetYeas() const
 
     std::map<uint256, CBudgetVote>::const_iterator it = mapVotes.begin();
     while (it != mapVotes.end()) {
-        if ((*it).second.GetDirection() == VOTE_YES && (*it).second.IsValid()) ret++;
+        if ((*it).second.GetDirection() == CBudgetVote::VOTE_YES && (*it).second.IsValid()) ret++;
         ++it;
     }
 
@@ -1678,7 +1678,7 @@ int CBudgetProposal::GetNays() const
 
     std::map<uint256, CBudgetVote>::const_iterator it = mapVotes.begin();
     while (it != mapVotes.end()) {
-        if ((*it).second.GetDirection() == VOTE_NO && (*it).second.IsValid()) ret++;
+        if ((*it).second.GetDirection() == CBudgetVote::VOTE_NO && (*it).second.IsValid()) ret++;
         ++it;
     }
 
@@ -1691,7 +1691,7 @@ int CBudgetProposal::GetAbstains() const
 
     std::map<uint256, CBudgetVote>::const_iterator it = mapVotes.begin();
     while (it != mapVotes.end()) {
-        if ((*it).second.GetDirection() == VOTE_ABSTAIN && (*it).second.IsValid()) ret++;
+        if ((*it).second.GetDirection() == CBudgetVote::VOTE_ABSTAIN && (*it).second.IsValid()) ret++;
         ++it;
     }
 
@@ -1780,7 +1780,7 @@ CBudgetVote::CBudgetVote() :
         vin()
 { }
 
-CBudgetVote::CBudgetVote(CTxIn vinIn, uint256 nProposalHashIn, int nVoteIn) :
+CBudgetVote::CBudgetVote(CTxIn vinIn, uint256 nProposalHashIn, VoteDirection nVoteIn) :
         CSignedMessage(),
         fValid(true),
         fSynced(false),
@@ -1802,7 +1802,7 @@ uint256 CBudgetVote::GetHash() const
     CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
     ss << vin;
     ss << nProposalHash;
-    ss << nVote;
+    ss << (int) nVote;
     ss << nTime;
     return ss.GetHash();
 }

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -766,16 +766,6 @@ std::vector<CBudgetProposal*> CBudgetManager::GetBudget()
     return vBudgetProposalsRet;
 }
 
-// Sort by votes, if there's a tie sort by their feeHash TX
-struct sortFinalizedBudgetsByVotes {
-    bool operator()(const std::pair<CFinalizedBudget*, int>& left, const std::pair<CFinalizedBudget*, int>& right)
-    {
-        if (left.second != right.second)
-            return left.second > right.second;
-        return (left.first->GetFeeTXHash() > right.first->GetFeeTXHash());
-    }
-};
-
 std::vector<CFinalizedBudget*> CBudgetManager::GetFinalizedBudgets()
 {
     LOCK(cs);

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -458,20 +458,12 @@ bool CBudgetManager::AddProposal(CBudgetProposal& budgetProposal)
 
 void CBudgetManager::CheckAndRemove()
 {
-    int nHeight = WITH_LOCK(cs_main, return chainActive.Height());
-    if (nHeight <= 0) return;
-
-    LogPrint(BCLog::MNBUDGET, "%s: Height=%d\n", __func__, nHeight);
-
     std::map<uint256, CFinalizedBudget> tmpMapFinalizedBudgets;
     std::map<uint256, CBudgetProposal> tmpMapProposals;
 
-    std::string strError = "";
-
     LogPrint(BCLog::MNBUDGET, "%s: mapFinalizedBudgets cleanup - size before: %d\n", __func__, mapFinalizedBudgets.size());
-    auto it = mapFinalizedBudgets.begin();
-    while (it != mapFinalizedBudgets.end()) {
-        CFinalizedBudget* pfinalizedBudget = &((*it).second);
+    for (auto& it: mapFinalizedBudgets) {
+        CFinalizedBudget* pfinalizedBudget = &(it.second);
         if (!pfinalizedBudget->UpdateValid()) {
             LogPrint(BCLog::MNBUDGET,"%s: Invalid finalized budget: %s\n", __func__, pfinalizedBudget->IsInvalidReason());
         } else {
@@ -480,13 +472,11 @@ void CBudgetManager::CheckAndRemove()
             pfinalizedBudget->CheckAndVote();
             tmpMapFinalizedBudgets.insert(std::make_pair(pfinalizedBudget->GetHash(), *pfinalizedBudget));
         }
-        ++it;
     }
 
     LogPrint(BCLog::MNBUDGET, "%s: mapProposals cleanup - size before: %d\n", __func__, mapProposals.size());
-    auto it2 = mapProposals.begin();
-    while (it2 != mapProposals.end()) {
-        CBudgetProposal* pbudgetProposal = &((*it2).second);
+    for (auto& it: mapProposals) {
+        CBudgetProposal* pbudgetProposal = &(it.second);
         if (!pbudgetProposal->UpdateValid()) {
             LogPrint(BCLog::MNBUDGET,"%s: Invalid budget proposal - %s\n", __func__, pbudgetProposal->IsInvalidReason());
         } else {
@@ -494,15 +484,11 @@ void CBudgetManager::CheckAndRemove()
                       pbudgetProposal->GetName(), pbudgetProposal->GetFeeTXHash().ToString());
              tmpMapProposals.insert(std::make_pair(pbudgetProposal->GetHash(), *pbudgetProposal));
         }
-        ++it2;
     }
+
     // Remove invalid entries by overwriting complete map
     mapFinalizedBudgets.swap(tmpMapFinalizedBudgets);
     mapProposals.swap(tmpMapProposals);
-
-    // clang doesn't accept copy assignemnts :-/
-    // mapFinalizedBudgets = tmpMapFinalizedBudgets;
-    // mapProposals = tmpMapProposals;
 
     LogPrint(BCLog::MNBUDGET, "%s: mapFinalizedBudgets cleanup - size after: %d\n", __func__, mapFinalizedBudgets.size());
     LogPrint(BCLog::MNBUDGET, "%s: mapProposals cleanup - size after: %d\n", __func__, mapProposals.size());
@@ -1491,7 +1477,7 @@ bool CBudgetProposal::UpdateValid(bool fCheckCollateral)
     }
 
     fValid = true;
-    strInvalid = "";
+    strInvalid.clear();
     return true;
 }
 
@@ -2104,7 +2090,7 @@ bool CFinalizedBudget::UpdateValid(bool fCheckCollateral)
     }
 
     fValid = true;
-    strInvalid = "";
+    strInvalid.clear();
     return true;
 }
 

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -385,27 +385,8 @@ public:
     int GetVoteCount() const { return (int)mapVotes.size(); }
     bool IsPaidAlready(uint256 nProposalHash, int nBlockHeight) const;
     TrxValidationStatus IsTransactionValid(const CTransaction& txNew, int nBlockHeight) const;
-    bool GetBudgetPaymentByBlock(int64_t nBlockHeight, CTxBudgetPayment& payment) const
-    {
-        LOCK(cs);
-
-        int i = nBlockHeight - GetBlockStart();
-        if (i < 0) return false;
-        if (i > (int)vecBudgetPayments.size() - 1) return false;
-        payment = vecBudgetPayments[i];
-        return true;
-    }
-    bool GetPayeeAndAmount(int64_t nBlockHeight, CScript& payee, CAmount& nAmount) const
-    {
-        LOCK(cs);
-
-        int i = nBlockHeight - GetBlockStart();
-        if (i < 0) return false;
-        if (i > (int)vecBudgetPayments.size() - 1) return false;
-        payee = vecBudgetPayments[i].payee;
-        nAmount = vecBudgetPayments[i].nAmount;
-        return true;
-    }
+    bool GetBudgetPaymentByBlock(int64_t nBlockHeight, CTxBudgetPayment& payment) const;
+    bool GetPayeeAndAmount(int64_t nBlockHeight, CScript& payee, CAmount& nAmount) const;
 
     // Verify and vote on finalized budget
     void CheckAndVote();

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -277,7 +277,7 @@ public:
     CFinalizedBudget* FindFinalizedBudget(const uint256& nHash);
 
     CAmount GetTotalBudget(int nHeight);
-    std::vector<CBudgetProposal*> GetBudget();
+    std::vector<CBudgetProposal*> GetBudget(int nHeight);
     std::vector<CBudgetProposal*> GetAllProposals();
     std::vector<CFinalizedBudget*> GetFinalizedBudgets();
     bool IsBudgetPaymentBlock(int nBlockHeight);
@@ -529,7 +529,7 @@ public:
     std::string IsInvalidReason() const { return strInvalid; }
 
     bool IsEstablished() const;
-    bool IsPassing(const CBlockIndex* pindexPrev, int nBlockStartBudget, int nBlockEndBudget, int mnCount) const;
+    bool IsPassing(int nBlockStartBudget, int nBlockEndBudget, int mnCount) const;
 
     std::string GetName() const { return strProposalName; }
     std::string GetURL() const { return strURL; }

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -227,7 +227,7 @@ private:
 
     void SetSynced(bool synced);
 
-    // Memory Only. Updated in ActivateBestChain
+    // Memory Only. Updated in NewBlock (blocks arrive in order)
     std::atomic<int> nBestHeight;
 
 public:
@@ -276,7 +276,7 @@ public:
     int GetBestHeight() const { return nBestHeight.load(std::memory_order_acquire); }
 
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
-    void NewBlock();
+    void NewBlock(int height);
     CBudgetProposal* FindProposal(const uint256& nHash);
     // finds the proposal with the given name, with highest net yes count.
     const CBudgetProposal* FindProposalByName(const std::string& strProposalName) const;

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -214,6 +214,8 @@ private:
     // XX42    std::map<uint256, CTransaction> mapCollateral;
     std::map<uint256, uint256> mapCollateralTxids;
 
+    void SetSynced(bool synced);
+
 public:
     // critical section to protect the inner data structures
     mutable RecursiveMutex cs;
@@ -246,8 +248,8 @@ public:
     int sizeFinalized() { return (int)mapFinalizedBudgets.size(); }
     int sizeProposals() { return (int)mapProposals.size(); }
 
-    void ResetSync();
-    void MarkSynced();
+    void ResetSync() { SetSynced(false); }
+    void MarkSynced() { SetSynced(true); }
     void Sync(CNode* node, const uint256& nProp, bool fPartial = false);
 
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -351,11 +351,11 @@ private:
 
 protected:
     std::map<uint256, CFinalizedBudgetVote> mapVotes;
+    std::string strBudgetName;
+    int nBlockStart;
 
 public:
     bool fValid;
-    std::string strBudgetName;
-    int nBlockStart;
     std::vector<CTxBudgetPayment> vecBudgetPayments;
     uint256 nFeeTXHash;
     int64_t nTime;
@@ -373,14 +373,14 @@ public:
 
     bool IsValid(std::string& strError, bool fCheckCollateral = true);
 
-    std::string GetName() { return strBudgetName; }
+    std::string GetName() const { return strBudgetName; }
     std::string GetProposals();
-    int GetBlockStart() { return nBlockStart; }
-    int GetBlockEnd() { return nBlockStart + (int)(vecBudgetPayments.size() - 1); }
-    int GetVoteCount() { return (int)mapVotes.size(); }
+    int GetBlockStart() const { return nBlockStart; }
+    int GetBlockEnd() const { return nBlockStart + (int)(vecBudgetPayments.size() - 1); }
+    int GetVoteCount() const { return (int)mapVotes.size(); }
     bool IsPaidAlready(uint256 nProposalHash, int nBlockHeight);
     TrxValidationStatus IsTransactionValid(const CTransaction& txNew, int nBlockHeight);
-    bool GetBudgetPaymentByBlock(int64_t nBlockHeight, CTxBudgetPayment& payment)
+    bool GetBudgetPaymentByBlock(int64_t nBlockHeight, CTxBudgetPayment& payment) const
     {
         LOCK(cs);
 
@@ -390,7 +390,7 @@ public:
         payment = vecBudgetPayments[i];
         return true;
     }
-    bool GetPayeeAndAmount(int64_t nBlockHeight, CScript& payee, CAmount& nAmount)
+    bool GetPayeeAndAmount(int64_t nBlockHeight, CScript& payee, CAmount& nAmount) const
     {
         LOCK(cs);
 
@@ -412,7 +412,7 @@ public:
     //checks the hashes to make sure we know about them
     std::string GetStatus();
 
-    uint256 GetHash()
+    uint256 GetHash() const
     {
         CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
         ss << strBudgetName;
@@ -499,20 +499,15 @@ private:
 
 protected:
     std::map<uint256, CBudgetVote> mapVotes;
-
-public:
-    bool fValid;
     std::string strProposalName;
-
-    /*
-        json object with name, short-description, long-description, pdf-url and any other info
-        This allows the proposal website to stay 100% decentralized
-    */
     std::string strURL;
     int nBlockStart;
     int nBlockEnd;
     CAmount nAmount;
     CScript address;
+
+public:
+    bool fValid;
     int64_t nTime;
     uint256 nFeeTXHash;
 
@@ -534,24 +529,24 @@ public:
     bool IsEstablished();
     bool IsPassing(const CBlockIndex* pindexPrev, int nBlockStartBudget, int nBlockEndBudget, int mnCount);
 
-    std::string GetName() { return strProposalName; }
-    std::string GetURL() { return strURL; }
-    int GetBlockStart() { return nBlockStart; }
-    int GetBlockEnd() { return nBlockEnd; }
-    CScript GetPayee() { return address; }
-    int GetTotalPaymentCount();
-    int GetRemainingPaymentCount();
-    int GetBlockStartCycle();
-    int GetBlockCurrentCycle();
-    int GetBlockEndCycle();
-    double GetRatio();
+    std::string GetName() const { return strProposalName; }
+    std::string GetURL() const { return strURL; }
+    int GetBlockStart() const { return nBlockStart; }
+    int GetBlockEnd() const { return nBlockEnd; }
+    CScript GetPayee() const { return address; }
+    int GetTotalPaymentCount() const;
+    int GetRemainingPaymentCount() const;
+    int GetBlockStartCycle() const;
+    int GetBlockCurrentCycle() const;
+    int GetBlockEndCycle() const;
+    double GetRatio() const;
     int GetVoteCount(CBudgetVote::VoteDirection vd) const;
     int GetYeas() const { return GetVoteCount(CBudgetVote::VOTE_YES); }
     int GetNays() const { return GetVoteCount(CBudgetVote::VOTE_NO); }
     int GetAbstains() const { return GetVoteCount(CBudgetVote::VOTE_ABSTAIN); };
-    CAmount GetAmount() { return nAmount; }
+    CAmount GetAmount() const { return nAmount; }
     void SetAllotted(CAmount nAllotedIn) { nAlloted = nAllotedIn; }
-    CAmount GetAllotted() { return nAlloted; }
+    CAmount GetAllotted() const { return nAlloted; }
 
     void CleanAndRemove();
 

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -254,8 +254,9 @@ public:
 
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
     void NewBlock();
-    CBudgetProposal* FindProposal(const std::string& strProposalName);
     CBudgetProposal* FindProposal(const uint256& nHash);
+    // finds the proposal with the given name, with highest yes count.
+    const CBudgetProposal* FindProposalByName(const std::string& strProposalName) const;
     CFinalizedBudget* FindFinalizedBudget(const uint256& nHash);
     std::pair<std::string, std::string> GetVotes(std::string strProposalName);
 
@@ -526,7 +527,7 @@ public:
     void SyncVotes(CNode* pfrom, bool fPartial, int& nInvCount) const;
 
     bool IsValid(std::string& strError, bool fCheckCollateral = true);
-    bool IsEstablished();
+    bool IsEstablished() const;
     bool IsPassing(const CBlockIndex* pindexPrev, int nBlockStartBudget, int nBlockEndBudget, int mnCount);
 
     std::string GetName() const { return strProposalName; }

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -436,6 +436,11 @@ public:
         READWRITE(fAutoChecked);
         READWRITE(mapVotes);
     }
+
+    // compare finalized budget by votes (sort tie with feeHash)
+    bool operator>(const CFinalizedBudget& other) const;
+    // compare finalized budget pointers
+    static bool PtrGreater(CFinalizedBudget* a, CFinalizedBudget* b) { return *a > *b; }
 };
 
 // FinalizedBudget are cast then sent to peers with this object, which leaves the votes out
@@ -557,8 +562,7 @@ public:
         ss << nBlockEnd;
         ss << nAmount;
         ss << std::vector<unsigned char>(address.begin(), address.end());
-        uint256 h1 = ss.GetHash();
-        return h1;
+        return ss.GetHash();
     }
 
     ADD_SERIALIZE_METHODS;
@@ -579,6 +583,14 @@ public:
         //for saving to the serialized db
         READWRITE(mapVotes);
     }
+
+    // compare proposals by proposal hash
+    inline bool operator>(const CBudgetProposal& other) const { return GetHash() > other.GetHash(); }
+    // compare proposals pointers by hash
+    static inline bool PtrGreater(CBudgetProposal* a, CBudgetProposal* b) { return *a > *b; }
+    // compare proposals pointers by net yes count (solve tie with feeHash)
+    static bool PtrHigherYes(CBudgetProposal* a, CBudgetProposal* b);
+
 };
 
 // Proposals are cast then sent to peers with this object, which leaves the votes out

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -27,10 +27,6 @@ class CBudgetProposal;
 class CBudgetProposalBroadcast;
 class CTxBudgetPayment;
 
-#define VOTE_ABSTAIN 0
-#define VOTE_YES 1
-#define VOTE_NO 2
-
 enum class TrxValidationStatus {
     InValid,         /** Transaction verification failed */
     Valid,           /** Transaction successfully verified */
@@ -59,17 +55,24 @@ bool IsBudgetCollateralValid(const uint256& nTxCollateralHash, const uint256& nE
 
 class CBudgetVote : public CSignedMessage
 {
+public:
+    enum VoteDirection {
+        VOTE_ABSTAIN = 0,
+        VOTE_YES = 1,
+        VOTE_NO = 2
+    };
+
 private:
     bool fValid;  //if the vote is currently valid / counted
     bool fSynced; //if we've sent this to our peers
     uint256 nProposalHash;
-    int nVote;      // YES, NO, ABSTAIN
+    VoteDirection nVote;
     int64_t nTime;
     CTxIn vin;
 
 public:
     CBudgetVote();
-    CBudgetVote(CTxIn vin, uint256 nProposalHash, int nVoteIn);
+    CBudgetVote(CTxIn vin, uint256 nProposalHash, VoteDirection nVoteIn);
 
     void Relay() const;
 
@@ -90,7 +93,7 @@ public:
 
     UniValue ToJSON() const;
 
-    int GetDirection() const { return nVote; }
+    VoteDirection GetDirection() const { return nVote; }
     uint256 GetProposalHash() const { return nProposalHash; }
     int64_t GetTime() const { return nTime; }
     bool IsSynced() const { return fSynced; }
@@ -107,7 +110,10 @@ public:
     {
         READWRITE(vin);
         READWRITE(nProposalHash);
-        READWRITE(nVote);
+        int nVoteInt = (int) nVote;
+        READWRITE(nVoteInt);
+        if (ser_action.ForRead())
+            nVote = (VoteDirection) nVoteInt;
         READWRITE(nTime);
         READWRITE(vchSig);
         try

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -250,7 +250,6 @@ public:
     void MarkSynced();
     void Sync(CNode* node, const uint256& nProp, bool fPartial = false);
 
-    void Calculate();
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
     void NewBlock();
     CBudgetProposal* FindProposal(const std::string& strProposalName);
@@ -269,7 +268,6 @@ public:
 
     bool UpdateProposal(CBudgetVote& vote, CNode* pfrom, std::string& strError);
     bool UpdateFinalizedBudget(CFinalizedBudgetVote& vote, CNode* pfrom, std::string& strError);
-    bool PropExists(const uint256& nHash);
     TrxValidationStatus IsTransactionValid(const CTransaction& txNew, int nBlockHeight);
     std::string GetRequiredPaymentsString(int nBlockHeight);
     void FillBlockPayee(CMutableTransaction& txNew, const CBlockIndex* pindexPrev, bool fProofOfStake);
@@ -292,9 +290,7 @@ public:
     void CheckAndRemove();
     std::string ToString() const;
 
-
     ADD_SERIALIZE_METHODS;
-
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action)
     {
@@ -304,7 +300,6 @@ public:
         READWRITE(mapSeenFinalizedBudgetVotes);
         READWRITE(mapOrphanMasternodeBudgetVotes);
         READWRITE(mapOrphanFinalizedBudgetVotes);
-
         READWRITE(mapProposals);
         READWRITE(mapFinalizedBudgets);
     }
@@ -366,8 +361,6 @@ public:
 
     void CleanAndRemove();
     bool AddOrUpdateVote(CFinalizedBudgetVote& vote, std::string& strError);
-    double GetScore();
-    bool HasMinimumRequiredSupport();
 
     bool IsValid(std::string& strError, bool fCheckCollateral = true);
 
@@ -518,9 +511,7 @@ public:
     CBudgetProposal(const CBudgetProposal& other);
     CBudgetProposal(std::string strProposalNameIn, std::string strURLIn, int nBlockStartIn, int nBlockEndIn, CScript addressIn, CAmount nAmountIn, uint256 nFeeTXHashIn);
 
-    void Calculate();
     bool AddOrUpdateVote(CBudgetVote& vote, std::string& strError);
-    bool HasMinimumRequiredSupport();
     std::pair<std::string, std::string> GetVotes();
 
     bool IsValid(std::string& strError, bool fCheckCollateral = true);

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -347,12 +347,14 @@ private:
     mutable RecursiveMutex cs;
     bool fAutoChecked; //If it matches what we see, we'll auto vote for it (masternode only)
 
+protected:
+    std::map<uint256, CFinalizedBudgetVote> mapVotes;
+
 public:
     bool fValid;
     std::string strBudgetName;
     int nBlockStart;
     std::vector<CTxBudgetPayment> vecBudgetPayments;
-    std::map<uint256, CFinalizedBudgetVote> mapVotes;
     uint256 nFeeTXHash;
     int64_t nTime;
 
@@ -361,6 +363,11 @@ public:
 
     void CleanAndRemove();
     bool AddOrUpdateVote(CFinalizedBudgetVote& vote, std::string& strError);
+    UniValue GetVotesObject() const;
+    void SetSynced(bool synced);    // sets fSynced on votes (true only if valid)
+
+    // sync budget votes with a node
+    void SyncVotes(CNode* pfrom, bool fPartial, int& nInvCount) const;
 
     bool IsValid(std::string& strError, bool fCheckCollateral = true);
 
@@ -488,6 +495,9 @@ private:
     mutable RecursiveMutex cs;
     CAmount nAlloted;
 
+protected:
+    std::map<uint256, CBudgetVote> mapVotes;
+
 public:
     bool fValid;
     std::string strProposalName;
@@ -504,7 +514,6 @@ public:
     int64_t nTime;
     uint256 nFeeTXHash;
 
-    std::map<uint256, CBudgetVote> mapVotes;
     //cache object
 
     CBudgetProposal();
@@ -513,9 +522,13 @@ public:
 
     bool AddOrUpdateVote(CBudgetVote& vote, std::string& strError);
     std::pair<std::string, std::string> GetVotes();
+    UniValue GetVotesArray() const;
+    void SetSynced(bool synced);    // sets fSynced on votes (true only if valid)
+
+    // sync proposal votes with a node
+    void SyncVotes(CNode* pfrom, bool fPartial, int& nInvCount) const;
 
     bool IsValid(std::string& strError, bool fCheckCollateral = true);
-
     bool IsEstablished();
     bool IsPassing(const CBlockIndex* pindexPrev, int nBlockStartBudget, int nBlockEndBudget, int mnCount);
 

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -539,9 +539,10 @@ public:
     int GetBlockCurrentCycle();
     int GetBlockEndCycle();
     double GetRatio();
-    int GetYeas() const;
-    int GetNays() const;
-    int GetAbstains() const;
+    int GetVoteCount(CBudgetVote::VoteDirection vd) const;
+    int GetYeas() const { return GetVoteCount(CBudgetVote::VOTE_YES); }
+    int GetNays() const { return GetVoteCount(CBudgetVote::VOTE_NO); }
+    int GetAbstains() const { return GetVoteCount(CBudgetVote::VOTE_ABSTAIN); };
     CAmount GetAmount() { return nAmount; }
     void SetAllotted(CAmount nAllotedIn) { nAlloted = nAllotedIn; }
     CAmount GetAllotted() { return nAlloted; }

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -258,7 +258,6 @@ public:
     // finds the proposal with the given name, with highest yes count.
     const CBudgetProposal* FindProposalByName(const std::string& strProposalName) const;
     CFinalizedBudget* FindFinalizedBudget(const uint256& nHash);
-    std::pair<std::string, std::string> GetVotes(std::string strProposalName);
 
     CAmount GetTotalBudget(int nHeight);
     std::vector<CBudgetProposal*> GetBudget();
@@ -524,7 +523,6 @@ public:
     CBudgetProposal(std::string strProposalNameIn, std::string strURLIn, int nBlockStartIn, int nBlockEndIn, CScript addressIn, CAmount nAmountIn, uint256 nFeeTXHashIn);
 
     bool AddOrUpdateVote(CBudgetVote& vote, std::string& strError);
-    std::pair<std::string, std::string> GetVotes();
     UniValue GetVotesArray() const;
     void SetSynced(bool synced);    // sets fSynced on votes (true only if valid)
 

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -349,6 +349,8 @@ private:
     // critical section to protect the inner data structures
     mutable RecursiveMutex cs;
     bool fAutoChecked; //If it matches what we see, we'll auto vote for it (masternode only)
+    bool fValid;
+    std::string strInvalid;
 
 protected:
     std::map<uint256, CFinalizedBudgetVote> mapVotes;
@@ -356,7 +358,6 @@ protected:
     int nBlockStart;
 
 public:
-    bool fValid;
     std::vector<CTxBudgetPayment> vecBudgetPayments;
     uint256 nFeeTXHash;
     int64_t nTime;
@@ -372,7 +373,10 @@ public:
     // sync budget votes with a node
     void SyncVotes(CNode* pfrom, bool fPartial, int& nInvCount) const;
 
-    bool IsValid(std::string& strError, bool fCheckCollateral = true);
+    // sets fValid and strInvalid, returns fValid
+    bool UpdateValid(bool fCheckCollateral = true);
+    bool IsValid() const  { return fValid; }
+    std::string IsInvalidReason() const { return strInvalid; }
 
     std::string GetName() const { return strBudgetName; }
     std::string GetProposals();
@@ -497,6 +501,8 @@ private:
     // critical section to protect the inner data structures
     mutable RecursiveMutex cs;
     CAmount nAlloted;
+    bool fValid;
+    std::string strInvalid;
 
 protected:
     std::map<uint256, CBudgetVote> mapVotes;
@@ -508,7 +514,6 @@ protected:
     CScript address;
 
 public:
-    bool fValid;
     int64_t nTime;
     uint256 nFeeTXHash;
 
@@ -526,7 +531,11 @@ public:
     // sync proposal votes with a node
     void SyncVotes(CNode* pfrom, bool fPartial, int& nInvCount) const;
 
-    bool IsValid(std::string& strError, bool fCheckCollateral = true);
+    // sets fValid and strInvalid, returns fValid
+    bool UpdateValid(bool fCheckCollateral = true);
+    bool IsValid() const  { return fValid; }
+    std::string IsInvalidReason() const { return strInvalid; }
+
     bool IsEstablished() const;
     bool IsPassing(const CBlockIndex* pindexPrev, int nBlockStartBudget, int nBlockEndBudget, int mnCount);
 

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -272,7 +272,7 @@ public:
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
     void NewBlock();
     CBudgetProposal* FindProposal(const uint256& nHash);
-    // finds the proposal with the given name, with highest yes count.
+    // finds the proposal with the given name, with highest net yes count.
     const CBudgetProposal* FindProposalByName(const std::string& strProposalName) const;
     CFinalizedBudget* FindFinalizedBudget(const uint256& nHash);
 

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -355,10 +355,10 @@ protected:
     std::map<uint256, CFinalizedBudgetVote> mapVotes;
     std::string strBudgetName;
     int nBlockStart;
-
-public:
     std::vector<CTxBudgetPayment> vecBudgetPayments;
     uint256 nFeeTXHash;
+
+public:
     int64_t nTime;
 
     CFinalizedBudget();
@@ -381,9 +381,10 @@ public:
     std::string GetProposals();
     int GetBlockStart() const { return nBlockStart; }
     int GetBlockEnd() const { return nBlockStart + (int)(vecBudgetPayments.size() - 1); }
+    const uint256& GetFeeTXHash() const { return nFeeTXHash;  }
     int GetVoteCount() const { return (int)mapVotes.size(); }
-    bool IsPaidAlready(uint256 nProposalHash, int nBlockHeight);
-    TrxValidationStatus IsTransactionValid(const CTransaction& txNew, int nBlockHeight);
+    bool IsPaidAlready(uint256 nProposalHash, int nBlockHeight) const;
+    TrxValidationStatus IsTransactionValid(const CTransaction& txNew, int nBlockHeight) const;
     bool GetBudgetPaymentByBlock(int64_t nBlockHeight, CTxBudgetPayment& payment) const
     {
         LOCK(cs);
@@ -409,12 +410,12 @@ public:
     // Verify and vote on finalized budget
     void CheckAndVote();
     //total pivx paid out by this budget
-    CAmount GetTotalPayout();
+    CAmount GetTotalPayout() const;
     //vote on this finalized budget as a masternode
     void SubmitVote();
 
     //checks the hashes to make sure we know about them
-    std::string GetStatus();
+    std::string GetStatus() const;
 
     uint256 GetHash() const
     {
@@ -511,10 +512,10 @@ protected:
     int nBlockEnd;
     CAmount nAmount;
     CScript address;
+    uint256 nFeeTXHash;
 
 public:
     int64_t nTime;
-    uint256 nFeeTXHash;
 
     //cache object
 
@@ -535,7 +536,7 @@ public:
     std::string IsInvalidReason() const { return strInvalid; }
 
     bool IsEstablished() const;
-    bool IsPassing(const CBlockIndex* pindexPrev, int nBlockStartBudget, int nBlockEndBudget, int mnCount);
+    bool IsPassing(const CBlockIndex* pindexPrev, int nBlockStartBudget, int nBlockEndBudget, int mnCount) const;
 
     std::string GetName() const { return strProposalName; }
     std::string GetURL() const { return strURL; }
@@ -547,6 +548,7 @@ public:
     int GetBlockStartCycle() const;
     int GetBlockCurrentCycle() const;
     int GetBlockEndCycle() const;
+    const uint256& GetFeeTXHash() const { return nFeeTXHash;  }
     double GetRatio() const;
     int GetVoteCount(CBudgetVote::VoteDirection vd) const;
     int GetYeas() const { return GetVoteCount(CBudgetVote::VOTE_YES); }

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -301,7 +301,7 @@ void FillBlockPayee(CMutableTransaction& txNew, const CBlockIndex* pindexPrev, b
     if (!pindexPrev) return;
 
     if (sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS) && budget.IsBudgetPaymentBlock(pindexPrev->nHeight + 1)) {
-        budget.FillBlockPayee(txNew, pindexPrev, fProofOfStake);
+        budget.FillBlockPayee(txNew, fProofOfStake);
     } else {
         masternodePayments.FillBlockPayee(txNew, pindexPrev, fProofOfStake);
     }

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -106,7 +106,7 @@ void CMasternodeSync::Reset()
     nAssetSyncStarted = GetTime();
 }
 
-void CMasternodeSync::AddedMasternodeList(uint256 hash)
+void CMasternodeSync::AddedMasternodeList(const uint256& hash)
 {
     if (mnodeman.mapSeenMasternodeBroadcast.count(hash)) {
         if (mapSeenSyncMNB[hash] < MASTERNODE_SYNC_THRESHOLD) {
@@ -119,7 +119,7 @@ void CMasternodeSync::AddedMasternodeList(uint256 hash)
     }
 }
 
-void CMasternodeSync::AddedMasternodeWinner(uint256 hash)
+void CMasternodeSync::AddedMasternodeWinner(const uint256& hash)
 {
     if (masternodePayments.mapMasternodePayeeVotes.count(hash)) {
         if (mapSeenSyncMNW[hash] < MASTERNODE_SYNC_THRESHOLD) {
@@ -132,10 +132,12 @@ void CMasternodeSync::AddedMasternodeWinner(uint256 hash)
     }
 }
 
-void CMasternodeSync::AddedBudgetItem(uint256 hash)
+void CMasternodeSync::AddedBudgetItem(const uint256& hash)
 {
-    if (budget.mapSeenMasternodeBudgetProposals.count(hash) || budget.mapSeenMasternodeBudgetVotes.count(hash) ||
-        budget.mapSeenFinalizedBudgets.count(hash) || budget.mapSeenFinalizedBudgetVotes.count(hash)) {
+    if (budget.HaveSeenProposal(hash) ||
+            budget.HaveSeenProposalVote(hash) ||
+            budget.HaveSeenFinalizedBudget(hash) ||
+            budget.HaveSeenFinalizedBudgetVote(hash)) {
         if (mapSeenSyncBudget[hash] < MASTERNODE_SYNC_THRESHOLD) {
             lastBudgetItem = GetTime();
             mapSeenSyncBudget[hash]++;

--- a/src/masternode-sync.h
+++ b/src/masternode-sync.h
@@ -64,9 +64,9 @@ public:
 
     CMasternodeSync();
 
-    void AddedMasternodeList(uint256 hash);
-    void AddedMasternodeWinner(uint256 hash);
-    void AddedBudgetItem(uint256 hash);
+    void AddedMasternodeList(const uint256& hash);
+    void AddedMasternodeWinner(const uint256& hash);
+    void AddedBudgetItem(const uint256& hash);
     void GetNextAsset();
     std::string GetSyncStatus();
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -223,7 +223,7 @@ bool CMasternodeMan::Add(CMasternode& mn)
     return false;
 }
 
-void CMasternodeMan::AskForMN(CNode* pnode, CTxIn& vin)
+void CMasternodeMan::AskForMN(CNode* pnode, const CTxIn& vin)
 {
     std::map<COutPoint, int64_t>::iterator i = mWeAskedForMasternodeListEntry.find(vin.prevout);
     if (i != mWeAskedForMasternodeListEntry.end()) {

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -102,7 +102,7 @@ public:
     bool Add(CMasternode& mn);
 
     /// Ask (source) node for mnb
-    void AskForMN(CNode* pnode, CTxIn& vin);
+    void AskForMN(CNode* pnode, const CTxIn& vin);
 
     /// Check all Masternodes
     void Check();

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -27,7 +27,7 @@ std::string COutPoint::ToStringShort() const
     return strprintf("%s-%u", hash.ToString().substr(0,64), n);
 }
 
-uint256 COutPoint::GetHash()
+uint256 COutPoint::GetHash() const
 {
     return Hash(BEGIN(hash), END(hash), BEGIN(n), END(n));
 }

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -58,7 +58,7 @@ public:
 
     size_t DynamicMemoryUsage() const { return 0; }
 
-    uint256 GetHash();
+    uint256 GetHash() const;
 
 };
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1147,7 +1147,8 @@ UniValue invalidateblock(const JSONRPCRequest& request)
     }
 
     if (state.IsValid()) {
-        ActivateBestChain(state, nullptr, false, g_connman.get(), &budget);
+        ActivateBestChain(state, nullptr, false, g_connman.get());
+        budget.SetBestHeight(WITH_LOCK(cs_main, return chainActive.Height(); ));
     }
 
     if (!state.IsValid()) {
@@ -1185,7 +1186,8 @@ UniValue reconsiderblock(const JSONRPCRequest& request)
     }
 
     if (state.IsValid()) {
-        ActivateBestChain(state, nullptr, false, g_connman.get(), &budget);
+        ActivateBestChain(state, nullptr, false, g_connman.get());
+        budget.SetBestHeight(WITH_LOCK(cs_main, return chainActive.Height(); ));
     }
 
     if (!state.IsValid()) {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -11,6 +11,7 @@
 #include "consensus/upgrades.h"
 #include "kernel.h"
 #include "main.h"
+#include "masternode-budget.h"
 #include "policy/policy.h"
 #include "rpc/server.h"
 #include "sync.h"
@@ -1146,7 +1147,7 @@ UniValue invalidateblock(const JSONRPCRequest& request)
     }
 
     if (state.IsValid()) {
-        ActivateBestChain(state, nullptr, false, g_connman.get());
+        ActivateBestChain(state, nullptr, false, g_connman.get(), &budget);
     }
 
     if (!state.IsValid()) {
@@ -1184,7 +1185,7 @@ UniValue reconsiderblock(const JSONRPCRequest& request)
     }
 
     if (state.IsValid()) {
-        ActivateBestChain(state, nullptr, false, g_connman.get());
+        ActivateBestChain(state, nullptr, false, g_connman.get(), &budget);
     }
 
     if (!state.IsValid()) {

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -571,7 +571,11 @@ UniValue getbudgetprojection(const JSONRPCRequest& request)
     UniValue resultObj(UniValue::VOBJ);
     CAmount nTotalAllotted = 0;
 
-    std::vector<CBudgetProposal*> winningProps = budget.GetBudget();
+    int nCurrentHeight = WITH_LOCK(cs_main, return chainActive.Height(); );
+    if (nCurrentHeight <= 0)
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Unable to get chain tip. No blocks yet.");
+
+    std::vector<CBudgetProposal*> winningProps = budget.GetBudget(nCurrentHeight);
     for (CBudgetProposal* pbudgetProposal : winningProps) {
         nTotalAllotted += pbudgetProposal->GetAllotted();
 

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -29,7 +29,7 @@ void budgetToJSON(const CBudgetProposal* pbudgetProposal, UniValue& bObj)
     bObj.push_back(Pair("Name", pbudgetProposal->GetName()));
     bObj.push_back(Pair("URL", pbudgetProposal->GetURL()));
     bObj.push_back(Pair("Hash", pbudgetProposal->GetHash().ToString()));
-    bObj.push_back(Pair("FeeHash", pbudgetProposal->nFeeTXHash.ToString()));
+    bObj.push_back(Pair("FeeHash", pbudgetProposal->GetFeeTXHash().ToString()));
     bObj.push_back(Pair("BlockStart", (int64_t)pbudgetProposal->GetBlockStart()));
     bObj.push_back(Pair("BlockEnd", (int64_t)pbudgetProposal->GetBlockEnd()));
     bObj.push_back(Pair("TotalPaymentCount", (int64_t)pbudgetProposal->GetTotalPaymentCount()));
@@ -859,7 +859,7 @@ UniValue mnfinalbudget(const JSONRPCRequest& request)
         std::vector<CFinalizedBudget*> winningFbs = budget.GetFinalizedBudgets();
         for (CFinalizedBudget* finalizedBudget : winningFbs) {
             UniValue bObj(UniValue::VOBJ);
-            bObj.push_back(Pair("FeeTX", finalizedBudget->nFeeTXHash.ToString()));
+            bObj.push_back(Pair("FeeTX", finalizedBudget->GetFeeTXHash().ToString()));
             bObj.push_back(Pair("Hash", finalizedBudget->GetHash().ToString()));
             bObj.push_back(Pair("BlockStart", (int64_t)finalizedBudget->GetBlockStart()));
             bObj.push_back(Pair("BlockEnd", (int64_t)finalizedBudget->GetBlockEnd()));

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -21,7 +21,7 @@
 
 #include <fstream>
 
-void budgetToJSON(CBudgetProposal* pbudgetProposal, UniValue& bObj)
+void budgetToJSON(const CBudgetProposal* pbudgetProposal, UniValue& bObj)
 {
     CTxDestination address1;
     ExtractDestination(pbudgetProposal->GetPayee(), address1);
@@ -44,9 +44,8 @@ void budgetToJSON(CBudgetProposal* pbudgetProposal, UniValue& bObj)
     bObj.push_back(Pair("IsEstablished", pbudgetProposal->IsEstablished()));
 
     std::string strError = "";
-    bObj.push_back(Pair("IsValid", pbudgetProposal->IsValid(strError)));
+    bObj.push_back(Pair("IsValid", pbudgetProposal->fValid));
     bObj.push_back(Pair("IsValidReason", strError.c_str()));
-    bObj.push_back(Pair("fValid", pbudgetProposal->fValid));
 }
 
 void checkBudgetInputs(const UniValue& params, std::string &strProposalName, std::string &strURL,
@@ -515,7 +514,7 @@ UniValue getbudgetvotes(const JSONRPCRequest& request)
             HelpExampleCli("getbudgetvotes", "\"test-proposal\"") + HelpExampleRpc("getbudgetvotes", "\"test-proposal\""));
 
     std::string strProposalName = SanitizeString(request.params[0].get_str());
-    CBudgetProposal* pbudgetProposal = budget.FindProposal(strProposalName);
+    const CBudgetProposal* pbudgetProposal = budget.FindProposalByName(strProposalName);
     if (pbudgetProposal == NULL) throw std::runtime_error("Unknown proposal name");
     return pbudgetProposal->GetVotesArray();
 }
@@ -569,7 +568,6 @@ UniValue getbudgetprojection(const JSONRPCRequest& request)
             "    \"IsEstablished\": true|false,  (boolean) Established (true) or (false)\n"
             "    \"IsValid\": true|false,        (boolean) Valid (true) or Invalid (false)\n"
             "    \"IsValidReason\": \"xxxx\",      (string) Error message, if any\n"
-            "    \"fValid\": true|false,         (boolean) Valid (true) or Invalid (false)\n"
             "    \"Alloted\": xxx.xxx,           (numeric) Amount alloted in current period\n"
             "    \"TotalBudgetAlloted\": xxx.xxx (numeric) Total alloted\n"
             "  }\n"
@@ -632,7 +630,6 @@ UniValue getbudgetinfo(const JSONRPCRequest& request)
             "    \"IsEstablished\": true|false,  (boolean) Established (true) or (false)\n"
             "    \"IsValid\": true|false,        (boolean) Valid (true) or Invalid (false)\n"
             "    \"IsValidReason\": \"xxxx\",      (string) Error message, if any\n"
-            "    \"fValid\": true|false,         (boolean) Valid (true) or Invalid (false)\n"
             "  }\n"
             "  ,...\n"
             "]\n"
@@ -645,7 +642,7 @@ UniValue getbudgetinfo(const JSONRPCRequest& request)
     std::string strShow = "valid";
     if (request.params.size() == 1) {
         std::string strProposalName = SanitizeString(request.params[0].get_str());
-        CBudgetProposal* pbudgetProposal = budget.FindProposal(strProposalName);
+        const CBudgetProposal* pbudgetProposal = budget.FindProposalByName(strProposalName);
         if (pbudgetProposal == NULL) throw std::runtime_error("Unknown proposal name");
         UniValue bObj(UniValue::VOBJ);
         budgetToJSON(pbudgetProposal, bObj);
@@ -875,7 +872,7 @@ UniValue mnfinalbudget(const JSONRPCRequest& request)
             bObj.push_back(Pair("Status", finalizedBudget->GetStatus()));
 
             std::string strError = "";
-            bObj.push_back(Pair("IsValid", finalizedBudget->IsValid(strError)));
+            bObj.push_back(Pair("IsValid", finalizedBudget->fValid));
             bObj.push_back(Pair("IsValidReason", strError.c_str()));
 
             resultObj.push_back(Pair(finalizedBudget->GetName(), bObj));

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -894,7 +894,9 @@ UniValue checkbudgets(const JSONRPCRequest& request)
             "\nExamples:\n" +
             HelpExampleCli("checkbudgets", "") + HelpExampleRpc("checkbudgets", ""));
 
-    budget.CheckAndRemove();
+    if (!masternodeSync.IsSynced())
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Masternode/Budget sync not finished yet");
 
+    budget.CheckAndRemove();
     return NullUniValue;
 }

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -269,9 +269,9 @@ UniValue mnbudgetvote(const JSONRPCRequest& request)
     std::string strVote = request.params[2].get_str();
 
     if (strVote != "yes" && strVote != "no") return "You can only vote 'yes' or 'no'";
-    int nVote = VOTE_ABSTAIN;
-    if (strVote == "yes") nVote = VOTE_YES;
-    if (strVote == "no") nVote = VOTE_NO;
+    CBudgetVote::VoteDirection nVote = CBudgetVote::VOTE_ABSTAIN;
+    if (strVote == "yes") nVote = CBudgetVote::VOTE_YES;
+    if (strVote == "no") nVote = CBudgetVote::VOTE_NO;
 
     int success = 0;
     int failed = 0;
@@ -706,9 +706,9 @@ UniValue mnbudgetrawvote(const JSONRPCRequest& request)
     std::string strVote = request.params[3].get_str();
 
     if (strVote != "yes" && strVote != "no") return "You can only vote 'yes' or 'no'";
-    int nVote = VOTE_ABSTAIN;
-    if (strVote == "yes") nVote = VOTE_YES;
-    if (strVote == "no") nVote = VOTE_NO;
+    CBudgetVote::VoteDirection nVote = CBudgetVote::VOTE_ABSTAIN;
+    if (strVote == "yes") nVote = CBudgetVote::VOTE_YES;
+    if (strVote == "no") nVote = CBudgetVote::VOTE_NO;
 
     int64_t nTime = request.params[4].get_int64();
     std::string strSig = request.params[5].get_str();

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -211,7 +211,7 @@ UniValue submitbudget(const JSONRPCRequest& request)
         throw std::runtime_error("Must wait for client to sync with masternode network. Try again in a minute or so.");
     }
 
-    budget.mapSeenMasternodeBudgetProposals.insert(std::make_pair(budgetProposalBroadcast.GetHash(), budgetProposalBroadcast));
+    budget.AddSeenProposal(budgetProposalBroadcast);
     budgetProposalBroadcast.Relay();
     if(budget.AddProposal(budgetProposalBroadcast)) {
         return budgetProposalBroadcast.GetHash().ToString();
@@ -317,10 +317,8 @@ UniValue mnbudgetvote(const JSONRPCRequest& request)
             }
 
             std::string strError = "";
-            if (budget.UpdateProposal(vote, NULL, strError)) {
+            if (budget.AddAndRelayProposalVote(vote, strError)) {
                 success++;
-                budget.mapSeenMasternodeBudgetVotes.insert(std::make_pair(vote.GetHash(), vote));
-                vote.Relay();
                 statusObj.push_back(Pair("node", "local"));
                 statusObj.push_back(Pair("result", "success"));
                 statusObj.push_back(Pair("error", ""));
@@ -383,9 +381,7 @@ UniValue mnbudgetvote(const JSONRPCRequest& request)
             }
 
             std::string strError = "";
-            if (budget.UpdateProposal(vote, NULL, strError)) {
-                budget.mapSeenMasternodeBudgetVotes.insert(std::make_pair(vote.GetHash(), vote));
-                vote.Relay();
+            if (budget.AddAndRelayProposalVote(vote, strError)) {
                 success++;
                 statusObj.push_back(Pair("node", mne.getAlias()));
                 statusObj.push_back(Pair("result", "success"));
@@ -457,9 +453,7 @@ UniValue mnbudgetvote(const JSONRPCRequest& request)
             }
 
             std::string strError = "";
-            if(budget.UpdateProposal(vote, NULL, strError)) {
-                budget.mapSeenMasternodeBudgetVotes.insert(std::make_pair(vote.GetHash(), vote));
-                vote.Relay();
+            if(budget.AddAndRelayProposalVote(vote, strError)) {
                 success++;
                 statusObj.push_back(Pair("node", mne.getAlias()));
                 statusObj.push_back(Pair("result", "success"));
@@ -716,9 +710,7 @@ UniValue mnbudgetrawvote(const JSONRPCRequest& request)
     }
 
     std::string strError = "";
-    if (budget.UpdateProposal(vote, NULL, strError)) {
-        budget.mapSeenMasternodeBudgetVotes.insert(std::make_pair(vote.GetHash(), vote));
-        vote.Relay();
+    if (budget.AddAndRelayProposalVote(vote, strError)) {
         return "Voted successfully";
     } else {
         return "Error voting : " + strError;
@@ -795,7 +787,7 @@ UniValue mnfinalbudget(const JSONRPCRequest& request)
 
             std::string strError = "";
             if (budget.UpdateFinalizedBudget(vote, NULL, strError)) {
-                budget.mapSeenFinalizedBudgetVotes.insert(std::make_pair(vote.GetHash(), vote));
+                budget.AddSeenFinalizedBudgetVote(vote);
                 vote.Relay();
                 success++;
                 statusObj.push_back(Pair("result", "success"));
@@ -845,7 +837,7 @@ UniValue mnfinalbudget(const JSONRPCRequest& request)
 
         std::string strError = "";
         if (budget.UpdateFinalizedBudget(vote, NULL, strError)) {
-            budget.mapSeenFinalizedBudgetVotes.insert(std::make_pair(vote.GetHash(), vote));
+            budget.AddSeenFinalizedBudgetVote(vote);
             vote.Relay();
             return "success";
         } else {

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -522,17 +522,9 @@ UniValue getbudgetvotes(const JSONRPCRequest& request)
 
     if (pbudgetProposal == NULL) throw std::runtime_error("Unknown proposal name");
 
-    std::map<uint256, CBudgetVote>::iterator it = pbudgetProposal->mapVotes.begin();
+    auto it = pbudgetProposal->mapVotes.begin();
     while (it != pbudgetProposal->mapVotes.end()) {
-        UniValue bObj(UniValue::VOBJ);
-        bObj.push_back(Pair("mnId", (*it).second.vin.prevout.hash.ToString()));
-        bObj.push_back(Pair("nHash", (*it).first.ToString().c_str()));
-        bObj.push_back(Pair("Vote", (*it).second.GetVoteString()));
-        bObj.push_back(Pair("nTime", (int64_t)(*it).second.nTime));
-        bObj.push_back(Pair("fValid", (*it).second.fValid));
-
-        ret.push_back(bObj);
-
+        ret.push_back((*it).second.ToJSON());
         it++;
     }
 
@@ -732,7 +724,7 @@ UniValue mnbudgetrawvote(const JSONRPCRequest& request)
     }
 
     CBudgetVote vote(vin, hashProposal, nVote);
-    vote.nTime = nTime;
+    vote.SetTime(nTime);
     vote.SetVchSig(vchSig);
 
     if (!vote.CheckSignature()) {
@@ -916,15 +908,10 @@ UniValue mnfinalbudget(const JSONRPCRequest& request)
 
         if (pfinalBudget == NULL) return "Unknown budget hash";
 
-        std::map<uint256, CFinalizedBudgetVote>::iterator it = pfinalBudget->mapVotes.begin();
+        auto it = pfinalBudget->mapVotes.begin();
         while (it != pfinalBudget->mapVotes.end()) {
-            UniValue bObj(UniValue::VOBJ);
-            bObj.push_back(Pair("nHash", (*it).first.ToString().c_str()));
-            bObj.push_back(Pair("nTime", (int64_t)(*it).second.nTime));
-            bObj.push_back(Pair("fValid", (*it).second.fValid));
-
-            obj.push_back(Pair((*it).second.vin.prevout.ToStringShort(), bObj));
-
+            const CFinalizedBudgetVote& vote = (*it).second;
+            obj.push_back(Pair(vote.GetVin().prevout.ToStringShort(), vote.ToJSON()));
             it++;
         }
 

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -515,20 +515,9 @@ UniValue getbudgetvotes(const JSONRPCRequest& request)
             HelpExampleCli("getbudgetvotes", "\"test-proposal\"") + HelpExampleRpc("getbudgetvotes", "\"test-proposal\""));
 
     std::string strProposalName = SanitizeString(request.params[0].get_str());
-
-    UniValue ret(UniValue::VARR);
-
     CBudgetProposal* pbudgetProposal = budget.FindProposal(strProposalName);
-
     if (pbudgetProposal == NULL) throw std::runtime_error("Unknown proposal name");
-
-    auto it = pbudgetProposal->mapVotes.begin();
-    while (it != pbudgetProposal->mapVotes.end()) {
-        ret.push_back((*it).second.ToJSON());
-        it++;
-    }
-
-    return ret;
+    return pbudgetProposal->GetVotesArray();
 }
 
 UniValue getnextsuperblock(const JSONRPCRequest& request)
@@ -901,21 +890,9 @@ UniValue mnfinalbudget(const JSONRPCRequest& request)
 
         std::string strHash = request.params[1].get_str();
         uint256 hash(uint256S(strHash));
-
-        UniValue obj(UniValue::VOBJ);
-
         CFinalizedBudget* pfinalBudget = budget.FindFinalizedBudget(hash);
-
         if (pfinalBudget == NULL) return "Unknown budget hash";
-
-        auto it = pfinalBudget->mapVotes.begin();
-        while (it != pfinalBudget->mapVotes.end()) {
-            const CFinalizedBudgetVote& vote = (*it).second;
-            obj.push_back(Pair(vote.GetVin().prevout.ToStringShort(), vote.ToJSON()));
-            it++;
-        }
-
-        return obj;
+        return pfinalBudget->GetVotesObject();
     }
 
     return NullUniValue;


### PR DESCRIPTION
Refactoring of the masternode budget classes (`CBudgetManager`, `CBudgetProposal`, `CBudgetVote`, `CFinalizedBudget`, `CFinalizedBudgetVote`), providing better encapsulation of the data, removing unused functions, and giving a first round of styling cleanup.