### PR TITLE
[Core] Optimize reindex

### DIFF
--- a/src/guiinterface.h
+++ b/src/guiinterface.h
@@ -103,6 +103,9 @@ public:
     /** New block has been accepted */
     boost::signals2::signal<void(bool fInitialDownload, const CBlockIndex* newTip)> NotifyBlockTip;
 
+    /** Best header has changed */
+    boost::signals2::signal<void (bool, const CBlockIndex *)> NotifyHeaderTip;
+
     /** New block has been accepted and is over a certain size */
     boost::signals2::signal<void(int size, const uint256& hash)> NotifyBlockSize;
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -417,6 +417,7 @@ std::string HelpMessage(HelpMessageMode mode)
 #ifndef WIN32
     strUsage += HelpMessageOpt("-pid=<file>", strprintf(_("Specify pid file (default: %s)"), PIVX_PID_FILENAME));
 #endif
+    strUsage += HelpMessageOpt("-reindex-chainstate", _("Rebuild chain state from the currently indexed blocks"));
     strUsage += HelpMessageOpt("-reindex", _("Rebuild block chain index from current blk000??.dat files") + " " + _("on startup"));
     strUsage += HelpMessageOpt("-reindexmoneysupply", strprintf(_("Reindex the %s and z%s money supply statistics"), CURRENCY_UNIT, CURRENCY_UNIT) + " " + _("on startup"));
     strUsage += HelpMessageOpt("-resync", _("Delete blockchain folders and resync from scratch") + " " + _("on startup"));
@@ -1462,6 +1463,7 @@ bool AppInit2()
     // ********************************************************* Step 7: load block chain
 
     fReindex = GetBoolArg("-reindex", false);
+    bool fReindexChainState = GetBoolArg("-reindex-chainstate", false);
 
     // Create blocks directory if it doesn't already exist
     fs::create_directories(GetDataDir() / "blocks");
@@ -1504,7 +1506,7 @@ bool AppInit2()
                 pSporkDB = new CSporkDB(0, false, false);
 
                 pblocktree = new CBlockTreeDB(nBlockTreeDBCache, false, fReindex);
-                pcoinsdbview = new CCoinsViewDB(nCoinDBCache, false, fReindex);
+                pcoinsdbview = new CCoinsViewDB(nCoinDBCache, false, fReindex || fReindexChainState);
                 pcoinscatcher = new CCoinsViewErrorCatcher(pcoinsdbview);
                 pcoinsTip = new CCoinsViewCache(pcoinscatcher);
 
@@ -1550,7 +1552,7 @@ bool AppInit2()
 
                 // Check for changed -txindex state
                 if (fTxIndex != GetBoolArg("-txindex", DEFAULT_TXINDEX)) {
-                    strLoadError = _("You need to rebuild the database using -reindex to change -txindex");
+                    strLoadError = _("You need to rebuild the database using -reindex-chainstate to change -txindex");
                     break;
                 }
 

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -112,7 +112,7 @@ private:
 
 Q_SIGNALS:
     void numConnectionsChanged(int count);
-    void numBlocksChanged(int count);
+    void numBlocksChanged(int count, bool headers);
     void strMasternodesChanged(const QString& strMasternodes);
     void alertsChanged(const QString& warnings);
     void bytesChanged(quint64 totalBytesIn, quint64 totalBytesOut);

--- a/src/qt/pivx/settings/settingsinformationwidget.cpp
+++ b/src/qt/pivx/settings/settingsinformationwidget.cpp
@@ -118,7 +118,7 @@ void SettingsInformationWidget::loadClientModel()
         setNumConnections(clientModel->getNumConnections());
         connect(clientModel, &ClientModel::numConnectionsChanged, this, &SettingsInformationWidget::setNumConnections);
 
-        setNumBlocks(clientModel->getNumBlocks());
+        setNumBlocks(clientModel->getNumBlocks(), false);
         connect(clientModel, &ClientModel::numBlocksChanged, this, &SettingsInformationWidget::setNumBlocks);
 
         connect(clientModel, &ClientModel::strMasternodesChanged, this, &SettingsInformationWidget::setMasternodeCount);
@@ -137,8 +137,9 @@ void SettingsInformationWidget::setNumConnections(int count)
     ui->labelInfoConnections->setText(connections);
 }
 
