### PR TITLE
Refactor CWallet::AvailableCoins method signature

### DIFF
--- a/src/coincontrol.h
+++ b/src/coincontrol.h
@@ -28,6 +28,11 @@ public:
     bool fOverrideFeeRate;
     //! Feerate to use if overrideFeeRate is true
     CFeeRate nFeeRate;
+    //! Flag to decide whether delegations utxo are included in the calculation or not.
+    bool fIncludeDelegated{true};
+    //! Flag to decide whether cold staking utxo are included in the calculation or not
+    //! (always false in spending process for obvious reasons).
+    bool fIncludeColdStaking{false};
 
     CCoinControl()
     {
@@ -46,6 +51,8 @@ public:
         fOverrideFeeRate = false;
         fSplitBlock = false;
         nSplitBlock = 1;
+        fIncludeDelegated = true;
+        fIncludeColdStaking = false;
     }
 
     bool HasSelected() const

--- a/src/coincontrol.h
+++ b/src/coincontrol.h
@@ -33,6 +33,8 @@ public:
     //! Flag to decide whether cold staking utxo are included in the calculation or not
     //! (always false in spending process for obvious reasons).
     bool fIncludeColdStaking{false};
+    //! Whether should only select trusted coins.
+    bool fOnlyTrusted{true};
 
     CCoinControl()
     {
@@ -53,6 +55,7 @@ public:
         nSplitBlock = 1;
         fIncludeDelegated = true;
         fIncludeColdStaking = false;
+        fOnlyTrusted = true;
     }
 
     bool HasSelected() const

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -418,7 +418,6 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
                                                   coinControl,
                                                   recipients[0].inputType,
                                                   true,
-                                                  recipients[0].useSwiftTX,
                                                   0,
                                                   fIncludeDelegations);
         transaction.setTransactionFee(nFeeRequired);

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -1,9 +1,10 @@
 // Copyright (c) 2009-2012 The Bitcoin developers
 // Copyright (c) 2015-2020 The PIVX developers
 // Distributed under the MIT/X11 software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 #include "activemasternode.h"
+#include "coincontrol.h"
 #include "db.h"
 #include "init.h"
 #include "main.h"
@@ -401,7 +402,9 @@ UniValue getmasternodeoutputs (const JSONRPCRequest& request)
 
     // Find possible candidates
     std::vector<COutput> possibleCoins;
-    pwalletMain->AvailableCoins(&possibleCoins, nullptr, false, false, ONLY_10000);
+    CCoinControl coinControl;
+    coinControl.fIncludeDelegated = false;
+    pwalletMain->AvailableCoins(&possibleCoins, &coinControl, ONLY_10000);
 
     UniValue ret(UniValue::VARR);
     for (COutput& out : possibleCoins) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3194,6 +3194,7 @@ UniValue listunspent(const JSONRPCRequest& request)
 
     CCoinControl coinControl;
     coinControl.fAllowWatchOnly = nWatchonlyConfig == 2;
+    coinControl.fOnlyTrusted = false;
 
     UniValue results(UniValue::VARR);
     std::vector<COutput> vecOutputs;
