### PR TITLE
CActiveMasternode::ManageStatus remove unneded GetAvailableBalance check

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -460,7 +460,7 @@ bool CMasternodeBroadcast::CheckDefaultPort(CService service, std::string& strEr
     if (service.GetPort() != nDefaultPort && !Params().IsRegTestNet()) {
         strErrorRet = strprintf("Invalid port %u for masternode %s, only %d is supported on %s-net.",
             service.GetPort(), service.ToString(), nDefaultPort, Params().NetworkIDString());
-        LogPrint(BCLog::MASTERNODE, "%s - %s\n", strContext, strErrorRet);
+        LogPrintf("%s - %s\n", strContext, strErrorRet);
         return false;
     }
 


### PR DESCRIPTION
Removed a not needed balance check in `CActiveMasternode::ManageStatus` (the remote masternode doesn't need to have balance), plus added better logging for the `notCapableReason`.

long talk with zebra about this ☕ , will need further cleanup but this is going for the right track.