### PR TITLE
[Core] Add reindex-chainstate startup option

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -417,6 +417,7 @@ std::string HelpMessage(HelpMessageMode mode)
 #ifndef WIN32
     strUsage += HelpMessageOpt("-pid=<file>", strprintf(_("Specify pid file (default: %s)"), PIVX_PID_FILENAME));
 #endif
+    strUsage += HelpMessageOpt("-reindex-chainstate", _("Rebuild chain state from the currently indexed blocks"));
     strUsage += HelpMessageOpt("-reindex", _("Rebuild block chain index from current blk000??.dat files") + " " + _("on startup"));
     strUsage += HelpMessageOpt("-resync", _("Delete blockchain folders and resync from scratch") + " " + _("on startup"));
 #if !defined(WIN32)
@@ -1456,6 +1457,7 @@ bool AppInit2()
     // ********************************************************* Step 7: load block chain
 
     fReindex = GetBoolArg("-reindex", false);
+    bool fReindexChainState = GetBoolArg("-reindex-chainstate", false);
 
     // Create blocks directory if it doesn't already exist
     fs::create_directories(GetDataDir() / "blocks");
@@ -1498,7 +1500,7 @@ bool AppInit2()
                 pSporkDB = new CSporkDB(0, false, false);
 
                 pblocktree = new CBlockTreeDB(nBlockTreeDBCache, false, fReindex);
-                pcoinsdbview = new CCoinsViewDB(nCoinDBCache, false, fReindex);
+                pcoinsdbview = new CCoinsViewDB(nCoinDBCache, false, fReindex || fReindexChainState);
                 pcoinscatcher = new CCoinsViewErrorCatcher(pcoinsdbview);
                 pcoinsTip = new CCoinsViewCache(pcoinscatcher);
 
@@ -1544,7 +1546,7 @@ bool AppInit2()
 
                 // Check for changed -txindex state
                 if (fTxIndex != GetBoolArg("-txindex", DEFAULT_TXINDEX)) {
-                    strLoadError = _("You need to rebuild the database using -reindex to change -txindex");
+                    strLoadError = _("You need to rebuild the database using -reindex-chainstate to change -txindex");
                     break;
                 }
 

--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -19,19 +19,25 @@ class ReindexTest(PivxTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 1
 
-    def reindex(self):
+    def reindex(self, justchainstate=False):
         self.nodes[0].generate(3)
         blockcount = self.nodes[0].getblockcount()
         self.stop_nodes()
+        self.log.info("Stopping node...")
         time.sleep(5)
-        extra_args = [["-reindex", "-checkblockindex=1"]]
+        extra_args = [["-reindex-chainstate" if justchainstate else "-reindex", "-checkblockindex=1"]]
+        self.log.info("Reindexing %s [block count: %d]" % (
+            "chainstate" if justchainstate else "blocks", blockcount))
         self.start_nodes(extra_args)
         time.sleep(15)
         wait_until(lambda: self.nodes[0].getblockcount() == blockcount)
         self.log.info("Success")
 
     def run_test(self):
-        self.reindex()
+        self.reindex(False)
+        self.reindex(True)
+        self.reindex(False)
+        self.reindex(True)
 
 if __name__ == '__main__':
     ReindexTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -61,6 +61,7 @@ BASE_SCRIPTS= [
 
     # vv Tests less than 5m vv
     'wallet_zapwallettxes.py',                  # ~ 300 sec
+    'feature_reindex.py',                       # ~ 290 sec
     'p2p_time_offset.py',                       # ~ 267 sec
     'rpc_fundrawtransaction.py',                # ~ 260 sec
     'mining_pos_coldStaking.py',                # ~ 215 sec
@@ -84,7 +85,6 @@ BASE_SCRIPTS= [
     'p2p_disconnect_ban.py',                    # ~ 118 sec
     'wallet_listreceivedby.py',                 # ~ 117 sec
     'mining_pos_fakestake.py',                  # ~ 113 sec
-    'feature_reindex.py',                       # ~ 110 sec
     'interface_http.py',                        # ~ 105 sec
     'wallet_listtransactions.py',               # ~ 97 sec
     'mempool_reorg.py',                         # ~ 92 sec


### PR DESCRIPTION
Extracted from #1864 
Implements `--reindex-chainstate` startup flag, to throw out and reindex only the chainstate, keeping the block index.