### PR TITLE
[Validation] v8 blocks, Sapling merkle tree inclusion.

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -67,6 +67,7 @@ const CBlockIndex* CChain::FindFork(const CBlockIndex* pindex) const
 CBlockIndex::CBlockIndex(const CBlock& block):
         nVersion{block.nVersion},
         hashMerkleRoot{block.hashMerkleRoot},
+        hashFinalSaplingRoot(block.hashFinalSaplingRoot),
         nTime{block.nTime},
         nBits{block.nBits},
         nNonce{block.nNonce}
@@ -115,6 +116,7 @@ CBlockHeader CBlockIndex::GetBlockHeader() const
     block.nBits = nBits;
     block.nNonce = nNonce;
     if (nVersion > 3 && nVersion < 7) block.nAccumulatorCheckpoint = nAccumulatorCheckpoint;
+    if (nVersion >= 8) block.hashFinalSaplingRoot = hashFinalSaplingRoot;
     return block;
 }
 

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -239,6 +239,20 @@ uint256 CBlockIndex::GetStakeModifierV2() const
     return nStakeModifier;
 }
 
+void CBlockIndex::SetChainSaplingValue()
+{
+    // Sapling, update chain value
+    if (pprev) {
+        if (pprev->nChainSaplingValue) {
+            nChainSaplingValue = *pprev->nChainSaplingValue + nSaplingValue;
+        } else {
+            nChainSaplingValue = nullopt;
+        }
+    } else {
+        nChainSaplingValue = nSaplingValue;
+    }
+}
+
 //! Check whether this block index entry is valid up to the passed validity level.
 bool CBlockIndex::IsValid(enum BlockStatus nUpTo) const
 {

--- a/src/chain.h
+++ b/src/chain.h
@@ -230,6 +230,7 @@ public:
     //! block header
     int nVersion{0};
     uint256 hashMerkleRoot{};
+    uint256 hashFinalSaplingRoot{};
     unsigned int nTime{0};
     unsigned int nBits{0};
     unsigned int nNonce{0};
@@ -288,7 +289,6 @@ public:
 // New serialization introduced with 4.0.99
 static const int DBI_OLD_SER_VERSION = 4009900;
 static const int DBI_SER_VERSION_NO_ZC = 4009902;   // removes mapZerocoinSupply, nMoneySupply
-static const int DBI_SER_VERSION_SAPLING = 4009903;   // adds Sapling block values: nSaplingValue
 
 class CDiskBlockIndex : public CBlockIndex
 {
@@ -337,10 +337,9 @@ public:
             if(this->nVersion > 3 && this->nVersion < 7)
                 READWRITE(nAccumulatorCheckpoint);
 
-
-            // Only read/write nSaplingValue if the client version used to create
-            // this index was storing them.
-            if (nSerVersion >= DBI_SER_VERSION_SAPLING) {
+            // Sapling blocks
+            if (this->nVersion >= 8) {
+                READWRITE(hashFinalSaplingRoot);
                 READWRITE(nSaplingValue);
             }
 
@@ -414,6 +413,8 @@ public:
         block.nNonce = nNonce;
         if (nVersion > 3 && nVersion < 7)
             block.nAccumulatorCheckpoint = nAccumulatorCheckpoint;
+        if (nVersion >= 8)
+            block.hashFinalSaplingRoot = hashFinalSaplingRoot;
         return block.GetHash();
     }
 

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -36,12 +36,13 @@ uint256 CBlockHeader::GetHash() const
 std::string CBlock::ToString() const
 {
     std::stringstream s;
-    s << strprintf("CBlock(hash=%s, ver=%d, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, vtx=%u)\n",
+    s << strprintf("CBlock(hash=%s, ver=%d, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, hashFinalSaplingRoot=%s, vtx=%u)\n",
         GetHash().ToString(),
         nVersion,
         hashPrevBlock.ToString(),
         hashMerkleRoot.ToString(),
         nTime, nBits, nNonce,
+        hashFinalSaplingRoot.ToString(),
         vtx.size());
     for (unsigned int i = 0; i < vtx.size(); i++)
     {

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -31,6 +31,7 @@ public:
     uint32_t nBits;
     uint32_t nNonce;
     uint256 nAccumulatorCheckpoint;             // only for version 4, 5 and 6.
+    uint256 hashFinalSaplingRoot;               // only for version 8
 
     CBlockHeader()
     {
@@ -51,6 +52,10 @@ public:
         //zerocoin active, header changes to include accumulator checksum
         if(nVersion > 3 && nVersion < 7)
             READWRITE(nAccumulatorCheckpoint);
+
+        // Sapling active
+        if (nVersion >= 8)
+            READWRITE(hashFinalSaplingRoot);
     }
 
     void SetNull()
@@ -62,6 +67,7 @@ public:
         nBits = 0;
         nNonce = 0;
         nAccumulatorCheckpoint.SetNull();
+        hashFinalSaplingRoot.SetNull();
     }
 
     bool IsNull() const
@@ -130,6 +136,8 @@ public:
         block.nNonce         = nNonce;
         if(nVersion > 3 && nVersion < 7)
             block.nAccumulatorCheckpoint = nAccumulatorCheckpoint;
+        if (nVersion >= 8)
+            block.hashFinalSaplingRoot   = hashFinalSaplingRoot;
         return block;
     }
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1206,7 +1206,7 @@ UniValue invalidateblock(const JSONRPCRequest& request)
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
 
         CBlockIndex* pblockindex = mapBlockIndex[hash];
-        InvalidateBlock(state, pblockindex);
+        InvalidateBlock(state, Params(), pblockindex);
     }
 
     if (state.IsValid()) {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -128,6 +128,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     result.pushKV("version", block.nVersion);
     result.pushKV("merkleroot", block.hashMerkleRoot.GetHex());
     result.pushKV("acc_checkpoint", block.nAccumulatorCheckpoint.GetHex());
+    result.pushKV("finalsaplingroot", block.hashFinalSaplingRoot.GetHex());
     UniValue txs(UniValue::VARR);
     for (const auto& txIn : block.vtx) {
         const CTransaction& tx = *txIn;
@@ -502,6 +503,7 @@ UniValue getblock(const JSONRPCRequest& request)
             "  \"height\" : n,          (numeric) The block height or index\n"
             "  \"version\" : n,         (numeric) The block version\n"
             "  \"merkleroot\" : \"xxxx\", (string) The merkle root\n"
+            "  \"finalsaplingroot\" : \"xxxx\", (string) The root of the Sapling commitment tree after applying this block\n"
             "  \"tx\" : [               (array of string) The transaction ids\n"
             "     \"transactionid\"     (string) The transaction id\n"
             "     ,...\n"

--- a/src/swifttx.cpp
+++ b/src/swifttx.cpp
@@ -119,7 +119,7 @@ void ProcessMessageSwiftTX(CNode* pfrom, std::string& strCommand, CDataStream& v
                         LogPrintf("%s : Found Existing Complete IX Lock\n", __func__);
 
                         //reprocess the last 15 blocks
-                        ReprocessBlocks(15);
+                        ReprocessBlocks(15, Params());
                         mapTxLockReq.emplace(tx.GetHash(), tx);
                     }
                 }
@@ -391,7 +391,7 @@ bool ProcessConsensusVote(CNode* pnode, CConsensusVote& ctx)
                 //if this tx lock was rejected, we need to remove the conflicting blocks
                 if (mapTxLockReqRejected.count((*i).second.txHash)) {
                     //reprocess the last 15 blocks
-                    ReprocessBlocks(15);
+                    ReprocessBlocks(15, Params());
                 }
             }
         }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -278,6 +278,10 @@ bool CBlockTreeDB::LoadBlockIndexGuts(boost::function<CBlockIndex*(const uint256
                 pindexNew->nStatus = diskindex.nStatus;
                 pindexNew->nTx = diskindex.nTx;
 
+                // sapling
+                pindexNew->nSaplingValue  = diskindex.nSaplingValue;
+                pindexNew->hashFinalSaplingRoot = diskindex.hashFinalSaplingRoot;
+
                 //zerocoin
                 pindexNew->nAccumulatorCheckpoint = diskindex.nAccumulatorCheckpoint;
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -323,8 +323,8 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex);
 bool DisconnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex, CCoinsViewCache& coins, bool* pfClean = NULL);
 
 /** Reprocess a number of blocks to try and get on the correct chain again **/
-bool DisconnectBlocks(int nBlocks);
-void ReprocessBlocks(int nBlocks);
+bool DisconnectBlocks(int nBlocks, const CChainParams& chainparams);
+void ReprocessBlocks(int nBlocks, const CChainParams& chainparams);
 
 /** Apply the effects of this block (with given index) on the UTXO set represented by coins */
 bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pindex, CCoinsViewCache& coins, bool fJustCheck, bool fAlreadyChecked = false);
