### PR TITLE
[Refactoring] Budget, round 5: proposals/budgets FeeTX indexes

### DIFF
--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -234,14 +234,7 @@ public:
     mutable RecursiveMutex cs_finalizedvotes;
     mutable RecursiveMutex cs_votes;
 
-    CBudgetManager()
-    {
-        LOCK2(cs_budgets, cs_proposals);
-        mapProposals.clear();
-        mapFinalizedBudgets.clear();
-        mapFeeTxToProposal.clear();
-        mapFeeTxToBudget.clear();
-    }
+    CBudgetManager() {}
 
     void ClearSeen()
     {

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -335,6 +335,9 @@ public:
     void CheckAndRemove();
     std::string ToString() const;
 
+    // Remove proposal/budget by FeeTx (called when a block is disconnected)
+    void RemoveByFeeTxId(const uint256& feeTxId);
+
     ADD_SERIALIZE_METHODS;
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action)
@@ -451,6 +454,7 @@ public:
     int GetBlockEnd() const { return nBlockStart + (int)(vecBudgetPayments.size() - 1); }
     const uint256& GetFeeTXHash() const { return nFeeTXHash;  }
     int GetVoteCount() const { return (int)mapVotes.size(); }
+    std::vector<uint256> GetVotesHashes() const;
     bool IsPaidAlready(const uint256& nProposalHash, const uint256& nBlockHash, int nBlockHeight) const;
     TrxValidationStatus IsTransactionValid(const CTransaction& txNew, const uint256& nBlockHash, int nBlockHeight) const;
     bool GetBudgetPaymentByBlock(int64_t nBlockHeight, CTxBudgetPayment& payment) const;
@@ -565,6 +569,7 @@ public:
     const uint256& GetFeeTXHash() const { return nFeeTXHash;  }
     double GetRatio() const;
     int GetVoteCount(CBudgetVote::VoteDirection vd) const;
+    std::vector<uint256> GetVotesHashes() const;
     int GetYeas() const { return GetVoteCount(CBudgetVote::VOTE_YES); }
     int GetNays() const { return GetVoteCount(CBudgetVote::VOTE_NO); }
     int GetAbstains() const { return GetVoteCount(CBudgetVote::VOTE_ABSTAIN); };

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1211,7 +1211,6 @@ UniValue reconsiderblock(const JSONRPCRequest& request)
 
     if (state.IsValid()) {
         ActivateBestChain(state);
-        budget.SetBestHeight(WITH_LOCK(cs_main, return chainActive.Height(); ));
         int nHeight = WITH_LOCK(cs_main, return chainActive.Height(); );
         budget.SetBestHeight(nHeight);
         mnodeman.SetBestHeight(nHeight);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1342,8 +1342,10 @@ DisconnectResult DisconnectBlock(CBlock& block, CBlockIndex* pindex, CCoinsViewC
             return DISCONNECT_FAILED;
 
         nValueOut += tx.GetValueOut();
-        uint256 hash = tx.GetHash();
+        const uint256& hash = tx.GetHash();
 
+        // if tx is a budget collateral tx, remove relative object
+        budget.RemoveByFeeTxId(hash);
 
         // Check that all outputs are available and match the outputs in the block itself
         // exactly.


### PR DESCRIPTION
Based on top of:
- [x] #1851 

Starting with `[Budget] Introduce mapFeeTxToProposal and mapFeeTxToBudget` (0eb9e45)

Since #1845 we no longer check repeatedly the active chain, when updating a budget object, we just save the height of the block including the collateral tx (ref #1845), when we first add the proposal/budget to the map.

Therefore we need to handle the case where said block is disconnected from the chain.

In order to do so efficiently, this PR adds two indexes (`mapFeeTxToBudget`/`mapFeeTxToProposal`), mapping collateral txids to the relative budget objects (while such objects are stored in the map).
A simple function `CBudgetManager::RemoveByFeeTxId()` can then be called from `DisconnectBlock` when undoing transactions, in order to remove the now-conflicted budget objects (without performing any expensive search).