### PR TITLE
[Refactoring] Budget, round 2: review locks

### DIFF
--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -18,7 +18,6 @@
 
 
 CBudgetManager budget;
-RecursiveMutex cs_budget;
 
 std::map<uint256, int64_t> askedForSourceProposalOrBudget;
 std::vector<CBudgetProposalBroadcast> vecImmatureBudgetProposals;
@@ -1027,8 +1026,6 @@ void CBudgetManager::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
     if (!masternodeSync.IsBlockchainSynced()) return;
 
     int nCurrentHeight = GetBestHeight();
-
-    LOCK(cs_budget);
 
     if (strCommand == NetMsgType::BUDGETVOTESYNC) { //Masternode vote sync
         uint256 nProp;

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -230,10 +230,9 @@ void CBudgetManager::SubmitFinalBudget()
         return;
     }
 
-    LOCK(cs);
     AddSeenFinalizedBudget(finalizedBudgetBroadcast);
     finalizedBudgetBroadcast.Relay();
-    budget.AddFinalizedBudget(finalizedBudgetBroadcast);
+    AddFinalizedBudget(finalizedBudgetBroadcast);
     nSubmittedHeight = nCurrentHeight;
     LogPrint(BCLog::MNBUDGET,"%s: Done! %s\n", __func__, finalizedBudgetBroadcast.GetHash().ToString());
 }
