### PR TITLE
[Wallet] Lock Sapling wallet functionality to regtest only for now.

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -41,14 +41,6 @@ BITCOIN_TESTS =\
   test/zerocoin_bignum_tests.cpp \
   test/addrman_tests.cpp \
   test/allocator_tests.cpp \
-  test/librust/libsapling_utils_tests.cpp \
-  test/librust/sapling_key_tests.cpp \
-  test/librust/pedersen_hash_tests.cpp \
-  test/librust/noteencryption_tests.cpp \
-  test/librust/sapling_note_tests.cpp \
-  test/librust/sapling_keystore_tests.cpp \
-  test/librust/zip32_tests.cpp \
-  test/librust/wallet_zkeys_tests.cpp \
   test/base32_tests.cpp \
   test/base58_tests.cpp \
   test/base64_tests.cpp \
@@ -101,7 +93,6 @@ BITCOIN_TESTS =\
 if ENABLE_WALLET
 BITCOIN_TESTS += \
   test/accounting_tests.cpp \
-  test/librust/sapling_rpc_wallet_tests.cpp \
   wallet/test/wallet_tests.cpp \
   wallet/test/crypto_tests.cpp
 endif
@@ -111,11 +102,13 @@ test_test_pivx_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -I$(builddir)/test/
 test_test_pivx_LDADD =
 
 test_test_pivx_LDADD += $(LIBBITCOIN_SERVER) $(LIBBITCOIN_CLI) $(LIBBITCOIN_COMMON) $(LIBBITCOIN_UTIL) $(LIBBITCOIN_CRYPTO) $(LIBUNIVALUE) $(LIBBITCOIN_ZEROCOIN) \
-  $(LIBLEVELDB) $(LIBLEVELDB_SSE42) $(LIBMEMENV) $(BOOST_LIBS) $(BOOST_UNIT_TEST_FRAMEWORK_LIB) $(LIBSECP256K1) $(LIBSAPLING) $(EVENT_LIBS) $(EVENT_PTHREADS_LIBS)
+  $(LIBLEVELDB) $(LIBLEVELDB_SSE42) $(LIBMEMENV) $(BOOST_LIBS) $(BOOST_UNIT_TEST_FRAMEWORK_LIB) $(LIBSECP256K1) $(EVENT_LIBS) $(EVENT_PTHREADS_LIBS)
 
 if ENABLE_WALLET
 test_test_pivx_LDADD += $(LIBBITCOIN_WALLET)
 endif
+
+test_test_pivx_LDADD += $(LIBSAPLING)
 
 test_test_pivx_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1171,8 +1171,10 @@ bool AppInit2()
     CScheduler::Function serviceLoop = boost::bind(&CScheduler::serviceQueue, &scheduler);
     threadGroup.create_thread(boost::bind(&TraceThread<CScheduler::Function>, "scheduler", serviceLoop));
 
-    // Initialize Sapling circuit parameters
-    LoadSaplingParams();
+    if (Params().IsRegTestNet()) { // only for regtest for now
+        // Initialize Sapling circuit parameters
+        LoadSaplingParams();
+    }
 
     /* Start the RPC server already.  It will be started in "warmup" mode
      * and not really process calls already (but it will signify connections

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -81,14 +81,17 @@ bool WalletModel::isHDEnabled() const
 
 bool WalletModel::upgradeWallet(std::string& upgradeError)
 {
+    // For now, Sapling features are locked to regtest.
+    WalletFeature features = Params().IsRegTestNet() ? FEATURE_SAPLING : FEATURE_PRE_SPLIT_KEYPOOL;
+
     // This action must be performed in a separate thread and not the main one.
     LOCK2(cs_main, wallet->cs_wallet);
 
     // Get version
     int prev_version = wallet->GetVersion();
     // Upgrade wallet's version
-    wallet->SetMinVersion(FEATURE_LATEST);
-    wallet->SetMaxVersion(FEATURE_LATEST);
+    wallet->SetMinVersion(features);
+    wallet->SetMaxVersion(features);
 
     // Upgrade to HD
     return wallet->Upgrade(upgradeError, prev_version);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -390,9 +390,13 @@ UniValue upgradewallet(const JSONRPCRequest& request)
 
     // Get version
     int prev_version = pwalletMain->GetVersion();
+
+    // For now, Sapling features are locked to regtest.
+    WalletFeature features = Params().IsRegTestNet() ? FEATURE_SAPLING : FEATURE_PRE_SPLIT_KEYPOOL;
+
     // Upgrade wallet's version
-    pwalletMain->SetMinVersion(FEATURE_LATEST);
-    pwalletMain->SetMaxVersion(FEATURE_LATEST);
+    pwalletMain->SetMinVersion(features);
+    pwalletMain->SetMaxVersion(features);
 
     // Upgrade to HD
     std::string upgradeError;
@@ -513,6 +517,10 @@ UniValue getnewshieldedaddress(const JSONRPCRequest& request)
                 + HelpExampleCli("getnewshieldedaddress", "")
                 + HelpExampleRpc("getnewshieldedaddress", "")
         );
+
+    if (!Params().IsRegTestNet()) {
+        throw std::runtime_error("Sapling only available on regtest");
+    }
 
     EnsureWallet();
 
@@ -691,6 +699,10 @@ UniValue listshieldedaddresses(const JSONRPCRequest& request)
                 + HelpExampleCli("listshieldedaddresses", "")
                 + HelpExampleRpc("listshieldedaddresses", "")
         );
+
+    if (!Params().IsRegTestNet()) {
+        throw std::runtime_error("Sapling only available on regtest");
+    }
 
     EnsureWallet();
     LOCK2(cs_main, pwalletMain->cs_wallet);

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -24,7 +24,7 @@ void clean()
 
 WalletTestingSetup::WalletTestingSetup(): TestingSetup()
 {
-    initZKSNARKS(); // init zk-snarks lib
+    //initZKSNARKS(); // init zk-snarks lib
 
     clean(); // todo: research why we have an initialized bitdb here.
     bitdb.MakeMock();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -115,7 +115,7 @@ enum WalletFeature {
 
     FEATURE_SAPLING = 170000, // Upgraded to Saplings key manager.
 
-    FEATURE_LATEST = FEATURE_SAPLING
+    FEATURE_LATEST = FEATURE_PRE_SPLIT_KEYPOOL
 };
 
 enum AvailableCoinsType {


### PR DESCRIPTION
auto-descriptive title. Locking the wallet's Sapling functionality to only be run in regtest.