### PR TITLE
[Bug] Update budget manager best height even if mnSync is incomplete

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4195,9 +4195,9 @@ bool ProcessNewBlock(CValidationState& state, CNode* pfrom, const CBlock* pblock
         return error("%s : ActivateBestChain failed", __func__);
 
     if (!fLiteMode) {
+        budget.NewBlock(newHeight);
         if (masternodeSync.RequestedMasternodeAssets > MASTERNODE_SYNC_LIST) {
             masternodePayments.ProcessBlock(newHeight + 10);
-            budget.NewBlock(newHeight);
         }
     }
 


### PR DESCRIPTION
Update the cached chain height in budget manager as soon as possible  (no need to complete the mn sync first).