### PR TITLE
[Refactoring] Budget, round 6: masternode vote for finalized budgets

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -236,7 +236,7 @@ void PrepareShutdown()
     g_connman.reset();
 
     DumpMasternodes();
-    DumpBudgets();
+    DumpBudgets(g_budgetman);
     DumpMasternodePayments();
     UnregisterNodeSignals(GetNodeSignals());
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1769,8 +1769,8 @@ bool AppInit2()
 
     CBudgetDB budgetdb;
     const bool fDryRun = (nChainHeight <= 0);
-    if (!fDryRun) budget.SetBestHeight(nChainHeight);
-    CBudgetDB::ReadResult readResult2 = budgetdb.Read(budget, fDryRun);
+    if (!fDryRun) g_budgetman.SetBestHeight(nChainHeight);
+    CBudgetDB::ReadResult readResult2 = budgetdb.Read(g_budgetman, fDryRun);
 
     if (readResult2 == CBudgetDB::FileError)
         LogPrintf("Missing budget cache - budget.dat, will try to recreate\n");
@@ -1783,8 +1783,8 @@ bool AppInit2()
     }
 
     //flag our cached items so we send them to our peers
-    budget.ResetSync();
-    budget.ClearSeen();
+    g_budgetman.ResetSync();
+    g_budgetman.ClearSeen();
 
 
     uiInterface.InitMessage(_("Loading masternode payment cache..."));

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -352,7 +352,7 @@ CBudgetDB::ReadResult CBudgetDB::Read(CBudgetManager& objToLoad, bool fDryRun)
     return Ok;
 }
 
-void DumpBudgets()
+void DumpBudgets(CBudgetManager& budgetman)
 {
     int64_t nStart = GetTimeMillis();
 
@@ -374,7 +374,7 @@ void DumpBudgets()
         }
     }
     LogPrint(BCLog::MNBUDGET,"Writting info to budget.dat...\n");
-    budgetdb.Write(g_budgetman);
+    budgetdb.Write(budgetman);
 
     LogPrint(BCLog::MNBUDGET,"Budget dump finished  %dms\n", GetTimeMillis() - nStart);
 }

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -17,7 +17,7 @@
 #include "util.h"
 
 
-CBudgetManager budget;
+CBudgetManager g_budgetman;
 
 std::map<uint256, int64_t> askedForSourceProposalOrBudget;
 
@@ -374,7 +374,7 @@ void DumpBudgets()
         }
     }
     LogPrint(BCLog::MNBUDGET,"Writting info to budget.dat...\n");
-    budgetdb.Write(budget);
+    budgetdb.Write(g_budgetman);
 
     LogPrint(BCLog::MNBUDGET,"Budget dump finished  %dms\n", GetTimeMillis() - nStart);
 }
@@ -1892,9 +1892,10 @@ void CFinalizedBudget::CheckAndVote()
 
     fAutoChecked = true; //we only need to check this once
 
+    // !TODO: move it to CBudgetManager
     if (strBudgetMode == "auto") //only vote for exact matches
     {
-        std::vector<CBudgetProposal*> vBudgetProposals = budget.GetBudget();
+        std::vector<CBudgetProposal*> vBudgetProposals = g_budgetman.GetBudget();
 
         // We have to resort the proposals by hash (they are sorted by votes here) and sort the payments
         // by hash (they are not sorted at all) to make the following tests deterministic
@@ -2227,10 +2228,11 @@ void CFinalizedBudget::SubmitVote()
         return;
     }
 
-    if (budget.UpdateFinalizedBudget(vote, NULL, strError)) {
+    // !TODO: move to CBudgetManager
+    if (g_budgetman.UpdateFinalizedBudget(vote, NULL, strError)) {
         LogPrint(BCLog::MNBUDGET,"%s: new finalized budget vote - %s\n", __func__, vote.GetHash().ToString());
 
-        budget.AddSeenFinalizedBudgetVote(vote);
+        g_budgetman.AddSeenFinalizedBudgetVote(vote);
         vote.Relay();
     } else {
         LogPrint(BCLog::MNBUDGET,"%s: Error submitting vote - %s\n", __func__, strError);

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -737,7 +737,7 @@ void CBudgetManager::VoteOnFinalizedBudgets()
                 }
             }
             // exact match found. add budget hash to sign it later.
