### PR TITLE
[Refactor] Emplace elements in maps and vectors

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -153,7 +153,7 @@ bool CActiveMasternode::SendMasternodePing(std::string& errorMessage)
         }
 
         pmn->lastPing = mnp;
-        mnodeman.mapSeenMasternodePing.insert(std::make_pair(mnp.GetHash(), mnp));
+        mnodeman.mapSeenMasternodePing.emplace(mnp.GetHash(), mnp);
 
         //mnodeman.mapSeenMasternodeBroadcast.lastPing is probably outdated, so we'll update it
         CMasternodeBroadcast mnb(*pmn);

--- a/src/allocators.h
+++ b/src/allocators.h
@@ -57,7 +57,7 @@ public:
             if (it == histogram.end()) // Newly locked page
             {
                 locker.Lock(reinterpret_cast<void*>(page), page_size);
-                histogram.insert(std::make_pair(page, 1));
+                histogram.emplace(page, 1);
             } else // Page was already locked; increase counter
             {
                 it->second += 1;

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -17,7 +17,7 @@ benchmark::BenchRunner::BenchmarkMap &benchmark::BenchRunner::benchmarks() {
 
 benchmark::BenchRunner::BenchRunner(std::string name, benchmark::BenchFunction func)
 {
-    benchmarks().insert(std::make_pair(name, func));
+    benchmarks().emplace(name, func);
 }
 
 void

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -226,8 +226,8 @@ public:
         nDefaultPort = 51472;
 
         // Note that of those with the service bits flag, most only support a subset of possible options
-        vSeeds.push_back(CDNSSeedData("fuzzbawls.pw", "pivx.seed.fuzzbawls.pw", true));     // Primary DNS Seeder from Fuzzbawls
-        vSeeds.push_back(CDNSSeedData("fuzzbawls.pw", "pivx.seed2.fuzzbawls.pw", true));    // Secondary DNS Seeder from Fuzzbawls
+        vSeeds.emplace_back("fuzzbawls.pw", "pivx.seed.fuzzbawls.pw", true);     // Primary DNS Seeder from Fuzzbawls
+        vSeeds.emplace_back("fuzzbawls.pw", "pivx.seed2.fuzzbawls.pw", true);    // Secondary DNS Seeder from Fuzzbawls
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1, 30);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1, 13);
@@ -366,8 +366,8 @@ public:
         vFixedSeeds.clear();
         vSeeds.clear();
         // nodes with support for servicebits filtering should be at the top
-        vSeeds.push_back(CDNSSeedData("fuzzbawls.pw", "pivx-testnet.seed.fuzzbawls.pw", true));
-        vSeeds.push_back(CDNSSeedData("fuzzbawls.pw", "pivx-testnet.seed2.fuzzbawls.pw", true));
+        vSeeds.emplace_back("fuzzbawls.pw", "pivx-testnet.seed.fuzzbawls.pw", true);
+        vSeeds.emplace_back("fuzzbawls.pw", "pivx-testnet.seed2.fuzzbawls.pw", true);
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1, 139); // Testnet pivx addresses start with 'x' or 'y'
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1, 19);  // Testnet pivx script addresses start with '8' or '9'

--- a/src/consensus/zerocoin_verify.cpp
+++ b/src/consensus/zerocoin_verify.cpp
@@ -206,7 +206,7 @@ bool RecalculatePIVSupply(int nHeightStart, bool fSkipZpiv)
     if (!fSkipZpiv) {
         // initialize supply to 0
         mapZerocoinSupply.clear();
-        for (auto& denom : libzerocoin::zerocoinDenomList) mapZerocoinSupply.insert(std::make_pair(denom, 0));
+        for (auto& denom : libzerocoin::zerocoinDenomList) mapZerocoinSupply.emplace(denom, 0);
     }
 
     uiInterface.ShowProgress(_("Recalculating PIV supply..."), 0);

