### PR TITLE
[Sapling] Note Encryption unit tests back ported.

### DIFF
--- a/src/sapling/note.cpp
+++ b/src/sapling/note.cpp
@@ -49,7 +49,7 @@ SaplingNote::SaplingNote(const SaplingPaymentAddress& address, const uint64_t va
 }
 
 // Call librustzcash to compute the commitment
-boost::optional<uint256> SaplingNote::cm() const {
+boost::optional<uint256> SaplingNote::cmu() const {
     uint256 result;
     if (!librustzcash_sapling_compute_cm(
             d.data(),

--- a/src/sapling/note.hpp
+++ b/src/sapling/note.hpp
@@ -59,7 +59,7 @@ public:
 
     virtual ~SaplingNote() {};
 
-    boost::optional<uint256> cm() const;
+    boost::optional<uint256> cmu() const;
     boost::optional<uint256> nullifier(const SaplingFullViewingKey &vk, const uint64_t position) const;
 };
 

--- a/src/test/librust/noteencryption_tests.cpp
+++ b/src/test/librust/noteencryption_tests.cpp
@@ -8,10 +8,11 @@
 #include <array>
 #include <stdexcept>
 
+#include "sapling/address.hpp"
 #include "sapling/note.hpp"
 #include "sapling/noteencryption.hpp"
 #include "sapling/prf.h"
-#include "sapling/address.hpp"
+#include "sapling/uint252.h"
 #include "sapling/sapling_util.h"
 #include "crypto/sha256.h"
 
@@ -30,7 +31,7 @@ public:
     }
 };
 
-BOOST_AUTO_TEST_CASE(note_plain_text)
+BOOST_AUTO_TEST_CASE(note_plain_text_test)
 {
     using namespace libzcash;
     auto xsk = SaplingSpendingKey(uint256()).expanded_spending_key();
@@ -165,6 +166,326 @@ BOOST_AUTO_TEST_CASE(note_plain_text)
     BOOST_CHECK(bar.memo() == pt.memo());
     BOOST_CHECK(bar.d == pt.d);
     BOOST_CHECK(bar.rcm == pt.rcm);
+}
+
+BOOST_AUTO_TEST_CASE(SaplingApi_test)
+{
+    using namespace libzcash;
+
+    // Create recipient addresses
+    auto sk = SaplingSpendingKey(uint256()).expanded_spending_key();
+    auto vk = sk.full_viewing_key();
+    auto ivk = vk.in_viewing_key();
+    SaplingPaymentAddress pk_1 = *ivk.address({0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+    SaplingPaymentAddress pk_2 = *ivk.address({4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+
+    // Blob of stuff we're encrypting
+    std::array<unsigned char, ZC_SAPLING_ENCPLAINTEXT_SIZE> message;
+    for (size_t i = 0; i < ZC_SAPLING_ENCPLAINTEXT_SIZE; i++) {
+    // Fill the message with dummy data
+    message[i] = (unsigned char) i;
+    }
+
+    std::array<unsigned char, ZC_SAPLING_OUTPLAINTEXT_SIZE> small_message;
+    for (size_t i = 0; i < ZC_SAPLING_OUTPLAINTEXT_SIZE; i++) {
+    // Fill the message with dummy data
+    small_message[i] = (unsigned char) i;
+    }
+
+    // Invalid diversifier
+    BOOST_CHECK(boost::none == SaplingNoteEncryption::FromDiversifier({1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
+
+    // Encrypt to pk_1
+    auto enc = *SaplingNoteEncryption::FromDiversifier(pk_1.d);
+    auto ciphertext_1 = *enc.encrypt_to_recipient(
+            pk_1.pk_d,
+            message
+    );
+    auto epk_1 = enc.get_epk();
+    {
+        uint256 test_epk;
+        uint256 test_esk = enc.get_esk();
+        BOOST_CHECK(librustzcash_sapling_ka_derivepublic(pk_1.d.begin(), test_esk.begin(), test_epk.begin()));
+        BOOST_CHECK(test_epk == epk_1);
+    }
+    auto cv_1 = random_uint256();
+    auto cm_1 = random_uint256();
+    auto out_ciphertext_1 = enc.encrypt_to_ourselves(
+            sk.ovk,
+            cv_1,
+            cm_1,
+            small_message
+    );
+
+    // Encrypt to pk_2
+    enc = *SaplingNoteEncryption::FromDiversifier(pk_2.d);
+    auto ciphertext_2 = *enc.encrypt_to_recipient(
+            pk_2.pk_d,
+            message
+    );
+    auto epk_2 = enc.get_epk();
+
+    auto cv_2 = random_uint256();
+    auto cm_2 = random_uint256();
+    auto out_ciphertext_2 = enc.encrypt_to_ourselves(
+            sk.ovk,
+            cv_2,
+            cm_2,
+            small_message
+    );
+
+    // Test nonce-reuse resistance of API
+    {
+        auto tmp_enc = *SaplingNoteEncryption::FromDiversifier(pk_1.d);
+
+        tmp_enc.encrypt_to_recipient(
+                pk_1.pk_d,
+                message
+                );
+
+        BOOST_CHECK_THROW(tmp_enc.encrypt_to_recipient(
+                pk_1.pk_d,
+                message
+                ), std::logic_error);
+
+        tmp_enc.encrypt_to_ourselves(
+                sk.ovk,
+                cv_2,
+                cm_2,
+                small_message
+                );
+
+        BOOST_CHECK_THROW(tmp_enc.encrypt_to_ourselves(
+                sk.ovk,
+                cv_2,
+                cm_2,
+                small_message
+                ), std::logic_error);
+    }
+
+    // Try to decrypt
+    auto plaintext_1 = *AttemptSaplingEncDecryption(
+            ciphertext_1,
+            ivk,
+            epk_1
+    );
+    BOOST_CHECK(message == plaintext_1);
+
+    auto small_plaintext_1 = *AttemptSaplingOutDecryption(
+            out_ciphertext_1,
+            sk.ovk,
+            cv_1,
+            cm_1,
+            epk_1
+    );
+    BOOST_CHECK(small_message == small_plaintext_1);
+
+    auto plaintext_2 = *AttemptSaplingEncDecryption(
+            ciphertext_2,
+            ivk,
+            epk_2
+    );
+    BOOST_CHECK(message == plaintext_2);
+
+    auto small_plaintext_2 = *AttemptSaplingOutDecryption(
+            out_ciphertext_2,
+            sk.ovk,
+            cv_2,
+            cm_2,
+            epk_2
+    );
+    BOOST_CHECK(small_message == small_plaintext_2);
+
+    // Try to decrypt out ciphertext with wrong key material
+    BOOST_CHECK(!AttemptSaplingOutDecryption(
+            out_ciphertext_1,
+            random_uint256(),
+            cv_1,
+            cm_1,
+            epk_1
+    ));
+    BOOST_CHECK(!AttemptSaplingOutDecryption(
+            out_ciphertext_1,
+            sk.ovk,
+            random_uint256(),
+            cm_1,
+            epk_1
+    ));
+    BOOST_CHECK(!AttemptSaplingOutDecryption(
+            out_ciphertext_1,
+            sk.ovk,
+            cv_1,
+            random_uint256(),
+            epk_1
+    ));
+    BOOST_CHECK(!AttemptSaplingOutDecryption(
+            out_ciphertext_1,
+            sk.ovk,
+            cv_1,
+            cm_1,
+            random_uint256()
+    ));
+
+    // Try to decrypt with wrong ephemeral key
+    BOOST_CHECK(!AttemptSaplingEncDecryption(
+            ciphertext_1,
+            ivk,
+            epk_2
+    ));
+    BOOST_CHECK(!AttemptSaplingEncDecryption(
+            ciphertext_2,
+            ivk,
+            epk_1
+    ));
+
+    // Try to decrypt with wrong ivk
+    BOOST_CHECK(!AttemptSaplingEncDecryption(
+            ciphertext_1,
+            uint256(),
+            epk_1
+    ));
+    BOOST_CHECK(!AttemptSaplingEncDecryption(
+            ciphertext_2,
+            uint256(),
+            epk_2
+    ));
+}
+
+BOOST_AUTO_TEST_CASE(api_test)
+{
+    uint256 sk_enc = ZCNoteEncryption::generate_privkey(uint252(uint256S("21035d60bc1983e37950ce4803418a8fb33ea68d5b937ca382ecbae7564d6a07")));
+    uint256 pk_enc = ZCNoteEncryption::generate_pubkey(sk_enc);
+
+    ZCNoteEncryption b = ZCNoteEncryption(uint256());
+    for (size_t i = 0; i < 100; i++) {
+        ZCNoteEncryption c = ZCNoteEncryption(uint256());
+        BOOST_CHECK(b.get_epk() != c.get_epk());
+    }
+
+    std::array<unsigned char, ZC_NOTEPLAINTEXT_SIZE> message;
+    for (size_t i = 0; i < ZC_NOTEPLAINTEXT_SIZE; i++) {
+        // Fill the message with dummy data
+        message[i] = (unsigned char) i;
+    }
+
+    for (int i = 0; i < 255; i++) {
+        auto ciphertext = b.encrypt(pk_enc, message);
+
+        {
+            ZCNoteDecryption decrypter(sk_enc);
+
+            // Test decryption
+            auto plaintext = decrypter.decrypt(ciphertext, b.get_epk(), uint256(), i);
+            BOOST_CHECK(plaintext == message);
+
+            // Test wrong nonce
+            BOOST_CHECK_THROW(decrypter.decrypt(ciphertext, b.get_epk(), uint256(), (i == 0) ? 1 : (i - 1)),
+            libzcash::note_decryption_failed);
+
+            // Test wrong ephemeral key
+            {
+            ZCNoteEncryption c = ZCNoteEncryption(uint256());
+
+            BOOST_CHECK_THROW(decrypter.decrypt(ciphertext, c.get_epk(), uint256(), i),
+            libzcash::note_decryption_failed);
+            }
+
+            // Test wrong seed
+            BOOST_CHECK_THROW(decrypter.decrypt(ciphertext, b.get_epk(), uint256S("11035d60bc1983e37950ce4803418a8fb33ea68d5b937ca382ecbae7564d6a77"), i),
+            libzcash::note_decryption_failed);
+
+            // Test corrupted ciphertext
+            ciphertext[10] ^= 0xff;
+            BOOST_CHECK_THROW(decrypter.decrypt(ciphertext, b.get_epk(), uint256(), i),
+            libzcash::note_decryption_failed);
+            ciphertext[10] ^= 0xff;
+        }
+
+        {
+            // Test wrong private key
+            uint256 sk_enc_2 = ZCNoteEncryption::generate_privkey(uint252());
+            ZCNoteDecryption decrypter(sk_enc_2);
+
+            BOOST_CHECK_THROW(decrypter.decrypt(ciphertext, b.get_epk(), uint256(), i),
+            libzcash::note_decryption_failed);
+        }
+
+        {
+            TestNoteDecryption decrypter(sk_enc);
+
+            // Test decryption
+            auto plaintext = decrypter.decrypt(ciphertext, b.get_epk(), uint256(), i);
+            BOOST_CHECK(plaintext == message);
+
+            // Test wrong public key (test of KDF)
+            decrypter.change_pk_enc(uint256());
+            BOOST_CHECK_THROW(decrypter.decrypt(ciphertext, b.get_epk(), uint256(), i),
+            libzcash::note_decryption_failed);
+        }
+    }
+
+    // Nonce space should run out here
+    try {
+        b.encrypt(pk_enc, message);
+        BOOST_FAIL("Expected std::logic_error");
+    } catch(std::logic_error const & err) {
+        BOOST_CHECK(err.what() == std::string("no additional nonce space for KDF"));
+    } catch(...) {
+        BOOST_FAIL("Expected std::logic_error");
+    }
+}
+
+uint256 test_prf(
+        unsigned char distinguisher,
+        uint252 seed_x,
+        uint256 y
+) {
+    uint256 x = seed_x.inner();
+    *x.begin() &= 0x0f;
+    *x.begin() |= distinguisher;
+    CSHA256 hasher;
+    hasher.Write(x.begin(), 32);
+    hasher.Write(y.begin(), 32);
+
+    uint256 ret;
+    hasher.FinalizeNoPadding(ret.begin());
+    return ret;
+}
+
+BOOST_AUTO_TEST_CASE(PrfAddr_test)
+{
+    for (size_t i = 0; i < 100; i++) {
+        uint252 a_sk = random_uint252();
+        uint256 rest;
+        BOOST_CHECK(
+                test_prf(0xc0, a_sk, rest) == PRF_addr_a_pk(a_sk)
+        );
+    }
+
+    for (size_t i = 0; i < 100; i++) {
+        uint252 a_sk = random_uint252();
+        uint256 rest;
+        *rest.begin() = 0x01;
+        BOOST_CHECK(
+                test_prf(0xc0, a_sk, rest) == PRF_addr_sk_enc(a_sk)
+        );
+    }
+}
+
+BOOST_AUTO_TEST_CASE(PrfNf_test)
+{
+    for (size_t i = 0; i < 100; i++) {
+        uint252 a_sk = random_uint252();
+        uint256 rho = random_uint256();
+        BOOST_CHECK(
+                test_prf(0xe0, a_sk, rho) == PRF_nf(a_sk, rho)
+        );
+    }
+}
+
+BOOST_AUTO_TEST_CASE(uint252_test)
+{
+    BOOST_CHECK_THROW(uint252(uint256S("f6da8716682d600f74fc16bd0187faad6a26b4aa4c24d5c055b216d94516847e")), std::domain_error);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/librust/noteencryption_tests.cpp
+++ b/src/test/librust/noteencryption_tests.cpp
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(note_plain_text)
     }
 
     SaplingNote note(addr, 39393);
-    auto cmu_opt = note.cm();
+    auto cmu_opt = note.cmu();
     if (!cmu_opt) {
         BOOST_ERROR("SaplingNote cm failed");
     }
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(note_plain_text)
     BOOST_CHECK(note.d == new_note.d);
     BOOST_CHECK(note.pk_d == new_note.pk_d);
     BOOST_CHECK(note.r == new_note.r);
-    BOOST_CHECK(note.cm() == new_note.cm());
+    BOOST_CHECK(note.cmu() == new_note.cmu());
 
     SaplingOutgoingPlaintext out_pt;
     out_pt.pk_d = note.pk_d;

--- a/src/test/librust/noteencryption_tests.cpp
+++ b/src/test/librust/noteencryption_tests.cpp
@@ -33,11 +33,10 @@ public:
 
 BOOST_AUTO_TEST_CASE(note_plain_text_test)
 {
-    using namespace libzcash;
-    auto xsk = SaplingSpendingKey(uint256()).expanded_spending_key();
+    auto xsk = libzcash::SaplingSpendingKey(uint256()).expanded_spending_key();
     auto fvk = xsk.full_viewing_key();
     auto ivk = fvk.in_viewing_key();
-    SaplingPaymentAddress addr = *ivk.address({0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+    libzcash::SaplingPaymentAddress addr = *ivk.address({0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
 
     std::array<unsigned char, ZC_MEMO_SIZE> memo;
     for (size_t i = 0; i < ZC_MEMO_SIZE; i++) {
@@ -45,13 +44,13 @@ BOOST_AUTO_TEST_CASE(note_plain_text_test)
         memo[i] = (unsigned char) i;
     }
 
-    SaplingNote note(addr, 39393);
+    libzcash::SaplingNote note(addr, 39393);
     auto cmu_opt = note.cmu();
     if (!cmu_opt) {
         BOOST_ERROR("SaplingNote cm failed");
     }
     uint256 cmu = cmu_opt.get();
-    SaplingNotePlaintext pt(note, memo);
+    libzcash::SaplingNotePlaintext pt(note, memo);
 
     auto res = pt.encrypt(addr.pk_d);
     if (!res) {
@@ -65,7 +64,7 @@ BOOST_AUTO_TEST_CASE(note_plain_text_test)
     auto epk = encryptor.get_epk();
 
     // Try to decrypt with incorrect commitment
-    BOOST_CHECK(!SaplingNotePlaintext::decrypt(
+    BOOST_CHECK(!libzcash::SaplingNotePlaintext::decrypt(
         ct,
         ivk,
         epk,
@@ -73,7 +72,7 @@ BOOST_AUTO_TEST_CASE(note_plain_text_test)
     ));
 
     // Try to decrypt with correct commitment
-    auto foo = SaplingNotePlaintext::decrypt(
+    auto foo = libzcash::SaplingNotePlaintext::decrypt(
         ct,
         ivk,
         epk,
@@ -106,7 +105,7 @@ BOOST_AUTO_TEST_CASE(note_plain_text_test)
     BOOST_CHECK(note.r == new_note.r);
     BOOST_CHECK(note.cmu() == new_note.cmu());
 
-    SaplingOutgoingPlaintext out_pt;
+    libzcash::SaplingOutgoingPlaintext out_pt;
     out_pt.pk_d = note.pk_d;
     out_pt.esk = encryptor.get_esk();
 
@@ -139,7 +138,7 @@ BOOST_AUTO_TEST_CASE(note_plain_text_test)
     BOOST_CHECK(decrypted_out_ct_unwrapped.esk == out_pt.esk);
 
     // Test sender won't accept invalid commitments
-    BOOST_CHECK(!SaplingNotePlaintext::decrypt(
+    BOOST_CHECK(!libzcash::SaplingNotePlaintext::decrypt(
         ct,
         epk,
         decrypted_out_ct_unwrapped.esk,
@@ -148,7 +147,7 @@ BOOST_AUTO_TEST_CASE(note_plain_text_test)
     ));
 
     // Test sender can decrypt the note ciphertext.
-    foo = SaplingNotePlaintext::decrypt(
+    foo = libzcash::SaplingNotePlaintext::decrypt(
         ct,
         epk,
         decrypted_out_ct_unwrapped.esk,
@@ -170,14 +169,12 @@ BOOST_AUTO_TEST_CASE(note_plain_text_test)
 
 BOOST_AUTO_TEST_CASE(SaplingApi_test)
 {
-    using namespace libzcash;
-
     // Create recipient addresses
-    auto sk = SaplingSpendingKey(uint256()).expanded_spending_key();
+    auto sk = libzcash::SaplingSpendingKey(uint256()).expanded_spending_key();
     auto vk = sk.full_viewing_key();
     auto ivk = vk.in_viewing_key();
-    SaplingPaymentAddress pk_1 = *ivk.address({0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
-    SaplingPaymentAddress pk_2 = *ivk.address({4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+    libzcash::SaplingPaymentAddress pk_1 = *ivk.address({0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+    libzcash::SaplingPaymentAddress pk_2 = *ivk.address({4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
 
     // Blob of stuff we're encrypting
     std::array<unsigned char, ZC_SAPLING_ENCPLAINTEXT_SIZE> message;
@@ -193,10 +190,10 @@ BOOST_AUTO_TEST_CASE(SaplingApi_test)
     }
 
     // Invalid diversifier
-    BOOST_CHECK(boost::none == SaplingNoteEncryption::FromDiversifier({1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
+    BOOST_CHECK(boost::none == libzcash::SaplingNoteEncryption::FromDiversifier({1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
 
     // Encrypt to pk_1
-    auto enc = *SaplingNoteEncryption::FromDiversifier(pk_1.d);
+    auto enc = *libzcash::SaplingNoteEncryption::FromDiversifier(pk_1.d);
     auto ciphertext_1 = *enc.encrypt_to_recipient(
             pk_1.pk_d,
             message
@@ -218,7 +215,7 @@ BOOST_AUTO_TEST_CASE(SaplingApi_test)
     );
 
     // Encrypt to pk_2
-    enc = *SaplingNoteEncryption::FromDiversifier(pk_2.d);
+    enc = *libzcash::SaplingNoteEncryption::FromDiversifier(pk_2.d);
     auto ciphertext_2 = *enc.encrypt_to_recipient(
             pk_2.pk_d,
             message
@@ -236,7 +233,7 @@ BOOST_AUTO_TEST_CASE(SaplingApi_test)
 
     // Test nonce-reuse resistance of API
     {
-        auto tmp_enc = *SaplingNoteEncryption::FromDiversifier(pk_1.d);
+        auto tmp_enc = *libzcash::SaplingNoteEncryption::FromDiversifier(pk_1.d);
 
         tmp_enc.encrypt_to_recipient(
                 pk_1.pk_d,
@@ -271,7 +268,7 @@ BOOST_AUTO_TEST_CASE(SaplingApi_test)
     );
     BOOST_CHECK(message == plaintext_1);
 
-    auto small_plaintext_1 = *AttemptSaplingOutDecryption(
+    auto small_plaintext_1 = *libzcash::AttemptSaplingOutDecryption(
             out_ciphertext_1,
             sk.ovk,
             cv_1,
@@ -287,7 +284,7 @@ BOOST_AUTO_TEST_CASE(SaplingApi_test)
     );
     BOOST_CHECK(message == plaintext_2);
 
-    auto small_plaintext_2 = *AttemptSaplingOutDecryption(
+    auto small_plaintext_2 = *libzcash::AttemptSaplingOutDecryption(
             out_ciphertext_2,
             sk.ovk,
             cv_2,
@@ -297,28 +294,28 @@ BOOST_AUTO_TEST_CASE(SaplingApi_test)
     BOOST_CHECK(small_message == small_plaintext_2);
 
     // Try to decrypt out ciphertext with wrong key material
-    BOOST_CHECK(!AttemptSaplingOutDecryption(
+    BOOST_CHECK(!libzcash::AttemptSaplingOutDecryption(
             out_ciphertext_1,
             random_uint256(),
             cv_1,
             cm_1,
             epk_1
     ));
-    BOOST_CHECK(!AttemptSaplingOutDecryption(
+    BOOST_CHECK(!libzcash::AttemptSaplingOutDecryption(
             out_ciphertext_1,
             sk.ovk,
             random_uint256(),
             cm_1,
             epk_1
     ));
-    BOOST_CHECK(!AttemptSaplingOutDecryption(
+    BOOST_CHECK(!libzcash::AttemptSaplingOutDecryption(
             out_ciphertext_1,
             sk.ovk,
             cv_1,
             random_uint256(),
             epk_1
     ));
-    BOOST_CHECK(!AttemptSaplingOutDecryption(
+    BOOST_CHECK(!libzcash::AttemptSaplingOutDecryption(
             out_ciphertext_1,
             sk.ovk,
             cv_1,
@@ -339,12 +336,12 @@ BOOST_AUTO_TEST_CASE(SaplingApi_test)
     ));
 
     // Try to decrypt with wrong ivk
-    BOOST_CHECK(!AttemptSaplingEncDecryption(
+    BOOST_CHECK(!libzcash::AttemptSaplingEncDecryption(
             ciphertext_1,
             uint256(),
             epk_1
     ));
-    BOOST_CHECK(!AttemptSaplingEncDecryption(
+    BOOST_CHECK(!libzcash::AttemptSaplingEncDecryption(
             ciphertext_2,
             uint256(),
             epk_2

--- a/src/test/librust/sapling_note_tests.cpp
+++ b/src/test/librust/sapling_note_tests.cpp
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(testVectors) {
 
     // Test commitment
     SaplingNote note = SaplingNote(diversifier, pk_d, v, r);
-    BOOST_CHECK(note.cm().get() == cm);
+    BOOST_CHECK(note.cmu().get() == cm);
 
     // Test nullifier
     SaplingSpendingKey spendingKey(sk);

--- a/src/test/librust/sapling_note_tests.cpp
+++ b/src/test/librust/sapling_note_tests.cpp
@@ -20,7 +20,6 @@ BOOST_FIXTURE_TEST_SUITE(sapling_note_tests, BasicTestingSetup)
 
 // Test data from https://github.com/zcash-hackworks/zcash-test-vectors/blob/master/sapling_key_components.py
 BOOST_AUTO_TEST_CASE(testVectors) {
-    using namespace libzcash;
     uint64_t v = 0;
     uint64_t note_pos = 0;
     std::array<uint8_t, 11> diversifier{0xf1, 0x9d, 0x9b, 0x79, 0x7e, 0x39, 0xf3, 0x37, 0x44, 0x58, 0x39};
@@ -51,21 +50,20 @@ BOOST_AUTO_TEST_CASE(testVectors) {
     uint256 nf(v_nf);
 
     // Test commitment
-    SaplingNote note = SaplingNote(diversifier, pk_d, v, r);
+    libzcash::SaplingNote note = libzcash::SaplingNote(diversifier, pk_d, v, r);
     BOOST_CHECK(note.cmu().get() == cm);
 
     // Test nullifier
-    SaplingSpendingKey spendingKey(sk);
+    libzcash::SaplingSpendingKey spendingKey(sk);
     BOOST_CHECK(note.nullifier(spendingKey.full_viewing_key(), note_pos) == nf);
 }
 
 BOOST_AUTO_TEST_CASE(random) {
-    using namespace libzcash;
     CAmount MAX_MONEY_OUT = 21000000 * COIN;
     // Test creating random notes using the same spending key
-    auto address = SaplingSpendingKey::random().default_address();
-    SaplingNote note1(address, GetRand(MAX_MONEY_OUT));
-    SaplingNote note2(address, GetRand(MAX_MONEY_OUT));
+    auto address = libzcash::SaplingSpendingKey::random().default_address();
+    libzcash::SaplingNote note1(address, GetRand(MAX_MONEY_OUT));
+    libzcash::SaplingNote note2(address, GetRand(MAX_MONEY_OUT));
 
     BOOST_CHECK(note1.d == note2.d);
     BOOST_CHECK(note1.pk_d == note2.pk_d);
@@ -73,7 +71,7 @@ BOOST_AUTO_TEST_CASE(random) {
     BOOST_CHECK(note1.r != note2.r);
 
     // Test diversifier and pk_d are not the same for different spending keys
-    SaplingNote note3(SaplingSpendingKey::random().default_address(), GetRand(MAX_MONEY_OUT));
+    libzcash::SaplingNote note3(libzcash::SaplingSpendingKey::random().default_address(), GetRand(MAX_MONEY_OUT));
     BOOST_CHECK(note1.d != note3.d);
     BOOST_CHECK(note1.pk_d != note3.pk_d);
 }


### PR DESCRIPTION
Another decoupling from #1798. Similar to #1870, these changes are part of the primitives unit test coverage back port work.
Commits included: 

* change cm() to cmu() in SaplingNote class —> d437276a4b922c6c70d810cff0719a2e76f1a4bc
* Note Encryption unit tests back ported. —> e4c1bbf1618fd797599b6bf3511cea79e6d9d4d7