### PR TITLE
[RPC] Cache money supply on memory. Introduce getsupplyinfo

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -211,6 +211,7 @@ BITCOIN_CORE_H = \
   merkleblock.h \
   messagesigner.h \
   miner.h \
+  moneysupply.h \
   net.h \
   net_processing.h \
   netaddress.h \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1730,6 +1730,11 @@ bool AppInit2()
         uiInterface.NotifyBlockTip.disconnect(BlockNotifyGenesisWait);
     }
 
+    uiInterface.InitMessage(_("Calculating money supply..."));
+    int nChainHeight = WITH_LOCK(cs_main, return chainActive.Height(); );
+    MoneySupply.Update(pcoinsTip->GetTotalAmount(), nChainHeight);
+
+
     // ********************************************************* Step 10: setup layer 2 data
 
     uiInterface.InitMessage(_("Loading masternode cache..."));
@@ -1749,7 +1754,6 @@ bool AppInit2()
     uiInterface.InitMessage(_("Loading budget cache..."));
 
     CBudgetDB budgetdb;
-    int nChainHeight = WITH_LOCK(cs_main, return chainActive.Height(); );
     const bool fDryRun = (nChainHeight <= 0);
     if (!fDryRun) budget.SetBestHeight(nChainHeight);
     CBudgetDB::ReadResult readResult2 = budgetdb.Read(budget, fDryRun);

--- a/src/moneysupply.h
+++ b/src/moneysupply.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2020 The PIVX developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#ifndef PIVX_MONEYSUPPLY_H
+#define PIVX_MONEYSUPPLY_H
+
+#include "amount.h"
+#include "sync.h"
+
+/*
+ * Class used to cache the sum of utxo's values
+ */
+class CMoneySupply {
+private:
+    mutable RecursiveMutex cs;
+    CAmount nSupply;
+    // height of the chain when the supply was last updated
+    int64_t nHeight;
+
+public:
+    CMoneySupply(): nSupply(0), nHeight(0) {}
+
+    void Update(const CAmount& _nSupply, int _nHeight)
+    {
+        LOCK(cs);
+        nSupply = _nSupply;
+        nHeight = _nHeight;
+    }
+
+    CAmount Get() const { LOCK(cs); return nSupply; }
+    int64_t GetCacheHeight() const { LOCK(cs); return nHeight; }
+};
+
+#endif // PIVX_MONEYSUPPLY_H

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -594,6 +594,45 @@ UniValue getblockheader(const JSONRPCRequest& request)
     return blockheaderToJSON(pblockindex);
 }
 
+UniValue getsupplyinfo(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() > 1)
+        throw std::runtime_error(
+            "getsupplyinfo ( forceupdate )\n"
+            "\nIf forceupdate=false (default if no argument is given): return the last cached money supply"
+            "\n(sum of spendable transaction outputs) and the height of the chain when it was last updated"
+            "\n(it is updated periodically, whenever the chainstate is flushed)."
+            "\n"
+            "\nIf forceupdate=true: Flush the chainstate to disk and return the money supply updated to"
+            "\nthe current chain height.\n"
+
+            "\nArguments:\n"
+            "1. forceupdate       (boolean, optional, default=false) flush chainstate to disk and update cache\n"
+
+            "\nResult:\n"
+            "{\n"
+            "  \"updateheight\" : n, (numeric) The chain height when the supply was updated\n"
+            "  \"supply\" :       n   (numeric) The sum of all spendable transaction outputs at height updateheight\n"
+            "}\n"
+
+            "\nExamples:\n" +
+            HelpExampleCli("getsupplyinfo", "") + HelpExampleCli("getsupplyinfo", "true") +
+            HelpExampleRpc("getsupplyinfo", ""));
+
+    const bool fForceUpdate = request.params.size() > 0 ? request.params[0].get_bool() : false;
+
+    if (fForceUpdate) {
+        // Flush state to disk (which updates the cached supply)
+        FlushStateToDisk();
+    }
+
+    UniValue ret(UniValue::VOBJ);
+    ret.pushKV("updateheight", MoneySupply.GetCacheHeight());
+    ret.pushKV("supply", ValueFromAmount(MoneySupply.Get()));
+
+    return ret;
+}
+
 struct CCoinsStats
 {
     int nHeight;

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -176,6 +176,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
         {"getserials", 1},
         {"getserials", 2},
         {"getfeeinfo", 0},
+        {"getsupplyinfo", 0},
     };
 
 class CRPCConvertTable

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -66,8 +66,9 @@ UniValue getinfo(const JSONRPCRequest& request)
             "  \"proxy\": \"host:port\",       (string, optional) the proxy used by the server\n"
             "  \"difficulty\": xxxxxx,         (numeric) the current difficulty\n"
             "  \"testnet\": true|false,        (boolean) if the server is using testnet or not\n"
