### PR TITLE
[Test] Introducing tier two functional test suite + several fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -173,6 +173,19 @@ jobs:
         BUILD_TIMEOUT=800
 
     - stage: test
+      name: 'x86_64 Linux  [GOAL: install]  [bionic]  [no GUI, no unit tests - only tier two functional tests]'
+      env: >-
+        HOST=x86_64-unknown-linux-gnu
+        PACKAGES="python3-zmq protobuf-compiler libdbus-1-dev libharfbuzz-dev libprotobuf-dev"
+        DEP_OPTS="NO_QT=1 NO_UPNP=1 DEBUG=1 ALLOW_HOST_PACKAGES=1"
+        RUN_UNIT_TESTS=false
+        RUN_FUNCTIONAL_TESTS=true
+        TEST_RUNNER_EXTRA="--tiertwo"  # Run tier two functional tests only.
+        GOAL="install"
+        BITCOIN_CONFIG="--with-gui=no --enable-glibc-back-compat --enable-reduce-exports --disable-online-rust --with-params-dir=$PARAMS_DIR"
+        BUILD_TIMEOUT=800
+
+    - stage: test
       name: 'x86_64 Linux  [GOAL: install]  [xenial]  [no depends, only system libs]'
       env: >-
         HOST=x86_64-unknown-linux-gnu

--- a/.travis.yml
+++ b/.travis.yml
@@ -183,7 +183,7 @@ jobs:
         TEST_RUNNER_EXTRA="--tiertwo"  # Run tier two functional tests only.
         GOAL="install"
         BITCOIN_CONFIG="--with-gui=no --enable-glibc-back-compat --enable-reduce-exports --disable-online-rust --with-params-dir=$PARAMS_DIR"
-        BUILD_TIMEOUT=800
+        BUILD_TIMEOUT=1800
 
     - stage: test
       name: 'x86_64 Linux  [GOAL: install]  [xenial]  [no depends, only system libs]'

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -225,6 +225,7 @@ BITCOIN_CORE_H = \
   policy/fees.h \
   policy/policy.h \
   optional.h \
+  operationresult.h \
   pow.h \
   prevector.h \
   protocol.h \

--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -209,13 +209,18 @@ bool CActiveMasternode::SendMasternodePing(std::string& errorMessage)
             return false;
         }
 
-        pmn->lastPing = mnp;
+        // SetLastPing locks the masternode cs, be careful with the lock order.
+        pmn->SetLastPing(mnp);
         mnodeman.mapSeenMasternodePing.emplace(mnp.GetHash(), mnp);
 
         //mnodeman.mapSeenMasternodeBroadcast.lastPing is probably outdated, so we'll update it
         CMasternodeBroadcast mnb(*pmn);
         uint256 hash = mnb.GetHash();
-        if (mnodeman.mapSeenMasternodeBroadcast.count(hash)) mnodeman.mapSeenMasternodeBroadcast[hash].lastPing = mnp;
+        if (mnodeman.mapSeenMasternodeBroadcast.count(hash)) {
+            // SetLastPing locks the masternode cs, be careful with the lock order.
+            // TODO: check why are we double setting the last ping here..
+            mnodeman.mapSeenMasternodeBroadcast[hash].SetLastPing(mnp);
+        }
 
         mnp.Relay();
         return true;