--- a/src/denomination_functions.cpp
+++ b/src/denomination_functions.cpp
@@ -44,7 +44,7 @@ std::map<libzerocoin::CoinDenomination, CAmount> getSpendCoins(const CAmount nVa
     CAmount nRemainingValue = nValueTarget;
     // Initialize
     for (const auto& denom : libzerocoin::zerocoinDenomList)
-        mapUsed.insert(std::pair<libzerocoin::CoinDenomination, CAmount>(denom, 0));
+        mapUsed.emplace(denom, 0);
 
     // Start with the Highest Denomination coin and grab coins as long as the remaining amount is greater than the
     // current denomination value and we have the denom
@@ -69,7 +69,7 @@ std::map<libzerocoin::CoinDenomination, CAmount> getChange(const CAmount nValueT
     CAmount nRemainingValue = nValueTarget;
     // Initialize
     for (const auto& denom : libzerocoin::zerocoinDenomList)
-        mapChange.insert(std::pair<libzerocoin::CoinDenomination, CAmount>(denom, 0));
+        mapChange.emplace(denom, 0);
 
     // Start with the Highest Denomination coin and grab coins as long as the remaining amount is greater than the
     // current denomination value
@@ -98,7 +98,7 @@ bool getIdealSpends(
     CAmount nRemainingValue = nValueTarget;
     // Initialize
     for (const auto& denom : libzerocoin::zerocoinDenomList)
-        mapOfDenomsUsed.insert(std::pair<libzerocoin::CoinDenomination, CAmount>(denom, 0));
+        mapOfDenomsUsed.emplace(denom, 0);
 
     // Start with the Highest Denomination coin and grab coins as long as the remaining amount is greater than the
     // current denomination value
@@ -146,7 +146,7 @@ void listSpends(const std::vector<CZerocoinMint>& vSelectedMints)
 {
     std::map<libzerocoin::CoinDenomination, int64_t> mapZerocoinSupply;
     for (auto& denom : libzerocoin::zerocoinDenomList)
-        mapZerocoinSupply.insert(std::make_pair(denom, 0));
+        mapZerocoinSupply.emplace(denom, 0);
 
     for (const CZerocoinMint& mint : vSelectedMints) {
         libzerocoin::CoinDenomination denom = mint.GetDenomination();
@@ -316,7 +316,7 @@ int calculateChange(
     // Initialize
     mapOfDenomsUsed.clear();
     for (const auto& denom : libzerocoin::zerocoinDenomList)
-        mapOfDenomsUsed.insert(std::pair<libzerocoin::CoinDenomination, CAmount>(denom, 0));
+        mapOfDenomsUsed.emplace(denom, 0);
 
     for (const auto& denom : libzerocoin::zerocoinDenomList) {
         if (nValueTarget < ZerocoinDenominationToAmount(denom) && mapOfDenomsHeld.at(denom)) {

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -326,8 +326,8 @@ static bool HTTPBindAddresses(struct evhttp* http)
 
     // Determine what addresses to bind to
     if (!mapArgs.count("-rpcallowip")) { // Default to loopback if not allowing external IPs
-        endpoints.push_back(std::make_pair("::1", defaultPort));
-        endpoints.push_back(std::make_pair("127.0.0.1", defaultPort));
+        endpoints.emplace_back("::1", defaultPort);
+        endpoints.emplace_back("127.0.0.1", defaultPort);
         if (mapArgs.count("-rpcbind")) {
             LogPrintf("WARNING: option -rpcbind was ignored because -rpcallowip was not specified, refusing to allow everyone to connect\n");
         }
@@ -337,11 +337,11 @@ static bool HTTPBindAddresses(struct evhttp* http)
             int port = defaultPort;
             std::string host;
             SplitHostPort(*i, port, host);
-            endpoints.push_back(std::make_pair(host, port));
+            endpoints.emplace_back(host, port);
         }
     } else { // No specific bind address specified, bind to any
-        endpoints.push_back(std::make_pair("::", defaultPort));
-        endpoints.push_back(std::make_pair("0.0.0.0", defaultPort));
+        endpoints.emplace_back("::", defaultPort);
+        endpoints.emplace_back("0.0.0.0", defaultPort);
     }
 
     // Bind addresses

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -207,8 +207,8 @@ static bool InitHTTPAllowList()
     CNetAddr localv6;
     LookupHost("127.0.0.1", localv4, false);
     LookupHost("::1", localv6, false);
-    rpc_allow_subnets.push_back(CSubNet(localv4, 8));      // always allow IPv4 local subnet
-    rpc_allow_subnets.push_back(CSubNet(localv6));         // always allow IPv6 localhost
+    rpc_allow_subnets.emplace_back(localv4, 8);      // always allow IPv4 local subnet
+    rpc_allow_subnets.emplace_back(localv6);         // always allow IPv6 localhost
     if (mapMultiArgs.count("-rpcallowip")) {
         const std::vector<std::string>& vAllow = mapMultiArgs["-rpcallowip"];
         for (std::string strAllow : vAllow) {
@@ -669,7 +669,7 @@ HTTPRequest::RequestMethod HTTPRequest::GetRequestMethod()
 void RegisterHTTPHandler(const std::string &prefix, bool exactMatch, const HTTPRequestHandler &handler)
 {
     LogPrint(BCLog::HTTP, "Registering HTTP handler for %s (exactmatch %d)\n", prefix, exactMatch);
-    pathHandlers.push_back(HTTPPathHandler(prefix, exactMatch, handler));
+    pathHandlers.emplace_back(prefix, exactMatch, handler);
 }
 
 void UnregisterHTTPHandler(const std::string &prefix, bool exactMatch)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1552,7 +1552,7 @@ bool AppInit2()
 
                     // initialize PIV and zPIV supply to 0
                     mapZerocoinSupply.clear();
-                    for (auto& denom : libzerocoin::zerocoinDenomList) mapZerocoinSupply.insert(std::make_pair(denom, 0));
+                    for (auto& denom : libzerocoin::zerocoinDenomList) mapZerocoinSupply.emplace(denom, 0);
                     nMoneySupply = 0;
 
                     // Load PIV and zPIV supply from DB

--- a/src/legacy/stakemodifier.cpp
+++ b/src/legacy/stakemodifier.cpp
@@ -183,7 +183,7 @@ bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeMod
     const CBlockIndex* pindex = pindexPrev;
 
     while (pindex && pindex->GetBlockTime() >= nSelectionIntervalStart) {
-        vSortedByTimestamp.push_back(std::make_pair(pindex->GetBlockTime(), pindex->GetBlockHash()));
+        vSortedByTimestamp.emplace_back(pindex->GetBlockTime(), pindex->GetBlockHash());
         pindex = pindex->pprev;
     }
 
@@ -207,7 +207,7 @@ bool ComputeNextStakeModifier(const CBlockIndex* pindexPrev, uint64_t& nStakeMod
         nStakeModifierNew |= (((uint64_t)pindex->GetStakeEntropyBit()) << nRound);
 
         // add the selected block from candidates to selected list
-        mapSelectedBlocks.insert(std::make_pair(pindex->GetBlockHash(), pindex));
+        mapSelectedBlocks.emplace(pindex->GetBlockHash(), pindex);
         if (GetBoolArg("-printstakemodifier", false))
             LogPrintf("%s : selected round %d stop=%s height=%d bit=%d\n", __func__,
                 nRound, DateTimeStrFormat("%Y-%m-%d %H:%M:%S", nSelectionIntervalStop).c_str(), pindex->nHeight, pindex->GetStakeEntropyBit());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1706,7 +1706,7 @@ bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsVi
                 // Verify signature
                 CScriptCheck check(scriptPubKey, amount, tx, i, flags, cacheStore, &precomTxData);
                 if (pvChecks) {
-                    pvChecks->push_back(CScriptCheck());
+                    pvChecks->emplace_back();
                     check.swap(pvChecks->back());
                 } else if (!check()) {
                     if (flags & STANDARD_NOT_MANDATORY_VERIFY_FLAGS) {
@@ -4862,7 +4862,7 @@ void static ProcessGetData(CNode* pfrom, CConnman& connman, std::atomic<bool>& i
                         // and we want it right after the last block so they don't
                         // wait for other stuff first.
                         std::vector<CInv> vInv;
-                        vInv.push_back(CInv(MSG_BLOCK, chainActive.Tip()->GetBlockHash()));
+                        vInv.emplace_back(MSG_BLOCK, chainActive.Tip()->GetBlockHash());
                         connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::INV, vInv));
                         pfrom->hashContinue.SetNull();
                     }
@@ -6143,7 +6143,7 @@ bool SendMessages(CNode* pto, CConnman& connman, std::atomic<bool>& interruptMsg
             NodeId staller = -1;
             FindNextBlocksToDownload(pto->GetId(), MAX_BLOCKS_IN_TRANSIT_PER_PEER - state.nBlocksInFlight, vToDownload, staller);
             for (CBlockIndex* pindex : vToDownload) {
-                vGetData.push_back(CInv(MSG_BLOCK, pindex->GetBlockHash()));
+                vGetData.emplace_back(MSG_BLOCK, pindex->GetBlockHash());
                 MarkBlockAsInFlight(pto->GetId(), pindex->GetBlockHash(), pindex);
                 LogPrintf("Requesting block %s (%d) peer=%d\n", pindex->GetBlockHash().ToString(),
                     pindex->nHeight, pto->id);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2384,7 +2384,7 @@ bool static FlushStateToDisk(CValidationState& state, FlushStateMode mode)
                 std::vector<std::pair<int, const CBlockFileInfo*> > vFiles;
                 vFiles.reserve(setDirtyFileInfo.size());
                 for (std::set<int>::iterator it = setDirtyFileInfo.begin(); it != setDirtyFileInfo.end(); ) {
-                    vFiles.push_back(std::make_pair(*it, &vinfoBlockFile[*it]));
+                    vFiles.emplace_back(*it, &vinfoBlockFile[*it]);
                     setDirtyFileInfo.erase(it++);
                 }
                 std::vector<const CBlockIndex*> vBlocks;
@@ -2695,7 +2695,7 @@ static CBlockIndex* FindMostWorkChain()
                         // If we're missing data, then add back to mapBlocksUnlinked,
                         // so that if the block arrives in the future we can try adding
                         // to setBlockIndexCandidates again.
-                        mapBlocksUnlinked.insert(std::make_pair(pindexFailed->pprev, pindexFailed));
+                        mapBlocksUnlinked.emplace(pindexFailed->pprev, pindexFailed);
                     }
                     setBlockIndexCandidates.erase(pindexFailed);
                     pindexFailed = pindexFailed->pprev;
@@ -2998,7 +2998,7 @@ CBlockIndex* AddToBlockIndex(const CBlock& block)
     // to avoid miners withholding blocks but broadcasting headers, to get a
     // competitive advantage.
     pindexNew->nSequenceId = 0;
-    BlockMap::iterator mi = mapBlockIndex.insert(std::make_pair(hash, pindexNew)).first;
+    BlockMap::iterator mi = mapBlockIndex.emplace(hash, pindexNew).first;
 
     pindexNew->phashBlock = &((*mi).first);
     BlockMap::iterator miPrev = mapBlockIndex.find(block.hashPrevBlock);
@@ -3068,7 +3068,7 @@ bool ReceivedBlockTransactions(const CBlock& block, CValidationState& state, CBl
         }
     } else {
         if (pindexNew->pprev && pindexNew->pprev->IsValid(BLOCK_VALID_TREE)) {
-            mapBlocksUnlinked.insert(std::make_pair(pindexNew->pprev, pindexNew));
+            mapBlocksUnlinked.emplace(pindexNew->pprev, pindexNew);
         }
     }
 
@@ -3282,7 +3282,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
                 for (const CTxIn& in : tx.vin) {
                     if (mapLockedInputs.count(in.prevout)) {
                         if (mapLockedInputs[in.prevout] != tx.GetHash()) {
-                            mapRejectedBlocks.insert(std::make_pair(block.GetHash(), GetTime()));
+                            mapRejectedBlocks.emplace(block.GetHash(), GetTime());
                             return state.DoS(100, false, REJECT_INVALID, "conflicting-tx-ix", false, "conflicting tx with instantsend lock");
                         }
                     }
@@ -3320,7 +3320,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
         if (nHeight != 0 && !IsInitialBlockDownload()) {
             // Last output of Cold-Stake is not abused
             if (IsPoS && !CheckColdStakeFreeOutput(block.vtx[1], nHeight)) {
-                mapRejectedBlocks.insert(std::make_pair(block.GetHash(), GetTime()));
+                mapRejectedBlocks.emplace(block.GetHash(), GetTime());
                 return state.DoS(0, false, REJECT_INVALID, "bad-p2cs-outs", false, "invalid cold-stake output");
             }
 
@@ -3329,7 +3329,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
 
             // check masternode/budget payment
             if (!IsBlockPayeeValid(block, nHeight)) {
-                mapRejectedBlocks.insert(std::make_pair(block.GetHash(), GetTime()));
+                mapRejectedBlocks.emplace(block.GetHash(), GetTime());
                 return state.DoS(0, false, REJECT_INVALID, "bad-cb-payee", false, "Couldn't find masternode/budget payment");
             }
         } else {
@@ -4104,7 +4104,7 @@ CBlockIndex* InsertBlockIndex(uint256 hash)
     CBlockIndex* pindexNew = new CBlockIndex();
     if (!pindexNew)
         throw std::runtime_error("LoadBlockIndex() : new CBlockIndex failed");
-    mi = mapBlockIndex.insert(std::make_pair(hash, pindexNew)).first;
+    mi = mapBlockIndex.emplace(hash, pindexNew).first;
 
     pindexNew->phashBlock = &((*mi).first);
 
@@ -4123,7 +4123,7 @@ bool static LoadBlockIndexDB(std::string& strError)
     vSortedByHeight.reserve(mapBlockIndex.size());
     for (const std::pair<const uint256, CBlockIndex*>& item : mapBlockIndex) {
         CBlockIndex* pindex = item.second;
-        vSortedByHeight.push_back(std::make_pair(pindex->nHeight, pindex));
+        vSortedByHeight.emplace_back(pindex->nHeight, pindex);
     }
     std::sort(vSortedByHeight.begin(), vSortedByHeight.end());
     for (const PAIRTYPE(int, CBlockIndex*) & item : vSortedByHeight) {
@@ -4138,7 +4138,7 @@ bool static LoadBlockIndexDB(std::string& strError)
                     pindex->nChainTx = pindex->pprev->nChainTx + pindex->nTx;
                 } else {
                     pindex->nChainTx = 0;
-                    mapBlocksUnlinked.insert(std::make_pair(pindex->pprev, pindex));
+                    mapBlocksUnlinked.emplace(pindex->pprev, pindex);
                 }
             } else {
                 pindex->nChainTx = pindex->nTx;
@@ -4444,7 +4444,7 @@ bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos* dbp)
                     LogPrint(BCLog::REINDEX, "%s: Out of order block %s, parent %s not known\n", __func__,
                             hash.GetHex(), block.hashPrevBlock.GetHex());
                     if (dbp)
-                        mapBlocksUnknownParent.insert(std::make_pair(block.hashPrevBlock, *dbp));
+                        mapBlocksUnknownParent.emplace(block.hashPrevBlock, *dbp);
                     continue;
                 }
 
@@ -4512,7 +4512,7 @@ void static CheckBlockIndex()
     // Build forward-pointing map of the entire block tree.
     std::multimap<CBlockIndex*, CBlockIndex*> forward;
     for (BlockMap::iterator it = mapBlockIndex.begin(); it != mapBlockIndex.end(); it++) {
-        forward.insert(std::make_pair(it->second->pprev, it->second));
+        forward.emplace(it->second->pprev, it->second);
     }
 
     assert(forward.size() == mapBlockIndex.size());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2078,7 +2078,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                 libzerocoin::PublicCoin coin(consensus.Zerocoin_Params(false));
                 if (!TxOutToPublicCoin(out, coin, state))
                     return state.DoS(100, error("%s: failed final check of zerocoinmint for tx %s", __func__, tx.GetHash().GetHex()));
-                vMints.emplace_back(std::make_pair(coin, tx.GetHash()));
+                vMints.emplace_back(coin, tx.GetHash());
             }
         }
 
@@ -2115,14 +2115,14 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                     }
                     nValueIn += publicSpend.getDenomination() * COIN;
                     //queue for db write after the 'justcheck' section has concluded
-                    vSpends.emplace_back(std::make_pair(publicSpend, tx.GetHash()));
+                    vSpends.emplace_back(publicSpend, tx.GetHash());
                     if (!ContextualCheckZerocoinSpend(tx, &publicSpend, pindex->nHeight, hashBlock))
                         return state.DoS(100, error("%s: failed to add block %s with invalid public zc spend", __func__, tx.GetHash().GetHex()), REJECT_INVALID);
                 } else {
                     libzerocoin::CoinSpend spend = TxInToZerocoinSpend(txIn);
                     nValueIn += spend.getDenomination() * COIN;
                     //queue for db write after the 'justcheck' section has concluded
-                    vSpends.emplace_back(std::make_pair(spend, tx.GetHash()));
+                    vSpends.emplace_back(spend, tx.GetHash());
                     if (!ContextualCheckZerocoinSpend(tx, &spend, pindex->nHeight, hashBlock))
                         return state.DoS(100, error("%s: failed to add block %s with invalid zerocoinspend", __func__, tx.GetHash().GetHex()), REJECT_INVALID);
                 }

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -408,7 +408,7 @@ bool CBudgetManager::AddFinalizedBudget(CFinalizedBudget& finalizedBudget)
         return false;
     }
 
-    mapFinalizedBudgets.insert(std::make_pair(finalizedBudget.GetHash(), finalizedBudget));
+    mapFinalizedBudgets.emplace(finalizedBudget.GetHash(), finalizedBudget);
     return true;
 }
 
@@ -424,7 +424,7 @@ bool CBudgetManager::AddProposal(CBudgetProposal& budgetProposal)
         return false;
     }
 
-    mapProposals.insert(std::make_pair(budgetProposal.GetHash(), budgetProposal));
+    mapProposals.emplace(budgetProposal.GetHash(), budgetProposal);
     LogPrint(BCLog::MNBUDGET,"%s: proposal %s added\n", __func__, budgetProposal.GetName());
     return true;
 }
@@ -444,7 +444,7 @@ void CBudgetManager::CheckAndRemove()
             LogPrint(BCLog::MNBUDGET,"%s: Found valid finalized budget: %s %s\n", __func__,
                       pfinalizedBudget->GetName(), pfinalizedBudget->GetFeeTXHash().ToString());
             pfinalizedBudget->CheckAndVote();
-            tmpMapFinalizedBudgets.insert(std::make_pair(pfinalizedBudget->GetHash(), *pfinalizedBudget));
+            tmpMapFinalizedBudgets.emplace(pfinalizedBudget->GetHash(), *pfinalizedBudget);
         }
     }
 