-void SettingsInformationWidget::setNumBlocks(int count)
+void SettingsInformationWidget::setNumBlocks(int count, bool headers)
 {
+    if (headers) return;
     ui->labelInfoBlockNumber->setText(QString::number(count));
     if (clientModel) {
         ui->labelInfoBlockTime->setText(clientModel->getLastBlockDate().toString());

--- a/src/qt/pivx/settings/settingsinformationwidget.h
+++ b/src/qt/pivx/settings/settingsinformationwidget.h
@@ -25,7 +25,7 @@ public:
 
 private Q_SLOTS:
     void setNumConnections(int count);
-    void setNumBlocks(int count);
+    void setNumBlocks(int count, bool headers);
     void setMasternodeCount(const QString& strMasternodes);
     void showEvent(QShowEvent* event) override;
     void hideEvent(QHideEvent* event) override;

--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -373,7 +373,7 @@ void TopBar::loadClientModel()
         setNumConnections(clientModel->getNumConnections());
         connect(clientModel, &ClientModel::numConnectionsChanged, this, &TopBar::setNumConnections);
 
-        setNumBlocks(clientModel->getNumBlocks());
+        setNumBlocks(clientModel->getNumBlocks(), false);
         connect(clientModel, &ClientModel::numBlocksChanged, this, &TopBar::setNumBlocks);
 
         timerStakingIcon = new QTimer(ui->pushButtonStack);
@@ -420,7 +420,7 @@ void TopBar::setNumConnections(int count)
     ui->pushButtonConnection->setButtonText(tr("%n active connection(s)", "", count));
 }
 
-void TopBar::setNumBlocks(int count)
+void TopBar::setNumBlocks(int count, bool headers)
 {
     if (!clientModel)
         return;
@@ -430,15 +430,17 @@ void TopBar::setNumBlocks(int count)
     std::string text = "";
     switch (blockSource) {
         case BLOCK_SOURCE_NETWORK:
+            if (headers) return;
             text = "Synchronizing..";
             break;
         case BLOCK_SOURCE_DISK:
-            text = "Importing blocks from disk..";
+            text = headers ? "Indexing blocks from disk..." : "Processing blocks on disk...";
             break;
         case BLOCK_SOURCE_REINDEX:
             text = "Reindexing blocks on disk..";
             break;
         case BLOCK_SOURCE_NONE:
+            if (headers) return;
             // Case: not Importing, not Reindexing and no network connection
             text = "No block source available..";
             ui->pushButtonSync->setChecked(false);

--- a/src/qt/pivx/topbar.h
+++ b/src/qt/pivx/topbar.h
@@ -47,7 +47,7 @@ public Q_SLOTS:
     void updateDisplayUnit();
 
     void setNumConnections(int count);
-    void setNumBlocks(int count);
+    void setNumBlocks(int count, bool headers);
     void setStakingStatusActive(bool fActive);
     void updateStakingStatus();
     void updateHDState(const bool& upgraded, const QString& upgradeError);

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -387,7 +387,7 @@ void RPCConsole::setClientModel(ClientModel* model)
         setNumConnections(model->getNumConnections());
         connect(model, &ClientModel::numConnectionsChanged, this, &RPCConsole::setNumConnections);
 
-        setNumBlocks(model->getNumBlocks());
+        setNumBlocks(model->getNumBlocks(), false);
         connect(model, &ClientModel::numBlocksChanged, this, &RPCConsole::setNumBlocks);
 
         connect(model, &ClientModel::strMasternodesChanged, this, &RPCConsole::setMasternodeCount);
@@ -661,8 +661,9 @@ void RPCConsole::setNumConnections(int count)
     ui->numberOfConnections->setText(connections);
 }
 
-void RPCConsole::setNumBlocks(int count)
+void RPCConsole::setNumBlocks(int count, bool headers)
 {
+    if (headers) return;
     ui->numberOfBlocks->setText(QString::number(count));
     if (clientModel) {
         ui->lastBlockTime->setText(clientModel->getLastBlockDate().toString());

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -88,7 +88,7 @@ public Q_SLOTS:
     /** Set number of connections shown in the UI */
     void setNumConnections(int count);
     /** Set number of blocks shown in the UI */
-    void setNumBlocks(int count);
+    void setNumBlocks(int count, bool headers);
     /** Set number of masternodes shown in the UI */
     void setMasternodeCount(const QString& strMasternodes);
     /** Go forward or back in history */

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3016,7 +3016,7 @@ bool AcceptBlockHeader(const CBlock& block, CValidationState& state, CBlockIndex
     return true;
 }
 
-static bool AcceptBlock(const CBlock& block, CValidationState& state, CBlockIndex** ppindex, CDiskBlockPos* dbp = nullptr, bool fAlreadyCheckedBlock = false)
+static bool AcceptBlock(const CBlock& block, CValidationState& state, CBlockIndex** ppindex, const CDiskBlockPos* dbp = nullptr, bool fAlreadyCheckedBlock = false)
 {
     AssertLockHeld(cs_main);
 
@@ -3328,7 +3328,7 @@ void CBlockIndex::BuildSkip()
         pskip = pprev->GetAncestor(GetSkipHeight(nHeight));
 }
 
-bool ProcessNewBlock(CValidationState& state, CNode* pfrom, const CBlock* pblock, CDiskBlockPos* dbp, bool* fAccepted)
+bool ProcessNewBlock(CValidationState& state, CNode* pfrom, const CBlock* pblock, const CDiskBlockPos* dbp, bool* fAccepted)
 {
     AssertLockNotHeld(cs_main);
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3016,7 +3016,7 @@ bool AcceptBlockHeader(const CBlock& block, CValidationState& state, CBlockIndex
     return true;
 }
 
-bool AcceptBlock(const CBlock& block, CValidationState& state, CBlockIndex** ppindex, CDiskBlockPos* dbp, bool fAlreadyCheckedBlock)
+static bool AcceptBlock(const CBlock& block, CValidationState& state, CBlockIndex** ppindex, CDiskBlockPos* dbp = nullptr, bool fAlreadyCheckedBlock = false)
 {
     AssertLockHeld(cs_main);
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -340,8 +340,7 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
 bool TestBlockValidity(CValidationState& state, const CBlock& block, CBlockIndex* pindexPrev, bool fCheckPOW = true, bool fCheckMerkleRoot = true);
 
 /** Store block on disk. If dbp is provided, the file is known to already reside on disk */
-bool AcceptBlock(const CBlock& block, CValidationState& state, CBlockIndex** pindex, CDiskBlockPos* dbp = NULL, bool fAlreadyCheckedBlock = false);
-bool AcceptBlockHeader(const CBlock& block, CValidationState& state, CBlockIndex** ppindex = NULL);
+bool AcceptBlockHeader(const CBlock& block, CValidationState& state, CBlockIndex** ppindex = nullptr);
 
 
 /** RAII wrapper for VerifyDB: Verify consistency of the block and coin databases */

--- a/src/validation.h
+++ b/src/validation.h
@@ -166,11 +166,11 @@ static const uint64_t nMinDiskSpace = 52428800;
  * @param[out]  state      This may be set to an Error state if any error occurred processing it, including during validation/connection/etc of otherwise unrelated blocks during reorganisation; or it may be set to an Invalid state if pblock is itself invalid (but this is not guaranteed even when the block is checked). If you want to *possibly* get feedback on whether pblock is valid, you must also install a CValidationInterface - this will have its BlockChecked method called whenever *any* block completes validation.
  * @param[in]   pfrom      The node which we are receiving the block from; it is added to mapBlockSource and may be penalised if the block is invalid.
  * @param[in]   pblock     The block we want to process.
- * @param[out]  dbp        If pblock is stored to disk (or already there), this will be set to its location.
+ * @param[in]   dbp        The already known disk position of pblock, or NULL if not yet stored.
  * @param[out]  fAccepted  Whether the block is accepted or not
  * @return True if state.IsValid()
  */
-bool ProcessNewBlock(CValidationState& state, CNode* pfrom, const CBlock* pblock, CDiskBlockPos* dbp, bool* fAccepted = nullptr);
+bool ProcessNewBlock(CValidationState& state, CNode* pfrom, const CBlock* pblock, const CDiskBlockPos* dbp, bool* fAccepted = nullptr);
 /** Check whether enough disk space is available for an incoming block */
 bool CheckDiskSpace(uint64_t nAdditionalBytes = 0);
 /** Open a block file (blk?????.dat) */

--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -19,19 +19,25 @@ class ReindexTest(PivxTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 1
 
-    def reindex(self):
+    def reindex(self, justchainstate=False):
         self.nodes[0].generate(3)
         blockcount = self.nodes[0].getblockcount()
         self.stop_nodes()
+        self.log.info("Stopping node...")
         time.sleep(5)
-        extra_args = [["-reindex", "-checkblockindex=1"]]
+        extra_args = [["-reindex-chainstate" if justchainstate else "-reindex", "-checkblockindex=1"]]
+        self.log.info("Reindexing %s [block count: %d]" % (
+            "chainstate" if justchainstate else "blocks", blockcount))
         self.start_nodes(extra_args)
         time.sleep(15)
         wait_until(lambda: self.nodes[0].getblockcount() == blockcount)
         self.log.info("Success")
 
     def run_test(self):
-        self.reindex()
+        self.reindex(False)
+        self.reindex(True)
+        self.reindex(False)
+        self.reindex(True)
 
 if __name__ == '__main__':
     ReindexTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -61,6 +61,7 @@ BASE_SCRIPTS= [
 
     # vv Tests less than 5m vv
     'wallet_zapwallettxes.py',                  # ~ 300 sec
+    'feature_reindex.py',                       # ~ 290 sec
     'p2p_time_offset.py',                       # ~ 267 sec
     'rpc_fundrawtransaction.py',                # ~ 260 sec
     'mining_pos_coldStaking.py',                # ~ 215 sec
@@ -84,7 +85,6 @@ BASE_SCRIPTS= [
     'p2p_disconnect_ban.py',                    # ~ 118 sec
     'wallet_listreceivedby.py',                 # ~ 117 sec
     'mining_pos_fakestake.py',                  # ~ 113 sec
-    'feature_reindex.py',                       # ~ 110 sec
     'interface_http.py',                        # ~ 105 sec
     'wallet_listtransactions.py',               # ~ 97 sec
     'mempool_reorg.py',                         # ~ 92 sec


### PR DESCRIPTION
Another attempt at backporting bitcoin/bitcoin#7917.
Previously in #1334, but put in stand-by few months ago due to some issue after reindex.

Tested both syncing from scratch and using `-reindex` flags. It seems all good now.
Reindex is still slower than resync for some reason, but at least not as much as in master (about 63% faster now).