### PR TITLE
[wallet] Extra GetTransaction call in stakeable coins selection flow removed.

### DIFF
--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -45,7 +45,7 @@ CStakeKernel::CStakeKernel(const CBlockIndex* const pindexPrev, CStakeInput* sta
         // Modifier v2
         stakeModifier << pindexPrev->GetStakeModifierV2();
     }
-    CBlockIndex* pindexFrom = stakeInput->GetIndexFrom();
+    const CBlockIndex* pindexFrom = stakeInput->GetIndexFrom();
     nTimeBlockFrom = pindexFrom->nTime;
 }
 

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -110,9 +110,9 @@ bool LoadStakeInput(const CBlock& block, const CBlockIndex* pindexPrev, std::uni
     const CTxIn& txin = block.vtx[1]->vin[0];
     stake = txin.IsZerocoinSpend() ?
             std::unique_ptr<CStakeInput>(new CLegacyZPivStake()) :
-            std::unique_ptr<CStakeInput>(new CPivStake());
+            std::unique_ptr<CStakeInput>(CPivStake::NewPivStake(txin));
 
-    return stake->InitFromTxIn(txin);
+    return stake && stake->InitFromTxIn(txin);
 }
 
 /*

--- a/src/legacy/stakemodifier.cpp
+++ b/src/legacy/stakemodifier.cpp
@@ -112,7 +112,7 @@ bool GetOldModifier(const CBlockIndex* pindexFrom, uint64_t& nStakeModifier)
 
 bool GetOldStakeModifier(CStakeInput* stake, uint64_t& nStakeModifier)
 {
-    CBlockIndex* pindexFrom = stake->GetIndexFrom();
+    const CBlockIndex* pindexFrom = stake->GetIndexFrom();
     if (!pindexFrom) return error("%s : failed to get index from", __func__);
     if (stake->IsZPIV()) {
         int64_t nTimeBlockFrom = pindexFrom->GetBlockTime();

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -168,7 +168,7 @@ bool CreateCoinbaseTx(CBlock* pblock, const CScript& scriptPubKeyIn, CBlockIndex
     return true;
 }
 
-bool SolveProofOfStake(CBlock* pblock, CBlockIndex* pindexPrev, CWallet* pwallet, std::vector<COutput>* availableCoins)
+bool SolveProofOfStake(CBlock* pblock, CBlockIndex* pindexPrev, CWallet* pwallet, std::vector<CStakeableOutput>* availableCoins)
 {
     boost::this_thread::interruption_point();
     pblock->nBits = GetNextWorkRequired(pindexPrev, pblock);
@@ -194,7 +194,7 @@ bool SolveProofOfStake(CBlock* pblock, CBlockIndex* pindexPrev, CWallet* pwallet
     return true;
 }
 
-CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, bool fProofOfStake, std::vector<COutput>* availableCoins)
+CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, bool fProofOfStake, std::vector<CStakeableOutput>* availableCoins)
 {
     // Create new block
     std::unique_ptr<CBlockTemplate> pblocktemplate(new CBlockTemplate());
@@ -556,7 +556,7 @@ bool fGenerateBitcoins = false;
 bool fStakeableCoins = false;
 int nMintableLastCheck = 0;
 
-void CheckForCoins(CWallet* pwallet, const int minutes, std::vector<COutput>* availableCoins)
+void CheckForCoins(CWallet* pwallet, const int minutes, std::vector<CStakeableOutput>* availableCoins)
 {
     //control the amount of times the client will check for mintable coins
     int nTimeNow = GetTime();
@@ -581,7 +581,7 @@ void BitcoinMiner(CWallet* pwallet, bool fProofOfStake)
     }
 
     // Available UTXO set
-    std::vector<COutput> availableCoins;
+    std::vector<CStakeableOutput> availableCoins;
     unsigned int nExtraNonce = 0;
 
     while (fGenerateBitcoins || fProofOfStake) {

--- a/src/miner.h
+++ b/src/miner.h
@@ -14,7 +14,7 @@
 class CBlock;
 class CBlockHeader;
 class CBlockIndex;
-class COutput;
+class CStakeableOutput;
 class CReserveKey;
 class CScript;
 class CWallet;
@@ -24,7 +24,7 @@ static const bool DEFAULT_PRINTPRIORITY = false;
 struct CBlockTemplate;
 
 /** Generate a new block, without valid proof-of-work */
-CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, bool fProofOfStake, std::vector<COutput>* availableCoins = nullptr);
+CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, bool fProofOfStake, std::vector<CStakeableOutput>* availableCoins = nullptr);
 /** Modify the extranonce in a block */
 void IncrementExtraNonce(CBlock* pblock, CBlockIndex* pindexPrev, unsigned int& nExtraNonce);
 /** Check mined block */

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -160,7 +160,7 @@ UniValue generate(const JSONRPCRequest& request)
     while (nHeight < nHeightEnd && !ShutdownRequested()) {
 
         // Get available coins
-        std::vector<COutput> availableCoins;
+        std::vector<CStakeableOutput> availableCoins;
         if (fPoS && !pwalletMain->StakeableCoins(&availableCoins)) {
             throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "No available coins to stake");
         }

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -765,7 +765,7 @@ UniValue getstakingstatus(const JSONRPCRequest& request)
         obj.pushKV("haveconnections", (g_connman->GetNodeCount(CConnman::CONNECTIONS_ALL) > 0));
         obj.pushKV("mnsync", !masternodeSync.NotCompleted());
         obj.pushKV("walletunlocked", !pwalletMain->IsLocked());
-        std::vector<COutput> vCoins;
+        std::vector<CStakeableOutput> vCoins;
         pwalletMain->StakeableCoins(&vCoins);
         obj.pushKV("stakeablecoins", (int)vCoins.size());
         obj.pushKV("stakingbalance", ValueFromAmount(pwalletMain->GetStakingBalance(fColdStaking)));

--- a/src/stakeinput.cpp
+++ b/src/stakeinput.cpp
@@ -41,6 +41,11 @@ bool CPivStake::SetPrevout(const CTxOut& out, const COutPoint& outpointFrom)
     return true;
 }
 
+void CPivStake::SetIndexFrom(const CBlockIndex* pindex)
+{
+    this->pindexFrom = pindex;
+}
+
 bool CPivStake::GetTxOutFrom(CTxOut& out) const
 {
     if (!opOutputFrom || !opOutpointFrom)

--- a/src/stakeinput.cpp
+++ b/src/stakeinput.cpp
@@ -41,14 +41,6 @@ bool CPivStake::SetPrevout(CTransaction txPrev, unsigned int n)
     return true;
 }
 
-bool CPivStake::GetTxFrom(CTransaction& tx) const
-{
-    if (txFrom.IsNull())
-        return false;
-    tx = txFrom;
-    return true;
-}
-
 bool CPivStake::GetTxOutFrom(CTxOut& out) const
 {
     if (txFrom.IsNull() || nPosition >= txFrom.vout.size())

--- a/src/stakeinput.cpp
+++ b/src/stakeinput.cpp
@@ -118,7 +118,7 @@ CDataStream CPivStake::GetUniqueness() const
 }
 
 //The block that the UTXO was added to the chain