@@ -456,7 +456,7 @@ void CBudgetManager::CheckAndRemove()
         } else {
              LogPrint(BCLog::MNBUDGET,"%s: Found valid budget proposal: %s %s\n", __func__,
                       pbudgetProposal->GetName(), pbudgetProposal->GetFeeTXHash().ToString());
-             tmpMapProposals.insert(std::make_pair(pbudgetProposal->GetHash(), *pbudgetProposal));
+             tmpMapProposals.emplace(pbudgetProposal->GetHash(), *pbudgetProposal);
         }
     }
 
@@ -835,22 +835,22 @@ CAmount CBudgetManager::GetTotalBudget(int nHeight)
 
 void CBudgetManager::AddSeenProposal(const CBudgetProposalBroadcast& prop)
 {
-    mapSeenMasternodeBudgetProposals.insert(std::make_pair(prop.GetHash(), prop));
+    mapSeenMasternodeBudgetProposals.emplace(prop.GetHash(), prop);
 }
 
 void CBudgetManager::AddSeenProposalVote(const CBudgetVote& vote)
 {
-    mapSeenMasternodeBudgetVotes.insert(std::make_pair(vote.GetHash(), vote));
+    mapSeenMasternodeBudgetVotes.emplace(vote.GetHash(), vote);
 }
 
 void CBudgetManager::AddSeenFinalizedBudget(const CFinalizedBudgetBroadcast& bud)
 {
-    mapSeenFinalizedBudgets.insert(std::make_pair(bud.GetHash(), bud));
+    mapSeenFinalizedBudgets.emplace(bud.GetHash(), bud);
 }
 
 void CBudgetManager::AddSeenFinalizedBudgetVote(const CFinalizedBudgetVote& vote)
 {
-    mapSeenFinalizedBudgetVotes.insert(std::make_pair(vote.GetHash(), vote));
+    mapSeenFinalizedBudgetVotes.emplace(vote.GetHash(), vote);
 }
 
 
@@ -1097,8 +1097,8 @@ void CBudgetManager::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
             return;
         }
 
-
         AddSeenProposalVote(vote);
+
         if (!vote.CheckSignature()) {
             if (masternodeSync.IsSynced()) {
                 LogPrintf("mvote - signature invalid\n");
@@ -1177,6 +1177,7 @@ void CBudgetManager::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         }
 
         AddSeenFinalizedBudgetVote(vote);
+
         if (!vote.CheckSignature()) {
             if (masternodeSync.IsSynced()) {
                 LogPrintf("fbvote - signature from masternode %s invalid\n", HexStr(pmn->pubKeyMasternode));
@@ -2063,7 +2064,7 @@ bool CFinalizedBudget::IsPaidAlready(uint256 nProposalHash, int nBlockHeight) co
     // Now that we only have payments from the current payment cycle check if this budget was paid already
     if(mapPayment_History.count(nProposalHash) == 0) {
         // New proposal payment, insert into map for checks with later blocks from this cycle
-        mapPayment_History.insert(std::pair<uint256, int>(nProposalHash, nBlockHeight));
+        mapPayment_History.emplace(nProposalHash, nBlockHeight);
         LogPrint(BCLog::MNBUDGET, "%s: Budget Proposal %s, Block %d added to payment history\n",
                 __func__, nProposalHash.ToString().c_str(), nBlockHeight);
         return false;

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -115,7 +115,7 @@ void CMasternodeSync::AddedMasternodeList(const uint256& hash)
         }
     } else {
         lastMasternodeList = GetTime();
-        mapSeenSyncMNB.insert(std::make_pair(hash, 1));
+        mapSeenSyncMNB.emplace(hash, 1);
     }
 }
 
@@ -128,7 +128,7 @@ void CMasternodeSync::AddedMasternodeWinner(const uint256& hash)
         }
     } else {
         lastMasternodeWinner = GetTime();
-        mapSeenSyncMNW.insert(std::make_pair(hash, 1));
+        mapSeenSyncMNW.emplace(hash, 1);
     }
 }
 
@@ -144,7 +144,7 @@ void CMasternodeSync::AddedBudgetItem(const uint256& hash)
         }
     } else {
         lastBudgetItem = GetTime();
-        mapSeenSyncBudget.insert(std::make_pair(hash, 1));
+        mapSeenSyncBudget.emplace(hash, 1);
     }
 }
 

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -136,7 +136,7 @@ bool CMasternode::UpdateFromNewBroadcast(CMasternodeBroadcast& mnb)
         int nDoS = 0;
         if (mnb.lastPing.IsNull() || (!mnb.lastPing.IsNull() && mnb.lastPing.CheckAndUpdate(nDoS, false))) {
             lastPing = mnb.lastPing;
-            mnodeman.mapSeenMasternodePing.insert(std::make_pair(lastPing.GetHash(), lastPing));
+            mnodeman.mapSeenMasternodePing.emplace(lastPing.GetHash(), lastPing);
         }
         return true;
     }

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -509,7 +509,7 @@ CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight
         //make sure it has as many confirmations as there are masternodes
         if (pcoinsTip->GetCoinDepthAtHeight(mn.vin.prevout, nBlockHeight) < nMnCount) continue;
 
-        vecMasternodeLastPaid.push_back(std::make_pair(mn.SecondsSincePayment(), mn.vin));
+        vecMasternodeLastPaid.emplace_back(mn.SecondsSincePayment(), mn.vin);
     }
 
     nCount = (int)vecMasternodeLastPaid.size();
@@ -597,7 +597,7 @@ int CMasternodeMan::GetMasternodeRank(const CTxIn& vin, int64_t nBlockHeight, in
         uint256 n = mn.CalculateScore(1, nBlockHeight);
         int64_t n2 = n.GetCompact(false);
 
-        vecMasternodeScores.push_back(std::make_pair(n2, mn.vin));
+        vecMasternodeScores.emplace_back(n2, mn.vin);
     }
 
     sort(vecMasternodeScores.rbegin(), vecMasternodeScores.rend(), CompareScoreTxIn());
@@ -629,14 +629,14 @@ std::vector<std::pair<int, CMasternode> > CMasternodeMan::GetMasternodeRanks(int
         if (mn.protocolVersion < minProtocol) continue;
 
         if (!mn.IsEnabled()) {
-            vecMasternodeScores.push_back(std::make_pair(9999, mn));
+            vecMasternodeScores.emplace_back(9999, mn);
             continue;
         }
 
         uint256 n = mn.CalculateScore(1, nBlockHeight);
         int64_t n2 = n.GetCompact(false);
 
-        vecMasternodeScores.push_back(std::make_pair(n2, mn));
+        vecMasternodeScores.emplace_back(n2, mn);
     }
 
     sort(vecMasternodeScores.rbegin(), vecMasternodeScores.rend(), CompareScoreMN());
