### PR TITLE
[Sapling] Anchors and nullifiers integrated into the chain state view layered cache.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,7 @@ set(SERVER_SOURCES
         ./src/sporkdb.cpp
         ./src/timedata.cpp
         ./src/torcontrol.cpp
+        ./src/sapling/sapling_txdb.cpp
         ./src/txdb.cpp
         ./src/txmempool.cpp
         ./src/validation.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -336,6 +336,7 @@ libbitcoin_server_a_SOURCES = \
   timedata.cpp \
   torcontrol.cpp \
   txdb.cpp \
+  sapling/sapling_txdb.cpp \
   txmempool.cpp \
   validation.cpp \
   validationinterface.cpp \

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -333,6 +333,9 @@ CAmount CCoinsViewCache::GetValueIn(const CTransaction& tx) const
     for (unsigned int i = 0; i < tx.vin.size(); i++)
         nResult += AccessCoin(tx.vin[i].prevout).out.nValue;
 
+    // Sapling
+    nResult += tx.GetShieldedValueIn();
+
     return nResult;
 }
 

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -566,3 +566,20 @@ uint256 CCoinsViewCache::GetBestAnchor() const {
         hashSaplingAnchor = base->GetBestAnchor();
     return hashSaplingAnchor;
 }
+
+bool CCoinsViewCache::HaveShieldedRequirements(const CTransaction& tx) const
+{
+    if (tx.hasSaplingData()) {
+        for (const SpendDescription &spendDescription : tx.sapData->vShieldedSpend) {
+            if (GetNullifier(spendDescription.nullifier)) // Prevent double spends
+                return false;
+
+            SaplingMerkleTree tree;
+            if (!GetSaplingAnchorAt(spendDescription.anchor, tree)) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -15,19 +15,41 @@
 bool CCoinsView::GetCoin(const COutPoint& outpoint, Coin& coin) const { return false; }
 bool CCoinsView::HaveCoin(const COutPoint& outpoint) const { return false; }
 uint256 CCoinsView::GetBestBlock() const { return UINT256_ZERO; }
-bool CCoinsView::BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlock) { return false; }
 CCoinsViewCursor *CCoinsView::Cursor() const { return 0; }
+
+bool CCoinsView::BatchWrite(CCoinsMap& mapCoins,
+                            const uint256& hashBlock,
+                            const uint256& hashSaplingAnchor,
+                            CAnchorsSaplingMap& mapSaplingAnchors,
+                            CNullifiersMap& mapSaplingNullifiers) { return false; }
+
+// Sapling
+bool CCoinsView::GetSaplingAnchorAt(const uint256 &rt, SaplingMerkleTree &tree) const { return false; }
+bool CCoinsView::GetNullifier(const uint256 &nullifier) const { return false; }
+uint256 CCoinsView::GetBestAnchor() const { return uint256(); };
 
 CCoinsViewBacked::CCoinsViewBacked(CCoinsView* viewIn) : base(viewIn) {}
 bool CCoinsViewBacked::GetCoin(const COutPoint& outpoint, Coin& coin) const { return base->GetCoin(outpoint, coin); }
 bool CCoinsViewBacked::HaveCoin(const COutPoint& outpoint) const { return base->HaveCoin(outpoint); }
 uint256 CCoinsViewBacked::GetBestBlock() const { return base->GetBestBlock(); }
 void CCoinsViewBacked::SetBackend(CCoinsView& viewIn) { base = &viewIn; }
-bool CCoinsViewBacked::BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlock) { return base->BatchWrite(mapCoins, hashBlock); }
 CCoinsViewCursor *CCoinsViewBacked::Cursor() const { return base->Cursor(); }
 size_t CCoinsViewBacked::EstimateSize() const { return base->EstimateSize(); }
 
+bool CCoinsViewBacked::BatchWrite(CCoinsMap& mapCoins,
+                                  const uint256& hashBlock,
+                                  const uint256& hashSaplingAnchor,
+                                  CAnchorsSaplingMap& mapSaplingAnchors,
+                                  CNullifiersMap& mapSaplingNullifiers)
+{ return base->BatchWrite(mapCoins, hashBlock, hashSaplingAnchor, mapSaplingAnchors, mapSaplingNullifiers); }
+
+// Sapling
+bool CCoinsViewBacked::GetSaplingAnchorAt(const uint256 &rt, SaplingMerkleTree &tree) const { return base->GetSaplingAnchorAt(rt, tree); }
+bool CCoinsViewBacked::GetNullifier(const uint256 &nullifier) const { return base->GetNullifier(nullifier); }
+uint256 CCoinsViewBacked::GetBestAnchor() const { return base->GetBestAnchor(); }
+
 SaltedOutpointHasher::SaltedOutpointHasher() : k0(GetRand(std::numeric_limits<uint64_t>::max())), k1(GetRand(std::numeric_limits<uint64_t>::max())) {}
+SaltedIdHasher::SaltedIdHasher() : k0(GetRand(std::numeric_limits<uint64_t>::max())), k1(GetRand(std::numeric_limits<uint64_t>::max())) {}
 
 CCoinsViewCache::CCoinsViewCache(CCoinsView *baseIn) : CCoinsViewBacked(baseIn), cachedCoinsUsage(0) {}
 
@@ -147,7 +169,67 @@ void CCoinsViewCache::SetBestBlock(const uint256& hashBlockIn)
     hashBlock = hashBlockIn;
 }
 