-CBlockIndex* CPivStake::GetIndexFrom()
+const CBlockIndex* CPivStake::GetIndexFrom()
 {
     if (!pindexFrom) throw std::runtime_error("CPivStake: uninitialized pindexFrom");
     return pindexFrom;
@@ -129,7 +129,7 @@ bool CPivStake::ContextCheck(int nHeight, uint32_t nTime)
 {
     const Consensus::Params& consensus = Params().GetConsensus();
     // Get Stake input block time/height
-    CBlockIndex* pindexFrom = GetIndexFrom();
+    const CBlockIndex* pindexFrom = GetIndexFrom();
     if (!pindexFrom)
         return error("%s: unable to get previous index for stake input", __func__);
     const int nHeightBlockFrom = pindexFrom->nHeight;

--- a/src/stakeinput.cpp
+++ b/src/stakeinput.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2017-2020 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 #include "stakeinput.h"
 
@@ -120,21 +120,7 @@ CDataStream CPivStake::GetUniqueness() const
 //The block that the UTXO was added to the chain
 CBlockIndex* CPivStake::GetIndexFrom()
 {
-    if (pindexFrom)
-        return pindexFrom;
-    uint256 hashBlock = UINT256_ZERO;
-    CTransaction tx;
-    if (GetTransaction(opOutpointFrom->hash, tx, hashBlock, true)) {
-        // If the index is in the chain, then set it as the "index from"
-        if (mapBlockIndex.count(hashBlock)) {
-            CBlockIndex* pindex = mapBlockIndex.at(hashBlock);
-            if (chainActive.Contains(pindex))
-                pindexFrom = pindex;
-        }
-    } else {
-        LogPrintf("%s : failed to find tx %s\n", __func__, opOutpointFrom->hash.GetHex());
-    }
-
+    if (!pindexFrom) throw std::runtime_error("CPivStake: uninitialized pindexFrom");
     return pindexFrom;
 }
 

--- a/src/stakeinput.h
+++ b/src/stakeinput.h
@@ -43,6 +43,7 @@ public:
 
     bool InitFromTxIn(const CTxIn& txin) override;
     bool SetPrevout(const CTxOut& out, const COutPoint& outpointFrom);
+    void SetIndexFrom(const CBlockIndex* pindex);
 
     const CBlockIndex* GetIndexFrom() override;
     bool GetTxOutFrom(CTxOut& out) const override;

--- a/src/stakeinput.h
+++ b/src/stakeinput.h
@@ -35,14 +35,14 @@ public:
 class CPivStake : public CStakeInput
 {
 private:
-    CTransaction txFrom{CTransaction()};
-    unsigned int nPosition{0};
+    Optional<CTxOut> opOutputFrom{nullopt};
+    Optional<COutPoint> opOutpointFrom{nullopt};
 
 public:
     CPivStake() {}
 
     bool InitFromTxIn(const CTxIn& txin) override;
-    bool SetPrevout(CTransaction txPrev, unsigned int n);
+    bool SetPrevout(const CTxOut& out, const COutPoint& outpointFrom);
 
     CBlockIndex* GetIndexFrom() override;
     bool GetTxOutFrom(CTxOut& out) const override;

--- a/src/stakeinput.h
+++ b/src/stakeinput.h
@@ -16,12 +16,12 @@ class CWalletTx;
 class CStakeInput
 {
 protected:
-    CBlockIndex* pindexFrom = nullptr;
+    const CBlockIndex* pindexFrom = nullptr;
 
 public:
     virtual ~CStakeInput(){};
     virtual bool InitFromTxIn(const CTxIn& txin) = 0;
-    virtual CBlockIndex* GetIndexFrom() = 0;
+    virtual const CBlockIndex* GetIndexFrom() = 0;
     virtual bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = UINT256_ZERO) = 0;
     virtual bool GetTxOutFrom(CTxOut& out) const = 0;
     virtual CAmount GetValue() const = 0;
@@ -44,7 +44,7 @@ public:
     bool InitFromTxIn(const CTxIn& txin) override;
     bool SetPrevout(const CTxOut& out, const COutPoint& outpointFrom);
 
-    CBlockIndex* GetIndexFrom() override;
+    const CBlockIndex* GetIndexFrom() override;
     bool GetTxOutFrom(CTxOut& out) const override;
     CAmount GetValue() const override;
     CDataStream GetUniqueness() const override;

--- a/src/stakeinput.h
+++ b/src/stakeinput.h
@@ -23,7 +23,6 @@ public:
     virtual bool InitFromTxIn(const CTxIn& txin) = 0;
     virtual CBlockIndex* GetIndexFrom() = 0;
     virtual bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = UINT256_ZERO) = 0;
-    virtual bool GetTxFrom(CTransaction& tx) const = 0;
     virtual bool GetTxOutFrom(CTxOut& out) const = 0;
     virtual CAmount GetValue() const = 0;
     virtual bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal, const bool onlyP2PK) = 0;
@@ -46,7 +45,6 @@ public:
     bool SetPrevout(CTransaction txPrev, unsigned int n);
 
     CBlockIndex* GetIndexFrom() override;
-    bool GetTxFrom(CTransaction& tx) const override;
     bool GetTxOutFrom(CTxOut& out) const override;
     CAmount GetValue() const override;
     CDataStream GetUniqueness() const override;

--- a/src/stakeinput.h
+++ b/src/stakeinput.h
@@ -19,9 +19,10 @@ protected:
     const CBlockIndex* pindexFrom = nullptr;
 
 public:
+    CStakeInput(const CBlockIndex* _pindexFrom) : pindexFrom(_pindexFrom) {}
     virtual ~CStakeInput(){};
     virtual bool InitFromTxIn(const CTxIn& txin) = 0;
-    virtual const CBlockIndex* GetIndexFrom() = 0;
+    virtual const CBlockIndex* GetIndexFrom() const = 0;
     virtual bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = UINT256_ZERO) = 0;
     virtual bool GetTxOutFrom(CTxOut& out) const = 0;
     virtual CAmount GetValue() const = 0;