@@ -644,7 +644,7 @@ std::vector<std::pair<int, CMasternode> > CMasternodeMan::GetMasternodeRanks(int
     int rank = 0;
     for (PAIRTYPE(int64_t, CMasternode) & s : vecMasternodeScores) {
         rank++;
-        vecMasternodeRanks.push_back(std::make_pair(rank, s.second));
+        vecMasternodeRanks.emplace_back(rank, s.second);
     }
 
     return vecMasternodeRanks;
@@ -665,7 +665,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
             masternodeSync.AddedMasternodeList(mnb.GetHash());
             return;
         }
-        mapSeenMasternodeBroadcast.insert(std::make_pair(mnb.GetHash(), mnb));
+        mapSeenMasternodeBroadcast.emplace(mnb.GetHash(), mnb);
 
         int nDoS = 0;
         if (!mnb.CheckAndUpdate(nDoS)) {
@@ -709,7 +709,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         LogPrint(BCLog::MNPING, "mnp - Masternode ping, vin: %s\n", mnp.vin.prevout.hash.ToString());
 
         if (mapSeenMasternodePing.count(mnp.GetHash())) return; //seen
-        mapSeenMasternodePing.insert(std::make_pair(mnp.GetHash(), mnp));
+        mapSeenMasternodePing.emplace(mnp.GetHash(), mnp);
 
         int nDoS = 0;
         if (mnp.CheckAndUpdate(nDoS)) return;
@@ -768,7 +768,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
                     pfrom->PushInventory(CInv(MSG_MASTERNODE_ANNOUNCE, hash));
                     nInvCount++;
 
-                    if (!mapSeenMasternodeBroadcast.count(hash)) mapSeenMasternodeBroadcast.insert(std::make_pair(hash, mnb));
+                    if (!mapSeenMasternodeBroadcast.count(hash)) mapSeenMasternodeBroadcast.emplace(hash, mnb);
 
                     if (vin == mn.vin) {
                         LogPrint(BCLog::MASTERNODE, "dseg - Sent 1 Masternode entry to peer %i\n", pfrom->GetId());
@@ -802,8 +802,8 @@ void CMasternodeMan::Remove(CTxIn vin)
 
 void CMasternodeMan::UpdateMasternodeList(CMasternodeBroadcast mnb)
 {
-    mapSeenMasternodePing.insert(std::make_pair(mnb.lastPing.GetHash(), mnb.lastPing));
-    mapSeenMasternodeBroadcast.insert(std::make_pair(mnb.GetHash(), mnb));
+    mapSeenMasternodePing.emplace(mnb.lastPing.GetHash(), mnb.lastPing);
+    mapSeenMasternodeBroadcast.emplace(mnb.GetHash(), mnb);
     masternodeSync.AddedMasternodeList(mnb.GetHash());
 
     LogPrint(BCLog::MASTERNODE,"CMasternodeMan::UpdateMasternodeList() -- masternode=%s\n", mnb.vin.prevout.ToString());

--- a/src/merkleblock.cpp
+++ b/src/merkleblock.cpp
@@ -26,7 +26,7 @@ CMerkleBlock::CMerkleBlock(const CBlock& block, CBloomFilter& filter)
         const uint256& hash = block.vtx[i].GetHash();
         if (filter.IsRelevantAndUpdate(block.vtx[i])) {
             vMatch.push_back(true);
-            vMatchedTxn.push_back(std::make_pair(i, hash));
+            vMatchedTxn.emplace_back(i, hash);
         } else
             vMatch.push_back(false);
         vHashes.push_back(hash);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -324,7 +324,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, 
                 porphan->dPriority = dPriority;
                 porphan->feeRate = feeRate;
             } else
-                vecPriority.push_back(TxPriority(dPriority, feeRate, &mi->GetTx()));
+                vecPriority.emplace_back(dPriority, feeRate, &mi->GetTx());
         }
 
         // Collect transactions into block
@@ -419,7 +419,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, 
                     if (!porphan->setDependsOn.empty()) {
                         porphan->setDependsOn.erase(hash);
                         if (porphan->setDependsOn.empty()) {
-                            vecPriority.push_back(TxPriority(porphan->dPriority, porphan->feeRate, porphan->ptx));
+                            vecPriority.emplace_back(porphan->dPriority, porphan->feeRate, porphan->ptx);
                             std::push_heap(vecPriority.begin(), vecPriority.end(), comparer);
                         }
                     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -739,7 +739,7 @@ bool CNode::ReceiveMsgBytes(const char* pch, unsigned int nBytes, bool& complete
         // get current incomplete message, or create a new one
         if (vRecvMsg.empty() ||
             vRecvMsg.back().complete())
-            vRecvMsg.push_back(CNetMessage(Params().MessageStart(), SER_NETWORK, INIT_PROTO_VERSION));
+            vRecvMsg.emplace_back(Params().MessageStart(), SER_NETWORK, INIT_PROTO_VERSION);
 
         CNetMessage& msg = vRecvMsg.back();
 
@@ -1790,17 +1790,17 @@ std::vector<AddedNodeInfo> CConnman::GetAddedNodeInfo()
             // strAddNode is an IP:port
             auto it = mapConnected.find(service);
             if (it != mapConnected.end()) {
-                ret.push_back(AddedNodeInfo{strAddNode, service, true, it->second});
+                ret.emplace_back(strAddNode, service, true, it->second);
             } else {
-                ret.push_back(AddedNodeInfo{strAddNode, CService(), false, false});
+                ret.emplace_back(strAddNode, CService(), false, false);
             }
         } else {
             // strAddNode is a name
             auto it = mapConnectedByName.find(strAddNode);
             if (it != mapConnectedByName.end()) {
-                ret.push_back(AddedNodeInfo{strAddNode, it->second.second, true, it->second.first});
+                ret.emplace_back(strAddNode, it->second.second, true, it->second.first);
             } else {
-                ret.push_back(AddedNodeInfo{strAddNode, CService(), false, false});
+                ret.emplace_back(strAddNode, CService(), false, false);
             }
         }
     }
@@ -1999,7 +1999,7 @@ bool CConnman::BindListenPort(const CService& addrBind, std::string& strError, b
         return false;
     }
 
-    vhListenSocket.push_back(ListenSocket(hListenSocket, fWhitelisted));
+    vhListenSocket.emplace_back(hListenSocket, fWhitelisted);
 
     if (addrBind.IsRoutable() && fDiscover && !fWhitelisted)
         AddLocal(addrBind, LOCAL_BIND);

--- a/src/net.h
+++ b/src/net.h
@@ -100,6 +100,13 @@ struct AddedNodeInfo
     CService resolvedAddress;
     bool fConnected;
     bool fInbound;
+
+    AddedNodeInfo(const std::string& _strAddedNode, const CService& _resolvedAddress, bool _fConnected, bool _fInbound):
+        strAddedNode(_strAddedNode),
+        resolvedAddress(_resolvedAddress),
+        fConnected(_fConnected),
+        fInbound(_fInbound)
+    {}
 };
 
 class CTransaction;

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -101,19 +101,19 @@ bool static LookupIntern(const char* pszName, std::vector<CNetAddr>& vIP, unsign
     struct in_addr ipv4_addr;
 #ifdef HAVE_INET_PTON
     if (inet_pton(AF_INET, pszName, &ipv4_addr) > 0) {
-        vIP.push_back(CNetAddr(ipv4_addr));
+        vIP.emplace_back(ipv4_addr);
         return true;
     }
 
     struct in6_addr ipv6_addr;
     if (inet_pton(AF_INET6, pszName, &ipv6_addr) > 0) {
-        vIP.push_back(CNetAddr(ipv6_addr));
+        vIP.emplace_back(ipv6_addr);
         return true;
     }
 #else
     ipv4_addr.s_addr = inet_addr(pszName);
     if (ipv4_addr.s_addr != INADDR_NONE) {
-        vIP.push_back(CNetAddr(ipv4_addr));
+        vIP.emplace_back(ipv4_addr);
         return true;
     }
 #endif
@@ -163,12 +163,12 @@ bool static LookupIntern(const char* pszName, std::vector<CNetAddr>& vIP, unsign
     while (aiTrav != NULL && (nMaxSolutions == 0 || vIP.size() < nMaxSolutions)) {
         if (aiTrav->ai_family == AF_INET) {
             assert(aiTrav->ai_addrlen >= sizeof(sockaddr_in));
-            vIP.push_back(CNetAddr(((struct sockaddr_in*)(aiTrav->ai_addr))->sin_addr));
+            vIP.emplace_back(((struct sockaddr_in*)(aiTrav->ai_addr))->sin_addr);
         }
 
         if (aiTrav->ai_family == AF_INET6) {
             assert(aiTrav->ai_addrlen >= sizeof(sockaddr_in6));
-            vIP.push_back(CNetAddr(((struct sockaddr_in6*)(aiTrav->ai_addr))->sin6_addr));
+            vIP.emplace_back(((struct sockaddr_in6*)(aiTrav->ai_addr))->sin6_addr);
         }
 
         aiTrav = aiTrav->ai_next;

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -90,7 +90,7 @@ public:
         mapNodeRows.clear();
         int row = 0;
         Q_FOREACH (const CNodeCombinedStats& stats, cachedNodeStats)
-            mapNodeRows.insert(std::pair<NodeId, int>(stats.nodeStats.nodeid, row++));
+            mapNodeRows.emplace(stats.nodeStats.nodeid, row++);
     }
 
     int size()

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -471,10 +471,10 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(WalletModelTransaction& tran
                 std::string key("PaymentRequest");
                 std::string value;
                 rcp.paymentRequest.SerializeToString(&value);
-                newTx->vOrderForm.push_back(std::make_pair(key, value));
+                newTx->vOrderForm.emplace_back(key, value);
             } else if (!rcp.message.isEmpty()) // Message from normal pivx:URI (pivx:XyZ...?message=example)
             {
-                newTx->vOrderForm.push_back(std::make_pair("Message", rcp.message.toStdString()));
+                newTx->vOrderForm.emplace_back("Message", rcp.message.toStdString());
             }
         }
 
@@ -636,7 +636,7 @@ static std::vector<std::pair<uint256, ChangeType> > vQueueNotifications;
 static void NotifyTransactionChanged(WalletModel* walletmodel, CWallet* wallet, const uint256& hash, ChangeType status)
 {
     if (fQueueNotifications) {
-        vQueueNotifications.push_back(std::make_pair(hash, status));
+        vQueueNotifications.emplace_back(hash, status);
         return;
     }
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -330,7 +330,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
                 subtotal += out.amount();
                 const unsigned char* scriptStr = (const unsigned char*)out.script().data();
                 CScript scriptPubKey(scriptStr, scriptStr + out.script().size());
-                vecSend.push_back(CRecipient{scriptPubKey, static_cast<CAmount>(out.amount()), false});
+                vecSend.emplace_back(scriptPubKey, static_cast<CAmount>(out.amount()), false);
             }
             if (subtotal <= 0) {
                 return InvalidAmount;
@@ -370,7 +370,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
                 // Regular P2PK or P2PKH
                 scriptPubKey = GetScriptForDestination(out);
             }
-            vecSend.push_back(CRecipient{scriptPubKey, rcp.amount, false});
+            vecSend.emplace_back(scriptPubKey, rcp.amount, false);
 
             total += rcp.amount;
         }

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -440,7 +440,7 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
                 return RESTERR(req, HTTP_INTERNAL_SERVER_ERROR, "Parse error");
 
             txid.SetHex(strTxid);
