### PR TITLE
[Refactoring] Budget, round 4: remove Broadcast classes

### DIFF
--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -930,10 +930,7 @@ CDataStream CBudgetManager::GetProposalVoteSerialized(const uint256& voteHash) c
 CDataStream CBudgetManager::GetProposalSerialized(const uint256& propHash) const
 {
     LOCK(cs_proposals);
-    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-    ss.reserve(1000);
-    ss << mapSeenProposals.at(propHash);
-    return ss;
+    return mapProposals.at(propHash).GetBroadcast();
 }
 
 CDataStream CBudgetManager::GetFinalizedBudgetVoteSerialized(const uint256& voteHash) const
@@ -948,10 +945,7 @@ CDataStream CBudgetManager::GetFinalizedBudgetVoteSerialized(const uint256& vote
 CDataStream CBudgetManager::GetFinalizedBudgetSerialized(const uint256& budgetHash) const
 {
     LOCK(cs_budgets);
-    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-    ss.reserve(1000);
-    ss << mapSeenFinalizedBudgets.at(budgetHash);
-    return ss;
+    return mapFinalizedBudgets.at(budgetHash).GetBroadcast();
 }
 
 bool CBudgetManager::AddAndRelayProposalVote(const CBudgetVote& vote, std::string& strError)

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -1315,21 +1315,6 @@ CBudgetProposal::CBudgetProposal(const std::string& name,
     nBlockEnd = nCycleStart + (nBlocksPerCycle + 1)  * paycount;
 }
 
-CBudgetProposal::CBudgetProposal(const CBudgetProposal& other)
-{
-    strProposalName = other.strProposalName;
-    strURL = other.strURL;
-    nBlockStart = other.nBlockStart;
-    nBlockEnd = other.nBlockEnd;
-    address = other.address;
-    nAmount = other.nAmount;
-    nTime = other.nTime;
-    nFeeTXHash = other.nFeeTXHash;
-    mapVotes = other.mapVotes;
-    fValid = true;
-    strInvalid = "";
-}
-
 // initialize from network broadcast message
 bool CBudgetProposal::ParseBroadcast(CDataStream& broadcast)
 {
@@ -1718,19 +1703,6 @@ CFinalizedBudget::CFinalizedBudget(const std::string& name,
         nFeeTXHash(nfeetxhash),
         strProposals(""),
         nTime(0)
-{ }
-
-CFinalizedBudget::CFinalizedBudget(const CFinalizedBudget& other) :
-        fAutoChecked(false),
-        fValid(true),
-        strInvalid(),
-        mapVotes(other.mapVotes),
-        strBudgetName(other.strBudgetName),
-        nBlockStart(other.nBlockStart),
-        vecBudgetPayments(other.vecBudgetPayments),
-        nFeeTXHash(other.nFeeTXHash),
-        strProposals(other.strProposals),
-        nTime(other.nTime)
 { }
 
 bool CFinalizedBudget::ParseBroadcast(CDataStream& broadcast)

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -467,6 +467,7 @@ public:
     // Serialization for network messages.
     bool ParseBroadcast(CDataStream& broadcast);
     CDataStream GetBroadcast() const;
+    void Relay();
 
     // compare finalized budget by votes (sort tie with feeHash)
     bool operator>(const CFinalizedBudget& other) const;
@@ -625,6 +626,7 @@ public:
     // Serialization for network messages.
     bool ParseBroadcast(CDataStream& broadcast);
     CDataStream GetBroadcast() const;
+    void Relay();
 
     // compare proposals by proposal hash
     inline bool operator>(const CBudgetProposal& other) const { return GetHash() > other.GetHash(); }

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -471,6 +471,7 @@ public:
         return ss.GetHash();
     }
 
+    // Serialization for local DB
     ADD_SERIALIZE_METHODS;
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action)
@@ -484,6 +485,10 @@ public:
         READWRITE(mapVotes);
         READWRITE(strProposals);
     }
