### PR TITLE
[Bug][RPC] Guard RPC server during warm-up

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -138,12 +138,6 @@ UniValue getinfo(const JSONRPCRequest& request)
     obj.pushKV("difficulty", (double)GetDifficulty());
     obj.pushKV("testnet", Params().NetworkID() == CBaseChainParams::TESTNET);
 
-    // During inital block verification chainActive.Tip() might be not yet initialized
-    if (chainActive.Tip() == NULL) {
-        obj.pushKV("status", "Blockchain information not yet available");
-        return obj;
-    }
-
     FlushStateToDisk();
     obj.pushKV("moneysupply",ValueFromAmount(pcoinsTip->GetTotalAmount()));
     UniValue zpivObj(UniValue::VOBJ);

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -566,6 +566,12 @@ std::string JSONRPCExecBatch(const UniValue& vReq)
 
 UniValue CRPCTable::execute(const JSONRPCRequest &request) const
 {
+    // Return immediately if in warmup
+    std::string strWarmupStatus;
+    if (RPCIsInWarmup(&strWarmupStatus)) {
+        throw JSONRPCError(RPC_IN_WARMUP, "RPC in warm-up: " + strWarmupStatus);
+    }
+
     // Find method
     const CRPCCommand* pcmd = tableRPC[request.strMethod];
     if (!pcmd)


### PR DESCRIPTION
**Problem**:
Most RPC commands crash the wallet during the initialization phase.

**Solution**:
An attempt to fix this specifically for `getinfo` was made in #543, checking the existence of `chainActive.Tip()`.
A better solution, instead of checking all places that try to access the block index, (or  the chainstate, or the second layer maps, etc...), is to throw a JSON-RPC exception with any call, if the server is still in warm-up phase (returning the exact init message), directly from `CRPCTable::execute`.

Closes #1908