@@ -250,8 +249,6 @@ CBudgetDB::CBudgetDB()
 
 bool CBudgetDB::Write(const CBudgetManager& objToSave)
 {
-    LOCK(objToSave.cs);
-
     int64_t nStart = GetTimeMillis();
 
     // serialize, checksum data up to that point, then append checksum
@@ -283,8 +280,6 @@ bool CBudgetDB::Write(const CBudgetManager& objToSave)
 
 CBudgetDB::ReadResult CBudgetDB::Read(CBudgetManager& objToLoad, bool fDryRun)
 {
-    LOCK(objToLoad.cs);
-
     int64_t nStart = GetTimeMillis();
     // open input file, and associate with CAutoFile
     FILE* file = fsbridge::fopen(pathDB, "rb");
@@ -504,8 +499,6 @@ bool CBudgetManager::GetPayeeAndAmount(int chainHeight, CScript& payeeRet, CAmou
 
 void CBudgetManager::FillBlockPayee(CMutableTransaction& txNew, bool fProofOfStake) const
 {
-    LOCK(cs);
-
     int chainHeight = GetBestHeight();
     if (chainHeight <= 0) return;
 
@@ -891,8 +884,6 @@ void CBudgetManager::NewBlock(int height)
         MarkSynced();
     }
 
-    TRY_LOCK(cs, fBudgetNewBlock);
-    if (!fBudgetNewBlock) return;
     CheckAndRemove();
 
     //remove invalid votes once in a while (we have to check the signatures and validity of every vote, somewhat CPU intensive)
@@ -906,7 +897,8 @@ void CBudgetManager::NewBlock(int height)
         }
     }
     {
-        LOCK(cs_proposals);
+        TRY_LOCK(cs_proposals, fBudgetNewBlock);
+        if (!fBudgetNewBlock) return;
         LogPrint(BCLog::MNBUDGET,"%s:  mapProposals cleanup - size: %d\n", __func__, mapProposals.size());
         for (auto& it: mapProposals) {
             it.second.CleanAndRemove();
@@ -935,7 +927,8 @@ void CBudgetManager::NewBlock(int height)
         }
     }
     {
-        LOCK(cs_budgets);
+        TRY_LOCK(cs_budgets, fBudgetNewBlock);
+        if (!fBudgetNewBlock) return;
         LogPrint(BCLog::MNBUDGET,"%s:  mapFinalizedBudgets cleanup - size: %d\n", __func__, mapFinalizedBudgets.size());
         for (auto& it: mapFinalizedBudgets) {
             it.second.CleanAndRemove();
@@ -1185,21 +1178,8 @@ void CBudgetManager::SetSynced(bool synced)
 
 void CBudgetManager::Sync(CNode* pfrom, const uint256& nProp, bool fPartial)
 {
-    LOCK2(cs, cs_proposals);
-
-    /*
-        Sync with a client on the network
-
-        --
-
-        This code checks each of the hash maps for all known budget proposals and finalized budget proposals, then checks them against the
-        budget object to see if they're OK. If all checks pass, we'll send it to the peer.
-
-    */
-
     CNetMsgMaker msgMaker(pfrom->GetSendVersion());
     int nInvCount = 0;
-
     {
         LOCK(cs_proposals);
         for (auto& it: mapSeenProposals) {
@@ -1215,7 +1195,6 @@ void CBudgetManager::Sync(CNode* pfrom, const uint256& nProp, bool fPartial)
     LogPrint(BCLog::MNBUDGET, "%s: sent %d items\n", __func__, nInvCount);
 
     nInvCount = 0;
-
     {
         LOCK(cs_budgets);
         for (auto& it: mapSeenFinalizedBudgets) {

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -584,6 +584,26 @@ CBudgetProposal* CBudgetManager::FindProposal(const uint256& nHash)
     return NULL;
 }
 
+bool CBudgetManager::GetProposal(const uint256& nHash, CBudgetProposal& bp) const
+{
+    LOCK(cs_proposals);
+    if (mapProposals.count(nHash)) {
+        bp = mapProposals.at(nHash);
+        return true;
+    }
+    return false;
+}
+
+bool CBudgetManager::GetFinalizedBudget(const uint256& nHash, CFinalizedBudget& fb) const
+{
+    LOCK(cs_budgets);
+    if (mapFinalizedBudgets.count(nHash)) {
+        fb = mapFinalizedBudgets.at(nHash);
+        return true;
+    }
+    return false;
+}
+
 bool CBudgetManager::IsBudgetPaymentBlock(int nBlockHeight, int& nHighestCount, int& nFivePercent) const
 {
     nHighestCount = GetHighestVoteCount(nBlockHeight);

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -795,6 +795,7 @@ CAmount CBudgetManager::GetTotalBudget(int nHeight)
 
 void CBudgetManager::AddSeenProposal(const CBudgetProposalBroadcast& prop)
 {
+    LOCK(cs_proposals);
     mapSeenMasternodeBudgetProposals.emplace(prop.GetHash(), prop);
 }
 
@@ -805,6 +806,7 @@ void CBudgetManager::AddSeenProposalVote(const CBudgetVote& vote)
 
 void CBudgetManager::AddSeenFinalizedBudget(const CFinalizedBudgetBroadcast& bud)
 {
+    LOCK(cs_budgets);
     mapSeenFinalizedBudgets.emplace(bud.GetHash(), bud);
 }
 
@@ -824,6 +826,7 @@ CDataStream CBudgetManager::GetProposalVoteSerialized(const uint256& voteHash) c
 
 CDataStream CBudgetManager::GetProposalSerialized(const uint256& propHash) const
 {
+    LOCK(cs_proposals);
     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
     ss.reserve(1000);
     ss << mapSeenMasternodeBudgetProposals.at(propHash);
@@ -840,6 +843,7 @@ CDataStream CBudgetManager::GetFinalizedBudgetVoteSerialized(const uint256& vote
 
 CDataStream CBudgetManager::GetFinalizedBudgetSerialized(const uint256& budgetHash) const
 {
+    LOCK(cs_budgets);
     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
     ss.reserve(1000);
     ss << mapSeenFinalizedBudgets.at(budgetHash);

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -208,19 +208,19 @@ private:
     //hold txes until they mature enough to use
     std::map<uint256, uint256> mapCollateralTxids;
 
-    std::map<uint256, CBudgetProposal> mapProposals;                                // guarded by cs_proposals
-    std::map<uint256, CFinalizedBudget> mapFinalizedBudgets;                        // guarded by cs_budgets
+    std::map<uint256, CBudgetProposal> mapProposals;                        // guarded by cs_proposals
+    std::map<uint256, CFinalizedBudget> mapFinalizedBudgets;                // guarded by cs_budgets
 
-    std::map<uint256, CBudgetProposalBroadcast> mapSeenMasternodeBudgetProposals;   // guarded by cs_proposals
-    std::map<uint256, CFinalizedBudgetBroadcast> mapSeenFinalizedBudgets;           // guarded by cs_budgets
-    std::map<uint256, CBudgetVote> mapSeenMasternodeBudgetVotes;                    // guarded by cs_votes
-    std::map<uint256, CBudgetVote> mapOrphanMasternodeBudgetVotes;                  // guarded by cs_votes
-    std::map<uint256, CFinalizedBudgetVote> mapSeenFinalizedBudgetVotes;            // guarded by cs_finalizedvotes
-    std::map<uint256, CFinalizedBudgetVote> mapOrphanFinalizedBudgetVotes;          // guarded by cs_finalizedvotes
+    std::map<uint256, CBudgetProposalBroadcast> mapSeenProposals;           // guarded by cs_proposals
+    std::map<uint256, CFinalizedBudgetBroadcast> mapSeenFinalizedBudgets;   // guarded by cs_budgets
+    std::map<uint256, CBudgetVote> mapSeenProposalVotes;                    // guarded by cs_votes
+    std::map<uint256, CBudgetVote> mapOrphanProposalVotes;                  // guarded by cs_votes
+    std::map<uint256, CFinalizedBudgetVote> mapSeenFinalizedBudgetVotes;    // guarded by cs_finalizedvotes
+    std::map<uint256, CFinalizedBudgetVote> mapOrphanFinalizedBudgetVotes;  // guarded by cs_finalizedvotes
 
     // Memory only
-    std::vector<CBudgetProposalBroadcast> vecImmatureBudgetProposals;               // guarded by cs_proposals
-    std::vector<CFinalizedBudgetBroadcast> vecImmatureFinalizedBudgets;             // guarded by cs_budgets
+    std::vector<CBudgetProposalBroadcast> vecImmatureProposals;             // guarded by cs_proposals
+    std::vector<CFinalizedBudgetBroadcast> vecImmatureFinalizedBudgets;     // guarded by cs_budgets
 
     // Memory Only. Updated in NewBlock (blocks arrive in order)
     std::atomic<int> nBestHeight;
@@ -250,14 +250,14 @@ public:
 
     void ClearSeen()
     {
-        WITH_LOCK(cs_proposals, mapSeenMasternodeBudgetProposals.clear(); );
-        WITH_LOCK(cs_votes, mapSeenMasternodeBudgetVotes.clear(); );
+        WITH_LOCK(cs_proposals, mapSeenProposals.clear(); );
+        WITH_LOCK(cs_votes, mapSeenProposalVotes.clear(); );
         WITH_LOCK(cs_budgets, mapSeenFinalizedBudgets.clear(); );
         WITH_LOCK(cs_finalizedvotes, mapSeenFinalizedBudgetVotes.clear(); );
     }
 
-    bool HaveSeenProposal(const uint256& propHash) const { LOCK(cs_proposals); return mapSeenMasternodeBudgetProposals.count(propHash); }
-    bool HaveSeenProposalVote(const uint256& voteHash) const { LOCK(cs_votes); return mapSeenMasternodeBudgetVotes.count(voteHash); }
+    bool HaveSeenProposal(const uint256& propHash) const { LOCK(cs_proposals); return mapSeenProposals.count(propHash); }
+    bool HaveSeenProposalVote(const uint256& voteHash) const { LOCK(cs_votes); return mapSeenProposalVotes.count(voteHash); }
     bool HaveSeenFinalizedBudget(const uint256& budgetHash) const { LOCK(cs_budgets); return mapSeenFinalizedBudgets.count(budgetHash); }
     bool HaveSeenFinalizedBudgetVote(const uint256& voteHash) const { LOCK(cs_finalizedvotes); return mapSeenFinalizedBudgetVotes.count(voteHash); }
 
@@ -309,7 +309,7 @@ public:
         {
             LOCK(cs_proposals);
             mapProposals.clear();
-            mapSeenMasternodeBudgetProposals.clear();
+            mapSeenProposals.clear();
         }
         {
             LOCK(cs_budgets);
@@ -318,8 +318,8 @@ public:
         }
         {
             LOCK(cs_votes);
-            mapSeenMasternodeBudgetVotes.clear();
-            mapOrphanMasternodeBudgetVotes.clear();
+            mapSeenProposalVotes.clear();
+            mapOrphanProposalVotes.clear();
         }
         {
             LOCK(cs_finalizedvotes);
@@ -338,12 +338,12 @@ public:
         {
             LOCK(cs_proposals);
             READWRITE(mapProposals);
-            READWRITE(mapSeenMasternodeBudgetProposals);
+            READWRITE(mapSeenProposals);
         }
         {
             LOCK(cs_votes);
-            READWRITE(mapSeenMasternodeBudgetVotes);
-            READWRITE(mapOrphanMasternodeBudgetVotes);
+            READWRITE(mapSeenProposalVotes);
+            READWRITE(mapOrphanProposalVotes);
         }
         {
             LOCK(cs_budgets);

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -215,10 +215,10 @@ private:
     std::map<uint256, CBudgetProposal> mapProposals;                                // guarded by cs_proposals
     std::map<uint256, CFinalizedBudget> mapFinalizedBudgets;                        // guarded by cs_budgets
 
-    std::map<uint256, CBudgetProposalBroadcast> mapSeenMasternodeBudgetProposals;
+    std::map<uint256, CBudgetProposalBroadcast> mapSeenMasternodeBudgetProposals;   // guarded by cs_proposals
+    std::map<uint256, CFinalizedBudgetBroadcast> mapSeenFinalizedBudgets;           // guarded by cs_budgets
     std::map<uint256, CBudgetVote> mapSeenMasternodeBudgetVotes;
     std::map<uint256, CBudgetVote> mapOrphanMasternodeBudgetVotes;
-    std::map<uint256, CFinalizedBudgetBroadcast> mapSeenFinalizedBudgets;
     std::map<uint256, CFinalizedBudgetVote> mapSeenFinalizedBudgetVotes;
     std::map<uint256, CFinalizedBudgetVote> mapOrphanFinalizedBudgetVotes;
 

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -225,7 +225,9 @@ private:
     // Memory Only. Updated in NewBlock (blocks arrive in order)
     std::atomic<int> nBestHeight;
 
-    // Get block payee and amount for the finalized budget with highest vote count
+    // Returns a const pointer to the budget with highest vote count
+    const CFinalizedBudget* GetBudgetWithHighestVoteCount(int chainHeight) const;
+    // Get the payee and amount for the budget with the highest vote count
     bool GetPayeeAndAmount(int chainHeight, CScript& payeeRet, CAmount& nAmountRet) const;
     // Marks synced all votes in proposals and finalized budgets
     void SetSynced(bool synced);

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -276,6 +276,10 @@ public:
     // sets strProposal of a CFinalizedBudget reference
     void SetBudgetProposalsStr(CFinalizedBudget& finalizedBudget) const;
 
+    // checks finalized budget proposals (existence, payee, amount) for the finalized budget
+    // in the map, with given nHash. Returns error string if any, or "OK" otherwise
+    std::string GetFinalizedBudgetStatus(const uint256& nHash) const;
+
     void ResetSync() { SetSynced(false); }
     void MarkSynced() { SetSynced(true); }
     void Sync(CNode* node, const uint256& nProp, bool fPartial = false);
@@ -454,9 +458,6 @@ public:
     CAmount GetTotalPayout() const;
     //vote on this finalized budget as a masternode
     void SubmitVote();
-
-    //checks the hashes to make sure we know about them
-    std::string GetStatus() const;
 
     uint256 GetHash() const
     {

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -235,7 +235,6 @@ private:
 
 public:
     // critical sections to protect the inner data structures (must be locked in this order)
-    mutable RecursiveMutex cs;
     mutable RecursiveMutex cs_proposals;
     mutable RecursiveMutex cs_budgets;
     mutable RecursiveMutex cs_votes;

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -222,10 +222,13 @@ private:
     std::map<uint256, CFinalizedBudgetVote> mapSeenFinalizedBudgetVotes;
     std::map<uint256, CFinalizedBudgetVote> mapOrphanFinalizedBudgetVotes;
 
-    void SetSynced(bool synced);
-
     // Memory Only. Updated in NewBlock (blocks arrive in order)
     std::atomic<int> nBestHeight;
+
+    // Get block payee and amount for the finalized budget with highest vote count
+    bool GetPayeeAndAmount(int chainHeight, CScript& payeeRet, CAmount& nAmountRet) const;
+    // Marks synced all votes in proposals and finalized budgets
+    void SetSynced(bool synced);
 
 public:
     // critical sections to protect the inner data structures (must be locked in this order)
@@ -293,7 +296,7 @@ public:
     bool UpdateFinalizedBudget(CFinalizedBudgetVote& vote, CNode* pfrom, std::string& strError);
     TrxValidationStatus IsTransactionValid(const CTransaction& txNew, int nBlockHeight);
     std::string GetRequiredPaymentsString(int nBlockHeight);
-    void FillBlockPayee(CMutableTransaction& txNew, bool fProofOfStake);
+    void FillBlockPayee(CMutableTransaction& txNew, bool fProofOfStake) const;
 
     void CheckOrphanVotes();
     void Clear()

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -235,14 +235,14 @@ private:
 
 public:
     // critical sections to protect the inner data structures (must be locked in this order)
-    mutable RecursiveMutex cs_proposals;
     mutable RecursiveMutex cs_budgets;
-    mutable RecursiveMutex cs_votes;
+    mutable RecursiveMutex cs_proposals;
     mutable RecursiveMutex cs_finalizedvotes;
+    mutable RecursiveMutex cs_votes;
 
     CBudgetManager()
     {
-        LOCK2(cs_proposals, cs_budgets);
+        LOCK2(cs_budgets, cs_proposals);
         mapProposals.clear();
         mapFinalizedBudgets.clear();
     }

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -227,6 +227,7 @@ private:
 
     // Returns a const pointer to the budget with highest vote count
     const CFinalizedBudget* GetBudgetWithHighestVoteCount(int chainHeight) const;
+    int GetHighestVoteCount(int chainHeight) const;
     // Get the payee and amount for the budget with the highest vote count
     bool GetPayeeAndAmount(int chainHeight, CScript& payeeRet, CAmount& nAmountRet) const;
     // Marks synced all votes in proposals and finalized budgets
@@ -288,14 +289,15 @@ public:
     std::vector<CBudgetProposal*> GetBudget();
     std::vector<CBudgetProposal*> GetAllProposals();
     std::vector<CFinalizedBudget*> GetFinalizedBudgets();
-    bool IsBudgetPaymentBlock(int nBlockHeight);
+    bool IsBudgetPaymentBlock(int nBlockHeight) const;
+    bool IsBudgetPaymentBlock(int nBlockHeight, int& nHighestCount, int& nFivePercent) const;
     bool AddProposal(CBudgetProposal& budgetProposal);
     bool AddFinalizedBudget(CFinalizedBudget& finalizedBudget);
     void SubmitFinalBudget();
 
     bool UpdateProposal(const CBudgetVote& vote, CNode* pfrom, std::string& strError);
     bool UpdateFinalizedBudget(CFinalizedBudgetVote& vote, CNode* pfrom, std::string& strError);
-    TrxValidationStatus IsTransactionValid(const CTransaction& txNew, int nBlockHeight);
+    TrxValidationStatus IsTransactionValid(const CTransaction& txNew, int nBlockHeight) const;
     std::string GetRequiredPaymentsString(int nBlockHeight);
     void FillBlockPayee(CMutableTransaction& txNew, bool fProofOfStake) const;
 
@@ -401,7 +403,7 @@ public:
     std::string IsInvalidReason() const { return strInvalid; }
 
     std::string GetName() const { return strBudgetName; }
-    std::string GetProposals();
+    std::string GetProposals() const;
     int GetBlockStart() const { return nBlockStart; }
     int GetBlockEnd() const { return nBlockStart + (int)(vecBudgetPayments.size() - 1); }
     const uint256& GetFeeTXHash() const { return nFeeTXHash;  }

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -284,10 +284,15 @@ public:
 
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
     void NewBlock(int height);
+
+    // functions returning a pointer in the map. Need cs_proposals/cs_budgets locked from the caller
     CBudgetProposal* FindProposal(const uint256& nHash);
+    CFinalizedBudget* FindFinalizedBudget(const uint256& nHash);
+    // const functions, copying the budget object to a reference and returning true if found
+    bool GetProposal(const uint256& nHash, CBudgetProposal& bp) const;
+    bool GetFinalizedBudget(const uint256& nHash, CFinalizedBudget& fb) const;
     // finds the proposal with the given name, with highest net yes count.
     const CBudgetProposal* FindProposalByName(const std::string& strProposalName) const;
-    CFinalizedBudget* FindFinalizedBudget(const uint256& nHash);
 
     static CAmount GetTotalBudget(int nHeight);
     std::vector<CBudgetProposal*> GetBudget();

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -18,9 +18,6 @@
 #include <atomic>
 #include <univalue.h>
 
-
-extern RecursiveMutex cs_budget;
-
 class CBudgetManager;
 class CFinalizedBudgetBroadcast;
 class CFinalizedBudget;

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -273,6 +273,9 @@ public:
 
     bool AddAndRelayProposalVote(const CBudgetVote& vote, std::string& strError);
 
+    // sets strProposal of a CFinalizedBudget reference
+    void SetBudgetProposalsStr(CFinalizedBudget& finalizedBudget) const;
+
     void ResetSync() { SetSynced(false); }
     void MarkSynced() { SetSynced(true); }
     void Sync(CNode* node, const uint256& nProp, bool fPartial = false);
@@ -405,6 +408,7 @@ protected:
     int nBlockStart;
     std::vector<CTxBudgetPayment> vecBudgetPayments;
     uint256 nFeeTXHash;
+    std::string strProposals;
 
 public:
     int64_t nTime;
@@ -425,8 +429,11 @@ public:
     bool IsValid() const  { return fValid; }
     std::string IsInvalidReason() const { return strInvalid; }
 
+    void SetProposalsStr(const std::string _strProposals) { strProposals = _strProposals; }
+
     std::string GetName() const { return strBudgetName; }
-    std::string GetProposals() const;
+    std::string GetProposalsStr() const { return strProposals; }
+    std::vector<uint256> GetProposalsHashes() const;
     int GetBlockStart() const { return nBlockStart; }
     int GetBlockEnd() const { return nBlockStart + (int)(vecBudgetPayments.size() - 1); }
     const uint256& GetFeeTXHash() const { return nFeeTXHash;  }

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -38,9 +38,6 @@ static const CAmount BUDGET_FEE_TX = (5 * COIN);
 static const int64_t BUDGET_VOTE_UPDATE_MIN = 60 * 60;
 static std::map<uint256, int> mapPayment_History;
 
-extern std::vector<CBudgetProposalBroadcast> vecImmatureBudgetProposals;
-extern std::vector<CFinalizedBudgetBroadcast> vecImmatureFinalizedBudgets;
-
 extern CBudgetManager budget;
 void DumpBudgets();
 
@@ -220,6 +217,10 @@ private:
     std::map<uint256, CBudgetVote> mapOrphanMasternodeBudgetVotes;                  // guarded by cs_votes
     std::map<uint256, CFinalizedBudgetVote> mapSeenFinalizedBudgetVotes;            // guarded by cs_finalizedvotes
     std::map<uint256, CFinalizedBudgetVote> mapOrphanFinalizedBudgetVotes;          // guarded by cs_finalizedvotes
+
+    // Memory only
+    std::vector<CBudgetProposalBroadcast> vecImmatureBudgetProposals;               // guarded by cs_proposals
+    std::vector<CFinalizedBudgetBroadcast> vecImmatureFinalizedBudgets;             // guarded by cs_budgets
 
     // Memory Only. Updated in NewBlock (blocks arrive in order)
     std::atomic<int> nBestHeight;

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -251,9 +251,6 @@ public:
         mapSeenFinalizedBudgetVotes.clear();
     }
 
-    int sizeFinalized() { return (int)mapFinalizedBudgets.size(); }
-    int sizeProposals() { return (int)mapProposals.size(); }
-
     bool HaveSeenProposal(const uint256& propHash) const { return mapSeenMasternodeBudgetProposals.count(propHash); }
     bool HaveSeenProposalVote(const uint256& voteHash) const { return mapSeenMasternodeBudgetVotes.count(voteHash); }
     bool HaveSeenFinalizedBudget(const uint256& budgetHash) const { return mapSeenFinalizedBudgets.count(budgetHash); }

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -877,6 +877,7 @@ UniValue mnfinalbudget(const JSONRPCRequest& request)
         if (request.params.size() != 2)
             throw std::runtime_error("Correct usage is 'mnbudget getvotes budget-hash'");
 
+        LOCK(budget.cs_budgets);
         std::string strHash = request.params[1].get_str();
         uint256 hash(uint256S(strHash));
         CFinalizedBudget* pfinalBudget = budget.FindFinalizedBudget(hash);

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -853,14 +853,15 @@ UniValue mnfinalbudget(const JSONRPCRequest& request)
 
         std::vector<CFinalizedBudget*> winningFbs = budget.GetFinalizedBudgets();
         for (CFinalizedBudget* finalizedBudget : winningFbs) {
+            const uint256& nHash = finalizedBudget->GetHash();
             UniValue bObj(UniValue::VOBJ);
             bObj.pushKV("FeeTX", finalizedBudget->GetFeeTXHash().ToString());
-            bObj.pushKV("Hash", finalizedBudget->GetHash().ToString());
+            bObj.pushKV("Hash", nHash.ToString());
             bObj.pushKV("BlockStart", (int64_t)finalizedBudget->GetBlockStart());
             bObj.pushKV("BlockEnd", (int64_t)finalizedBudget->GetBlockEnd());
             bObj.pushKV("Proposals", finalizedBudget->GetProposalsStr());
             bObj.pushKV("VoteCount", (int64_t)finalizedBudget->GetVoteCount());
-            bObj.pushKV("Status", finalizedBudget->GetStatus());
+            bObj.pushKV("Status", budget.GetFinalizedBudgetStatus(nHash));
 
             bool fValid = finalizedBudget->IsValid();
             bObj.pushKV("IsValid", fValid);

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -858,7 +858,7 @@ UniValue mnfinalbudget(const JSONRPCRequest& request)
             bObj.pushKV("Hash", finalizedBudget->GetHash().ToString());
             bObj.pushKV("BlockStart", (int64_t)finalizedBudget->GetBlockStart());
             bObj.pushKV("BlockEnd", (int64_t)finalizedBudget->GetBlockEnd());
-            bObj.pushKV("Proposals", finalizedBudget->GetProposals());
+            bObj.pushKV("Proposals", finalizedBudget->GetProposalsStr());
             bObj.pushKV("VoteCount", (int64_t)finalizedBudget->GetVoteCount());
             bObj.pushKV("Status", finalizedBudget->GetStatus());
 


### PR DESCRIPTION
Keep going with the `masternode-budget` classes refactoring, mainly addressing the thread synchronization aspect.

There is currently a potential deadlock due to wrong lock order between `cs_main` and `cs_budgets`, which will be solved in a follow-up PR as it needs a more invasive refactoring (decoupling the checks in `UpdateValid`/`IsCollateralTransactionValid`, doing those that don't depend on the chainstate just once, and not requiring `cs_main` held for the others).