+
+    // Serialization for network messages.
+    bool ParseBroadcast(CDataStream& broadcast);
+    CDataStream GetBroadcast() const;
 
     // compare finalized budget by votes (sort tie with feeHash)
     bool operator>(const CFinalizedBudget& other) const;
@@ -623,23 +628,25 @@ public:
         return ss.GetHash();
     }
 
+    // Serialization for local DB
     ADD_SERIALIZE_METHODS;
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action)
     {
-        //for syncing with other clients
         READWRITE(LIMITED_STRING(strProposalName, 20));
         READWRITE(LIMITED_STRING(strURL, 64));
         READWRITE(nBlockStart);
         READWRITE(nBlockEnd);
         READWRITE(nAmount);
         READWRITE(*(CScriptBase*)(&address));
-        READWRITE(nTime);
         READWRITE(nFeeTXHash);
-
-        //for saving to the serialized db
+        READWRITE(nTime);
         READWRITE(mapVotes);
     }
+
+    // Serialization for network messages.
+    bool ParseBroadcast(CDataStream& broadcast);
+    CDataStream GetBroadcast() const;
 
     // compare proposals by proposal hash
     inline bool operator>(const CBudgetProposal& other) const { return GetHash() > other.GetHash(); }

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -402,6 +402,7 @@ public:
 
     CFinalizedBudget();
     CFinalizedBudget(const CFinalizedBudget& other);
+    CFinalizedBudget(const std::string& name, int blockstart, const std::vector<CTxBudgetPayment>& vecBudgetPaymentsIn, const uint256& nfeetxhash);
 
     void CleanAndRemove();
     bool AddOrUpdateVote(const CFinalizedBudgetVote& vote, std::string& strError);
@@ -543,8 +544,8 @@ protected:
     std::string strURL;
     int nBlockStart;
     int nBlockEnd;
-    CAmount nAmount;
     CScript address;
+    CAmount nAmount;
     uint256 nFeeTXHash;
 
 public:
@@ -553,7 +554,7 @@ public:
 
     CBudgetProposal();
     CBudgetProposal(const CBudgetProposal& other);
-    CBudgetProposal(std::string strProposalNameIn, std::string strURLIn, int nBlockStartIn, int nBlockEndIn, CScript addressIn, CAmount nAmountIn, uint256 nFeeTXHashIn);
+    CBudgetProposal(const std::string& name, const std::string& url, int paycount, const CScript& payee, const CAmount& amount, int blockstart, const uint256& nfeetxhash);
 
     bool AddOrUpdateVote(const CBudgetVote& vote, std::string& strError);
     UniValue GetVotesArray() const;

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -18,10 +18,8 @@
 #include <univalue.h>
 
 class CBudgetManager;
-class CFinalizedBudgetBroadcast;
 class CFinalizedBudget;
 class CBudgetProposal;
-class CBudgetProposalBroadcast;
 class CTxBudgetPayment;
 
 enum class TrxValidationStatus {
@@ -476,49 +474,6 @@ public:
     static bool PtrGreater(CFinalizedBudget* a, CFinalizedBudget* b) { return *a > *b; }
 };
 