-bool CCoinsViewCache::BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlockIn) {
+template<typename Map, typename MapIterator, typename MapEntry>
+void BatchWriteAnchors(
+        Map &mapAnchors,
+        Map &cacheAnchors
+)
+{
+    for (MapIterator child_it = mapAnchors.begin(); child_it != mapAnchors.end();)
+    {
+        if (child_it->second.flags & MapEntry::DIRTY) {
+            MapIterator parent_it = cacheAnchors.find(child_it->first);
+
+            if (parent_it == cacheAnchors.end()) {
+                MapEntry& entry = cacheAnchors[child_it->first];
+                entry.entered = child_it->second.entered;
+                entry.tree = child_it->second.tree;
+                entry.flags = MapEntry::DIRTY;
+
+                // TODO: Complete memory usage
+                //cachedCoinsUsage += entry.tree.DynamicMemoryUsage();
+            } else {
+                if (parent_it->second.entered != child_it->second.entered) {
+                    // The parent may have removed the entry.
+                    parent_it->second.entered = child_it->second.entered;
+                    parent_it->second.flags |= MapEntry::DIRTY;
+                }
+            }
+        }
+
+        MapIterator itOld = child_it++;
+        mapAnchors.erase(itOld);
+    }
+}
+
+void BatchWriteNullifiers(CNullifiersMap &mapNullifiers, CNullifiersMap &cacheNullifiers)
+{
+    for (CNullifiersMap::iterator child_it = mapNullifiers.begin(); child_it != mapNullifiers.end();) {
+        if (child_it->second.flags & CNullifiersCacheEntry::DIRTY) { // Ignore non-dirty entries (optimization).
+            CNullifiersMap::iterator parent_it = cacheNullifiers.find(child_it->first);
+
+            if (parent_it == cacheNullifiers.end()) {
+                CNullifiersCacheEntry& entry = cacheNullifiers[child_it->first];
+                entry.entered = child_it->second.entered;
+                entry.flags = CNullifiersCacheEntry::DIRTY;
+            } else {
+                if (parent_it->second.entered != child_it->second.entered) {
+                    parent_it->second.entered = child_it->second.entered;
+                    parent_it->second.flags |= CNullifiersCacheEntry::DIRTY;
+                }
+            }
+        }
+        CNullifiersMap::iterator itOld = child_it++;
+        mapNullifiers.erase(itOld);
+    }
+}
+
+bool CCoinsViewCache::BatchWrite(CCoinsMap& mapCoins,
+                                 const uint256& hashBlockIn,
+                                 const uint256 &hashSaplingAnchorIn,
+                                 CAnchorsSaplingMap& mapSaplingAnchors,
+                                 CNullifiersMap& mapSaplingNullifiers)
+{
     for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end();) {
         if (it->second.flags & CCoinsCacheEntry::DIRTY) { // Ignore non-dirty entries (optimization).
             CCoinsMap::iterator itUs = cacheCoins.find(it->first);
@@ -199,14 +281,27 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlockIn
         CCoinsMap::iterator itOld = it++;
         mapCoins.erase(itOld);
     }
+
+    // Sapling
+    // TODO: add cache coins usage
+    ::BatchWriteAnchors<CAnchorsSaplingMap, CAnchorsSaplingMap::iterator, CAnchorsSaplingCacheEntry>(mapSaplingAnchors, cacheSaplingAnchors);
+    ::BatchWriteNullifiers(mapSaplingNullifiers, cacheSaplingNullifiers);
+    hashSaplingAnchor = hashSaplingAnchorIn;
+
     hashBlock = hashBlockIn;
     return true;
 }
 
 bool CCoinsViewCache::Flush()
 {
-    bool fOk = base->BatchWrite(cacheCoins, hashBlock);
+    bool fOk = base->BatchWrite(cacheCoins,
+            hashBlock,
+            hashSaplingAnchor,
+            cacheSaplingAnchors,
+            cacheSaplingNullifiers);
     cacheCoins.clear();
+    cacheSaplingAnchors.clear();
+    cacheSaplingNullifiers.clear();
     cachedCoinsUsage = 0;
     return fOk;
 }
@@ -322,3 +417,152 @@ const Coin& AccessByTxid(const CCoinsViewCache& view, const uint256& txid)
     return coinEmpty;
 }
 
