### PR TITLE
[Refactor] Remove GetInputAge and GetMasternodeInputAge

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -268,6 +268,14 @@ double CCoinsViewCache::GetPriority(const CTransaction& tx, int nHeight, CAmount
     return tx.ComputePriority(dResult);
 }
 
+int CCoinsViewCache::GetCoinDepthAtHeight(const COutPoint& output, int nHeight) const
+{
+    const Coin& coin = AccessCoin(output);
+    if (!coin.IsSpent())
+        return nHeight - coin.nHeight + 1;
+    return -1;
+}
+
 static const size_t MAX_OUTPUTS_PER_BLOCK = MAX_BLOCK_SIZE_CURRENT /  ::GetSerializeSize(CTxOut(), SER_NETWORK, PROTOCOL_VERSION); // TODO: merge with similar definition in undo.h.
 
 const Coin& AccessByTxid(const CCoinsViewCache& view, const uint256& txid)

--- a/src/coins.h
+++ b/src/coins.h
@@ -285,6 +285,12 @@ public:
      */
     double GetPriority(const CTransaction& tx, int nHeight, CAmount &inChainInputValue) const;
 
+    /*
+     * Return the depth of a coin at height nHeight, or -1 if not found
+     */
+    int GetCoinDepthAtHeight(const COutPoint& output, int nHeight) const;
+
+
 private:
     CCoinsMap::iterator FetchCoin(const COutPoint& outpoint) const;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -742,24 +742,6 @@ unsigned int LimitOrphanTxSize(unsigned int nMaxOrphans) EXCLUSIVE_LOCKS_REQUIRE
     return nEvicted;
 }
 