@@ -359,7 +359,7 @@ public:
 CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& locator);
 
 /** Mark a block as invalid. */
-bool InvalidateBlock(CValidationState& state, CBlockIndex* pindex);
+bool InvalidateBlock(CValidationState& state, const CChainParams& chainparams, CBlockIndex* pindex);
 
 /** Remove invalidity status from a block and its descendants. */
 bool ReconsiderBlock(CValidationState& state, CBlockIndex* pindex);

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -17,6 +17,7 @@ void RegisterValidationInterface(CValidationInterface* pwalletIn)
 {
     g_signals.UpdatedBlockTip.connect(boost::bind(&CValidationInterface::UpdatedBlockTip, pwalletIn, _1, _2, _3));
     g_signals.SyncTransaction.connect(boost::bind(&CValidationInterface::SyncTransaction, pwalletIn, _1, _2, _3));
+    g_signals.ChainTip.connect(boost::bind(&CValidationInterface::ChainTip, pwalletIn, _1, _2, _3));
     g_signals.NotifyTransactionLock.connect(boost::bind(&CValidationInterface::NotifyTransactionLock, pwalletIn, _1));
     g_signals.UpdatedTransaction.connect(boost::bind(&CValidationInterface::UpdatedTransaction, pwalletIn, _1));
     g_signals.SetBestChain.connect(boost::bind(&CValidationInterface::SetBestChain, pwalletIn, _1));
@@ -34,6 +35,7 @@ void UnregisterValidationInterface(CValidationInterface* pwalletIn)
     g_signals.UpdatedTransaction.disconnect(boost::bind(&CValidationInterface::UpdatedTransaction, pwalletIn, _1));
     g_signals.NotifyTransactionLock.disconnect(boost::bind(&CValidationInterface::NotifyTransactionLock, pwalletIn, _1));
     g_signals.SyncTransaction.disconnect(boost::bind(&CValidationInterface::SyncTransaction, pwalletIn, _1, _2, _3));
+    g_signals.ChainTip.disconnect(boost::bind(&CValidationInterface::ChainTip, pwalletIn, _1, _2, _3));
     g_signals.UpdatedBlockTip.disconnect(boost::bind(&CValidationInterface::UpdatedBlockTip, pwalletIn, _1, _2, _3));
 }
 