-            vOutPoints.push_back(COutPoint(txid, (uint32_t)nOutput));
+            vOutPoints.emplace_back(txid, (uint32_t)nOutput);
         }
 
         if (vOutPoints.size() > 0)

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1440,8 +1440,8 @@ UniValue getblockindexstats(const JSONRPCRequest& request) {
     std::map<libzerocoin::CoinDenomination, int64_t> mapSpendCount;
     std::map<libzerocoin::CoinDenomination, int64_t> mapPublicSpendCount;
     for (auto& denom : libzerocoin::zerocoinDenomList) {
-        mapSpendCount.insert(std::make_pair(denom, 0));
-        mapPublicSpendCount.insert(std::make_pair(denom, 0));
+        mapSpendCount.emplace(denom, 0);
+        mapPublicSpendCount.emplace(denom, 0);
     }
 
     CBlockIndex* pindex = nullptr;

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -195,8 +195,7 @@ CRPCConvertTable::CRPCConvertTable()
         (sizeof(vRPCConvertParams) / sizeof(vRPCConvertParams[0]));
 
     for (unsigned int i = 0; i < n_elem; i++) {
-        members.insert(std::make_pair(vRPCConvertParams[i].methodName,
-            vRPCConvertParams[i].paramIdx));
+        members.emplace(vRPCConvertParams[i].methodName, vRPCConvertParams[i].paramIdx);
     }
 }
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -858,7 +858,7 @@ UniValue sendrawtransaction(const JSONRPCRequest& request)
     if (!fHaveMempool && !fHaveChain) {
         // push to local node and sync with wallets
         if (fSwiftX) {
-            mapTxLockReq.insert(std::make_pair(tx.GetHash(), tx));
+            mapTxLockReq.emplace(tx.GetHash(), tx);
             CreateNewLock(tx);
             g_connman->RelayTransactionLockReq(tx, true);
         }

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -201,7 +201,7 @@ std::string CRPCTable::help(std::string strCommand) const
     std::vector<std::pair<std::string, const CRPCCommand*> > vCommands;
 
     for (const auto& entry : mapCommands)
-        vCommands.push_back(std::make_pair(entry.second->category + entry.first, entry.second));
+        vCommands.emplace_back(entry.second->category + entry.first, entry.second);
     std::sort(vCommands.begin(), vCommands.end());
 
     for (const std::pair<std::string, const CRPCCommand*>& command : vCommands) {
@@ -630,7 +630,7 @@ void RPCRunLater(const std::string& name, std::function<void(void)> func, int64_
         throw JSONRPCError(RPC_INTERNAL_ERROR, "No timer handler registered for RPC");
     deadlineTimers.erase(name);
     LogPrint(BCLog::RPC, "queue run of timer %s in %i seconds (using %s)\n", name, nSeconds, timerInterface->Name());
-    deadlineTimers.insert(std::make_pair(name, boost::shared_ptr<RPCTimerBase>(timerInterface->NewTimer(func, nSeconds*1000))));
+    deadlineTimers.emplace(name, boost::shared_ptr<RPCTimerBase>(timerInterface->NewTimer(func, nSeconds*1000)));
 }
 
 CRPCTable tableRPC;

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -89,7 +89,7 @@ void CScheduler::schedule(CScheduler::Function f, boost::chrono::system_clock::t
 {
     {
         boost::unique_lock<boost::mutex> lock(newTaskMutex);
-        taskQueue.insert(std::make_pair(t, f));
+        taskQueue.emplace(t, f);
     }
     newTaskScheduled.notify_one();
 }

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -101,7 +101,7 @@ static bool SignStep(const BaseSignatureCreator& creator, const CScript& scriptP
         return true;
     case TX_SCRIPTHASH:
         if (creator.KeyStore().GetCScript(uint160(vSolutions[0]), scriptRet)) {
-            ret.push_back(std::vector<unsigned char>(scriptRet.begin(), scriptRet.end()));
+            ret.emplace_back(scriptRet.begin(), scriptRet.end());
             return true;
         }
         return false;
@@ -167,7 +167,7 @@ bool ProduceSignature(const BaseSignatureCreator& creator, const CScript& fromPu
         // and then the serialized subscript:
         script = subscript = CScript(result[0].begin(), result[0].end());
         solved = solved && SignStep(creator, script, result, whichType, SIGVERSION_BASE, fColdStake) && whichType != TX_SCRIPTHASH;
-        result.push_back(std::vector<unsigned char>(subscript.begin(), subscript.end()));
+        result.emplace_back(subscript.begin(), subscript.end());
     }
 
     sigdata.scriptSig = PushAll(result);
@@ -252,7 +252,7 @@ static std::vector<valtype> CombineMultisig(const CScript& scriptPubKey, const B
     }
     // Now build a merged CScript:
     unsigned int nSigsHave = 0;
-    std::vector<valtype> result; result.push_back(valtype()); // pop-one-too-many workaround
+    std::vector<valtype> result; result.emplace_back(); // pop-one-too-many workaround
     for (unsigned int i = 0; i < nPubKeys && nSigsHave < nSigsRequired; i++)
     {
         if (sigs.count(vSolutions[i+1]))

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -248,8 +248,8 @@ bool ExtractDestinations(const CScript& scriptPubKey, txnouttype& typeRet, std::
         if (vSolutions.size() < 2)
             return false;
         nRequiredRet = 2;
-        addressRet.push_back(CKeyID(uint160(vSolutions[0])));
-        addressRet.push_back(CKeyID(uint160(vSolutions[1])));
+        addressRet.emplace_back(uint160(vSolutions[0]));
+        addressRet.emplace_back(uint160(vSolutions[1]));
         return true;
 
     } else

--- a/src/stakeinput.cpp
+++ b/src/stakeinput.cpp
@@ -98,7 +98,7 @@ bool CPivStake::CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmoun
         scriptPubKey = scriptPubKeyKernel;
     }
 
-    vout.emplace_back(CTxOut(0, scriptPubKey));
+    vout.emplace_back(0, scriptPubKey);
 
     // Calculate if we need to split the output
     if (pwallet->nStakeSplitThreshold > 0) {
@@ -110,7 +110,7 @@ bool CPivStake::CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmoun
                 nSplit = txSizeMax;
             for (int i = nSplit; i > 1; i--) {
                 LogPrintf("%s: StakeSplit: nTotal = %d; adding output %d of %d\n", __func__, nTotal, (nSplit-i)+2, nSplit);
-                vout.emplace_back(CTxOut(0, scriptPubKey));
+                vout.emplace_back(0, scriptPubKey);
             }
         }
     }

--- a/src/swifttx.cpp
+++ b/src/swifttx.cpp
@@ -82,7 +82,7 @@ void ProcessMessageSwiftTX(CNode* pfrom, std::string& strCommand, CDataStream& v
 
             DoConsensusVote(tx, nBlockHeight);
 
-            mapTxLockReq.insert(std::make_pair(tx.GetHash(), tx));
+            mapTxLockReq.emplace(tx.GetHash(), tx);
 
             LogPrintf("%s : Transaction Lock Request: %s %s : accepted %s\n", __func__,
                     pfrom->addr.ToString().c_str(), pfrom->cleanSubVer.c_str(),
@@ -95,7 +95,7 @@ void ProcessMessageSwiftTX(CNode* pfrom, std::string& strCommand, CDataStream& v
             return;
 
         } else {
-            mapTxLockReqRejected.insert(std::make_pair(tx.GetHash(), tx));
+            mapTxLockReqRejected.emplace(tx.GetHash(), tx);
 
             // can we get the conflicting transaction as proof?
 
@@ -105,7 +105,7 @@ void ProcessMessageSwiftTX(CNode* pfrom, std::string& strCommand, CDataStream& v
 
             for (const CTxIn& in : tx.vin) {
                 if (!mapLockedInputs.count(in.prevout)) {
-                    mapLockedInputs.insert(std::make_pair(in.prevout, tx.GetHash()));
+                    mapLockedInputs.emplace(in.prevout, tx.GetHash());
                 }
             }
 
@@ -119,7 +119,7 @@ void ProcessMessageSwiftTX(CNode* pfrom, std::string& strCommand, CDataStream& v
 
                         //reprocess the last 15 blocks
                         ReprocessBlocks(15);
-                        mapTxLockReq.insert(std::make_pair(tx.GetHash(), tx));
+                        mapTxLockReq.emplace(tx.GetHash(), tx);
                     }
                 }
             }
@@ -138,7 +138,7 @@ void ProcessMessageSwiftTX(CNode* pfrom, std::string& strCommand, CDataStream& v
             return;
         }
 
-        mapTxLockVote.insert(std::make_pair(ctx.GetHash(), ctx));
+        mapTxLockVote.emplace(ctx.GetHash(), ctx);
 
         if (ProcessConsensusVote(pfrom, ctx)) {
             //Spam/Dos protection
@@ -249,7 +249,7 @@ int64_t CreateNewLock(CTransaction tx)
         newLock.nExpiration = GetTime() + (60 * 60); //locks expire after 60 minutes (24 confirmations)
         newLock.nTimeout = GetTime() + (60 * 5);
         newLock.txHash = tx.GetHash();
-        mapTxLocks.insert(std::make_pair(tx.GetHash(), newLock));
+        mapTxLocks.emplace(tx.GetHash(), newLock);
     } else {
         mapTxLocks[tx.GetHash()].nBlockHeight = nBlockHeight;
         LogPrint(BCLog::MASTERNODE, "%s : Transaction Lock Exists %s !\n", __func__, tx.GetHash().ToString().c_str());
@@ -341,7 +341,7 @@ bool ProcessConsensusVote(CNode* pnode, CConsensusVote& ctx)
         newLock.nExpiration = GetTime() + (60 * 60);
         newLock.nTimeout = GetTime() + (60 * 5);
         newLock.txHash = ctx.txHash;
-        mapTxLocks.insert(std::make_pair(ctx.txHash, newLock));
+        mapTxLocks.emplace(ctx.txHash, newLock);
     } else
         LogPrint(BCLog::MASTERNODE, "%s : Transaction Lock Exists %s !\n", __func__, ctx.txHash.ToString().c_str());
 
@@ -379,7 +379,7 @@ bool ProcessConsensusVote(CNode* pnode, CConsensusVote& ctx)
                 if (mapTxLockReq.count(ctx.txHash)) {
                     for (const CTxIn& in : tx.vin) {
                         if (!mapLockedInputs.count(in.prevout)) {
-                            mapLockedInputs.insert(std::make_pair(in.prevout, ctx.txHash));
+                            mapLockedInputs.emplace(in.prevout, ctx.txHash);
                         }
                     }
                 }

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -124,7 +124,7 @@ static void push_lock(void* c, const CLockLocation& locklocation)
     LockData& lockdata = GetLockData();
     std::lock_guard<std::mutex> lock(lockdata.dd_mutex);
 
-    g_lockstack.push_back(std::make_pair(c, locklocation));
+    g_lockstack.emplace_back(c, locklocation);
 
     for (const std::pair<void*, CLockLocation>& i : g_lockstack) {
         if (i.first == c)

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -27,7 +27,7 @@ struct TestVector {
     TestVector(std::string strHexMasterIn) : strHexMaster(strHexMasterIn) {}
 
     TestVector& operator()(std::string pub, std::string prv, unsigned int nChild) {
-        vDerive.push_back(TestDerivation());
+        vDerive.emplace_back();
         TestDerivation &der = vDerive.back();
         der.pub = pub;
         der.prv = prv;

--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -55,14 +55,14 @@ CBlock CreateDummyBlockWithSignature(CKey stakingKey, BlockSignatureType type, b
     // Add dummy input
     txCoinStake.vin.emplace_back(input);
     // Empty first output
-    txCoinStake.vout.emplace_back(CTxOut(0, CScript()));
+    txCoinStake.vout.emplace_back(0, CScript());
     // P2PK staking output
     CScript scriptPubKey = GetScriptForType(stakingKey.GetPubKey(), type);
-    txCoinStake.vout.emplace_back(CTxOut(0, scriptPubKey));
+    txCoinStake.vout.emplace_back(0, scriptPubKey);
 
     // Now the block.
     CBlock block;
-    block.vtx.emplace_back(CTransaction()); // dummy first tx
+    block.vtx.emplace_back(); // dummy first tx
     block.vtx.emplace_back(txCoinStake);
     SignBlockWithKey(block, stakingKey);
 

--- a/src/test/pmt_tests.cpp
+++ b/src/test/pmt_tests.cpp
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(pmt_test1)
         for (unsigned int j=0; j<nTx; j++) {
             CMutableTransaction tx;
             tx.nLockTime = rand(); // actual transaction data doesn't matter; just make the nLockTime's unique
-            block.vtx.push_back(CTransaction(tx));
+            block.vtx.emplace_back(tx);
         }
 
         // calculate actual merkle root and height

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -100,7 +100,7 @@ void static RandomTransaction(CMutableTransaction &tx, bool fSingle) {
     int ins = (InsecureRandBits(2)) + 1;
     int outs = fSingle ? ins : (InsecureRandBits(2)) + 1;
     for (int in = 0; in < ins; in++) {
-        tx.vin.push_back(CTxIn());
+        tx.vin.emplace_back();
         CTxIn &txin = tx.vin.back();
         txin.prevout.hash = InsecureRand256();
         txin.prevout.n = InsecureRandBits(2);
@@ -108,7 +108,7 @@ void static RandomTransaction(CMutableTransaction &tx, bool fSingle) {
         txin.nSequence = (InsecureRandBool()) ? InsecureRand32() : (unsigned int)-1;
     }
     for (int out = 0; out < outs; out++) {
-        tx.vout.push_back(CTxOut());
+        tx.vout.emplace_back();
         CTxOut &txout = tx.vout.back();
         txout.nValue = InsecureRandRange(100000000);
         RandomScript(txout.scriptPubKey);

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -394,7 +394,7 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction) {
         std::vector<CScriptCheck> vChecks;
         const CTxOut& output = coins[tx.vin[i].prevout.n].out;
         CScriptCheck check(output.scriptPubKey, output.nValue, tx, i, SCRIPT_VERIFY_P2SH, false, &precomTxData);
-        vChecks.push_back(CScriptCheck());
+        vChecks.emplace_back();
         check.swap(vChecks.back());
         control.Add(vChecks);
     }

--- a/src/test/zerocoin_denomination_tests.cpp
+++ b/src/test/zerocoin_denomination_tests.cpp
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(zerocoin_spend_test241)
             meta.nVersion = 1;
             listMints.push_back(meta);
         }
-        mapDenom.insert(std::pair<libzerocoin::CoinDenomination, CAmount>(denom, DenomAmounts[j]));
+        mapDenom.emplace(denom, DenomAmounts[j]);
         j++;
     }
     CoinsHeld = nTotalAmount / COIN;
@@ -182,7 +182,7 @@ BOOST_AUTO_TEST_CASE(zerocoin_spend_test115)
             meta.nVersion = 1;
             listMints.push_back(meta);
         }
-        mapDenom.insert(std::pair<libzerocoin::CoinDenomination, CAmount>(denom, DenomAmounts[j]));
+        mapDenom.emplace(denom, DenomAmounts[j]);
         j++;
     }
     CoinsHeld = nTotalAmount / COIN;
@@ -265,7 +265,7 @@ BOOST_AUTO_TEST_CASE(zerocoin_spend_test_from_245)
             meta.nVersion = 1;
             listMints.push_back(meta);
         }
-        mapOfDenomsHeld.insert(std::pair<libzerocoin::CoinDenomination, CAmount>(denom, DenomAmounts[j]));
+        mapOfDenomsHeld.emplace(denom, DenomAmounts[j]);
         j++;
     }
     CoinsHeld = nTotalAmount / COIN;
@@ -365,7 +365,7 @@ BOOST_AUTO_TEST_CASE(zerocoin_spend_test_from_145)
             meta.nVersion = 1;
             listMints.push_back(meta);
         }
-        mapOfDenomsHeld.insert(std::pair<libzerocoin::CoinDenomination, CAmount>(denom, DenomAmounts[j]));
+        mapOfDenomsHeld.emplace(denom, DenomAmounts[j]);
         j++;
     }
     CoinsHeld = nTotalAmount / COIN;
@@ -468,7 +468,7 @@ BOOST_AUTO_TEST_CASE(zerocoin_spend_test99)
             meta.nVersion = 1;
             listMints.push_back(meta);
         }
-        mapOfDenomsHeld.insert(std::pair<libzerocoin::CoinDenomination, CAmount>(denom, DenomAmounts[j]));
+        mapOfDenomsHeld.emplace(denom, DenomAmounts[j]);
         j++;
     }
     CoinsHeld = nTotalAmount / COIN;

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -203,7 +203,7 @@ bool CDBEnv::Salvage(std::string strFile, bool fAggressive, std::vector<CDBEnv::
         getline(strDump, keyHex);
         if (keyHex != "DATA=END") {
             getline(strDump, valueHex);
-            vResult.push_back(std::make_pair(ParseHex(keyHex), ParseHex(valueHex)));
+            vResult.emplace_back(ParseHex(keyHex), ParseHex(valueHex));
         }
     }
 

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -468,7 +468,7 @@ UniValue dumpwallet(const JSONRPCRequest& request)
     // sort time/key pairs
     std::vector<std::pair<int64_t, CKeyID> > vKeyBirth;
     for (std::map<CKeyID, int64_t>::const_iterator it = mapKeyBirth.begin(); it != mapKeyBirth.end(); it++) {
-        vKeyBirth.push_back(std::make_pair(it->second, it->first));
+        vKeyBirth.emplace_back(it->second, it->first);
     }
     mapKeyBirth.clear();
     std::sort(vKeyBirth.begin(), vKeyBirth.end());

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1896,7 +1896,7 @@ UniValue sendmany(const JSONRPCRequest& request)
         CAmount nAmount = AmountFromValue(sendTo[name_]);
         totalAmount += nAmount;
 
-        vecSend.push_back(CRecipient{scriptPubKey, nAmount, false});
+        vecSend.emplace_back(scriptPubKey, nAmount, false);
     }
 
     isminefilter filter = ISMINE_SPENDABLE;