+// Sapling
+
+bool CCoinsViewCache::GetSaplingAnchorAt(const uint256 &rt, SaplingMerkleTree &tree) const {
+
+    CAnchorsSaplingMap::const_iterator it = cacheSaplingAnchors.find(rt);
+    if (it != cacheSaplingAnchors.end()) {
+        if (it->second.entered) {
+            tree = it->second.tree;
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    if (!base->GetSaplingAnchorAt(rt, tree)) {
+        return false;
+    }
+
+    CAnchorsSaplingMap::iterator ret = cacheSaplingAnchors.insert(std::make_pair(rt, CAnchorsSaplingCacheEntry())).first;
+    ret->second.entered = true;
+    ret->second.tree = tree;
+
+    // TODO: add cached coins usage
+    //cachedCoinsUsage += ret->second.tree.DynamicMemoryUsage();
+
+    return true;
+}
+
+bool CCoinsViewCache::GetNullifier(const uint256 &nullifier) const {
+    CNullifiersMap* cacheToUse = &cacheSaplingNullifiers;
+    CNullifiersMap::iterator it = cacheToUse->find(nullifier);
+    if (it != cacheToUse->end())
+        return it->second.entered;
+
+    CNullifiersCacheEntry entry;
+    bool tmp = base->GetNullifier(nullifier);
+    entry.entered = tmp;
+
+    cacheToUse->insert(std::make_pair(nullifier, entry));
+    return tmp;
+}
+
+template<typename Tree, typename Cache, typename CacheIterator, typename CacheEntry>
+void CCoinsViewCache::AbstractPushAnchor(
+        const Tree &tree,
+        Cache &cacheAnchors,
+        uint256 &hash
+)
+{
+    uint256 newrt = tree.root();
+
+    auto currentRoot = GetBestAnchor();
+
+    // We don't want to overwrite an anchor we already have.
+    // This occurs when a block doesn't modify mapAnchors at all,
+    // because there are no joinsplits. We could get around this a
+    // different way (make all blocks modify mapAnchors somehow)
+    // but this is simpler to reason about.
+    if (currentRoot != newrt) {
+        auto insertRet = cacheAnchors.insert(std::make_pair(newrt, CacheEntry()));
+        CacheIterator ret = insertRet.first;
+
+        ret->second.entered = true;
+        ret->second.tree = tree;
+        ret->second.flags = CacheEntry::DIRTY;
+
+        if (insertRet.second) {
+            // An insert took place
+            // TODO: add coins usage..
+            //cachedCoinsUsage += ret->second.tree.DynamicMemoryUsage();
+        }
+
+        hash = newrt;
+    }
+}
+
+template<> void CCoinsViewCache::PushAnchor(const SaplingMerkleTree &tree)
+{
+    AbstractPushAnchor<SaplingMerkleTree, CAnchorsSaplingMap, CAnchorsSaplingMap::iterator, CAnchorsSaplingCacheEntry>(
+            tree,
+            cacheSaplingAnchors,
+            hashSaplingAnchor
+    );
+}
+
+template<>
+void CCoinsViewCache::BringBestAnchorIntoCache(
+        const uint256 &currentRoot,
+        SaplingMerkleTree &tree
+)
+{
+    assert(GetSaplingAnchorAt(currentRoot, tree));
+}
+
+template<typename Tree, typename Cache, typename CacheEntry>
+void CCoinsViewCache::AbstractPopAnchor(
+        const uint256 &newrt,
+        Cache &cacheAnchors,
+        uint256 &hash
+)
+{
+    auto currentRoot = GetBestAnchor();
+
+    // Blocks might not change the commitment tree, in which
+    // case restoring the "old" anchor during a reorg must
+    // have no effect.
+    if (currentRoot != newrt) {
+        // Bring the current best anchor into our local cache
+        // so that its tree exists in memory.
+        {
+            Tree tree;
+            BringBestAnchorIntoCache(currentRoot, tree);
+        }
+
+        // Mark the anchor as unentered, removing it from view
+        cacheAnchors[currentRoot].entered = false;
+
+        // Mark the cache entry as dirty so it's propagated
+        cacheAnchors[currentRoot].flags = CacheEntry::DIRTY;
+
+        // Mark the new root as the best anchor
+        hash = newrt;
+    }
+}
+
+void CCoinsViewCache::PopAnchor(const uint256 &newrt) {
+    AbstractPopAnchor<SaplingMerkleTree, CAnchorsSaplingMap, CAnchorsSaplingCacheEntry>(
+            newrt,
+            cacheSaplingAnchors,
+            hashSaplingAnchor
+    );
+}
+
+void CCoinsViewCache::SetNullifiers(const CTransaction& tx, bool spent) {
+    if (tx.sapData) {
+        for (const SpendDescription& spendDescription : tx.sapData->vShieldedSpend) {
+            std::pair<CNullifiersMap::iterator, bool> ret = cacheSaplingNullifiers.insert(
+                    std::make_pair(spendDescription.nullifier, CNullifiersCacheEntry()));
+            ret.first->second.entered = spent;
+            ret.first->second.flags |= CNullifiersCacheEntry::DIRTY;
+        }
+    }
+}
+
+uint256 CCoinsViewCache::GetBestAnchor() const {
+    if (hashSaplingAnchor.IsNull())
+        hashSaplingAnchor = base->GetBestAnchor();
+    return hashSaplingAnchor;
+}

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -309,7 +309,7 @@ CBlockPolicyEstimator::CBlockPolicyEstimator(const CFeeRate& _minRelayFee)
 
 void CBlockPolicyEstimator::processTransaction(const CTxMemPoolEntry& entry, bool fCurrentEstimate)
 {
-    if(entry.HasZerocoins()) {
+    if(entry.HasZerocoins() || entry.IsShielded()) {
         // Zerocoin spends/mints had fixed feerate. Skip them for the estimates.
         return;
     }
@@ -319,7 +319,7 @@ void CBlockPolicyEstimator::processTransaction(const CTxMemPoolEntry& entry, boo
     if (mapMemPoolTxs.count(hash)) {
         LogPrint(BCLog::ESTIMATEFEE, "Blockpolicy error mempool tx %s already being tracked\n",
                  hash.ToString().c_str());
-    return;
+        return;
     }
 
     if (txHeight < nBestSeenHeight) {
@@ -349,7 +349,7 @@ void CBlockPolicyEstimator::processTransaction(const CTxMemPoolEntry& entry, boo
 
 void CBlockPolicyEstimator::processBlockTx(unsigned int nBlockHeight, const CTxMemPoolEntry& entry)
 {
-    if(entry.HasZerocoins()) {
+    if(entry.HasZerocoins() || entry.IsShielded()) {
         // Zerocoin spends/mints had fixed feerate. Skip them for the estimates.
         return;
     }

--- a/src/sapling/sapling_txdb.cpp
+++ b/src/sapling/sapling_txdb.cpp
@@ -1,0 +1,81 @@
+// Copyright (c) 2016-2020 The PIVX developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "txdb.h"
+
+// Db keys
+static const char DB_SAPLING_ANCHOR = 'Z';
+static const char DB_SAPLING_NULLIFIER = 'S';
+static const char DB_BEST_SAPLING_ANCHOR = 'z';
+
+// Sapling
+bool CCoinsViewDB::GetSaplingAnchorAt(const uint256 &rt, SaplingMerkleTree &tree) const {
+    if (rt == SaplingMerkleTree::empty_root()) {
+        SaplingMerkleTree new_tree;
+        tree = new_tree;
+        return true;
+    }
+
+    bool read = db.Read(std::make_pair(DB_SAPLING_ANCHOR, rt), tree);
+
+    return read;
+}
+
+bool CCoinsViewDB::GetNullifier(const uint256 &nf) const {
+    bool spent = false;
+    return db.Read(std::make_pair(DB_SAPLING_NULLIFIER, nf), spent);
+}
+
+uint256 CCoinsViewDB::GetBestAnchor() const {
+    uint256 hashBestAnchor;
+    if (!db.Read(DB_BEST_SAPLING_ANCHOR, hashBestAnchor))
+        return SaplingMerkleTree::empty_root();
+    return hashBestAnchor;
+}
+
+void BatchWriteNullifiers(CDBBatch& batch, CNullifiersMap& mapToUse, const char& dbChar)
+{
+    for (CNullifiersMap::iterator it = mapToUse.begin(); it != mapToUse.end();) {
+        if (it->second.flags & CNullifiersCacheEntry::DIRTY) {
+            if (!it->second.entered)
+                batch.Erase(std::make_pair(dbChar, it->first));
+            else
+                batch.Write(std::make_pair(dbChar, it->first), true);
+            // TODO: changed++? ... See comment in CCoinsViewDB::BatchWrite. If this is needed we could return an int
+        }
+        CNullifiersMap::iterator itOld = it++;
+        mapToUse.erase(itOld);
+    }
+}
+
+template<typename Map, typename MapIterator, typename MapEntry, typename Tree>
+void BatchWriteAnchors(CDBBatch& batch, Map& mapToUse, const char& dbChar)
+{
+    for (MapIterator it = mapToUse.begin(); it != mapToUse.end();) {
+        if (it->second.flags & MapEntry::DIRTY) {
+            if (!it->second.entered)
+                batch.Erase(std::make_pair(dbChar, it->first));
+            else {
+                if (it->first != Tree::empty_root()) {
+                    batch.Write(std::make_pair(dbChar, it->first), it->second.tree);
+                }
+            }
+            // TODO: changed++?
+        }
+        MapIterator itOld = it++;
+        mapToUse.erase(itOld);
+    }
+}
+
+bool CCoinsViewDB::BatchWriteSapling(const uint256& hashSaplingAnchor,
+                              CAnchorsSaplingMap& mapSaplingAnchors,
+                              CNullifiersMap& mapSaplingNullifiers,
+                              CDBBatch& batch) {
+
+    ::BatchWriteAnchors<CAnchorsSaplingMap, CAnchorsSaplingMap::iterator, CAnchorsSaplingCacheEntry, SaplingMerkleTree>(batch, mapSaplingAnchors, DB_SAPLING_ANCHOR);
+    ::BatchWriteNullifiers(batch, mapSaplingNullifiers, DB_SAPLING_NULLIFIER);
+    if (!hashSaplingAnchor.IsNull())
+        batch.Write(DB_BEST_SAPLING_ANCHOR, hashSaplingAnchor);
+    return true;
+}

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -196,7 +196,9 @@ public:
     void SelfTest() const
     {
         // Manually recompute the dynamic usage of the whole data, and compare it.
-        size_t ret = memusage::DynamicUsage(cacheCoins);
+        size_t ret = memusage::DynamicUsage(cacheCoins) +
+                     memusage::DynamicUsage(cacheSaplingAnchors) +
+                     memusage::DynamicUsage(cacheSaplingNullifiers);
         size_t count = 0;
         for (CCoinsMap::iterator it = cacheCoins.begin(); it != cacheCoins.end(); it++) {
             ret += memusage::DynamicUsage(it->second.coin);

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -10,6 +10,7 @@
 #include "uint256.h"
 #include "undo.h"
 #include "utilstrencodings.h"
+#include "random.h"
 
 #include "sapling/incrementalmerkletree.hpp"
 
@@ -168,6 +169,25 @@ public:
     }
 };
 
+class TxWithNullifiers
+{
+public:
+    CTransaction tx;
+    uint256 saplingNullifier;
+
+    TxWithNullifiers()
+    {
+        CMutableTransaction mutableTx;
+
+        saplingNullifier = GetRandHash();
+        SpendDescription sd;
+        sd.nullifier = saplingNullifier;
+        mutableTx.sapData->vShieldedSpend.push_back(sd);
+        tx = CTransaction(mutableTx);
+    }
+};
+
+
 class CCoinsViewCacheTest : public CCoinsViewCache
 {
 public:
@@ -192,7 +212,402 @@ public:
 
 }
 
+template<typename Tree> bool GetAnchorAt(const CCoinsViewCache &cache, const uint256 &rt, Tree &tree);
+template<> bool GetAnchorAt(const CCoinsViewCache &cache, const uint256 &rt, SaplingMerkleTree &tree) { return cache.GetSaplingAnchorAt(rt, tree); }
+
 BOOST_FIXTURE_TEST_SUITE(coins_tests, BasicTestingSetup)
+
+void checkNullifierCache(const CCoinsViewCache &cache, const TxWithNullifiers &txWithNullifiers, bool shouldBeInCache) {
+    // Check if the nullifiers either are or are not in the cache
+    bool containsSaplingNullifier = cache.GetNullifier(txWithNullifiers.saplingNullifier);
+    BOOST_CHECK(containsSaplingNullifier == shouldBeInCache);
+}
+
+BOOST_AUTO_TEST_CASE(nullifier_regression_test)
+{
+    // Correct behavior:
+    {
+    CCoinsViewTest base;
+    CCoinsViewCache cache1(&base);
+
+    TxWithNullifiers txWithNullifiers;
+
+    // Insert a nullifier into the base.
+    cache1.SetNullifiers(txWithNullifiers.tx, true);
+    checkNullifierCache(cache1, txWithNullifiers, true);
+    cache1.Flush(); // Flush to base.
+
+    // Remove the nullifier from cache
+    cache1.SetNullifiers(txWithNullifiers.tx, false);
+
+    // The nullifier now should be `false`.
+    checkNullifierCache(cache1, txWithNullifiers, false);
+    }
+
+    // Also correct behavior:
+    {
+        CCoinsViewTest base;
+        CCoinsViewCache cache1(&base);
+
+        TxWithNullifiers txWithNullifiers;
+
+        // Insert a nullifier into the base.
+        cache1.SetNullifiers(txWithNullifiers.tx, true);
+        checkNullifierCache(cache1, txWithNullifiers, true);
+        cache1.Flush(); // Flush to base.
+
+        // Remove the nullifier from cache
+        cache1.SetNullifiers(txWithNullifiers.tx, false);
+        cache1.Flush(); // Flush to base.
+
+        // The nullifier now should be `false`.
+        checkNullifierCache(cache1, txWithNullifiers, false);
+    }
+
+    // Works because we bring it from the parent cache:
+    {
+        CCoinsViewTest base;
+        CCoinsViewCache cache1(&base);
+
+        // Insert a nullifier into the base.
+        TxWithNullifiers txWithNullifiers;
+        cache1.SetNullifiers(txWithNullifiers.tx, true);
+        checkNullifierCache(cache1, txWithNullifiers, true);
+        cache1.Flush(); // Empties cache.
+
+        // Create cache on top.
+        {
+            // Remove the nullifier.
+            CCoinsViewCache cache2(&cache1);
+            checkNullifierCache(cache2, txWithNullifiers, true);
+            cache1.SetNullifiers(txWithNullifiers.tx, false);
+            cache2.Flush(); // Empties cache, flushes to cache1.
+        }
+
+        // The nullifier now should be `false`.
+        checkNullifierCache(cache1, txWithNullifiers, false);
+    }
+
+    // Was broken:
+    {
+        CCoinsViewTest base;
+        CCoinsViewCache cache1(&base);
+
+        // Insert a nullifier into the base.
+        TxWithNullifiers txWithNullifiers;
+        cache1.SetNullifiers(txWithNullifiers.tx, true);
+        cache1.Flush(); // Empties cache.
+
+        // Create cache on top.
+        {
+            // Remove the nullifier.
+            CCoinsViewCache cache2(&cache1);
+            cache2.SetNullifiers(txWithNullifiers.tx, false);
+            cache2.Flush(); // Empties cache, flushes to cache1.
+        }
+
+        // The nullifier now should be `false`.
+        checkNullifierCache(cache1, txWithNullifiers, false);
+    }
+}
+
+template<typename Tree> void anchorPopRegressionTestImpl()
+{
+    // Correct behavior:
+    {
+        CCoinsViewTest base;
+        CCoinsViewCache cache1(&base);
+
+        // Create dummy anchor/commitment
+        Tree tree;
+        tree.append(GetRandHash());
+
+        // Add the anchor
+        cache1.PushAnchor(tree);
+        cache1.Flush();
+
+        // Remove the anchor
+        cache1.PopAnchor(Tree::empty_root());
+        cache1.Flush();
+
+        // Add the anchor back
+        cache1.PushAnchor(tree);
+        cache1.Flush();
+
+        // The base contains the anchor, of course!
+        {
+            Tree checkTree;
+            BOOST_CHECK(GetAnchorAt(cache1, tree.root(), checkTree));
+            BOOST_CHECK(checkTree.root() == tree.root());
+        }
+    }
+
+    // Previously incorrect behavior
+    {
+        CCoinsViewTest base;
+        CCoinsViewCache cache1(&base);
+
+        // Create dummy anchor/commitment
+        Tree tree;
+        tree.append(GetRandHash());
+
+        // Add the anchor and flush to disk
+        cache1.PushAnchor(tree);
+        cache1.Flush();
+
+        // Remove the anchor, but don't flush yet!
+        cache1.PopAnchor(Tree::empty_root());
+
+        {
+            CCoinsViewCache cache2(&cache1); // Build cache on top
+            cache2.PushAnchor(tree); // Put the same anchor back!
+            cache2.Flush(); // Flush to cache1
+        }
+
+        // cache2's flush kinda worked, i.e. cache1 thinks the
+        // tree is there, but it didn't bring down the correct
+        // treestate...
+        {
+            Tree checktree;
+            BOOST_CHECK(GetAnchorAt(cache1, tree.root(), checktree));
+            BOOST_CHECK(checktree.root() == tree.root()); // Oh, shucks.
+        }
+
+        // Flushing cache won't help either, just makes the inconsistency
+        // permanent.
+        cache1.Flush();
+        {
+            Tree checktree;
+            BOOST_CHECK(GetAnchorAt(cache1, tree.root(), checktree));
+            BOOST_CHECK(checktree.root() == tree.root()); // Oh, shucks.
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(anchor_pop_regression_test)
+{
+    anchorPopRegressionTestImpl<SaplingMerkleTree>();
+}
+
+template<typename Tree> void anchorRegressionTestImpl()
+{
+    // Correct behavior:
+    {
+        CCoinsViewTest base;
+        CCoinsViewCache cache1(&base);
+
+        // Insert anchor into base.
+        Tree tree;
+        tree.append(GetRandHash());
+
+        cache1.PushAnchor(tree);
+        cache1.Flush();
+
+        cache1.PopAnchor(Tree::empty_root());
+        BOOST_CHECK(cache1.GetBestAnchor() == Tree::empty_root());
+        BOOST_CHECK(!GetAnchorAt(cache1, tree.root(), tree));
+    }
+
+    // Also correct behavior:
+    {
+        CCoinsViewTest base;
+        CCoinsViewCache cache1(&base);
+
+        // Insert anchor into base.
+        Tree tree;
+        tree.append(GetRandHash());
+        cache1.PushAnchor(tree);
+        cache1.Flush();
+
+        cache1.PopAnchor(Tree::empty_root());
+        cache1.Flush();
+        BOOST_CHECK(cache1.GetBestAnchor() == Tree::empty_root());
+        BOOST_CHECK(!GetAnchorAt(cache1, tree.root(), tree));
+    }
+
+    // Works because we bring the anchor in from parent cache.
+    {
+        CCoinsViewTest base;
+        CCoinsViewCache cache1(&base);
+
+        // Insert anchor into base.
+        Tree tree;
+        tree.append(GetRandHash());
+        cache1.PushAnchor(tree);
+        cache1.Flush();
+
+        {
+            // Pop anchor.
+            CCoinsViewCache cache2(&cache1);
+            BOOST_CHECK(GetAnchorAt(cache2, tree.root(), tree));
+            cache2.PopAnchor(Tree::empty_root());
+            cache2.Flush();
+        }
+
+        BOOST_CHECK(cache1.GetBestAnchor() == Tree::empty_root());
+        BOOST_CHECK(!GetAnchorAt(cache1, tree.root(), tree));
+    }
+
+    // Was broken:
+    {
+        CCoinsViewTest base;
+        CCoinsViewCache cache1(&base);
+
+        // Insert anchor into base.
+        Tree tree;
+        tree.append(GetRandHash());
+        cache1.PushAnchor(tree);
+        cache1.Flush();
+
+        {
+            // Pop anchor.
+            CCoinsViewCache cache2(&cache1);
+            cache2.PopAnchor(Tree::empty_root());
+            cache2.Flush();
+        }
+
+        BOOST_CHECK(cache1.GetBestAnchor() == Tree::empty_root());
+        BOOST_CHECK(!GetAnchorAt(cache1, tree.root(), tree));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(anchor_regression_test)
+{
+    anchorRegressionTestImpl<SaplingMerkleTree>();
+}
+
+BOOST_AUTO_TEST_CASE(nullifiers_test)
+{
+    CCoinsViewTest base;
+    CCoinsViewCache cache(&base);
+
+    TxWithNullifiers txWithNullifiers;
+    checkNullifierCache(cache, txWithNullifiers, false);
+    cache.SetNullifiers(txWithNullifiers.tx, true);
+    checkNullifierCache(cache, txWithNullifiers, true);
+    cache.Flush();
+
+    CCoinsViewCache cache2(&base);
+
+    checkNullifierCache(cache2, txWithNullifiers, true);
+    cache2.SetNullifiers(txWithNullifiers.tx, false);
+    checkNullifierCache(cache2, txWithNullifiers, false);
+    cache2.Flush();
+
+    CCoinsViewCache cache3(&base);
+
+    checkNullifierCache(cache3, txWithNullifiers, false);
+}
+
+template<typename Tree> void anchorsFlushImpl()
+{
+    CCoinsViewTest base;
+    uint256 newrt;
+    {
+        CCoinsViewCache cache(&base);
+        Tree tree;
+        BOOST_CHECK(GetAnchorAt(cache, cache.GetBestAnchor(), tree));
+        tree.append(GetRandHash());
+
+        newrt = tree.root();
+
+        cache.PushAnchor(tree);
+        cache.Flush();
+    }
+
+    {
+        CCoinsViewCache cache(&base);
+        Tree tree;
+        BOOST_CHECK(GetAnchorAt(cache, cache.GetBestAnchor(), tree));
+
+        // Get the cached entry.
+        BOOST_CHECK(GetAnchorAt(cache, cache.GetBestAnchor(), tree));
+
+        uint256 check_rt = tree.root();
+
+        BOOST_CHECK(check_rt == newrt);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(anchors_flush_test)
+{
+    anchorsFlushImpl<SaplingMerkleTree>();
+}
+
+template<typename Tree> void anchorsTestImpl()
+{
+    // TODO: These tests should be more methodical.
+    //       Or, integrate with Bitcoin's tests later.
+
+    CCoinsViewTest base;
+    CCoinsViewCache cache(&base);
+
+    BOOST_CHECK(cache.GetBestAnchor() == Tree::empty_root());
+
+    {
+        Tree tree;
+
+        BOOST_CHECK(GetAnchorAt(cache, cache.GetBestAnchor(), tree));
+        BOOST_CHECK(cache.GetBestAnchor() == tree.root());
+        tree.append(GetRandHash());
+        tree.append(GetRandHash());
+        tree.append(GetRandHash());
+        tree.append(GetRandHash());
+        tree.append(GetRandHash());
+        tree.append(GetRandHash());
+        tree.append(GetRandHash());
+
+        Tree save_tree_for_later;
+        save_tree_for_later = tree;
+
+        uint256 newrt = tree.root();
+        uint256 newrt2;
+
+        cache.PushAnchor(tree);
+        BOOST_CHECK(cache.GetBestAnchor() == newrt);
+
+        {
+            Tree confirm_same;
+            BOOST_CHECK(GetAnchorAt(cache, cache.GetBestAnchor(), confirm_same));
+
+            BOOST_CHECK(confirm_same.root() == newrt);
+        }
+
+        tree.append(GetRandHash());
+        tree.append(GetRandHash());
+
+        newrt2 = tree.root();
+
+        cache.PushAnchor(tree);
+        BOOST_CHECK(cache.GetBestAnchor() == newrt2);
+
+        Tree test_tree;
+        BOOST_CHECK(GetAnchorAt(cache, cache.GetBestAnchor(), test_tree));
+
+        BOOST_CHECK(tree.root() == test_tree.root());
+
+        {
+            Tree test_tree2;
+            GetAnchorAt(cache, newrt, test_tree2);
+
+            BOOST_CHECK(test_tree2.root() == newrt);
+        }
+
+        {
+            cache.PopAnchor(newrt);
+            Tree obtain_tree;
+            assert(!GetAnchorAt(cache, newrt2, obtain_tree)); // should have been popped off
+            assert(GetAnchorAt(cache, newrt, obtain_tree));
+
+            assert(obtain_tree.root() == newrt);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(anchors_test)
+{
+    anchorsTestImpl<SaplingMerkleTree>();
+}
 
 static const unsigned int NUM_SIMULATION_ITERATIONS = 40000;
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -74,7 +74,11 @@ uint256 CCoinsViewDB::GetBestBlock() const
     return hashBestChain;
 }
 
-bool CCoinsViewDB::BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlock)
+bool CCoinsViewDB::BatchWrite(CCoinsMap& mapCoins,
+                              const uint256& hashBlock,
+                              const uint256& hashSaplingAnchor,
+                              CAnchorsSaplingMap& mapSaplingAnchors,
+                              CNullifiersMap& mapSaplingNullifiers)
 {
     CDBBatch batch;
     size_t count = 0;
@@ -92,6 +96,10 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlock)
         CCoinsMap::iterator itOld = it++;
         mapCoins.erase(itOld);
     }
+
+    // Write Sapling
+    BatchWriteSapling(hashSaplingAnchor, mapSaplingAnchors, mapSaplingNullifiers, batch);
+
     if (!hashBlock.IsNull())
         batch.Write(DB_BEST_BLOCK, hashBlock);
 

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -76,12 +76,26 @@ public:
     bool GetCoin(const COutPoint& outpoint, Coin& coin) const override;
     bool HaveCoin(const COutPoint& outpoint) const override;
     uint256 GetBestBlock() const override;
-    bool BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlock) override;
     CCoinsViewCursor* Cursor() const override;
 
     //! Attempt to update from an older database format. Returns whether an error occurred.
     bool Upgrade();
     size_t EstimateSize() const override;
+
+    bool BatchWrite(CCoinsMap& mapCoins,
+                    const uint256& hashBlock,
+                    const uint256& hashSaplingAnchor,
+                    CAnchorsSaplingMap& mapSaplingAnchors,
+                    CNullifiersMap& mapSaplingNullifiers) override;
+
+    // Sapling, the implementation of the following functions can be found in sapling_txdb.cpp.
+    bool GetSaplingAnchorAt(const uint256 &rt, SaplingMerkleTree &tree) const override;
+    bool GetNullifier(const uint256 &nf) const override;
+    uint256 GetBestAnchor() const override;
+    bool BatchWriteSapling(const uint256& hashSaplingAnchor,
+                           CAnchorsSaplingMap& mapSaplingAnchors,
+                           CNullifiersMap& mapSaplingNullifiers,
+                           CDBBatch& batch);
 };
 
 /** Specialization of CCoinsViewCursor to iterate over a CCoinsViewDB */

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -30,6 +30,7 @@ CTxMemPoolEntry::CTxMemPoolEntry(const CTransaction& _tx, const CAmount& _nFee,
     nModSize = tx.CalculateModifiedSize(nTxSize);
     nUsageSize = tx.DynamicMemoryUsage();
     hasZerocoins = tx.ContainsZerocoins();
+    m_isShielded = tx.hasSaplingData();
 
     nCountWithDescendants = 1;
     nSizeWithDescendants = nTxSize;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1009,5 +1009,4 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpends
         LogPrint(BCLog::MEMPOOL, "Removed %u txn, rolling minimum fee bumped to %s\n", nTxnRemoved, maxFeeRateRemoved.ToString());
 }
 
-SaltedTxidHasher::SaltedTxidHasher() : k0(GetRand(std::numeric_limits<uint64_t>::max())), k1(GetRand(std::numeric_limits<uint64_t>::max())) {}
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -38,20 +38,6 @@ inline bool AllowFree(double dPriority)
 /** Fake height value used in Coin to signify they are only in the memory pool (since 0.8) */
 static const uint32_t MEMPOOL_HEIGHT = 0x7FFFFFFF;
 
-class SaltedTxidHasher
-{
-private:
-    /** Salt */
-    const uint64_t k0, k1;
-
-public:
-    SaltedTxidHasher();
-
-    size_t operator()(const uint256& txid) const {
-        return SipHashUint256(k0, k1, txid);
-    }
-};
-
 class CTxMemPool;
 
 /** \class CTxMemPoolEntry
@@ -376,7 +362,7 @@ public:
         CTxMemPoolEntry,
         boost::multi_index::indexed_by<
             // sorted by txid
-            boost::multi_index::hashed_unique<mempoolentry_txid, SaltedTxidHasher>,
+            boost::multi_index::hashed_unique<mempoolentry_txid, SaltedIdHasher>,
             // sorted by fee rate
             boost::multi_index::ordered_non_unique<
                 boost::multi_index::identity<CTxMemPoolEntry>,

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -66,6 +66,7 @@ private:
     size_t nUsageSize;    //! ... and total memory usage
     CFeeRate feeRate;     //! ... and fee per kB
     bool hasZerocoins{false}; //! ... and checking if it contains zPIV (mints/spends)
+    bool m_isShielded{false}; //! ... and checking if it contains shielded spends/outputs
     int64_t nTime;        //! Local time when entering the mempool
     double entryPriority;     //! Priority when entering the mempool
     unsigned int entryHeight; //! Chain height when entering the mempool
@@ -102,6 +103,7 @@ public:
     int64_t GetTime() const { return nTime; }
     unsigned int GetHeight() const { return entryHeight; }
     bool HasZerocoins() const { return hasZerocoins; }
+    bool IsShielded() const { return m_isShielded; }
     bool WasClearAtEntry() const { return hadNoDependencies; }
     unsigned int GetSigOpCount() const { return sigOpCount; }
     int64_t GetModifiedFee() const { return nFee + feeDelta; }


### PR DESCRIPTION
One more PR decoupled from #1798 to make the review process faster.

Essentially, the chain view state will be storing and caching the best anchor hash and 2 new entry types: (1) Anchors, (2) Nullifiers (Each of them with their entry class and map).

Note: This PR is introducing the new capabilities and validating the functionality correct behavior with a good amount of unit tests (test coverage inside `coins_tests.cpp`), it's not connected to the network flow.

Note2: There is a functional tests in 1798 (`sapling_wallet_anchorfork.py`) that wasn't able to decouple here due larger features requirements (new RPC calls introduced down 1798 commits line) but can be easily run there.

#### List of commits gathered here from #1798:

* CoinsView, Anchor and nullifier view integration. —> 5a8f5ebd3b2d111572aa48ad34717fdb3e84bcbf
* CCoinsViewCache add missing SetNullifiers method —> 1e3aaf191fe4c0a64322239e1e704f475c7ab840
* coins_tests unit test back ported, up-to-date —> 3d46b5c015c0adf459df0a6a0a216012cbbcfba7
* Connect tx GetShieldedValueIn —> 1050850cb9baf3a055a7337f6c39050f95e98aaa [PARTIALLY, only the coins view side. No wallet changes]
* Missing optional sapData correction —> 8afcdd676058b40265fb56121970ee4f5661baee
* Add sapling tx priority to the GetPriority calculation —> 6ba51f2d002f8a62615645a90f81a9f948cb16a8
* fees: Do estimate fee/priority for shielded transaction. Those have fixed fee and priority. —> 84d61dfe24be82ce62195543a6efb62c7c551c5f
* coins_tests: remove not needed BOOST_TEST_CONTEXT. We only have Sapling tests. —> 94aca901b53f1ebae755bb3571a6ea12e41adc7e