@@ -46,5 +48,6 @@ void UnregisterAllValidationInterfaces()
     g_signals.UpdatedTransaction.disconnect_all_slots();
     g_signals.NotifyTransactionLock.disconnect_all_slots();
     g_signals.SyncTransaction.disconnect_all_slots();
+    g_signals.ChainTip.disconnect_all_slots();
     g_signals.UpdatedBlockTip.disconnect_all_slots();
 }

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -7,6 +7,9 @@
 #ifndef BITCOIN_VALIDATIONINTERFACE_H
 #define BITCOIN_VALIDATIONINTERFACE_H
 
+#include "optional.h"
+#include "sapling/incrementalmerkletree.hpp"
+
 #include <boost/signals2/signal.hpp>
 #include <boost/shared_ptr.hpp>
 
@@ -33,6 +36,7 @@ class CValidationInterface {
 protected:
     virtual void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) {}
     virtual void SyncTransaction(const CTransaction &tx, const CBlockIndex *pindex, int posInBlock) {}
+    virtual void ChainTip(const CBlockIndex *pindex, const CBlock *pblock, Optional<SaplingMerkleTree> added) {}
     virtual void NotifyTransactionLock(const CTransaction &tx) {}
     virtual void SetBestChain(const CBlockLocator &locator) {}
     virtual bool UpdatedTransaction(const uint256 &hash) { return false;}
@@ -64,6 +68,9 @@ struct CMainSignals {
     boost::signals2::signal<void (const CBlock&, const CValidationState&)> BlockChecked;
     /** Notifies listeners that a block has been successfully mined */
     boost::signals2::signal<void (const uint256 &)> BlockFound;
+
+    /** Notifies listeners of a change to the tip of the active block chain. */
+    boost::signals2::signal<void (const CBlockIndex *, const CBlock *, Optional<SaplingMerkleTree>)> ChainTip;
 };
 
 CMainSignals& GetMainSignals();


### PR DESCRIPTION
Another decoupling from #1798, built on top of #1903 and #1915.

Containing three topics:

1) Sapling merkle tree root hash inclusion in the block header.
   * Block version bumped to v8.
   * Miner crafting the new merkle tree root hash and setting it into the block.

2) Track network total value entering and exiting the shielded pool. (*)
   * Similar to the previous, initial, zc failsafe flow. (this can be done much better, like we did with zerocoin supply)
   * Block negative shielded value pool balances. -- Network validation consensus rule --

3) ChainTip signal implemented.
   * Signal to notify the listeners (wallet) about new blocks (or chain reorgs), broadcasting the new block and the current merkle tree so the listener can build upon it. -- Not connected to anything yet --

#### This PR is including the following commits decoupled from #1798.

* Track net value entering and exiting the Sapling circuit.—> 8dd2045034b146d68eb6ef592433348852d54edd
* Block: header hashFinalSaplingRoot inclusion.—> 5f55a76bd303e21ed31e1947eb12d44a999f667f
* Sapling: missing nSaplingValue in LoadBlockIndexGuts added.—> fbe07613cf296ccc3f0a1b55f0015e86e2ff3d39
* Miner: sapling tree hash connection.—> cb88fae28eaa760c7feb00ab5ccd6f1cb8e6db15
* Implement ChainTip signal. —> 4e96e6c97d258c87910d2e9ab13cbb79c25ebda5
* Signal ChainTip in ConnectTip and DisconnectTip methods —> 85f4435b4076c8d4c8e222a0e0d7b8f76465be63
* Pass chainparams as argument in DisconnectTip, InvalidateBlock, ReprocessBlocks, DisconnectBlocks, DisconnectTip —> 1c809536b862e59554dc9ebee8651c56935a0f9a
* Do not try to update tree anchor and witnesses if sapling is not active --> 1c64497d4f020d6c400c7aa836f75dce7d1517d4
* Validation: Adapted the cached incremental witnesses update flow to the syncTransaction changes. —> 6e6372df9270dba2f76836d5b964c2153e28bda6