@@ -4283,7 +4283,7 @@ extern UniValue DoZpivSpend(const CAmount nAmount, std::vector<CZerocoinMint>& v
         address = DecodeDestination(address_str, isStaking);
         if(!IsValidDestination(address) || isStaking)
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid PIVX address");
-        outputs.push_back(std::pair<CTxDestination, CAmount>(address, nAmount));
+        outputs.emplace_back(address, nAmount);
     }
 
     EnsureWalletIsUnlocked();

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3973,7 +3973,7 @@ UniValue listzerocoinamounts(const JSONRPCRequest& request)
 
     std::map<libzerocoin::CoinDenomination, CAmount> spread;
     for (const auto& denom : libzerocoin::zerocoinDenomList)
-        spread.insert(std::pair<libzerocoin::CoinDenomination, CAmount>(denom, 0));
+        spread.emplace(denom, 0);
     for (auto& meta : setMints) spread.at(meta.denom)++;
 
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -325,7 +325,7 @@ CBlockIndex* SimpleFakeMine(CWalletTx& wtx, CBlockIndex* pprev = nullptr)
     if (pprev) block.hashPrevBlock = pprev->GetBlockHash();
     CBlockIndex* fakeIndex = new CBlockIndex(block);
     fakeIndex->pprev = pprev;