-int GetInputAge(CTxIn& vin)
-{
-    CCoinsView viewDummy;
-    CCoinsViewCache view(&viewDummy);
-    {
-        LOCK(mempool.cs);
-        CCoinsViewMemPool viewMempool(pcoinsTip, mempool);
-        view.SetBackend(viewMempool); // temporarily switch cache backend to db+mempool view
-
-        const Coin& coin = view.AccessCoin(vin.prevout);
-
-        if (!coin.IsSpent()) {
-            return WITH_LOCK(cs_main, return chainActive.Height() + 1) - coin.nHeight;
-        } else
-            return -1;
-    }
-}
-
 int GetIXConfirmations(uint256 nTXHash)
 {
     int sigs = 0;

--- a/src/main.h
+++ b/src/main.h
@@ -260,7 +260,6 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
 
 bool AcceptableInputs(CTxMemPool& pool, CValidationState& state, const CTransaction& tx, bool fLimitFree, bool* pfMissingInputs, bool fRejectInsaneFee = false, bool isDSTX = false);
 
-int GetInputAge(CTxIn& vin);
 int GetIXConfirmations(uint256 nTXHash);
 
 /** Convert CValidationState to a human-readable message for logging */

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -592,6 +592,7 @@ bool CMasternodeBroadcast::CheckInputsAndAdd(int& nDoS)
     tx.vin.push_back(vin);
     tx.vout.push_back(vout);
 
+    int nChainHeight = 0;
     {
         TRY_LOCK(cs_main, lockMain);
         if (!lockMain) {
@@ -606,11 +607,13 @@ bool CMasternodeBroadcast::CheckInputsAndAdd(int& nDoS)
             state.IsInvalid(nDoS);
             return false;
         }
+
+        nChainHeight = chainActive.Height();
     }
 
     LogPrint(BCLog::MASTERNODE, "mnb - Accepted Masternode entry\n");
 
-    if (GetInputAge(vin) < MASTERNODE_MIN_CONFIRMATIONS) {
+    if (pcoinsTip->GetCoinDepthAtHeight(vin.prevout, nChainHeight) < MASTERNODE_MIN_CONFIRMATIONS) {
         LogPrint(BCLog::MASTERNODE,"mnb - Input must have at least %d confirmations\n", MASTERNODE_MIN_CONFIRMATIONS);
         // maybe we miss few blocks, let this mnb to be checked again later
         mnodeman.mapSeenMasternodeBroadcast.erase(GetHash());

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -69,8 +69,6 @@ CMasternode::CMasternode() :
     activeState = MASTERNODE_ENABLED;
     sigTime = GetAdjustedTime();
     lastPing = CMasternodePing();
-    cacheInputAge = 0;
-    cacheInputAgeBlock = 0;
     unitTest = false;
     allowFreeTx = true;
     protocolVersion = PROTOCOL_VERSION;
@@ -91,8 +89,6 @@ CMasternode::CMasternode(const CMasternode& other) :
     activeState = other.activeState;
     sigTime = other.sigTime;
     lastPing = other.lastPing;
-    cacheInputAge = other.cacheInputAge;
-    cacheInputAgeBlock = other.cacheInputAgeBlock;
     unitTest = other.unitTest;
     allowFreeTx = other.allowFreeTx;
     protocolVersion = other.protocolVersion;

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -134,8 +134,6 @@ public:
     CPubKey pubKeyMasternode1;
     int activeState;
     int64_t sigTime; //mnb message time
-    int cacheInputAge;
-    int cacheInputAgeBlock;
     bool unitTest;
     bool allowFreeTx;
     int protocolVersion;
@@ -169,8 +167,6 @@ public:
         swap(first.activeState, second.activeState);
         swap(first.sigTime, second.sigTime);
         swap(first.lastPing, second.lastPing);
-        swap(first.cacheInputAge, second.cacheInputAge);
-        swap(first.cacheInputAgeBlock, second.cacheInputAgeBlock);
         swap(first.unitTest, second.unitTest);
         swap(first.allowFreeTx, second.allowFreeTx);
         swap(first.protocolVersion, second.protocolVersion);
@@ -211,8 +207,6 @@ public:
         READWRITE(protocolVersion);
         READWRITE(activeState);
         READWRITE(lastPing);
-        READWRITE(cacheInputAge);
-        READWRITE(cacheInputAgeBlock);
         READWRITE(unitTest);
         READWRITE(allowFreeTx);
         READWRITE(nLastDsq);
@@ -247,19 +241,6 @@ public:
     bool IsEnabled()
     {
         return activeState == MASTERNODE_ENABLED;
-    }
-
-    int GetMasternodeInputAge()
-    {
-        int tipHeight = WITH_LOCK(cs_main, return chainActive.Height());
-        if (tipHeight < 0) return 0;
-
-        if (cacheInputAge == 0) {
-            cacheInputAge = pcoinsTip->GetCoinDepthAtHeight(vin.prevout, tipHeight);
-            cacheInputAgeBlock = tipHeight;
-        }
-
-        return cacheInputAge + (tipHeight - cacheInputAgeBlock);
     }
 
     std::string Status()

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -255,7 +255,7 @@ public:
         if (tipHeight < 0) return 0;
 
         if (cacheInputAge == 0) {
-            cacheInputAge = GetInputAge(vin);
+            cacheInputAge = pcoinsTip->GetCoinDepthAtHeight(vin.prevout, tipHeight);
             cacheInputAgeBlock = tipHeight;
         }
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -507,7 +507,7 @@ CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight
         if (fFilterSigTime && mn.sigTime + (nMnCount * 2.6 * 60) > GetAdjustedTime()) continue;
 
         //make sure it has as many confirmations as there are masternodes
-        if (mn.GetMasternodeInputAge() < nMnCount) continue;
+        if (pcoinsTip->GetCoinDepthAtHeight(mn.vin.prevout, nBlockHeight) < nMnCount) continue;
 
         vecMasternodeLastPaid.push_back(std::make_pair(mn.SecondsSincePayment(), mn.vin));
     }


### PR DESCRIPTION
Introduce a `GetCoinDepth()` utility function in CCoinsViewCache and use that instead (with `pcoinsTip`... no need to lock/load the mempool too in the  backend). 
This should fix the invalid lock order:
```
2020-09-02 10:23:17 POTENTIAL DEADLOCK DETECTED
2020-09-02 10:23:17 Previous lock order was:
2020-09-02 10:23:17  cs_process_message /src/masternodeman.cpp:690 (in thread pivx-msghand)
2020-09-02 10:23:17  (1) mempool.cs /src/main.cpp:777 (in thread pivx-msghand)
2020-09-02 10:23:17  (2) cs_main /src/main.cpp:785 (in thread pivx-msghand)
2020-09-02 10:23:17 Current lock order is:
2020-09-02 10:23:17  (2) cs_main /src/main.cpp:4571 (in thread )
2020-09-02 10:23:17  (1) cs /src/txmempool.cpp:590 (in thread )
```

To be able to use the new per-txout interface, this is based on top of:
- [x] #1801 

The present PR starts with `[Refactoring] Add GetCoinDepth utility function to CCoinsViewCache` (294e177bd1d282620f52ad14f0627da99381bfbe)

BONUS: remove the cached "ages" saved/serialized in CMasternode class... no comment.