--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -37,7 +37,7 @@ void initMasternode(const std::string& _strMasterNodePrivKey, const std::string&
 
     // Address parsing.
     const CChainParams& params = Params();
-    int nPort;
+    int nPort = 0;
     int nDefaultPort = params.GetDefaultPort();
     std::string strHost;
     SplitHostPort(strMasterNodeAddr, nPort, strHost);
@@ -118,7 +118,7 @@ void CActiveMasternode::ManageStatus()
                 return;
             }
         } else {
-            int nPort;
+            int nPort = 0;
             std::string strHost;
             SplitHostPort(strMasterNodeAddr, nPort, strHost);
             service = LookupNumeric(strHost.c_str(), nPort);

--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -14,11 +14,6 @@
 #include "netbase.h"
 #include "protocol.h"
 
-OperationResult errorOut(const std::string& errorStr)
-{
-    return OperationResult(false, errorStr);
-}
-
 OperationResult initMasternode(const std::string& _strMasterNodePrivKey, const std::string& _strMasterNodeAddr, bool isFromInit)
 {
     if (!isFromInit && fMasterNode) {

--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -14,6 +14,56 @@
 #include "netbase.h"
 #include "protocol.h"
 
+void initMasternode(const std::string& _strMasterNodePrivKey, const std::string& _strMasterNodeAddr, bool isFromInit)
+{
+    if (!isFromInit && fMasterNode) {
+        throw std::runtime_error("ERROR: Masternode already initialized.\n");
+    }
+
+    LOCK(cs_main); // Lock cs_main so the node doesn't perform any action while we setup the Masternode
+    LogPrintf("Initializing masternode, addr %s..\n", _strMasterNodeAddr.c_str());
+
+    if (_strMasterNodePrivKey.empty()) {
+        throw std::runtime_error("ERROR: Masternode priv key cannot be empty.\n");
+    }
+
+    if (_strMasterNodeAddr.empty()) {
+        throw std::runtime_error("ERROR: Empty masternodeaddr\n");
+    }
+
+    // Global params set
+    strMasterNodeAddr = _strMasterNodeAddr;
+    strMasterNodePrivKey = _strMasterNodePrivKey;
+
+    // Address parsing.
+    const CChainParams& params = Params();
+    int nPort;
+    int nDefaultPort = params.GetDefaultPort();
+    std::string strHost;
+    SplitHostPort(strMasterNodeAddr, nPort, strHost);
+
+    // Allow for the port number to be omitted here and just double check
+    // that if a port is supplied, it matches the required default port.
+    if (nPort == 0) nPort = nDefaultPort;
+    if (nPort != nDefaultPort && !params.IsRegTestNet()) {
+        throw std::runtime_error(strprintf(_("Invalid -masternodeaddr port %d, only %d is supported on %s-net."),
+                                           nPort, nDefaultPort, Params().NetworkIDString()));
+    }
+    CService addrTest(LookupNumeric(strHost.c_str(), nPort));
+    if (!addrTest.IsValid()) {
+        throw std::runtime_error(strprintf(_("Invalid -masternodeaddr address: %s"), strMasterNodeAddr));
+    }
+
+    CKey key;
+    CPubKey pubkey;
+
+    if (!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, key, pubkey)) {
+        throw std::runtime_error(_("Invalid masternodeprivkey. Please see documenation."));
+    }
+    activeMasternode.pubKeyMasternode = pubkey;
+    fMasterNode = true;
+}
+
 //
 // Bootup the Masternode, look for a 10000 PIVX input and register on the network
 //

--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -14,21 +14,26 @@
 #include "netbase.h"
 #include "protocol.h"
 
-void initMasternode(const std::string& _strMasterNodePrivKey, const std::string& _strMasterNodeAddr, bool isFromInit)
+OperationResult errorOut(const std::string& errorStr)
+{
+    return OperationResult(false, errorStr);
+}
+
+OperationResult initMasternode(const std::string& _strMasterNodePrivKey, const std::string& _strMasterNodeAddr, bool isFromInit)
 {
     if (!isFromInit && fMasterNode) {
-        throw std::runtime_error("ERROR: Masternode already initialized.\n");
+        return errorOut( "ERROR: Masternode already initialized.");
     }
 
     LOCK(cs_main); // Lock cs_main so the node doesn't perform any action while we setup the Masternode
     LogPrintf("Initializing masternode, addr %s..\n", _strMasterNodeAddr.c_str());
 
     if (_strMasterNodePrivKey.empty()) {
-        throw std::runtime_error("ERROR: Masternode priv key cannot be empty.\n");
+        return errorOut("ERROR: Masternode priv key cannot be empty.");
     }
 
     if (_strMasterNodeAddr.empty()) {
-        throw std::runtime_error("ERROR: Empty masternodeaddr\n");
+        return errorOut("ERROR: Empty masternodeaddr");
     }
 
     // Global params set
@@ -46,22 +51,23 @@ void initMasternode(const std::string& _strMasterNodePrivKey, const std::string&
     // that if a port is supplied, it matches the required default port.
     if (nPort == 0) nPort = nDefaultPort;
     if (nPort != nDefaultPort && !params.IsRegTestNet()) {
-        throw std::runtime_error(strprintf(_("Invalid -masternodeaddr port %d, only %d is supported on %s-net."),
+        return errorOut(strprintf(_("Invalid -masternodeaddr port %d, only %d is supported on %s-net."),
                                            nPort, nDefaultPort, Params().NetworkIDString()));
     }
     CService addrTest(LookupNumeric(strHost.c_str(), nPort));
     if (!addrTest.IsValid()) {
-        throw std::runtime_error(strprintf(_("Invalid -masternodeaddr address: %s"), strMasterNodeAddr));
+        return errorOut(strprintf(_("Invalid -masternodeaddr address: %s"), strMasterNodeAddr));
     }
 
     CKey key;
     CPubKey pubkey;
 
     if (!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, key, pubkey)) {
-        throw std::runtime_error(_("Invalid masternodeprivkey. Please see documenation."));
+        return errorOut(_("Invalid masternodeprivkey. Please see the documentation."));
     }
     activeMasternode.pubKeyMasternode = pubkey;
     fMasterNode = true;
+    return OperationResult(true);
 }
 
 //

--- a/src/activemasternode.h
+++ b/src/activemasternode.h
@@ -18,8 +18,19 @@
 #define ACTIVE_MASTERNODE_NOT_CAPABLE 3
 #define ACTIVE_MASTERNODE_STARTED 4
 
+class OperationResult
+{
+public:
+    OperationResult(bool _res, const std::string& _error) : res(_res), error(_error) { }
+    OperationResult(bool _res) : res(_res) { }
+
+    bool res{false};
+    Optional<std::string> error{nullopt};
+    explicit operator bool() const { return res; }
+};
+
 // Responsible for initializing the masternode
-void initMasternode(const std::string& strMasterNodePrivKey, const std::string& strMasterNodeAddr, bool isFromInit);
+OperationResult initMasternode(const std::string& strMasterNodePrivKey, const std::string& strMasterNodeAddr, bool isFromInit);
 
 // Responsible for activating the Masternode and pinging the network
 class CActiveMasternode

--- a/src/activemasternode.h
+++ b/src/activemasternode.h
@@ -10,6 +10,7 @@
 #include "key.h"
 #include "masternode.h"
 #include "net.h"
+#include "operationresult.h"
 #include "sync.h"
 #include "wallet/wallet.h"
 
@@ -17,20 +18,6 @@
 #define ACTIVE_MASTERNODE_SYNC_IN_PROCESS 1
 #define ACTIVE_MASTERNODE_NOT_CAPABLE 3
 #define ACTIVE_MASTERNODE_STARTED 4
-
-class OperationResult
-{
-private:
-    bool res{false};
-    Optional<std::string> error{nullopt};
-
-public:
-    OperationResult(bool _res, const std::string& _error) : res(_res), error(_error) { }
-    OperationResult(bool _res) : res(_res) { }
-
-    std::string getError() const { return (error ? *error : ""); }
-    explicit operator bool() const { return res; }
-};
 
 // Responsible for initializing the masternode
 OperationResult initMasternode(const std::string& strMasterNodePrivKey, const std::string& strMasterNodeAddr, bool isFromInit);

--- a/src/activemasternode.h
+++ b/src/activemasternode.h
@@ -20,12 +20,15 @@
 
 class OperationResult
 {
+private:
+    bool res{false};
+    Optional<std::string> error{nullopt};
+
 public:
     OperationResult(bool _res, const std::string& _error) : res(_res), error(_error) { }
     OperationResult(bool _res) : res(_res) { }
 
-    bool res{false};
-    Optional<std::string> error{nullopt};
+    std::string getError() const { return (error ? *error : ""); }
     explicit operator bool() const { return res; }
 };
 

--- a/src/activemasternode.h
+++ b/src/activemasternode.h
@@ -18,6 +18,9 @@
 #define ACTIVE_MASTERNODE_NOT_CAPABLE 3
 #define ACTIVE_MASTERNODE_STARTED 4
 
+// Responsible for initializing the masternode
+void initMasternode(const std::string& strMasterNodePrivKey, const std::string& strMasterNodeAddr, bool isFromInit);
+
 // Responsible for activating the Masternode and pinging the network
 class CActiveMasternode
 {

--- a/src/activemasternode.h
+++ b/src/activemasternode.h
@@ -36,9 +36,6 @@ OperationResult initMasternode(const std::string& strMasterNodePrivKey, const st
 class CActiveMasternode
 {
 private:
-    /// Ping Masternode
-    bool SendMasternodePing(std::string& errorMessage);
-
     int status;
     std::string notCapableReason;
 
@@ -64,6 +61,8 @@ public:
     std::string GetStatusMessage() const;
     int GetStatus() const { return status; }
 
+    /// Ping Masternode
+    bool SendMasternodePing(std::string& errorMessage);
     /// Enable cold wallet mode (run a Masternode with no funds)
     bool EnableHotColdMasterNode(CTxIn& vin, CService& addr);
 };

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1809,46 +1809,7 @@ bool AppInit2()
 
     if (fMasterNode) {
         LogPrintf("IS MASTER NODE\n");
-        strMasterNodeAddr = gArgs.GetArg("-masternodeaddr", "");
-
-        LogPrintf(" addr %s\n", strMasterNodeAddr.c_str());
-
-        if (!strMasterNodeAddr.empty()) {
-            const CChainParams& params = Params();
-            int nPort;
-            int nDefaultPort = params.GetDefaultPort();
-            std::string strHost;
-            SplitHostPort(strMasterNodeAddr, nPort, strHost);
-
-            // Allow for the port number to be omitted here and just double check
-            // that if a port is supplied, it matches the required default port.
-            if (nPort == 0) nPort = nDefaultPort;
-            if (nPort != nDefaultPort && !params.IsRegTestNet()) {
-                return UIError(strprintf(_("Invalid -masternodeaddr port %d, only %d is supported on %s-net."),
-                    nPort, nDefaultPort, Params().NetworkIDString()));
-            }
-            CService addrTest(LookupNumeric(strHost.c_str(), nPort));
-            if (!addrTest.IsValid()) {
-                return UIError(strprintf(_("Invalid -masternodeaddr address: %s"), strMasterNodeAddr));
-            }
-        }
-
-        strMasterNodePrivKey = gArgs.GetArg("-masternodeprivkey", "");
-        if (!strMasterNodePrivKey.empty()) {
-            std::string errorMessage;
-
-            CKey key;
-            CPubKey pubkey;
-
-            if (!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, key, pubkey)) {
-                return UIError(_("Invalid masternodeprivkey. Please see documenation."));
-            }
-
-            activeMasternode.pubKeyMasternode = pubkey;
-
-        } else {
-            return UIError(_("You must specify a masternodeprivkey in the configuration. Please see documentation for help."));
-        }
+        initMasternode(gArgs.GetArg("-masternodeprivkey", ""), gArgs.GetArg("-masternodeaddr", ""), true);
     }
 
     //get the mode of budget voting for this masternode

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1810,7 +1810,7 @@ bool AppInit2()
     if (fMasterNode) {
         LogPrintf("IS MASTER NODE\n");
         auto res = initMasternode(gArgs.GetArg("-masternodeprivkey", ""), gArgs.GetArg("-masternodeaddr", ""), true);
-        if (!res) UIError(*res.error);
+        if (!res) UIError(res.getError());
     }
 
     //get the mode of budget voting for this masternode

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1809,7 +1809,8 @@ bool AppInit2()
 
     if (fMasterNode) {
         LogPrintf("IS MASTER NODE\n");
-        initMasternode(gArgs.GetArg("-masternodeprivkey", ""), gArgs.GetArg("-masternodeaddr", ""), true);
+        auto res = initMasternode(gArgs.GetArg("-masternodeprivkey", ""), gArgs.GetArg("-masternodeaddr", ""), true);
+        if (!res) UIError(*res.error);
     }
 
     //get the mode of budget voting for this masternode

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1719,7 +1719,9 @@ bool AppInit2()
     {
         LOCK(g_best_block_mutex);
         if (g_best_block.IsNull() && chainActive.Tip()) {
-            g_best_block = chainActive.Tip()->GetBlockHash();
+            CBlockIndex* tip = chainActive.Tip();
+            g_best_block = tip->GetBlockHash();
+            g_best_block_time = tip->GetBlockTime();;
             g_best_block_cv.notify_all();
         }
     }

--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -1600,6 +1600,7 @@ void CBudgetProposal::SetSynced(bool synced)
 // If masternode voted for a proposal, but is now invalid -- remove the vote
 void CBudgetProposal::CleanAndRemove()
 {
+    LogPrint(BCLog::MNBUDGET, "Cleaning budget votes for %s. Before: YES=%d, NO=%d\n", GetName(), GetYeas(), GetNays());
     std::map<uint256, CBudgetVote>::iterator it = mapVotes.begin();
 
     while (it != mapVotes.end()) {
@@ -1607,6 +1608,7 @@ void CBudgetProposal::CleanAndRemove()
         (*it).second.SetValid(pmn != nullptr);
         ++it;
     }
+    LogPrint(BCLog::MNBUDGET, "Cleaned budget votes for %s. After: YES=%d, NO=%d\n", GetName(), GetYeas(), GetNays());
 }
 
 double CBudgetProposal::GetRatio() const

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -291,7 +291,7 @@ public:
     bool IsBudgetPaymentBlock(int nBlockHeight, int& nCountThreshold) const;
     bool AddProposal(CBudgetProposal& budgetProposal);
     bool AddFinalizedBudget(CFinalizedBudget& finalizedBudget);
-    void SubmitFinalBudget();
+    uint256 SubmitFinalBudget();
 
     bool UpdateProposal(const CBudgetVote& vote, CNode* pfrom, std::string& strError);
     bool UpdateFinalizedBudget(CFinalizedBudgetVote& vote, CNode* pfrom, std::string& strError);

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -278,8 +278,7 @@ void CMasternodeSync::Process()
     if (RequestedMasternodeAssets == MASTERNODE_SYNC_INITIAL) GetNextAsset();
 
     // sporks synced but blockchain is not, wait until we're almost at a recent block to continue
-    bool isSynced = IsBlockchainSynced(); // This is needed in regtest as well due how IsBlockchainSynced is implemented..
-    if (!isRegTestNet && !isSynced &&
+    if (!IsBlockchainSynced() &&
         RequestedMasternodeAssets > MASTERNODE_SYNC_SPORKS) return;
 
     CMasternodeSync* sync = this;

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -65,11 +65,9 @@ bool CMasternodeSync::IsBlockchainSynced()
 
     int64_t blockTime = 0;
     {
-        TRY_LOCK(cs_main, lockMain);
-        if (!lockMain) return false;
-        CBlockIndex *pindex = chainActive.Tip();
-        if (pindex == nullptr) return false;
-        blockTime = pindex->nTime;
+        TRY_LOCK(g_best_block_mutex, lock);
+        if (!lock) return false;
+        blockTime = g_best_block_time;
     }
 
     if (blockTime + 60 * 60 < lastProcess)

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -280,7 +280,8 @@ void CMasternodeSync::Process()
     if (RequestedMasternodeAssets == MASTERNODE_SYNC_INITIAL) GetNextAsset();
 
     // sporks synced but blockchain is not, wait until we're almost at a recent block to continue
-    if (!isRegTestNet && !IsBlockchainSynced() &&
+    bool isSynced = IsBlockchainSynced(); // This is needed in regtest as well due how IsBlockchainSynced is implemented..
+    if (!isRegTestNet && !isSynced &&
         RequestedMasternodeAssets > MASTERNODE_SYNC_SPORKS) return;
 
     CMasternodeSync* sync = this;

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -727,7 +727,8 @@ bool CMasternodePing::CheckAndUpdate(int& nDos, bool fRequireEnabled, bool fChec
                 return false;
             }
 
-            pmn->lastPing = *this;
+            // SetLastPing locks masternode cs. Be careful with the lock ordering.
+            pmn->SetLastPing(*this);
 
             //mnodeman.mapSeenMasternodeBroadcast.lastPing is probably outdated, so we'll update it
             CMasternodeBroadcast mnb(*pmn);

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -558,11 +558,16 @@ bool CMasternodeBroadcast::CheckInputsAndAdd(int& nDoS)
     // we are a masternode with the same vin (i.e. already activated) and this mnb is ours (matches our Masternode privkey)
     // so nothing to do here for us
     if (fMasterNode && activeMasternode.vin != nullopt &&
-            vin.prevout == activeMasternode.vin->prevout && pubKeyMasternode == activeMasternode.pubKeyMasternode)
+            vin.prevout == activeMasternode.vin->prevout &&
+            pubKeyMasternode == activeMasternode.pubKeyMasternode &&
+            activeMasternode.GetStatus() == ACTIVE_MASTERNODE_STARTED) {
         return true;
+    }
 
     // incorrect ping or its sigTime
-    if(lastPing.IsNull() || !lastPing.CheckAndUpdate(nDoS, false, true)) return false;
+    if(lastPing.IsNull() || !lastPing.CheckAndUpdate(nDoS, false, true)) {
+        return false;
+    }
 
     // search existing Masternode list
     CMasternode* pmn = mnodeman.Find(vin);

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -348,7 +348,7 @@ bool CMasternodeBroadcast::Create(const std::string& strService,
         return false;
     }
 
-    int nPort;
+    int nPort = 0;
     int nDefaultPort = Params().GetDefaultPort();
     std::string strHost;
     SplitHostPort(strService, nPort, strHost);

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -147,6 +147,8 @@ public:
     const CTxIn GetVin() const override { return vin; };
     const CPubKey GetPublicKey(std::string& strErrorRet) const override { return pubKeyCollateralAddress; }
 
+    void SetLastPing(const CMasternodePing& _lastPing) { WITH_LOCK(cs, lastPing = _lastPing;); }
+
     void swap(CMasternode& first, CMasternode& second) // nothrow
     {
         CSignedMessage::swap(first, second);

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -245,19 +245,18 @@ public:
         return WITH_LOCK(cs, return activeState == MASTERNODE_PRE_ENABLED );
     }
 
-    std::string Status()
+    std::string Status() const
     {
-        std::string strStatus = "ACTIVE";
-
         LOCK(cs);
-        if (activeState == CMasternode::MASTERNODE_ENABLED) strStatus = "ENABLED";
-        if (activeState == CMasternode::MASTERNODE_EXPIRED) strStatus = "EXPIRED";
-        if (activeState == CMasternode::MASTERNODE_VIN_SPENT) strStatus = "VIN_SPENT";
-        if (activeState == CMasternode::MASTERNODE_REMOVE) strStatus = "REMOVE";
-        if (activeState == CMasternode::MASTERNODE_POS_ERROR) strStatus = "POS_ERROR";
-        if (activeState == CMasternode::MASTERNODE_MISSING) strStatus = "MISSING";
+        if (activeState == CMasternode::MASTERNODE_PRE_ENABLED) return "PRE_ENABLED";
+        if (activeState == CMasternode::MASTERNODE_ENABLED)     return "ENABLED";
+        if (activeState == CMasternode::MASTERNODE_EXPIRED)     return "EXPIRED";
+        if (activeState == CMasternode::MASTERNODE_VIN_SPENT)   return "VIN_SPENT";
+        if (activeState == CMasternode::MASTERNODE_REMOVE)      return "REMOVE";
+        if (activeState == CMasternode::MASTERNODE_POS_ERROR)   return "POS_ERROR";
+        if (activeState == CMasternode::MASTERNODE_MISSING)     return "MISSING";
 
-        return strStatus;
+        return strprintf("INVALID_%d", activeState);
     }
 
     int64_t GetLastPaid();

--- a/src/masternodeconfig.cpp
+++ b/src/masternodeconfig.cpp
@@ -2,9 +2,10 @@
 // Copyright (c) 2015-2019 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
-
-#include "netbase.h"
 #include "masternodeconfig.h"
+
+#include "fs.h"
+#include "netbase.h"
 #include "util.h"
 #include "guiinterface.h"
 #include <base58.h>
@@ -19,6 +20,7 @@ CMasternodeConfig::CMasternodeEntry* CMasternodeConfig::add(std::string alias, s
 }
 
 void CMasternodeConfig::remove(std::string alias) {
+    LOCK(cs_entries);
     int pos = -1;
     for (int i = 0; i < ((int) entries.size()); ++i) {
         CMasternodeEntry e = entries[i];
@@ -32,6 +34,7 @@ void CMasternodeConfig::remove(std::string alias) {
 
 bool CMasternodeConfig::read(std::string& strErr)
 {
+    LOCK(cs_entries);
     int linenumber = 1;
     fs::path pathMasternodeConfigFile = GetMasternodeConfigFile();
     fs::ifstream streamConfig(pathMasternodeConfigFile);

--- a/src/masternodeconfig.cpp
+++ b/src/masternodeconfig.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2014-2015 The Dash developers
 // Copyright (c) 2015-2019 The PIVX developers
-// Distributed under the MIT/X11 software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 #include "netbase.h"
 #include "masternodeconfig.h"

--- a/src/masternodeconfig.h
+++ b/src/masternodeconfig.h
@@ -1,7 +1,7 @@
 // Copyright (c) 2014-2015 The Dash developers
 // Copyright (c) 2015-2019 The PIVX developers
-// Distributed under the MIT/X11 software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 #ifndef SRC_MASTERNODECONFIG_H_
 #define SRC_MASTERNODECONFIG_H_
@@ -10,7 +10,6 @@
 
 #include <string>
 #include <vector>
-
 
 class CMasternodeConfig;
 extern CMasternodeConfig masternodeConfig;
@@ -28,88 +27,31 @@ public:
         std::string outputIndex;
 
     public:
-        CMasternodeEntry(std::string alias, std::string ip, std::string privKey, std::string txHash, std::string outputIndex)
-        {
-            this->alias = alias;
-            this->ip = ip;
-            this->privKey = privKey;
-            this->txHash = txHash;
-            this->outputIndex = outputIndex;
-        }
+        CMasternodeEntry(std::string& _alias, std::string& _ip, std::string& _privKey, std::string& _txHash, std::string& _outputIndex) :
+            alias(_alias), ip(_ip), privKey(_privKey), txHash(_txHash), outputIndex(_outputIndex) { }
 
-        const std::string& getAlias() const
-        {
-            return alias;
-        }
-
-        void setAlias(const std::string& alias)
-        {
-            this->alias = alias;
-        }
-
-        const std::string& getOutputIndex() const
-        {
-            return outputIndex;
-        }
-
+        const std::string& getAlias() const { return alias; }
+        const std::string& getOutputIndex() const { return outputIndex; }
         bool castOutputIndex(int& n) const;
-
-        void setOutputIndex(const std::string& outputIndex)
-        {
-            this->outputIndex = outputIndex;
-        }
-
-        const std::string& getPrivKey() const
-        {
-            return privKey;
-        }
-
-        void setPrivKey(const std::string& privKey)
-        {
-            this->privKey = privKey;
-        }
-
-        const std::string& getTxHash() const
-        {
-            return txHash;
-        }
-
-        void setTxHash(const std::string& txHash)
-        {
-            this->txHash = txHash;
-        }
-
-        const std::string& getIp() const
-        {
-            return ip;
-        }
-
-        void setIp(const std::string& ip)
-        {
-            this->ip = ip;
-        }
+        const std::string& getPrivKey() const { return privKey; }
+        const std::string& getTxHash() const { return txHash; }
+        const std::string& getIp() const { return ip; }
     };
 
-    CMasternodeConfig()
-    {
-        entries = std::vector<CMasternodeEntry>();
-    }
+    CMasternodeConfig() { entries = std::vector<CMasternodeEntry>(); }
 
-    void clear();
+    void clear() { entries.clear(); }
     bool read(std::string& strErr);
     CMasternodeConfig::CMasternodeEntry* add(std::string alias, std::string ip, std::string privKey, std::string txHash, std::string outputIndex);
     void remove(std::string alias);
 
-    std::vector<CMasternodeEntry>& getEntries()
-    {
-        return entries;
-    }
+    std::vector<CMasternodeEntry>& getEntries() { return entries; }
 
     int getCount()
     {
         int c = -1;
-        for (CMasternodeEntry e : entries) {
-            if (e.getAlias() != "") c++;
+        for (const auto& e : entries) {
+            if (!e.getAlias().empty()) c++;
         }
         return c;
     }

--- a/src/masternodeconfig.h
+++ b/src/masternodeconfig.h
@@ -6,8 +6,7 @@
 #ifndef SRC_MASTERNODECONFIG_H_
 #define SRC_MASTERNODECONFIG_H_
 
-#include "fs.h"
-
+#include "sync.h"
 #include <string>
 #include <vector>
 
@@ -40,15 +39,16 @@ public:
 
     CMasternodeConfig() { entries = std::vector<CMasternodeEntry>(); }
 
-    void clear() { entries.clear(); }
+    void clear() { LOCK(cs_entries); entries.clear(); }
     bool read(std::string& strErr);
     CMasternodeConfig::CMasternodeEntry* add(std::string alias, std::string ip, std::string privKey, std::string txHash, std::string outputIndex);
     void remove(std::string alias);
 
-    std::vector<CMasternodeEntry>& getEntries() { return entries; }
+    std::vector<CMasternodeEntry> getEntries() { LOCK(cs_entries); return entries; }
 
     int getCount()
     {
+        LOCK(cs_entries);
         int c = -1;
         for (const auto& e : entries) {
             if (!e.getAlias().empty()) c++;
@@ -58,6 +58,7 @@ public:
 
 private:
     std::vector<CMasternodeEntry> entries;
+    Mutex cs_entries;
 };
 
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -909,11 +909,12 @@ void ThreadCheckMasternodes()
             if (masternodeSync.IsBlockchainSynced()) {
                 c++;
 
-            // check if we should activate or ping every few minutes,
-            // start right after sync is considered to be done
-            if (c % MasternodePingSeconds() == 1) activeMasternode.ManageStatus();
+                // check if we should activate or ping every few minutes,
+                // start right after sync is considered to be done
+                if (c % (MasternodePingSeconds()/2) == 0)
+                    activeMasternode.ManageStatus();
 
-                if (c % 60 == 0) {
+                if (c % (MasternodePingSeconds()/5) == 0) {
                     mnodeman.CheckAndRemove();
                     masternodePayments.CleanPaymentList();
                 }

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -270,7 +270,7 @@ void CMasternodeMan::CheckAndRemove(bool forceExpiredRemoval)
             while (it3 != mapSeenMasternodeBroadcast.end()) {
                 if ((*it3).second.vin == (*it).vin) {
                     masternodeSync.mapSeenSyncMNB.erase((*it3).first);
-                    mapSeenMasternodeBroadcast.erase(it3++);
+                    it3 = mapSeenMasternodeBroadcast.erase(it3);
                 } else {
                     ++it3;
                 }
@@ -280,7 +280,7 @@ void CMasternodeMan::CheckAndRemove(bool forceExpiredRemoval)
             std::map<COutPoint, int64_t>::iterator it2 = mWeAskedForMasternodeListEntry.begin();
             while (it2 != mWeAskedForMasternodeListEntry.end()) {
                 if ((*it2).first == (*it).vin.prevout) {
-                    mWeAskedForMasternodeListEntry.erase(it2++);
+                    it2 = mWeAskedForMasternodeListEntry.erase(it2);
                 } else {
                     ++it2;
                 }
@@ -296,7 +296,7 @@ void CMasternodeMan::CheckAndRemove(bool forceExpiredRemoval)
     std::map<CNetAddr, int64_t>::iterator it1 = mAskedUsForMasternodeList.begin();
     while (it1 != mAskedUsForMasternodeList.end()) {
         if ((*it1).second < GetTime()) {
-            mAskedUsForMasternodeList.erase(it1++);
+            it1 = mAskedUsForMasternodeList.erase(it1);
         } else {
             ++it1;
         }
@@ -306,7 +306,7 @@ void CMasternodeMan::CheckAndRemove(bool forceExpiredRemoval)
     it1 = mWeAskedForMasternodeList.begin();
     while (it1 != mWeAskedForMasternodeList.end()) {
         if ((*it1).second < GetTime()) {
-            mWeAskedForMasternodeList.erase(it1++);
+            it1 = mWeAskedForMasternodeList.erase(it1);
         } else {
             ++it1;
         }
@@ -316,7 +316,7 @@ void CMasternodeMan::CheckAndRemove(bool forceExpiredRemoval)
     std::map<COutPoint, int64_t>::iterator it2 = mWeAskedForMasternodeListEntry.begin();
     while (it2 != mWeAskedForMasternodeListEntry.end()) {
         if ((*it2).second < GetTime()) {
-            mWeAskedForMasternodeListEntry.erase(it2++);
+            it2 = mWeAskedForMasternodeListEntry.erase(it2);
         } else {
             ++it2;
         }
@@ -326,8 +326,8 @@ void CMasternodeMan::CheckAndRemove(bool forceExpiredRemoval)
     std::map<uint256, CMasternodeBroadcast>::iterator it3 = mapSeenMasternodeBroadcast.begin();
     while (it3 != mapSeenMasternodeBroadcast.end()) {
         if ((*it3).second.lastPing.sigTime < GetTime() - (MasternodeRemovalSeconds() * 2)) {
-            mapSeenMasternodeBroadcast.erase(it3++);
             masternodeSync.mapSeenSyncMNB.erase((*it3).second.GetHash());
+            it3 = mapSeenMasternodeBroadcast.erase(it3);
         } else {
             ++it3;
         }
@@ -337,7 +337,7 @@ void CMasternodeMan::CheckAndRemove(bool forceExpiredRemoval)
     std::map<uint256, CMasternodePing>::iterator it4 = mapSeenMasternodePing.begin();
     while (it4 != mapSeenMasternodePing.end()) {
         if ((*it4).second.sigTime < GetTime() - (MasternodeRemovalSeconds() * 2)) {
-            mapSeenMasternodePing.erase(it4++);
+            it4 = mapSeenMasternodePing.erase(it4);
         } else {
             ++it4;
         }

--- a/src/operationresult.h
+++ b/src/operationresult.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#ifndef OPERATIONRESULT_H
+#define OPERATIONRESULT_H
+
+#include "optional.h"
+#include <string>
+
+class OperationResult
+{
+private:
+    bool m_res{false};
+    Optional<std::string> m_error{nullopt};
+
+public:
+    OperationResult(bool _res, const std::string& _error) : m_res(_res), m_error(_error) { }
+    OperationResult(bool _res) : m_res(_res) { }
+
+    std::string getError() const { return (m_error ? *m_error : ""); }
+    explicit operator bool() const { return m_res; }
+};
+
+inline OperationResult errorOut(const std::string& errorStr)
+{
+    return OperationResult(false, errorStr);
+}
+
+#endif //OPERATIONRESULT_H

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -58,6 +58,8 @@ static const char* ppszTypeName[] = {
     NetMsgType::TX,
     NetMsgType::BLOCK,
     "filtered block", // Should never occur
+    "ix",   // deprecated
+    "txlvote", // deprecated
     NetMsgType::SPORK,
     NetMsgType::GETSPORKS,
     NetMsgType::MNBROADCAST,

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -957,6 +957,7 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
             "  \"verificationprogress\": xxxx, (numeric) estimate of verification progress [0..1]\n"
             "  \"chainwork\": \"xxxx\"     (string) total amount of work in active chain, in hexadecimal\n"
             "  \"shielded_pool_value\": (object) Chain tip shielded pool value\n"
+            "  \"initial_block_downloading\" (boolean) whether the node is in initial block downloading state or not"
             "  {\n"
             "     \"chainValue\":        (numeric) Total value held by the Sapling circuit up to and including the chain tip\n"
             "     \"valueDelta\":        (numeric) Change in value held by the Sapling circuit over the chain tip block\n"
@@ -997,6 +998,7 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
     obj.pushKV("chainwork", pChainTip ? pChainTip->nChainWork.GetHex() : "");
     // Sapling shielded pool value
     obj.pushKV("shielded_pool_value", ValuePoolDesc(pChainTip->nChainSaplingValue, pChainTip->nSaplingValue));
+    obj.pushKV("initial_block_downloading", IsInitialBlockDownload());
     UniValue softforks(UniValue::VARR);
     softforks.push_back(SoftForkDesc("bip65", 5, pChainTip));
     obj.pushKV("softforks",             softforks);

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -708,14 +708,15 @@ UniValue mnfinalbudgetsuggest(const JSONRPCRequest& request)
     if (request.fHelp || !request.params.empty())
         throw std::runtime_error(
                 "mnfinalbudgetsuggest\n"
-                "\nTry to submit a budget finalization\n");
+                "\nTry to submit a budget finalization\n"
+                "returns the budget hash if it was broadcasted sucessfully");
 
     if (!Params().IsRegTestNet()) {
         throw std::runtime_error("mnfinalbudgetsuggest enabled only in regtest");
     }
 
-    budget.SubmitFinalBudget();
-    return NullUniValue;
+    uint256 budgetHash = budget.SubmitFinalBudget();
+    return (budgetHash.IsNull()) ? NullUniValue : budgetHash.ToString();
 }
 
 UniValue mnfinalbudget(const JSONRPCRequest& request)

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -712,7 +712,7 @@ UniValue mnfinalbudgetsuggest(const JSONRPCRequest& request)
                 "returns the budget hash if it was broadcasted sucessfully");
 
     if (!Params().IsRegTestNet()) {
-        throw std::runtime_error("mnfinalbudgetsuggest enabled only in regtest");
+        throw JSONRPCError(RPC_MISC_ERROR, "command available only for RegTest network");
     }
 
     uint256 budgetHash = budget.SubmitFinalBudget();

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -715,7 +715,7 @@ UniValue mnfinalbudgetsuggest(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_MISC_ERROR, "command available only for RegTest network");
     }
 
-    uint256 budgetHash = budget.SubmitFinalBudget();
+    const uint256& budgetHash = budget.SubmitFinalBudget();
     return (budgetHash.IsNull()) ? NullUniValue : budgetHash.ToString();
 }
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -141,6 +141,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
         {"submitbudget", 7},
         // disabled until removal of the legacy 'masternode' command
         //{"startmasternode", 1},
+        {"startmasternode", 3},
         {"mnvoteraw", 1},
         {"mnvoteraw", 4},
         {"setstakesplitthreshold", 0},

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -29,7 +29,8 @@ UniValue initmasternode(const JSONRPCRequest& request)
 
     std::string _strMasterNodePrivKey = request.params[0].get_str();
     std::string _strMasterNodeAddr = request.params[1].get_str();
-    initMasternode(_strMasterNodePrivKey, _strMasterNodeAddr, false);
+    auto res = initMasternode(_strMasterNodePrivKey, _strMasterNodeAddr, false);
+    if (!res) throw std::runtime_error(*res.error);
     return NullUniValue;
 }
 

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -283,17 +283,18 @@ UniValue startmasternode (const JSONRPCRequest& request)
         if (strCommand == "start-disabled") strCommand = "disabled";
     }
 
-    if (request.fHelp || request.params.size() < 2 || request.params.size() > 3 ||
+    if (request.fHelp || request.params.size() < 2 || request.params.size() > 4 ||
         (request.params.size() == 2 && (strCommand != "local" && strCommand != "all" && strCommand != "many" && strCommand != "missing" && strCommand != "disabled")) ||
-        (request.params.size() == 3 && strCommand != "alias"))
+        ( (request.params.size() == 3 || request.params.size() == 4) && strCommand != "alias"))
         throw std::runtime_error(
-            "startmasternode \"local|all|many|missing|disabled|alias\" lockwallet ( \"alias\" )\n"
+            "startmasternode \"local|all|many|missing|disabled|alias\" lockwallet ( \"alias\" reload_conf )\n"
             "\nAttempts to start one or more masternode(s)\n"
 
             "\nArguments:\n"
             "1. set         (string, required) Specify which set of masternode(s) to start.\n"
             "2. lockwallet  (boolean, required) Lock wallet after completion.\n"
             "3. alias       (string) Masternode alias. Required if using 'alias' as the set.\n"
+            "4. reload_conf (boolean) if true and \"alias\" was selected, reload the masternodes.conf data from disk"
 
             "\nResult: (for 'local' set):\n"
             "\"status\"     (string) Masternode status message\n"
@@ -367,6 +368,15 @@ UniValue startmasternode (const JSONRPCRequest& request)
 
     if (strCommand == "alias") {
         std::string alias = request.params[2].get_str();
+
+        // Check reload param
+        if(request.params[3].getBool()) {
+            masternodeConfig.clear();
+            std::string error;
+            if (!masternodeConfig.read(error)) {
+                throw std::runtime_error("Error reloading masternode.conf, " + error);
+            }
+        }
 
         bool found = false;
 

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -24,14 +24,23 @@ UniValue initmasternode(const JSONRPCRequest& request)
         throw std::runtime_error(
                 "initmasternode ( \"masternodePrivKey\" \"masternodeAddr\" )\n"
                 "\nInitialize masternode on demand if it's not already initialized.\n"
-        );
+                "\nArguments:\n"
+                "1. masternodePrivKey          (string, required) The masternode private key.\n"
+                "2. masternodeAddr             (string, required) The IP:Port of this masternode.\n"
+
+                "\nResult:\n"
+                " success                      (string) if the masternode initialization succeeded.\n"
+
+                "\nExamples:\n" +
+                HelpExampleCli("initmasternode", "\"9247iC59poZmqBYt9iDh9wDam6v9S1rW5XekjLGyPnDhrDkP4AK\" \"187.24.32.124:51472\"") +
+                HelpExampleRpc("initmasternode", "\"9247iC59poZmqBYt9iDh9wDam6v9S1rW5XekjLGyPnDhrDkP4AK\" \"187.24.32.124:51472\""));
     }
 
     std::string _strMasterNodePrivKey = request.params[0].get_str();
     std::string _strMasterNodeAddr = request.params[1].get_str();
     auto res = initMasternode(_strMasterNodePrivKey, _strMasterNodeAddr, false);
     if (!res) throw std::runtime_error(*res.error);
-    return NullUniValue;
+    return "success";
 }
 
 UniValue getcachedblockhashes(const JSONRPCRequest& request)

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -18,6 +18,21 @@
 
 #include <boost/tokenizer.hpp>
 
+UniValue initmasternode(const JSONRPCRequest& request)
+{
+    if (request.fHelp || (request.params.empty() || request.params.size() > 2)) {
+        throw std::runtime_error(
+                "initmasternode ( \"masternodePrivKey\" \"masternodeAddr\" )\n"
+                "\nInitialize masternode on demand if it's not already initialized.\n"
+        );
+    }
+
+    std::string _strMasterNodePrivKey = request.params[0].get_str();
+    std::string _strMasterNodeAddr = request.params[1].get_str();
+    initMasternode(_strMasterNodePrivKey, _strMasterNodeAddr, false);
+    return NullUniValue;
+}
+
 UniValue getcachedblockhashes(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() > 0)
@@ -923,6 +938,7 @@ static const CRPCCommand commands[] =
     { "masternode",         "createmasternodebroadcast", &createmasternodebroadcast, true  },
     { "masternode",         "decodemasternodebroadcast", &decodemasternodebroadcast, true  },
     { "masternode",         "relaymasternodebroadcast",  &relaymasternodebroadcast,  true  },
+    { "masternode",         "initmasternode",            &initmasternode,            true  },
 
     /* Not shown in help */
     { "hidden",             "getcachedblockhashes",      &getcachedblockhashes,      true  },

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -18,6 +18,37 @@
 
 #include <boost/tokenizer.hpp>
 
+UniValue mnping(const JSONRPCRequest& request)
+{
+    if (request.fHelp || !request.params.empty()) {
+        throw std::runtime_error(
+            "mnping \n"
+            "\nSend masternode ping. Only for remote masternodes on Regtest\n"
+
+            "\nResult:\n"
+            "{\n"
+            "  \"sent\":           (string YES|NO) Whether the ping was sent and, if not, the error.\n"
+            "}\n"
+
+            "\nExamples:\n" +
+            HelpExampleCli("mnping", "") + HelpExampleRpc("mnping", ""));
+    }
+
+    if (!Params().IsRegTestNet()) {
+        throw JSONRPCError(RPC_MISC_ERROR, "command available only for RegTest network");
+    }
+
+    if (!fMasterNode) {
+        throw JSONRPCError(RPC_MISC_ERROR, "this is not a masternode");
+    }
+
+    UniValue ret(UniValue::VOBJ);
+    std::string strError;
+    ret.pushKV("sent", activeMasternode.SendMasternodePing(strError) ?
+                       "YES" : strprintf("NO (%s)", strError));
+    return ret;
+}
+
 UniValue initmasternode(const JSONRPCRequest& request)
 {
     if (request.fHelp || (request.params.empty() || request.params.size() > 2)) {
@@ -962,6 +993,7 @@ static const CRPCCommand commands[] =
 
     /* Not shown in help */
     { "hidden",             "getcachedblockhashes",      &getcachedblockhashes,      true  },
+    { "hidden",             "mnping",                    &mnping,                    true  },
 };
 
 void RegisterMasternodeRPCCommands(CRPCTable &tableRPC)

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -70,7 +70,7 @@ UniValue initmasternode(const JSONRPCRequest& request)
     std::string _strMasterNodePrivKey = request.params[0].get_str();
     std::string _strMasterNodeAddr = request.params[1].get_str();
     auto res = initMasternode(_strMasterNodePrivKey, _strMasterNodeAddr, false);
-    if (!res) throw std::runtime_error(*res.error);
+    if (!res) throw std::runtime_error(res.getError());
     return "success";
 }
 

--- a/src/sapling/sapling_operation.cpp
+++ b/src/sapling/sapling_operation.cpp
@@ -9,11 +9,6 @@
 #include "sapling/key_io_sapling.h"
 #include "utilmoneystr.h"        // for FormatMoney
 
-OperationResult errorOut(const std::string& serror)
-{
-    return OperationResult(false, serror);
-}
-
 struct TxValues
 {
     CAmount transInTotal{0};

--- a/src/sapling/sapling_operation.h
+++ b/src/sapling/sapling_operation.h
@@ -7,6 +7,7 @@
 
 #include "amount.h"
 #include "sapling/transaction_builder.h"
+#include "operationresult.h"
 #include "primitives/transaction.h"
 #include "wallet/wallet.h"
 
@@ -33,15 +34,6 @@ public:
 
     CTxDestination fromTaddr{CNoDestination()};
     Optional<libzcash::SaplingPaymentAddress> fromSapAddr{nullopt};
-};
-
-class OperationResult {
-public:
-    explicit OperationResult(bool result, const std::string& error = "") : m_result(result), m_error(error)  {}
-    bool m_result;
-    std::string m_error;
-
-    explicit operator bool() const { return m_result; }
 };
 
 class SaplingOperation {

--- a/src/spork.h
+++ b/src/spork.h
@@ -119,8 +119,9 @@ public:
     bool SetPrivKey(std::string strPrivKey);
     std::string ToString() const;
 
-    // Process SPORK message
-    void ProcessSporkMsg(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
+    // Process SPORK message, returning the banning score (or 0 if no banning is needed)
+    int ProcessSporkMsg(CDataStream& vRecv);
+    int ProcessSporkMsg(CSporkMessage& spork);
     // Process GETSPORKS message
     void ProcessGetSporks(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
 };

--- a/src/test/librust/sapling_rpc_wallet_tests.cpp
+++ b/src/test/librust/sapling_rpc_wallet_tests.cpp
@@ -338,7 +338,7 @@ BOOST_AUTO_TEST_CASE(saplingOperationTests) {
         operation.setFromAddress(DecodeDestination(taddr1));
         auto res = operation.setShieldedRecipients(recipients)->send(ret);
         BOOST_CHECK(!res);
-        BOOST_CHECK(res.m_error.find("Insufficient funds, no available UTXO to spend") != std::string::npos);
+        BOOST_CHECK(res.getError().find("Insufficient funds, no available UTXO to spend") != std::string::npos);
     }
 
     // minconf cannot be zero when sending from zaddr
@@ -348,7 +348,7 @@ BOOST_AUTO_TEST_CASE(saplingOperationTests) {
         operation.setFromAddress(pa);
         auto res = operation.setShieldedRecipients(recipients)->setMinDepth(0)->send(ret);
         BOOST_CHECK(!res);
-        BOOST_CHECK(res.m_error.find("Minconf cannot be zero when sending from shielded address") != std::string::npos);
+        BOOST_CHECK(res.getError().find("Minconf cannot be zero when sending from shielded address") != std::string::npos);
     }
 
     // there are no unspent notes to spend
@@ -358,7 +358,7 @@ BOOST_AUTO_TEST_CASE(saplingOperationTests) {
         operation.setFromAddress(pa);
         auto res = operation.setTransparentRecipients(recipients)->send(ret);
         BOOST_CHECK(!res);
-        BOOST_CHECK(res.m_error.find("Insufficient funds, no available notes to spend") != std::string::npos);
+        BOOST_CHECK(res.getError().find("Insufficient funds, no available notes to spend") != std::string::npos);
     }
 
     // get_memo_from_hex_string())

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -89,7 +89,7 @@ const char * const PIVX_MASTERNODE_CONF_FILENAME = "masternode.conf";
 
 // PIVX only features
 // Masternode
-bool fMasterNode = false;
+std::atomic<bool> fMasterNode{false};
 std::string strMasterNodePrivKey = "";
 std::string strMasterNodeAddr = "";
 bool fLiteMode = false;

--- a/src/util.h
+++ b/src/util.h
@@ -42,7 +42,7 @@ extern const char * const DEFAULT_DEBUGLOGFILE;
 
 //PIVX only features
 
-extern bool fMasterNode;
+extern std::atomic<bool> fMasterNode;
 extern bool fLiteMode;
 extern int64_t enforceMasternodePaymentsTime;
 extern std::string strMasterNodeAddr;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -86,6 +86,7 @@ CBlockIndex* pindexBestHeader = NULL;
 Mutex g_best_block_mutex;
 std::condition_variable g_best_block_cv;
 uint256 g_best_block;
+int64_t g_best_block_time = 0;
 
 int nScriptCheckThreads = 0;
 std::atomic<bool> fImporting{false};
@@ -1909,6 +1910,7 @@ void static UpdateTip(CBlockIndex* pindexNew)
     {
         LOCK(g_best_block_mutex);
         g_best_block = pindexNew->GetBlockHash();
+        g_best_block_time = pindexNew->GetBlockTime();
         g_best_block_cv.notify_all();
     }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -137,6 +137,7 @@ extern int64_t nTimeBestReceived;
 extern Mutex g_best_block_mutex;
 extern std::condition_variable g_best_block_cv;
 extern uint256 g_best_block;
+extern int64_t g_best_block_time;
 
 extern std::atomic<bool> fImporting;
 extern std::atomic<bool> fReindex;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1637,7 +1637,7 @@ UniValue shielded_sendmany(const JSONRPCRequest& request) {
             ->setTransparentRecipients(taddrRecipients)
             ->send(txHash);
 
-    if (!res) throw JSONRPCError(RPC_WALLET_ERROR, res.m_error);
+    if (!res) throw JSONRPCError(RPC_WALLET_ERROR, res.getError());
     return txHash;
 }
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1124,12 +1124,13 @@ class PivxTestFramework():
         SYNC_FINISHED = [999] * self.num_nodes
         synced = [-1] * self.num_nodes
         time.sleep(2)
-        timeout = time.time() + 300
+        timeout = time.time() + 45
         while synced != SYNC_FINISHED and time.time() < timeout:
             for i in range(self.num_nodes):
                 if synced[i] != SYNC_FINISHED[i]:
                     synced[i] = self.nodes[i].mnsync("status")["RequestedMasternodeAssets"]
             if synced != SYNC_FINISHED:
+                self.advance_mocktime(2)
                 time.sleep(5)
         if synced != SYNC_FINISHED:
             raise AssertionError("Unable to complete mnsync: %s" % str(synced))
@@ -1379,6 +1380,8 @@ class PivxTier2TestFramework(PivxTestFramework):
         self.log.info("masternodes setup completed, initializing them..")
 
         # now both are configured, let's activate the masternodes
+        self.stake(1)
+        time.sleep(3)
         self.advance_mocktime(10)
         remoteOnePort = p2p_port(self.remoteTwoPos)
         remoteTwoPort = p2p_port(self.remoteOnePos)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -124,6 +124,8 @@ class PivxTestFramework():
                           help="Location of the test framework config file")
         parser.add_option('--legacywallet', dest="legacywallet", default=False, action="store_true",
                           help='create pre-HD wallets only')
+        parser.add_option('--tiertwo', dest="tiertwo", default=False, action="store_true",
+                          help='run tier two tests only')
         parser.add_option("--pdbonfailure", dest="pdbonfailure", default=False, action="store_true",
                           help="Attach a python debugger if test fails")
         parser.add_option("--usecli", dest="usecli", default=False, action="store_true",

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1099,6 +1099,13 @@ class PivxTestFramework():
         return self.nodes[node_id].spork("active")[sporkName]
 
 
+    def get_mn_lastseen(self, node, mnTxHash):
+        mnData = node.listmasternodes(mnTxHash)
+        if len(mnData) == 0:
+            return -1
+        return mnData[0]["lastseen"]
+
+
     def get_mn_status(self, node, mnTxHash):
         mnData = node.listmasternodes(mnTxHash)
         if len(mnData) == 0:
@@ -1183,7 +1190,7 @@ class PivxTestFramework():
         # confirm and verify reception
         self.stake_and_sync(self.nodes.index(miner), 1)
         assert_equal(mnOwner.getbalance(), Decimal('10000'))
-        assert(mnOwner.getrawtransaction(collateralTxId, 1)["confirmations"] > 0)
+        assert_greater_than(mnOwner.getrawtransaction(collateralTxId, 1)["confirmations"], 0)
 
         self.log.info("all good, creating masternode " + masternodeAlias + "..")
 
@@ -1320,7 +1327,7 @@ class PivxTier2TestFramework(PivxTestFramework):
             self.mocktime = self.generate_pow(self.minerPos, self.mocktime)
         sync_blocks(self.nodes)
         # Then start staking
-        self.stake_and_ping(self.minerPos, 9)
+        self.stake(9)
 
         self.log.info("masternodes setup..")
         # setup first masternode node, corresponding to nodeOne

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -207,7 +207,7 @@ def str_to_b64str(string):
 def satoshi_round(amount):
     return Decimal(amount).quantize(Decimal('0.00000001'), rounding=ROUND_DOWN)
 
-def wait_until(predicate, *, attempts=float('inf'), timeout=float('inf'), lock=None):
+def wait_until(predicate, *, attempts=float('inf'), timeout=float('inf'), lock=None, mocktime=None):
     if attempts == float('inf') and timeout == float('inf'):
         timeout = 60
     attempt = 0
@@ -223,6 +223,9 @@ def wait_until(predicate, *, attempts=float('inf'), timeout=float('inf'), lock=N
                 return
         attempt += 1
         time.sleep(0.5)
+        if mocktime is not None:
+            mocktime(1)
+
 
     # Print the cause of the timeout
     assert_greater_than(attempts, attempt)

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -207,7 +207,14 @@ def str_to_b64str(string):
 def satoshi_round(amount):
     return Decimal(amount).quantize(Decimal('0.00000001'), rounding=ROUND_DOWN)
 
-def wait_until(predicate, *, attempts=float('inf'), timeout=float('inf'), lock=None, mocktime=None):
+def wait_until(predicate,
+               *,
+               attempts=float('inf'),
+               timeout=float('inf'),
+               lock=None,
+               sendpings=None,
+               mocktime=None):
+
     if attempts == float('inf') and timeout == float('inf'):
         timeout = 60
     attempt = 0
@@ -223,9 +230,10 @@ def wait_until(predicate, *, attempts=float('inf'), timeout=float('inf'), lock=N
                 return
         attempt += 1
         time.sleep(0.5)
+        if sendpings is not None:
+            sendpings()
         if mocktime is not None:
             mocktime(1)
-
 
     # Print the cause of the timeout
     assert_greater_than(attempts, attempt)

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -424,22 +424,6 @@ def sync_mempools(rpc_connections, *, wait=1, timeout=60, flush_scheduler=True):
         "".join("\n  {!r}".format(m) for m in pool),
     ))
 
-def sync_tiertwo(rpc_connections, *, wait=5, timeout=60):
-    """
-    Wait until everybody has the tier two synced
-    pools
-    """
-    stop_time = time.time() + timeout
-    while time.time() <= stop_time:
-        # Check that each peer has at least one connection
-        assert (all([len(x.getpeerinfo()) for x in rpc_connections]))
-        time.sleep(wait)
-
-        sync_status = [x.mnsync("status")["RequestedMasternodeAssets"] for x in rpc_connections]
-        if sync_status.count(999) == len(rpc_connections):
-            return
-    raise AssertionError("Tier two sync timed out")
-
 # Transaction/Block functions
 #############################
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -144,6 +144,12 @@ BASE_SCRIPTS= [
 
 ]
 
+TIERTWO_SCRIPTS = [
+    'tiertwo_masternode_activation.py',
+    'tiertwo_governance_sync_basic.py',
+
+]
+
 EXTENDED_SCRIPTS = [
     # These tests are not run by the travis build process.
     # Longest test should go first, to favor running tests in parallel
@@ -223,6 +229,7 @@ def main():
     parser.add_argument('--keepcache', '-k', action='store_true', help='the default behavior is to flush the cache directory on startup. --keepcache retains the cache from the previous testrun.')
     parser.add_argument('--quiet', '-q', action='store_true', help='only print dots, results summary and failure logs')
     parser.add_argument('--legacywallet', '-w', action='store_true', help='create pre-HD wallets only')
+    parser.add_argument('--tiertwo', '-m', action='store_true', help='run tier two tests only')
     parser.add_argument('--tmpdirprefix', '-t', default=tempfile.gettempdir(), help="Root directory for datadirs")
     args, unknown_args = parser.parse_known_args()
 
@@ -238,6 +245,8 @@ def main():
     passon_args.append("--configfile=%s" % configfile)
     if args.legacywallet:
         passon_args.append("--legacywallet")
+    if args.tiertwo:
+        passon_args.append("--tiertwo")
 
     # Set up logging
     logging_level = logging.INFO if args.quiet else logging.DEBUG
@@ -276,13 +285,17 @@ def main():
             else:
                 print("{}WARNING!{} Test '{}' not found in full test list.".format(BOLD[1], BOLD[0], t))
     else:
-        # No individual tests have been specified.
-        # Run all base tests, and optionally run extended tests.
-        test_list = BASE_SCRIPTS
-        if args.extended:
-            # place the EXTENDED_SCRIPTS first since the three longest ones
-            # are there and the list is shorter
-            test_list = EXTENDED_SCRIPTS + test_list
+        if args.tiertwo:
+            # If --tiertwo, only run the tier two tests
+            test_list = TIERTWO_SCRIPTS
+        else:
+            # No individual tests have been specified.
+            # Run all base tests, and optionally run extended tests.
+            test_list = BASE_SCRIPTS
+            if args.extended:
+                # place the EXTENDED_SCRIPTS first since the three longest ones
+                # are there and the list is shorter
+                test_list = EXTENDED_SCRIPTS + test_list
 
     # Remove the test cases that the user has explicitly asked to exclude.
     if args.exclude:

--- a/test/functional/tiertwo_governance_sync_basic.py
+++ b/test/functional/tiertwo_governance_sync_basic.py
@@ -3,8 +3,12 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
-from test_framework.test_framework import PivxTestFramework
-from test_framework.util import *
+from test_framework.test_framework import PivxTier2TestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_true,
+)
+
 import time
 
 """
@@ -16,38 +20,7 @@ Test checking:
  5) Proposal and vote sync.
 """
 
-class MasternodeGovernanceBasicTest(PivxTestFramework):
-
-    def set_test_params(self):
-        self.setup_clean_chain = True
-        self.num_nodes = 5
-        self.extra_args = [[], ["-listen", "-externalip=127.0.0.1"], [], ["-listen", "-externalip=127.0.0.1"], ["-sporkkey=932HEevBSujW2ud7RfB1YF91AFygbBRQj3de3LyaCRqNzKKgWXi"]]
-        self.setup_clean_chain = True
-        self.enable_mocktime()
-
-        self.ownerOnePos = 0
-        self.remoteOnePos = 1
-        self.ownerTwoPos = 2
-        self.remoteTwoPos = 3
-        self.minerPos = 4
-
-        self.mnOnePrivkey = "9247iC59poZmqBYt9iDh9wDam6v9S1rW5XekjLGyPnDhrDkP4AK"
-        self.mnTwoPrivkey = "92Hkebp3RHdDidGZ7ARgS4orxJAGyFUPDXNqtsYsiwho1HGVRbF"
-
-    def wait_until_mnsync_finished(self, _timeout):
-        for node in self.nodes:
-            wait_until(lambda: node.mnsync("status")["RequestedMasternodeAssets"] == 999,
-                       timeout=_timeout, mocktime=self.advance_mocktime)
-
-    def get_mn_status(self, node, mnTxHash):
-        mnData = node.listmasternodes(mnTxHash)
-        if len(mnData) == 0:
-            self.log.warn("Masternode not found in the list")
-            return ""
-        return mnData[0]["status"]
-
-    def check_mn_list_empty(self, node):
-        assert(len(node.listmasternodes()) == 0)
+class MasternodeGovernanceBasicTest(PivxTier2TestFramework):
 
     def check_budget_finalization_sync(self, votesCount, status):
         for i in range(0, len(self.nodes)):
@@ -57,10 +30,6 @@ class MasternodeGovernanceBasicTest(PivxTestFramework):
             budget = budFin[next(iter(budFin))]
             assert_equal(budget["VoteCount"], votesCount)
             assert_equal(budget["Status"], status)
-
-    def start_masternode(self, mnOwner, masternodeAlias):
-        ret = mnOwner.startmasternode("alias", "false", masternodeAlias, True)
-        assert_equal(ret["result"], "success")
 
     def broadcastbudgetfinalization(self, node, with_ping_mns=[]):
         self.log.info("suggesting the budget finalization..")
@@ -72,64 +41,6 @@ class MasternodeGovernanceBasicTest(PivxTestFramework):
 
         self.log.info("broadcasting the budget finalization..")
         return node.mnfinalbudgetsuggest()
-
-    def stake(self, num_blocks, with_ping_mns=[]):
-        # stake blocks and send mn pings in between
-        for i in range(num_blocks):
-            self.generate(1)
-            if len(with_ping_mns) > 0:
-                self.send_pings(with_ping_mns)
-
-    def send_pings(self, mnodes):
-        for node in mnodes:
-            sent = node.mnping()["sent"]
-            if sent != "YES" and "Too early to send Masternode Ping" not in sent:
-                raise AssertionError("Unable to send ping: \"sent\" = %s" % sent)
-            time.sleep(1)
-
-
-    def wait_until_mn_enabled(self, mnTxHash, _timeout):
-        for node in self.nodes:
-            wait_until(lambda: self.get_mn_status(node, mnTxHash) == "ENABLED",
-                       timeout=_timeout, mocktime=self.advance_mocktime)
-
-    def setupMasternode(self,
-                        mnOwner,
-                        miner,
-                        masternodeAlias,
-                        mnOwnerDirPath,
-                        mnRemotePos,
-                        masternodePrivKey):
-        self.log.info("adding balance to the mn owner for " + masternodeAlias + "..")
-        mnAddress = mnOwner.getnewaddress(masternodeAlias)
-        # send to the owner the collateral tx cost
-        collateralTxId = miner.sendtoaddress(mnAddress, Decimal('10000'))
-        # confirm and verify reception
-        self.generate(1)
-        assert_equal(mnOwner.getbalance(), Decimal('10000'))
-        assert(mnOwner.getrawtransaction(collateralTxId, 1)["confirmations"] > 0)
-
-        self.log.info("all good, creating masternode " + masternodeAlias + "..")
-
-        # get the collateral output using the RPC command
-        mnCollateralOutput = mnOwner.getmasternodeoutputs()[0]
-        assert_equal(mnCollateralOutput["txhash"], collateralTxId)
-        mnCollateralOutputIndex = mnCollateralOutput["outputidx"]
-
-        self.log.info("collateral accepted for "+ masternodeAlias +".. updating masternode.conf and stopping the node")
-
-        # verify collateral confirmed
-
-        # create the masternode.conf and add it
-        confData = masternodeAlias + " 127.0.0.1:" + str(p2p_port(mnRemotePos)) + " " + str(masternodePrivKey) + " " + str(mnCollateralOutput["txhash"]) + " " + str(mnCollateralOutputIndex)
-        destinationDirPath = mnOwnerDirPath
-        destPath = os.path.join(destinationDirPath, "masternode.conf")
-        with open(destPath, "a+") as file_object:
-            file_object.write("\n")
-            file_object.write(confData)
-
-        # return the collateral id
-        return collateralTxId
 
     def check_proposal_existence(self, proposalName, proposalHash):
         for node in self.nodes:
@@ -149,108 +60,27 @@ class MasternodeGovernanceBasicTest(PivxTestFramework):
                     found = True
             assert_true(found, "Error checking vote existence in node " + str(i))
 
-
-    def generate(self, gen):
-        for i in range(gen):
-            self.mocktime = self.generate_pos(self.minerPos, self.mocktime)
-        sync_blocks(self.nodes)
-        time.sleep(1)
-
-    def advance_mocktime(self, secs):
-        self.mocktime += secs
-        set_node_times(self.nodes, self.mocktime)
-        time.sleep(1)
+    def stake(self, num_blocks, with_ping_mns=[]):
+        self.stake_and_ping(self.minerPos, num_blocks, with_ping_mns)
 
     def run_test(self):
         self.enable_mocktime()
-        ownerOne = self.nodes[self.ownerOnePos]
-        remoteOne = self.nodes[self.remoteOnePos]
-        ownerTwo = self.nodes[self.ownerTwoPos]
-        remoteTwo = self.nodes[self.remoteTwoPos]
-        miner = self.nodes[self.minerPos]
+        (masternodeOneAlias,
+         masternodeTwoAlias,
+         mnOneTxHash,
+         mnTwoTxHash,
+         ) = self.setup_2_masternodes_network()
 
-        ownerOneDir = os.path.join(self.options.tmpdir, "node0")
-        remoteOneDir = os.path.join(self.options.tmpdir, "node1")
-        ownerTwoDir = os.path.join(self.options.tmpdir, "node2")
-        remoteTwoDir = os.path.join(self.options.tmpdir, "node3")
-
-        self.log.info("generating 259 blocks..")
-        # First mine 250 PoW blocks
-        for i in range(250):
-            self.mocktime = self.generate_pow(self.minerPos, self.mocktime)
-        sync_blocks(self.nodes)
-        # Then start staking
-        self.generate(9)
-
-        self.log.info("masternodes setup..")
-        # setup first masternode node, corresponding to nodeOne
-        masternodeOneAlias = "mnOne"
-        mnOneTxHash = self.setupMasternode(
-            ownerOne,
-            miner,
-            masternodeOneAlias,
-            os.path.join(ownerOneDir, "regtest"),
-            self.remoteOnePos,
-            self.mnOnePrivkey)
-
-        # setup second masternode node, corresponding to nodeTwo
-        masternodeTwoAlias = "mntwo"
-        mnTwoTxHash = self.setupMasternode(
-            ownerTwo,
-            miner,
-            masternodeTwoAlias,
-            os.path.join(ownerTwoDir, "regtest"),
-            self.remoteTwoPos,
-            self.mnTwoPrivkey)
-
-        self.log.info("masternodes setup completed, initializing them..")
-        # now both are configured,
-        # let's activate the masternodes
-
-        self.advance_mocktime(10)
-
-        # init masternodes at runtime
-        remoteOnePort = p2p_port(self.remoteTwoPos)
-        remoteTwoPort = p2p_port(self.remoteOnePos)
-        remoteOne.initmasternode(self.mnOnePrivkey, "127.0.0.1:"+str(remoteOnePort))
-        remoteTwo.initmasternode(self.mnTwoPrivkey, "127.0.0.1:"+str(remoteTwoPort))
-
-        self.advance_mocktime(3)
-
-        # now need connection
-        self.stake(1)
-        self.wait_until_mnsync_finished(15)
-        self.log.info("tier two synced! starting masternodes..")
-        #
-        # ## Now everything is set, can start both masternodes
-        self.start_masternode(ownerOne, masternodeOneAlias)
-        self.start_masternode(ownerTwo, masternodeTwoAlias)
-
-        self.advance_mocktime(30)
-        self.send_pings([remoteOne, remoteTwo])
-
-        self.log.info("masternodes started, waiting until both gets enabled..")
-
-        self.stake(1, [remoteOne, remoteTwo])
-        self.advance_mocktime(30)
-        self.send_pings([remoteOne, remoteTwo])
-        time.sleep(2)
-        self.wait_until_mn_enabled(mnOneTxHash, 60)
-        self.wait_until_mn_enabled(mnTwoTxHash, 60)
-
-        #
-        self.log.info("masternodes enabled and running properly!")
-
-        # now let's prepare the proposal
+        # Prepare the proposal
         self.log.info("preparing budget proposal..")
         firstProposalName = "super-cool"
         firstProposalLink = "https://forum.pivx.org/t/test-proposal"
         firstProposalCycles = 2
-        firstProposalAddress = miner.getnewaddress()
+        firstProposalAddress = self.miner.getnewaddress()
         firstProposalAmountPerCycle = 300
-        nextSuperBlockHeight = miner.getnextsuperblock()
+        nextSuperBlockHeight = self.miner.getnextsuperblock()
 
-        proposalFeeTxId = miner.preparebudget(
+        proposalFeeTxId = self.miner.preparebudget(
             firstProposalName,
             firstProposalLink,
             firstProposalCycles,
@@ -259,19 +89,19 @@ class MasternodeGovernanceBasicTest(PivxTestFramework):
             firstProposalAmountPerCycle)
 
         # generate 3 blocks to confirm the tx (and update the mnping)
-        self.stake(3, [remoteOne, remoteTwo])
+        self.stake(3, [self.remoteOne, self.remoteTwo])
 
         # activate sporks
         self.activate_spork(self.minerPos, "SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT")
         self.activate_spork(self.minerPos, "SPORK_9_MASTERNODE_BUDGET_ENFORCEMENT")
         self.activate_spork(self.minerPos, "SPORK_13_ENABLE_SUPERBLOCKS")
 
-        txinfo = miner.gettransaction(proposalFeeTxId)
+        txinfo = self.miner.gettransaction(proposalFeeTxId)
         assert_equal(txinfo['amount'], -50.00)
 
         self.log.info("submitting the budget proposal..")
 
-        proposalHash = miner.submitbudget(
+        proposalHash = self.miner.submitbudget(
             firstProposalName,
             firstProposalLink,
             firstProposalCycles,
@@ -287,38 +117,39 @@ class MasternodeGovernanceBasicTest(PivxTestFramework):
 
         # Proposal is established after 5 minutes. Mine 7 blocks
         # Proposal needs to be on the chain > 5 min.
-        self.stake(7, [remoteOne, remoteTwo])
+        self.stake(7, [self.remoteOne, self.remoteTwo])
 
         # now let's vote for the proposal with the first MN
         self.log.info("broadcasting votes for the proposal now..")
-        voteResult = ownerOne.mnbudgetvote("alias", proposalHash, "yes", masternodeOneAlias)
+        voteResult = self.ownerOne.mnbudgetvote("alias", proposalHash, "yes", masternodeOneAlias)
         assert_equal(voteResult["detail"][0]["result"], "success")
 
         # check that the vote was accepted everywhere
-        self.stake(1, [remoteOne, remoteTwo])
+        self.stake(1, [self.remoteOne, self.remoteTwo])
         self.check_vote_existence(firstProposalName, mnOneTxHash, "YES")
         self.log.info("all good, MN1 vote accepted everywhere!")
 
         # now let's vote for the proposal with the second MN
-        voteResult = ownerTwo.mnbudgetvote("alias", proposalHash, "yes", masternodeTwoAlias)
+        voteResult = self.ownerTwo.mnbudgetvote("alias", proposalHash, "yes", masternodeTwoAlias)
         assert_equal(voteResult["detail"][0]["result"], "success")
 
         # check that the vote was accepted everywhere
-        self.stake(1, [remoteOne, remoteTwo])
+        self.stake(1, [self.remoteOne, self.remoteTwo])
         self.check_vote_existence(firstProposalName, mnTwoTxHash, "YES")
         self.log.info("all good, MN2 vote accepted everywhere!")
 
         # Quick block count check.
-        assert_equal(ownerOne.getblockcount(), 275)
+        assert_equal(self.ownerOne.getblockcount(), 275)
 
         self.log.info("starting budget finalization sync test..")
-        self.stake(5, [remoteOne, remoteTwo])
+        self.stake(5, [self.remoteOne, self.remoteTwo])
 
         # assert that there is no budget finalization first.
-        assert_true(len(ownerOne.mnfinalbudget("show")) == 0)
+        assert_true(len(self.ownerOne.mnfinalbudget("show")) == 0)
 
         # suggest the budget finalization and confirm the tx (+4 blocks).
-        budgetFinHash = self.broadcastbudgetfinalization(miner, with_ping_mns=[remoteOne, remoteTwo])
+        budgetFinHash = self.broadcastbudgetfinalization(self.miner,
+                                                         with_ping_mns=[self.remoteOne, self.remoteTwo])
         assert (budgetFinHash != "")
         time.sleep(1)
 
@@ -327,15 +158,15 @@ class MasternodeGovernanceBasicTest(PivxTestFramework):
 
         self.log.info("budget finalization synced!, now voting for the budget finalization..")
 
-        ownerOne.mnfinalbudget("vote-many", budgetFinHash)
-        ownerTwo.mnfinalbudget("vote-many", budgetFinHash)
-        self.stake(2, [remoteOne, remoteTwo])
+        self.ownerOne.mnfinalbudget("vote-many", budgetFinHash)
+        self.ownerTwo.mnfinalbudget("vote-many", budgetFinHash)
+        self.stake(2, [self.remoteOne, self.remoteTwo])
 
         self.log.info("checking finalization votes..")
         self.check_budget_finalization_sync(2, "OK")
 
-        self.stake(8, [remoteOne, remoteTwo])
-        addrInfo = miner.listreceivedbyaddress(0, False, False, firstProposalAddress)
+        self.stake(8, [self.remoteOne, self.remoteTwo])
+        addrInfo = self.miner.listreceivedbyaddress(0, False, False, firstProposalAddress)
         assert_equal(addrInfo[0]["amount"], firstProposalAmountPerCycle)
 
         self.log.info("budget proposal paid!, all good")

--- a/test/functional/tiertwo_governance_sync_basic.py
+++ b/test/functional/tiertwo_governance_sync_basic.py
@@ -132,7 +132,7 @@ class MasternodeGovernanceBasicTest(PivxTier2TestFramework):
         self.log.info("all good, MN2 vote accepted everywhere!")
 
         # Quick block count check.
-        assert_equal(self.ownerOne.getblockcount(), 275)
+        assert_equal(self.ownerOne.getblockcount(), 276)
 
         self.log.info("starting budget finalization sync test..")
         self.stake(5, [self.remoteOne, self.remoteTwo])

--- a/test/functional/tiertwo_governance_sync_basic.py
+++ b/test/functional/tiertwo_governance_sync_basic.py
@@ -60,16 +60,9 @@ class MasternodeGovernanceBasicTest(PivxTier2TestFramework):
                     found = True
             assert_true(found, "Error checking vote existence in node " + str(i))
 
-    def stake(self, num_blocks, with_ping_mns=[]):
-        self.stake_and_ping(self.minerPos, num_blocks, with_ping_mns)
-
     def run_test(self):
         self.enable_mocktime()
-        (masternodeOneAlias,
-         masternodeTwoAlias,
-         mnOneTxHash,
-         mnTwoTxHash,
-         ) = self.setup_2_masternodes_network()
+        self.setup_2_masternodes_network()
 
         # Prepare the proposal
         self.log.info("preparing budget proposal..")
@@ -121,21 +114,21 @@ class MasternodeGovernanceBasicTest(PivxTier2TestFramework):
 
         # now let's vote for the proposal with the first MN
         self.log.info("broadcasting votes for the proposal now..")
-        voteResult = self.ownerOne.mnbudgetvote("alias", proposalHash, "yes", masternodeOneAlias)
+        voteResult = self.ownerOne.mnbudgetvote("alias", proposalHash, "yes", self.masternodeOneAlias)
         assert_equal(voteResult["detail"][0]["result"], "success")
 
         # check that the vote was accepted everywhere
         self.stake(1, [self.remoteOne, self.remoteTwo])
-        self.check_vote_existence(firstProposalName, mnOneTxHash, "YES")
+        self.check_vote_existence(firstProposalName, self.mnOneTxHash, "YES")
         self.log.info("all good, MN1 vote accepted everywhere!")
 
         # now let's vote for the proposal with the second MN
-        voteResult = self.ownerTwo.mnbudgetvote("alias", proposalHash, "yes", masternodeTwoAlias)
+        voteResult = self.ownerTwo.mnbudgetvote("alias", proposalHash, "yes", self.masternodeTwoAlias)
         assert_equal(voteResult["detail"][0]["result"], "success")
 
         # check that the vote was accepted everywhere
         self.stake(1, [self.remoteOne, self.remoteTwo])
-        self.check_vote_existence(firstProposalName, mnTwoTxHash, "YES")
+        self.check_vote_existence(firstProposalName, self.mnTwoTxHash, "YES")
         self.log.info("all good, MN2 vote accepted everywhere!")
 
         # Quick block count check.

--- a/test/functional/tiertwo_masternode_activation.py
+++ b/test/functional/tiertwo_masternode_activation.py
@@ -3,8 +3,16 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
-from test_framework.test_framework import PivxTestFramework
-from test_framework.util import *
+from test_framework.test_framework import PivxTier2TestFramework
+from test_framework.util import (
+    assert_equal,
+    connect_nodes_clique,
+    disconnect_nodes,
+    satoshi_round,
+    sync_blocks,
+    wait_until,
+)
+
 import time
 
 """
@@ -18,202 +26,94 @@ Test checking:
  7) Masternode collateral spent removal.
 """
 
-class MasternodeActivationTest(PivxTestFramework):
+class MasternodeActivationTest(PivxTier2TestFramework):
 
-    def set_test_params(self):
-        self.num_nodes = 3
-        self.extra_args = [[], [], []]
-        self.setup_clean_chain = True
+    def disconnect_remotes(self):
+        for i in [self.remoteOnePos, self.remoteTwoPos]:
+            disconnect_nodes(self.nodes[i + 1], i)
+            disconnect_nodes(self.nodes[i], i - 1)
 
-    def check_mnsync_finished(self):
-        for i in range(0, 2):
-            status = self.nodes[i].mnsync("status")["RequestedMasternodeAssets"]
-            assert_equal(status, 999) # sync finished
+    def reconnect_remotes(self):
+        # !TODO: for some reason we need two-way connections now...
+        connect_nodes_clique(self.nodes)
+        self.sync_all()
 
-    def check_first_mn_in_mnlist_status(self, node, status):
-        listMNs = node.listmasternodes()
-        assert(len(listMNs) > 0)
-        assert_equal(listMNs[0]["status"], status)
+    def reconnect_and_restart_masternodes(self):
+        self.log.info("Reconnecting nodes and sending start message again...")
+        self.reconnect_remotes()
+        time.sleep(2)
+        self.wait_until_mnsync_finished(15)
+        self.controller_start_all_masternodes()
 
-    def check_mn_list_empty(self, node):
-        assert(len(node.listmasternodes()) == 0)
-
-    def start_masternode(self, mnOwner, masternodeAlias, mnRemote, miner):
-        ret = mnOwner.startmasternode("alias", "false", masternodeAlias)
-        assert_equal(ret["result"], "success")
-
-        self.log.info("masternode started, waiting 125 seconds until it's enabled..")
-        for i in range(1, 5):
-            miner.generate(1)
-            sync_blocks(self.nodes)
-            time.sleep(25)
-
-        # check masternode enabled
-        self.check_first_mn_in_mnlist_status(mnRemote, "ENABLED")
-        self.check_first_mn_in_mnlist_status(mnOwner, "ENABLED")
-        self.check_first_mn_in_mnlist_status(miner, "ENABLED")
-
-    def start_remote_mn_and_sync_tier_two(self, miner):
-        self.start_node(1)
-        connect_nodes(self.nodes[0], 1)
-        connect_nodes(self.nodes[1], 0)
-        connect_nodes(self.nodes[1], 2)
-        connect_nodes(self.nodes[2], 1)
-
-        self.log.info("syncing tier two across recently started peers..")
-        # let the nodes sync the tier two
-        time.sleep(20)
-        miner.generate(1)
-        sync_blocks(self.nodes)
-
-        # wait a little bit until the tier two is synced.
-        time.sleep(20)
-        self.check_mnsync_finished()
-
-    # Build a transaction that spends parent_txid:vout
-    def spend_transaction(self, node, parent_txid, vout, value, fee):
-        send_value = satoshi_round(value - fee)
-        inputs = [{'txid' : parent_txid, 'vout' : vout}]
+    def spend_collateral(self):
+        mnCollateralOutput = self.ownerOne.getmasternodeoutputs()[0]
+        assert_equal(mnCollateralOutput["txhash"], self.mnOneTxHash)
+        mnCollateralOutputIndex = mnCollateralOutput["outputidx"]
+        send_value = satoshi_round(10000 - 0.001)
+        inputs = [{'txid' : self.mnOneTxHash, 'vout' : mnCollateralOutputIndex}]
         outputs = {}
-        outputs[node.getnewaddress()] = float(send_value)
-        rawtx = node.createrawtransaction(inputs, outputs)
-        signedtx = node.signrawtransaction(rawtx)
-        txid = node.sendrawtransaction(signedtx['hex'])
-        return txid
+        outputs[self.ownerOne.getnewaddress()] = float(send_value)
+        rawtx = self.ownerOne.createrawtransaction(inputs, outputs)
+        signedtx = self.ownerOne.signrawtransaction(rawtx)
+        txid = self.miner.sendrawtransaction(signedtx['hex'])
+        self.log.info("Collateral spent in %s" % txid)
+        self.send_pings([self.remoteOne, self.remoteTwo])
+        self.stake(1, [self.remoteOne, self.remoteTwo])
+
+    # Similar to base class wait_until_mn_status but skipping the disconnected nodes
+    def wait_until_mn_expired(self, _timeout, removed=False):
+        collaterals = {
+            self.remoteOnePos: self.mnOneTxHash,
+            self.remoteTwoPos: self.mnTwoTxHash
+        }
+        for k in collaterals:
+            for i in range(self.num_nodes):
+                # skip check on disconnected remote node
+                if i == k:
+                    continue
+                try:
+                    if removed:
+                        wait_until(lambda: (self.get_mn_status(self.nodes[i], collaterals[k]) == "" or
+                                            self.get_mn_status(self.nodes[i], collaterals[k]) == "REMOVE"),
+                                   timeout=_timeout, mocktime=self.advance_mocktime)
+                    else:
+                        wait_until(lambda: self.get_mn_status(self.nodes[i], collaterals[k]) == "EXPIRED",
+                                   timeout=_timeout, mocktime=self.advance_mocktime)
+                except AssertionError:
+                    s = "EXPIRED" if not removed else "REMOVE"
+                    strErr = "Unable to get status \"%s\" on node %d for mnode %s" % (s, i, collaterals[k])
+                    raise AssertionError(strErr)
+
 
     def run_test(self):
-        mnOwner = self.nodes[0]
-        mnRemote = self.nodes[1]
-        miner = self.nodes[2]
+        self.enable_mocktime()
+        self.setup_2_masternodes_network()
 
-        self.log.info("generating 301 blocks..")
-        miner.generate(301)
+        # check masternode expiration
+        self.log.info("testing expiration now.")
+        expiration_time = 180  # regtest expiration time
+        self.log.info("disconnect remote and move time %d seconds in the future..." % expiration_time)
+        self.disconnect_remotes()
+        self.advance_mocktime_and_stake(expiration_time)
+        self.wait_until_mn_expired(30)
+        self.log.info("masternodes expired successfully")
 
-        self.log.info("adding balance to the mn owner..")
-        mnOwnerAddr = mnOwner.getnewaddress()
-        # send to the owner the collateral tx cost
-        miner.sendtoaddress(mnOwnerAddr, Decimal('10001'))
-        sync_mempools(self.nodes)
-        # confirm the tx
-        miner.generate(1)
-        self.sync_all()
-        # verify reception
-        assert_equal(mnOwner.getbalance(), Decimal('10001'))
-
-        # get the remote MN port
-        remotePort = p2p_port(1)
-
-        self.log.info("all good, creating the masternode..")
-        ## Owner side
-
-        # Let's create the masternode
-        masternodePrivKey = mnOwner.createmasternodekey()
-        masternodeAlias = "masternode1"
-        mnAddress = mnOwner.getnewaddress(masternodeAlias)
-        collateralTxId = mnOwner.sendtoaddress(mnAddress, Decimal('10000'))
-
-        sync_mempools(self.nodes)
-        miner.generate(2)
-        self.sync_all()
-        # check if tx got confirmed
-        assert(mnOwner.getrawtransaction(collateralTxId, 1)["confirmations"] > 0)
-
-        # get the collateral output using the RPC command
-        mnCollateralOutput = mnOwner.getmasternodeoutputs()[0]
-        assert_equal(mnCollateralOutput["txhash"], collateralTxId)
-        mnCollateralOutputIndex = mnCollateralOutput["outputidx"]
-
-        self.log.info("collateral accepted.. updating masternode.conf and stopping the node")
-
-        # verify collateral confirmed
-
-        # create the masternode.conf and add it
-        confData = masternodeAlias + " 127.0.0.1:" + str(remotePort) + " " + str(masternodePrivKey) + " " + str(mnCollateralOutput["txhash"]) + " " + str(mnCollateralOutputIndex)
-        destinationDirPath = os.path.join(self.options.tmpdir, "node0", "regtest")
-        destPath = os.path.join(destinationDirPath, "masternode.conf")
-        with open(destPath, "a+") as file_object:
-            file_object.write("\n")
-            file_object.write(confData)
-
-
-        ## Remote side
-        self.stop_node(1)
-
-        # change the .conf
-        destinationDirPath = os.path.join(self.options.tmpdir, "node1")
-        destPath = os.path.join(destinationDirPath, "pivx.conf")
-        with open(destPath, "a+") as file_object:
-            file_object.write("\n")
-            file_object.write("listen=1\n")
-            file_object.write("masternode=1\n")
-            file_object.write("externalip=127.0.0.1\n")
-            file_object.write("masternodeaddr=127.0.0.1:"+str(remotePort)+"\n")
-            file_object.write("masternodeprivkey=" + str(masternodePrivKey))
-
-        self.log.info("starting nodes again..")
-        self.restart_node(0)
-        self.start_remote_mn_and_sync_tier_two(miner)
-
-        self.log.info("tier two synced! starting masternode..")
-
-        ## Now everything is set, start the masternode
-        self.start_masternode(mnOwner, masternodeAlias, mnRemote, miner)
-
-        self.log.info("masternode enabled and running properly!")
-
-        self.log.info("testing now the expiration, stopping masternode and waiting +180 seconds until expires")
-        # now let's stop answering the ping and see how it gets disabled.
-        mnRemote.stop()
-        expiration_time = 180 # regtest expiration time
-        time.sleep(expiration_time)
-
-        # check masternode expired
-        self.check_first_mn_in_mnlist_status(mnOwner, "EXPIRED")
-        self.check_first_mn_in_mnlist_status(miner, "EXPIRED")
-
-        self.log.info("masternode expired, good. Starting masternode again before gets removed..")
-
-        # start again remote mn again.
-        self.start_remote_mn_and_sync_tier_two(miner)
-
-        # now let's try to re enable it before it gets removed.
-        self.start_masternode(mnOwner, masternodeAlias, mnRemote, miner)
-
-        self.log.info("testing removal now, remote will not answer any ping for 200 seconds..")
         # check masternode removal
-        mnRemote.stop()
-        removal_time = 200 # regtest removal time
-        time.sleep(removal_time)
+        self.log.info("testing removal now.")
+        removal_time = 200  # regtest removal time
+        self.advance_mocktime_and_stake(removal_time - expiration_time)
+        self.wait_until_mn_expired(30, removed=True)
+        self.log.info("masternodes removed successfully")
 
-        ## Check masternode removed
-        listMNs = mnOwner.listmasternodes()
-        if (len(listMNs) > 0):
-            assert_equal(listMNs[0]["status"], "REMOVE")
-
-        listMNs = miner.listmasternodes()
-        if (len(listMNs) > 0):
-            assert_equal(listMNs[0]["status"], "REMOVE")
-
-        self.log.info("masternode removed successfully")
-
-        self.log.info("re starting the remote node and re enabling MN..")
-        # Starting MN, activating it and spending the collateral now.
-        self.start_remote_mn_and_sync_tier_two(miner)
-        self.start_masternode(mnOwner, masternodeAlias, mnRemote, miner)
-
+        # restart and check spending the collateral now.
+        self.reconnect_and_restart_masternodes()
+        self.advance_mocktime(30)
         self.log.info("spending the collateral now..")
-        self.spend_transaction(mnOwner, collateralTxId, mnCollateralOutputIndex, 10000, 0.001)
-        sync_mempools(self.nodes)
-        miner.generate(2)
-        self.sync_all()
-
+        self.spend_collateral()
+        sync_blocks(self.nodes)
         self.log.info("checking mn status..")
-        time.sleep(10) # wait a little bit
-        # Now check vin spent
-        self.check_first_mn_in_mnlist_status(mnOwner, "VIN_SPENT")
-        self.check_first_mn_in_mnlist_status(miner, "VIN_SPENT")
-        self.check_first_mn_in_mnlist_status(mnRemote, "VIN_SPENT")
-
+        time.sleep(5)           # wait a little bit
+        self.wait_until_mn_vinspent(self.mnOneTxHash, 30)
         self.log.info("masternode list updated successfully, vin spent")
 
 

--- a/test/functional/tiertwo_masternode_activation.py
+++ b/test/functional/tiertwo_masternode_activation.py
@@ -42,7 +42,7 @@ class MasternodeActivationTest(PivxTier2TestFramework):
         self.log.info("Reconnecting nodes and sending start message again...")
         self.reconnect_remotes()
         time.sleep(2)
-        self.wait_until_mnsync_finished(15)
+        self.wait_until_mnsync_finished(35)
         self.controller_start_all_masternodes()
 
     def spend_collateral(self):
@@ -113,7 +113,7 @@ class MasternodeActivationTest(PivxTier2TestFramework):
         sync_blocks(self.nodes)
         self.log.info("checking mn status..")
         time.sleep(5)           # wait a little bit
-        self.wait_until_mn_vinspent(self.mnOneTxHash, 30)
+        self.wait_until_mn_vinspent(self.mnOneTxHash, 30, [self.remoteTwo])
         self.log.info("masternode list updated successfully, vin spent")
 
 

--- a/test/functional/tiertwo_masternode_activation.py
+++ b/test/functional/tiertwo_masternode_activation.py
@@ -10,6 +10,7 @@ from test_framework.util import (
     disconnect_nodes,
     satoshi_round,
     sync_blocks,
+    sync_mempools,
     wait_until,
 )
 
@@ -55,9 +56,10 @@ class MasternodeActivationTest(PivxTier2TestFramework):
         rawtx = self.ownerOne.createrawtransaction(inputs, outputs)
         signedtx = self.ownerOne.signrawtransaction(rawtx)
         txid = self.miner.sendrawtransaction(signedtx['hex'])
+        sync_mempools(self.nodes)
         self.log.info("Collateral spent in %s" % txid)
-        self.send_pings([self.remoteOne, self.remoteTwo])
-        self.stake(1, [self.remoteOne, self.remoteTwo])
+        self.send_pings([self.remoteTwo])
+        self.stake(1, [self.remoteTwo])
 
     # Similar to base class wait_until_mn_status but skipping the disconnected nodes
     def wait_until_mn_expired(self, _timeout, removed=False):
@@ -111,7 +113,7 @@ class MasternodeActivationTest(PivxTier2TestFramework):
         self.spend_collateral()
         sync_blocks(self.nodes)
         self.log.info("checking mn status..")
-        time.sleep(5)           # wait a little bit
+        time.sleep(3)           # wait a little bit
         self.wait_until_mn_vinspent(self.mnOneTxHash, 30, [self.remoteTwo])
         self.log.info("masternode list updated successfully, vin spent")
 

--- a/test/functional/tiertwo_masternode_activation.py
+++ b/test/functional/tiertwo_masternode_activation.py
@@ -30,19 +30,18 @@ class MasternodeActivationTest(PivxTier2TestFramework):
 
     def disconnect_remotes(self):
         for i in [self.remoteOnePos, self.remoteTwoPos]:
-            disconnect_nodes(self.nodes[i + 1], i)
-            disconnect_nodes(self.nodes[i], i - 1)
+            for j in range(self.num_nodes):
+                if i != j:
+                    disconnect_nodes(self.nodes[i], j)
 
     def reconnect_remotes(self):
-        # !TODO: for some reason we need two-way connections now...
         connect_nodes_clique(self.nodes)
         self.sync_all()
 
     def reconnect_and_restart_masternodes(self):
         self.log.info("Reconnecting nodes and sending start message again...")
         self.reconnect_remotes()
-        time.sleep(2)
-        self.wait_until_mnsync_finished(35)
+        self.wait_until_mnsync_finished()
         self.controller_start_all_masternodes()
 
     def spend_collateral(self):

--- a/test/functional/tiertwo_masternode_ping.py
+++ b/test/functional/tiertwo_masternode_ping.py
@@ -76,6 +76,12 @@ class MasternodePingTest(PivxTestFramework):
         self.log.info("initializing remote masternode...")
         remote.initmasternode(mnPrivkey, "127.0.0.1:" + str(p2p_port(2)))
 
+        # sanity check, verify that we are not in IBD
+        for i in range(0, len(self.nodes)):
+            node = self.nodes[i]
+            if (node.getblockchaininfo()['initial_block_downloading']):
+                raise AssertionError("Error, node(%s) shouldn't be in IBD." % str(i))
+
         # Wait until mnsync is complete (max 120 seconds)
         self.log.info("waiting to complete mnsync...")
         start_time = time.time()

--- a/test/functional/tiertwo_masternode_ping.py
+++ b/test/functional/tiertwo_masternode_ping.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The PIVX developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import PivxTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    connect_nodes_clique,
+    disconnect_nodes,
+    Decimal,
+    p2p_port,
+    satoshi_round,
+    sync_blocks,
+    wait_until,
+)
+
+import os
+import time
+
+"""
+Test checking masternode ping thread
+Does not use functions of PivxTier2TestFramework as we don't want to send
+pings on demand. Here, instead, mocktime is disabled, and we just wait with
+time.sleep to verify that masternodes send pings correctly.
+"""
+
+class MasternodePingTest(PivxTestFramework):
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        # 0=miner 1=mn_owner 2=mn_remote
+        self.num_nodes = 3
+
+
+    def run_test(self):
+        miner = self.nodes[0]
+        owner = self.nodes[1]
+        remote = self.nodes[2]
+        mnPrivkey = "9247iC59poZmqBYt9iDh9wDam6v9S1rW5XekjLGyPnDhrDkP4AK"
+
+        self.log.info("generating 141 blocks...")
+        miner.generate(141)
+        sync_blocks(self.nodes)
+
+        # Create collateral
+        self.log.info("funding masternode controller...")
+        masternodeAlias = "mnode"
+        mnAddress = owner.getnewaddress(masternodeAlias)
+        collateralTxId = miner.sendtoaddress(mnAddress, Decimal('10000'))
+        miner.generate(1)
+        sync_blocks(self.nodes)
+        assert_equal(owner.getbalance(), Decimal('10000'))
+        assert_greater_than(owner.getrawtransaction(collateralTxId, 1)["confirmations"], 0)
+
+        # Setup controller
+        self.log.info("controller setup...")
+        o = owner.getmasternodeoutputs()
+        assert_equal(len(o), 1)
+        assert_equal(o[0]["txhash"], collateralTxId)
+        vout = o[0]["outputidx"]
+        self.log.info("collateral accepted for "+ masternodeAlias +".. updating masternode.conf and stopping the node")
+        confData = masternodeAlias + " 127.0.0.1:" + str(p2p_port(2)) + " " + \
+                   str(mnPrivkey) +  " " + str(collateralTxId) + " " + str(vout)
+        destPath = os.path.join(self.options.tmpdir, "node1", "regtest", "masternode.conf")
+        with open(destPath, "a+") as file_object:
+            file_object.write("\n")
+            file_object.write(confData)
+
+        # Init remote
+        self.log.info("initializing remote masternode...")
+        remote.initmasternode(mnPrivkey, "127.0.0.1:" + str(p2p_port(2)))
+
+        # Wait until mnsync is complete (max 30 seconds)
+        self.log.info("waiting complete mnsync...")
+        synced = [False] * 3
+        timeout = time.time() + 30
+        while time.time() < timeout:
+            for i in range(3):
+                if not synced[i]:
+                    synced[i] = (self.nodes[i].mnsync("status")["RequestedMasternodeAssets"] == 999)
+            if synced != [True] * 3:
+                time.sleep(1)
+        if synced != [True] * 3:
+            raise AssertionError("Unable to complete mnsync: %s" % str(synced))
+
+        # Send Start message
+        self.log.info("sending masternode broadcast...")
+        self.controller_start_masternode(owner, masternodeAlias)
+        miner.generate(1)
+        sync_blocks(self.nodes)
+        time.sleep(1)
+
+        # Wait until masternode is enabled anywhere (max 100 secs)
+        self.log.info("waiting till masternode gets enabled...")
+        enabled = [""] * 3
+        timeout = time.time() + 100
+        while time.time() < timeout:
+            for i in range(3):
+                if enabled[i] != "ENABLED":
+                    enabled[i] = self.get_mn_status(self.nodes[i], collateralTxId)
+            if enabled != ["ENABLED"] * 3:
+                time.sleep(1)
+        if enabled != ["ENABLED"] * 3:
+            raise AssertionError("Unable to get to \"ENABLED\" state: %s" % str(enabled))
+        self.log.info("Good. Masternode enabled")
+        miner.generate(1)
+        sync_blocks(self.nodes)
+        time.sleep(1)
+
+        last_seen = [self.get_mn_lastseen(node, collateralTxId) for node in self.nodes]
+        self.log.info("Current lastseen: %s" % str(last_seen))
+        self.log.info("Waiting 2 * 25 seconds and check new lastseen...")
+        time.sleep(50)
+        new_last_seen = [self.get_mn_lastseen(node, collateralTxId) for node in self.nodes]
+        self.log.info("New lastseen: %s" % str(new_last_seen))
+        for i in range(self.num_nodes):
+            assert_greater_than(new_last_seen[i], last_seen[i])
+        self.log.info("All good.")
+
+
+
+if __name__ == '__main__':
+    MasternodePingTest().main()


### PR DESCRIPTION
Follow up to #1829, focused on decrease the testing time and continue improving the tier two functional tests.

Introduced the following changes:

1) Implemented a new RPC command `initmasternode` to initialize the masternode at runtime, with direct impact in the functional test time. The tests don't need to shut the nodes down and restart them anymore in order to setup the masternode/s.

2) Adapted `tiertwo_governance_sync_basic.py` to the new runtime initialization feature.

3) Further tier two cleanup. `Masternodeconfig` code refactored properly.

It's still in WIP (because it need some more work) but the results are very favorable for now:

Test previous time:
- 9:43 min

Test time with this changes:
- 3:21 min