### PR TITLE
[BUG][GUI] Fix wallet crashing on faq-buttons press

### DIFF
--- a/src/qt/pivx/dashboardwidget.cpp
+++ b/src/qt/pivx/dashboardwidget.cpp
@@ -205,8 +205,8 @@ void DashboardWidget::loadWalletModel()
             ui->comboBoxSort->setVisible(false);
         }
 
-        connect(ui->pushImgEmpty, &QPushButton::clicked, window, &PIVXGUI::openFAQ);
-        connect(ui->btnHowTo, &QPushButton::clicked, window, &PIVXGUI::openFAQ);
+        connect(ui->pushImgEmpty, &QPushButton::clicked, [this](){window->openFAQ();});
+        connect(ui->btnHowTo, &QPushButton::clicked, [this](){window->openFAQ();});
         connect(txModel, &TransactionTableModel::txArrived, this, &DashboardWidget::onTxArrived);
 
         // Notification pop-up for new transaction

--- a/src/qt/pivx/masternodeswidget.cpp
+++ b/src/qt/pivx/masternodeswidget.cpp
@@ -126,8 +126,8 @@ MasterNodesWidget::MasterNodesWidget(PIVXGUI *parent) :
         onStartAllClicked(REQUEST_START_MISSING);
     });
     connect(ui->listMn, &QListView::clicked, this, &MasterNodesWidget::onMNClicked);
-    connect(ui->btnAbout, &OptionButton::clicked, [this](){window->openFAQ(9);});
-    connect(ui->btnAboutController, &OptionButton::clicked, [this](){window->openFAQ(10);});
+    connect(ui->btnAbout, &OptionButton::clicked, [this](){window->openFAQ(SettingsFaqWidget::Section::MASTERNODE);});
+    connect(ui->btnAboutController, &OptionButton::clicked, [this](){window->openFAQ(SettingsFaqWidget::Section::MNCONTROLLER);});
 }
 
 void MasterNodesWidget::showEvent(QShowEvent *event)

--- a/src/qt/pivx/pivxgui.cpp
+++ b/src/qt/pivx/pivxgui.cpp
@@ -16,7 +16,6 @@
 #include "guiinterface.h"
 #include "qt/pivx/qtutils.h"
 #include "qt/pivx/defaultdialog.h"
-#include "qt/pivx/settings/settingsfaqwidget.h"
 
 #include "init.h"
 #include "util.h"
@@ -587,11 +586,11 @@ int PIVXGUI::getNavWidth()
     return this->navMenu->width();
 }
 
-void PIVXGUI::openFAQ(int section)
+void PIVXGUI::openFAQ(SettingsFaqWidget::Section section)
 {
     showHide(true);
     SettingsFaqWidget* dialog = new SettingsFaqWidget(this);
-    if (section > 0) dialog->setSection(section);
+    dialog->setSection(section);
     openDialogWithOpaqueBackgroundFullScreen(dialog, this);
     dialog->deleteLater();
 }

--- a/src/qt/pivx/pivxgui.h
+++ b/src/qt/pivx/pivxgui.h
@@ -24,6 +24,7 @@
 #include "qt/pivx/masternodeswidget.h"
 #include "qt/pivx/snackbar.h"
 #include "qt/pivx/settings/settingswidget.h"
+#include "qt/pivx/settings/settingsfaqwidget.h"
 #include "qt/rpcconsole.h"
 
 
@@ -87,7 +88,7 @@ public Q_SLOTS:
     void messageInfo(const QString& message);
     bool execDialog(QDialog *dialog, int xDiv = 3, int yDiv = 5);
     /** Open FAQ dialog **/
-    void openFAQ(int section = 0);
+    void openFAQ(SettingsFaqWidget::Section section = SettingsFaqWidget::Section::INTRO);
 
     /** Show incoming transaction notification for new transactions. */
     void incomingTransaction(const QString& date, int unit, const CAmount& amount, const QString& type, const QString& address);

