### PR TITLE
[BUG] Fix regression with emplace_back on cold-staking scripts

### DIFF
--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -248,8 +248,8 @@ bool ExtractDestinations(const CScript& scriptPubKey, txnouttype& typeRet, std::
         if (vSolutions.size() < 2)
             return false;
         nRequiredRet = 2;
-        addressRet.emplace_back(uint160(vSolutions[0]));
-        addressRet.emplace_back(uint160(vSolutions[1]));
+        addressRet.push_back(CKeyID(uint160(vSolutions[0])));
+        addressRet.push_back(CKeyID(uint160(vSolutions[1])));
         return true;
 
     } else


### PR DESCRIPTION
Bug introduced in #1830 (hunted down with @furszy ).

Emplacing `uint160(key1)` into a vector of `CTxDestination` makes it construct the destination as a `CScriptID` instead of `CKeyID`. Therefore `ExtractDestinations` returns wrong addresses for cold staking scripts.