### PR TITLE
[bug] Swiftx DoConsensusVote missing brackets always returning without doing anything.

### DIFF
--- a/src/swifttx.cpp
+++ b/src/swifttx.cpp
@@ -264,9 +264,10 @@ void DoConsensusVote(CTransaction& tx, int64_t nBlockHeight)
 {
     if (!fMasterNode) return;
 
-    if (activeMasternode.vin == nullopt)
+    if (activeMasternode.vin == nullopt) {
         LogPrint(BCLog::MASTERNODE, "%s: Active Masternode not initialized.", __func__);
         return;
+    }
 
     int n = mnodeman.GetMasternodeRank(*(activeMasternode.vin), nBlockHeight, MIN_SWIFTTX_PROTO_VERSION);
 


### PR DESCRIPTION
Was walking around the sources and discovered this strange way of blocking functionality, cuak :p .

As swiftx is disabled, this doesn't represent any problem, just showing us the need of using brackets always.