--- a/src/qt/pivx/settings/settingsfaqwidget.cpp
+++ b/src/qt/pivx/settings/settingsfaqwidget.cpp
@@ -87,18 +87,14 @@ SettingsFaqWidget::SettingsFaqWidget(PIVXGUI *parent) :
 
 void SettingsFaqWidget::showEvent(QShowEvent *event)
 {
-    if (pos != 0) {
-        QPushButton* btn = getButtons()[pos - 1];
-        QMetaObject::invokeMethod(btn, "setChecked", Qt::QueuedConnection, Q_ARG(bool, true));
-        QMetaObject::invokeMethod(btn, "clicked", Qt::QueuedConnection);
-    }
+    QPushButton* btn = getButtons()[section];
+    QMetaObject::invokeMethod(btn, "setChecked", Qt::QueuedConnection, Q_ARG(bool, true));
+    QMetaObject::invokeMethod(btn, "clicked", Qt::QueuedConnection);
 }
 
-void SettingsFaqWidget::setSection(int num)
+void SettingsFaqWidget::setSection(Section _section)
 {
-    if (num < 1 || num > 10)
-        return;
-    pos = num;
+    section = _section;
 }
 
 void SettingsFaqWidget::onFaqClicked(const QWidget* const widget)

--- a/src/qt/pivx/settings/settingsfaqwidget.h
+++ b/src/qt/pivx/settings/settingsfaqwidget.h
@@ -16,8 +16,16 @@ class SettingsFaqWidget;
 class SettingsFaqWidget : public QDialog
 {
     Q_OBJECT
-
 public:
+    enum Section {
+        INTRO,
+        UNSPENDABLE,
+        STAKE,
+        SUPPORT,
+        MASTERNODE,
+        MNCONTROLLER
+    };
+
     explicit SettingsFaqWidget(PIVXGUI *parent = nullptr);
     ~SettingsFaqWidget();
 
@@ -25,13 +33,14 @@ public:
 
 public Q_SLOTS:
    void windowResizeEvent(QResizeEvent* event);
-   void setSection(int num);
+   void setSection(Section _section);
 private Q_SLOTS:
     void onFaqClicked(const QWidget* const widget);
 private:
     Ui::SettingsFaqWidget *ui;
-    int pos = 0;
+    Section section = INTRO;
 
+    // This needs to be edited if changes are made to the Section enum.
     std::vector<QPushButton*> getButtons();
 };
 

--- a/src/qt/pivx/settings/settingswidget.cpp
+++ b/src/qt/pivx/settings/settingswidget.cpp
@@ -136,7 +136,7 @@ SettingsWidget::SettingsWidget(PIVXGUI* parent) :
 
     // Help
     connect(ui->pushButtonHelp, &QPushButton::clicked, this, &SettingsWidget::onHelpClicked);
-    connect(ui->pushButtonHelp1, &QPushButton::clicked, window, &PIVXGUI::openFAQ);
+    connect(ui->pushButtonHelp1, &QPushButton::clicked, [this](){window->openFAQ();});
     connect(ui->pushButtonHelp2, &QPushButton::clicked, this, &SettingsWidget::onAboutClicked);
 
     // Get restart command-line parameters and handle restart


### PR DESCRIPTION
Bug reported today on discord.
Wallet (GUI 4.3.0) crashes when the FAQ buttons from the masternode widget are pressed.

**Cause:**
The FAQs sections have been recently reduced to only 6 (old zerocoin sections have been removed).
But the buttons in the masternode widget still reference the old indexes (9 and 10),  which are now out of bounds.
Further, the safety check inside `setSection`, still has the old (10) max value hardcoded, so does not prevent this.

**Fix:**
This clearly shows the difficulty in maintaining code with fixed magic numbers (which depend on a list of objects that may be modified in future releases).
So, let's introduce a proper enumeration inside `SettingsFaqWidget`, and use that to manage the sections, instead of just integers.