### PR TITLE
BugFix: g_IsSaplingActive flag is not initialized at startup.

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3600,6 +3600,10 @@ bool static LoadBlockIndexDB(std::string& strError)
     PruneBlockIndexCandidates();
 
     const CBlockIndex* pChainTip = chainActive.Tip();
+
+    // initial global flag update
+    g_IsSaplingActive = Params().GetConsensus().NetworkUpgradeActive(pChainTip->nHeight, Consensus::UPGRADE_V5_DUMMY);
+
     LogPrintf("LoadBlockIndexDB(): hashBestChain=%s height=%d date=%s progress=%f\n",
             pChainTip->GetBlockHash().GetHex(), pChainTip->nHeight,
             DateTimeStrFormat("%Y-%m-%d %H:%M:%S", pChainTip->GetBlockTime()),


### PR DESCRIPTION
Small bug introduced in #1814, the flag is set on every new tip but not initialized at startup.
Discovered rebasing #1798 on top of master and running any sapling functional test. As `g_IsSaplingActive` is false at startup, the transaction hash is different, making the merkle tree hash different, failing in `VerifyDB`.