-// FinalizedBudget are cast then sent to peers with this object, which leaves the votes out
-class CFinalizedBudgetBroadcast : public CFinalizedBudget
-{
-public:
-    CFinalizedBudgetBroadcast();
-    CFinalizedBudgetBroadcast(const CFinalizedBudget& other);
-    CFinalizedBudgetBroadcast(std::string strBudgetNameIn, int nBlockStartIn, const std::vector<CTxBudgetPayment>& vecBudgetPaymentsIn, uint256 nFeeTXHashIn);
-
-    void swap(CFinalizedBudgetBroadcast& first, CFinalizedBudgetBroadcast& second) // nothrow
-    {
-        // enable ADL (not necessary in our case, but good practice)
-        using std::swap;
-        // by swapping the members of two classes,
-        // the two classes are effectively swapped
-        swap(first.strBudgetName, second.strBudgetName);
-        swap(first.nBlockStart, second.nBlockStart);
-        first.mapVotes.swap(second.mapVotes);
-        first.vecBudgetPayments.swap(second.vecBudgetPayments);
-        swap(first.nFeeTXHash, second.nFeeTXHash);
-        swap(first.nTime, second.nTime);
-        swap(first.strProposals, second.strProposals);
-    }
-
-    CFinalizedBudgetBroadcast& operator=(CFinalizedBudgetBroadcast from)
-    {
-        swap(*this, from);
-        return *this;
-    }
-
-    void Relay();
-
-    ADD_SERIALIZE_METHODS;
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        //for syncing with other clients
-        READWRITE(LIMITED_STRING(strBudgetName, 20));
-        READWRITE(nBlockStart);
-        READWRITE(vecBudgetPayments);
-        READWRITE(nFeeTXHash);
-    }
-};
-
 
 //
 // Budget Proposal : Contains the masternode votes for each budget
@@ -637,56 +592,5 @@ public:
     static bool PtrHigherYes(CBudgetProposal* a, CBudgetProposal* b);
 
 };
-
-// Proposals are cast then sent to peers with this object, which leaves the votes out
-class CBudgetProposalBroadcast : public CBudgetProposal
-{
-public:
-    CBudgetProposalBroadcast() : CBudgetProposal() {}
-    CBudgetProposalBroadcast(const CBudgetProposal& other) : CBudgetProposal(other) {}
-    CBudgetProposalBroadcast(const CBudgetProposalBroadcast& other) : CBudgetProposal(other) {}
-    CBudgetProposalBroadcast(std::string strProposalNameIn, std::string strURLIn, int nPaymentCount, CScript addressIn, CAmount nAmountIn, int nBlockStartIn, uint256 nFeeTXHashIn);
-
-    void swap(CBudgetProposalBroadcast& first, CBudgetProposalBroadcast& second) // nothrow
-    {
-        // enable ADL (not necessary in our case, but good practice)
-        using std::swap;
-        // by swapping the members of two classes,
-        // the two classes are effectively swapped
-        swap(first.strProposalName, second.strProposalName);
-        swap(first.nBlockStart, second.nBlockStart);
-        swap(first.strURL, second.strURL);
-        swap(first.nBlockEnd, second.nBlockEnd);
-        swap(first.nAmount, second.nAmount);
-        swap(first.address, second.address);
-        swap(first.nTime, second.nTime);
-        swap(first.nFeeTXHash, second.nFeeTXHash);
-        first.mapVotes.swap(second.mapVotes);
-    }
-
-    CBudgetProposalBroadcast& operator=(CBudgetProposalBroadcast from)
-    {
-        swap(*this, from);
-        return *this;
-    }
-
-    void Relay();
-
-    ADD_SERIALIZE_METHODS;
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        //for syncing with other clients
-        READWRITE(LIMITED_STRING(strProposalName, 20));
-        READWRITE(LIMITED_STRING(strURL, 64));
-        READWRITE(nTime);
-        READWRITE(nBlockStart);
-        READWRITE(nBlockEnd);
-        READWRITE(nAmount);
-        READWRITE(*(CScriptBase*)(&address));
-        READWRITE(nFeeTXHash);
-    }
-};
-
 
 #endif

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -399,7 +399,6 @@ public:
     int64_t nTime;
 
     CFinalizedBudget();
-    CFinalizedBudget(const CFinalizedBudget& other);
     CFinalizedBudget(const std::string& name, int blockstart, const std::vector<CTxBudgetPayment>& vecBudgetPaymentsIn, const uint256& nfeetxhash);
 
     void CleanAndRemove();
@@ -508,7 +507,6 @@ public:
     int64_t nTime;
 
     CBudgetProposal();
