### PR TITLE
[Backport] test: remove glibc fdelt sanity check

### DIFF
--- a/src/compat/glibc_sanity.cpp
+++ b/src/compat/glibc_sanity.cpp
@@ -9,10 +9,6 @@
 
 #include <cstddef>
 
-#if defined(HAVE_SYS_SELECT_H)
-#include <sys/select.h>
-#endif
-
 extern "C" void* memcpy(void* a, const void* b, size_t c);
 void* memcpy_int(void* a, const void* b, size_t c)
 {
@@ -43,27 +39,9 @@ bool sanity_test_memcpy()
     return true;
 }
 
-#if defined(HAVE_SYS_SELECT_H)
-// trigger: Call FD_SET to trigger __fdelt_chk. FORTIFY_SOURCE must be defined
-//   as >0 and optimizations must be set to at least -O2.
-// test: Add a file descriptor to an empty fd_set. Verify that it has been
-//   correctly added.
-bool sanity_test_fdelt()
-{
-    fd_set fds;
-    FD_ZERO(&fds);
-    FD_SET(0, &fds);
-    return FD_ISSET(0, &fds);
-}
-#endif
-
 } // anon namespace
 
 bool glibc_sanity_test()
 {
-#if defined(HAVE_SYS_SELECT_H)
-    if (!sanity_test_fdelt())
-        return false;
-#endif
     return sanity_test_memcpy<1025>();
 }


### PR DESCRIPTION
Directly coming from upstream df6bde031b24112abf3a94337a2c096698acde6e (full explanation there).