### PR TITLE
[RPC][BUG] Fix ActivateBestChain calls in reconsider(invalidate)block

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1133,7 +1133,7 @@ UniValue invalidateblock(const JSONRPCRequest& request)
     }
 
     if (state.IsValid()) {
-        ActivateBestChain(state, NULL, g_connman.get());
+        ActivateBestChain(state, nullptr, false, g_connman.get());
     }
 
     if (!state.IsValid()) {
@@ -1171,7 +1171,7 @@ UniValue reconsiderblock(const JSONRPCRequest& request)
     }
 
     if (state.IsValid()) {
-        ActivateBestChain(state, NULL, g_connman.get());
+        ActivateBestChain(state, nullptr, false, g_connman.get());
     }
 
     if (!state.IsValid()) {


### PR DESCRIPTION
The third argument of ABC should be `fAlreadyChecked` (defaulted to `false`).
In reconsiderblock and invalidateblock RPC, the pointer returned by `g_connman.get()` (which can be automatically cast to bool) is improperly added as third (instead of fourth) argument.