@@ -35,17 +36,17 @@ public:
 class CPivStake : public CStakeInput
 {
 private:
-    Optional<CTxOut> opOutputFrom{nullopt};
-    Optional<COutPoint> opOutpointFrom{nullopt};
+    const CTxOut outputFrom;
+    const COutPoint outpointFrom;
 
 public:
-    CPivStake() {}
+    CPivStake(const CTxOut& _from, const COutPoint& _outPointFrom, const CBlockIndex* _pindexFrom) :
+            CStakeInput(_pindexFrom), outputFrom(_from), outpointFrom(_outPointFrom) {}
 
-    bool InitFromTxIn(const CTxIn& txin) override;
-    bool SetPrevout(const CTxOut& out, const COutPoint& outpointFrom);
-    void SetIndexFrom(const CBlockIndex* pindex);
+    static CPivStake* NewPivStake(const CTxIn& txin);
 
-    const CBlockIndex* GetIndexFrom() override;
+    bool InitFromTxIn(const CTxIn& txin) override { return pindexFrom; }
+    const CBlockIndex* GetIndexFrom() const override;
     bool GetTxOutFrom(CTxOut& out) const override;
     CAmount GetValue() const override;
     CDataStream GetUniqueness() const override;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2695,7 +2695,7 @@ bool CWallet::CreateCoinStake(
     int nAttempts = 0;
     for (const COutput &out : *availableCoins) {
         CPivStake stakeInput;
-        stakeInput.SetPrevout((CTransaction) *out.tx, out.i);
+        stakeInput.SetPrevout(out.tx->vout[out.i], COutPoint(out.tx->GetHash(), out.i));
 
         //new block came in, move on
         if (WITH_LOCK(cs_main, return chainActive.Height()) != pindexPrev->nHeight) return false;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1910,13 +1910,13 @@ void CWallet::GetAvailableP2CSCoins(std::vector<COutput>& vCoins) const {
 /**
  * Test if the transaction is spendable.
  */
-bool CheckTXAvailability(const CWalletTx* pcoin, bool fOnlyConfirmed, bool fUseIX, int& nDepth)
+bool CheckTXAvailability(const CWalletTx* pcoin, bool fOnlyConfirmed, bool fUseIX, int& nDepth, const CBlockIndex*& pindexRet)
 {
     if (!CheckFinalTx(*pcoin)) return false;
     if (fOnlyConfirmed && !pcoin->IsTrusted()) return false;
     if (pcoin->GetBlocksToMaturity() > 0) return false;
 
-    nDepth = pcoin->GetDepthInMainChain(false);
+    nDepth = pcoin->GetDepthInMainChain(pindexRet, false);
     // do not use IX for inputs that have less then 6 blockchain confirmations
     if (fUseIX && nDepth < 6) return false;
 
@@ -1925,6 +1925,12 @@ bool CheckTXAvailability(const CWalletTx* pcoin, bool fOnlyConfirmed, bool fUseI
     if (nDepth == 0 && !pcoin->InMempool()) return false;
 
     return true;
+}
+
+bool CheckTXAvailability(const CWalletTx* pcoin, bool fOnlyConfirmed, bool fUseIX, int& nDepth)
+{
+    const CBlockIndex* pindexRet = nullptr;
+    return CheckTXAvailability(pcoin, fOnlyConfirmed, fUseIX, nDepth, pindexRet);
 }
 
 bool CWallet::GetMasternodeVinAndKeys(CTxIn& txinRet, CPubKey& pubKeyRet, CKey& keyRet, std::string strTxHash, std::string strOutputIndex, std::string& strError)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4430,3 +4430,8 @@ bool CWalletTx::IsFromMe(const isminefilter& filter) const
 {
     return (GetDebit(filter) > 0);
 }
+
+CStakeableOutput::CStakeableOutput(const CWalletTx* txIn, int iIn, int nDepthIn, bool fSpendableIn, bool fSolvableIn,
+                                   const CBlockIndex*& _pindex) : COutput(txIn, iIn, nDepthIn, fSpendableIn, fSolvableIn),
+                                                                pindex(_pindex) {}
+

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2757,6 +2757,7 @@ bool CWallet::CreateCoinStake(
     for (const auto& out : *availableCoins) {
         CPivStake stakeInput;
         stakeInput.SetPrevout(out.tx->vout[out.i], COutPoint(out.tx->GetHash(), out.i));
+        stakeInput.SetIndexFrom(out.pindex);
 
         //new block came in, move on
         if (WITH_LOCK(cs_main, return chainActive.Height()) != pindexPrev->nHeight) return false;
@@ -4043,7 +4044,7 @@ void CMerkleTx::SetMerkleBranch(const CBlockIndex* pindex, int posInBlock)
 
 int CMerkleTx::GetDepthInMainChain(bool enableIX) const
 {
-    const CBlockIndex* pindexRet;
+    const CBlockIndex* pindexRet = nullptr;
     return GetDepthInMainChain(pindexRet, enableIX);
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2755,9 +2755,9 @@ bool CWallet::CreateCoinStake(
     bool fKernelFound = false;
     int nAttempts = 0;
     for (const auto& out : *availableCoins) {
-        CPivStake stakeInput;
-        stakeInput.SetPrevout(out.tx->vout[out.i], COutPoint(out.tx->GetHash(), out.i));
-        stakeInput.SetIndexFrom(out.pindex);
+        CPivStake stakeInput(out.tx->vout[out.i],
+                             COutPoint(out.tx->GetHash(), out.i),
+                             out.pindex);
 
         //new block came in, move on
         if (WITH_LOCK(cs_main, return chainActive.Height()) != pindexPrev->nHeight) return false;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -96,6 +96,7 @@ class CAddressBookIterator;
 class CAccountingEntry;
 class CCoinControl;
 class COutput;
+class CStakeableOutput;
 class CReserveKey;
 class CScript;
 class CWalletTx;
@@ -1072,6 +1073,15 @@ public:
     std::string ToString() const;
 };
 
+class CStakeableOutput : public COutput
+{
+public:
+    const CBlockIndex* pindex{nullptr};
+
+    CStakeableOutput(const CWalletTx* txIn, int iIn, int nDepthIn, bool fSpendableIn, bool fSolvableIn,
+                     const CBlockIndex*& pindex);
+
+};
 
 /** Private key that includes an expiration date in case it never gets used. */
 class CWalletKey

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -446,7 +446,7 @@ public:
     bool SelectCoinsToSpend(const std::vector<COutput>& vAvailableCoins, const CAmount& nTargetValue, std::set<std::pair<const CWalletTx*, unsigned int> >& setCoinsRet, CAmount& nValueRet, const CCoinControl* coinControl = nullptr) const;
     bool SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*, unsigned int> >& setCoinsRet, CAmount& nValueRet) const;
     //! >> Available coins (staking)
-    bool StakeableCoins(std::vector<COutput>* pCoins = nullptr);
+    bool StakeableCoins(std::vector<CStakeableOutput>* pCoins = nullptr);
     //! >> Available coins (P2CS)
     void GetAvailableP2CSCoins(std::vector<COutput>& vCoins) const;
 
@@ -628,7 +628,7 @@ public:
                          unsigned int nBits,
                          CMutableTransaction& txNew,
                          int64_t& nTxNewTime,
-                         std::vector<COutput>* availableCoins);
+                         std::vector<CStakeableOutput>* availableCoins);
     bool MultiSend();
     void AutoCombineDust(CConnman* connman);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -318,6 +318,22 @@ private:
 
     bool IsKeyUsed(const CPubKey& vchPubKey);
 
+    struct OutputAvailabilityResult
+    {
+        bool available{false};
+        bool solvable{false};
+        bool spendable{false};
+    };
+
+    OutputAvailabilityResult CheckOutputAvailability(const CTxOut& output,
+                                                     const unsigned int outIndex,
+                                                     const uint256& wtxid,
+                                                     AvailableCoinsType nCoinType,
+                                                     const CCoinControl* coinControl,
+                                                     const bool fCoinsSelected,
+                                                     const bool fIncludeColdStaking,
+                                                     const bool fIncludeDelegated) const;
+
     // Zerocoin wallet
     CzPIVWallet* zwallet{nullptr};
 

--- a/src/zpiv/zpos.cpp
+++ b/src/zpiv/zpos.cpp
@@ -43,7 +43,7 @@ bool CLegacyZPivStake::InitFromTxIn(const CTxIn& txin)
     return true;
 }
 
-CLegacyZPivStake::CLegacyZPivStake(const libzerocoin::CoinSpend& spend)
+CLegacyZPivStake::CLegacyZPivStake(const libzerocoin::CoinSpend& spend) : CStakeInput(nullptr)
 {
     this->nChecksum = spend.getAccumulatorChecksum();
     this->denom = spend.getDenomination();
@@ -51,7 +51,7 @@ CLegacyZPivStake::CLegacyZPivStake(const libzerocoin::CoinSpend& spend)
     this->hashSerial = Hash(nSerial.begin(), nSerial.end());
 }
 
-const CBlockIndex* CLegacyZPivStake::GetIndexFrom()
+const CBlockIndex* CLegacyZPivStake::GetIndexFrom() const
 {
     // First look in the legacy database
     int nHeightChecksum = 0;

--- a/src/zpiv/zpos.cpp
+++ b/src/zpiv/zpos.cpp
@@ -51,7 +51,7 @@ CLegacyZPivStake::CLegacyZPivStake(const libzerocoin::CoinSpend& spend)
     this->hashSerial = Hash(nSerial.begin(), nSerial.end());
 }
 
-CBlockIndex* CLegacyZPivStake::GetIndexFrom()
+const CBlockIndex* CLegacyZPivStake::GetIndexFrom()
 {
     // First look in the legacy database
     int nHeightChecksum = 0;

--- a/src/zpiv/zpos.h
+++ b/src/zpiv/zpos.h
@@ -16,13 +16,13 @@ private:
     uint256 hashSerial;
 
 public:
-    CLegacyZPivStake() {}
+    CLegacyZPivStake() : CStakeInput(nullptr) {}
 
     explicit CLegacyZPivStake(const libzerocoin::CoinSpend& spend);
     bool InitFromTxIn(const CTxIn& txin) override;
     bool IsZPIV() const override { return true; }
     uint32_t GetChecksum() const { return nChecksum; }
-    const CBlockIndex* GetIndexFrom() override;
+    const CBlockIndex* GetIndexFrom() const override;
     CAmount GetValue() const override;
     CDataStream GetUniqueness() const override;
     bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = UINT256_ZERO) override { return false; /* creation disabled */}

--- a/src/zpiv/zpos.h
+++ b/src/zpiv/zpos.h
@@ -27,7 +27,6 @@ public:
     CDataStream GetUniqueness() const override;
     bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = UINT256_ZERO) override { return false; /* creation disabled */}
     bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal, const bool onlyP2PK) override { return false; /* creation disabled */}
-    bool GetTxFrom(CTransaction& tx) const override { return false; /* not available */ }
     bool GetTxOutFrom(CTxOut& out) const override { return false; /* not available */ }
     virtual bool ContextCheck(int nHeight, uint32_t nTime) override;
 };

--- a/src/zpiv/zpos.h
+++ b/src/zpiv/zpos.h
@@ -22,7 +22,7 @@ public:
     bool InitFromTxIn(const CTxIn& txin) override;
     bool IsZPIV() const override { return true; }
     uint32_t GetChecksum() const { return nChecksum; }
-    CBlockIndex* GetIndexFrom() override;
+    const CBlockIndex* GetIndexFrom() override;
     CAmount GetValue() const override;
     CDataStream GetUniqueness() const override;
     bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = UINT256_ZERO) override { return false; /* creation disabled */}


### PR DESCRIPTION
Essentially, this work is removing an unneeded `GetTransaction` call from `CPivStake::GetIndexFrom` for every stakeable output during each cycle of the staking process.
As `GetTransaction` is a direct access to disk (txindex), this means faster staking.

Future work, the methods `StakeableCoins` and `AvailableCoins` can be abstracted even more. They are sharing almost the same code with an specific distinction that makes this change possible without introducing an extra blockIndex set into `AvailableCoins`.