### PR TITLE
[Refactoring] Budget, round 3: split UpdateValid checks for proposals / finalized budgets

### DIFF
--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -92,7 +92,7 @@ bool CheckCollateral(const uint256& nTxCollateralHash, const uint256& nExpectedH
     return true;
 }
 
-bool IsBudgetCollateralValid(const uint256& nTxCollateralHash, int nCurrentHeight, int nProposalHeight, std::string& strError)
+bool CheckCollateralConfs(const uint256& nTxCollateralHash, int nCurrentHeight, int nProposalHeight, std::string& strError)
 {
     //if we're syncing we won't have swiftTX information, so accept 1 confirmation
     const int nRequiredConfs = Params().GetConsensus().nBudgetFeeConfirmations;
@@ -1431,8 +1431,7 @@ bool CBudgetProposal::CheckAddress()
 
 bool CBudgetProposal::CheckRequiredConfs(int nCurrentHeight)
 {
-    std::string strError;
-    return IsBudgetCollateralValid(nFeeTXHash, nCurrentHeight, nBlockFeeTx, strError);
+    return CheckCollateralConfs(nFeeTXHash, nCurrentHeight, nBlockFeeTx, strInvalid);
 }
 
 bool CBudgetProposal::IsWellFormed(const CAmount& nTotalBudget)
@@ -1990,8 +1989,7 @@ bool CFinalizedBudget::CheckName()
 
 bool CFinalizedBudget::CheckRequiredConfs(int nCurrentHeight)
 {
-    std::string strError;
-    return IsBudgetCollateralValid(nFeeTXHash, nCurrentHeight, nBlockFeeTx, strError);
+    return CheckCollateralConfs(nFeeTXHash, nCurrentHeight, nBlockFeeTx, strInvalid);
 }
 
 bool CFinalizedBudget::IsExpired(int nCurrentHeight)

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -30,8 +30,8 @@ bool CheckCollateralConfs(const uint256& nTxCollateralHash, int nCurrentHeight, 
     const int nConf = GetIXConfirmations(nTxCollateralHash) + nCurrentHeight - nProposalHeight + 1;
 
     if (nConf < nRequiredConfs) {
-        strError = strprintf("Collateral requires at least %d confirmations - %d confirmations "
-                "(current height: %d, fee tx height: %d)", nRequiredConfs, nConf, nCurrentHeight, nProposalHeight);
+        strError = strprintf("Collateral requires at least %d confirmations - %d confirmations (current height: %d, fee tx height: %d)",
+                nRequiredConfs, nConf, nCurrentHeight, nProposalHeight);
         LogPrint(BCLog::MNBUDGET,"%s: %s\n", __func__, strError);
         return false;
     }

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -681,6 +681,8 @@ bool CBudgetManager::IsBudgetPaymentBlock(int nBlockHeight, int& nCountThreshold
     int nFivePercent = nCountEnabled / 20;
     // threshold for highest finalized budgets (highest vote count - 10% of active masternodes)
     nCountThreshold = nHighestCount - (nCountEnabled / 10);
+    // reduce the threshold if there are less than 10 enabled masternodes
+    if (nCountThreshold == nHighestCount) nCountThreshold--;
 
     LogPrint(BCLog::MNBUDGET,"%s: nHighestCount: %lli, 5%% of Masternodes: %lli.\n",
             __func__, nHighestCount, nFivePercent);

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -1362,12 +1362,6 @@ bool CBudgetProposal::CheckStartEnd()
         return false;
     }
 
-    int nProposalEnd = nBlockStart + (Params().GetConsensus().nBudgetCycleBlocks + 1) * GetTotalPaymentCount();
-    if (nBlockEnd != nProposalEnd) {
-        strInvalid = "Invalid nBlockEnd (mismatch with payments count)";
-        return false;
-    }
-
     return true;
 }
 

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -1953,15 +1953,12 @@ bool CFinalizedBudget::CheckName()
 
 bool CFinalizedBudget::IsExpired(int nCurrentHeight)
 {
-    // Remove obsolete finalized budgets after some time
+    // Remove budgets after their last payment block
+    const int nBlockEnd = GetBlockEnd();
     const int nBlocksPerCycle = Params().GetConsensus().nBudgetCycleBlocks;
-    const int nBlockStart = nCurrentHeight - nCurrentHeight % nBlocksPerCycle + nBlocksPerCycle;
-
-    // Remove budgets where the last payment (from max. 100) ends before 2 budget-cycles before the current one
-    const int nMaxAge = nBlockStart - (2 * nBlocksPerCycle);
-
-    if (GetBlockEnd() < nMaxAge) {
-        strInvalid = strprintf("(ends at block %ld) too old and obsolete", GetBlockEnd());
+    const int nLastSuperBlock = nCurrentHeight - nCurrentHeight % nBlocksPerCycle;
+    if (nBlockEnd < nLastSuperBlock) {
+        strInvalid = strprintf("(ends at block %ld) too old and obsolete", nBlockEnd);
         return true;
     }
 

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -1390,7 +1390,7 @@ void CBudgetProposal::SyncVotes(CNode* pfrom, bool fPartial, int& nInvCount) con
 bool CBudgetProposal::IsHeavilyDownvoted()
 {
     if (GetNays() - GetYeas() > mnodeman.CountEnabled(ActiveProtocol()) / 10) {
-        strInvalid = "Proposal " + strProposalName + ": Active removal";
+        strInvalid = "Active removal";
         return true;
     }
     return false;
@@ -1404,13 +1404,13 @@ bool CBudgetProposal::CheckStartEnd()
     }
 
     if (nBlockEnd < nBlockStart) {
-        strInvalid = "Proposal " + strProposalName + ": Invalid nBlockEnd (end before start)";
+        strInvalid = "Invalid nBlockEnd (end before start)";
         return false;
     }
 
     int nProposalEnd = nBlockStart + (Params().GetConsensus().nBudgetCycleBlocks + 1) * GetTotalPaymentCount();
     if (nBlockEnd != nProposalEnd) {
-        strInvalid = "Proposal " + strProposalName + ": Invalid nBlockEnd (mismatch with payments count)";
+        strInvalid = "Invalid nBlockEnd (mismatch with payments count)";
         return false;
     }
 
@@ -1421,14 +1421,14 @@ bool CBudgetProposal::CheckAmount(const CAmount& nTotalBudget)
 {
     // check minimum amount
     if (nAmount < 10 * COIN) {
-        strInvalid = "Proposal " + strProposalName + ": Invalid nAmount (too low)";
+        strInvalid = "Invalid nAmount (too low)";
         return false;
     }
 
     // check maximum amount
     // can only pay out 10% of the possible coins (min value of coins)
     if (nAmount > nTotalBudget) {
-        strInvalid = "Proposal " + strProposalName + ": Invalid nAmount (too high)";
+        strInvalid = "Invalid nAmount (too high)";
         return false;
     }
 
@@ -1440,18 +1440,18 @@ bool CBudgetProposal::CheckAddress()
     // !TODO: There might be an issue with multisig in the coinbase on mainnet
     // we will add support for it in a future release.
     if (address.IsPayToScriptHash()) {
-        strInvalid = "Proposal " + strProposalName + ": Multisig is not currently supported.";
+        strInvalid = "Multisig is not currently supported.";
         return false;
     }
 
     // Check address
     CTxDestination dest;
     if (!ExtractDestination(address, dest, false)) {
-        strInvalid = "Proposal " + strProposalName + ": Invalid script";
+        strInvalid = "Invalid script";
         return false;
     }
     if (!IsValidDestination(dest)) {
-        strInvalid = "Proposal " + strProposalName + ": Invalid recipient address";
+        strInvalid = "Invalid recipient address";
         return false;
     }
 
@@ -1466,7 +1466,7 @@ bool CBudgetProposal::IsWellFormed(const CAmount& nTotalBudget)
 bool CBudgetProposal::IsExpired(int nCurrentHeight)
 {
     if (nBlockEnd < nCurrentHeight) {
-        strInvalid = "Proposal " + strProposalName + ": Proposal expired";
+        strInvalid = "Proposal expired";
         return true;
     }
     return false;
@@ -1493,7 +1493,7 @@ bool CBudgetProposal::UpdateValid(int nCurrentHeight, bool fCheckCollateral)
         int nConf = 0;
         std::string strError;
         if (!IsBudgetCollateralValid(nFeeTXHash, GetHash(), strError, nTime, nConf)) {
-            strInvalid = "Proposal " + strProposalName + ": Invalid collateral (" + strError + ")";
+            strInvalid = "Invalid collateral (" + strError + ")";
             return false;
         }
     }

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -23,7 +23,7 @@ std::map<uint256, int64_t> askedForSourceProposalOrBudget;
 
 int nSubmittedFinalBudget;
 
-bool CheckCollateral(const uint256& nTxCollateralHash, const uint256& nExpectedHash, std::string& strError, int64_t& nTime, int& nConf, bool fBudgetFinalization)
+bool CheckCollateral(const uint256& nTxCollateralHash, const uint256& nExpectedHash, std::string& strError, int64_t& nTime, int& nHeight, bool fBudgetFinalization)
 {
     CTransaction txCollateral;
     uint256 nBlockHash;
@@ -57,8 +57,7 @@ bool CheckCollateral(const uint256& nTxCollateralHash, const uint256& nExpectedH
                     foundOpReturn = true;
                 }
             }
-        }
-        else {
+        } else {
             // Collateral for normal budget proposal
             LogPrint(BCLog::MNBUDGET, "Normal Budget: o.scriptPubKey(%s) == findScript(%s) ?\n", HexStr(o.scriptPubKey), HexStr(findScript));
             if (o.scriptPubKey == findScript) {
@@ -76,19 +75,15 @@ bool CheckCollateral(const uint256& nTxCollateralHash, const uint256& nExpectedH
         return false;
     }
 
-    // RETRIEVE CONFIRMATIONS AND NTIME
-    /*
-        - nTime starts as zero and is passed-by-reference out of this function and stored in the external proposal
-        - nTime is never validated via the hashing mechanism and comes from a full-validated source (the blockchain)
-    */
-
-    nConf = GetIXConfirmations(nTxCollateralHash);
+    // Retrieve block height (checking that i's in the active chain) and time
+    // both get set in CBudgetProposal/CFinalizedBudget by the caller (AddProposal/AddFinalizedBudget)
     if (!nBlockHash.IsNull()) {
+        LOCK(cs_main);
         BlockMap::iterator mi = mapBlockIndex.find(nBlockHash);
         if (mi != mapBlockIndex.end() && (*mi).second) {
             CBlockIndex* pindex = (*mi).second;
             if (chainActive.Contains(pindex)) {
-                nConf += chainActive.Height() - pindex->nHeight + 1;
+                nHeight = pindex->nHeight;
                 nTime = pindex->nTime;
             }
         }
@@ -97,22 +92,18 @@ bool CheckCollateral(const uint256& nTxCollateralHash, const uint256& nExpectedH
     return true;
 }
 
-bool IsBudgetCollateralValid(const uint256& nTxCollateralHash, const uint256& nExpectedHash, std::string& strError, int64_t& nTime, int& nConf, bool fBudgetFinalization)
+bool IsBudgetCollateralValid(const uint256& nTxCollateralHash, int nCurrentHeight, int nProposalHeight, std::string& strError)
 {
-    // Static checks. !TODO: move from here - they should be done only once (or after reorgs).
-    uint256 nBlockHash;
-    if (!CheckCollateral(nTxCollateralHash, nExpectedHash, strError, nTime, nConf, fBudgetFinalization))
-        return false;
-
     //if we're syncing we won't have swiftTX information, so accept 1 confirmation
     const int nRequiredConfs = Params().GetConsensus().nBudgetFeeConfirmations;
-    if (nConf >= nRequiredConfs) {
-        return true;
-    } else {
+    const int nConf = GetIXConfirmations(nTxCollateralHash) + nCurrentHeight - nProposalHeight + 1;
+
+    if (nConf < nRequiredConfs) {
         strError = strprintf("Collateral requires at least %d confirmations - %d confirmations", nRequiredConfs, nConf);
         LogPrint(BCLog::MNBUDGET,"%s: %s\n", __func__, strError);
         return false;
     }
+    return true;
 }
 
 void CBudgetManager::CheckOrphanVotes()
@@ -222,27 +213,18 @@ void CBudgetManager::SubmitFinalBudget()
         txidCollateral = mapCollateralTxids[budgetHash];
     }
 
-    //create the proposal incase we're the first to make it
+    // create the proposal incase we're the first to make it
     CFinalizedBudgetBroadcast finalizedBudgetBroadcast(strBudgetName, nBlockStart, vecTxBudgetPayments, txidCollateral);
     const uint256& nHash = finalizedBudgetBroadcast.GetHash();
 
-    // check
-    int nConf = 0;
-    int64_t nTime = 0;
-    std::string strError = "";
-    if (!IsBudgetCollateralValid(txidCollateral, nHash, strError, nTime, nConf, true)) {
-        LogPrint(BCLog::MNBUDGET,"%s: Invalid Collateral for finalized budget - %s \n", __func__, strError);
+    // check and add
+    CFinalizedBudget fb = CFinalizedBudget(finalizedBudgetBroadcast);
+    if (!AddFinalizedBudget(fb)) {
+        LogPrint(BCLog::MNBUDGET,"%s: Invalid finalized budget %s %s\n", __func__, nHash.ToString(), fb.IsInvalidLogStr());
         return;
     }
-
-    if (!finalizedBudgetBroadcast.UpdateValid(nCurrentHeight)) {
-        LogPrint(BCLog::MNBUDGET,"%s: Invalid finalized budget %s %s\n", __func__, nHash.ToString(), finalizedBudgetBroadcast.IsInvalidLogStr());
-        return;
-    }
-
     AddSeenFinalizedBudget(finalizedBudgetBroadcast);
     finalizedBudgetBroadcast.Relay();
-    AddFinalizedBudget(finalizedBudgetBroadcast);
     nSubmittedHeight = nCurrentHeight;
     LogPrint(BCLog::MNBUDGET,"%s: Done! %s\n", __func__, nHash.ToString());
 }
@@ -458,16 +440,21 @@ bool CBudgetManager::AddFinalizedBudget(CFinalizedBudget& finalizedBudget)
         return false;
     }
 
-    if (!finalizedBudget.IsWellFormed(GetTotalBudget(GetBestHeight()))) {
+    if (!finalizedBudget.IsWellFormed(GetTotalBudget(finalizedBudget.GetBlockStart()))) {
         LogPrint(BCLog::MNBUDGET,"%s: invalid finalized budget: %s %s\n", __func__, nHash.ToString(), finalizedBudget.IsInvalidLogStr());
         return false;
     }
 
-    int nConf = 0;
     std::string strError;
-    if (!CheckCollateral(finalizedBudget.GetFeeTXHash(), nHash, strError, finalizedBudget.nTime, nConf, true)) {
+    if (!CheckCollateral(finalizedBudget.GetFeeTXHash(), nHash, strError, finalizedBudget.nTime, finalizedBudget.nBlockFeeTx, true)) {
         LogPrint(BCLog::MNBUDGET,"%s: invalid finalized budget (%s) collateral - %s\n",
                 __func__, nHash.ToString(), strError);
+        return false;
+    }
+
+    // update confirms/expiration
+    if (!finalizedBudget.UpdateValid(GetBestHeight())) {
+        LogPrint(BCLog::MNBUDGET,"%s: invalid finalized budget: %s %s\n", __func__, nHash.ToString(), finalizedBudget.IsInvalidLogStr());
         return false;
     }
 
@@ -493,11 +480,16 @@ bool CBudgetManager::AddProposal(CBudgetProposal& budgetProposal)
         return false;
     }
 
-    int nConf = 0;
     std::string strError;
-    if (!CheckCollateral(budgetProposal.GetFeeTXHash(), nHash, strError, budgetProposal.nTime, nConf, false)) {
+    if (!CheckCollateral(budgetProposal.GetFeeTXHash(), nHash, strError, budgetProposal.nTime, budgetProposal.nBlockFeeTx, false)) {
         LogPrint(BCLog::MNBUDGET,"%s: invalid budget proposal (%s) collateral - %s\n",
                 __func__, nHash.ToString(), strError);
+        return false;
+    }
+
+    // update confirms/expiration
+    if (!budgetProposal.UpdateValid(GetBestHeight())) {
+        LogPrint(BCLog::MNBUDGET,"%s: Invalid budget proposal %s %s\n", __func__, nHash.ToString(), budgetProposal.IsInvalidLogStr());
         return false;
     }
 
@@ -1010,23 +1002,12 @@ void CBudgetManager::NewBlock(int height)
         LogPrint(BCLog::MNBUDGET,"%s:  vecImmatureProposals cleanup - size: %d\n", __func__, vecImmatureProposals.size());
         std::vector<CBudgetProposalBroadcast>::iterator it = vecImmatureProposals.begin();
         while (it != vecImmatureProposals.end()) {
-            std::string strError = "";
-            int nConf = 0;
-            const uint256& nHash = it->GetHash();
-            if (!IsBudgetCollateralValid(it->GetFeeTXHash(), nHash, strError, it->nTime, nConf)) {
+            CBudgetProposal budgetProposal(*it);
+            if (!AddProposal(budgetProposal)) {
                 ++it;
                 continue;
             }
-            if (!it->UpdateValid(nCurrentHeight)) {
-                LogPrint(BCLog::MNBUDGET,"mprop (immature/invalid) %s %s\n", nHash.ToString(), it->IsInvalidLogStr());
-                it = vecImmatureProposals.erase(it);
-                continue;
-            }
-            LogPrint(BCLog::MNBUDGET,"mprop (new) %s", nHash.ToString());
-            CBudgetProposal budgetProposal(*it);
-            if (AddProposal(budgetProposal)) {
-                it->Relay();
-            }
+            it->Relay();
             it = vecImmatureProposals.erase(it);
         }
     }
@@ -1040,23 +1021,12 @@ void CBudgetManager::NewBlock(int height)
         LogPrint(BCLog::MNBUDGET,"%s:  vecImmatureFinalizedBudgets cleanup - size: %d\n", __func__, vecImmatureFinalizedBudgets.size());
         std::vector<CFinalizedBudgetBroadcast>::iterator it = vecImmatureFinalizedBudgets.begin();
         while (it != vecImmatureFinalizedBudgets.end()) {
-            std::string strError = "";
-            int nConf = 0;
-            const uint256& nHash = it->GetHash();
-            if (!IsBudgetCollateralValid(it->GetFeeTXHash(), nHash, strError, it->nTime, nConf, true)) {
+            CFinalizedBudget finalizedBudget(*it);
+            if (!AddFinalizedBudget(finalizedBudget)) {
                 ++it;
                 continue;
             }
-            if (!it->UpdateValid(nCurrentHeight)) {
-                LogPrint(BCLog::MNBUDGET,"fbs (immature/invalid) %s %s\n", nHash.ToString(), it->IsInvalidLogStr());
-                it = vecImmatureFinalizedBudgets.erase(it);
-                continue;
-            }
-            LogPrint(BCLog::MNBUDGET,"fbs (new) %s\n", nHash.ToString());
-            CFinalizedBudget finalizedBudget(*it);
-            if (AddFinalizedBudget(finalizedBudget)) {
-                it->Relay();
-            }
+            it->Relay();
             it = vecImmatureFinalizedBudgets.erase(it);
         }
     }
@@ -1068,8 +1038,6 @@ void CBudgetManager::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
     // lite mode is not supported
     if (fLiteMode) return;
     if (!masternodeSync.IsBlockchainSynced()) return;
-
-    int nCurrentHeight = GetBestHeight();
 
     if (strCommand == NetMsgType::BUDGETVOTESYNC) { //Masternode vote sync
         uint256 nProp;
@@ -1095,35 +1063,19 @@ void CBudgetManager::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         CBudgetProposalBroadcast budgetProposalBroadcast;
         vRecv >> budgetProposalBroadcast;
 
-        if (HaveSeenProposal(budgetProposalBroadcast.GetHash())) {
-            masternodeSync.AddedBudgetItem(budgetProposalBroadcast.GetHash());
-            return;
-        }
-
-        std::string strError = "";
-        int nConf = 0;
         const uint256& nHash = budgetProposalBroadcast.GetHash();
-        const uint256& nFeeTXHash = budgetProposalBroadcast.GetFeeTXHash();
-        if (!IsBudgetCollateralValid(nFeeTXHash, nHash, strError, budgetProposalBroadcast.nTime, nConf)) {
-            LogPrint(BCLog::MNBUDGET,"Proposal FeeTX is not valid - %s - %s\n", nFeeTXHash.ToString(), strError);
-            if (nConf >= 1) {
-                LOCK(cs_proposals);
-                vecImmatureProposals.push_back(budgetProposalBroadcast);
-            }
-            return;
-        }
-
-        AddSeenProposal(budgetProposalBroadcast);
-
-        if (!budgetProposalBroadcast.UpdateValid(nCurrentHeight)) {
-            LogPrint(BCLog::MNBUDGET,"mprop (immature/invalid) %s %s\n", nHash.ToString(), budgetProposalBroadcast.IsInvalidLogStr());
+        if (HaveSeenProposal(nHash)) {
+            masternodeSync.AddedBudgetItem(nHash);
             return;
         }
 
         CBudgetProposal budgetProposal(budgetProposalBroadcast);
-        if (AddProposal(budgetProposal)) {
-            budgetProposalBroadcast.Relay();
+        if (!AddProposal(budgetProposal)) {
+            LogPrint(BCLog::MNBUDGET,"mprop (immature/invalid) %s %s\n", nHash.ToString(), budgetProposal.IsInvalidLogStr());
+            return;
         }
+        AddSeenProposal(budgetProposalBroadcast);
+        budgetProposalBroadcast.Relay();
         masternodeSync.AddedBudgetItem(nHash);
 
         LogPrint(BCLog::MNBUDGET,"mprop (new) %s\n", nHash.ToString());
@@ -1176,38 +1128,22 @@ void CBudgetManager::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         CFinalizedBudgetBroadcast finalizedBudgetBroadcast;
         vRecv >> finalizedBudgetBroadcast;
 
-        if (HaveSeenFinalizedBudget(finalizedBudgetBroadcast.GetHash())) {
-            masternodeSync.AddedBudgetItem(finalizedBudgetBroadcast.GetHash());
-            return;
-        }
-
-        std::string strError = "";
-        int nConf = 0;
         const uint256& nHash = finalizedBudgetBroadcast.GetHash();
-        const uint256& nFeeTXHash = finalizedBudgetBroadcast.GetFeeTXHash();
-        if (!IsBudgetCollateralValid(nFeeTXHash, nHash, strError, finalizedBudgetBroadcast.nTime, nConf, true)) {
-            LogPrint(BCLog::MNBUDGET,"fbs - Finalized Budget FeeTX is not valid - %s - %s\n", nFeeTXHash.ToString(), strError);
-            if (nConf >= 1) {
-                LOCK(cs_budgets);
-                vecImmatureFinalizedBudgets.push_back(finalizedBudgetBroadcast);
-            }
+        if (HaveSeenFinalizedBudget(nHash)) {
+            masternodeSync.AddedBudgetItem(nHash);
             return;
         }
 
-        AddSeenFinalizedBudget(finalizedBudgetBroadcast);
-
-        if (!finalizedBudgetBroadcast.UpdateValid(nCurrentHeight)) {
+        CFinalizedBudget finalizedBudget(finalizedBudgetBroadcast);
+        if (!AddFinalizedBudget(finalizedBudget)) {
             LogPrint(BCLog::MNBUDGET,"fbs (immature/invalid) %s %s\n", nHash.ToString(), finalizedBudgetBroadcast.IsInvalidLogStr());
             return;
         }
+        AddSeenFinalizedBudget(finalizedBudgetBroadcast);
+        finalizedBudgetBroadcast.Relay();
+        masternodeSync.AddedBudgetItem(nHash);
 
         LogPrint(BCLog::MNBUDGET,"fbs (new) %s\n", nHash.ToString());
-
-        CFinalizedBudget finalizedBudget(finalizedBudgetBroadcast);
-        if (AddFinalizedBudget(finalizedBudget)) {
-            finalizedBudgetBroadcast.Relay();
-        }
-        masternodeSync.AddedBudgetItem(nHash);
 
         //we might have active votes for this budget that are now valid
         CheckOrphanVotes();
@@ -1375,6 +1311,7 @@ CBudgetProposal::CBudgetProposal()
     nBlockStart = 0;
     nBlockEnd = 0;
     nAmount = 0;
+    nBlockFeeTx = 0;
     nTime = 0;
     fValid = true;
     strInvalid = "";
@@ -1388,6 +1325,7 @@ CBudgetProposal::CBudgetProposal(std::string strProposalNameIn, std::string strU
     nBlockEnd = nBlockEndIn;
     address = addressIn;
     nAmount = nAmountIn;
+    nBlockFeeTx = 0;
     nFeeTXHash = nFeeTXHashIn;
     fValid = true;
     strInvalid = "";
@@ -1402,6 +1340,7 @@ CBudgetProposal::CBudgetProposal(const CBudgetProposal& other)
     address = other.address;
     nAmount = other.nAmount;
     nTime = other.nTime;
+    nBlockFeeTx = other.nBlockFeeTx;
     nFeeTXHash = other.nFeeTXHash;
     mapVotes = other.mapVotes;
     fValid = true;
@@ -1490,6 +1429,12 @@ bool CBudgetProposal::CheckAddress()
     return true;
 }
 
+bool CBudgetProposal::CheckRequiredConfs(int nCurrentHeight)
+{
+    std::string strError;
+    return IsBudgetCollateralValid(nFeeTXHash, nCurrentHeight, nBlockFeeTx, strError);
+}
+
 bool CBudgetProposal::IsWellFormed(const CAmount& nTotalBudget)
 {
     return CheckStartEnd() && CheckAmount(nTotalBudget) && CheckAddress();
@@ -1504,7 +1449,7 @@ bool CBudgetProposal::IsExpired(int nCurrentHeight)
     return false;
 }
 
-bool CBudgetProposal::UpdateValid(int nCurrentHeight, bool fCheckCollateral)
+bool CBudgetProposal::UpdateValid(int nCurrentHeight)
 {
     fValid = false;
 
@@ -1516,13 +1461,8 @@ bool CBudgetProposal::UpdateValid(int nCurrentHeight, bool fCheckCollateral)
         return false;
     }
 
-    if (fCheckCollateral) {
-        int nConf = 0;
-        std::string strError;
-        if (!IsBudgetCollateralValid(nFeeTXHash, GetHash(), strError, nTime, nConf)) {
-            strInvalid = "Invalid collateral (" + strError + ")";
-            return false;
-        }
+    if (!CheckRequiredConfs(nCurrentHeight)) {
+        return false;
     }
 
     fValid = true;
@@ -1783,7 +1723,8 @@ CFinalizedBudget::CFinalizedBudget() :
         vecBudgetPayments(),
         nFeeTXHash(),
         strProposals(""),
-        nTime(0)
+        nTime(0),
+        nBlockFeeTx(0)
 { }
 
 CFinalizedBudget::CFinalizedBudget(const CFinalizedBudget& other) :
@@ -1796,7 +1737,8 @@ CFinalizedBudget::CFinalizedBudget(const CFinalizedBudget& other) :
         vecBudgetPayments(other.vecBudgetPayments),
         nFeeTXHash(other.nFeeTXHash),
         strProposals(other.strProposals),
-        nTime(other.nTime)
+        nTime(other.nTime),
+        nBlockFeeTx(other.nBlockFeeTx)
 { }
 
 bool CFinalizedBudget::AddOrUpdateVote(const CFinalizedBudgetVote& vote, std::string& strError)
@@ -2046,6 +1988,12 @@ bool CFinalizedBudget::CheckName()
     return true;
 }
 
+bool CFinalizedBudget::CheckRequiredConfs(int nCurrentHeight)
+{
+    std::string strError;
+    return IsBudgetCollateralValid(nFeeTXHash, nCurrentHeight, nBlockFeeTx, strError);
+}
+
 bool CFinalizedBudget::IsExpired(int nCurrentHeight)
 {
     // Remove obsolete finalized budgets after some time
@@ -2068,22 +2016,15 @@ bool CFinalizedBudget::IsWellFormed(const CAmount& nTotalBudget)
     return CheckStartEnd() && CheckAmount(nTotalBudget) && CheckName();
 }
 
-bool CFinalizedBudget::UpdateValid(int nCurrentHeight, bool fCheckCollateral)
+bool CFinalizedBudget::UpdateValid(int nCurrentHeight)
 {
     fValid = false;
 
-    std::string strError = "";
-    if (fCheckCollateral) {
-        int nConf = 0;
-        if (!IsBudgetCollateralValid(nFeeTXHash, GetHash(), strError, nTime, nConf, true)) {
-            {
-                strInvalid = "Invalid Collateral : " + strError;
-                return false;
-            }
-        }
+    if (IsExpired(nCurrentHeight)) {
+        return false;
     }
 
-    if (IsExpired(nCurrentHeight)) {
+    if (!CheckRequiredConfs(nCurrentHeight)) {
         return false;
     }
 

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -106,7 +106,8 @@ bool CheckCollateralConfs(const uint256& nTxCollateralHash, int nCurrentHeight, 
     const int nConf = GetIXConfirmations(nTxCollateralHash) + nCurrentHeight - nProposalHeight + 1;
 
     if (nConf < nRequiredConfs) {
-        strError = strprintf("Collateral requires at least %d confirmations - %d confirmations", nRequiredConfs, nConf);
+        strError = strprintf("Collateral requires at least %d confirmations - %d confirmations "
+                "(current height: %d, fee tx height: %d)", nRequiredConfs, nConf, nCurrentHeight, nProposalHeight);
         LogPrint(BCLog::MNBUDGET,"%s: %s\n", __func__, strError);
         return false;
     }

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -1437,16 +1437,21 @@ bool CBudgetProposal::CheckAmount(const CAmount& nTotalBudget)
 
 bool CBudgetProposal::CheckAddress()
 {
-    if (address == CScript()) {
-        strInvalid = "Proposal " + strProposalName + ": Invalid Payment Address (null)";
+    // !TODO: There might be an issue with multisig in the coinbase on mainnet
+    // we will add support for it in a future release.
+    if (address.IsPayToScriptHash()) {
+        strInvalid = "Proposal " + strProposalName + ": Multisig is not currently supported.";
         return false;
     }
 
-    /*
-        TODO: There might be an issue with multisig in the coinbase on mainnet, we will add support for it in a future release.
-    */
-    if (address.IsPayToScriptHash()) {
-        strInvalid = "Proposal " + strProposalName + ": Multisig is not currently supported.";
+    // Check address
+    CTxDestination dest;
+    if (!ExtractDestination(address, dest, false)) {
+        strInvalid = "Proposal " + strProposalName + ": Invalid script";
+        return false;
+    }
+    if (!IsValidDestination(dest)) {
+        strInvalid = "Proposal " + strProposalName + ": Invalid recipient address";
         return false;
     }
 

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -415,6 +415,7 @@ private:
     bool CheckStartEnd();
     bool CheckAmount(const CAmount& nTotalBudget);
     bool CheckName();
+    bool CheckRequiredConfs(int nCurrentHeight);
 
 protected:
     std::map<uint256, CFinalizedBudgetVote> mapVotes;
@@ -425,7 +426,9 @@ protected:
     std::string strProposals;
 
 public:
+    // Set in CBudgetManager::AddFinalizedBudget via CheckCollateral
     int64_t nTime;
+    int nBlockFeeTx;
 
     CFinalizedBudget();
     CFinalizedBudget(const CFinalizedBudget& other);
@@ -439,7 +442,7 @@ public:
     void SyncVotes(CNode* pfrom, bool fPartial, int& nInvCount) const;
 
     // sets fValid and strInvalid, returns fValid
-    bool UpdateValid(int nHeight, bool fCheckCollateral = true);
+    bool UpdateValid(int nHeight);
     // Static checks that should be done only once - sets strInvalid
     bool IsWellFormed(const CAmount& nTotalBudget);
     bool IsValid() const  { return fValid; }
@@ -482,6 +485,7 @@ public:
     {
         READWRITE(LIMITED_STRING(strBudgetName, 20));
         READWRITE(nFeeTXHash);
+        READWRITE(nBlockFeeTx);
         READWRITE(nTime);
         READWRITE(nBlockStart);
         READWRITE(vecBudgetPayments);
@@ -555,6 +559,7 @@ private:
     bool CheckStartEnd();
     bool CheckAmount(const CAmount& nTotalBudget);
     bool CheckAddress();
+    bool CheckRequiredConfs(int nCurrentHeight);
 
 protected:
     std::map<uint256, CBudgetVote> mapVotes;
@@ -567,7 +572,9 @@ protected:
     uint256 nFeeTXHash;
 
 public:
+    // Set in CBudgetManager::AddProposal via CheckCollateral
     int64_t nTime;
+    int nBlockFeeTx;
 
     CBudgetProposal();
     CBudgetProposal(const CBudgetProposal& other);
@@ -581,7 +588,7 @@ public:
     void SyncVotes(CNode* pfrom, bool fPartial, int& nInvCount) const;
 
     // sets fValid and strInvalid, returns fValid
-    bool UpdateValid(int nHeight, bool fCheckCollateral = true);
+    bool UpdateValid(int nHeight);
     // Static checks that should be done only once - sets strInvalid
     bool IsWellFormed(const CAmount& nTotalBudget);
     bool IsValid() const  { return fValid; }
@@ -639,6 +646,7 @@ public:
         READWRITE(*(CScriptBase*)(&address));
         READWRITE(nTime);
         READWRITE(nFeeTXHash);
+        READWRITE(nBlockFeeTx);
 
         //for saving to the serialized db
         READWRITE(mapVotes);

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -540,14 +540,12 @@ private:
     bool fValid;
     std::string strInvalid;
 
-    // Functions used inside UpdateValid() (!TODO: move) - setting strInvalid
+    // Functions used inside UpdateValid()/IsWellFormed - setting strInvalid
     bool IsHeavilyDownvoted();
     bool IsExpired(int nCurrentHeight);
     bool CheckStartEnd();
     bool CheckAmount(const CAmount& nTotalBudget);
     bool CheckAddress();
-    // Static checks that should be done only once
-    bool IsWellFormed(const CAmount& nTotalBudget);
 
 protected:
     std::map<uint256, CBudgetVote> mapVotes;
@@ -575,6 +573,8 @@ public:
 
     // sets fValid and strInvalid, returns fValid
     bool UpdateValid(int nHeight, bool fCheckCollateral = true);
+    // Static checks that should be done only once - sets strInvalid
+    bool IsWellFormed(const CAmount& nTotalBudget);
     bool IsValid() const  { return fValid; }
     std::string IsInvalidReason() const { return strInvalid; }
 

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -40,9 +40,6 @@ static std::map<uint256, int> mapPayment_History;
 extern CBudgetManager budget;
 void DumpBudgets();
 
-//Check the collateral transaction for the budget proposal/finalized budget
-bool IsBudgetCollateralValid(const uint256& nTxCollateralHash, const uint256& nExpectedHash, std::string& strError, int64_t& nTime, int& nConf, bool fBudgetFinalization=false);
-
 //
 // CBudgetVote - Allow a masternode node to vote and broadcast throughout the network
 //

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -409,7 +409,6 @@ private:
     bool CheckStartEnd();
     bool CheckAmount(const CAmount& nTotalBudget);
     bool CheckName();
-    bool CheckRequiredConfs(int nCurrentHeight);
 
 protected:
     std::map<uint256, CFinalizedBudgetVote> mapVotes;
@@ -422,7 +421,6 @@ protected:
 public:
     // Set in CBudgetManager::AddFinalizedBudget via CheckCollateral
     int64_t nTime;
-    int nBlockFeeTx;
 
     CFinalizedBudget();
     CFinalizedBudget(const CFinalizedBudget& other);
@@ -479,7 +477,6 @@ public:
     {
         READWRITE(LIMITED_STRING(strBudgetName, 20));
         READWRITE(nFeeTXHash);
-        READWRITE(nBlockFeeTx);
         READWRITE(nTime);
         READWRITE(nBlockStart);
         READWRITE(vecBudgetPayments);
@@ -553,7 +550,6 @@ private:
     bool CheckStartEnd();
     bool CheckAmount(const CAmount& nTotalBudget);
     bool CheckAddress();
-    bool CheckRequiredConfs(int nCurrentHeight);
 
 protected:
     std::map<uint256, CBudgetVote> mapVotes;
@@ -568,7 +564,6 @@ protected:
 public:
     // Set in CBudgetManager::AddProposal via CheckCollateral
     int64_t nTime;
-    int nBlockFeeTx;
 
     CBudgetProposal();
     CBudgetProposal(const CBudgetProposal& other);
@@ -633,14 +628,12 @@ public:
         //for syncing with other clients
         READWRITE(LIMITED_STRING(strProposalName, 20));
         READWRITE(LIMITED_STRING(strURL, 64));
-        READWRITE(nTime);
         READWRITE(nBlockStart);
         READWRITE(nBlockEnd);
         READWRITE(nAmount);
         READWRITE(*(CScriptBase*)(&address));
         READWRITE(nTime);
         READWRITE(nFeeTXHash);
-        READWRITE(nBlockFeeTx);
 
         //for saving to the serialized db
         READWRITE(mapVotes);

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -436,6 +436,7 @@ public:
     bool UpdateValid(int nHeight, bool fCheckCollateral = true);
     bool IsValid() const  { return fValid; }
     std::string IsInvalidReason() const { return strInvalid; }
+    std::string IsInvalidLogStr() const { return strprintf("[%s (%s)]: %s", GetName(), GetProposalsStr(), IsInvalidReason()); }
 
     void SetProposalsStr(const std::string _strProposals) { strProposals = _strProposals; }
 
@@ -577,6 +578,7 @@ public:
     bool IsWellFormed(const CAmount& nTotalBudget);
     bool IsValid() const  { return fValid; }
     std::string IsInvalidReason() const { return strInvalid; }
+    std::string IsInvalidLogStr() const { return strprintf("[%s]: %s", GetName(), IsInvalidReason()); }
 
     bool IsEstablished() const;
     bool IsPassing(int nBlockStartBudget, int nBlockEndBudget, int mnCount) const;

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -540,6 +540,15 @@ private:
     bool fValid;
     std::string strInvalid;
 
+    // Functions used inside UpdateValid() (!TODO: move) - setting strInvalid
+    bool IsHeavilyDownvoted();
+    bool IsExpired(int nCurrentHeight);
+    bool CheckStartEnd();
+    bool CheckAmount(const CAmount& nTotalBudget);
+    bool CheckAddress();
+    // Static checks that should be done only once
+    bool IsWellFormed(const CAmount& nTotalBudget);
+
 protected:
     std::map<uint256, CBudgetVote> mapVotes;
     std::string strProposalName;

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -305,7 +305,7 @@ public:
     bool UpdateFinalizedBudget(CFinalizedBudgetVote& vote, CNode* pfrom, std::string& strError);
     TrxValidationStatus IsTransactionValid(const CTransaction& txNew, int nBlockHeight) const;
     std::string GetRequiredPaymentsString(int nBlockHeight);
-    void FillBlockPayee(CMutableTransaction& txNew, bool fProofOfStake) const;
+    bool FillBlockPayee(CMutableTransaction& txNew, bool fProofOfStake) const;
 
     void CheckOrphanVotes();
     void Clear()

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -35,7 +35,7 @@ static const CAmount PROPOSAL_FEE_TX = (50 * COIN);
 static const CAmount BUDGET_FEE_TX_OLD = (50 * COIN);
 static const CAmount BUDGET_FEE_TX = (5 * COIN);
 static const int64_t BUDGET_VOTE_UPDATE_MIN = 60 * 60;
-static std::map<uint256, int> mapPayment_History;
+static std::map<uint256, std::pair<uint256,int> > mapPayment_History;   // proposal hash --> (block hash, block height)
 
 extern CBudgetManager budget;
 void DumpBudgets();
@@ -303,7 +303,7 @@ public:
 
     bool UpdateProposal(const CBudgetVote& vote, CNode* pfrom, std::string& strError);
     bool UpdateFinalizedBudget(CFinalizedBudgetVote& vote, CNode* pfrom, std::string& strError);
-    TrxValidationStatus IsTransactionValid(const CTransaction& txNew, int nBlockHeight) const;
+    TrxValidationStatus IsTransactionValid(const CTransaction& txNew, const uint256& nBlockHash, int nBlockHeight) const;
     std::string GetRequiredPaymentsString(int nBlockHeight);
     bool FillBlockPayee(CMutableTransaction& txNew, bool fProofOfStake) const;
 
@@ -450,8 +450,8 @@ public:
     int GetBlockEnd() const { return nBlockStart + (int)(vecBudgetPayments.size() - 1); }
     const uint256& GetFeeTXHash() const { return nFeeTXHash;  }
     int GetVoteCount() const { return (int)mapVotes.size(); }
-    bool IsPaidAlready(uint256 nProposalHash, int nBlockHeight) const;
-    TrxValidationStatus IsTransactionValid(const CTransaction& txNew, int nBlockHeight) const;
+    bool IsPaidAlready(const uint256& nProposalHash, const uint256& nBlockHash, int nBlockHeight) const;
+    TrxValidationStatus IsTransactionValid(const CTransaction& txNew, const uint256& nBlockHash, int nBlockHeight) const;
     bool GetBudgetPaymentByBlock(int64_t nBlockHeight, CTxBudgetPayment& payment) const;
     bool GetPayeeAndAmount(int64_t nBlockHeight, CScript& payee, CAmount& nAmount) const;
 

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -482,6 +482,7 @@ public:
         READWRITE(vecBudgetPayments);
         READWRITE(fAutoChecked);
         READWRITE(mapVotes);
+        READWRITE(strProposals);
     }
 
     // compare finalized budget by votes (sort tie with feeHash)
@@ -510,6 +511,7 @@ public:
         first.vecBudgetPayments.swap(second.vecBudgetPayments);
         swap(first.nFeeTXHash, second.nFeeTXHash);
         swap(first.nTime, second.nTime);
+        swap(first.strProposals, second.strProposals);
     }
 
     CFinalizedBudgetBroadcast& operator=(CFinalizedBudgetBroadcast from)

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -410,6 +410,12 @@ private:
     bool fValid;
     std::string strInvalid;
 
+    // Functions used inside IsWellFormed/UpdateValid - setting strInvalid
+    bool IsExpired(int nCurrentHeight);
+    bool CheckStartEnd();
+    bool CheckAmount(const CAmount& nTotalBudget);
+    bool CheckName();
+
 protected:
     std::map<uint256, CFinalizedBudgetVote> mapVotes;
     std::string strBudgetName;
@@ -434,6 +440,8 @@ public:
 
     // sets fValid and strInvalid, returns fValid
     bool UpdateValid(int nHeight, bool fCheckCollateral = true);
+    // Static checks that should be done only once - sets strInvalid
+    bool IsWellFormed(const CAmount& nTotalBudget);
     bool IsValid() const  { return fValid; }
     std::string IsInvalidReason() const { return strInvalid; }
     std::string IsInvalidLogStr() const { return strprintf("[%s (%s)]: %s", GetName(), GetProposalsStr(), IsInvalidReason()); }

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -201,7 +201,8 @@ public:
 class CBudgetManager
 {
 private:
-    //hold txes until they mature enough to use
+    // map budget hash --> CollTx hash.
+    // hold finalized-budgets collateral txes until they mature enough to use
     std::map<uint256, uint256> mapCollateralTxids;
 
     std::map<uint256, CBudgetProposal> mapProposals;                        // guarded by cs_proposals
@@ -213,10 +214,6 @@ private:
     std::map<uint256, CBudgetVote> mapOrphanProposalVotes;                  // guarded by cs_votes
     std::map<uint256, CFinalizedBudgetVote> mapSeenFinalizedBudgetVotes;    // guarded by cs_finalizedvotes
     std::map<uint256, CFinalizedBudgetVote> mapOrphanFinalizedBudgetVotes;  // guarded by cs_finalizedvotes
-
-    // Memory only
-    std::vector<CBudgetProposalBroadcast> vecImmatureProposals;             // guarded by cs_proposals
-    std::vector<CFinalizedBudgetBroadcast> vecImmatureFinalizedBudgets;     // guarded by cs_budgets
 
     // Memory Only. Updated in NewBlock (blocks arrive in order)
     std::atomic<int> nBestHeight;

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -296,7 +296,7 @@ public:
     std::vector<CBudgetProposal*> GetAllProposals();
     std::vector<CFinalizedBudget*> GetFinalizedBudgets();
     bool IsBudgetPaymentBlock(int nBlockHeight) const;
-    bool IsBudgetPaymentBlock(int nBlockHeight, int& nHighestCount, int& nFivePercent) const;
+    bool IsBudgetPaymentBlock(int nBlockHeight, int& nCountThreshold) const;
     bool AddProposal(CBudgetProposal& budgetProposal);
     bool AddFinalizedBudget(CFinalizedBudget& finalizedBudget);
     void SubmitFinalBudget();

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -265,7 +265,7 @@ bool IsBlockPayeeValid(const CBlock& block, int nBlockHeight)
     //check if it's a budget block
     if (sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS)) {
         if (budget.IsBudgetPaymentBlock(nBlockHeight)) {
-            transactionStatus = budget.IsTransactionValid(txNew, nBlockHeight);
+            transactionStatus = budget.IsTransactionValid(txNew, block.GetHash(), nBlockHeight);
             if (transactionStatus == TrxValidationStatus::Valid) {
                 return true;
             }

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -301,9 +301,10 @@ void FillBlockPayee(CMutableTransaction& txNew, const CBlockIndex* pindexPrev, b
 {
     if (!pindexPrev) return;
 
-    if (sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS) && budget.IsBudgetPaymentBlock(pindexPrev->nHeight + 1)) {
-        budget.FillBlockPayee(txNew, fProofOfStake);
-    } else {
+    if (!sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS) ||  // if superblocks are not enabled
+            !budget.IsBudgetPaymentBlock(pindexPrev->nHeight + 1) || // or this is not a superblock
+            !budget.FillBlockPayee(txNew, fProofOfStake) ) {         // or there's no budget with enough votes
+        // pay a masternode
         masternodePayments.FillBlockPayee(txNew, pindexPrev, fProofOfStake);
     }
 }

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -134,11 +134,10 @@ UniValue preparebudget(const JSONRPCRequest& request)
 
     // create transaction 15 minutes into the future, to allow for confirmation time
     CBudgetProposalBroadcast budgetProposalBroadcast(strProposalName, strURL, nPaymentCount, scriptPubKey, nAmount, nBlockStart, UINT256_ZERO);
-    const uint256& proposalHash = budgetProposalBroadcast.GetHash();
 
     int nChainHeight = chainActive.Height();
     if (!budgetProposalBroadcast.UpdateValid(nChainHeight, false))
-        throw std::runtime_error("Proposal is not valid - " + proposalHash.ToString() + " - " + budgetProposalBroadcast.IsInvalidReason());
+        throw std::runtime_error("Proposal is not valid " + budgetProposalBroadcast.IsInvalidReason());
 
     bool useIX = false; //true;
     // if (request.params.size() > 7) {
@@ -150,7 +149,7 @@ UniValue preparebudget(const JSONRPCRequest& request)
     CWalletTx wtx;
     // make our change address
     CReserveKey keyChange(pwalletMain);
-    if (!pwalletMain->CreateBudgetFeeTX(wtx, proposalHash, keyChange, false)) { // 50 PIV collateral for proposal
+    if (!pwalletMain->CreateBudgetFeeTX(wtx, budgetProposalBroadcast.GetHash(), keyChange, false)) { // 50 PIV collateral for proposal
         throw std::runtime_error("Error making collateral transaction for proposal. Please check your wallet balance.");
     }
 

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -843,7 +843,6 @@ UniValue mnfinalbudget(const JSONRPCRequest& request)
             const uint256& nHash = finalizedBudget->GetHash();
             UniValue bObj(UniValue::VOBJ);
             bObj.pushKV("FeeTX", finalizedBudget->GetFeeTXHash().ToString());
-            bObj.pushKV("Hash", nHash.ToString());
             bObj.pushKV("BlockStart", (int64_t)finalizedBudget->GetBlockStart());
             bObj.pushKV("BlockEnd", (int64_t)finalizedBudget->GetBlockEnd());
             bObj.pushKV("Proposals", finalizedBudget->GetProposalsStr());
@@ -855,7 +854,8 @@ UniValue mnfinalbudget(const JSONRPCRequest& request)
             if (!fValid)
                 bObj.pushKV("IsInvalidReason", finalizedBudget->IsInvalidReason());
 
-            resultObj.pushKV(finalizedBudget->GetName(), bObj);
+            std::string strName = strprintf("%s (%s)", finalizedBudget->GetName(), nHash.ToString());
+            resultObj.pushKV(strName, bObj);
         }
 
         return resultObj;

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -134,18 +134,10 @@ UniValue preparebudget(const JSONRPCRequest& request)
 
     // create transaction 15 minutes into the future, to allow for confirmation time
     CBudgetProposalBroadcast budgetProposalBroadcast(strProposalName, strURL, nPaymentCount, scriptPubKey, nAmount, nBlockStart, UINT256_ZERO);
-
-    int nChainHeight = chainActive.Height();
-    if (!budgetProposalBroadcast.UpdateValid(nChainHeight, false))
+    if (!budgetProposalBroadcast.IsWellFormed(budget.GetTotalBudget(budgetProposalBroadcast.GetBlockStart())))
         throw std::runtime_error("Proposal is not valid " + budgetProposalBroadcast.IsInvalidReason());
 
-    bool useIX = false; //true;
-    // if (request.params.size() > 7) {
-    //     if(request.params[7].get_str() != "false" && request.params[7].get_str() != "true")
-    //         return "Invalid use_ix, must be true or false";
-    //     useIX = request.params[7].get_str() == "true" ? true : false;
-    // }
-
+    bool useIX = false;
     CWalletTx wtx;
     // make our change address
     CReserveKey keyChange(pwalletMain);
@@ -201,22 +193,18 @@ UniValue submitbudget(const JSONRPCRequest& request)
     //create the proposal incase we're the first to make it
     CBudgetProposalBroadcast budgetProposalBroadcast(strProposalName, strURL, nPaymentCount, scriptPubKey, nAmount, nBlockStart, hash);
 
-    std::string strError = "";
-    int nConf = 0;
-    if (!IsBudgetCollateralValid(hash, budgetProposalBroadcast.GetHash(), strError, budgetProposalBroadcast.nTime, nConf)) {
-        throw std::runtime_error("Proposal FeeTX is not valid - " + hash.ToString() + " - " + strError);
-    }
-
     if (!masternodeSync.IsBlockchainSynced()) {
         throw std::runtime_error("Must wait for client to sync with masternode network. Try again in a minute or so.");
     }
 
     budget.AddSeenProposal(budgetProposalBroadcast);
     budgetProposalBroadcast.Relay();
-    if(budget.AddProposal(budgetProposalBroadcast)) {
-        return budgetProposalBroadcast.GetHash().ToString();
+
+    if(!budget.AddProposal(budgetProposalBroadcast)) {
+        throw std::runtime_error("Invalid proposal, see debug.log for details.");
     }
-    throw std::runtime_error("Invalid proposal, see debug.log for details.");
+
+    return budgetProposalBroadcast.GetHash().ToString();
 }
 
 UniValue mnbudgetvote(const JSONRPCRequest& request)

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -190,19 +190,20 @@ UniValue submitbudget(const JSONRPCRequest& request)
 
     uint256 hash = ParseHashV(request.params[6], "parameter 1");
 
-    //create the proposal incase we're the first to make it
-    CBudgetProposalBroadcast budgetProposalBroadcast(strProposalName, strURL, nPaymentCount, scriptPubKey, nAmount, nBlockStart, hash);
-
     if (!masternodeSync.IsBlockchainSynced()) {
         throw std::runtime_error("Must wait for client to sync with masternode network. Try again in a minute or so.");
     }
 
-    budget.AddSeenProposal(budgetProposalBroadcast);
-    budgetProposalBroadcast.Relay();
+    //create the proposal incase we're the first to make it
+    CBudgetProposalBroadcast budgetProposalBroadcast(strProposalName, strURL, nPaymentCount, scriptPubKey, nAmount, nBlockStart, hash);
 
     if(!budget.AddProposal(budgetProposalBroadcast)) {
-        throw std::runtime_error("Invalid proposal, see debug.log for details.");
+        std::string strError = strprintf("invalid budget proposal - %s", budgetProposalBroadcast.IsInvalidReason());
+        throw std::runtime_error(strError);
     }
+
+    budget.AddSeenProposal(budgetProposalBroadcast);
+    budgetProposalBroadcast.Relay();
 
     return budgetProposalBroadcast.GetHash().ToString();
 }


### PR DESCRIPTION
Based on top of:
- [x] #1843 
- [x] #1844 

Current PR starts with `[Refactor] Decouple CBudgetProposal::UpdateValid checks` (6c6a97e3b27ffc3fe953d88e0f008c3fa9cdee4c).

This focuses on extracting context-independent checks and doing them only once in `AddProposal`/`AddFinalizedBudget`.
As for the confirmation/expiration check (which is the only thing left for `UpdateValid`) , it is done without locking `cs_main` (while holding `cs_budgets`/`cs_proposals`) by caching the height of the block with the collateral transaction and relying on it (todo: it needs to be addressed the case of it being reorganized from the chain). 

This new field, called `nBlockFeeTx` is added directly to the serialization of CBudgetProposal and CFinalizedBudget, so the old budget.dat will be invalidated and recreated new at startup.