-    mapBlockIndex.insert(std::make_pair(block.GetHash(), fakeIndex));
+    mapBlockIndex.emplace(block.GetHash(), fakeIndex);
     fakeIndex->phashBlock = &mapBlockIndex.find(block.GetHash())->first;
     chainActive.SetTip(fakeIndex);
     BOOST_CHECK(chainActive.Contains(fakeIndex));

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1898,7 +1898,7 @@ void CWallet::GetAvailableP2CSCoins(std::vector<COutput>& vCoins) const {
                         bool isMineSpendable = mine & ISMINE_SPENDABLE_DELEGATED;
                         if (mine & ISMINE_COLD || isMineSpendable)
                             // Depth and solvability members are not used, no need waste resources and set them for now.
-                            vCoins.emplace_back(COutput(pcoin, i, 0, isMineSpendable, true));
+                            vCoins.emplace_back(pcoin, i, 0, isMineSpendable, true);
                     }
                 }
             }
@@ -2076,7 +2076,7 @@ bool CWallet::AvailableCoins(std::vector<COutput>* pCoins,      // --> populates
 
                 // found valid coin
                 if (!pCoins) return true;
-                pCoins->emplace_back(COutput(pcoin, i, nDepth, spendable, solvable));
+                pCoins->emplace_back(pcoin, i, nDepth, spendable, solvable);
             }
         }
         return (pCoins && pCoins->size() > 0);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2322,7 +2322,7 @@ bool CWallet::CreateBudgetFeeTX(CWalletTx& tx, const uint256& hash, CReserveKey&
     std::vector<CRecipient> vecSend;
     vecSend.emplace_back(scriptChange, (fFinalization ? BUDGET_FEE_TX : BUDGET_FEE_TX_OLD), false);
 
-    CCoinControl* coinControl = NULL;
+    CCoinControl* coinControl = nullptr;
     int nChangePosInOut = -1;
     bool success = CreateTransaction(vecSend, tx, keyChange, nFeeRet, nChangePosInOut, strFail, coinControl, ALL_COINS, true, false /*useIX*/, (CAmount)0);
     if (!success) {
@@ -2457,9 +2457,9 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend,
                         for (int i = 0; i < nSplitBlock; i++) {
                             if (i == nSplitBlock - 1) {
                                 uint64_t nRemainder = rec.nAmount % nSplitBlock;
-                                txNew.vout.push_back(CTxOut((rec.nAmount / nSplitBlock) + nRemainder, rec.scriptPubKey));
+                                txNew.vout.emplace_back((rec.nAmount / nSplitBlock) + nRemainder, rec.scriptPubKey);
                             } else
-                                txNew.vout.push_back(CTxOut(rec.nAmount / nSplitBlock, rec.scriptPubKey));
+                                txNew.vout.emplace_back(rec.nAmount / nSplitBlock, rec.scriptPubKey);
                         }
                     }
                 }
@@ -2567,7 +2567,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend,
 
                 // Fill vin
                 for (const PAIRTYPE(const CWalletTx*, unsigned int) & coin : setCoins)
-                    txNew.vin.push_back(CTxIn(coin.first->GetHash(), coin.second));
+                    txNew.vin.emplace_back(coin.first->GetHash(), coin.second);
 
                 // Sign
                 int nIn = 0;
