### PR TITLE
Missing mnping category added to logcategories

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -123,6 +123,7 @@ const CLogCategoryDesc LogCategories[] = {
         {BCLog::MASTERNODE,     "masternode"},
         {BCLog::MNBUDGET,       "mnbudget"},
         {BCLog::LEGACYZC,       "zero"},
+        {BCLog::MNPING,         "mnping"},
         {BCLog::ALL,            "1"},
         {BCLog::ALL,            "all"},
 };


### PR DESCRIPTION
For some reason mnping log category wasn't added to the logcategories vector. Discovered it trying to exclude it with `debugexclude=mnping` which notifies the error.