### PR TITLE
[Masternodes] dead end over the activation process.

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -704,7 +704,11 @@ bool CMasternodePing::CheckAndUpdate(int& nDos, bool fRequireEnabled, bool fChec
     LogPrint(BCLog::MNPING, "%s: New Ping - %s - %s - %lli\n", __func__, GetHash().ToString(), blockHash.ToString(), sigTime);
 
     if (isMasternodeFound && pmn->protocolVersion >= ActiveProtocol()) {
-        if (fRequireEnabled && !pmn->IsEnabled()) return false;
+
+        // Update ping only if the masternode is active/enabled
+        if (fRequireEnabled && (!pmn->IsEnabled() && !pmn->IsPreEnabled())) {
+            return false;
+        }
 
         // update only if there is no known ping for this masternode or
         // last ping was more then MASTERNODE_MIN_MNP_SECONDS-60 ago comparing to this one

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -244,6 +244,11 @@ public:
         return WITH_LOCK(cs, return activeState == MASTERNODE_ENABLED);
     }
 
+    bool IsPreEnabled()
+    {
+        return WITH_LOCK(cs, return activeState == MASTERNODE_PRE_ENABLED );
+    }
+
     std::string Status()
     {
         std::string strStatus = "ACTIVE";


### PR DESCRIPTION
Solving a dead end inconsistency over the masternode activation process.

Context:

A valid masternode is created, mn start message is broadcasted and the entire network receives it. Peers moves the masternode status to pre_enable (active) and are waiting for a mn ping update to fulfill the min ping time requirement to move the status to enable.

Issue:

As the mnping update message work flow is not performing any action until the masternode is in an enable status (masternode.cpp, line 707), the masternode ping is never updated, there by the masternode will never be moved to enable status.

Why this is working now:

It's working because (1) the masternodes list is being requested, cleaned and re requested an insane amount of times, (2) some peers are broadcasting the start message twice and (3) peers are broadcasting a start message with an inner ping time in the future, fulfilling the min ping requirements. 

Final thoughts:

This is most likely one of the reason of the different masternodes list views across peers in the network (over the recently active/enable MNs) and why the activation process takes in some occasions few days (the mn list needs to be refreshed)

Extra data:

1) The masternodes list request + re-request network bloat, as is mentioned in point 1 of the "Why is working now" section, will not happen anymore in the future moving forward with #1829 new tier two syncing process subsequent steps, the deterministic masternodes implementation and all of the PRs refactoring & cleaning the tier two sources (in other words, after the whole tier two sources revamp..).

2) This PR makes #1829 4963953 hack unneeded.