### PR TITLE
[RPC][BUG] Fix 'mnfinalbudget show' returning a single budget

### DIFF
--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -855,7 +855,6 @@ UniValue mnfinalbudget(const JSONRPCRequest& request)
             const uint256& nHash = finalizedBudget->GetHash();
             UniValue bObj(UniValue::VOBJ);
             bObj.pushKV("FeeTX", finalizedBudget->GetFeeTXHash().ToString());
-            bObj.pushKV("Hash", nHash.ToString());
             bObj.pushKV("BlockStart", (int64_t)finalizedBudget->GetBlockStart());
             bObj.pushKV("BlockEnd", (int64_t)finalizedBudget->GetBlockEnd());
             bObj.pushKV("Proposals", finalizedBudget->GetProposalsStr());
@@ -867,7 +866,8 @@ UniValue mnfinalbudget(const JSONRPCRequest& request)
             if (!fValid)
                 bObj.pushKV("IsInvalidReason", finalizedBudget->IsInvalidReason());
 
-            resultObj.pushKV(finalizedBudget->GetName(), bObj);
+            std::string strName = strprintf("%s (%s)", finalizedBudget->GetName(), nHash.ToString());
+            resultObj.pushKV(strName, bObj);
         }
 
         return resultObj;


### PR DESCRIPTION
Fixes a bug in the RPC `mnfinalbudget show`.

All finalized budgets have the same name (`"main"`).
This is used as key for the object returned by the RPC, therefore only **one single** finalized budget is returned (despite there being many more in the map).

Fix it by adding the hash to the object key (removing it from the object value).

Side note: why finalized budgets  do even need a `strBudgetName` (which is the same for every one) is a mystery to me... but, since it's part of the broadcast, we can't just outright remove it, it needs to be guarded with a network upgrade (future work).