-    CBudgetProposal(const CBudgetProposal& other);
     CBudgetProposal(const std::string& name, const std::string& url, int paycount, const CScript& payee, const CAmount& amount, int blockstart, const uint256& nfeetxhash);
 
     bool AddOrUpdateVote(const CBudgetVote& vote, std::string& strError);

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -133,9 +133,9 @@ void CMasternodeSync::AddedMasternodeWinner(const uint256& hash)
 
 void CMasternodeSync::AddedBudgetItem(const uint256& hash)
 {
-    if (budget.HaveSeenProposal(hash) ||
+    if (budget.HaveProposal(hash) ||
             budget.HaveSeenProposalVote(hash) ||
-            budget.HaveSeenFinalizedBudget(hash) ||
+            budget.HaveFinalizedBudget(hash) ||
             budget.HaveSeenFinalizedBudgetVote(hash)) {
         if (mapSeenSyncBudget[hash] < MASTERNODE_SYNC_THRESHOLD) {
             lastBudgetItem = GetTime();

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -711,7 +711,7 @@ bool static AlreadyHave(const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
         }
         return false;
     case MSG_BUDGET_PROPOSAL:
-        if (budget.HaveSeenProposal(inv.hash)) {
+        if (budget.HaveProposal(inv.hash)) {
             masternodeSync.AddedBudgetItem(inv.hash);
             return true;
         }
@@ -723,7 +723,7 @@ bool static AlreadyHave(const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
         }
         return false;
     case MSG_BUDGET_FINALIZED:
-        if (budget.HaveSeenFinalizedBudget(inv.hash)) {
+        if (budget.HaveFinalizedBudget(inv.hash)) {
             masternodeSync.AddedBudgetItem(inv.hash);
             return true;
         }
@@ -919,7 +919,7 @@ void static ProcessGetData(CNode* pfrom, CConnman& connman, std::atomic<bool>& i
                 }
 
                 if (!pushed && inv.type == MSG_BUDGET_PROPOSAL) {
-                    if (budget.HaveSeenProposal(inv.hash)) {
+                    if (budget.HaveProposal(inv.hash)) {
                         connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::BUDGETPROPOSAL, budget.GetProposalSerialized(inv.hash)));
                         pushed = true;
                     }
@@ -933,7 +933,7 @@ void static ProcessGetData(CNode* pfrom, CConnman& connman, std::atomic<bool>& i
                 }
 
                 if (!pushed && inv.type == MSG_BUDGET_FINALIZED) {
-                    if (budget.HaveSeenFinalizedBudget(inv.hash)) {
+                    if (budget.HaveFinalizedBudget(inv.hash)) {
                         connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::FINALBUDGET, budget.GetFinalizedBudgetSerialized(inv.hash)));
                         pushed = true;
                     }

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -201,8 +201,6 @@ UniValue submitbudget(const JSONRPCRequest& request)
         std::string strError = strprintf("invalid budget proposal - %s", budgetProposalBroadcast.IsInvalidReason());
         throw std::runtime_error(strError);
     }
-
-    budget.AddSeenProposal(budgetProposalBroadcast);
     budgetProposalBroadcast.Relay();
 
     return budgetProposalBroadcast.GetHash().ToString();


### PR DESCRIPTION
Continues the budget-refactoring thread.

Remove the following classes entirely
- `CBudgetProposalBroadcast`
- `CFinalizedBudgetBroadcast`

Replace them with a new dastream-based constructor and a `GetBroadcast` function (returning the serialized stream) inside `CBudgetProposal` / `CFinalizedBudget` classes.

This allows us to get rid also of `mapSeenProposals` and `mapSeenFinalizedBudgets` and all the relative ugly code duplication (just rely on `mapProposals` and `mapFinalizedBudgets` to check for existence, and to get the broadcast messages to send).

Based on top of
- [x] #1845 

Starts with `[Refactoring] Introduce CFinalizedBudget/CBudgetProposal::GetBroadcast` (37c629881372e492a65ea17a4b18ad02cd53ed58)