@@ -2681,7 +2681,7 @@ bool CWallet::CreateCoinStake(
     // Mark coin stake transaction
     txNew.vin.clear();
     txNew.vout.clear();
-    txNew.vout.emplace_back(CTxOut(0, CScript()));
+    txNew.vout.emplace_back(0, CScript());
 
     // update staker status (hash)
     pStakerStatus->SetLastTip(pindexPrev);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -638,7 +638,7 @@ bool CWallet::IsSpent(const uint256& hash, unsigned int n) const
 
 void CWallet::AddToSpends(const COutPoint& outpoint, const uint256& wtxid)
 {
-    mapTxSpends.insert(std::make_pair(outpoint, wtxid));
+    mapTxSpends.emplace(outpoint, wtxid);
     setLockedCoins.erase(outpoint);
 
     std::pair<TxSpends::iterator, TxSpends::iterator> range;
@@ -849,14 +849,14 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose)
     uint256 hash = wtxIn.GetHash();
 
     // Inserts only if not already there, returns tx inserted or tx found
-    std::pair<std::map<uint256, CWalletTx>::iterator, bool> ret = mapWallet.insert(std::make_pair(hash, wtxIn));
+    std::pair<std::map<uint256, CWalletTx>::iterator, bool> ret = mapWallet.emplace(hash, wtxIn);
     CWalletTx& wtx = (*ret.first).second;
     wtx.BindWallet(this);
     bool fInsertedNew = ret.second;
     if (fInsertedNew) {
         wtx.nTimeReceived = GetAdjustedTime();
         wtx.nOrderPos = IncOrderPosNext(&walletdb);
-        wtxOrdered.insert(std::make_pair(wtx.nOrderPos, TxPair(&wtx, (CAccountingEntry*)0)));
+        wtxOrdered.emplace(wtx.nOrderPos, TxPair(&wtx, (CAccountingEntry*)0));
         wtx.UpdateTimeSmart();
         AddToSpends(hash);
     }
@@ -916,7 +916,7 @@ bool CWallet::LoadToWallet(const CWalletTx& wtxIn)
     mapWallet[hash] = wtxIn;
     CWalletTx& wtx = mapWallet[hash];
     wtx.BindWallet(this);
-    wtxOrdered.insert(std::make_pair(wtx.nOrderPos, TxPair(&wtx, (CAccountingEntry*)0)));
+    wtxOrdered.emplace(wtx.nOrderPos, TxPair(&wtx, (CAccountingEntry*)0));
     AddToSpends(hash);
     for (const CTxIn& txin : wtx.vin) {
         if (mapWallet.count(txin.prevout.hash)) {
@@ -1544,7 +1544,7 @@ void CWallet::ReacceptWalletTransactions(bool fFirstLoad)
 
         int nDepth = wtx.GetDepthInMainChain();
         if (!wtx.IsCoinBase() && !wtx.IsCoinStake() && nDepth == 0  && !wtx.isAbandoned()) {
-            mapSorted.insert(std::make_pair(wtx.nOrderPos, &wtx));
+            mapSorted.emplace(wtx.nOrderPos, &wtx);
         }
     }
 
@@ -1582,7 +1582,7 @@ void CWalletTx::RelayWalletTransaction(CConnman* connman, std::string strCommand
 
             int invType = MSG_TX;
             if (strCommand == NetMsgType::IX) {
-                mapTxLockReq.insert(std::make_pair(hash, (CTransaction) * this));
+                mapTxLockReq.emplace(hash, (CTransaction) * this);
                 CreateNewLock(((CTransaction) * this));
                 invType = MSG_TXLOCK_REQUEST;
             }
@@ -1690,7 +1690,7 @@ void CWallet::ResendWalletTransactions(CConnman* connman)
             // Don't rebroadcast until it's had plenty of time that
             // it should have gotten in already by now.
             if (nTimeBestReceived - (int64_t)wtx.nTimeReceived > 5 * 60)
-                mapSorted.insert(std::make_pair(wtx.nTimeReceived, &wtx));
+                mapSorted.emplace(wtx.nTimeReceived, &wtx);
         }
         for (PAIRTYPE(const unsigned int, CWalletTx*) & item : mapSorted) {
             CWalletTx& wtx = *item.second;
@@ -2265,7 +2265,7 @@ bool CWallet::SelectCoinsToSpend(const std::vector<COutput>& vAvailableCoins, co
                 continue;
 
             nValueRet += out.tx->vout[out.i].nValue;
-            setCoinsRet.insert(std::make_pair(out.tx, out.i));
+            setCoinsRet.emplace(out.tx, out.i);
         }
         return (nValueRet >= nTargetValue);
     }
@@ -2285,7 +2285,7 @@ bool CWallet::SelectCoinsToSpend(const std::vector<COutput>& vAvailableCoins, co
             if (pcoin->vout.size() <= outpoint.n)
                 return false;
             nValueFromPresetInputs += pcoin->vout[outpoint.n].nValue;
-            setPresetCoins.insert(std::make_pair(pcoin, outpoint.n));
+            setPresetCoins.emplace(pcoin, outpoint.n);
         } else
             return false; // TODO: Allow non-wallet inputs
     }
@@ -2874,7 +2874,7 @@ bool CWallet::AddAccountingEntry(const CAccountingEntry& acentry, CWalletDB & pw
 
     laccentries.push_back(acentry);
     CAccountingEntry & entry = laccentries.back();
-    wtxOrdered.insert(std::make_pair(entry.nOrderPos, TxPair((CWalletTx*)0, &entry)));
+    wtxOrdered.emplace(entry.nOrderPos, TxPair((CWalletTx*)0, &entry));
 
     return true;
 }
@@ -3437,7 +3437,7 @@ bool CWallet::AddDestData(const CTxDestination& dest, const std::string& key, co
     if (!IsValidDestination(dest))
         return false;
 
-    mapAddressBook[dest].destdata.insert(std::make_pair(key, value));
+    mapAddressBook[dest].destdata.emplace(key, value);
     if (!fFileBacked)
         return true;
     return CWalletDB(strWalletFile).WriteDestData(EncodeDestination(dest), key, value);
@@ -3454,7 +3454,7 @@ bool CWallet::EraseDestData(const CTxDestination& dest, const std::string& key)
 
 bool CWallet::LoadDestData(const CTxDestination& dest, const std::string& key, const std::string& value)
 {
-    mapAddressBook[dest].destdata.insert(std::make_pair(key, value));
+    mapAddressBook[dest].destdata.emplace(key, value);
     return true;
 }
 

--- a/src/wallet/wallet_zerocoin.cpp
+++ b/src/wallet/wallet_zerocoin.cpp
@@ -324,7 +324,7 @@ bool CWallet::CreateZerocoinMintTransaction(const CAmount nValue,
 
     // Fill vin
     for (const std::pair<const CWalletTx*, unsigned int>& coin : setCoins)
-        txNew.vin.push_back(CTxIn(coin.first->GetHash(), coin.second));
+        txNew.vin.emplace_back(coin.first->GetHash(), coin.second);
 
 
     //any change that is less than 0.0100000 will be ignored and given as an extra fee

--- a/src/wallet/wallet_zerocoin.cpp
+++ b/src/wallet/wallet_zerocoin.cpp
@@ -684,7 +684,7 @@ bool CWallet::CreateZCPublicSpendTransaction(
                 CPubKey pubkey;
                 assert(reserveKey.GetReservedKey(pubkey)); // should never fail
                 destinationAddr = pubkey.GetID();
-                addressesTo.push_back(std::make_pair(destinationAddr, nValue));
+                addressesTo.emplace_back(destinationAddr, nValue);
             }
 
             for (std::pair<CTxDestination,CAmount> pair : addressesTo){
@@ -719,7 +719,7 @@ bool CWallet::CreateZCPublicSpendTransaction(
             CBlockIndex* pindexCheckpoint = nullptr;
             std::map<CBigNum, CZerocoinMint> mapSelectedMints;
             for (const CZerocoinMint& mint : vSelectedMints)
-                mapSelectedMints.insert(std::make_pair(mint.GetValue(), mint));
+                mapSelectedMints.emplace(mint.GetValue(), mint);
 
             //add all of the mints to the transaction as inputs
             std::vector<CTxIn> vin;
@@ -798,7 +798,7 @@ std::map<libzerocoin::CoinDenomination, CAmount> CWallet::GetMyZerocoinDistribut
 {
     std::map<libzerocoin::CoinDenomination, CAmount> spread;
     for (const auto& denom : libzerocoin::zerocoinDenomList)
-        spread.insert(std::pair<libzerocoin::CoinDenomination, CAmount>(denom, 0));
+        spread.emplace(denom, 0);
     {
         LOCK(cs_wallet);
         std::set<CMintMeta> setMints = zpivTracker->ListMints(true, true, true);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -427,12 +427,12 @@ DBErrors CWalletDB::ReorderTransactions(CWallet* pwallet)
 
     for (std::map<uint256, CWalletTx>::iterator it = pwallet->mapWallet.begin(); it != pwallet->mapWallet.end(); ++it) {
         CWalletTx* wtx = &((*it).second);
-        txByTime.insert(std::make_pair(wtx->nTimeReceived, TxPair(wtx, (CAccountingEntry*)0)));
+        txByTime.emplace(wtx->nTimeReceived, TxPair(wtx, (CAccountingEntry*)0));
     }
     std::list<CAccountingEntry> acentries;
     ListAccountCreditDebit("", acentries);
     for (CAccountingEntry& entry : acentries) {
-        txByTime.insert(std::make_pair(entry.nTime, TxPair((CWalletTx*)0, &entry)));
+        txByTime.emplace(entry.nTime, TxPair((CWalletTx*)0, &entry));
     }
 
     int64_t& nOrderPosNext = pwallet->nOrderPosNext;
@@ -898,7 +898,7 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
     pwallet->laccentries.clear();
     ListAccountCreditDebit("*", pwallet->laccentries);
     for (CAccountingEntry& entry : pwallet->laccentries) {
-        pwallet->wtxOrdered.insert(std::make_pair(entry.nOrderPos, CWallet::TxPair((CWalletTx*)0, &entry)));
+        pwallet->wtxOrdered.emplace(entry.nOrderPos, CWallet::TxPair((CWalletTx*)0, &entry));
     }
 
     return result;
@@ -1504,7 +1504,7 @@ std::map<uint256, std::vector<std::pair<uint256, uint32_t> > > CWalletDB::MapMin
         } else {
             std::vector<std::pair<uint256, uint32_t> > vPairs;
             vPairs.emplace_back(pMint);
-            mapPool.insert(std::make_pair(hashMasterSeed, vPairs));
+            mapPool.emplace(hashMasterSeed, vPairs);
         }
     }
 

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -82,7 +82,7 @@ bool CZMQAbstractPublishNotifier::Initialize(void *pcontext)
         }
 
         // register this notifier for the address, so it can be reused for other publish notifier
-        mapPublishNotifiers.insert(std::make_pair(address, this));
+        mapPublishNotifiers.emplace(address, this);
         return true;
     }
     else
@@ -90,7 +90,7 @@ bool CZMQAbstractPublishNotifier::Initialize(void *pcontext)
         LogPrint(BCLog::ZMQ, "Reusing socket for address %s\n", address);
 
         psocket = i->second->psocket;
-        mapPublishNotifiers.insert(std::make_pair(address, this));
+        mapPublishNotifiers.emplace(address, this);
 
         return true;
     }

--- a/src/zpiv/zpivtracker.cpp
+++ b/src/zpiv/zpivtracker.cpp
@@ -129,7 +129,7 @@ CAmount CzPIVTracker::GetBalance(bool fConfirmedOnly, bool fUnconfirmedOnly) con
     //! zerocoin specific fields
     std::map<libzerocoin::CoinDenomination, unsigned int> myZerocoinSupply;
     for (auto& denom : libzerocoin::zerocoinDenomList) {
-        myZerocoinSupply.insert(std::make_pair(denom, 0));
+        myZerocoinSupply.emplace(denom, 0);
     }
 
     {
@@ -328,7 +328,7 @@ void CzPIVTracker::SetPubcoinUsed(const uint256& hashPubcoin, const uint256& txi
         return;
     CMintMeta meta = GetMetaFromPubcoin(hashPubcoin);
     meta.isUsed = true;
-    mapPendingSpends.insert(std::make_pair(meta.hashSerial, txid));
+    mapPendingSpends.emplace(meta.hashSerial, txid);
     UpdateState(meta);
 }
 

--- a/src/zpivchain.cpp
+++ b/src/zpivchain.cpp
@@ -259,7 +259,7 @@ std::string ReindexZerocoinDB()
 
     // initialize supply to 0
     mapZerocoinSupply.clear();
-    for (auto& denom : libzerocoin::zerocoinDenomList) mapZerocoinSupply.insert(std::make_pair(denom, 0));
+    for (auto& denom : libzerocoin::zerocoinDenomList) mapZerocoinSupply.emplace(denom, 0);
 
     const Consensus::Params& consensus = Params().GetConsensus();
     const int zc_start_height = consensus.vUpgrades[Consensus::UPGRADE_ZC].nActivationHeight;
@@ -299,10 +299,10 @@ std::string ReindexZerocoinDB()
                                 if (!ZPIVModule::ParseZerocoinPublicSpend(in, tx, state, publicSpend)){
                                     return _("Failed to parse public spend");
                                 }
-                                vSpendInfo.push_back(std::make_pair(publicSpend, txid));
+                                vSpendInfo.emplace_back(publicSpend, txid);
                             } else {
                                 libzerocoin::CoinSpend spend = TxInToZerocoinSpend(in);
-                                vSpendInfo.push_back(std::make_pair(spend, txid));
+                                vSpendInfo.emplace_back(spend, txid);
                             }
                         }
                     }
@@ -317,7 +317,7 @@ std::string ReindexZerocoinDB()
                             const bool v1params = !consensus.NetworkUpgradeActive(pindex->nHeight, Consensus::UPGRADE_ZC_V2);
                             libzerocoin::PublicCoin coin(consensus.Zerocoin_Params(v1params));
                             TxOutToPublicCoin(out, coin, state);
-                            vMintInfo.push_back(std::make_pair(coin, txid));
+                            vMintInfo.emplace_back(coin, txid);
                         }
                     }
                 }


### PR DESCRIPTION
With C++11, variadic templates and perfect forwarding offer a new way of adding elements into a container by means of emplacing (creating in place).

- https://en.cppreference.com/w/cpp/container/map/emplace
- https://en.cppreference.com/w/cpp/container/vector/emplace_back

This is particularly useful. 
With the traditional `insert()`/`push_back()` we are likely to make unnecessary copies (or move); for example, with maps, first the `std::pair<const K, V>` is created, and then it's copied to the container.
With `emplace()`, instead, references to the key/value objects are forwarded directly to the constructor of the `value_type` inside the data structure without making any copy of `std::pair<const K,V>`.

This PR replaces most instances of:
- `.insert(std::make_pair(K,V))` with `.emplace(K, V)`
- `.push_back(Class(Args...))` with `.emplace_back(Args...)` 

in the whole code base.
It touches many files (therefore is surely conflicting with many open pull requests), but changes are trivial.