### PR TITLE
[BugFix] Migrate list serialization to the current flow.

### DIFF
--- a/src/serialize.h
+++ b/src/serialize.h
@@ -729,37 +729,36 @@ void Unserialize(Stream& is, std::basic_string<C>& str)
 /**
   * list
   */
-template<typename T, typename A> unsigned int GetSerializeSize(const std::list<T, A>& m, int nType, int nVersion);
-template<typename Stream, typename T, typename A> void Serialize(Stream& os, const std::list<T, A>& m, int nType, int nVersion);
-template<typename Stream, typename T, typename A> void Unserialize(Stream& is, std::list<T, A>& m, int nType, int nVersion);
+template<typename T, typename A> unsigned int GetSerializeSize(const std::list<T, A>& m);
+template<typename Stream, typename T, typename A> void Serialize(Stream& os, const std::list<T, A>& m);
+template<typename Stream, typename T, typename A> void Unserialize(Stream& is, std::list<T, A>& m);
 
 template<typename T, typename A>
-unsigned int GetSerializeSize(const std::list<T, A>& l, int nType, int nVersion)
+unsigned int GetSerializeSize(const std::list<T, A>& l)
 {
     unsigned int nSize = GetSizeOfCompactSize(l.size());
     for (typename std::list<T, A>::const_iterator it = l.begin(); it != l.end(); ++it)
-        nSize += GetSerializeSize((*it), nType, nVersion);
+        nSize += GetSerializeSize((*it));
     return nSize;
 }
 
 template<typename Stream, typename T, typename A>
-void Serialize(Stream& os, const std::list<T, A>& l, int nType, int nVersion)
+void Serialize(Stream& os, const std::list<T, A>& l)
 {
     WriteCompactSize(os, l.size());
     for (typename std::list<T, A>::const_iterator it = l.begin(); it != l.end(); ++it)
-        Serialize(os, (*it), nType, nVersion);
+        Serialize(os, (*it));
 }
 
 template<typename Stream, typename T, typename A>
-void Unserialize(Stream& is, std::list<T, A>& l, int nType, int nVersion)
+void Unserialize(Stream& is, std::list<T, A>& l)
 {
     l.clear();
     unsigned int nSize = ReadCompactSize(is);
-    typename std::list<T, A>::iterator it = l.begin();
     for (unsigned int i = 0; i < nSize; i++)
     {
         T item;
-        Unserialize(is, item, nType, nVersion);
+        Unserialize(is, item);
         l.push_back(item);
     }
 }


### PR DESCRIPTION
Straightforward and easy to check PR.
The list serialization wasn't updated to the latest serialization format (`nType` and `nVersion` removal).

Decoupled from #1798 --> 4053e97b . 