-            "  \"moneysupply\" : \"supply\"    (numeric) The current spendable supply (sum of the value of all unspent\n"
-            "                                            transaction outputs)\n"
+            "  \"moneysupply\" : \"supply\"    (numeric) The sum of the value of all unspent outputs when the chainstate was\n"
+            "                                            last flushed to disk (use getsupplyinfo to know the update-height, or\n"
+            "                                            to trigger the money supply update/recalculation)"
             "  \"zPIVsupply\" :\n"
             "  {\n"
             "     \"1\" : n,            (numeric) supply of 1 zPIV denomination\n"
@@ -138,8 +139,10 @@ UniValue getinfo(const JSONRPCRequest& request)
     obj.pushKV("difficulty", (double)GetDifficulty());
     obj.pushKV("testnet", Params().NetworkID() == CBaseChainParams::TESTNET);
 
-    FlushStateToDisk();
-    obj.pushKV("moneysupply",ValueFromAmount(pcoinsTip->GetTotalAmount()));
+    // Add (cached) money supply via getsupplyinfo RPC
+    UniValue supply_info = getsupplyinfo(JSONRPCRequest());
+    obj.pushKV("moneysupply", supply_info["supply"]);
+
     UniValue zpivObj(UniValue::VOBJ);
     for (auto denom : libzerocoin::zerocoinDenomList) {
         if (mapZerocoinSupply.empty())

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -311,6 +311,7 @@ static const CRPCCommand vRPCCommands[] =
         {"blockchain", "getdifficulty", &getdifficulty, true },
         {"blockchain", "getfeeinfo", &getfeeinfo, true },
         {"blockchain", "getmempoolinfo", &getmempoolinfo, true },
+        {"blockchain", "getsupplyinfo", &getsupplyinfo, true },
         {"blockchain", "getrawmempool", &getrawmempool, true },
         {"blockchain", "gettxout", &gettxout, true },
         {"blockchain", "gettxoutsetinfo", &gettxoutsetinfo, true },

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -252,6 +252,7 @@ extern UniValue createrawzerocoinspend(const JSONRPCRequest& request);
 extern UniValue findserial(const JSONRPCRequest& request); // in rpc/blockchain.cpp
 extern UniValue getblockcount(const JSONRPCRequest& request);
 extern UniValue getbestblockhash(const JSONRPCRequest& request);
+extern UniValue getsupplyinfo(const JSONRPCRequest& request);
 extern UniValue waitfornewblock(const JSONRPCRequest& request);
 extern UniValue waitforblock(const JSONRPCRequest& request);
 extern UniValue waitforblockheight(const JSONRPCRequest& request);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1718,6 +1718,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
  * Update the on-disk chain state.
  * The caches and indexes are flushed if either they're too large, forceWrite is set, or
  * fast is not set and it's been a while since the last write.
+ * Full flush also updates the money supply from disk (except during shutdown)
  */
 bool static FlushStateToDisk(CValidationState& state, FlushStateMode mode)
 {
@@ -1799,6 +1800,10 @@ bool static FlushStateToDisk(CValidationState& state, FlushStateMode mode)
             if (!pcoinsTip->Flush())
                 return AbortNode(state, "Failed to write to coin database");
             nLastFlush = nNow;
+            // Update money supply on memory, reading data from disk
+            if (!ShutdownRequested()) {
+                MoneySupply.Update(pcoinsTip->GetTotalAmount(), chainActive.Height());
+            }
         }
         if ((mode == FLUSH_STATE_ALWAYS || mode == FLUSH_STATE_PERIODIC) && nNow > nLastSetChain + (int64_t)DATABASE_WRITE_INTERVAL * 1000000) {
             // Update best block in wallet (so we can detect restored wallets).

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -108,6 +108,8 @@ CTxMemPool mempool(::minRelayTxFee);
 
 std::map<uint256, int64_t> mapRejectedBlocks;
 
+CMoneySupply MoneySupply;
+
 static void CheckBlockIndex();
 
 /** Constant stuff for coinbase transactions we create: */

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1801,7 +1801,7 @@ bool static FlushStateToDisk(CValidationState& state, FlushStateMode mode)
                 return AbortNode(state, "Failed to write to coin database");
             nLastFlush = nNow;
             // Update money supply on memory, reading data from disk
-            if (!ShutdownRequested()) {
+            if (!ShutdownRequested() && !IsInitialBlockDownload()) {
                 MoneySupply.Update(pcoinsTip->GetTotalAmount(), chainActive.Height());
             }
         }

--- a/src/validation.h
+++ b/src/validation.h
@@ -20,6 +20,7 @@
 #include "coins.h"
 #include "consensus/validation.h"
 #include "fs.h"
+#include "moneysupply.h"
 #include "script/script_error.h"
 #include "sync.h"
 #include "txmempool.h"
@@ -150,6 +151,8 @@ extern bool fLargeWorkForkFound;
 extern bool fLargeWorkInvalidChainFound;
 
 extern std::map<uint256, int64_t> mapRejectedBlocks;
+
+extern CMoneySupply MoneySupply;
 
 /** Best header we've seen so far (used for getheaders queries' starting points). */
 extern CBlockIndex* pindexBestHeader;

--- a/test/functional/mining_pos_reorg.py
+++ b/test/functional/mining_pos_reorg.py
@@ -52,12 +52,15 @@ class ReorgStakeTest(PivxTestFramework):
         return wi['balance'] + wi['immature_balance']
 
     def check_money_supply(self, expected_piv, expected_zpiv):
-        g_info = [self.nodes[i].getinfo() for i in range(self.num_nodes)]
         # verify that nodes have the expected PIV and zPIV supply
-        for node in g_info:
-            assert_equal(node['moneysupply'], DecimalAmt(expected_piv))
-            for denom in node['zPIVsupply']:
-                assert_equal(node['zPIVsupply'][denom], DecimalAmt(expected_zpiv[denom]))
+        piv_supply = [self.nodes[i].getsupplyinfo(True)['supply']
+                      for i in range(self.num_nodes)]
+        assert_equal(piv_supply, [DecimalAmt(expected_piv)] * self.num_nodes)
+        zpiv_supply = [self.nodes[i].getinfo()['zPIVsupply']
+                       for i in range(self.num_nodes)]
+        for s in zpiv_supply:
+            for denom in s:
+                assert_equal(s[denom], DecimalAmt(expected_zpiv[denom]))
 
 
     def run_test(self):


### PR DESCRIPTION
With #1878 the RPC call `getinfo` becomes awfully slow (it triggers a flush of the chainstate to disk and recalculates the amount).

In this PR we introduce a in-memory global object (instance of a dumb storage class) to cache the money supply, as well as the height of the chain when it was last updated.
The cache is updated in 3 cases:
- at startup
- after periodic full flushes to disk (blocks and chainstate), except during shutdown or IBD
- on-demand via RPC (see below)

A new RPC `getsupplyinfo` is introduced. It returns the contents of the cached object, after an optional flush/recalculation (if the `forceupdate` argument is set to true).

The money supply is still part of `getinfo` output, for backward compatibility, but the fetching is redirected to the new `getsupplyinfo` (with default value, false, for the `forceupdate` argument, thus without flush/recalculation).

Examples:
```
> getblockcount
2542258

> getsupplyinfo
{
  "updateheight": 2542240,
  "supply": 64090963.91257160
}

> getinfo
{
  ...
  "moneysupply": 64090963.91257160
  ...
}

> getmoneysupplyinfo true
{
  "updateheight": 2542258,
  "supply": 64091053.91230406
}

> getinfo
{
  ...
  "moneysupply": 64091053.91230406
  ...
}
```

Based on top of
- [x] #1878

Starts with `[Core] Introduce CMoneySupply class` (65547579d157c5e42b69bd3f53647be21651c496)