-            vBudgetHashes.push_back(pfb->GetHash());
+            vBudgetHashes.emplace_back(pfb->GetHash());
         }
     }
 
@@ -905,7 +905,7 @@ std::vector<CBudgetProposal> CBudgetManager::GetBudget()
 
     int nHeight = GetBestHeight();
     if (nHeight <= 0)
-        return std::vector<CBudgetProposal>();
+        return {};
 
     // ------- Sort budgets by net Yes Count
     std::vector<CBudgetProposal*> vBudgetPorposalsSort;
@@ -936,7 +936,7 @@ std::vector<CBudgetProposal> CBudgetManager::GetBudget()
             if (pbudgetProposal->GetAmount() + nBudgetAllocated <= nTotalBudget) {
                 pbudgetProposal->SetAllotted(pbudgetProposal->GetAmount());
                 nBudgetAllocated += pbudgetProposal->GetAmount();
-                vBudgetProposalsRet.push_back(*pbudgetProposal);
+                vBudgetProposalsRet.emplace_back(*pbudgetProposal);
                 LogPrint(BCLog::MNBUDGET,"%s:  -     Check 2 passed: Budget added\n", __func__);
             } else {
                 pbudgetProposal->SetAllotted(0);
@@ -1972,7 +1972,7 @@ bool CFinalizedBudget::CheckProposals(const std::map<uint256, CBudgetProposal>& 
         LogPrint(BCLog::MNBUDGET,"%s: Budget-Proposals - nAmount %lli\n", __func__, (it.second).GetAmount());
     }
 
-    for (const CTxBudgetPayment& p: vecBudgetPayments) {
+    for (const CTxBudgetPayment& p : vecBudgetPayments) {
         const auto& it = mapWinningProposals.find(p.nProposalHash);
         if (it == mapWinningProposals.end()) {
             LogPrint(BCLog::MNBUDGET,"%s: Proposal %s not found\n", __func__, p.nProposalHash.ToString());

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -1796,7 +1796,7 @@ CBudgetVote::CBudgetVote() :
         vin()
 { }
 
-CBudgetVote::CBudgetVote(CTxIn vinIn, uint256 nProposalHashIn, VoteDirection nVoteIn) :
+CBudgetVote::CBudgetVote(const CTxIn& vinIn, const uint256& nProposalHashIn, VoteDirection nVoteIn) :
         CSignedMessage(),
         fValid(true),
         fSynced(false),
@@ -2277,7 +2277,7 @@ CFinalizedBudgetVote::CFinalizedBudgetVote() :
         nTime(0)
 { }
 
-CFinalizedBudgetVote::CFinalizedBudgetVote(CTxIn vinIn, uint256 nBudgetHashIn) :
+CFinalizedBudgetVote::CFinalizedBudgetVote(const CTxIn& vinIn, const uint256& nBudgetHashIn) :
         CSignedMessage(),
         fValid(true),
         fSynced(false),

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -299,6 +299,9 @@ public:
     std::string GetRequiredPaymentsString(int nBlockHeight);
     bool FillBlockPayee(CMutableTransaction& txNew, bool fProofOfStake) const;
 
+    // Only initialized masternodes: sign and submit vote on a finalized budget with given key
+    void SubmitVote(const uint256& nBudgetHash);
+
     void CheckOrphanVotes();
     void Clear()
     {
@@ -457,8 +460,6 @@ public:
     void CheckAndVote();
     //total pivx paid out by this budget
     CAmount GetTotalPayout() const;
-    //vote on this finalized budget as a masternode
-    void SubmitVote();
 
     uint256 GetHash() const
     {

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -300,7 +300,7 @@ public:
     bool FillBlockPayee(CMutableTransaction& txNew, bool fProofOfStake) const;
 
     // Only initialized masternodes: sign and submit vote on a finalized budget with given key
-    void SubmitVote(const uint256& nBudgetHash);
+    void SubmitVote(CFinalizedBudget* pfb);
 
     void CheckOrphanVotes();
     void Clear()
@@ -441,6 +441,9 @@ public:
     std::string IsInvalidReason() const { return strInvalid; }
     std::string IsInvalidLogStr() const { return strprintf("[%s (%s)]: %s", GetName(), GetProposalsStr(), IsInvalidReason()); }
 
+    bool IsAutoChecked() const { return fAutoChecked; }
+    void SetAutoChecked(bool _fAutoChecked) { fAutoChecked = _fAutoChecked; }
+
     void SetProposalsStr(const std::string _strProposals) { strProposals = _strProposals; }
 
     std::string GetName() const { return strBudgetName; }
@@ -456,9 +459,9 @@ public:
     bool GetBudgetPaymentByBlock(int64_t nBlockHeight, CTxBudgetPayment& payment) const;
     bool GetPayeeAndAmount(int64_t nBlockHeight, CScript& payee, CAmount& nAmount) const;
 
-    // Verify and vote on finalized budget
-    void CheckAndVote();
-    //total pivx paid out by this budget
+    // Check finalized budget proposals. Masternodes only (when voting on finalized budgets)
+    bool CheckProposals(const std::vector<CBudgetProposal*>& vBudgetProposalsSortedByHash) const;
+    // Total amount paid out by this budget
     CAmount GetTotalPayout() const;
 
     uint256 GetHash() const

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -284,7 +284,7 @@ public:
     const CBudgetProposal* FindProposalByName(const std::string& strProposalName) const;
 
     static CAmount GetTotalBudget(int nHeight);
-    std::vector<CBudgetProposal*> GetBudget();
+    std::vector<CBudgetProposal> GetBudget();
     std::vector<CBudgetProposal*> GetAllProposals();
     std::vector<CFinalizedBudget*> GetFinalizedBudgets();
     bool IsBudgetPaymentBlock(int nBlockHeight) const;
@@ -460,7 +460,7 @@ public:
     bool GetPayeeAndAmount(int64_t nBlockHeight, CScript& payee, CAmount& nAmount) const;
 
     // Check finalized budget proposals. Masternodes only (when voting on finalized budgets)
-    bool CheckProposals(std::vector<CBudgetProposal*>& vBudget) const;
+    bool CheckProposals(std::vector<CBudgetProposal>& vBudget) const;
     // Total amount paid out by this budget
     CAmount GetTotalPayout() const;
 

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -460,7 +460,7 @@ public:
     bool GetPayeeAndAmount(int64_t nBlockHeight, CScript& payee, CAmount& nAmount) const;
 
     // Check finalized budget proposals. Masternodes only (when voting on finalized budgets)
-    bool CheckProposals(std::vector<CBudgetProposal>& vBudget) const;
+    bool CheckProposals(const std::map<uint256, CBudgetProposal>& mapWinningProposals) const;
     // Total amount paid out by this budget
     CAmount GetTotalPayout() const;
 

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -299,8 +299,8 @@ public:
     std::string GetRequiredPaymentsString(int nBlockHeight);
     bool FillBlockPayee(CMutableTransaction& txNew, bool fProofOfStake) const;
 
-    // Only initialized masternodes: sign and submit vote on a finalized budget with given key
-    void SubmitVote(CFinalizedBudget* pfb);
+    // Only initialized masternodes: sign and submit votes on valid finalized budgets
+    void VoteOnFinalizedBudgets();
 
     void CheckOrphanVotes();
     void Clear()
@@ -460,7 +460,7 @@ public:
     bool GetPayeeAndAmount(int64_t nBlockHeight, CScript& payee, CAmount& nAmount) const;
 
     // Check finalized budget proposals. Masternodes only (when voting on finalized budgets)
-    bool CheckProposals(const std::vector<CBudgetProposal*>& vBudgetProposalsSortedByHash) const;
+    bool CheckProposals(std::vector<CBudgetProposal*>& vBudget) const;
     // Total amount paid out by this budget
     CAmount GetTotalPayout() const;
 

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -36,7 +36,7 @@ static const int64_t BUDGET_VOTE_UPDATE_MIN = 60 * 60;
 static std::map<uint256, std::pair<uint256,int> > mapPayment_History;   // proposal hash --> (block hash, block height)
 
 extern CBudgetManager g_budgetman;
-void DumpBudgets();
+void DumpBudgets(CBudgetManager& budgetman);
 
 //
 // CBudgetVote - Allow a masternode node to vote and broadcast throughout the network

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -611,8 +611,6 @@ public:
 
     // compare proposals by proposal hash
     inline bool operator>(const CBudgetProposal& other) const { return GetHash() > other.GetHash(); }
-    // compare proposals pointers by hash
-    static inline bool PtrGreater(CBudgetProposal* a, CBudgetProposal* b) { return *a > *b; }
     // compare proposals pointers by net yes count (solve tie with feeHash)
     static bool PtrHigherYes(CBudgetProposal* a, CBudgetProposal* b);
 

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -35,7 +35,7 @@ static const CAmount BUDGET_FEE_TX = (5 * COIN);
 static const int64_t BUDGET_VOTE_UPDATE_MIN = 60 * 60;
 static std::map<uint256, std::pair<uint256,int> > mapPayment_History;   // proposal hash --> (block hash, block height)
 
-extern CBudgetManager budget;
+extern CBudgetManager g_budgetman;
 void DumpBudgets();
 
 //

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -61,7 +61,7 @@ private:
 
 public:
     CBudgetVote();
-    CBudgetVote(CTxIn vin, uint256 nProposalHash, VoteDirection nVoteIn);
+    CBudgetVote(const CTxIn& vin, const uint256& nProposalHash, VoteDirection nVoteIn);
 
     void Relay() const;
 
@@ -129,7 +129,7 @@ private:
 
 public:
     CFinalizedBudgetVote();
-    CFinalizedBudgetVote(CTxIn vinIn, uint256 nBudgetHashIn);
+    CFinalizedBudgetVote(const CTxIn& vinIn, const uint256& nBudgetHashIn);
 
     void Relay() const;
     uint256 GetHash() const;

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -240,7 +240,7 @@ bool IsBlockValueValid(int nHeight, CAmount nExpectedValue, CAmount nMinted)
         // we're synced and have data so check the budget schedule
         // if the superblock spork is enabled
         if (sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS) &&
-            budget.IsBudgetPaymentBlock(nHeight)) {
+                g_budgetman.IsBudgetPaymentBlock(nHeight)) {
             //the value of the block is evaluated in CheckBlock
             return true;
         }
@@ -264,8 +264,8 @@ bool IsBlockPayeeValid(const CBlock& block, int nBlockHeight)
 
     //check if it's a budget block
     if (sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS)) {
-        if (budget.IsBudgetPaymentBlock(nBlockHeight)) {
-            transactionStatus = budget.IsTransactionValid(txNew, block.GetHash(), nBlockHeight);
+        if (g_budgetman.IsBudgetPaymentBlock(nBlockHeight)) {
+            transactionStatus = g_budgetman.IsTransactionValid(txNew, block.GetHash(), nBlockHeight);
             if (transactionStatus == TrxValidationStatus::Valid) {
                 return true;
             }
@@ -301,9 +301,9 @@ void FillBlockPayee(CMutableTransaction& txNew, const CBlockIndex* pindexPrev, b
 {
     if (!pindexPrev) return;
 
-    if (!sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS) ||  // if superblocks are not enabled
-            !budget.IsBudgetPaymentBlock(pindexPrev->nHeight + 1) || // or this is not a superblock
-            !budget.FillBlockPayee(txNew, fProofOfStake) ) {         // or there's no budget with enough votes
+    if (!sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS) ||       // if superblocks are not enabled
+            !g_budgetman.IsBudgetPaymentBlock(pindexPrev->nHeight + 1) || // or this is not a superblock
+            !g_budgetman.FillBlockPayee(txNew, fProofOfStake) ) {         // or there's no budget with enough votes
         // pay a masternode
         masternodePayments.FillBlockPayee(txNew, pindexPrev, fProofOfStake);
     }
@@ -311,8 +311,8 @@ void FillBlockPayee(CMutableTransaction& txNew, const CBlockIndex* pindexPrev, b
 
 std::string GetRequiredPaymentsString(int nBlockHeight)
 {
-    if (sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS) && budget.IsBudgetPaymentBlock(nBlockHeight)) {
-        return budget.GetRequiredPaymentsString(nBlockHeight);
+    if (sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS) && g_budgetman.IsBudgetPaymentBlock(nBlockHeight)) {
+        return g_budgetman.GetRequiredPaymentsString(nBlockHeight);
     } else {
         return masternodePayments.GetRequiredPaymentsString(nBlockHeight);
     }
@@ -662,7 +662,7 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight)
 
     CMasternodePaymentWinner newWinner(*(activeMasternode.vin));
 
-    if (budget.IsBudgetPaymentBlock(nBlockHeight)) {
+    if (g_budgetman.IsBudgetPaymentBlock(nBlockHeight)) {
         //is budget payment block -- handled by the budgeting software
     } else {
         LogPrint(BCLog::MASTERNODE,"CMasternodePayments::ProcessBlock() Start nHeight %d - vin %s. \n", nBlockHeight, activeMasternode.vin->prevout.hash.ToString());

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -131,10 +131,10 @@ void CMasternodeSync::AddedMasternodeWinner(const uint256& hash)
 
 void CMasternodeSync::AddedBudgetItem(const uint256& hash)
 {
-    if (budget.HaveProposal(hash) ||
-            budget.HaveSeenProposalVote(hash) ||
-            budget.HaveFinalizedBudget(hash) ||
-            budget.HaveSeenFinalizedBudgetVote(hash)) {
+    if (g_budgetman.HaveProposal(hash) ||
+            g_budgetman.HaveSeenProposalVote(hash) ||
+            g_budgetman.HaveFinalizedBudget(hash) ||
+            g_budgetman.HaveSeenFinalizedBudgetVote(hash)) {
         if (mapSeenSyncBudget[hash] < MASTERNODE_SYNC_THRESHOLD) {
             lastBudgetItem = GetTime();
             mapSeenSyncBudget[hash]++;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -705,25 +705,25 @@ bool static AlreadyHave(const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
         }
         return false;
     case MSG_BUDGET_VOTE:
-        if (budget.HaveSeenProposalVote(inv.hash)) {
+        if (g_budgetman.HaveSeenProposalVote(inv.hash)) {
             masternodeSync.AddedBudgetItem(inv.hash);
             return true;
         }
         return false;
     case MSG_BUDGET_PROPOSAL:
-        if (budget.HaveProposal(inv.hash)) {
+        if (g_budgetman.HaveProposal(inv.hash)) {
             masternodeSync.AddedBudgetItem(inv.hash);
             return true;
         }
         return false;
     case MSG_BUDGET_FINALIZED_VOTE:
-        if (budget.HaveSeenFinalizedBudgetVote(inv.hash)) {
+        if (g_budgetman.HaveSeenFinalizedBudgetVote(inv.hash)) {
             masternodeSync.AddedBudgetItem(inv.hash);
             return true;
         }
         return false;
     case MSG_BUDGET_FINALIZED:
-        if (budget.HaveFinalizedBudget(inv.hash)) {
+        if (g_budgetman.HaveFinalizedBudget(inv.hash)) {
             masternodeSync.AddedBudgetItem(inv.hash);
             return true;
         }
@@ -893,29 +893,29 @@ void static ProcessGetData(CNode* pfrom, CConnman& connman, std::atomic<bool>& i
                     }
                 }
                 if (!pushed && inv.type == MSG_BUDGET_VOTE) {
-                    if (budget.HaveSeenProposalVote(inv.hash)) {
-                        connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::BUDGETVOTE, budget.GetProposalVoteSerialized(inv.hash)));
+                    if (g_budgetman.HaveSeenProposalVote(inv.hash)) {
+                        connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::BUDGETVOTE, g_budgetman.GetProposalVoteSerialized(inv.hash)));
                         pushed = true;
                     }
                 }
 
                 if (!pushed && inv.type == MSG_BUDGET_PROPOSAL) {
-                    if (budget.HaveProposal(inv.hash)) {
-                        connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::BUDGETPROPOSAL, budget.GetProposalSerialized(inv.hash)));
+                    if (g_budgetman.HaveProposal(inv.hash)) {
+                        connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::BUDGETPROPOSAL, g_budgetman.GetProposalSerialized(inv.hash)));
                         pushed = true;
                     }
                 }
 
                 if (!pushed && inv.type == MSG_BUDGET_FINALIZED_VOTE) {
-                    if (budget.HaveSeenFinalizedBudgetVote(inv.hash)) {
-                        connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::FINALBUDGETVOTE, budget.GetFinalizedBudgetVoteSerialized(inv.hash)));
+                    if (g_budgetman.HaveSeenFinalizedBudgetVote(inv.hash)) {
+                        connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::FINALBUDGETVOTE, g_budgetman.GetFinalizedBudgetVoteSerialized(inv.hash)));
                         pushed = true;
                     }
                 }
 
                 if (!pushed && inv.type == MSG_BUDGET_FINALIZED) {
-                    if (budget.HaveFinalizedBudget(inv.hash)) {
-                        connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::FINALBUDGET, budget.GetFinalizedBudgetSerialized(inv.hash)));
+                    if (g_budgetman.HaveFinalizedBudget(inv.hash)) {
+                        connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::FINALBUDGET, g_budgetman.GetFinalizedBudgetSerialized(inv.hash)));
                         pushed = true;
                     }
                 }
@@ -1822,7 +1822,7 @@ bool static ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vR
             if (!masternodeSync.MessageDispatcher(pfrom, strCommand, vRecv)) {
                 //probably one the extensions
                 mnodeman.ProcessMessage(pfrom, strCommand, vRecv);
-                budget.ProcessMessage(pfrom, strCommand, vRecv);
+                g_budgetman.ProcessMessage(pfrom, strCommand, vRecv);
                 masternodePayments.ProcessMessageMasternodePayments(pfrom, strCommand, vRecv);
                 sporkManager.ProcessSpork(pfrom, strCommand, vRecv);
                 masternodeSync.ProcessMessage(pfrom, strCommand, vRecv);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1173,7 +1173,7 @@ UniValue invalidateblock(const JSONRPCRequest& request)
     if (state.IsValid()) {
         ActivateBestChain(state);
         int nHeight = WITH_LOCK(cs_main, return chainActive.Height(); );
-        budget.SetBestHeight(nHeight);
+        g_budgetman.SetBestHeight(nHeight);
         mnodeman.SetBestHeight(nHeight);
     }
 
@@ -1214,7 +1214,7 @@ UniValue reconsiderblock(const JSONRPCRequest& request)
     if (state.IsValid()) {
         ActivateBestChain(state);
         int nHeight = WITH_LOCK(cs_main, return chainActive.Height(); );
-        budget.SetBestHeight(nHeight);
+        g_budgetman.SetBestHeight(nHeight);
         mnodeman.SetBestHeight(nHeight);
     }
 

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -41,11 +41,11 @@ void budgetToJSON(const CBudgetProposal* pbudgetProposal, UniValue& bObj, int nC
     bObj.pushKV("TotalPayment", ValueFromAmount(pbudgetProposal->GetAmount() * pbudgetProposal->GetTotalPaymentCount()));
     bObj.pushKV("MonthlyPayment", ValueFromAmount(pbudgetProposal->GetAmount()));
     bObj.pushKV("IsEstablished", pbudgetProposal->IsEstablished());
-
     bool fValid = pbudgetProposal->IsValid();
     bObj.pushKV("IsValid", fValid);
     if (!fValid)
         bObj.pushKV("IsInvalidReason", pbudgetProposal->IsInvalidReason());
+    bObj.pushKV("Alloted", ValueFromAmount(pbudgetProposal->GetAllotted()));
 }
 
 void checkBudgetInputs(const UniValue& params, std::string &strProposalName, std::string &strURL,
@@ -557,18 +557,12 @@ UniValue getbudgetprojection(const JSONRPCRequest& request)
     UniValue resultObj(UniValue::VOBJ);
     CAmount nTotalAllotted = 0;
 
-    std::vector<CBudgetProposal*> winningProps = g_budgetman.GetBudget();
-    for (CBudgetProposal* pbudgetProposal : winningProps) {
-        nTotalAllotted += pbudgetProposal->GetAllotted();
-
-        CTxDestination address1;
-        ExtractDestination(pbudgetProposal->GetPayee(), address1);
-
+    std::vector<CBudgetProposal> winningProps = g_budgetman.GetBudget();
+    for (const CBudgetProposal& p : winningProps) {
         UniValue bObj(UniValue::VOBJ);
-        budgetToJSON(pbudgetProposal, bObj, g_budgetman.GetBestHeight());
-        bObj.pushKV("Alloted", ValueFromAmount(pbudgetProposal->GetAllotted()));
+        budgetToJSON(&p, bObj, g_budgetman.GetBestHeight());;
+        nTotalAllotted += p.GetAllotted();
         bObj.pushKV("TotalBudgetAlloted", ValueFromAmount(nTotalAllotted));
-
         ret.push_back(bObj);
     }
 

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -560,7 +560,7 @@ UniValue getbudgetprojection(const JSONRPCRequest& request)
     std::vector<CBudgetProposal> winningProps = g_budgetman.GetBudget();
     for (const CBudgetProposal& p : winningProps) {
         UniValue bObj(UniValue::VOBJ);
-        budgetToJSON(&p, bObj, g_budgetman.GetBestHeight());;
+        budgetToJSON(&p, bObj, g_budgetman.GetBestHeight());
         nTotalAllotted += p.GetAllotted();
         bObj.pushKV("TotalBudgetAlloted", ValueFromAmount(nTotalAllotted));
         ret.push_back(bObj);

--- a/src/test/budget_tests.cpp
+++ b/src/test/budget_tests.cpp
@@ -14,7 +14,7 @@ BOOST_FIXTURE_TEST_SUITE(budget_tests, TestingSetup)
 void CheckBudgetValue(int nHeight, std::string strNetwork, CAmount nExpectedValue)
 {
     CBudgetManager budget;
-    CAmount nBudget = budget.GetTotalBudget(nHeight);
+    CAmount nBudget = g_budgetman.GetTotalBudget(nHeight);
     std::string strError = strprintf("Budget is not as expected for %s. Result: %s, Expected: %s", strNetwork, FormatMoney(nBudget), FormatMoney(nExpectedValue));
     BOOST_CHECK_MESSAGE(nBudget == nExpectedValue, strError);
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1319,7 +1319,7 @@ DisconnectResult DisconnectBlock(CBlock& block, CBlockIndex* pindex, CCoinsViewC
         const uint256& hash = tx.GetHash();
 
         // if tx is a budget collateral tx, remove relative object
-        budget.RemoveByFeeTxId(hash);
+        g_budgetman.RemoveByFeeTxId(hash);
 
         // Check that all outputs are available and match the outputs in the block itself
         // exactly.
@@ -2710,7 +2710,7 @@ bool CheckColdStakeFreeOutput(const CTransaction& tx, const int nHeight)
         }
 
         // Check that this is indeed a superblock.
-        if (budget.IsBudgetPaymentBlock(nHeight)) {
+        if (g_budgetman.IsBudgetPaymentBlock(nHeight)) {
             // if superblocks are not enabled, reject
             if (!sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS))
                 return error("%s: superblocks are not enabled", __func__);
@@ -3462,7 +3462,7 @@ bool ProcessNewBlock(CValidationState& state, CNode* pfrom, const std::shared_pt
 
     if (!fLiteMode) {
         mnodeman.SetBestHeight(newHeight);
-        budget.NewBlock(newHeight);
+        g_budgetman.NewBlock(newHeight);
         if (masternodeSync.RequestedMasternodeAssets > MASTERNODE_SYNC_LIST) {
             masternodePayments.ProcessBlock(newHeight + 10);
         }


### PR DESCRIPTION
Based on top of 
-  [x] #1858 

Starting with `[Trivial] Rename global budget object to g_budgetman` (64f0840)

This refactors `CFinalizedBudget::SubmitVote`, moving it to the budget manager (`VoteOnFinalizedBudgets`), and removing the nested locking issues.
It also does some trivial cleanup:
- rename the global budget manager `g_budgetman`
- pass const references to  `CBudgetVote`/`CFinalizedBudget` constructors
- pass the manager externally to `DumpBudgets` (instead of using the global one)