### PR TITLE
[Refactor] Pass previous index from AcceptBlock to AcceptBlockHeader

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -341,7 +341,7 @@ bool TestBlockValidity(CValidationState& state, const CBlock& block, CBlockIndex
 
 /** Store block on disk. If dbp is provided, the file is known to already reside on disk */
 bool AcceptBlock(const CBlock& block, CValidationState& state, CBlockIndex** pindex, CDiskBlockPos* dbp = NULL, bool fAlreadyCheckedBlock = false);
-bool AcceptBlockHeader(const CBlock& block, CValidationState& state, CBlockIndex** ppindex = NULL);
+bool AcceptBlockHeader(const CBlock& block, CValidationState& state, CBlockIndex** ppindex = nullptr, CBlockIndex* pindexPrev = nullptr);
 
 
 /** RAII wrapper for VerifyDB: Verify consistency of the block and coin databases */


### PR DESCRIPTION
Simple one.
Remove code duplication and inefficiency, passing the previous block index from `AcceptBlock` to `AcceptBlockHeader`.