### PR TITLE
[GUI] do not decode the address twice in save contact.

### DIFF
--- a/src/qt/pivx/addresseswidget.cpp
+++ b/src/qt/pivx/addresseswidget.cpp
@@ -181,14 +181,15 @@ void AddressesWidget::onStoreContactClicked()
         QString label = ui->lineEditName->text();
         QString address = ui->lineEditAddress->text();
 
-        if (!walletModel->validateAddress(address)) {
+        bool isStakingAddress = false;
+        auto pivAdd = DecodeDestination(address.toUtf8().constData(), isStakingAddress);
+
+        if (!IsValidDestination(pivAdd) || isStakingAddress) {
             setCssEditLine(ui->lineEditAddress, false, true);
             inform(tr("Invalid Contact Address"));
             return;
         }
 
-        bool isStakingAddress = false;
-        CTxDestination pivAdd = DecodeDestination(address.toUtf8().constData(), isStakingAddress);
         if (walletModel->isMine(pivAdd)) {
             setCssEditLine(ui->lineEditAddress, false, true);
             inform(tr("Cannot store your own address as contact"));

--- a/src/qt/pivx/send.cpp
+++ b/src/qt/pivx/send.cpp
@@ -644,11 +644,15 @@ void SendWidget::onContactMultiClicked()
             inform(tr("Address field is empty"));
             return;
         }
-        if (!walletModel->validateAddress(address)) {
+
+        bool isStakingAddr = false;
+        auto pivAdd = DecodeDestination(address.toStdString(), isStakingAddr);
+
+        if (!IsValidDestination(pivAdd) || isStakingAddr) {
             inform(tr("Invalid address"));
             return;
         }
-        CTxDestination pivAdd = DecodeDestination(address.toStdString());
+
         if (walletModel->isMine(pivAdd)) {
             inform(tr("Cannot store your own address as contact"));
             return;


### PR DESCRIPTION
Improved two similar methods that are calling `WalletModel::validateAddress` and `DecodeDestination` right after it.
As `WalletModel::validateAddress` is calling internally to `DecodeDestination`, the address is being decoded twice.
This PR improves it to only decode the address once.