### PR TITLE
[RPC] re introducing filtering args in getbalance

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1814,10 +1814,17 @@ CAmount CWallet::loopTxsBalance(std::function<void(const uint256&, const CWallet
 
 CAmount CWallet::GetAvailableBalance(bool fIncludeDelegated) const
 {
-    isminetype filter = fIncludeDelegated ? ISMINE_SPENDABLE_ALL : ISMINE_SPENDABLE;
-    return loopTxsBalance([filter](const uint256& id, const CWalletTx& pcoin, CAmount& nTotal){
-        if (pcoin.IsTrusted()) {
-            nTotal += pcoin.GetAvailableCredit(true, filter);
+    isminefilter filter = fIncludeDelegated ? ISMINE_SPENDABLE_ALL : ISMINE_SPENDABLE;
+    return GetAvailableBalance(filter, true, 0);
+}
+
+CAmount CWallet::GetAvailableBalance(isminefilter& filter, bool useCache, int minDepth) const
+{
+    return loopTxsBalance([filter, useCache, minDepth](const uint256& id, const CWalletTx& pcoin, CAmount& nTotal){
+        bool fConflicted;
+        int depth;
+        if (pcoin.IsTrusted(depth, fConflicted) && depth >= minDepth) {
+            nTotal += pcoin.GetAvailableCredit(useCache, filter);
         }
     });
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -517,6 +517,7 @@ public:
 
     CAmount loopTxsBalance(std::function<void(const uint256&, const CWalletTx&, CAmount&)>method) const;
     CAmount GetAvailableBalance(bool fIncludeDelegated = true) const;
+    CAmount GetAvailableBalance(isminefilter& filter, bool useCache = false, int minDepth = 1) const;
     CAmount GetColdStakingBalance() const;  // delegated coins for which we have the staking key
     CAmount GetImmatureColdStakingBalance() const;
     CAmount GetStakingBalance(const bool fIncludeColdStaking = true) const;


### PR DESCRIPTION
Have re introduced the filtering arguments that were removed when the accounts system got deprecated in `getbalance`. With this, `getbalance` RPC command will be able, again, to filter by watch-only, minimum depth and include/exclude delegated balance.