@@ -3201,9 +3202,8 @@ UniValue listunspent(const JSONRPCRequest& request)
     LOCK2(cs_main, pwalletMain->cs_wallet);
     pwalletMain->AvailableCoins(&vecOutputs,
                                 &coinControl,    // coin control
-                                ALL_COINS,  // coin type
-                                false      // only confirmed
-                                );
+                                ALL_COINS);  // coin type
+
     for (const COutput& out : vecOutputs) {
         if (out.nDepth < nMinDepth || out.nDepth > nMaxDepth)
             continue;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3201,8 +3201,6 @@ UniValue listunspent(const JSONRPCRequest& request)
     LOCK2(cs_main, pwalletMain->cs_wallet);
     pwalletMain->AvailableCoins(&vecOutputs,
                                 &coinControl,    // coin control
-                                true,       // include delegated
-                                false,      // include cold staking
                                 ALL_COINS,  // coin type
                                 false,      // only confirmed
                                 false       // use IX

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1097,7 +1097,7 @@ UniValue CreateColdStakeDelegation(const UniValue& params, CWalletTx& wtxNew, CR
 
     // Create the transaction
     CAmount nFeeRequired;
-    if (!pwalletMain->CreateTransaction(scriptPubKey, nValue, wtxNew, reservekey, nFeeRequired, strError, nullptr, ALL_COINS, /*fUseIX*/ false, (CAmount)0, fUseDelegated)) {
+    if (!pwalletMain->CreateTransaction(scriptPubKey, nValue, wtxNew, reservekey, nFeeRequired, strError, nullptr, ALL_COINS, (CAmount)0, fUseDelegated)) {
         if (nValue + nFeeRequired > currBalance)
             strError = strprintf("Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!", FormatMoney(nFeeRequired));
         LogPrintf("%s : %s\n", __func__, strError);
@@ -3202,8 +3202,7 @@ UniValue listunspent(const JSONRPCRequest& request)
     pwalletMain->AvailableCoins(&vecOutputs,
                                 &coinControl,    // coin control
                                 ALL_COINS,  // coin type
-                                false,      // only confirmed
-                                false       // use IX
+                                false      // only confirmed
                                 );
     for (const COutput& out : vecOutputs) {
         if (out.nDepth < nMinDepth || out.nDepth > nMaxDepth)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -386,8 +386,6 @@ public:
     //! >> Available coins (generic)
     bool AvailableCoins(std::vector<COutput>* pCoins,   // --> populates when != nullptr
                         const CCoinControl* coinControl = nullptr,
-                        bool fIncludeDelegated          = true,
-                        bool fIncludeColdStaking        = false,
                         AvailableCoinsType nCoinType    = ALL_COINS,
                         bool fOnlyConfirmed             = true,
                         bool fUseIX                     = false

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -386,9 +386,7 @@ public:
     //! >> Available coins (generic)
     bool AvailableCoins(std::vector<COutput>* pCoins,   // --> populates when != nullptr
                         const CCoinControl* coinControl = nullptr,
-                        AvailableCoinsType nCoinType    = ALL_COINS,
-                        bool fOnlyConfirmed             = true
-                        ) const;
+                        AvailableCoinsType nCoinType    = ALL_COINS) const;
     //! >> Available coins (spending)
     bool SelectCoinsToSpend(const std::vector<COutput>& vAvailableCoins, const CAmount& nTargetValue, std::set<std::pair<const CWalletTx*, unsigned int> >& setCoinsRet, CAmount& nValueRet, const CCoinControl* coinControl = nullptr) const;
     bool SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int nConfTheirs, std::vector<COutput> vCoins, std::set<std::pair<const CWalletTx*, unsigned int> >& setCoinsRet, CAmount& nValueRet) const;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -387,8 +387,7 @@ public:
     bool AvailableCoins(std::vector<COutput>* pCoins,   // --> populates when != nullptr
                         const CCoinControl* coinControl = nullptr,
                         AvailableCoinsType nCoinType    = ALL_COINS,
-                        bool fOnlyConfirmed             = true,
-                        bool fUseIX                     = false
+                        bool fOnlyConfirmed             = true
                         ) const;
     //! >> Available coins (spending)
     bool SelectCoinsToSpend(const std::vector<COutput>& vAvailableCoins, const CAmount& nTargetValue, std::set<std::pair<const CWalletTx*, unsigned int> >& setCoinsRet, CAmount& nValueRet, const CCoinControl* coinControl = nullptr) const;
@@ -548,10 +547,9 @@ public:
         const CCoinControl* coinControl = NULL,
         AvailableCoinsType coin_type = ALL_COINS,
         bool sign = true,
-        bool useIX = false,
         CAmount nFeePay = 0,
         bool fIncludeDelegated = false);
-    bool CreateTransaction(CScript scriptPubKey, const CAmount& nValue, CWalletTx& wtxNew, CReserveKey& reservekey, CAmount& nFeeRet, std::string& strFailReason, const CCoinControl* coinControl = NULL, AvailableCoinsType coin_type = ALL_COINS, bool useIX = false, CAmount nFeePay = 0, bool fIncludeDelegated = false);
+    bool CreateTransaction(CScript scriptPubKey, const CAmount& nValue, CWalletTx& wtxNew, CReserveKey& reservekey, CAmount& nFeeRet, std::string& strFailReason, const CCoinControl* coinControl = NULL, AvailableCoinsType coin_type = ALL_COINS, CAmount nFeePay = 0, bool fIncludeDelegated = false);
 
     // enumeration for CommitResult (return status of CommitTransaction)
     enum CommitStatus


### PR DESCRIPTION
Purely an aesthetic improvement, no functional changes. Combining parameters that should had been coded into `CoinControl` wrapper class in the first place.