### PR TITLE
[Sapling] Sapling transaction: builder, sapData net validation and builder unit tests coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -453,6 +453,7 @@ set(SAPLING_SOURCES
         ./src/sapling/zip32.cpp
         ./src/sapling/crypter_sapling.cpp
         ./src/sapling/incrementalmerkletree.cpp
+        ./src/sapling/transaction_builder.cpp
         ./src/sapling/saplingscriptpubkeyman.cpp
         )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,7 @@ set(SERVER_SOURCES
         ./src/torcontrol.cpp
         ./src/txdb.cpp
         ./src/txmempool.cpp
+        ./src/sapling/sapling_validation.cpp
         ./src/validation.cpp
         ./src/validationinterface.cpp
         ./src/zpivchain.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -202,6 +202,7 @@ BITCOIN_CORE_H = \
   limitedmap.h \
   logging.h \
   legacy/validation_zerocoin_legacy.h \
+  sapling/sapling_validation.h \
   memusage.h \
   masternode.h \
   masternode-payments.h \
@@ -314,6 +315,7 @@ libbitcoin_server_a_SOURCES = \
   init.cpp \
   dbwrapper.cpp \
   legacy/validation_zerocoin_legacy.cpp \
+  sapling/sapling_validation.cpp \
   merkleblock.cpp \
   miner.cpp \
   net.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -137,7 +137,8 @@ LIBSAPLING_H = \
   sapling/saplingscriptpubkeyman.h \
   sapling/proof.hpp \
   sapling/sapling_transaction.h \
-  sapling/incrementalmerkletree.hpp
+  sapling/incrementalmerkletree.hpp \
+  sapling/transaction_builder.h
 
 .PHONY: FORCE cargo-build check-symbols check-security
 # pivx core #
@@ -551,7 +552,8 @@ libsapling_a_SOURCES = \
   sapling/crypter_sapling.cpp \
   sapling/saplingscriptpubkeyman.cpp \
   sapling/proof.cpp \
-  sapling/incrementalmerkletree.cpp
+  sapling/incrementalmerkletree.cpp \
+  sapling/transaction_builder.cpp
 
 if GLIBC_BACK_COMPAT
 libsapling_a_SOURCES += compat/glibc_compat.cpp

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -33,7 +33,9 @@ BITCOIN_TEST_SUITE = \
   test/test_pivx.cpp \
   test/librust/json_test_vectors.h \
   test/librust/sapling_test_fixture.h \
-  test/librust/sapling_test_fixture.cpp
+  test/librust/sapling_test_fixture.cpp \
+  test/librust/utiltest.h \
+  test/librust/utiltest.cpp
 
 if ENABLE_WALLET
 BITCOIN_TEST_SUITE += \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -60,6 +60,7 @@ BITCOIN_TESTS =\
   test/librust/zip32_tests.cpp \
   test/librust/wallet_zkeys_tests.cpp \
   test/librust/merkletree_tests.cpp \
+  test/librust/transaction_builder_tests.cpp \
   test/base32_tests.cpp \
   test/base58_tests.cpp \
   test/base64_tests.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -31,7 +31,9 @@ GENERATED_TEST_FILES = $(JSON_TEST_FILES:.json=.json.h) $(RAW_TEST_FILES:.raw=.r
 BITCOIN_TEST_SUITE = \
   test/test_pivx.h \
   test/test_pivx.cpp \
-  test/librust/json_test_vectors.h
+  test/librust/json_test_vectors.h \
+  test/librust/sapling_test_fixture.h \
+  test/librust/sapling_test_fixture.cpp
 
 if ENABLE_WALLET
 BITCOIN_TEST_SUITE += \

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -156,7 +156,7 @@ CTransaction::CTransaction(const CMutableTransaction &tx) : nVersion(tx.nVersion
     UpdateHash();
 }
 
-CTransaction::CTransaction(CMutableTransaction &&tx) : nVersion(tx.nVersion), vin(std::move(tx.vin)), vout(std::move(tx.vout)), nLockTime(tx.nLockTime) {
+CTransaction::CTransaction(CMutableTransaction &&tx) : nVersion(tx.nVersion), vin(std::move(tx.vin)), vout(std::move(tx.vout)), nLockTime(tx.nLockTime), sapData(tx.sapData) {
     UpdateHash();
 }
 

--- a/src/sapling/sapling_validation.cpp
+++ b/src/sapling/sapling_validation.cpp
@@ -1,0 +1,162 @@
+// Copyright (c) 2016-2020 The ZCash developers
+// Copyright (c) 2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include "sapling/sapling_validation.h"
+
+#include "consensus/consensus.h" // for MAX_BLOCK_SIZE_CURRENT
+#include "validation.h" // for MAX_ZEROCOIN_TX_SIZE
+#include "script/interpreter.h" // for SigHash
+#include "consensus/validation.h" // for CValidationState
+#include "util.h" // for error()
+#include "consensus/upgrades.h" // for CurrentEpochBranchId()
+
+#include <librustzcash.h>
+
+namespace SaplingValidation {
+
+/**
+* Check a transaction contextually against a set of consensus rules valid at a given block height.
+*
+* Notes:
+* 1. AcceptToMemoryPool calls CheckTransaction and this function.
+* 2. ProcessNewBlock calls AcceptBlock, which calls CheckBlock (which calls CheckTransaction)
+*    and ContextualCheckBlock (which calls this function).
+* 3. For consensus rules that relax restrictions (where a transaction that is invalid at
+*    nHeight can become valid at a later height), we make the bans conditional on not
+*    being in Initial Block Download mode.
+* 4. The isInitBlockDownload argument is a function parameter to assist with testing.
+*
+* todo: For now, this is NOT connected, only used in unit tests.
+*/
+bool ContextualCheckTransaction(
+        const CTransaction& tx,
+        CValidationState &state,
+        const CChainParams& chainparams,
+        const int nHeight,
+        const bool isMined,
+        bool isInitBlockDownload)
+{
+    const int DOS_LEVEL_BLOCK = 100;
+    // DoS level set to 10 to be more forgiving.
+    const int DOS_LEVEL_MEMPOOL = 10;
+
+    // For constricting rules, we don't need to account for IBD mode.
+    auto dosLevelConstricting = isMined ? DOS_LEVEL_BLOCK : DOS_LEVEL_MEMPOOL;
+    // For rules that are relaxing (or might become relaxing when a future
+    // network upgrade is implemented), we need to account for IBD mode.
+    auto dosLevelPotentiallyRelaxing = isMined ? DOS_LEVEL_BLOCK : (
+            isInitBlockDownload ? 0 : DOS_LEVEL_MEMPOOL);
+
+    // If Sapling is not active return quickly
+    if (!chainparams.GetConsensus().NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V5_DUMMY)) {
+        return state.DoS(
+                dosLevelConstricting,
+                error("%s: Sapling not active", __func__ ),
+                REJECT_INVALID, "bad-tx-sapling-not-active");
+    }
+
+    // Reject transactions with invalid version
+    if (tx.nVersion < CTransaction::SAPLING_VERSION ) {
+        return state.DoS(
+                dosLevelConstricting,
+                error("%s: Sapling version too low", __func__ ),
+                REJECT_INVALID, "bad-tx-sapling-version-too-low");
+    }
+
+    // Reject transactions with invalid version
+    if (tx.nVersion > CTransaction::SAPLING_VERSION ) {
+        return state.DoS(
+                dosLevelPotentiallyRelaxing,
+                error("%s: Sapling version too high", __func__),
+                REJECT_INVALID, "bad-tx-sapling-version-too-high");
+    }
+
+    // Size limits
+    BOOST_STATIC_ASSERT(MAX_BLOCK_SIZE_CURRENT > MAX_ZEROCOIN_TX_SIZE); // sanity
+    if (::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION) > MAX_ZEROCOIN_TX_SIZE)
+        return state.DoS(
+                dosLevelPotentiallyRelaxing,
+                error("%s: size limits failed", __func__ ),
+                REJECT_INVALID, "bad-txns-oversize");
+
+    bool hasShieldedData = tx.hasSaplingData();
+    // A coinbase/coinstake transaction cannot have output descriptions nor shielded spends
+    if (tx.IsCoinBase() || tx.IsCoinStake()) {
+        if (hasShieldedData)
+            return state.DoS(
+                    dosLevelPotentiallyRelaxing,
+                    error("%s: coinbase/coinstake has output/spend descriptions", __func__ ),
+                    REJECT_INVALID, "bad-cs-has-shielded-data");
+    }
+
+    if (hasShieldedData) {
+        uint256 dataToBeSigned;
+        // Empty output script.
+        CScript scriptCode;
+        try {
+            dataToBeSigned = SignatureHash(scriptCode, tx, NOT_AN_INPUT, SIGHASH_ALL, 0, SIGVERSION_SAPLING);
+        } catch (const std::logic_error& ex) {
+            // A logic error should never occur because we pass NOT_AN_INPUT and
+            // SIGHASH_ALL to SignatureHash().
+            return state.DoS(100, error("%s: error computing signature hash", __func__ ),
+                             REJECT_INVALID, "error-computing-signature-hash");
+        }
+
+        // Sapling verification process
+        auto ctx = librustzcash_sapling_verification_ctx_init();
+
+        for (const SpendDescription &spend : tx.sapData->vShieldedSpend) {
+            if (!librustzcash_sapling_check_spend(
+                    ctx,
+                    spend.cv.begin(),
+                    spend.anchor.begin(),
+                    spend.nullifier.begin(),
+                    spend.rk.begin(),
+                    spend.zkproof.begin(),
+                    spend.spendAuthSig.begin(),
+                    dataToBeSigned.begin())) {
+                librustzcash_sapling_verification_ctx_free(ctx);
+                return state.DoS(
+                        dosLevelPotentiallyRelaxing,
+                        error("%s: Sapling spend description invalid", __func__ ),
+                        REJECT_INVALID, "bad-txns-sapling-spend-description-invalid");
+            }
+        }
+
+        for (const OutputDescription &output : tx.sapData->vShieldedOutput) {
+            if (!librustzcash_sapling_check_output(
+                    ctx,
+                    output.cv.begin(),
+                    output.cmu.begin(),
+                    output.ephemeralKey.begin(),
+                    output.zkproof.begin())) {
+                librustzcash_sapling_verification_ctx_free(ctx);
+                // This should be a non-contextual check, but we check it here
+                // as we need to pass over the outputs anyway in order to then
+                // call librustzcash_sapling_final_check().
+                return state.DoS(100, error("%s: Sapling output description invalid", __func__ ),
+                                 REJECT_INVALID, "bad-txns-sapling-output-description-invalid");
+            }
+        }
+
+        if (!librustzcash_sapling_final_check(
+                ctx,
+                tx.sapData->valueBalance,
+                tx.sapData->bindingSig.begin(),
+                dataToBeSigned.begin())) {
+            librustzcash_sapling_verification_ctx_free(ctx);
+            return state.DoS(
+                    dosLevelPotentiallyRelaxing,
+                    error("%s: Sapling binding signature invalid", __func__ ),
+                    REJECT_INVALID, "bad-txns-sapling-binding-signature-invalid");
+        }
+
+        librustzcash_sapling_verification_ctx_free(ctx);
+    }
+    return true;
+}
+
+
+} // End SaplingValidation namespace

--- a/src/sapling/sapling_validation.h
+++ b/src/sapling/sapling_validation.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2020 The ZCash developers
+// Copyright (c) 2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef PIVX_SAPLING_VALIDATION_H
+#define PIVX_SAPLING_VALIDATION_H
+
+#include "chainparams.h"
+
+class CTransaction;
+class CValidationState;
+
+namespace SaplingValidation {
+
+/** Check a transaction contextually against a set of consensus rules */
+bool ContextualCheckTransaction(const CTransaction &tx, CValidationState &state,
+                                const CChainParams &chainparams, int nHeight, bool isMined,
+                                bool sInitBlockDownload);
+
+}; // End SaplingValidation namespace
+
+#endif //PIVX_SAPLING_VALIDATION_H

--- a/src/sapling/transaction_builder.cpp
+++ b/src/sapling/transaction_builder.cpp
@@ -1,0 +1,346 @@
+// Copyright (c) 2018-2020 The Zcash developers
+// Copyright (c) 2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+#include "sapling/transaction_builder.h"
+
+#include "script/sign.h"
+#include "utilmoneystr.h"
+#include "consensus/upgrades.h"
+
+#include <librustzcash.h>
+
+SpendDescriptionInfo::SpendDescriptionInfo(
+    libzcash::SaplingExpandedSpendingKey expsk,
+    libzcash::SaplingNote note,
+    uint256 anchor,
+    SaplingWitness witness) : expsk(expsk), note(note), anchor(anchor), witness(witness)
+{
+    librustzcash_sapling_generate_r(alpha.begin());
+}
+
+Optional<OutputDescription> OutputDescriptionInfo::Build(void* ctx) {
+    auto cmu = this->note.cmu();
+    if (!cmu) {
+        return nullopt;
+    }
+
+    libzcash::SaplingNotePlaintext notePlaintext(this->note, this->memo);
+
+    auto res = notePlaintext.encrypt(this->note.pk_d);
+    if (!res) {
+        return nullopt;
+    }
+    auto enc = res.get();
+    auto encryptor = enc.second;
+
+    libzcash::SaplingPaymentAddress address(this->note.d, this->note.pk_d);
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << address;
+    std::vector<unsigned char> addressBytes(ss.begin(), ss.end());
+
+    OutputDescription odesc;
+    if (!librustzcash_sapling_output_proof(
+            ctx,
+            encryptor.get_esk().begin(),
+            addressBytes.data(),
+            this->note.r.begin(),
+            this->note.value(),
+            odesc.cv.begin(),
+            odesc.zkproof.begin())) {
+        return nullopt;
+    }
+
+    odesc.cmu = *cmu;
+    odesc.ephemeralKey = encryptor.get_epk();
+    odesc.encCiphertext = enc.first;
+
+    libzcash::SaplingOutgoingPlaintext outPlaintext(this->note.pk_d, encryptor.get_esk());
+    odesc.outCiphertext = outPlaintext.encrypt(
+        this->ovk,
+        odesc.cv,
+        odesc.cmu,
+        encryptor);
+
+    return odesc;
+}
+
+TransactionBuilderResult::TransactionBuilderResult(const CTransaction& tx) : maybeTx(tx) {}
+
+TransactionBuilderResult::TransactionBuilderResult(const std::string& error) : maybeError(error) {}
+
+bool TransactionBuilderResult::IsTx() { return maybeTx != nullopt; }
+
+bool TransactionBuilderResult::IsError() { return maybeError != nullopt; }
+
+CTransaction TransactionBuilderResult::GetTxOrThrow() {
+    if (maybeTx) {
+        return maybeTx.get();
+    } else {
+        throw std::runtime_error("Failed to build transaction: " + GetError());
+    }
+}
+
+Optional<CTransaction> TransactionBuilderResult::GetTx() {
+    return maybeTx;
+}
+
+std::string TransactionBuilderResult::GetError() {
+    if (maybeError) {
+        return maybeError.get();
+    } else {
+        // This can only happen if isTx() is true in which case we should not call getError()
+        throw std::runtime_error("getError() was called in TransactionBuilderResult, but the result was not initialized as an error.");
+    }
+}
+
+// Set default values of new CMutableTransaction based on consensus rules at given height.
+CMutableTransaction CreateNewContextualCMutableTransaction(const Consensus::Params& consensusParams, int nHeight)
+{
+    CMutableTransaction mtx;
+    bool isSapling = consensusParams.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V5_DUMMY);
+    mtx.nVersion = isSapling ? CTransaction::SAPLING_VERSION : CTransaction::STANDARD_VERSION;
+    return mtx;
+}
+
+TransactionBuilder::TransactionBuilder(
+    const Consensus::Params& _consensusParams,
+    int _nHeight,
+    CKeyStore* _keystore) :
+    consensusParams(_consensusParams),
+    nHeight(_nHeight),
+    keystore(_keystore)
+{
+    mtx = CreateNewContextualCMutableTransaction(consensusParams, nHeight);
+}
+
+void TransactionBuilder::AddSaplingSpend(
+    libzcash::SaplingExpandedSpendingKey expsk,
+    libzcash::SaplingNote note,
+    uint256 anchor,
+    SaplingWitness witness)
+{
+    // Sanity check: cannot add Sapling spend to pre-Sapling transaction
+    if (mtx.nVersion < CTransaction::SAPLING_VERSION) {
+        throw std::runtime_error("TransactionBuilder cannot add Sapling spend to pre-Sapling transaction");
+    }
+
+    // Consistency check: all anchors must equal the first one
+    if (spends.size() > 0 && spends[0].anchor != anchor) {
+        throw std::runtime_error("Anchor does not match previously-added Sapling spends.");
+    }
+
+    spends.emplace_back(expsk, note, anchor, witness);
+    mtx.sapData->valueBalance += note.value();
+}
+
+void TransactionBuilder::AddSaplingOutput(
+    uint256 ovk,
+    libzcash::SaplingPaymentAddress to,
+    CAmount value,
+    std::array<unsigned char, ZC_MEMO_SIZE> memo)
+{
+    // Sanity check: cannot add Sapling output to pre-Sapling transaction
+    if (mtx.nVersion < CTransaction::SAPLING_VERSION) {
+        throw std::runtime_error("TransactionBuilder cannot add Sapling output to pre-Sapling transaction");
+    }
+
+    auto note = libzcash::SaplingNote(to, value);
+    outputs.emplace_back(ovk, note, memo);
+    mtx.sapData->valueBalance -= value;
+}
+
+void TransactionBuilder::AddTransparentInput(COutPoint utxo, CScript scriptPubKey, CAmount value)
+{
+    if (keystore == nullptr) {
+        throw std::runtime_error("Cannot add transparent inputs to a TransactionBuilder without a keystore");
+    }
+
+    mtx.vin.emplace_back(utxo);
+    tIns.emplace_back(scriptPubKey, value);
+}
+
+void TransactionBuilder::AddTransparentOutput(const CTxDestination& to, CAmount value)
+{
+    if (!IsValidDestination(to)) {
+        throw std::runtime_error("Invalid output address, not a valid taddr.");
+    }
+
+    CScript scriptPubKey = GetScriptForDestination(to);
+    CTxOut out(value, scriptPubKey);
+    mtx.vout.push_back(out);
+}
+
+void TransactionBuilder::SetFee(CAmount _fee)
+{
+    this->fee = _fee;
+}
+
+void TransactionBuilder::SendChangeTo(libzcash::SaplingPaymentAddress changeAddr, uint256 ovk)
+{
+    saplingChangeAddr = std::make_pair(ovk, changeAddr);
+    tChangeAddr = nullopt;
+}
+
+void TransactionBuilder::SendChangeTo(CTxDestination& changeAddr)
+{
+    if (!IsValidDestination(changeAddr)) {
+        throw std::runtime_error("Invalid change address, not a valid taddr.");
+    }
+
+    tChangeAddr = changeAddr;
+    saplingChangeAddr = nullopt;
+}
+
+TransactionBuilderResult TransactionBuilder::Build()
+{
+    //
+    // Consistency checks
+    //
+
+    // Valid change
+    CAmount change = mtx.sapData->valueBalance - fee;
+    for (auto& tIn : tIns) {
+        change += tIn.value;
+    }
+    for (auto& tOut : mtx.vout) {
+        change -= tOut.nValue;
+    }
+    if (change < 0) {
+        return TransactionBuilderResult("Change cannot be negative");
+    }
+
+    //
+    // Change output
+    //
+
+    if (change > 0) {
+        // Send change to the specified change address. If no change address
+        // was set, send change to the first Sapling address given as input
+        // (A t-address can only be used as the change address if explicitly set.)
+        if (saplingChangeAddr) {
+            AddSaplingOutput(saplingChangeAddr->first, saplingChangeAddr->second, change);
+        } else if (tChangeAddr) {
+            // tChangeAddr has already been validated.
+            AddTransparentOutput(tChangeAddr.value(), change);
+        } else if (!spends.empty()) {
+            auto fvk = spends[0].expsk.full_viewing_key();
+            auto note = spends[0].note;
+            libzcash::SaplingPaymentAddress changeAddr(note.d, note.pk_d);
+            AddSaplingOutput(fvk.ovk, changeAddr, change);
+        } else {
+            return TransactionBuilderResult("Could not determine change address");
+        }
+    }
+
+    //
+    // Sapling spends and outputs
+    //
+
+    auto ctx = librustzcash_sapling_proving_ctx_init();
+
+    // Create Sapling SpendDescriptions
+    for (auto spend : spends) {
+        auto cm = spend.note.cmu();
+        auto nf = spend.note.nullifier(
+            spend.expsk.full_viewing_key(), spend.witness.position());
+        if (!cm || !nf) {
+            librustzcash_sapling_proving_ctx_free(ctx);
+            return TransactionBuilderResult("Spend is invalid");
+        }
+
+        CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+        ss << spend.witness.path();
+        std::vector<unsigned char> witness(ss.begin(), ss.end());
+
+        SpendDescription sdesc;
+        if (!librustzcash_sapling_spend_proof(
+                ctx,
+                spend.expsk.full_viewing_key().ak.begin(),
+                spend.expsk.nsk.begin(),
+                spend.note.d.data(),
+                spend.note.r.begin(),
+                spend.alpha.begin(),
+                spend.note.value(),
+                spend.anchor.begin(),
+                witness.data(),
+                sdesc.cv.begin(),
+                sdesc.rk.begin(),
+                sdesc.zkproof.data())) {
+            librustzcash_sapling_proving_ctx_free(ctx);
+            return TransactionBuilderResult("Spend proof failed");
+        }
+
+        sdesc.anchor = spend.anchor;
+        sdesc.nullifier = *nf;
+        mtx.sapData->vShieldedSpend.push_back(sdesc);
+    }
+
+    // Create Sapling OutputDescriptions
+    for (auto output : outputs) {
+        // Check this out here as well to provide better logging.
+        if (!output.note.cmu()) {
+            librustzcash_sapling_proving_ctx_free(ctx);
+            return TransactionBuilderResult("Output is invalid");
+        }
+
+        auto odesc = output.Build(ctx);
+        if (!odesc) {
+            librustzcash_sapling_proving_ctx_free(ctx);
+            return TransactionBuilderResult("Failed to create output description");
+        }
+
+        mtx.sapData->vShieldedOutput.push_back(odesc.get());
+    }
+
+    //
+    // Signatures
+    //
+
+    // Empty output script.
+    uint256 dataToBeSigned;
+    CScript scriptCode;
+    try {
+        dataToBeSigned = SignatureHash(scriptCode, mtx, NOT_AN_INPUT, SIGHASH_ALL, 0, SIGVERSION_SAPLING);
+    } catch (const std::logic_error& ex) {
+        librustzcash_sapling_proving_ctx_free(ctx);
+        return TransactionBuilderResult("Could not construct signature hash: " + std::string(ex.what()));
+    }
+
+    // Create Sapling spendAuth and binding signatures
+    for (size_t i = 0; i < spends.size(); i++) {
+        librustzcash_sapling_spend_sig(
+            spends[i].expsk.ask.begin(),
+            spends[i].alpha.begin(),
+            dataToBeSigned.begin(),
+            mtx.sapData->vShieldedSpend[i].spendAuthSig.data());
+    }
+
+    librustzcash_sapling_binding_sig(
+        ctx,
+        mtx.sapData->valueBalance,
+        dataToBeSigned.begin(),
+        mtx.sapData->bindingSig.data());
+
+    librustzcash_sapling_proving_ctx_free(ctx);
+
+    // Transparent signatures
+    CTransaction txNewConst(mtx);
+    for (int nIn = 0; nIn < (int) mtx.vin.size(); nIn++) {
+        auto tIn = tIns[nIn];
+        SignatureData sigdata;
+        bool signSuccess = ProduceSignature(
+            TransactionSignatureCreator(
+                keystore, &txNewConst, nIn, tIn.value, SIGHASH_ALL),
+            tIn.scriptPubKey, sigdata, false);
+
+        if (!signSuccess) {
+            return TransactionBuilderResult("Failed to sign transaction");
+        } else {
+            UpdateTransaction(mtx, nIn, sigdata);
+        }
+    }
+
+    return TransactionBuilderResult(CTransaction(mtx));
+}

