### PR TITLE
[BUG] Set budget best height before reading budget DB during init

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1762,9 +1762,8 @@ bool AppInit2()
     CBudgetDB budgetdb;
     int nChainHeight = WITH_LOCK(cs_main, return chainActive.Height(); );
     const bool fDryRun = (nChainHeight <= 0);
+    if (!fDryRun) budget.SetBestHeight(nChainHeight);
     CBudgetDB::ReadResult readResult2 = budgetdb.Read(budget, fDryRun);
-    if (nChainHeight > 0)
-        budget.SetBestHeight(nChainHeight);
 
     if (readResult2 == CBudgetDB::FileError)
         LogPrintf("Missing budget cache - budget.dat, will try to recreate\n");


### PR DESCRIPTION
Fix a bug Introduced in #1826, which makes the node erase all proposals and finalized budgets, after reading them from the DB during startup (and thus having to ask everything again from the peers).

**Cause:**
The budget manager best height is set after reading the budgetdb.
As non-dry runs of `CBudgetDB::Read` include a call to `CheckAndRemove()` at the end (to delete expired objects), the manager's best-height needs to be already set.