### PR TITLE
[QT] fixing qt flag deprecation

### DIFF
--- a/src/qt/pivx.cpp
+++ b/src/qt/pivx.cpp
@@ -367,7 +367,7 @@ void BitcoinApplication::createWindow(const NetworkStyle* networkStyle)
 
 void BitcoinApplication::createSplashScreen(const NetworkStyle* networkStyle)
 {
-    Splash* splash = new Splash(0, networkStyle);
+    Splash* splash = new Splash(networkStyle);
     // We don't hold a direct pointer to the splash screen after creation, so use
     // Qt::WA_DeleteOnClose to make sure that the window will be deleted eventually.
     splash->setAttribute(Qt::WA_DeleteOnClose);

--- a/src/qt/pivx/splash.cpp
+++ b/src/qt/pivx/splash.cpp
@@ -23,8 +23,8 @@
 
 #include <iostream>
 
-Splash::Splash(Qt::WindowFlags f, const NetworkStyle* networkStyle) :
-    QWidget(0, f), ui(new Ui::Splash)
+Splash::Splash(const NetworkStyle* networkStyle) :
+    QWidget(nullptr), ui(new Ui::Splash)
 {
     ui->setupUi(this);
     QString titleText = tr("PIVX Core");

--- a/src/qt/pivx/splash.h
+++ b/src/qt/pivx/splash.h
@@ -18,7 +18,7 @@ class Splash : public QWidget
     Q_OBJECT
 
 public:
-    explicit Splash(Qt::WindowFlags f, const NetworkStyle* networkStyle);
+    explicit Splash(const NetworkStyle* networkStyle);
     ~Splash();
 
 public Q_SLOTS:


### PR DESCRIPTION
Removing an obsolete `QFlags` member. Not compiling in qt 5.15.
Issue reported by @Rhubarbarian in discord 👌   .