### PR TITLE
[Cleanup] removing unused mapRelay and cs_mapRelay.

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -78,9 +78,6 @@ static bool vfLimited[NET_MAX] = {};
 static CNode* pnodeLocalHost = NULL;
 std::string strSubVersion;
 
-std::map<CInv, CDataStream> mapRelay;
-std::deque<std::pair<int64_t, CInv> > vRelayExpiration;
-RecursiveMutex cs_mapRelay;
 limitedmap<CInv, int64_t> mapAlreadyAskedFor(MAX_INV_SZ);
 
 // Signals for message handling

--- a/src/net.h
+++ b/src/net.h
@@ -456,10 +456,6 @@ bool validateMasternodeIP(const std::string& addrStr);          // valid, reacha
 extern bool fDiscover;
 extern bool fListen;
 
-extern std::map<CInv, CDataStream> mapRelay;
-extern std::deque<std::pair<int64_t, CInv> > vRelayExpiration;
-extern RecursiveMutex cs_mapRelay;
-
 extern limitedmap<CInv, int64_t> mapAlreadyAskedFor;
 
 /** Subversion as sent to the P2P network in `version` messages */

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -863,16 +863,8 @@ void static ProcessGetData(CNode* pfrom, CConnman& connman, std::atomic<bool>& i
             } else if (inv.IsKnownType()) {
                 // Send stream from relay memory
                 bool pushed = false;
-                {
-                    LOCK(cs_mapRelay);
-                    std::map<CInv, CDataStream>::iterator mi = mapRelay.find(inv);
-                    if (mi != mapRelay.end()) {
-                        connman.PushMessage(pfrom, msgMaker.Make(inv.GetCommand(), (*mi).second));
-                        pushed = true;
-                    }
-                }
 
-                if (!pushed && inv.type == MSG_TX) {
+                if (inv.type == MSG_TX) {
                     CTransaction tx;
                     if (mempool.lookup(inv.hash, tx)) {
                         CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);


### PR DESCRIPTION
Cleaning the currently not unused `mapRelay` and `cs_mapRelay`. Making #1786 obsolete.