### PR TITLE
[Trivial][GUI] Fix init messages

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1470,8 +1470,6 @@ bool AppInit2()
         bool fReset = fReindex;
         std::string strLoadError;
 
-        uiInterface.InitMessage(_("Loading block index..."));
-
         do {
             const int64_t load_block_index_start_time = GetTimeMillis();
 
@@ -1496,6 +1494,7 @@ bool AppInit2()
                 if (fReindex) {
                     pblocktree->WriteReindexing(true);
                 } else {
+                    uiInterface.InitMessage(_("Upgrading coins database..."));
                     // If necessary, upgrade from older database format.
                     if (!pcoinsdbview->Upgrade()) {
                         strLoadError = _("Error upgrading chainstate database");


### PR DESCRIPTION
After #1801 the coins database is updated to the new format.
During this time (which could take a minute or so), QT wallet reports "Loading block index..."

<img src="https://user-images.githubusercontent.com/18186894/93999833-9bdb8c80-fd96-11ea-9c40-d58417a122a0.png" width="60%">

which is wrong: even without the coins DB upgrade, it loads first the sporks DB, before the block index.

So:
- remove the misplaced init message for BlockIndex load (there's another one in the right place).
- add a new init message for the coins DB upgrade (if the DB is already upgraded, the function returns immediately so this is shown only for a fraction of a second before "Loading sporks...").

Note: As 4.3 is the first release including the new DB, we should probably backport this trivial PR.