### PR TITLE
[Validation] Introduce rolling cache for block hashes in masternode manager

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -179,6 +179,7 @@ BITCOIN_CORE_H = \
   core_io.h \
   cuckoocache.h \
   crypter.h \
+  cyclingvector.h \
   pairresult.h \
   addressbook.h \
   denomination_functions.h \

--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -138,7 +138,8 @@ bool CActiveMasternode::SendMasternodePing(std::string& errorMessage)
 
     LogPrintf("CActiveMasternode::SendMasternodePing() - Relay Masternode Ping vin = %s\n", vin->ToString());
 
-    CMasternodePing mnp(*vin);
+    const uint256& nBlockHash = mnodeman.GetBlockHashToPing();
+    CMasternodePing mnp(*vin, nBlockHash);
     if (!mnp.Sign(keyMasternode, pubKeyMasternode)) {
         errorMessage = "Couldn't sign Masternode Ping";
         return false;

--- a/src/cyclingvector.h
+++ b/src/cyclingvector.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef PIVX_CYCLINGVECTOR_H
+#define PIVX_CYCLINGVECTOR_H
+
+#include <sync.h>
+#include <vector>
+
+/*
+ * Vector container that keeps only MAX_SIZE elements.
+ * Initialized with empty objects.
+ * Exposes only atomic getter and setter
+ * (which cycles the vector index modulo MAX_SIZE)
+ */
+template <typename T>
+class CyclingVector
+{
+private:
+    mutable RecursiveMutex cs;
+    unsigned int MAX_SIZE;
+    std::vector<T> vec;
+
+public:
+    CyclingVector(unsigned int _MAX_SIZE, const T& defaultVal):
+        MAX_SIZE(_MAX_SIZE),
+        vec(_MAX_SIZE, defaultVal)
+    {}
+
+    T Get(int idx) const { LOCK(cs); return vec[idx % MAX_SIZE]; }
+    void Set(int idx, const T& value) { LOCK(cs); vec[idx % MAX_SIZE] = value; }
+    std::vector<T> GetCache() const { LOCK(cs); return vec; }
+};
+
+#endif // PIVX_CYCLINGVECTOR_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1739,6 +1739,7 @@ bool AppInit2()
 
     uiInterface.InitMessage(_("Loading masternode cache..."));
 
+    mnodeman.SetBestHeight(nChainHeight);
     CMasternodeDB mndb;
     CMasternodeDB::ReadResult readResult = mndb.Read(mnodeman);
     if (readResult == CMasternodeDB::FileError)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -942,6 +942,19 @@ static std::string ResolveErrMsg(const char * const optname, const std::string& 
     return strprintf(_("Cannot resolve -%s address: '%s'"), optname, strBind);
 }
 
+// Sets the last CACHED_BLOCK_HASHES hashes into masternode manager cache
+static void LoadBlockHashesCache(CMasternodeMan& man)
+{
+    LOCK(cs_main);
+    const CBlockIndex* pindex = chainActive.Tip();
+    unsigned int inserted = 0;
+    while (pindex && inserted < CACHED_BLOCK_HASHES) {
+        man.CacheBlockHash(pindex);
+        pindex = pindex->pprev;
+        ++inserted;
+    }
+}
+
 void InitLogging()
 {
     //g_logger->m_print_to_file = !IsArgNegated("-debuglogfile");
@@ -1740,6 +1753,7 @@ bool AppInit2()
     uiInterface.InitMessage(_("Loading masternode cache..."));
 
     mnodeman.SetBestHeight(nChainHeight);
+    LoadBlockHashesCache(mnodeman);
     CMasternodeDB mndb;
     CMasternodeDB::ReadResult readResult = mndb.Read(mnodeman);
     if (readResult == CMasternodeDB::FileError)

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -413,12 +413,7 @@ void CMasternodePayments::ProcessMessageMasternodePayments(CNode* pfrom, std::st
 
         if (pfrom->nVersion < ActiveProtocol()) return;
 
-        int nHeight;
-        {
-            TRY_LOCK(cs_main, locked);
-            if (!locked || chainActive.Tip() == NULL) return;
-            nHeight = chainActive.Tip()->nHeight;
-        }
+        int nHeight = mnodeman.GetBestHeight();
 
         if (masternodePayments.mapMasternodePayeeVotes.count(winner.GetHash())) {
             LogPrint(BCLog::MASTERNODE, "mnw - Already seen - %s bestHeight %d\n", winner.GetHash().ToString().c_str(), nHeight);
@@ -487,12 +482,7 @@ bool CMasternodePayments::IsScheduled(CMasternode& mn, int nNotBlockHeight)
 {
     LOCK(cs_mapMasternodeBlocks);
 
-    int nHeight;
-    {
-        TRY_LOCK(cs_main, locked);
-        if (!locked || chainActive.Tip() == NULL) return false;
-        nHeight = chainActive.Tip()->nHeight;
-    }
+    int nHeight = mnodeman.GetBestHeight();
 
     CScript mnpayee;
     mnpayee = GetScriptForDestination(mn.pubKeyCollateralAddress.GetID());
@@ -628,12 +618,7 @@ void CMasternodePayments::CleanPaymentList()
 {
     LOCK2(cs_mapMasternodePayeeVotes, cs_mapMasternodeBlocks);
 
-    int nHeight;
-    {
-        TRY_LOCK(cs_main, locked);
-        if (!locked || chainActive.Tip() == NULL) return;
-        nHeight = chainActive.Tip()->nHeight;
-    }
+    int nHeight = mnodeman.GetBestHeight();
 
     //keep up to five cycles for historical sake
     int nLimit = std::max(int(mnodeman.size() * 1.25), 1000);
@@ -730,13 +715,7 @@ void CMasternodePayments::Sync(CNode* node, int nCountNeeded)
 {
     LOCK(cs_mapMasternodePayeeVotes);
 
-    int nHeight;
-    {
-        TRY_LOCK(cs_main, locked);
-        if (!locked || chainActive.Tip() == NULL) return;
-        nHeight = chainActive.Tip()->nHeight;
-    }
-
+    int nHeight = mnodeman.GetBestHeight();
     int nCount = (mnodeman.CountEnabled() * 1.25);
     if (nCountNeeded > nCount) nCountNeeded = nCount;
 

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -514,8 +514,8 @@ bool CMasternodePayments::IsScheduled(CMasternode& mn, int nNotBlockHeight)
 
 bool CMasternodePayments::AddWinningMasternode(CMasternodePaymentWinner& winnerIn)
 {
-    uint256 blockHash;
-    if (!GetBlockHash(blockHash, winnerIn.nBlockHeight - 100)) {
+    // check winner height
+    if (winnerIn.nBlockHeight - 100 > mnodeman.GetBestHeight() + 1) {
         return false;
     }
 

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -661,7 +661,6 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight)
         return error("%s: Active Masternode not initialized.", __func__);
 
     //reference node - hybrid mode
-
     int n = mnodeman.GetMasternodeRank(*(activeMasternode.vin), nBlockHeight - 100, ActiveProtocol());
 
     if (n == -1) {

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -194,33 +194,19 @@ bool CMasternode::UpdateFromNewBroadcast(CMasternodeBroadcast& mnb)
 // the proof of work for that block. The further away they are the better, the furthest will win the election
 // and get paid this block
 //
-uint256 CMasternode::CalculateScore(int mod, int64_t nBlockHeight)
+uint256 CMasternode::CalculateScore(const uint256& hash) const
 {
-    {
-        LOCK(cs_main);
-        if (!chainActive.Tip()) return UINT256_ZERO;
-    }
-
-    uint256 hash;
-    uint256 aux = vin.prevout.hash + vin.prevout.n;
-
-    if (!GetBlockHash(hash, nBlockHeight)) {
-        LogPrint(BCLog::MASTERNODE,"CalculateScore ERROR - nHeight %d - Returned 0\n", nBlockHeight);
-        return UINT256_ZERO;
-    }
-
     CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
     ss << hash;
-    uint256 hash2 = ss.GetHash();
+    const uint256& hash2 = ss.GetHash();
 
     CHashWriter ss2(SER_GETHASH, PROTOCOL_VERSION);
     ss2 << hash;
+    const uint256& aux = vin.prevout.hash + vin.prevout.n;
     ss2 << aux;
-    uint256 hash3 = ss2.GetHash();
+    const uint256& hash3 = ss2.GetHash();
 
-    uint256 r = (hash3 > hash2 ? hash3 - hash2 : hash2 - hash3);
-
-    return r;
+    return (hash3 > hash2 ? hash3 - hash2 : hash2 - hash3);
 }
 
 void CMasternode::Check(bool forceCheck)

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -35,43 +35,6 @@ std::map<uint256, int> mapSeenMasternodeScanningErrors;
 // cache block hashes as we calculate them
 std::map<int64_t, uint256> mapCacheBlockHashes;
 
-//Get the last hash that matches the modulus given. Processed in reverse order
-bool GetBlockHash(uint256& hash, int nBlockHeight)
-{
-    const CBlockIndex* tipIndex = GetChainTip();
-    if (!tipIndex || !tipIndex->nHeight) return false;
-
-    if (nBlockHeight == 0)
-        nBlockHeight = tipIndex->nHeight;
-
-    if (mapCacheBlockHashes.count(nBlockHeight)) {
-        hash = mapCacheBlockHashes[nBlockHeight];
-        return true;
-    }
-
-    int nBlocksAgo = 0;
-    if (nBlockHeight > 0) nBlocksAgo = (tipIndex->nHeight + 1) - nBlockHeight;
-    if (nBlocksAgo < 0) return false;
-
-    const CBlockIndex* BlockReading = tipIndex;
-    int n = 0;
-    for (unsigned int i = 1; BlockReading && BlockReading->nHeight > 0; i++) {
-        if (n >= nBlocksAgo) {
-            hash = BlockReading->GetBlockHash();
-            mapCacheBlockHashes[nBlockHeight] = hash;
-            return true;
-        }
-        n++;
-
-        if (BlockReading->pprev == NULL) {
-            assert(BlockReading);
-            break;
-        }
-        BlockReading = BlockReading->pprev;
-    }
-
-    return false;
-}
 
 int MasternodeMinPingSeconds()
 {
@@ -102,6 +65,7 @@ int MasternodeRemovalSeconds()
 {
     return Params().IsRegTestNet() ? MASTERNODE_REMOVAL_SECONDS_REGTEST : MASTERNODE_REMOVAL_SECONDS;
 }
+
 
 CMasternode::CMasternode() :
         CSignedMessage()

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -720,23 +720,11 @@ bool CMasternodePing::CheckAndUpdate(int& nDos, bool fRequireEnabled, bool fChec
                 return false;
             }
 
-            // Check if the ping block hash exists in disk
-            BlockMap::iterator mi = mapBlockIndex.find(blockHash);
-            if (mi == mapBlockIndex.end() || !(*mi).second) {
-                LogPrint(BCLog::MNPING,"%s: ping block not in disk. Masternode %s block hash %s\n", __func__, vin.prevout.hash.ToString(), blockHash.ToString());
+            // Check if the ping block hash exists and it's within 24 blocks from the tip
+            if (!mnodeman.IsWithinDepth(blockHash, 2 * MNPING_DEPTH)) {
+                LogPrint(BCLog::MNPING,"%s: Masternode %s block hash %s is too old or has an invalid block hash\n",
+                                                __func__, vin.prevout.hash.ToString(), blockHash.ToString());
                 return false;
-            }
-
-            // Verify ping block hash in main chain and in the [ tip > x > tip - 24 ] range.
-            {
-                LOCK(cs_main);
-                if (!chainActive.Contains((*mi).second) || (chainActive.Height() - (*mi).second->nHeight > 24)) {
-                    LogPrint(BCLog::MNPING,"%s: Masternode %s block hash %s is too old or has an invalid block hash\n",
-                            __func__, vin.prevout.hash.ToString(), blockHash.ToString());
-                    // Do nothing here (no Masternode update, no mnping relay)
-                    // Let this node to be visible but fail to accept mnping
-                    return false;
-                }
             }
 
             pmn->lastPing = *this;

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -32,8 +32,6 @@
 
 // keep track of the scanning errors I've seen
 std::map<uint256, int> mapSeenMasternodeScanningErrors;
-// cache block hashes as we calculate them
-std::map<int64_t, uint256> mapCacheBlockHashes;
 
 
 int MasternodeMinPingSeconds()

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -314,7 +314,13 @@ CMasternodeBroadcast::CMasternodeBroadcast(const CMasternode& mn) :
         CMasternode(mn)
 { }
 
-bool CMasternodeBroadcast::Create(std::string strService, std::string strKeyMasternode, std::string strTxHash, std::string strOutputIndex, std::string& strErrorRet, CMasternodeBroadcast& mnbRet, bool fOffline)
+bool CMasternodeBroadcast::Create(const std::string& strService,
+                                  const std::string& strKeyMasternode,
+                                  const std::string& strTxHash,
+                                  const std::string& strOutputIndex,
+                                  std::string& strErrorRet,
+                                  CMasternodeBroadcast& mnbRet,
+                                  bool fOffline)
 {
     CTxIn txin;
     CPubKey pubKeyCollateralAddressNew;
@@ -356,7 +362,14 @@ bool CMasternodeBroadcast::Create(std::string strService, std::string strKeyMast
     return Create(txin, _service, keyCollateralAddressNew, pubKeyCollateralAddressNew, keyMasternodeNew, pubKeyMasternodeNew, strErrorRet, mnbRet);
 }
 
-bool CMasternodeBroadcast::Create(CTxIn txin, CService service, CKey keyCollateralAddressNew, CPubKey pubKeyCollateralAddressNew, CKey keyMasternodeNew, CPubKey pubKeyMasternodeNew, std::string& strErrorRet, CMasternodeBroadcast& mnbRet)
+bool CMasternodeBroadcast::Create(const CTxIn& txin,
+                                  const CService& service,
+                                  const CKey& keyCollateralAddressNew,
+                                  const CPubKey& pubKeyCollateralAddressNew,
+                                  const CKey& keyMasternodeNew,
+                                  const CPubKey& pubKeyMasternodeNew,
+                                  std::string& strErrorRet,
+                                  CMasternodeBroadcast& mnbRet)
 {
     // wait for reindex and/or import to finish
     if (fImporting || fReindex) return false;
@@ -365,7 +378,9 @@ bool CMasternodeBroadcast::Create(CTxIn txin, CService service, CKey keyCollater
              EncodeDestination(pubKeyCollateralAddressNew.GetID()),
         pubKeyMasternodeNew.GetID().ToString());
 
-    CMasternodePing mnp(txin);
+    // Get block hash to ping (TODO: move outside of this function)
+    const uint256& nBlockHashToPing = mnodeman.GetBlockHashToPing();
+    CMasternodePing mnp(txin, nBlockHashToPing);
     if (!mnp.Sign(keyMasternodeNew, pubKeyMasternodeNew)) {
         strErrorRet = strprintf("Failed to sign ping, masternode=%s", txin.prevout.hash.ToString());
         LogPrint(BCLog::MASTERNODE,"CMasternodeBroadcast::Create -- %s\n", strErrorRet);
@@ -640,19 +655,12 @@ CMasternodePing::CMasternodePing() :
         sigTime(GetAdjustedTime())
 { }
 
-CMasternodePing::CMasternodePing(CTxIn& newVin) :
+CMasternodePing::CMasternodePing(const CTxIn& newVin, const uint256& nBlockHash) :
         CSignedMessage(),
         vin(newVin),
+        blockHash(nBlockHash),
         sigTime(GetAdjustedTime())
-{
-    int nHeight;
-    {
-        LOCK(cs_main);
-        nHeight = chainActive.Height();
-        if (nHeight > 12)
-            blockHash = chainActive[nHeight - 12]->GetBlockHash();
-    }
-}
+{ }
 
 uint256 CMasternodePing::GetHash() const
 {

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -19,8 +19,6 @@ class CMasternodeBroadcast;
 class CMasternodePing;
 extern std::map<int64_t, uint256> mapCacheBlockHashes;
 
-bool GetBlockHash(uint256& hash, int nBlockHeight);
-
 int MasternodeMinPingSeconds();
 int MasternodeBroadcastSeconds();
 int MasternodeCollateralMinConf();

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -17,7 +17,6 @@
 class CMasternode;
 class CMasternodeBroadcast;
 class CMasternodePing;
-extern std::map<int64_t, uint256> mapCacheBlockHashes;
 
 int MasternodeMinPingSeconds();
 int MasternodeBroadcastSeconds();

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -14,6 +14,9 @@
 #include "timedata.h"
 #include "util.h"
 
+/* Depth of the block pinged by masternodes */
+static const unsigned int MNPING_DEPTH = 12;
+
 class CMasternode;
 class CMasternodeBroadcast;
 class CMasternodePing;
@@ -37,7 +40,7 @@ public:
     int64_t sigTime; //mnb message times
 
     CMasternodePing();
-    CMasternodePing(CTxIn& newVin);
+    CMasternodePing(const CTxIn& newVin, const uint256& nBlockHash);
 
     ADD_SERIALIZE_METHODS;
 
@@ -307,8 +310,8 @@ public:
     }
 
     /// Create Masternode broadcast, needs to be relayed manually after that
-    static bool Create(CTxIn vin, CService service, CKey keyCollateralAddressNew, CPubKey pubKeyCollateralAddressNew, CKey keyMasternodeNew, CPubKey pubKeyMasternodeNew, std::string& strErrorRet, CMasternodeBroadcast& mnbRet);
-    static bool Create(std::string strService, std::string strKey, std::string strTxHash, std::string strOutputIndex, std::string& strErrorRet, CMasternodeBroadcast& mnbRet, bool fOffline = false);
+    static bool Create(const CTxIn& vin, const CService& service, const CKey& keyCollateralAddressNew, const CPubKey& pubKeyCollateralAddressNew, const CKey& keyMasternodeNew, const CPubKey& pubKeyMasternodeNew, std::string& strErrorRet, CMasternodeBroadcast& mnbRet);
+    static bool Create(const std::string& strService, const std::string& strKey, const std::string& strTxHash, const std::string& strOutputIndex, std::string& strErrorRet, CMasternodeBroadcast& mnbRet, bool fOffline = false);
     static bool CheckDefaultPort(CService service, std::string& strErrorRet, const std::string& strContext);
 };
 

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -185,7 +185,7 @@ public:
         return !(a.vin == b.vin);
     }
 
-    uint256 CalculateScore(int mod = 1, int64_t nBlockHeight = 0);
+    uint256 CalculateScore(const uint256& hash) const;
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -528,11 +528,12 @@ CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight
     int nTenthNetwork = CountEnabled() / 10;
     int nCountTenth = 0;
     uint256 nHigh;
+    const uint256& hash = GetHashAtHeight(nBlockHeight - 101);
     for (PAIRTYPE(int64_t, CTxIn) & s : vecMasternodeLastPaid) {
         CMasternode* pmn = Find(s.second);
         if (!pmn) break;
 
-        uint256 n = pmn->CalculateScore(1, nBlockHeight - 100);
+        const uint256& n = pmn->CalculateScore(hash);
         if (n > nHigh) {
             nHigh = n;
             pBestMasternode = pmn;
@@ -547,6 +548,7 @@ CMasternode* CMasternodeMan::GetCurrentMasterNode(int mod, int64_t nBlockHeight,
 {
     int64_t score = 0;
     CMasternode* winner = NULL;
+    const uint256& hash = GetHashAtHeight(nBlockHeight - 1);
 
     // scan for winner
     for (CMasternode& mn : vMasternodes) {
@@ -554,7 +556,7 @@ CMasternode* CMasternodeMan::GetCurrentMasterNode(int mod, int64_t nBlockHeight,
         if (mn.protocolVersion < minProtocol || !mn.IsEnabled()) continue;
 
         // calculate the score for each Masternode
-        uint256 n = mn.CalculateScore(mod, nBlockHeight);
+        uint256 n = mn.CalculateScore(hash);
         int64_t n2 = n.GetCompact(false);
 
         // determine the winner
@@ -573,8 +575,9 @@ int CMasternodeMan::GetMasternodeRank(const CTxIn& vin, int64_t nBlockHeight, in
     int64_t nMasternode_Min_Age = MN_WINNER_MINIMUM_AGE;
     int64_t nMasternode_Age = 0;
 
-    // check height
-    if (nBlockHeight > GetBestHeight() + 1) return -1;
+    const uint256& hash = GetHashAtHeight(nBlockHeight - 1);
+    // height outside range
+    if (!hash) return -1;
 
     // scan for winner
     for (CMasternode& mn : vMasternodes) {
@@ -594,7 +597,7 @@ int CMasternodeMan::GetMasternodeRank(const CTxIn& vin, int64_t nBlockHeight, in
             mn.Check();
             if (!mn.IsEnabled()) continue;
         }
-        uint256 n = mn.CalculateScore(1, nBlockHeight);
+        uint256 n = mn.CalculateScore(hash);
         int64_t n2 = n.GetCompact(false);
 
         vecMasternodeScores.emplace_back(n2, mn.vin);
@@ -618,8 +621,9 @@ std::vector<std::pair<int, CMasternode> > CMasternodeMan::GetMasternodeRanks(int
     std::vector<std::pair<int64_t, CMasternode> > vecMasternodeScores;
     std::vector<std::pair<int, CMasternode> > vecMasternodeRanks;
 
-    // check height
-    if (nBlockHeight > GetBestHeight() + 1) return vecMasternodeRanks;
+    const uint256& hash = GetHashAtHeight(nBlockHeight - 1);
+    // height outside range
+    if (!hash) return vecMasternodeRanks;
 
     // scan for winner
     for (CMasternode& mn : vMasternodes) {
@@ -632,7 +636,7 @@ std::vector<std::pair<int, CMasternode> > CMasternodeMan::GetMasternodeRanks(int
             continue;
         }
 
-        uint256 n = mn.CalculateScore(1, nBlockHeight);
+        uint256 n = mn.CalculateScore(hash);
         int64_t n2 = n.GetCompact(false);
 
         vecMasternodeScores.emplace_back(n2, mn);
@@ -841,7 +845,26 @@ void CMasternodeMan::UncacheBlockHash(const CBlockIndex* pindex)
 
 uint256 CMasternodeMan::GetHashAtHeight(int nHeight) const
 {
-    return cvLastBlockHashes.Get(nHeight);
+    // return zero if outside bounds
+    if (nHeight < 0) {
+        LogPrint(BCLog::MASTERNODE, "%s: Negative height. Returning 0\n",  __func__);
+        return UINT256_ZERO;
+    }
+    int nCurrentHeight = GetBestHeight();
+    if (nHeight > nCurrentHeight) {
+        LogPrint(BCLog::MASTERNODE, "%s: height %d over current height %d. Returning 0\n",
+                __func__, nHeight, nCurrentHeight);
+        return UINT256_ZERO;
+    }
+
+    if (nHeight > nCurrentHeight - (int) CACHED_BLOCK_HASHES) {
+        // Use cached hash
+        return cvLastBlockHashes.Get(nHeight);
+    } else {
+        // Use chainActive
+        LOCK(cs_main);
+        return chainActive[nHeight]->GetBlockHash();
+    }
 }
 
 bool CMasternodeMan::IsWithinDepth(const uint256& nHash, int depth) const

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -573,9 +573,8 @@ int CMasternodeMan::GetMasternodeRank(const CTxIn& vin, int64_t nBlockHeight, in
     int64_t nMasternode_Min_Age = MN_WINNER_MINIMUM_AGE;
     int64_t nMasternode_Age = 0;
 
-    //make sure we know about this block
-    uint256 hash;
-    if (!GetBlockHash(hash, nBlockHeight)) return -1;
+    // check height
+    if (nBlockHeight > GetBestHeight() + 1) return -1;
 
     // scan for winner
     for (CMasternode& mn : vMasternodes) {
@@ -619,9 +618,8 @@ std::vector<std::pair<int, CMasternode> > CMasternodeMan::GetMasternodeRanks(int
     std::vector<std::pair<int64_t, CMasternode> > vecMasternodeScores;
     std::vector<std::pair<int, CMasternode> > vecMasternodeRanks;
 
-    //make sure we know about this block
-    uint256 hash;
-    if (!GetBlockHash(hash, nBlockHeight)) return vecMasternodeRanks;
+    // check height
+    if (nBlockHeight > GetBestHeight() + 1) return vecMasternodeRanks;
 
     // scan for winner
     for (CMasternode& mn : vMasternodes) {

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -202,10 +202,10 @@ void DumpMasternodes()
     LogPrint(BCLog::MASTERNODE,"Masternode dump finished  %dms\n", GetTimeMillis() - nStart);
 }
 
-CMasternodeMan::CMasternodeMan()
-{
-    nDsqCount = 0;
-}
+CMasternodeMan::CMasternodeMan():
+        cvLastBlockHashes(CACHED_BLOCK_HASHES, UINT256_ZERO),
+        nDsqCount(0)
+{}
 
 bool CMasternodeMan::Add(CMasternode& mn)
 {
@@ -827,6 +827,40 @@ std::string CMasternodeMan::ToString() const
     info << "Masternodes: " << (int)vMasternodes.size() << ", peers who asked us for Masternode list: " << (int)mAskedUsForMasternodeList.size() << ", peers we asked for Masternode list: " << (int)mWeAskedForMasternodeList.size() << ", entries in Masternode list we asked for: " << (int)mWeAskedForMasternodeListEntry.size();
 
     return info.str();
+}
+
+void CMasternodeMan::CacheBlockHash(const CBlockIndex* pindex)
+{
+    cvLastBlockHashes.Set(pindex->nHeight, pindex->GetBlockHash());
+}
+
+void CMasternodeMan::UncacheBlockHash(const CBlockIndex* pindex)
+{
+    cvLastBlockHashes.Set(pindex->nHeight, UINT256_ZERO);
+}
+
+uint256 CMasternodeMan::GetHashAtHeight(int nHeight) const
+{
+    return cvLastBlockHashes.Get(nHeight);
+}
+
+bool CMasternodeMan::IsWithinDepth(const uint256& nHash, int depth) const
+{
+    // Sanity checks
+    if (nHash.IsNull()) {
+        return error("%s: Called with null hash\n", __func__);
+    }
+    if (depth < 0 || (unsigned) depth >= CACHED_BLOCK_HASHES) {
+        return error("%s: Invalid depth %d. Cached block hashes: %d\n", __func__, depth, CACHED_BLOCK_HASHES);
+    }
+    // Check last depth blocks to find one with matching hash
+    const int nCurrentHeight = GetBestHeight();
+    int nStopHeight = std::max(0, nCurrentHeight - depth);
+    for (int i = nCurrentHeight; i >= nStopHeight; i--) {
+        if (GetHashAtHeight(i) == nHash)
+            return true;
+    }
+    return false;
 }
 
 void ThreadCheckMasternodes()

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -8,6 +8,7 @@
 
 #include "activemasternode.h"
 #include "base58.h"
+#include "cyclingvector.h"
 #include "key.h"
 #include "masternode.h"
 #include "net.h"
@@ -17,6 +18,8 @@
 #define MASTERNODES_DUMP_SECONDS (15 * 60)
 #define MASTERNODES_DSEG_SECONDS (3 * 60 * 60)
 
+/** Maximum number of block hashes to cache */
+static const unsigned int CACHED_BLOCK_HASHES = 200;
 
 class CMasternodeMan;
 class CActiveMasternode;
@@ -71,6 +74,9 @@ private:
 
     // Memory Only. Updated in NewBlock (blocks arrive in order)
     std::atomic<int> nBestHeight;
+
+    // Memory Only. Cache last block hashes. Used to verify mn pings and winners.
+    CyclingVector<uint256> cvLastBlockHashes;
 
 public:
     // Keep track of all broadcasts I've seen
@@ -161,6 +167,12 @@ public:
 
     /// Update masternode list and maps using provided CMasternodeBroadcast
     void UpdateMasternodeList(CMasternodeBroadcast mnb);
+
+    // Block hashes cycling vector management
+    void CacheBlockHash(const CBlockIndex* pindex);
+    void UncacheBlockHash(const CBlockIndex* pindex);
+    uint256 GetHashAtHeight(int nHeight) const;
+    bool IsWithinDepth(const uint256& nHash, int depth) const;
 };
 
 void ThreadCheckMasternodes();

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -173,6 +173,7 @@ public:
     void UncacheBlockHash(const CBlockIndex* pindex);
     uint256 GetHashAtHeight(int nHeight) const;
     bool IsWithinDepth(const uint256& nHash, int depth) const;
+    uint256 GetBlockHashToPing() const { return GetHashAtHeight(GetBestHeight() - MNPING_DEPTH); }
     std::vector<uint256> GetCachedBlocks() const { return cvLastBlockHashes.GetCache(); }
 };
 

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -69,6 +69,9 @@ private:
     // which Masternodes we've asked for
     std::map<COutPoint, int64_t> mWeAskedForMasternodeListEntry;
 
+    // Memory Only. Updated in NewBlock (blocks arrive in order)
+    std::atomic<int> nBestHeight;
+
 public:
     // Keep track of all broadcasts I've seen
     std::map<uint256, CMasternodeBroadcast> mapSeenMasternodeBroadcast;
@@ -111,6 +114,9 @@ public:
 
     /// Clear Masternode vector
     void Clear();
+
+    void SetBestHeight(int height) { nBestHeight.store(height, std::memory_order_release); };
+    int GetBestHeight() const { return nBestHeight.load(std::memory_order_acquire); }
 
     int CountEnabled(int protocolVersion = -1);
 

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -173,6 +173,7 @@ public:
     void UncacheBlockHash(const CBlockIndex* pindex);
     uint256 GetHashAtHeight(int nHeight) const;
     bool IsWithinDepth(const uint256& nHash, int depth) const;
+    std::vector<uint256> GetCachedBlocks() const { return cvLastBlockHashes.GetCache(); }
 };
 
 void ThreadCheckMasternodes();

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -11,6 +11,7 @@
 #include "consensus/upgrades.h"
 #include "kernel.h"
 #include "masternode-budget.h"
+#include "masternodeman.h"
 #include "policy/policy.h"
 #include "rpc/server.h"
 #include "sync.h"
@@ -1185,7 +1186,9 @@ UniValue invalidateblock(const JSONRPCRequest& request)
 
     if (state.IsValid()) {
         ActivateBestChain(state);
-        budget.SetBestHeight(WITH_LOCK(cs_main, return chainActive.Height(); ));
+        int nHeight = WITH_LOCK(cs_main, return chainActive.Height(); );
+        budget.SetBestHeight(nHeight);
+        mnodeman.SetBestHeight(nHeight);
     }
 
     if (!state.IsValid()) {
@@ -1225,6 +1228,9 @@ UniValue reconsiderblock(const JSONRPCRequest& request)
     if (state.IsValid()) {
         ActivateBestChain(state);
         budget.SetBestHeight(WITH_LOCK(cs_main, return chainActive.Height(); ));
+        int nHeight = WITH_LOCK(cs_main, return chainActive.Height(); );
+        budget.SetBestHeight(nHeight);
+        mnodeman.SetBestHeight(nHeight);
     }
 
     if (!state.IsValid()) {

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -667,15 +667,16 @@ UniValue getmasternodescores (const JSONRPCRequest& request)
             throw std::runtime_error("Exception on param 2");
         }
     }
-    int nChainHeight = WITH_LOCK(cs_main, return chainActive.Height());
+    int nChainHeight = mnodeman.GetBestHeight();
     if (nChainHeight < 0) return "unknown";
     UniValue obj(UniValue::VOBJ);
     std::vector<CMasternode> vMasternodes = mnodeman.GetFullMasternodeVector();
     for (int nHeight = nChainHeight - nLast; nHeight < nChainHeight + 20; nHeight++) {
+        const uint256& hash = mnodeman.GetHashAtHeight(nHeight - 101);
         uint256 nHigh;
         CMasternode* pBestMasternode = NULL;
         for (CMasternode& mn : vMasternodes) {
-            uint256 n = mn.CalculateScore(1, nHeight - 100);
+            const uint256& n = mn.CalculateScore(hash);
             if (n > nHigh) {
                 nHigh = n;
                 pBestMasternode = &mn;

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -18,6 +18,31 @@
 
 #include <boost/tokenizer.hpp>
 
+UniValue getcachedblockhashes(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() > 0)
+        throw std::runtime_error(
+            "getcachedblockhashes \n"
+            "\nReturn the block hashes cached in the masternode manager\n"
+
+            "\nResult:\n"
+            "[\n"
+            "  ...\n"
+            "  \"xxxx\",   (string) hash at Index d (height modulo max cache size)\n"
+            "  ...\n"
+            "]\n"
+
+            "\nExamples:\n" +
+            HelpExampleCli("getcachedblockhashes", "") + HelpExampleRpc("getcachedblockhashes", ""));
+
+    std::vector<uint256> vCacheCopy = mnodeman.GetCachedBlocks();
+    UniValue ret(UniValue::VARR);
+    for (int i = 0; (unsigned) i < vCacheCopy.size(); i++) {
+        ret.push_back(vCacheCopy[i].ToString());
+    }
+    return ret;
+}
+
 UniValue listmasternodes(const JSONRPCRequest& request)
 {
     std::string strFilter = "";

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -361,6 +361,7 @@ static const CRPCCommand vRPCCommands[] =
 
         /* PIVX features */
         {"pivx", "listmasternodes", &listmasternodes, true },
+        {"pivx", "getcachedblockhashes", &getcachedblockhashes, true },
         {"pivx", "getmasternodecount", &getmasternodecount, true },
         {"pivx", "createmasternodebroadcast", &createmasternodebroadcast, true },
         {"pivx", "decodemasternodebroadcast", &decodemasternodebroadcast, true },

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -275,6 +275,7 @@ extern void validaterange(const UniValue& params, int& heightStart, int& heightE
 
 // in rpc/masternode.cpp
 extern UniValue listmasternodes(const JSONRPCRequest& request);
+extern UniValue getcachedblockhashes(const JSONRPCRequest& request);
 extern UniValue getmasternodecount(const JSONRPCRequest& request);
 extern UniValue createmasternodebroadcast(const JSONRPCRequest& request);
 extern UniValue decodemasternodebroadcast(const JSONRPCRequest& request);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3343,6 +3343,7 @@ bool ProcessNewBlock(CValidationState& state, CNode* pfrom, const std::shared_pt
         return error("%s : ActivateBestChain failed", __func__);
 
     if (!fLiteMode) {
+        mnodeman.SetBestHeight(newHeight);
         budget.NewBlock(newHeight);
         if (masternodeSync.RequestedMasternodeAssets > MASTERNODE_SYNC_LIST) {
             masternodePayments.ProcessBlock(newHeight + 10);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1907,7 +1907,13 @@ bool static DisconnectTip(CValidationState& state)
     // block that were added back and cleans up the mempool state.
     mempool.UpdateTransactionsFromBlock(vHashUpdate);
     // Update MN manager cache
-    mnodeman.UncacheBlockHash(pindexDelete);
+    // replace the cached hash of pindexDelete with the hash of the block
+    // at depth CACHED_BLOCK_HASHES if it exists, or empty hash otherwise.
+    if ((unsigned) pindexDelete->nHeight >= CACHED_BLOCK_HASHES) {
+        mnodeman.CacheBlockHash(chainActive[pindexDelete->nHeight - CACHED_BLOCK_HASHES]);
+    } else {
+        mnodeman.UncacheBlockHash(pindexDelete);
+    }
     // Update chainActive and related variables.
     UpdateTip(pindexDelete->pprev);
     // Let wallets know transactions went from 1-confirmed to

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1906,6 +1906,8 @@ bool static DisconnectTip(CValidationState& state)
     // UpdateTransactionsFromBlock finds descendants of any transactions in this
     // block that were added back and cleans up the mempool state.
     mempool.UpdateTransactionsFromBlock(vHashUpdate);
+    // Update MN manager cache
+    mnodeman.UncacheBlockHash(pindexDelete);
     // Update chainActive and related variables.
     UpdateTip(pindexDelete->pprev);
     // Let wallets know transactions went from 1-confirmed to
@@ -1994,6 +1996,8 @@ bool static ConnectTip(CValidationState& state, CBlockIndex* pindexNew, const st
     mempool.removeForBlock(blockConnecting.vtx, pindexNew->nHeight, connectTrace.txConflicted, !IsInitialBlockDownload());
     // Update chainActive & related variables.
     UpdateTip(pindexNew);
+    // Update MN manager cache
+    mnodeman.CacheBlockHash(pindexNew);
 
     int64_t nTime6 = GetTimeMicros();
     nTimePostConnect += nTime6 - nTime5;

--- a/test/functional/feature_blockhashcache.py
+++ b/test/functional/feature_blockhashcache.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019-2020 The PIVX developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import PivxTestFramework
+from test_framework.util import (
+    assert_equal,
+)
+import random
+from time import sleep
+
+class BlockHashCacheTest(PivxTestFramework):
+
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def log_title(self):
+        title = "*** Starting %s ***" % self.__class__.__name__
+        underline = "-" * len(title)
+        description = "Tests the block-hashes rolling cache."
+        self.log.info("\n\n%s\n%s\n%s\n", title, underline, description)
+
+    def run_test(self):
+        self.log_title()
+        self.node = self.nodes[0]
+        CACHE_SIZE = 200
+        # Start with the genesis block
+        vBlocks = [self.node.getbestblockhash()]
+
+        # Mine blocks and save the hashes
+        self.log.info("Mining %d blocks..." % (CACHE_SIZE - 1))
+        for i in range(CACHE_SIZE-1):
+            vBlocks.append(self.node.generate(1)[0])
+
+        # Check the cache
+        cache = self.node.getcachedblockhashes()
+        assert_equal(vBlocks, cache)
+        self.log.info("First %d blocks check out" % (CACHE_SIZE - 1))
+
+        # Mine a block and check the cache
+        self.log.info("Mining another block...")
+        vBlocks.append(self.node.generate(1)[0])
+        height = self.node.getblockcount()
+        assert_equal(height, CACHE_SIZE)
+        assert_equal(len(vBlocks), height + 1)      # genesis included
+        cache = self.node.getcachedblockhashes()
+        assert_equal(vBlocks[CACHE_SIZE], cache[0])
+        self.log.info("Block %d correctly cached (overwriting genesis hash)" % CACHE_SIZE)
+
+        # Mine a random number of blocks between 1 and CACHE_SIZE-1
+        x = random.randint(1, CACHE_SIZE)
+        self.log.info("Mining %d more blocks..." % x)
+        for i in range(x):
+            vBlocks.append(self.node.generate(1)[0])
+
+        # Check that the cache is (partially) overwritten
+        cache = self.node.getcachedblockhashes()
+        for i in range(1, x+1):
+            assert_equal(vBlocks[CACHE_SIZE + i], cache[i])
+        # ...but not completely
+        for i in range(x+1, CACHE_SIZE):
+            assert_equal(vBlocks[i], cache[i])
+        self.log.info("Cached correctly")
+
+        # Disconnect one block
+        self.log.info("Disconnecting one block...")
+        height = self.node.getblockcount()
+        old_hash = self.node.getbestblockhash()
+        self.node.invalidateblock(old_hash)
+        assert_equal(self.node.getblockcount(), height - 1)
+        vBlocks.pop()
+        assert_equal(len(vBlocks), height)  # genesis included
+
+        # Check that the cache cycles back
+        cache = self.node.getcachedblockhashes()
+        assert_equal(vBlocks[height - CACHE_SIZE], cache[height % CACHE_SIZE])
+        self.log.info("Disconnecting %d, block at height %d cycles back in" % (
+            height, height - CACHE_SIZE))
+
+        # Reconsider the block, mine another on top, and check the cache again
+        self.log.info("Reconsidering and mining one more block...")
+        self.node.reconsiderblock(old_hash)
+        assert_equal(self.node.getblockcount(), height)
+        vBlocks.append(old_hash)
+        vBlocks.append(self.node.generate(1)[0])
+        assert_equal(self.node.getblockcount(), height + 1)
+        assert_equal(len(vBlocks), height + 2)  # genesis included
+        assert_equal(vBlocks[height], old_hash)
+        cache = self.node.getcachedblockhashes()
+        assert_equal(vBlocks[height], cache[height % CACHE_SIZE])
+        assert_equal(vBlocks[height + 1], cache[(height + 1) % CACHE_SIZE])
+        self.log.info("Cached correctly")
+
+        # Restart the node and check that the cache is correctly initialized
+        self.log.info("Restarting the node...")
+        self.stop_nodes()
+        sleep(5)
+        self.start_nodes()
+        assert_equal(self.node.getcachedblockhashes(), cache)
+        self.log.info("All good.")
+
+
+
+if __name__ == '__main__':
+    BlockHashCacheTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -86,6 +86,7 @@ BASE_SCRIPTS= [
     'mining_pos_fakestake.py',                  # ~ 113 sec
     'feature_reindex.py',                       # ~ 110 sec
     'interface_http.py',                        # ~ 105 sec
+    'feature_blockhashcache.py',                # ~ 100 sec
     'wallet_listtransactions.py',               # ~ 97 sec
     'mempool_reorg.py',                         # ~ 92 sec
     'sapling_wallet_persistence.py',            # ~ 90 sec


### PR DESCRIPTION
**Problem**:
Validation of many objects on the second layer (masternode pings, winners/scores, etc...) requires access to chainActive to get the hashes of blocks at a certain height. This is done very often (especially for masternode pings) and means holding `cs_main` lock every time, making the process slow and possibly leading to locking order inconsistencies.

**Solution**:
Cache the last N block hashes in the masternode manager.
In order to implement this efficiently, we introduce a new data structure called `CyclingVector`, which is a fixed-size vector, exposing only a setter `Set(i,  value)` which modifies the index `i % N`.
The cache is initialized at startup and updated when blocks get connected to /  disconnected from the tip.

The size (`CACHED_BLOCK_HASHES`) is currently set a default value of 200 making it possible to validate all masternode pings (but not all masternode winners) without accessing chainActive. In the future we could add a startup flag to let the user customize this (higher cache size would, as usual, mean faster execution but higher memory usage).

An RPC `getcachedblockhashes` is introduced, in order to print the content of the cache. This can be used later in the functional test suite for better testing.

This PR also removes the accesses to chainActive to get the current chain-height (using a value cached in the manager).


 