--- a/src/sapling/transaction_builder.h
+++ b/src/sapling/transaction_builder.h
@@ -1,0 +1,123 @@
+// Copyright (c) 2018-2020 The Zcash developers
+// Copyright (c) 2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+#ifndef TRANSACTION_BUILDER_H
+#define TRANSACTION_BUILDER_H
+
+#include "coins.h"
+#include "consensus/params.h"
+#include "keystore.h"
+#include "optional.h"
+#include "primitives/transaction.h"
+#include "script/script.h"
+#include "script/standard.h"
+#include "uint256.h"
+#include "sapling/address.hpp"
+#include "sapling/incrementalmerkletree.hpp"
+#include "sapling/note.hpp"
+#include "sapling/noteencryption.hpp"
+
+struct SpendDescriptionInfo {
+    libzcash::SaplingExpandedSpendingKey expsk;
+    libzcash::SaplingNote note;
+    uint256 alpha;
+    uint256 anchor;
+    SaplingWitness witness;
+
+    SpendDescriptionInfo(
+        libzcash::SaplingExpandedSpendingKey expsk,
+        libzcash::SaplingNote note,
+        uint256 anchor,
+        SaplingWitness witness);
+};
+
+struct OutputDescriptionInfo {
+    uint256 ovk;
+    libzcash::SaplingNote note;
+    std::array<unsigned char, ZC_MEMO_SIZE> memo;
+
+    OutputDescriptionInfo(
+        uint256 ovk,
+        libzcash::SaplingNote note,
+        std::array<unsigned char, ZC_MEMO_SIZE> memo) : ovk(ovk), note(note), memo(memo) {}
+
+    Optional<OutputDescription> Build(void* ctx);
+};
+
+struct TransparentInputInfo {
+    CScript scriptPubKey;
+    CAmount value;
+
+    TransparentInputInfo(
+        CScript scriptPubKey,
+        CAmount value) : scriptPubKey(scriptPubKey), value(value) {}
+};
+
+class TransactionBuilderResult {
+private:
+    Optional<CTransaction> maybeTx;
+    Optional<std::string> maybeError;
+public:
+    TransactionBuilderResult() = delete;
+    TransactionBuilderResult(const CTransaction& tx);
+    TransactionBuilderResult(const std::string& error);
+    bool IsTx();
+    bool IsError();
+    CTransaction GetTxOrThrow();
+    Optional<CTransaction> GetTx();
+    std::string GetError();
+};
+
+class TransactionBuilder
+{
+private:
+    Consensus::Params consensusParams;
+    int nHeight;
+    const CKeyStore* keystore;
+    CMutableTransaction mtx;
+    CAmount fee = 10000;
+
+    std::vector<SpendDescriptionInfo> spends;
+    std::vector<OutputDescriptionInfo> outputs;
+    std::vector<TransparentInputInfo> tIns;
+
+    Optional<std::pair<uint256, libzcash::SaplingPaymentAddress>> saplingChangeAddr;
+    Optional<CTxDestination> tChangeAddr;
+
+public:
+    TransactionBuilder(
+        const Consensus::Params& consensusParams,
+        int nHeight,
+        CKeyStore* keyStore = nullptr);
+
+    void SetFee(CAmount _fee);
+
+    // Throws if the anchor does not match the anchor used by
+    // previously-added Sapling spends.
+    void AddSaplingSpend(
+        libzcash::SaplingExpandedSpendingKey expsk,
+        libzcash::SaplingNote note,
+        uint256 anchor,
+        SaplingWitness witness);
+
+    void AddSaplingOutput(
+        uint256 ovk,
+        libzcash::SaplingPaymentAddress to,
+        CAmount value,
+        std::array<unsigned char, ZC_MEMO_SIZE> memo = {{0xF6}});
+
+    // Assumes that the value correctly corresponds to the provided UTXO.
+    void AddTransparentInput(COutPoint utxo, CScript scriptPubKey, CAmount value);
+
+    void AddTransparentOutput(const CTxDestination& to, CAmount value);
+
+    void SendChangeTo(libzcash::SaplingPaymentAddress changeAddr, uint256 ovk);
+
+    void SendChangeTo(CTxDestination& changeAddr);
+
+    TransactionBuilderResult Build();
+};
+
+#endif /* TRANSACTION_BUILDER_H */

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -80,6 +80,7 @@ set(BITCOIN_TESTS
         ${CMAKE_CURRENT_SOURCE_DIR}/librust/zip32_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/librust/wallet_zkeys_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/librust/merkletree_tests.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/librust/transaction_builder_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/base32_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/base58_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/base64_tests.cpp

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -59,6 +59,8 @@ set(BITCOIN_TEST_SUITE
         ${CMAKE_CURRENT_SOURCE_DIR}/librust/sapling_test_fixture.cpp
         ${CMAKE_SOURCE_DIR}/src/wallet/test/wallet_test_fixture.h
         ${CMAKE_SOURCE_DIR}/src/wallet/test/wallet_test_fixture.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/librust/utiltest.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/librust/utiltest.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/librust/json_test_vectors.h
         )
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -55,6 +55,8 @@ GenerateHeaders(${JSON_TEST_FILES})
 set(BITCOIN_TEST_SUITE
         ${CMAKE_CURRENT_SOURCE_DIR}/test_pivx.h
         ${CMAKE_CURRENT_SOURCE_DIR}/test_pivx.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/librust/sapling_test_fixture.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/librust/sapling_test_fixture.cpp
         ${CMAKE_SOURCE_DIR}/src/wallet/test/wallet_test_fixture.h
         ${CMAKE_SOURCE_DIR}/src/wallet/test/wallet_test_fixture.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/librust/json_test_vectors.h

--- a/src/test/librust/sapling_keystore_tests.cpp
+++ b/src/test/librust/sapling_keystore_tests.cpp
@@ -4,6 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "test/test_pivx.h"
+#include "test/librust/utiltest.h"
 
 #include "sapling/address.hpp"
 #include "sapling/sapling_util.h"
@@ -14,13 +15,6 @@
 
 // In script_tests.cpp
 extern UniValue read_json(const std::string& jsondata);
-
-// todo: Move to a sapling tests utils in the future
-libzcash::SaplingExtendedSpendingKey GetTestMasterSaplingSpendingKey() {
-    std::vector<unsigned char, secure_allocator<unsigned char>> rawSeed(32);
-    HDSeed seed(rawSeed);
-    return libzcash::SaplingExtendedSpendingKey::Master(seed);
-}
 
 BOOST_FIXTURE_TEST_SUITE(sapling_keystore_tests, BasicTestingSetup)
 

--- a/src/test/librust/sapling_test_fixture.cpp
+++ b/src/test/librust/sapling_test_fixture.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include "test/librust/sapling_test_fixture.h"
+#include "sapling/sapling_util.h"
+
+SaplingTestingSetup::SaplingTestingSetup() : TestingSetup()
+{
+    initZKSNARKS(); // init zk-snarks lib
+}
+
+SaplingTestingSetup::~SaplingTestingSetup()
+{
+}

--- a/src/test/librust/sapling_test_fixture.h
+++ b/src/test/librust/sapling_test_fixture.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#ifndef PIVX_SAPLING_TEST_FIXTURE_H
+#define PIVX_SAPLING_TEST_FIXTURE_H
+
+#include "test/test_pivx.h"
+
+/**
+ * Testing setup that configures a complete environment for Sapling testing.
+ */
+struct SaplingTestingSetup : public TestingSetup {
+    SaplingTestingSetup();
+    ~SaplingTestingSetup();
+};
+
+
+#endif //PIVX_SAPLING_TEST_FIXTURE_H

--- a/src/test/librust/transaction_builder_tests.cpp
+++ b/src/test/librust/transaction_builder_tests.cpp
@@ -1,0 +1,321 @@
+// Copyright (c) 2016-2020 The ZCash developers
+// Copyright (c) 2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include "test/librust/sapling_test_fixture.h"
+#include "test/librust/utiltest.h"
+
+#include "sapling/sapling.h"
+#include "sapling/transaction_builder.h"
+#include "sapling/sapling_validation.h"
+
+#include <univalue.h>
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(sapling_transaction_builder_tests, SaplingTestingSetup)
+
+BOOST_AUTO_TEST_CASE(TransparentToSapling)
+{
+    auto consensusParams = RegtestActivateSapling();
+
+    CBasicKeyStore keystore;
+    CKey tsk = AddTestCKeyToKeyStore(keystore);
+    auto scriptPubKey = GetScriptForDestination(tsk.GetPubKey().GetID());
+
+    auto sk_from = libzcash::SaplingSpendingKey::random();
+    auto fvk_from = sk_from.full_viewing_key();
+
+    auto sk = libzcash::SaplingSpendingKey::random();
+    auto fvk = sk.full_viewing_key();
+    auto ivk = fvk.in_viewing_key();
+    diversifier_t d = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    auto pk = *ivk.address(d);
+
+    // Create a shielding transaction from transparent to Sapling
+    // 0.0005 t-PIV in, 0.0004 shielded-PIV out, 0.0001 t-PIV fee
+    auto builder = TransactionBuilder(consensusParams, 1, &keystore);
+    builder.AddTransparentInput(COutPoint(uint256S("1234"), 0), scriptPubKey, 50000);
+    builder.AddSaplingOutput(fvk_from.ovk, pk, 40000, {});
+    auto tx = builder.Build().GetTxOrThrow();
+
+    BOOST_CHECK_EQUAL(tx.vin.size(), 1);
+    BOOST_CHECK_EQUAL(tx.vout.size(), 0);
+    BOOST_CHECK_EQUAL(tx.sapData->vShieldedSpend.size(), 0);
+    BOOST_CHECK_EQUAL(tx.sapData->vShieldedOutput.size(), 1);
+    BOOST_CHECK_EQUAL(tx.sapData->valueBalance, -40000);
+
+    CValidationState state;
+    BOOST_CHECK(SaplingValidation::ContextualCheckTransaction(tx, state, Params(), 2, true, false));
+    BOOST_CHECK_EQUAL(state.GetRejectReason(), "");
+
+    // Revert to default
+    RegtestDeactivateSapling();
+}
+
+BOOST_AUTO_TEST_CASE(SaplingToSapling) {
+    auto consensusParams = RegtestActivateSapling();
+
+    auto sk = libzcash::SaplingSpendingKey::random();
+    auto expsk = sk.expanded_spending_key();
+    auto fvk = sk.full_viewing_key();
+    auto pa = sk.default_address();
+
+    auto testNote = GetTestSaplingNote(pa, 40000);
+
+    // Create a Sapling-only transaction
+    // 0.0004 shielded-PIV in, 0.00025 shielded-PIV out, 0.0001 t-PIV fee, 0.00005 shielded-PIV change
+    auto builder = TransactionBuilder(consensusParams, 2);
+    builder.AddSaplingSpend(expsk, testNote.note, testNote.tree.root(), testNote.tree.witness());
+
+    // Check that trying to add a different anchor fails
+    // TODO: the following check can be split out in to another test
+    BOOST_CHECK_THROW(builder.AddSaplingSpend(expsk, testNote.note, uint256(), testNote.tree.witness()), std::runtime_error);
+
+    builder.AddSaplingOutput(fvk.ovk, pa, 25000, {});
+    auto tx = builder.Build().GetTxOrThrow();
+
+    BOOST_CHECK_EQUAL(tx.vin.size(), 0);
+    BOOST_CHECK_EQUAL(tx.vout.size(), 0);
+    BOOST_CHECK_EQUAL(tx.sapData->vShieldedSpend.size(), 1);
+    BOOST_CHECK_EQUAL(tx.sapData->vShieldedOutput.size(), 2);
+    BOOST_CHECK_EQUAL(tx.sapData->valueBalance, 10000);
+
+    CValidationState state;
+    BOOST_CHECK(SaplingValidation::ContextualCheckTransaction(tx, state, Params(), 3, true, false));
+    BOOST_CHECK_EQUAL(state.GetRejectReason(), "");
+
+    // Revert to default
+    RegtestDeactivateSapling();
+}
+
+BOOST_AUTO_TEST_CASE(ThrowsOnTransparentInputWithoutKeyStore)
+{
+    SelectParams(CBaseChainParams::REGTEST);
+    auto consensusParams = Params().GetConsensus();
+
+    auto builder = TransactionBuilder(consensusParams, 1);
+    BOOST_CHECK_THROW(builder.AddTransparentInput(COutPoint(), CScript(), 1), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(RejectsInvalidTransparentOutput)
+{
+    SelectParams(CBaseChainParams::REGTEST);
+    auto consensusParams = Params().GetConsensus();
+
+    // Default CTxDestination type is an invalid address
+    CTxDestination taddr;
+    auto builder = TransactionBuilder(consensusParams, 1);
+    BOOST_CHECK_THROW(builder.AddTransparentOutput(taddr, 50), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(RejectsInvalidTransparentChangeAddress)
+{
+    SelectParams(CBaseChainParams::REGTEST);
+    auto consensusParams = Params().GetConsensus();
+
+    // Default CTxDestination type is an invalid address
+    CTxDestination taddr;
+    auto builder = TransactionBuilder(consensusParams, 1);
+    BOOST_CHECK_THROW(builder.SendChangeTo(taddr), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(FailsWithNegativeChange)
+{
+    auto consensusParams = RegtestActivateSapling();
+
+    // Generate dummy Sapling address
+    auto sk = libzcash::SaplingSpendingKey::random();
+    auto expsk = sk.expanded_spending_key();
+    auto fvk = sk.full_viewing_key();
+    auto pa = sk.default_address();
+
+    // Set up dummy transparent address
+    CBasicKeyStore keystore;
+    CKey tsk = AddTestCKeyToKeyStore(keystore);
+    auto tkeyid = tsk.GetPubKey().GetID();
+    auto scriptPubKey = GetScriptForDestination(tkeyid);
+    CTxDestination taddr = tkeyid;
+
+    auto testNote = GetTestSaplingNote(pa, 59999);
+
+    // Fail if there is only a Sapling output
+    // 0.0005 shielded-PIV out, 0.0001 t-PIV fee
+    auto builder = TransactionBuilder(consensusParams, 1);
+    builder.AddSaplingOutput(fvk.ovk, pa, 50000, {});
+    BOOST_CHECK_EQUAL("Change cannot be negative", builder.Build().GetError());
+
+    // Fail if there is only a transparent output
+    // 0.0005 t-PIV out, 0.0001 t-PIV fee
+    builder = TransactionBuilder(consensusParams, 1, &keystore);
+    builder.AddTransparentOutput(taddr, 50000);
+    BOOST_CHECK_EQUAL("Change cannot be negative", builder.Build().GetError());
+
+    // Fails if there is insufficient input
+    // 0.0005 t-PIV out, 0.0001 t-PIV fee, 0.00059999 shielded-PIV in
+    builder.AddSaplingSpend(expsk, testNote.note, testNote.tree.root(), testNote.tree.witness());
+    BOOST_CHECK_EQUAL("Change cannot be negative", builder.Build().GetError());
+
+    // Succeeds if there is sufficient input
+    builder.AddTransparentInput(COutPoint(), scriptPubKey, 1);
+    BOOST_CHECK(builder.Build().IsTx());
+
+    // Revert to default
+    RegtestDeactivateSapling();
+}
+
+BOOST_AUTO_TEST_CASE(ChangeOutput)
+{
+    auto consensusParams = RegtestActivateSapling();
+
+    // Generate dummy Sapling address
+    auto sk = libzcash::SaplingSpendingKey::random();
+    auto expsk = sk.expanded_spending_key();
+    auto pa = sk.default_address();
+
+    auto testNote = GetTestSaplingNote(pa, 25000);
+
+    // Generate change Sapling address
+    auto sk2 = libzcash::SaplingSpendingKey::random();
+    auto fvkOut = sk2.full_viewing_key();
+    auto zChangeAddr = sk2.default_address();
+
+    // Set up dummy transparent address
+    CBasicKeyStore keystore;
+    CKey tsk = AddTestCKeyToKeyStore(keystore);
+    auto tkeyid = tsk.GetPubKey().GetID();
+    auto scriptPubKey = GetScriptForDestination(tkeyid);
+    CTxDestination taddr = tkeyid;
+
+    // No change address and no Sapling spends
+    {
+        auto builder = TransactionBuilder(consensusParams, 1, &keystore);
+        builder.AddTransparentInput(COutPoint(), scriptPubKey, 25000);
+        BOOST_CHECK_EQUAL("Could not determine change address", builder.Build().GetError());
+    }
+
+    // Change to the same address as the first Sapling spend
+    {
+        auto builder = TransactionBuilder(consensusParams, 1, &keystore);
+        builder.AddTransparentInput(COutPoint(), scriptPubKey, 25000);
+        builder.AddSaplingSpend(expsk, testNote.note, testNote.tree.root(), testNote.tree.witness());
+        auto tx = builder.Build().GetTxOrThrow();
+
+        BOOST_CHECK_EQUAL(tx.vin.size(), 1);
+        BOOST_CHECK_EQUAL(tx.vout.size(), 0);
+        BOOST_CHECK_EQUAL(tx.sapData->vShieldedSpend.size(), 1);
+        BOOST_CHECK_EQUAL(tx.sapData->vShieldedOutput.size(), 1);
+        BOOST_CHECK_EQUAL(tx.sapData->valueBalance, -15000);
+    }
+
+    // Change to a Sapling address
+    {
+        auto builder = TransactionBuilder(consensusParams, 1, &keystore);
+        builder.AddTransparentInput(COutPoint(), scriptPubKey, 25000);
+        builder.SendChangeTo(zChangeAddr, fvkOut.ovk);
+        auto tx = builder.Build().GetTxOrThrow();
+
+        BOOST_CHECK_EQUAL(tx.vin.size(), 1);
+        BOOST_CHECK_EQUAL(tx.vout.size(), 0);
+        BOOST_CHECK_EQUAL(tx.sapData->vShieldedSpend.size(), 0);
+        BOOST_CHECK_EQUAL(tx.sapData->vShieldedOutput.size(), 1);
+        BOOST_CHECK_EQUAL(tx.sapData->valueBalance, -15000);
+    }
+
+    // Change to a transparent address
+    {
+        auto builder = TransactionBuilder(consensusParams, 1, &keystore);
+        builder.AddTransparentInput(COutPoint(), scriptPubKey, 25000);
+        builder.SendChangeTo(taddr);
+        auto tx = builder.Build().GetTxOrThrow();
+
+        BOOST_CHECK_EQUAL(tx.vin.size(), 1);
+        BOOST_CHECK_EQUAL(tx.vout.size(), 1);
+        BOOST_CHECK_EQUAL(tx.sapData->vShieldedSpend.size(), 0);
+        BOOST_CHECK_EQUAL(tx.sapData->vShieldedOutput.size(), 0);
+        BOOST_CHECK_EQUAL(tx.sapData->valueBalance, 0);
+        BOOST_CHECK_EQUAL(tx.vout[0].nValue, 15000);
+    }
+
+    // Revert to default
+    RegtestDeactivateSapling();
+}
+
+BOOST_AUTO_TEST_CASE(SetFee)
+{
+    auto consensusParams = RegtestActivateSapling();
+
+    // Generate dummy Sapling address
+    auto sk = libzcash::SaplingSpendingKey::random();
+    auto expsk = sk.expanded_spending_key();
+    auto fvk = sk.full_viewing_key();
+    auto pa = sk.default_address();
+
+    auto testNote = GetTestSaplingNote(pa, 50000);
+
+    // Default fee
+    {
+        auto builder = TransactionBuilder(consensusParams, 1);
+        builder.AddSaplingSpend(expsk, testNote.note, testNote.tree.root(), testNote.tree.witness());
+        builder.AddSaplingOutput(fvk.ovk, pa, 25000, {});
+        auto tx = builder.Build().GetTxOrThrow();
+
+        BOOST_CHECK_EQUAL(tx.vin.size(), 0);
+        BOOST_CHECK_EQUAL(tx.vout.size(), 0);
+        BOOST_CHECK_EQUAL(tx.sapData->vShieldedSpend.size(), 1);
+        BOOST_CHECK_EQUAL(tx.sapData->vShieldedOutput.size(), 2);
+        BOOST_CHECK_EQUAL(tx.sapData->valueBalance, 10000);
+    }
+
+    // Configured fee
+    {
+        auto builder = TransactionBuilder(consensusParams, 1);
+        builder.AddSaplingSpend(expsk, testNote.note, testNote.tree.root(), testNote.tree.witness());
+        builder.AddSaplingOutput(fvk.ovk, pa, 25000, {});
+        builder.SetFee(20000);
+        auto tx = builder.Build().GetTxOrThrow();
+
+        BOOST_CHECK_EQUAL(tx.vin.size(), 0);
+        BOOST_CHECK_EQUAL(tx.vout.size(), 0);
+        BOOST_CHECK_EQUAL(tx.sapData->vShieldedSpend.size(), 1);
+        BOOST_CHECK_EQUAL(tx.sapData->vShieldedOutput.size(), 2);
+        BOOST_CHECK_EQUAL(tx.sapData->valueBalance, 20000);
+    }
+
+    // Revert to default
+    RegtestDeactivateSapling();
+}
+
+BOOST_AUTO_TEST_CASE(CheckSaplingTxVersion)
+{
+    SelectParams(CBaseChainParams::REGTEST);
+    auto consensusParams = Params().GetConsensus();
+
+    auto sk = libzcash::SaplingSpendingKey::random();
+    auto expsk = sk.expanded_spending_key();
+    auto pk = sk.default_address();
+
+    // Cannot add Sapling outputs to a non-Sapling transaction
+    auto builder = TransactionBuilder(consensusParams, 1);
+    try {
+        builder.AddSaplingOutput(uint256(), pk, 12345, {});
+    } catch (std::runtime_error const & err) {
+        BOOST_CHECK_EQUAL(err.what(), std::string("TransactionBuilder cannot add Sapling output to pre-Sapling transaction"));
+    } catch(...) {
+        BOOST_CHECK_MESSAGE(false, "Expected std::runtime_error");
+    }
+
+    // Cannot add Sapling spends to a non-Sapling transaction
+    libzcash::SaplingNote note(pk, 50000);
+    SaplingMerkleTree tree;
+    try {
+        builder.AddSaplingSpend(expsk, note, uint256(), tree.witness());
+    } catch (std::runtime_error const & err) {
+        BOOST_CHECK_EQUAL(err.what(), std::string("TransactionBuilder cannot add Sapling spend to pre-Sapling transaction"));
+    } catch(...) {
+        BOOST_CHECK_MESSAGE(false, "Expected std::runtime_error");
+    }
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/librust/utiltest.cpp
+++ b/src/test/librust/utiltest.cpp
@@ -1,0 +1,66 @@
+// Copyright (c) 2016-2020 The Zcash developers
+// Copyright (c) 2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+#include "utiltest.h"
+
+#include "key_io.h"
+#include "consensus/upgrades.h"
+#include "sapling/transaction_builder.h"
+
+#include <array>
+
+static const std::string T_SECRET_REGTEST = "cND2ZvtabDbJ1gucx9GWH6XT9kgTAqfb6cotPt5Q5CyxVDhid2EN";
+
+const Consensus::Params& RegtestActivateSapling() {
+    SelectParams(CBaseChainParams::REGTEST);
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_V5_DUMMY, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    return Params().GetConsensus();
+}
+
+void RegtestDeactivateSapling() {
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_V5_DUMMY, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+}
+
+libzcash::SaplingExtendedSpendingKey GetTestMasterSaplingSpendingKey() {
+    std::vector<unsigned char, secure_allocator<unsigned char>> rawSeed(32);
+    HDSeed seed(rawSeed);
+    return libzcash::SaplingExtendedSpendingKey::Master(seed);
+}
+
+CKey AddTestCKeyToKeyStore(CBasicKeyStore& keyStore) {
+    CKey tsk = KeyIO::DecodeSecret(T_SECRET_REGTEST);
+    keyStore.AddKey(tsk);
+    return tsk;
+}
+
+TestSaplingNote GetTestSaplingNote(const libzcash::SaplingPaymentAddress& pa, CAmount value) {
+    // Generate dummy Sapling note
+    libzcash::SaplingNote note(pa, value);
+    uint256 cm = note.cmu().get();
+    SaplingMerkleTree tree;
+    tree.append(cm);
+    return { note, tree };
+}
+
+CWalletTx GetValidSaplingReceive(const Consensus::Params& consensusParams,
+                                 CBasicKeyStore& keyStore,
+                                 const libzcash::SaplingExtendedSpendingKey &sk,
+                                 CAmount value) {
+    // From taddr
+    CKey tsk = AddTestCKeyToKeyStore(keyStore);
+    auto scriptPubKey = GetScriptForDestination(tsk.GetPubKey().GetID());
+    // To shielded addr
+    auto fvk = sk.expsk.full_viewing_key();
+    auto pa = sk.DefaultAddress();
+
+    auto builder = TransactionBuilder(consensusParams, 1, &keyStore);
+    builder.SetFee(0);
+    builder.AddTransparentInput(COutPoint(), scriptPubKey, value);
+    builder.AddSaplingOutput(fvk.ovk, pa, value, {});
+
+    CTransaction tx = builder.Build().GetTxOrThrow();
+    CWalletTx wtx {NULL, tx};
+    return wtx;
+}

--- a/src/test/librust/utiltest.cpp
+++ b/src/test/librust/utiltest.cpp
@@ -16,11 +16,13 @@ static const std::string T_SECRET_REGTEST = "cND2ZvtabDbJ1gucx9GWH6XT9kgTAqfb6co
 const Consensus::Params& RegtestActivateSapling() {
     SelectParams(CBaseChainParams::REGTEST);
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_V5_DUMMY, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    g_IsSaplingActive = true;
     return Params().GetConsensus();
 }
 
 void RegtestDeactivateSapling() {
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_V5_DUMMY, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    g_IsSaplingActive = false;
 }
 
 libzcash::SaplingExtendedSpendingKey GetTestMasterSaplingSpendingKey() {

--- a/src/test/librust/utiltest.h
+++ b/src/test/librust/utiltest.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-2020 The Zcash developers
+// Copyright (c) 2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php .
+
+#ifndef PIVX_UTIL_TEST_H
+#define PIVX_UTIL_TEST_H
+
+#include "sapling/address.hpp"
+#include "sapling/incrementalmerkletree.hpp"
+#include "sapling/note.hpp"
+#include "sapling/noteencryption.hpp"
+#include "wallet/wallet.h"
+
+struct TestSaplingNote {
+    libzcash::SaplingNote note;
+    SaplingMerkleTree tree;
+};
+
+const Consensus::Params& RegtestActivateSapling();
+
+void RegtestDeactivateSapling();
+
+libzcash::SaplingExtendedSpendingKey GetTestMasterSaplingSpendingKey();
+
+CKey AddTestCKeyToKeyStore(CBasicKeyStore& keyStore);
+
+/**
+ * Generate a dummy SaplingNote and a SaplingMerkleTree with that note's commitment.
+ */
+TestSaplingNote GetTestSaplingNote(const libzcash::SaplingPaymentAddress& pa, CAmount value);
+
+CWalletTx GetValidSaplingReceive(const Consensus::Params& consensusParams,
+                                 CBasicKeyStore& keyStore,
+                                 const libzcash::SaplingExtendedSpendingKey &sk,
+                                 CAmount value);
+
+#endif // PIVX_UTIL_TEST_H

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -22,10 +22,8 @@ void clean()
     bitdb.Reset();
 }
 
-WalletTestingSetup::WalletTestingSetup(): TestingSetup()
+WalletTestingSetup::WalletTestingSetup(): SaplingTestingSetup()
 {
-    initZKSNARKS(); // init zk-snarks lib
-
     clean(); // todo: research why we have an initialized bitdb here.
     bitdb.MakeMock();
     walletRegisterRPCCommands();

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -5,11 +5,11 @@
 #ifndef BITCOIN_WALLET_TEST_FIXTURE_H
 #define BITCOIN_WALLET_TEST_FIXTURE_H
 
-#include "test/test_pivx.h"
+#include "test/librust/sapling_test_fixture.h"
 
 /** Testing setup and teardown for wallet.
  */
-struct WalletTestingSetup: public TestingSetup {
+struct WalletTestingSetup : public SaplingTestingSetup {
     WalletTestingSetup();
     ~WalletTestingSetup();
 };


### PR DESCRIPTION
Another decoupling from #1798 . Focused on three points:

1) Standalone builder class encapsulating the shielded transaction building process.

2) Basic network validations for the shielded transaction primitive data. -- NOT connected to the network in any way, only used in the unit tests (point 3) --

3) Transaction builder unit tests coverage verifying the correct behavior of the included functionality.


#### List of base commits decoupled from #1798:

* Sapling transaction builder back port. --> 3fbf19855889881c5888b6cc80b4d2871932bfaa
* [NET] Sapling validation files created. --> 267b088d6270e752e3550e70c0f30f8a3770762d
* sapling test fixture implemented. --> eb12b515dcea420e0bd7d848d2e79a5f6f2d1764
* Backport utiltest files. --> 27168c6a54d7e54c7787d3cfcdc8856e15fb27a7
* Sapling transaction builder tests back ported. --> d6786297ee944ea6fd408b3e95dcb0f8be17216e
* TransactionBuilder: Not used members cleanup + moved RPC exceptions to std::runtime_error. --> 8ac8b00289cd2a3af4ca5f7bf6432bee90a8d35a
* transaction_builder_test: cleaning trailing whitespace. --> 227c6066be18da939647a9d6b438a55d54c9668b
* Enable/disable global sapling flag in the unit test. --> f34d57810004bc15f0ed00d54ee837373f9a5bd3
* Transaction: missing sapData initialization on constructor fix. --> 8d8f1ff9ea358a31e0f6cb32170c6cf43a986608