### PR TITLE
[Wallet] Sapling notes, nullifiers and witnesses management.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -139,11 +139,24 @@ jobs:
         HOST=x86_64-unknown-linux-gnu
         PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools libqt5svg5-dev libqt5charts5-dev libqrencode-dev protobuf-compiler libdbus-1-dev libharfbuzz-dev libprotobuf-dev"
         DEP_OPTS="NO_QT=1 NO_UPNP=1 DEBUG=1 ALLOW_HOST_PACKAGES=1"
+        RUN_UNIT_TESTS=false
         RUN_FUNCTIONAL_TESTS=true
         #TEST_RUNNER_EXTRA="--coverage --extended"  # Run extended tests so that coverage does not fail, but exclude the very slow dbcrash
         GOAL="install"
         BITCOIN_CONFIG="--enable-zmq --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports --disable-online-rust --with-params-dir=$PARAMS_DIR"
         BUILD_TIMEOUT=540
+
+    - stage: test
+      name: 'x86_64 Linux  [GOAL: install]  [bionic]  [only unit tests]'
+      env: >-
+        HOST=x86_64-unknown-linux-gnu
+        PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools libqt5svg5-dev libqt5charts5-dev libqrencode-dev protobuf-compiler libdbus-1-dev libharfbuzz-dev libprotobuf-dev"
+        DEP_OPTS="NO_QT=1 NO_UPNP=1 DEBUG=1 ALLOW_HOST_PACKAGES=1"
+        RUN_UNIT_TESTS=true
+        RUN_FUNCTIONAL_TESTS=false
+        GOAL="install"
+        BITCOIN_CONFIG="--enable-zmq --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports --disable-online-rust --with-params-dir=$PARAMS_DIR"
+        BUILT_TIMEOUT=1200
 
     - stage: test
       name: 'x86_64 Linux  [GOAL: install]  [bionic]  [no GUI, no unit tests - only functional tests on legacy pre-HD wallets]'

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -61,7 +61,6 @@ BITCOIN_TESTS =\
   test/librust/wallet_zkeys_tests.cpp \
   test/librust/merkletree_tests.cpp \
   test/librust/transaction_builder_tests.cpp \
-  test/librust/sapling_wallet_tests.cpp \
   test/base32_tests.cpp \
   test/base58_tests.cpp \
   test/base64_tests.cpp \
@@ -117,7 +116,8 @@ if ENABLE_WALLET
 BITCOIN_TESTS += \
   test/librust/sapling_rpc_wallet_tests.cpp \
   wallet/test/wallet_tests.cpp \
-  wallet/test/crypto_tests.cpp
+  wallet/test/crypto_tests.cpp \
+  test/librust/sapling_wallet_tests.cpp
 endif
 
 test_test_pivx_SOURCES = $(BITCOIN_TEST_SUITE) $(BITCOIN_TESTS) $(JSON_TEST_FILES) $(RAW_TEST_FILES)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -61,6 +61,7 @@ BITCOIN_TESTS =\
   test/librust/wallet_zkeys_tests.cpp \
   test/librust/merkletree_tests.cpp \
   test/librust/transaction_builder_tests.cpp \
+  test/librust/sapling_wallet_tests.cpp \
   test/base32_tests.cpp \
   test/base58_tests.cpp \
   test/base64_tests.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -168,8 +168,10 @@ if EMBEDDED_UNIVALUE
 endif
 
 %.cpp.test: %.cpp
-	@echo Running tests: `cat $< | grep -E "(BOOST_FIXTURE_TEST_SUITE\\(|BOOST_AUTO_TEST_SUITE\\()" | cut -d '(' -f 2 | cut -d ',' -f 1 | cut -d ')' -f 1` from $<
-	$(AM_V_at)$(TEST_BINARY) -l test_suite -t "`cat $< | grep -E "(BOOST_FIXTURE_TEST_SUITE\\(|BOOST_AUTO_TEST_SUITE\\()" | cut -d '(' -f 2 | cut -d ',' -f 1 | cut -d ')' -f 1`" > $<.log 2>&1 || (cat $<.log && false)
+	@echo "" && echo Running tests: `cat $< | grep -E "(BOOST_FIXTURE_TEST_SUITE\\(|BOOST_AUTO_TEST_SUITE\\()" | cut -d '(' -f 2 | cut -d ',' -f 1 | cut -d ')' -f 1` from $<
+	$(AM_V_at)$(TEST_BINARY) -l test_suite -t "`cat $< | grep -E "(BOOST_FIXTURE_TEST_SUITE\\(|BOOST_AUTO_TEST_SUITE\\()" | cut -d '(' -f 2 | cut -d ',' -f 1 | cut -d ')' -f 1`" > $<.log 2>&1 || (cat $<.log && false) & echo "$$!" > "$<.pid"
+	@while kill -0 `cat $<.pid` > /dev/null 2>&1; do echo -n "." > /dev/tty | sleep 0.5; done
+	@echo -e "\r\033[1A\033[0K" | rm $<.pid
 
 %.json.h: %.json
 	@$(MKDIR_P) $(@D)

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -291,7 +291,9 @@ void SaplingScriptPubKeyMan::DecrementNoteWitnesses(const CBlockIndex* pindex)
     nWitnessCacheSize -= 1;
     nWitnessCacheNeedsUpdate = true;
     // TODO: If nWitnessCache is zero, we need to regenerate the caches (#1302)
-    assert(nWitnessCacheSize > 0);
+    if (Params().IsRegTestNet()) { // throw an error in regtest to be able to catch it from the sapling_wallet_tests.cpp unit test.
+        if (nWitnessCacheSize <= 0) throw std::runtime_error("nWitnessCacheSize > 0");
+    } else assert(nWitnessCacheSize > 0);
 
     // For performance reasons, we write out the witness cache in
     // CWallet::SetBestChain() (which also ensures that overall consistency

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -262,6 +262,13 @@ std::pair<mapSaplingNoteData_t, SaplingIncomingViewingKeyMap> SaplingScriptPubKe
     return std::make_pair(noteData, viewingKeysToAdd);
 }
 
+bool SaplingScriptPubKeyMan::IsSaplingNullifierFromMe(const uint256& nullifier) const
+{
+    LOCK(wallet->cs_wallet);
+    return mapSaplingNullifiersToNotes.count(nullifier) &&
+        wallet->mapWallet.count(mapSaplingNullifiersToNotes.at(nullifier).hash);
+}
+
 bool SaplingScriptPubKeyMan::UpdatedNoteData(const CWalletTx& wtxIn, CWalletTx& wtx)
 {
     bool unchangedSaplingFlag = (wtxIn.mapSaplingNoteData.empty() || wtxIn.mapSaplingNoteData == wtx.mapSaplingNoteData);

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -72,6 +72,21 @@ void SaplingScriptPubKeyMan::UpdateSaplingNullifierNoteMapWithTx(CWalletTx& wtx)
     }
 }
 
+/**
+ * Update mapSaplingNullifiersToNotes with the cached nullifiers in this tx.
+ */
+void SaplingScriptPubKeyMan::UpdateNullifierNoteMapWithTx(const CWalletTx& wtx)
+{
+    {
+        LOCK(wallet->cs_wallet);
+        for (const mapSaplingNoteData_t::value_type& item : wtx.mapSaplingNoteData) {
+            if (item.second.nullifier) {
+                mapSaplingNullifiersToNotes[*item.second.nullifier] = item.first;
+            }
+        }
+    }
+}
+
 template<typename NoteDataMap>
 void CopyPreviousWitnesses(NoteDataMap& noteDataMap, int indexHeight, int64_t nWitnessCacheSize)
 {

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -210,6 +210,8 @@ void SaplingScriptPubKeyMan::IncrementNoteWitnesses(const CBlockIndex* pindex,
     }
 
     for (const auto& tx : pblock->vtx) {
+        if (!tx->hasSaplingData()) continue;
+
         const uint256& hash = tx->GetHash();
         bool txIsOurs = wallet->mapWallet.count(hash);
 

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -7,6 +7,15 @@
 #include "chain.h" // for CBlockIndex
 #include "validation.h" // for ReadBlockFromDisk()
 
+void SaplingScriptPubKeyMan::AddToSaplingSpends(const uint256& nullifier, const uint256& wtxid)
+{
+    mapTxSaplingNullifiers.emplace(nullifier, wtxid);
+
+    std::pair<TxNullifiers::iterator, TxNullifiers::iterator> range;
+    range = mapTxSaplingNullifiers.equal_range(nullifier);
+    wallet->SyncMetaDataN(range);
+}
+
 template<typename NoteDataMap>
 void CopyPreviousWitnesses(NoteDataMap& noteDataMap, int indexHeight, int64_t nWitnessCacheSize)
 {

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -17,6 +17,21 @@ void SaplingScriptPubKeyMan::AddToSaplingSpends(const uint256& nullifier, const 
     wallet->SyncMetaDataN(range);
 }
 
+bool SaplingScriptPubKeyMan::IsSaplingSpent(const uint256& nullifier) const {
+    LOCK(cs_main);
+    std::pair<TxNullifiers::const_iterator, TxNullifiers::const_iterator> range;
+    range = mapTxSaplingNullifiers.equal_range(nullifier);
+
+    for (TxNullifiers::const_iterator it = range.first; it != range.second; ++it) {
+        const uint256& wtxid = it->second;
+        std::map<uint256, CWalletTx>::const_iterator mit = wallet->mapWallet.find(wtxid);
+        if (mit != wallet->mapWallet.end() && mit->second.GetDepthInMainChain() >= 0) {
+            return true; // Spent
+        }
+    }
+    return false;
+}
+
 void SaplingScriptPubKeyMan::UpdateSaplingNullifierNoteMapForBlock(const CBlock *pblock) {
     LOCK(wallet->cs_wallet);
 

--- a/src/sapling/saplingscriptpubkeyman.h
+++ b/src/sapling/saplingscriptpubkeyman.h
@@ -206,6 +206,12 @@ public:
     //! Whether the nullifier is from this wallet
     bool IsSaplingNullifierFromMe(const uint256& nullifier) const;
 
+    //! Return all of the witnesses for the input notes
+    void GetSaplingNoteWitnesses(
+            const std::vector<SaplingOutPoint>& notes,
+            std::vector<Optional<SaplingWitness>>& witnesses,
+            uint256& final_anchor);
+
     //! Update note data if is needed
     bool UpdatedNoteData(const CWalletTx& wtxIn, CWalletTx& wtx);
 

--- a/src/sapling/saplingscriptpubkeyman.h
+++ b/src/sapling/saplingscriptpubkeyman.h
@@ -176,6 +176,9 @@ public:
     //! Return the spending key for the payment address (nullopt if the wallet has no spending key for such address)
     Optional<libzcash::SaplingExtendedSpendingKey> GetSpendingKeyForPaymentAddress(const libzcash::SaplingPaymentAddress &addr) const;
 
+    //! Update note data if is needed
+    bool UpdatedNoteData(const CWalletTx& wtxIn, CWalletTx& wtx);
+
     //! Clear every notesData from every wallet tx and reset the witness cache size
     void ClearNoteWitnessCache();
 

--- a/src/sapling/saplingscriptpubkeyman.h
+++ b/src/sapling/saplingscriptpubkeyman.h
@@ -182,6 +182,9 @@ public:
     //! SaplingPaymentAddress in this wallet
     std::pair<mapSaplingNoteData_t, SaplingIncomingViewingKeyMap> FindMySaplingNotes(const CTransaction& tx) const;
 
+    //! Whether the nullifier is from this wallet
+    bool IsSaplingNullifierFromMe(const uint256& nullifier) const;
+
     //! Update note data if is needed
     bool UpdatedNoteData(const CWalletTx& wtxIn, CWalletTx& wtx);
 

--- a/src/sapling/saplingscriptpubkeyman.h
+++ b/src/sapling/saplingscriptpubkeyman.h
@@ -116,6 +116,18 @@ public:
     void DecrementNoteWitnesses(const CBlockIndex* pindex);
 
     /**
+     *  Update mapSaplingNullifiersToNotes, computing the nullifier
+     *  from a cached witness if necessary.
+     */
+    void UpdateSaplingNullifierNoteMapWithTx(CWalletTx& wtx);
+
+    /**
+     * Iterate over transactions in a block and update the cached Sapling nullifiers
+     * for transactions which belong to the wallet.
+     */
+    void UpdateSaplingNullifierNoteMapForBlock(const CBlock* pblock);
+
+    /**
      * Set and initialize the Sapling HD chain.
      */
     bool SetupGeneration(const CKeyID& keyID, bool force = false);

--- a/src/sapling/saplingscriptpubkeyman.h
+++ b/src/sapling/saplingscriptpubkeyman.h
@@ -98,6 +98,11 @@ public:
     ~SaplingScriptPubKeyMan() {};
 
     /**
+     * Keep track of the used nullifier.
+     */
+    void AddToSaplingSpends(const uint256& nullifier, const uint256& wtxid);
+
+    /**
      * pindex is the new tip being connected.
      */
     void IncrementNoteWitnesses(const CBlockIndex* pindex,
@@ -190,6 +195,14 @@ private:
     CWallet* wallet{nullptr};
     /* the HD chain data model (external/internal chain counters) */
     CHDChain hdChain;
+
+
+    /**
+     * Used to keep track of spent Notes, and
+     * detect and report conflicts (double-spends).
+     */
+    typedef std::multimap<uint256, uint256> TxNullifiers;
+    TxNullifiers mapTxSaplingNullifiers;
 };
 
 #endif //PIVX_SAPLINGSCRIPTPUBKEYMAN_H

--- a/src/sapling/saplingscriptpubkeyman.h
+++ b/src/sapling/saplingscriptpubkeyman.h
@@ -116,6 +116,12 @@ public:
     void DecrementNoteWitnesses(const CBlockIndex* pindex);
 
     /**
+     * Update mapSaplingNullifiersToNotes
+     * with the cached nullifiers in this tx.
+     */
+    void UpdateNullifierNoteMapWithTx(const CWalletTx& wtx);
+
+    /**
      *  Update mapSaplingNullifiersToNotes, computing the nullifier
      *  from a cached witness if necessary.
      */

--- a/src/sapling/saplingscriptpubkeyman.h
+++ b/src/sapling/saplingscriptpubkeyman.h
@@ -153,6 +153,8 @@ public:
     /* Encrypt Sapling keys */
     bool EncryptSaplingKeys(CKeyingMaterial& vMasterKeyIn);
 
+    void GetConflicts(const CWalletTx& wtx, std::set<uint256>& result) const;
+
     // Add full viewing key if it's not already in the wallet
     KeyAddResult AddViewingKeyToWallet(const libzcash::SaplingExtendedFullViewingKey &extfvk) const;
 

--- a/src/sapling/saplingscriptpubkeyman.h
+++ b/src/sapling/saplingscriptpubkeyman.h
@@ -86,6 +86,8 @@ enum KeyAddResult {
     KeyNotAdded,
 };
 
+typedef std::map<SaplingOutPoint, SaplingNoteData> mapSaplingNoteData_t;
+
 /*
  * Sapling keys manager
  * todo: add real description..
@@ -175,6 +177,10 @@ public:
 
     //! Return the spending key for the payment address (nullopt if the wallet has no spending key for such address)
     Optional<libzcash::SaplingExtendedSpendingKey> GetSpendingKeyForPaymentAddress(const libzcash::SaplingPaymentAddress &addr) const;
+
+    //! Finds all output notes in the given tx that have been sent to a
+    //! SaplingPaymentAddress in this wallet
+    std::pair<mapSaplingNoteData_t, SaplingIncomingViewingKeyMap> FindMySaplingNotes(const CTransaction& tx) const;
 
     //! Update note data if is needed
     bool UpdatedNoteData(const CWalletTx& wtxIn, CWalletTx& wtx);

--- a/src/sapling/saplingscriptpubkeyman.h
+++ b/src/sapling/saplingscriptpubkeyman.h
@@ -103,6 +103,7 @@ public:
      * Keep track of the used nullifier.
      */
     void AddToSaplingSpends(const uint256& nullifier, const uint256& wtxid);
+    bool IsSaplingSpent(const uint256& nullifier) const;
 
     /**
      * pindex is the new tip being connected.

--- a/src/sapling/saplingscriptpubkeyman.h
+++ b/src/sapling/saplingscriptpubkeyman.h
@@ -171,6 +171,9 @@ public:
     //! Return the spending key for the payment address (nullopt if the wallet has no spending key for such address)
     Optional<libzcash::SaplingExtendedSpendingKey> GetSpendingKeyForPaymentAddress(const libzcash::SaplingPaymentAddress &addr) const;
 
+    //! Clear every notesData from every wallet tx and reset the witness cache size
+    void ClearNoteWitnessCache();
+
     // Sapling metadata
     std::map<libzcash::SaplingIncomingViewingKey, CKeyMetadata> mapSaplingZKeyMetadata;
 
@@ -179,7 +182,8 @@ public:
      * This will always be greater than or equal to the size of the largest
      * incremental witness cache in any transaction in mapWallet.
      */
-    int64_t nWitnessCacheSize;
+    int64_t nWitnessCacheSize{0};
+    bool nWitnessCacheNeedsUpdate{false};
 
 private:
     /* Parent wallet */

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -81,6 +81,7 @@ set(BITCOIN_TESTS
         ${CMAKE_CURRENT_SOURCE_DIR}/librust/wallet_zkeys_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/librust/merkletree_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/librust/transaction_builder_tests.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/librust/sapling_wallet_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/base32_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/base58_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/base64_tests.cpp

--- a/src/test/librust/sapling_rpc_wallet_tests.cpp
+++ b/src/test/librust/sapling_rpc_wallet_tests.cpp
@@ -53,9 +53,6 @@ BOOST_FIXTURE_TEST_SUITE(sapling_rpc_wallet_tests, WalletTestingSetup)
 BOOST_AUTO_TEST_CASE(rpc_wallet_sapling_validateaddress)
 {
     SelectParams(CBaseChainParams::MAIN);
-
-    LOCK2(cs_main, pwalletMain->cs_wallet);
-
     UniValue retValue;
 
     // Check number of args
@@ -87,8 +84,11 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_sapling_validateaddress)
 
 BOOST_AUTO_TEST_CASE(rpc_wallet_sapling_importkey_paymentaddress) {
     SelectParams(CBaseChainParams::MAIN);
-    LOCK2(cs_main, pwalletMain->cs_wallet);
-    pwalletMain->SetupSPKM(false);
+    {
+        LOCK(pwalletMain->cs_wallet);
+        pwalletMain->SetMinVersion(FEATURE_SAPLING);
+        pwalletMain->SetupSPKM(false);
+    }
 
     auto testAddress = [](const std::string& key) {
         UniValue ret;
@@ -113,8 +113,11 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_sapling_importkey_paymentaddress) {
  */
 BOOST_AUTO_TEST_CASE(rpc_wallet_sapling_importexport)
 {
-    LOCK2(cs_main, pwalletMain->cs_wallet);
-    pwalletMain->SetupSPKM(false);
+    {
+        LOCK(pwalletMain->cs_wallet);
+        pwalletMain->SetMinVersion(FEATURE_SAPLING);
+        pwalletMain->SetupSPKM(false);
+    }
     UniValue retValue;
     int n1 = 1000; // number of times to import/export
     int n2 = 1000; // number of addresses to create and list
@@ -204,9 +207,9 @@ void CheckHaveAddr(const libzcash::PaymentAddress& addr) {
 
 BOOST_AUTO_TEST_CASE(rpc_wallet_getnewshieldedaddress) {
     UniValue addr;
-
-    LOCK2(cs_main, pwalletMain->cs_wallet);
-    if (!pwalletMain->HasSaplingSPKM()) {
+    {
+        LOCK(pwalletMain->cs_wallet);
+        pwalletMain->SetMinVersion(FEATURE_SAPLING);
         pwalletMain->SetupSPKM(false);
     }
 
@@ -219,11 +222,12 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_getnewshieldedaddress) {
 
 BOOST_AUTO_TEST_CASE(rpc_wallet_encrypted_wallet_sapzkeys)
 {
-    LOCK2(cs_main, pwalletMain->cs_wallet);
     UniValue retValue;
     int n = 100;
 
-    if(!pwalletMain->HasSaplingSPKM()) {
+    {
+        LOCK(pwalletMain->cs_wallet);
+        pwalletMain->SetMinVersion(FEATURE_SAPLING);
         pwalletMain->SetupSPKM(false);
     }
 

--- a/src/test/librust/sapling_wallet_tests.cpp
+++ b/src/test/librust/sapling_wallet_tests.cpp
@@ -1,0 +1,1130 @@
+// Copyright (c) 2016-2020 The ZCash developers
+// Copyright (c) 2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include "wallet/test/wallet_test_fixture.h"
+
+#include <sodium.h>
+
+#include "base58.h"
+#include "chainparams.h"
+#include "key_io.h"
+#include "validation.h"
+#include "optional.h"
+#include "primitives/block.h"
+#include "random.h"
+#include "sapling/transaction_builder.h"
+#include "test/librust/utiltest.h"
+#include "wallet/wallet.h"
+#include "consensus/merkle.h"
+#include "sapling/note.hpp"
+#include "sapling/noteencryption.hpp"
+
+#include <boost/filesystem.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+void setupWallet(CWallet& wallet)
+{
+    wallet.SetMinVersion(FEATURE_SAPLING);
+    wallet.SetupSPKM(false);
+}
+
+std::vector<SaplingOutPoint> SetSaplingNoteData(CWalletTx& wtx) {
+    mapSaplingNoteData_t saplingNoteData;
+    SaplingOutPoint saplingOutPoint = {wtx.GetHash(), 0};
+    SaplingNoteData saplingNd;
+    saplingNoteData[saplingOutPoint] = saplingNd;
+    wtx.SetSaplingNoteData(saplingNoteData);
+    std::vector<SaplingOutPoint> saplingNotes {saplingOutPoint};
+    return saplingNotes;
+}
+
+SaplingOutPoint CreateValidBlock(CWallet& wallet,
+                                libzcash::SaplingExtendedSpendingKey& sk,
+                                const CBlockIndex& index,
+                                CBlock& block,
+                                SaplingMerkleTree& saplingTree)
+{
+    CWalletTx wtx = GetValidSaplingReceive(Params().GetConsensus(),
+                                           wallet, sk, 0, true);
+    auto saplingNotes = SetSaplingNoteData(wtx);
+    wallet.LoadToWallet(wtx);
+
+    block.vtx.emplace_back(MakeTransactionRef(wtx));
+    wallet.IncrementNoteWitnesses(&index, &block, saplingTree);
+
+    return saplingNotes[0];
+}
+
+uint256 GetWitnessesAndAnchors(CWallet& wallet,
+                               std::vector<SaplingOutPoint>& saplingNotes,
+                               std::vector<Optional<SaplingWitness>>& saplingWitnesses)
+{
+    saplingWitnesses.clear();
+    uint256 saplingAnchor;
+    wallet.GetSaplingScriptPubKeyMan()->GetSaplingNoteWitnesses(saplingNotes, saplingWitnesses, saplingAnchor);
+    return saplingAnchor;
+}
+
+BOOST_FIXTURE_TEST_SUITE(sapling_wallet_tests, WalletTestingSetup)
+
+BOOST_AUTO_TEST_CASE(SetSaplingNoteAddrsInCWalletTx) {
+    auto consensusParams = RegtestActivateSapling();
+
+    CWallet& wallet = *pwalletMain;
+    LOCK(wallet.cs_wallet);
+    setupWallet(wallet);
+
+    auto sk = GetTestMasterSaplingSpendingKey();
+    auto expsk = sk.expsk;
+    auto fvk = expsk.full_viewing_key();
+    auto ivk = fvk.in_viewing_key();
+    auto pk = sk.DefaultAddress();
+
+    libzcash::SaplingNote note(pk, 50000);
+    auto cm = note.cmu().get();
+    SaplingMerkleTree tree;
+    tree.append(cm);
+    auto anchor = tree.root();
+    auto witness = tree.witness();
+
+    Optional<uint256> nf = note.nullifier(fvk, witness.position());
+    BOOST_CHECK(nf != boost::none);
+    uint256 nullifier = nf.get();
+
+    auto builder = TransactionBuilder(consensusParams, 1);
+    builder.AddSaplingSpend(expsk, note, anchor, witness);
+    builder.AddSaplingOutput(fvk.ovk, pk, 50000, {});
+    builder.SetFee(0);
+    auto tx = builder.Build().GetTxOrThrow();
+
+    CWalletTx wtx {&wallet, tx};
+
+    BOOST_CHECK_EQUAL(0, wtx.mapSaplingNoteData.size());
+    mapSaplingNoteData_t noteData;
+
+    SaplingOutPoint op {wtx.GetHash(), 0};
+    SaplingNoteData nd;
+    nd.nullifier = nullifier;
+    nd.ivk = ivk;
+    nd.witnesses.push_front(witness);
+    nd.witnessHeight = 123;
+    noteData.insert(std::make_pair(op, nd));
+
+    wtx.SetSaplingNoteData(noteData);
+    BOOST_CHECK(noteData == wtx.mapSaplingNoteData);
+
+    // Test individual fields in case equality operator is defined/changed.
+    BOOST_CHECK(ivk == wtx.mapSaplingNoteData[op].ivk);
+    BOOST_CHECK(nullifier == wtx.mapSaplingNoteData[op].nullifier);
+    BOOST_CHECK(nd.witnessHeight == wtx.mapSaplingNoteData[op].witnessHeight);
+    BOOST_CHECK(witness == wtx.mapSaplingNoteData[op].witnesses.front());
+
+    // Revert to default
+    RegtestDeactivateSapling();
+}
+
+// Cannot add note data for an index which does not exist in tx.vShieldedOutput
+BOOST_AUTO_TEST_CASE(SetInvalidSaplingNoteDataInCWalletTx) {
+    CWalletTx wtx;
+    BOOST_CHECK_EQUAL(0, wtx.mapSaplingNoteData.size());
+
+    mapSaplingNoteData_t noteData;
+    SaplingOutPoint op {uint256(), 1};
+    SaplingNoteData nd;
+    noteData.insert(std::make_pair(op, nd));
+
+    BOOST_CHECK_THROW(wtx.SetSaplingNoteData(noteData), std::logic_error);
+}
+
+BOOST_AUTO_TEST_CASE(FindMySaplingNotes) {
+    auto consensusParams = RegtestActivateSapling();
+
+    CWallet& wallet = *pwalletMain;
+    LOCK(wallet.cs_wallet);
+    wallet.SetupSPKM(false);
+
+    // Generate dummy Sapling address
+    auto sk = GetTestMasterSaplingSpendingKey();
+    auto expsk = sk.expsk;
+    auto extfvk = sk.ToXFVK();
+    auto pa = sk.DefaultAddress();
+
+    auto testNote = GetTestSaplingNote(pa, 50000);
+
+    // Generate transaction
+    auto builder = TransactionBuilder(consensusParams, 1);
+    builder.AddSaplingSpend(expsk, testNote.note, testNote.tree.root(), testNote.tree.witness());
+    builder.AddSaplingOutput(extfvk.fvk.ovk, pa, 25000, {});
+    auto tx = builder.Build().GetTxOrThrow();
+
+    // No Sapling notes can be found in tx which does not belong to the wallet
+    CWalletTx wtx {&wallet, tx};
+    BOOST_CHECK(!wallet.HaveSaplingSpendingKey(extfvk));
+    auto noteMap = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(wtx).first;
+    BOOST_CHECK_EQUAL(0, noteMap.size());
+
+    // Add spending key to wallet, so Sapling notes can be found
+    BOOST_CHECK(wallet.AddSaplingZKey(sk));
+    BOOST_CHECK(wallet.HaveSaplingSpendingKey(extfvk));
+    noteMap = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(wtx).first;
+    BOOST_CHECK_EQUAL(2, noteMap.size());
+
+    // Revert to default
+    RegtestDeactivateSapling();
+}
+
+// Generate note A and spend to create note B, from which we spend to create two conflicting transactions
+BOOST_AUTO_TEST_CASE(GetConflictedSaplingNotes) {
+    auto consensusParams = RegtestActivateSapling();
+
+    CWallet& wallet = *pwalletMain;
+    LOCK2(cs_main, wallet.cs_wallet);
+    setupWallet(wallet);
+
+    // Generate Sapling address
+    auto sk = GetTestMasterSaplingSpendingKey();
+    auto expsk = sk.expsk;
+    auto extfvk = sk.ToXFVK();
+    auto ivk = extfvk.fvk.in_viewing_key();
+    auto pk = sk.DefaultAddress();
+
+    BOOST_CHECK(wallet.AddSaplingZKey(sk));
+    BOOST_CHECK(wallet.HaveSaplingSpendingKey(extfvk));
+
+    // Generate note A
+    libzcash::SaplingNote note(pk, 50000);
+    auto cm = note.cmu().get();
+    SaplingMerkleTree saplingTree;
+    saplingTree.append(cm);
+    auto anchor = saplingTree.root();
+    auto witness = saplingTree.witness();
+
+    // Generate tx to create output note B
+    auto builder = TransactionBuilder(consensusParams, 1);
+    builder.AddSaplingSpend(expsk, note, anchor, witness);
+    builder.AddSaplingOutput(extfvk.fvk.ovk, pk, 35000, {});
+    auto tx = builder.Build().GetTxOrThrow();
+    CWalletTx wtx {&wallet, tx};
+
+    // Fake-mine the transaction
+    BOOST_CHECK_EQUAL(0, chainActive.Height());
+    CBlock block;
+    block.hashPrevBlock = chainActive[0]->GetBlockHash();
+    block.vtx.emplace_back(MakeTransactionRef(wtx));
+    block.hashMerkleRoot = BlockMerkleRoot(block);
+    const auto& blockHash = block.GetHash();
+    CBlockIndex fakeIndex {block};
+    BlockMap::iterator mi = mapBlockIndex.emplace(blockHash, &fakeIndex).first;
+    fakeIndex.phashBlock = &((*mi).first);
+    chainActive.SetTip(&fakeIndex);
+    BOOST_CHECK(chainActive.Contains(&fakeIndex));
+    BOOST_CHECK_EQUAL(0, chainActive.Height());
+
+    // Simulate SyncTransaction which calls AddToWalletIfInvolvingMe
+    auto saplingNoteData = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(wtx).first;
+    BOOST_CHECK(saplingNoteData.size() > 0);
+    wtx.SetSaplingNoteData(saplingNoteData);
+    wtx.SetMerkleBranch(mapBlockIndex[blockHash], 0);
+    BOOST_CHECK(wallet.LoadToWallet(wtx));
+
+    // Simulate receiving new block and ChainTip signal
+    wallet.IncrementNoteWitnesses(&fakeIndex, &block, saplingTree);
+    wallet.GetSaplingScriptPubKeyMan()->UpdateSaplingNullifierNoteMapForBlock(&block);
+
+    // Retrieve the updated wtx from wallet
+    const uint256& hash = wtx.GetHash();
+    wtx = wallet.mapWallet[hash];
+
+    // Decrypt output note B
+    auto maybe_pt = libzcash::SaplingNotePlaintext::decrypt(
+            wtx.sapData->vShieldedOutput[0].encCiphertext,
+            ivk,
+            wtx.sapData->vShieldedOutput[0].ephemeralKey,
+            wtx.sapData->vShieldedOutput[0].cmu);
+    BOOST_CHECK(static_cast<bool>(maybe_pt) == true);
+    auto maybe_note = maybe_pt.get().note(ivk);
+    BOOST_CHECK(static_cast<bool>(maybe_note) == true);
+    auto note2 = maybe_note.get();
+
+    SaplingOutPoint sop0(wtx.GetHash(), 0);
+    auto spend_note_witness =  wtx.mapSaplingNoteData[sop0].witnesses.front();
+    auto maybe_nf = note2.nullifier(extfvk.fvk, spend_note_witness.position());
+    BOOST_CHECK(static_cast<bool>(maybe_nf) == true);
+
+    anchor = saplingTree.root();
+
+    // Create transaction to spend note B
+    auto builder2 = TransactionBuilder(consensusParams, 2);
+    builder2.AddSaplingSpend(expsk, note2, anchor, spend_note_witness);
+    builder2.AddSaplingOutput(extfvk.fvk.ovk, pk, 20000, {});
+    auto tx2 = builder2.Build().GetTxOrThrow();
+
+    // Create conflicting transaction which also spends note B
+    auto builder3 = TransactionBuilder(consensusParams, 2);
+    builder3.AddSaplingSpend(expsk, note2, anchor, spend_note_witness);
+    builder3.AddSaplingOutput(extfvk.fvk.ovk, pk, 19999, {});
+    auto tx3 = builder3.Build().GetTxOrThrow();
+
+    CWalletTx wtx2 {&wallet, tx2};
+    CWalletTx wtx3 {&wallet, tx3};
+
+    const auto& hash2 = wtx2.GetHash();
+    const auto& hash3 = wtx3.GetHash();
+
+    // No conflicts for no spends (wtx is currently the only transaction in the wallet)
+    BOOST_CHECK_EQUAL(0, wallet.GetConflicts(hash2).size());
+    BOOST_CHECK_EQUAL(0, wallet.GetConflicts(hash3).size());
+
+    // No conflicts for one spend
+    BOOST_CHECK(wallet.LoadToWallet(wtx2));
+    BOOST_CHECK_EQUAL(0, wallet.GetConflicts(hash2).size());
+
+    // Conflicts for two spends
+    BOOST_CHECK(wallet.LoadToWallet(wtx3));
+    auto c3 = wallet.GetConflicts(hash2);
+    BOOST_CHECK_EQUAL(2, c3.size());
+    BOOST_CHECK(std::set<uint256>({hash2, hash3}) == c3);
+
+    // Tear down
+    chainActive.SetTip(NULL);
+    mapBlockIndex.erase(blockHash);
+
+    // Revert to default
+    RegtestDeactivateSapling();
+}
+
+BOOST_AUTO_TEST_CASE(SaplingNullifierIsSpent) {
+    auto consensusParams = RegtestActivateSapling();
+
+    CWallet& wallet = *pwalletMain;
+    LOCK2(cs_main, wallet.cs_wallet);
+    setupWallet(wallet);
+
+    // Generate dummy Sapling address
+    auto sk = GetTestMasterSaplingSpendingKey();
+    auto expsk = sk.expsk;
+    auto extfvk = sk.ToXFVK();
+    auto pa = sk.DefaultAddress();
+
+    auto testNote = GetTestSaplingNote(pa, 50000);
+
+    // Generate transaction
+    auto builder = TransactionBuilder(consensusParams, 1);
+    builder.AddSaplingSpend(expsk,  testNote.note, testNote.tree.root(), testNote.tree.witness());
+    builder.AddSaplingOutput(extfvk.fvk.ovk, pa, 25000, {});
+    auto tx = builder.Build().GetTxOrThrow();
+
+    CWalletTx wtx {&wallet, tx};
+    BOOST_CHECK(wallet.AddSaplingZKey(sk));
+    BOOST_CHECK(wallet.HaveSaplingSpendingKey(extfvk));
+
+    // Manually compute the nullifier based on the known position
+    auto nf = testNote.note.nullifier(extfvk.fvk, testNote.tree.witness().position());
+    BOOST_CHECK(nf);
+    uint256 nullifier = nf.get();
+
+    // Verify note has not been spent
+    BOOST_CHECK(!wallet.GetSaplingScriptPubKeyMan()->IsSaplingSpent(nullifier));
+
+    // Fake-mine the transaction
+    BOOST_CHECK_EQUAL(0, chainActive.Height());
+    CBlock block;
+    block.hashPrevBlock = chainActive[0]->GetBlockHash();
+    block.vtx.emplace_back(MakeTransactionRef(wtx));
+    block.hashMerkleRoot = BlockMerkleRoot(block);
+    const auto& blockHash = block.GetHash();
+    CBlockIndex fakeIndex {block};
+    BlockMap::iterator mi = mapBlockIndex.emplace(blockHash, &fakeIndex).first;
+    fakeIndex.phashBlock = &((*mi).first);
+    chainActive.SetTip(&fakeIndex);
+    BOOST_CHECK(chainActive.Contains(&fakeIndex));
+    BOOST_CHECK_EQUAL(0, chainActive.Height());
+
+    wtx.SetMerkleBranch(mapBlockIndex[blockHash], 0);
+    wallet.LoadToWallet(wtx);
+
+    // Verify note has been spent
+    BOOST_CHECK(wallet.GetSaplingScriptPubKeyMan()->IsSaplingSpent(nullifier));
+
+    // Tear down
+    chainActive.SetTip(NULL);
+    mapBlockIndex.erase(blockHash);
+
+    // Revert to default
+    RegtestDeactivateSapling();
+}
+
+BOOST_AUTO_TEST_CASE(NavigateFromSaplingNullifierToNote) {
+    auto consensusParams = RegtestActivateSapling();
+
+    CWallet& wallet = *pwalletMain;
+    LOCK2(cs_main, wallet.cs_wallet);
+    setupWallet(wallet);
+
+    // Generate dummy Sapling address
+    auto sk = GetTestMasterSaplingSpendingKey();
+    auto expsk = sk.expsk;
+    auto extfvk = sk.ToXFVK();
+    auto pa = sk.DefaultAddress();
+
+    auto testNote = GetTestSaplingNote(pa, 50000);
+
+    // Generate transaction
+    auto builder = TransactionBuilder(consensusParams, 1);
+    builder.AddSaplingSpend(expsk, testNote.note, testNote.tree.root(), testNote.tree.witness());
+    builder.AddSaplingOutput(extfvk.fvk.ovk, pa, 25000, {});
+    auto tx = builder.Build().GetTxOrThrow();
+
+    CWalletTx wtx {&wallet, tx};
+    BOOST_CHECK(wallet.AddSaplingZKey(sk));
+    BOOST_CHECK(wallet.HaveSaplingSpendingKey(extfvk));
+
+    // Manually compute the nullifier based on the expected position
+    auto nf = testNote.note.nullifier(extfvk.fvk, testNote.tree.witness().position());
+    BOOST_CHECK(nf);
+    uint256 nullifier = nf.get();
+
+    // Verify dummy note is unspent
+    BOOST_CHECK(!wallet.GetSaplingScriptPubKeyMan()->IsSaplingSpent(nullifier));
+
+    // Fake-mine the transaction
+    BOOST_CHECK_EQUAL(0, chainActive.Height());
+    CBlock block;
+    block.hashPrevBlock = chainActive[0]->GetBlockHash();
+    block.vtx.emplace_back(MakeTransactionRef(wtx));
+    block.hashMerkleRoot = BlockMerkleRoot(block);
+    const auto& blockHash = block.GetHash();
+    CBlockIndex fakeIndex {block};
+    BlockMap::iterator mi = mapBlockIndex.emplace(blockHash, &fakeIndex).first;
+    fakeIndex.phashBlock = &((*mi).first);
+    chainActive.SetTip(&fakeIndex);
+    BOOST_CHECK(chainActive.Contains(&fakeIndex));
+    BOOST_CHECK_EQUAL(0, chainActive.Height());
+
+    // Simulate SyncTransaction which calls AddToWalletIfInvolvingMe
+    wtx.SetMerkleBranch(mapBlockIndex[blockHash], 0);
+    auto saplingNoteData = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(wtx).first;
+    BOOST_CHECK(saplingNoteData.size() > 0);
+    wtx.SetSaplingNoteData(saplingNoteData);
+    wallet.LoadToWallet(wtx);
+
+    // Verify dummy note is now spent, as AddToWallet invokes AddToSpends()
+    BOOST_CHECK(wallet.GetSaplingScriptPubKeyMan()->IsSaplingSpent(nullifier));
+
+    // Test invariant: no witnesses means no nullifier.
+    BOOST_CHECK_EQUAL(0, wallet.GetSaplingScriptPubKeyMan()->mapSaplingNullifiersToNotes.size());
+    for (mapSaplingNoteData_t::value_type &item : wtx.mapSaplingNoteData) {
+        SaplingNoteData nd = item.second;
+        BOOST_CHECK(nd.witnesses.empty());
+        BOOST_CHECK(!nd.nullifier);
+    }
+
+    // Simulate receiving new block and ChainTip signal
+    wallet.IncrementNoteWitnesses(&fakeIndex, &block, testNote.tree);
+    wallet.GetSaplingScriptPubKeyMan()->UpdateSaplingNullifierNoteMapForBlock(&block);
+
+    // Retrieve the updated wtx from wallet
+    const uint256& hash = wtx.GetHash();
+    wtx = wallet.mapWallet[hash];
+
+    // Verify Sapling nullifiers map to SaplingOutPoints
+    BOOST_CHECK_EQUAL(2, wallet.GetSaplingScriptPubKeyMan()->mapSaplingNullifiersToNotes.size());
+    for (mapSaplingNoteData_t::value_type &item : wtx.mapSaplingNoteData) {
+        SaplingOutPoint op = item.first;
+        SaplingNoteData nd = item.second;
+        BOOST_CHECK(hash == op.hash);
+        BOOST_CHECK_EQUAL(1, nd.witnesses.size());
+        BOOST_CHECK(nd.nullifier);
+        auto nf = nd.nullifier.get();
+        BOOST_CHECK_EQUAL(1, wallet.GetSaplingScriptPubKeyMan()->mapSaplingNullifiersToNotes.count(nf));
+        BOOST_CHECK(op.hash == wallet.GetSaplingScriptPubKeyMan()->mapSaplingNullifiersToNotes[nf].hash);
+        BOOST_CHECK_EQUAL(op.n, wallet.GetSaplingScriptPubKeyMan()->mapSaplingNullifiersToNotes[nf].n);
+    }
+
+    // Tear down
+    chainActive.SetTip(NULL);
+    mapBlockIndex.erase(blockHash);
+
+    // Revert to default
+    RegtestDeactivateSapling();
+}
+
+// Create note A, spend A to create note B, spend and verify note B is from me.
+BOOST_AUTO_TEST_CASE(SpentSaplingNoteIsFromMe) {
+    auto consensusParams = RegtestActivateSapling();
+
+    CWallet& wallet = *pwalletMain;
+    LOCK2(cs_main, wallet.cs_wallet);
+    setupWallet(wallet);
+
+    // Generate Sapling address
+    auto sk = GetTestMasterSaplingSpendingKey();
+    auto expsk = sk.expsk;
+    auto extfvk = sk.ToXFVK();
+    auto ivk = extfvk.fvk.in_viewing_key();
+    auto pk = sk.DefaultAddress();
+
+    // Generate Sapling note A
+    libzcash::SaplingNote note(pk, 50000);
+    auto cm = note.cmu().get();
+    SaplingMerkleTree saplingTree;
+    saplingTree.append(cm);
+    auto anchor = saplingTree.root();
+    auto witness = saplingTree.witness();
+
+    // Generate transaction, which sends funds to note B
+    auto builder = TransactionBuilder(consensusParams, 1);
+    builder.AddSaplingSpend(expsk, note, anchor, witness);
+    builder.AddSaplingOutput(extfvk.fvk.ovk, pk, 25000, {});
+    auto tx = builder.Build().GetTxOrThrow();
+
+    CWalletTx wtx {&wallet, tx};
+    BOOST_CHECK(wallet.AddSaplingZKey(sk));
+    BOOST_CHECK(wallet.HaveSaplingSpendingKey(extfvk));
+
+    // Fake-mine the transaction
+    BOOST_CHECK_EQUAL(0, chainActive.Height());
+    CBlock block;
+    block.hashPrevBlock = chainActive[0]->GetBlockHash();
+    block.vtx.emplace_back(MakeTransactionRef(wtx));
+    block.hashMerkleRoot = BlockMerkleRoot(block);
+    const auto& blockHash = block.GetHash();
+    CBlockIndex fakeIndex {block};
+    BlockMap::iterator mi = mapBlockIndex.emplace(blockHash, &fakeIndex).first;
+    fakeIndex.phashBlock = &((*mi).first);
+    chainActive.SetTip(&fakeIndex);
+    BOOST_CHECK(chainActive.Contains(&fakeIndex));
+    BOOST_CHECK_EQUAL(0, chainActive.Height());
+
+    auto saplingNoteData = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(wtx).first;
+    BOOST_CHECK(saplingNoteData.size() > 0);
+    wtx.SetSaplingNoteData(saplingNoteData);
+    wtx.SetMerkleBranch(mapBlockIndex[blockHash], 0);
+    wallet.LoadToWallet(wtx);
+
+    // Simulate receiving new block and ChainTip signal.
+    // This triggers calculation of nullifiers for notes belonging to this wallet
+    // in the output descriptions of wtx.
+    wallet.IncrementNoteWitnesses(&fakeIndex, &block, saplingTree);
+    wallet.GetSaplingScriptPubKeyMan()->UpdateSaplingNullifierNoteMapForBlock(&block);
+
+    // Retrieve the updated wtx from wallet
+    wtx = wallet.mapWallet[wtx.GetHash()];
+
+    // The test wallet never received the fake note which is being spent, so there
+    // is no mapping from nullifier to notedata stored in mapSaplingNullifiersToNotes.
+    // Therefore the wallet does not know the tx belongs to the wallet.
+    BOOST_CHECK(!wallet.IsFromMe(wtx));
+
+    // Manually compute the nullifier and check map entry does not exist
+    auto nf = note.nullifier(extfvk.fvk, witness.position());
+    BOOST_CHECK(nf);
+    BOOST_CHECK(!wallet.GetSaplingScriptPubKeyMan()->mapSaplingNullifiersToNotes.count(nf.get()));
+
+    // Decrypt note B
+    auto maybe_pt = libzcash::SaplingNotePlaintext::decrypt(
+            wtx.sapData->vShieldedOutput[0].encCiphertext,
+            ivk,
+            wtx.sapData->vShieldedOutput[0].ephemeralKey,
+            wtx.sapData->vShieldedOutput[0].cmu);
+    BOOST_CHECK_EQUAL(static_cast<bool>(maybe_pt), true);
+    auto maybe_note = maybe_pt.get().note(ivk);
+    BOOST_CHECK_EQUAL(static_cast<bool>(maybe_note), true);
+    auto note2 = maybe_note.get();
+
+    // Get witness to retrieve position of note B we want to spend
+    SaplingOutPoint sop0(wtx.GetHash(), 0);
+    auto spend_note_witness =  wtx.mapSaplingNoteData[sop0].witnesses.front();
+    auto maybe_nf = note2.nullifier(extfvk.fvk, spend_note_witness.position());
+    BOOST_CHECK_EQUAL(static_cast<bool>(maybe_nf), true);
+    auto nullifier2 = maybe_nf.get();
+
+    // NOTE: Not updating the anchor results in a core dump.  Shouldn't builder just return error?
+    // *** Error in `./zcash-gtest': double free or corruption (out): 0x00007ffd8755d990 ***
+    anchor = saplingTree.root();
+
+    // Create transaction to spend note B
+    auto builder2 = TransactionBuilder(consensusParams, 2);
+    builder2.AddSaplingSpend(expsk, note2, anchor, spend_note_witness);
+    builder2.AddSaplingOutput(extfvk.fvk.ovk, pk, 12500, {});
+    auto tx2 = builder2.Build().GetTxOrThrow();
+    BOOST_CHECK_EQUAL(tx2.vin.size(), 0);
+    BOOST_CHECK_EQUAL(tx2.vout.size(), 0);
+    BOOST_CHECK_EQUAL(tx2.sapData->vShieldedSpend.size(), 1);
+    BOOST_CHECK_EQUAL(tx2.sapData->vShieldedOutput.size(), 2);
+    BOOST_CHECK_EQUAL(tx2.sapData->valueBalance, 10000);
+
+    CWalletTx wtx2 {&wallet, tx2};
+
+    // Fake-mine this tx into the next block
+    BOOST_CHECK_EQUAL(0, chainActive.Height());
+    CBlock block2;
+    block2.vtx.emplace_back(MakeTransactionRef(wtx2));
+    block.hashMerkleRoot = BlockMerkleRoot(block);
+    block2.hashPrevBlock = blockHash;
+    auto blockHash2 = block2.GetHash();
+    CBlockIndex fakeIndex2 {block2};
+    BlockMap::iterator mi2 = mapBlockIndex.emplace(blockHash2, &fakeIndex2).first;
+    fakeIndex2.phashBlock = &((*mi2).first);
+    fakeIndex2.nHeight = 1;
+    chainActive.SetTip(&fakeIndex2);
+    BOOST_CHECK(chainActive.Contains(&fakeIndex2));
+    BOOST_CHECK_EQUAL(1, chainActive.Height());
+
+    auto saplingNoteData2 = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(wtx2).first;
+    BOOST_CHECK(saplingNoteData2.size() > 0);
+    wtx2.SetSaplingNoteData(saplingNoteData2);
+    wtx2.SetMerkleBranch(mapBlockIndex[blockHash2], 0);
+    wallet.LoadToWallet(wtx2);
+
+    // Verify note B is spent. AddToWallet invokes AddToSpends which updates mapTxSaplingNullifiers
+    BOOST_CHECK(wallet.GetSaplingScriptPubKeyMan()->IsSaplingSpent(nullifier2));
+
+    // Verify note B belongs to wallet.
+    BOOST_CHECK(wallet.IsFromMe(wtx2));
+    BOOST_CHECK(wallet.GetSaplingScriptPubKeyMan()->mapSaplingNullifiersToNotes.count(nullifier2));
+
+    // Tear down
+    chainActive.SetTip(NULL);
+    mapBlockIndex.erase(blockHash);
+    mapBlockIndex.erase(blockHash2);
+
+    // Revert to default
+    RegtestDeactivateSapling();
+}
+
+BOOST_AUTO_TEST_CASE(CachedWitnessesEmptyChain) {
+    auto consensusParams = RegtestActivateSapling();
+
+    CWallet& wallet = *pwalletMain;
+    LOCK(wallet.cs_wallet);
+    setupWallet(wallet);
+
+    auto sk = GetTestMasterSaplingSpendingKey();
+    CWalletTx wtx = GetValidSaplingReceive(Params().GetConsensus(), wallet, sk, 10, true);
+
+    std::vector<SaplingOutPoint> saplingNotes = SetSaplingNoteData(wtx);
+    std::vector<Optional<SaplingWitness>> saplingWitnesses;
+
+    ::GetWitnessesAndAnchors(wallet, saplingNotes, saplingWitnesses);
+
+    BOOST_CHECK(!(bool) saplingWitnesses[0]);
+
+    wallet.LoadToWallet(wtx);
+
+    ::GetWitnessesAndAnchors(wallet, saplingNotes, saplingWitnesses);
+
+    BOOST_CHECK(!(bool) saplingWitnesses[0]);
+
+    CBlock block;
+    block.vtx.emplace_back(MakeTransactionRef(wtx));
+    CBlockIndex index(block);
+    SaplingMerkleTree saplingTree;
+    wallet.IncrementNoteWitnesses(&index, &block, saplingTree);
+
+    ::GetWitnessesAndAnchors(wallet, saplingNotes, saplingWitnesses);
+
+    BOOST_CHECK((bool) saplingWitnesses[0]);
+
+    // Until zcash#1302 is implemented, this should triggger an assertion
+    BOOST_CHECK_THROW(wallet.DecrementNoteWitnesses(&index), std::runtime_error);
+
+    // Revert to default
+    RegtestDeactivateSapling();
+}
+
+BOOST_AUTO_TEST_CASE(CachedWitnessesChainTip) {
+    auto consensusParams = RegtestActivateSapling();
+
+    CWallet& wallet = *pwalletMain;
+    LOCK(wallet.cs_wallet);
+    setupWallet(wallet);
+
+    uint256 anchors1;
+    CBlock block1;
+    SaplingMerkleTree saplingTree;
+
+    libzcash::SaplingExtendedSpendingKey sk = GetTestMasterSaplingSpendingKey();
+    BOOST_CHECK(wallet.AddSaplingZKey(sk));
+    BOOST_CHECK(wallet.HaveSaplingSpendingKey(sk.ToXFVK()));
+
+    {
+        // First block (case tested in _empty_chain)
+        CBlockIndex index1(block1);
+        index1.nHeight = 1;
+        auto output = CreateValidBlock(wallet, sk, index1, block1, saplingTree);
+
+        // Called to fetch anchor
+        std::vector<SaplingOutPoint> saplingNotes {output};
+        std::vector<Optional<SaplingWitness>> saplingWitnesses;
+
+        anchors1 = GetWitnessesAndAnchors(wallet, saplingNotes, saplingWitnesses);
+    }
+
+    {
+        // Second transaction
+        CWalletTx wtx = GetValidSaplingReceive(Params().GetConsensus(),
+                wallet, sk, 50, true);
+
+        std::vector<SaplingOutPoint> saplingNotes = SetSaplingNoteData(wtx);
+        wallet.LoadToWallet(wtx);
+
+        std::vector<Optional<SaplingWitness>> saplingWitnesses;
+        GetWitnessesAndAnchors(wallet , saplingNotes, saplingWitnesses);
+
+        BOOST_CHECK(!(bool) saplingWitnesses[0]);
+
+        // Second block
+        CBlock block2;
+        block2.hashPrevBlock = block1.GetHash();
+        block2.vtx.emplace_back(MakeTransactionRef(wtx));
+        CBlockIndex index2(block2);
+        index2.nHeight = 2;
+        SaplingMerkleTree saplingTree2 {saplingTree};
+        wallet.IncrementNoteWitnesses(&index2, &block2, saplingTree2);
+
+        auto anchors2 = GetWitnessesAndAnchors(wallet, saplingNotes, saplingWitnesses);
+        BOOST_CHECK((bool) saplingWitnesses[0]);
+        BOOST_CHECK(anchors1 != anchors2);
+
+        // Decrementing should give us the previous anchor
+        wallet.DecrementNoteWitnesses(&index2);
+        auto anchors3 = GetWitnessesAndAnchors(wallet, saplingNotes, saplingWitnesses);
+
+        BOOST_CHECK(!(bool) saplingWitnesses[0]);
+        // Should not equal first anchor because none of these notes had witnesses
+        BOOST_CHECK(anchors1 != anchors3);
+
+        // Re-incrementing with the same block should give the same result
+        wallet.IncrementNoteWitnesses(&index2, &block2, saplingTree);
+        auto anchors4 = GetWitnessesAndAnchors(wallet, saplingNotes, saplingWitnesses);
+        BOOST_CHECK((bool) saplingWitnesses[0]);
+        BOOST_CHECK(anchors2 == anchors4);
+
+        // Incrementing with the same block again should not change the cache
+        wallet.IncrementNoteWitnesses(&index2, &block2, saplingTree);
+        std::vector<Optional<SaplingWitness>> saplingWitnesses5;
+
+        auto anchors5 = GetWitnessesAndAnchors(wallet, saplingNotes, saplingWitnesses5);
+        BOOST_CHECK(saplingWitnesses == saplingWitnesses5);
+        BOOST_CHECK(anchors4 == anchors5);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(CachedWitnessesDecrementFirst) {
+    auto consensusParams = RegtestActivateSapling();
+
+    CWallet& wallet = *pwalletMain;
+    LOCK(wallet.cs_wallet);
+    setupWallet(wallet);
+
+    SaplingMerkleTree saplingTree;
+
+    libzcash::SaplingExtendedSpendingKey sk = GetTestMasterSaplingSpendingKey();
+    BOOST_CHECK(wallet.AddSaplingZKey(sk));
+
+    {
+        // First block (case tested in _empty_chain)
+        CBlock block1;
+        CBlockIndex index1(block1);
+        index1.nHeight = 1;
+        CreateValidBlock(wallet, sk, index1, block1, saplingTree);
+    }
+
+    uint256 anchors2;
+    CBlock block2;
+    CBlockIndex index2(block2);
+
+    {
+        // Second block (case tested in _chain_tip)
+        index2.nHeight = 2;
+        auto output = CreateValidBlock(wallet, sk, index2, block2, saplingTree);
+
+        // Called to fetch anchor
+        std::vector<SaplingOutPoint> saplingNotes {output};
+        std::vector<Optional<SaplingWitness>> saplingWitnesses;
+        anchors2 = GetWitnessesAndAnchors(wallet, saplingNotes, saplingWitnesses);
+    }
+
+    {
+        // Third transaction - never mined
+        CWalletTx wtx = GetValidSaplingReceive(Params().GetConsensus(),
+                                               wallet, sk, 20, true);
+        std::vector<SaplingOutPoint> saplingNotes = SetSaplingNoteData(wtx);
+        wallet.LoadToWallet(wtx);
+
+        std::vector<Optional<SaplingWitness>> saplingWitnesses;
+
+        auto anchors3 = GetWitnessesAndAnchors(wallet, saplingNotes, saplingWitnesses);
+
+        BOOST_CHECK(!(bool) saplingWitnesses[0]);
+
+        // Decrementing (before the transaction has ever seen an increment)
+        // should give us the previous anchor
+        wallet.DecrementNoteWitnesses(&index2);
+
+        auto anchors4 = GetWitnessesAndAnchors(wallet, saplingNotes, saplingWitnesses);
+
+        BOOST_CHECK(!(bool) saplingWitnesses[0]);
+        // Should not equal second anchor because none of these notes had witnesses
+        BOOST_CHECK(anchors2 != anchors4);
+
+        // Re-incrementing with the same block should give the same result
+        wallet.IncrementNoteWitnesses(&index2, &block2, saplingTree);
+
+        auto anchors5 = GetWitnessesAndAnchors(wallet, saplingNotes, saplingWitnesses);
+
+        BOOST_CHECK(!(bool) saplingWitnesses[0]);
+        BOOST_CHECK(anchors3 == anchors5);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(CachedWitnessesCleanIndex) {
+    auto consensusParams = RegtestActivateSapling();
+
+    CWallet& wallet = *pwalletMain;
+    LOCK(wallet.cs_wallet);
+    setupWallet(wallet);
+
+    std::vector<CBlock> blocks;
+    std::vector<CBlockIndex> indices;
+    std::vector<SaplingOutPoint> saplingNotes;
+    std::vector<uint256> saplingAnchors;
+    SaplingMerkleTree saplingTree;
+    SaplingMerkleTree saplingRiTree = saplingTree;
+    std::vector<Optional<SaplingWitness>> saplingWitnesses;
+
+    libzcash::SaplingExtendedSpendingKey sk = GetTestMasterSaplingSpendingKey();
+    BOOST_CHECK(wallet.AddSaplingZKey(sk));
+
+    // Generate a chain
+    size_t numBlocks = WITNESS_CACHE_SIZE + 10;
+    blocks.resize(numBlocks);
+    indices.resize(numBlocks);
+    for (size_t i = 0; i < numBlocks; i++) {
+        indices[i].nHeight = i;
+        auto oldSaplingRoot = saplingTree.root();
+        auto outpts = CreateValidBlock(wallet, sk, indices[i], blocks[i], saplingTree);
+        BOOST_CHECK(oldSaplingRoot != saplingTree.root());
+        saplingNotes.push_back(outpts);
+
+        auto anchor = GetWitnessesAndAnchors(wallet, saplingNotes, saplingWitnesses);
+        for (size_t j = 0; j <= i; j++) {
+            BOOST_CHECK((bool) saplingWitnesses[j]);
+        }
+        saplingAnchors.push_back(anchor);
+    }
+
+    // Now pretend we are reindexing: the chain is cleared, and each block is
+    // used to increment witnesses again.
+    for (size_t i = 0; i < numBlocks; i++) {
+        SaplingMerkleTree saplingRiPrevTree {saplingRiTree};
+        wallet.IncrementNoteWitnesses(&(indices[i]), &(blocks[i]), saplingRiTree);
+
+        auto anchors = GetWitnessesAndAnchors(wallet, saplingNotes, saplingWitnesses);
+        for (size_t j = 0; j < numBlocks; j++) {
+            BOOST_CHECK((bool) saplingWitnesses[j]);
+        }
+        // Should equal final anchor because witness cache unaffected
+        BOOST_CHECK(saplingAnchors.back() == anchors);
+
+        if ((i == 5) || (i == 50)) {
+            // Pretend a reorg happened that was recorded in the block files
+            {
+                wallet.DecrementNoteWitnesses(&(indices[i]));
+
+                auto anchors = GetWitnessesAndAnchors(wallet, saplingNotes, saplingWitnesses);
+                for (size_t j = 0; j < numBlocks; j++) {
+                    BOOST_CHECK((bool) saplingWitnesses[j]);
+                }
+                // Should equal final anchor because witness cache unaffected
+                BOOST_CHECK(saplingAnchors.back() == anchors);
+            }
+
+            {
+                wallet.IncrementNoteWitnesses(&(indices[i]), &(blocks[i]), saplingRiPrevTree);
+                auto anchors = GetWitnessesAndAnchors(wallet, saplingNotes, saplingWitnesses);
+                for (size_t j = 0; j < numBlocks; j++) {
+                    BOOST_CHECK((bool) saplingWitnesses[j]);
+                }
+                // Should equal final anchor because witness cache unaffected
+                BOOST_CHECK(saplingAnchors.back() == anchors);
+            }
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(ClearNoteWitnessCache) {
+    auto consensusParams = RegtestActivateSapling();
+
+    CWallet& wallet = *pwalletMain;
+    LOCK(wallet.cs_wallet);
+    setupWallet(wallet);
+
+    libzcash::SaplingExtendedSpendingKey sk = GetTestMasterSaplingSpendingKey();
+    BOOST_CHECK(wallet.AddSaplingZKey(sk));
+
+    CWalletTx wtx = GetValidSaplingReceive(Params().GetConsensus(),
+                                           wallet, sk, 10, true);
+    auto hash = wtx.GetHash();
+    auto saplingNotes = SetSaplingNoteData(wtx);
+
+    // Pretend we mined the tx by adding a fake witness
+    SaplingMerkleTree saplingTree;
+    wtx.mapSaplingNoteData[saplingNotes[0]].witnesses.push_front(saplingTree.witness());
+    wtx.mapSaplingNoteData[saplingNotes[0]].witnessHeight = 1;
+    wallet.GetSaplingScriptPubKeyMan()->nWitnessCacheSize = 1;
+
+    wallet.LoadToWallet(wtx);
+
+    // SetSaplingNoteData() only created a single Sapling output
+    // which is in the wallet, so we add a second SaplingOutPoint here to
+    // exercise the "note not in wallet" case.
+    saplingNotes.emplace_back(wtx.GetHash(), 1);
+    BOOST_CHECK_EQUAL(saplingNotes.size(), 2);
+
+    std::vector<Optional<SaplingWitness>> saplingWitnesses;
+
+    // Before clearing, we should have a witness for one note
+    GetWitnessesAndAnchors(wallet, saplingNotes, saplingWitnesses);
+    BOOST_CHECK((bool) saplingWitnesses[0]);
+    BOOST_CHECK(!(bool) saplingWitnesses[1]);
+    BOOST_CHECK_EQUAL(1, wallet.mapWallet[hash].mapSaplingNoteData[saplingNotes[0]].witnessHeight);
+    BOOST_CHECK_EQUAL(1, wallet.GetSaplingScriptPubKeyMan()->nWitnessCacheSize);
+
+    // After clearing, we should not have a witness for either note
+    wallet.GetSaplingScriptPubKeyMan()->ClearNoteWitnessCache();
+    GetWitnessesAndAnchors(wallet, saplingNotes, saplingWitnesses);
+    BOOST_CHECK(!(bool) saplingWitnesses[0]);
+    BOOST_CHECK(!(bool) saplingWitnesses[1]);
+    BOOST_CHECK_EQUAL(-1, wallet.mapWallet[hash].mapSaplingNoteData[saplingNotes[0]].witnessHeight);
+    BOOST_CHECK_EQUAL(0, wallet.GetSaplingScriptPubKeyMan()->nWitnessCacheSize);
+}
+
+BOOST_AUTO_TEST_CASE(UpdatedSaplingNoteData) {
+    auto consensusParams = RegtestActivateSapling();
+
+    CWallet& wallet = *pwalletMain;
+    LOCK(wallet.cs_wallet);
+    setupWallet(wallet);
+
+    auto m = GetTestMasterSaplingSpendingKey();
+
+    // Generate dummy Sapling address
+    auto sk = m.Derive(0);
+    auto expsk = sk.expsk;
+    auto extfvk = sk.ToXFVK();
+    auto pa = sk.DefaultAddress();
+
+    // Generate dummy recipient Sapling address
+    auto sk2 = m.Derive(1);
+    auto extfvk2 = sk2.ToXFVK();
+    auto pa2 = sk2.DefaultAddress();
+
+    auto testNote = GetTestSaplingNote(pa, 50000);
+
+    // Generate transaction
+    auto builder = TransactionBuilder(consensusParams, 1);
+    builder.AddSaplingSpend(expsk, testNote.note, testNote.tree.root(), testNote.tree.witness());
+    builder.AddSaplingOutput(extfvk.fvk.ovk, pa2, 25000, {});
+    auto tx = builder.Build().GetTxOrThrow();
+
+    // Wallet contains extfvk1 but not extfvk2
+    CWalletTx wtx {&wallet, tx};
+    BOOST_CHECK(wallet.AddSaplingZKey(sk));
+    BOOST_CHECK(wallet.HaveSaplingSpendingKey(extfvk));
+    BOOST_CHECK(!wallet.HaveSaplingSpendingKey(extfvk2));
+
+    // Fake-mine the transaction
+    BOOST_CHECK_EQUAL(0, chainActive.Height());
+    CBlock block;
+    block.vtx.emplace_back(MakeTransactionRef(wtx));
+    block.hashMerkleRoot = BlockMerkleRoot(block);
+    const auto& blockHash = block.GetHash();
+    CBlockIndex fakeIndex {block};
+    BlockMap::iterator mi = mapBlockIndex.emplace(blockHash, &fakeIndex).first;
+    fakeIndex.phashBlock = &((*mi).first);
+    chainActive.SetTip(&fakeIndex);
+    BOOST_CHECK(chainActive.Contains(&fakeIndex));
+    BOOST_CHECK_EQUAL(0, chainActive.Height());
+
+    // Simulate SyncTransaction which calls AddToWalletIfInvolvingMe
+    auto saplingNoteData = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(wtx).first;
+    BOOST_CHECK(saplingNoteData.size() == 1); // wallet only has key for change output
+    wtx.SetSaplingNoteData(saplingNoteData);
+    wtx.SetMerkleBranch(mapBlockIndex[blockHash], 0);
+    wallet.LoadToWallet(wtx);
+
+    // Simulate receiving new block and ChainTip signal
+    wallet.IncrementNoteWitnesses(&fakeIndex, &block, testNote.tree);
+    wallet.GetSaplingScriptPubKeyMan()->UpdateSaplingNullifierNoteMapForBlock(&block);
+
+    // Retrieve the updated wtx from wallet
+    const uint256& hash = wtx.GetHash();
+    wtx = wallet.mapWallet[hash];
+
+    // Now lets add key extfvk2 so wallet can find the payment note sent to pa2
+    BOOST_CHECK(wallet.AddSaplingZKey(sk2));
+    BOOST_CHECK(wallet.HaveSaplingSpendingKey(extfvk2));
+    CWalletTx wtx2 = wtx;
+    auto saplingNoteData2 = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(wtx2).first;
+    BOOST_CHECK(saplingNoteData2.size() == 2);
+    wtx2.SetSaplingNoteData(saplingNoteData2);
+
+    // The payment note has not been witnessed yet, so let's fake the witness.
+    SaplingOutPoint sop0(wtx2.GetHash(), 0);
+    SaplingOutPoint sop1(wtx2.GetHash(), 1);
+    wtx2.mapSaplingNoteData[sop0].witnesses.push_front(testNote.tree.witness());
+    wtx2.mapSaplingNoteData[sop0].witnessHeight = 0;
+
+    // The txs are different as wtx is aware of just the change output,
+    // whereas wtx2 is aware of both payment and change outputs.
+    BOOST_CHECK(wtx.mapSaplingNoteData != wtx2.mapSaplingNoteData);
+    BOOST_CHECK_EQUAL(1, wtx.mapSaplingNoteData.size());
+    BOOST_CHECK_EQUAL(1, wtx.mapSaplingNoteData[sop1].witnesses.size());    // wtx has witness for change
+
+    BOOST_CHECK_EQUAL(2, wtx2.mapSaplingNoteData.size());
+    BOOST_CHECK_EQUAL(1, wtx2.mapSaplingNoteData[sop0].witnesses.size());    // wtx2 has fake witness for payment output
+    BOOST_CHECK_EQUAL(0, wtx2.mapSaplingNoteData[sop1].witnesses.size());    // wtx2 never had incrementnotewitness called
+
+    // After updating, they should be the same
+    BOOST_CHECK(wallet.GetSaplingScriptPubKeyMan()->UpdatedNoteData(wtx2, wtx));
+
+    // We can't do this:
+    // BOOST_CHECK_EQUAL(wtx.mapSaplingNoteData, wtx2.mapSaplingNoteData);
+    // because nullifiers (if part of == comparator) have not all been computed
+    // Also note that mapwallet[hash] is not updated with the updated wtx.
+    // wtx = wallet.mapWallet[hash];
+
+    BOOST_CHECK_EQUAL(2, wtx.mapSaplingNoteData.size());
+    BOOST_CHECK_EQUAL(2, wtx2.mapSaplingNoteData.size());
+    // wtx copied over the fake witness from wtx2 for the payment output
+    BOOST_CHECK(wtx.mapSaplingNoteData[sop0].witnesses.front() == wtx2.mapSaplingNoteData[sop0].witnesses.front());
+    // wtx2 never had its change output witnessed even though it has been in wtx
+    BOOST_CHECK_EQUAL(0, wtx2.mapSaplingNoteData[sop1].witnesses.size());
+    BOOST_CHECK(wtx.mapSaplingNoteData[sop1].witnesses.front() == testNote.tree.witness());
+
+    // Tear down
+    chainActive.SetTip(NULL);
+    mapBlockIndex.erase(blockHash);
+
+    // Revert to default
+    RegtestDeactivateSapling();
+}
+
+BOOST_AUTO_TEST_CASE(MarkAffectedSaplingTransactionsDirty) {
+    auto consensusParams = RegtestActivateSapling();
+
+    CWallet& wallet = *pwalletMain;
+    LOCK2(cs_main, wallet.cs_wallet);
+    setupWallet(wallet);
+
+    // Generate Sapling address
+    auto sk = GetTestMasterSaplingSpendingKey();
+    auto expsk = sk.expsk;
+    auto extfvk = sk.ToXFVK();
+    auto ivk = extfvk.fvk.in_viewing_key();
+    auto pk = sk.DefaultAddress();
+
+    BOOST_CHECK(wallet.AddSaplingZKey(sk));
+    BOOST_CHECK(wallet.HaveSaplingSpendingKey(extfvk));
+
+    // Set up transparent address
+    CBasicKeyStore keystore;
+    CKey tsk = AddTestCKeyToKeyStore(keystore);
+    auto scriptPubKey = GetScriptForDestination(tsk.GetPubKey().GetID());
+
+    // Generate shielding tx from transparent to Sapling
+    // 0.0005 t-PIV in, 0.0004 z-PIV out, 0.0001 t-PIV fee
+    auto builder = TransactionBuilder(consensusParams, 1, &keystore);
+    builder.AddTransparentInput(COutPoint(), scriptPubKey, 50000);
+    builder.AddSaplingOutput(extfvk.fvk.ovk, pk, 40000, {});
+    auto tx1 = builder.Build().GetTxOrThrow();
+
+    BOOST_CHECK_EQUAL(tx1.vin.size(), 1);
+    BOOST_CHECK_EQUAL(tx1.vout.size(), 0);
+    BOOST_CHECK_EQUAL(tx1.sapData->vShieldedSpend.size(), 0);
+    BOOST_CHECK_EQUAL(tx1.sapData->vShieldedOutput.size(), 1);
+    BOOST_CHECK_EQUAL(tx1.sapData->valueBalance, -40000);
+
+    CWalletTx wtx {&wallet, tx1};
+
+    // Fake-mine the transaction
+    BOOST_CHECK_EQUAL(0, chainActive.Height());
+    SaplingMerkleTree saplingTree;
+    CBlock block;
+    block.vtx.emplace_back(MakeTransactionRef(wtx));
+    block.hashMerkleRoot = BlockMerkleRoot(block);
+    const auto& blockHash = block.GetHash();
+    CBlockIndex fakeIndex {block};
+    BlockMap::iterator mi = mapBlockIndex.emplace(blockHash, &fakeIndex).first;
+    fakeIndex.phashBlock = &((*mi).first);
+    chainActive.SetTip(&fakeIndex);
+    BOOST_CHECK(chainActive.Contains(&fakeIndex));
+    BOOST_CHECK_EQUAL(0, chainActive.Height());
+
+    // Simulate SyncTransaction which calls AddToWalletIfInvolvingMe
+    auto saplingNoteData = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(wtx).first;
+    BOOST_CHECK(saplingNoteData.size() > 0);
+    wtx.SetSaplingNoteData(saplingNoteData);
+    wtx.SetMerkleBranch(mapBlockIndex[blockHash], 0);
+    wallet.LoadToWallet(wtx);
+
+    // Simulate receiving new block and ChainTip signal
+    wallet.IncrementNoteWitnesses(&fakeIndex, &block, saplingTree);
+    wallet.GetSaplingScriptPubKeyMan()->UpdateSaplingNullifierNoteMapForBlock(&block);
+
+    // Retrieve the updated wtx from wallet
+    const uint256& hash = wtx.GetHash();
+    wtx = wallet.mapWallet[hash];
+
+    // Prepare to spend the note that was just created
+    auto maybe_pt = libzcash::SaplingNotePlaintext::decrypt(
+            tx1.sapData->vShieldedOutput[0].encCiphertext, ivk, tx1.sapData->vShieldedOutput[0].ephemeralKey, tx1.sapData->vShieldedOutput[0].cmu);
+    BOOST_CHECK(static_cast<bool>(maybe_pt));
+    auto maybe_note = maybe_pt.get().note(ivk);
+    BOOST_CHECK(static_cast<bool>(maybe_note));
+    auto note = maybe_note.get();
+    auto anchor = saplingTree.root();
+    auto witness = saplingTree.witness();
+
+    // Create a Sapling-only transaction
+    // 0.0004 z-ZEC in, 0.00025 z-ZEC out, 0.0001 t-ZEC fee, 0.00005 z-ZEC change
+    auto builder2 = TransactionBuilder(consensusParams, 2);
+    builder2.AddSaplingSpend(expsk, note, anchor, witness);
+    builder2.AddSaplingOutput(extfvk.fvk.ovk, pk, 25000, {});
+    auto tx2 = builder2.Build().GetTxOrThrow();
+
+    BOOST_CHECK_EQUAL(tx2.vin.size(), 0);
+    BOOST_CHECK_EQUAL(tx2.vout.size(), 0);
+    BOOST_CHECK_EQUAL(tx2.sapData->vShieldedSpend.size(), 1);
+    BOOST_CHECK_EQUAL(tx2.sapData->vShieldedOutput.size(), 2);
+    BOOST_CHECK_EQUAL(tx2.sapData->valueBalance, 10000);
+
+    CWalletTx wtx2 {&wallet, tx2};
+
+    wallet.MarkAffectedTransactionsDirty(wtx);
+
+    // After getting a cached value, the first tx should be clean
+    wallet.mapWallet[hash].GetDebit(ISMINE_ALL);
+    BOOST_CHECK(wallet.mapWallet[hash].GetDebit(ISMINE_SPENDABLE));
+
+    // After adding the note spend, the first tx should be dirty
+    wallet.LoadToWallet(wtx2);
+    wallet.MarkAffectedTransactionsDirty(wtx2);
+    BOOST_CHECK(!wallet.mapWallet[hash].GetDebit(ISMINE_SPENDABLE));
+
+    // Tear down
+    chainActive.SetTip(NULL);
+    mapBlockIndex.erase(blockHash);
+
+    // Revert to default
+    RegtestDeactivateSapling();
+}
+
+// TODO: Back port WriteWitnessCache & SetBestChainIgnoresTxsWithoutShieldedData test cases.
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/librust/sapling_wallet_tests.cpp
+++ b/src/test/librust/sapling_wallet_tests.cpp
@@ -1109,13 +1109,13 @@ BOOST_AUTO_TEST_CASE(MarkAffectedSaplingTransactionsDirty) {
     wallet.MarkAffectedTransactionsDirty(wtx);
 
     // After getting a cached value, the first tx should be clean
-    wallet.mapWallet[hash].GetDebit(ISMINE_ALL);
-    BOOST_CHECK(wallet.mapWallet[hash].GetDebit(ISMINE_SPENDABLE));
+    wallet.mapWallet[hash].GetDebit(ISMINE_SPENDABLE);
+    BOOST_CHECK(wallet.mapWallet[hash].IsAmountCached(CWalletTx::AmountType::DEBIT, ISMINE_SPENDABLE));
 
     // After adding the note spend, the first tx should be dirty
     wallet.LoadToWallet(wtx2);
     wallet.MarkAffectedTransactionsDirty(wtx2);
-    BOOST_CHECK(!wallet.mapWallet[hash].GetDebit(ISMINE_SPENDABLE));
+    BOOST_CHECK(!wallet.mapWallet[hash].IsAmountCached(CWalletTx::AmountType::DEBIT, ISMINE_SPENDABLE));
 
     // Tear down
     chainActive.SetTip(NULL);

--- a/src/test/librust/utiltest.cpp
+++ b/src/test/librust/utiltest.cpp
@@ -31,8 +31,11 @@ libzcash::SaplingExtendedSpendingKey GetTestMasterSaplingSpendingKey() {
     return libzcash::SaplingExtendedSpendingKey::Master(seed);
 }
 
-CKey AddTestCKeyToKeyStore(CBasicKeyStore& keyStore) {
-    CKey tsk = KeyIO::DecodeSecret(T_SECRET_REGTEST);
+CKey AddTestCKeyToKeyStore(CBasicKeyStore& keyStore, bool genNewKey) {
+    CKey tsk;
+    if (genNewKey) tsk.MakeNewKey(true);
+    else tsk = KeyIO::DecodeSecret(T_SECRET_REGTEST);
+    if (!tsk.IsValid()) throw std::runtime_error("AddTestCKeyToKeyStore:: Invalid priv key");
     keyStore.AddKey(tsk);
     return tsk;
 }
@@ -49,9 +52,10 @@ TestSaplingNote GetTestSaplingNote(const libzcash::SaplingPaymentAddress& pa, CA
 CWalletTx GetValidSaplingReceive(const Consensus::Params& consensusParams,
                                  CBasicKeyStore& keyStore,
                                  const libzcash::SaplingExtendedSpendingKey &sk,
-                                 CAmount value) {
+                                 CAmount value,
+                                 bool genNewKey) {
     // From taddr
-    CKey tsk = AddTestCKeyToKeyStore(keyStore);
+    CKey tsk = AddTestCKeyToKeyStore(keyStore, genNewKey);
     auto scriptPubKey = GetScriptForDestination(tsk.GetPubKey().GetID());
     // To shielded addr
     auto fvk = sk.expsk.full_viewing_key();

--- a/src/test/librust/utiltest.h
+++ b/src/test/librust/utiltest.h
@@ -23,7 +23,7 @@ void RegtestDeactivateSapling();
 
 libzcash::SaplingExtendedSpendingKey GetTestMasterSaplingSpendingKey();
 
-CKey AddTestCKeyToKeyStore(CBasicKeyStore& keyStore);
+CKey AddTestCKeyToKeyStore(CBasicKeyStore& keyStore, bool genNewKey = false);
 
 /**
  * Generate a dummy SaplingNote and a SaplingMerkleTree with that note's commitment.
@@ -33,6 +33,7 @@ TestSaplingNote GetTestSaplingNote(const libzcash::SaplingPaymentAddress& pa, CA
 CWalletTx GetValidSaplingReceive(const Consensus::Params& consensusParams,
                                  CBasicKeyStore& keyStore,
                                  const libzcash::SaplingExtendedSpendingKey &sk,
-                                 CAmount value);
+                                 CAmount value,
+                                 bool genNewKey = false);
 
 #endif // PIVX_UTIL_TEST_H

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -457,7 +457,11 @@ void CWallet::ChainTip(const CBlockIndex *pindex,
 void CWallet::SetBestChain(const CBlockLocator& loc)
 {
     CWalletDB walletdb(strWalletFile);
+    SetBestChainInternal(walletdb, loc);
+}
 
+void CWallet::SetBestChainInternal(CWalletDB& walletdb, const CBlockLocator& loc)
+{
     if (!walletdb.TxnBegin()) {
         // This needs to be done atomically, so don't do it at all
         LogPrintf("%s: Couldn't start atomic write\n", __func__);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1313,7 +1313,8 @@ CAmount CWalletTx::GetCachableAmount(AmountType type, const isminefilter& filter
     return amount.m_value[filter];
 }
 
-bool CWalletTx::IsAmountCached(AmountType type, const isminefilter& filter) const {
+bool CWalletTx::IsAmountCached(AmountType type, const isminefilter& filter) const
+{
     return m_amounts[type].m_cached[filter];
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -885,6 +885,8 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose)
     std::pair<std::map<uint256, CWalletTx>::iterator, bool> ret = mapWallet.emplace(hash, wtxIn);
     CWalletTx& wtx = (*ret.first).second;
     wtx.BindWallet(this);
+    // Sapling
+    m_sspk_man->UpdateNullifierNoteMapWithTx(wtx);
     bool fInsertedNew = ret.second;
     if (fInsertedNew) {
         wtx.nTimeReceived = GetAdjustedTime();
@@ -952,6 +954,8 @@ bool CWallet::LoadToWallet(const CWalletTx& wtxIn)
     mapWallet[hash] = wtxIn;
     CWalletTx& wtx = mapWallet[hash];
     wtx.BindWallet(this);
+    // Sapling
+    m_sspk_man->UpdateNullifierNoteMapWithTx(mapWallet[hash]);
     wtxOrdered.emplace(wtx.nOrderPos, &wtx);
     AddToSpends(hash);
     for (const CTxIn& txin : wtx.vin) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1451,8 +1451,9 @@ void CWalletTx::GetAmounts(std::list<COutputEntry>& listReceived,
     CAmount nDebit = GetDebit(filter);
     if (nDebit > 0) // debit>0 means we signed/sent this transaction
     {
-        CAmount nValueOut = GetValueOut();
-        nFee = nDebit - nValueOut;
+        CAmount nValueOut = GetValueOut(); // transasparent outputs plus the negative Sapling valueBalance
+        CAmount nValueIn = GetShieldedValueIn();
+        nFee = nDebit - nValueOut + nValueIn;
     }
 
     // Sent/received.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4245,6 +4245,12 @@ int CWallet::GetVersion()
 
 libzcash::SaplingPaymentAddress CWallet::GenerateNewSaplingZKey() { return m_sspk_man->GenerateNewSaplingZKey(); }
 
+void CWallet::IncrementNoteWitnesses(const CBlockIndex* pindex,
+                            const CBlock* pblock,
+                            SaplingMerkleTree& saplingTree) { m_sspk_man->IncrementNoteWitnesses(pindex, pblock, saplingTree); }
+
+void CWallet::DecrementNoteWitnesses(const CBlockIndex* pindex) { m_sspk_man->DecrementNoteWitnesses(pindex); }
+
 bool CWallet::AddSaplingZKey(const libzcash::SaplingExtendedSpendingKey &key) { return m_sspk_man->AddSaplingZKey(key); }
 
 bool CWallet::AddSaplingIncomingViewingKeyW(

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -892,6 +892,9 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose)
             wtx.nIndex = wtxIn.nIndex;
             fUpdated = true;
         }
+        if (HasSaplingSPKM() && m_sspk_man->UpdatedNoteData(wtxIn, wtx)) {
+            fUpdated = true;
+        }
         if (wtxIn.fFromMe && wtxIn.fFromMe != wtx.fFromMe) {
             wtx.fFromMe = wtxIn.fFromMe;
             fUpdated = true;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -549,6 +549,12 @@ std::set<uint256> CWallet::GetConflicts(const uint256& txid) const
         for (TxSpends::const_iterator it = range.first; it != range.second; ++it)
             result.insert(it->second);
     }
+
+    // Sapling
+    if (HasSaplingSPKM()) {
+        m_sspk_man->GetConflicts(wtx, result);
+    }
+
     return result;
 }
 
@@ -664,7 +670,7 @@ ScriptPubKeyMan* CWallet::GetScriptPubKeyMan() const
     return m_spk_man.get();
 }
 
-bool CWallet::HasSaplingSPKM()
+bool CWallet::HasSaplingSPKM() const
 {
     return GetSaplingScriptPubKeyMan()->IsEnabled();
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4274,7 +4274,19 @@ bool CWallet::IsMine(const CTransaction& tx) const
 
 bool CWallet::IsFromMe(const CTransaction& tx) const
 {
-    return (GetDebit(tx, ISMINE_ALL) > 0);
+    if (GetDebit(tx, ISMINE_ALL) > 0) {
+        return true;
+    }
+
+    if (tx.hasSaplingData()) {
+        for (const SpendDescription& spend : tx.sapData->vShieldedSpend) {
+            if (m_sspk_man->IsSaplingNullifierFromMe(spend.nullifier)) {
+                return true;
+            }
+        }
+    }
+
+    return false;
 }
 
 CAmount CWallet::GetDebit(const CTransaction& tx, const isminefilter& filter) const

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4292,6 +4292,7 @@ void CWalletTx::Init(const CWallet* pwalletIn)
 {
     pwallet = pwalletIn;
     mapValue.clear();
+    mapSaplingNoteData.clear();
     vOrderForm.clear();
     fTimeReceivedIsTxTime = false;
     nTimeReceived = 0;
@@ -4372,6 +4373,17 @@ void CWalletTx::BindWallet(CWallet* pwalletIn)
     MarkDirty();
 }
 
+void CWalletTx::SetSaplingNoteData(mapSaplingNoteData_t &noteData)
+{
+    mapSaplingNoteData.clear();
+    for (const std::pair<SaplingOutPoint, SaplingNoteData> nd : noteData) {
+        if (nd.first.n < sapData->vShieldedOutput.size()) {
+            mapSaplingNoteData[nd.first] = nd.second;
+        } else {
+            throw std::logic_error("CWalletTx::SetSaplingNoteData(): Invalid note");
+        }
+    }
+}
 
 bool CWalletTx::HasP2CSInputs() const
 {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -434,6 +434,26 @@ bool CWallet::ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase,
     return false;
 }
 
+void CWallet::ChainTipAdded(const CBlockIndex *pindex,
+                            const CBlock *pblock,
+                            SaplingMerkleTree saplingTree)
+{
+    IncrementNoteWitnesses(pindex, pblock, saplingTree);
+    m_sspk_man->UpdateSaplingNullifierNoteMapForBlock(pblock);
+}
+
+void CWallet::ChainTip(const CBlockIndex *pindex,
+                       const CBlock *pblock,
+                       Optional<SaplingMerkleTree> added)
+{
+    if (added) {
+        ChainTipAdded(pindex, pblock, added.get());
+    } else {
+        DecrementNoteWitnesses(pindex);
+        m_sspk_man->UpdateSaplingNullifierNoteMapForBlock(pblock);
+    }
+}
+
 void CWallet::SetBestChain(const CBlockLocator& loc)
 {
     CWalletDB walletdb(strWalletFile);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -476,6 +476,16 @@ public:
 
     //! Generates new Sapling key
     libzcash::SaplingPaymentAddress GenerateNewSaplingZKey();
+
+    //! pindex is the new tip being connected.
+    void IncrementNoteWitnesses(const CBlockIndex* pindex,
+                                const CBlock* pblock,
+                                SaplingMerkleTree& saplingTree);
+
+    //! pindex is the old tip being disconnected.
+    void DecrementNoteWitnesses(const CBlockIndex* pindex);
+
+
     //! Adds Sapling spending key to the store, and saves it to disk
     bool AddSaplingZKey(const libzcash::SaplingExtendedSpendingKey &key);
     bool AddSaplingIncomingViewingKeyW(

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -277,6 +277,9 @@ private:
     std::map<CTxDestination, AddressBook::CAddressBookData>::iterator itEnd;
 };
 
+template <class T>
+using TxSpendMap = std::multimap<T, uint256>;
+
 /**
  * A CWallet is an extension of a keystore, which also maintains a set of transactions and balances,
  * and provides the ability to create new transactions.
@@ -307,7 +310,7 @@ private:
      * detect and report conflicts (double-spends or
      * mutated transactions where the mutant gets mined).
      */
-    typedef std::multimap<COutPoint, uint256> TxSpends;
+    typedef TxSpendMap<COutPoint> TxSpends;
     TxSpends mapTxSpends;
     void AddToSpends(const COutPoint& outpoint, const uint256& wtxid);
     void AddToSpends(const uint256& wtxid);
@@ -315,7 +318,8 @@ private:
     /* Mark a transaction (and its in-wallet descendants) as conflicting with a particular block. */
     void MarkConflicted(const uint256& hashBlock, const uint256& hashTx);
 
-    void SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator>);
+    template <class T>
+    void SyncMetaData(std::pair<typename TxSpendMap<T>::iterator, typename TxSpendMap<T>::iterator> range);
 
     bool IsKeyUsed(const CPubKey& vchPubKey);
 
@@ -422,6 +426,9 @@ public:
     std::set<COutPoint> setLockedCoins;
 
     int64_t nTimeFirstKey;
+
+    // Public SyncMetadata interface used for the sapling spent nullifier map.
+    void SyncMetaDataN(std::pair<TxSpendMap<uint256>::iterator, TxSpendMap<uint256>::iterator> range);
 
     const CWalletTx* GetWalletTx(const uint256& hash) const;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -366,7 +366,7 @@ public:
     ScriptPubKeyMan* GetScriptPubKeyMan() const;
     SaplingScriptPubKeyMan* GetSaplingScriptPubKeyMan() const { return m_sspk_man.get(); }
 
-    bool HasSaplingSPKM();
+    bool HasSaplingSPKM() const;
 
     /*
      * Main wallet lock.

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -320,6 +320,7 @@ private:
 
     template <class T>
     void SyncMetaData(std::pair<typename TxSpendMap<T>::iterator, typename TxSpendMap<T>::iterator> range);
+    void ChainTipAdded(const CBlockIndex *pindex, const CBlock *pblock, SaplingMerkleTree saplingTree);
 
     bool IsKeyUsed(const CPubKey& vchPubKey);
 
@@ -686,6 +687,12 @@ public:
     CAmount GetDebit(const CTransaction& tx, const isminefilter& filter) const;
     CAmount GetCredit(const CTransaction& tx, const isminefilter& filter) const;
     CAmount GetChange(const CTransaction& tx) const;
+
+    //! Sapling merkle tree update
+    void ChainTip(const CBlockIndex *pindex,
+            const CBlock *pblock,
+            Optional<SaplingMerkleTree> added);
+
     void SetBestChain(const CBlockLocator& loc);
 
     DBErrors LoadWallet(bool& fFirstRunRet);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -339,6 +339,9 @@ private:
                                                      const bool fIncludeColdStaking,
                                                      const bool fIncludeDelegated) const;
 
+    // Force balance recomputation if any transaction got conflicted
+    void MarkAffectedTransactionsDirty(const CTransaction& tx);
+
     // Zerocoin wallet
     CzPIVWallet* zwallet{nullptr};
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -101,6 +101,7 @@ class CScript;
 class CWalletTx;
 class ScriptPubKeyMan;
 class SaplingScriptPubKeyMan;
+class SaplingNoteData;
 
 /** (client) version numbers for particular wallet features */
 enum WalletFeature {
@@ -917,6 +918,9 @@ public:
     void setAbandoned() { hashBlock = ABANDON_HASH; }
 };
 
+// Sapling map
+typedef std::map<SaplingOutPoint, SaplingNoteData> mapSaplingNoteData_t;
+
 /**
  * A transaction with a bunch of additional info that only the owner cares about.
  * It includes any unrecorded transactions needed to link it back to the block chain.
@@ -928,6 +932,7 @@ private:
 
 public:
     mapValue_t mapValue;
+    mapSaplingNoteData_t mapSaplingNoteData;
     std::vector<std::pair<std::string, std::string> > vOrderForm;
     unsigned int fTimeReceivedIsTxTime;
     unsigned int nTimeReceived; //! time received by this node
@@ -982,6 +987,10 @@ public:
         READWRITE(fFromMe);
         READWRITE(fSpent);
 
+        if (this->nVersion >= CTransaction::SAPLING_VERSION) {
+            READWRITE(mapSaplingNoteData);
+        }
+
         if (ser_action.ForRead()) {
             ReadOrderPos(nOrderPos, mapValue);
 
@@ -999,6 +1008,9 @@ public:
     void MarkDirty();
 
     void BindWallet(CWallet* pwalletIn);
+
+    void SetSaplingNoteData(mapSaplingNoteData_t &noteData);
+
     //! checks whether a tx has P2CS inputs or not
     bool HasP2CSInputs() const;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -340,9 +340,6 @@ private:
                                                      const bool fIncludeColdStaking,
                                                      const bool fIncludeDelegated) const;
 
-    // Force balance recomputation if any transaction got conflicted
-    void MarkAffectedTransactionsDirty(const CTransaction& tx);
-
     // Zerocoin wallet
     CzPIVWallet* zwallet{nullptr};
 
@@ -694,6 +691,9 @@ public:
             Optional<SaplingMerkleTree> added);
 
     void SetBestChain(const CBlockLocator& loc);
+    void SetBestChainInternal(CWalletDB& walletdb, const CBlockLocator& loc); // only public for testing purposes, must never be called directly in any other situation
+    // Force balance recomputation if any transaction got conflicted
+    void MarkAffectedTransactionsDirty(const CTransaction& tx); // only public for testing purposes, must never be called directly in any other situation
 
     DBErrors LoadWallet(bool& fFirstRunRet);
     DBErrors ZapWalletTx(std::vector<CWalletTx>& vWtx);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -149,6 +149,12 @@ bool CWalletDB::WriteCryptedSaplingZKey(
     return true;
 }
 
+bool CWalletDB::WriteWitnessCacheSize(int64_t nWitnessCacheSize)
+{
+    nWalletDBUpdateCounter++;
+    return Write(std::string("witnesscachesize"), nWitnessCacheSize);
+}
+
 bool CWalletDB::WriteMasterKey(unsigned int nID, const CMasterKey& kMasterKey)
 {
     nWalletDBUpdateCounter++;
@@ -687,6 +693,8 @@ bool ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue, CW
                 strErr = "Error reading wallet database: LoadSaplingPaymentAddress failed";
                 return false;
             }
+        } else if (strType == "witnesscachesize") {
+            ssValue >> pwallet->GetSaplingScriptPubKeyMan()->nWitnessCacheSize;
         }
     } catch (...) {
         return false;

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -164,6 +164,8 @@ public:
                                  const std::vector<unsigned char>& vchCryptedSecret,
                                  const CKeyMetadata &keyMeta);
 
+    bool WriteWitnessCacheSize(int64_t nWitnessCacheSize);
+
     /// Write destination data key,value tuple to database
     bool WriteDestData(const std::string& address, const std::string& key, const std::string& value);
     /// Erase destination data tuple from wallet database


### PR DESCRIPTION
Another PR decoupled from #1798. Built on top of #1912. PR starting on 69c58a2.

Focused on introducing sapling notes, nullifiers and witnesses management capabilities to the wallet and the sspkm (essentially wallet support for Sapling primitives). Tested by a wide range of unit tests that can be found in `sapling_wallet_tests.cpp`.

Further functional tests verifying the correct behavior of the implementation are included down the commits line in 1798: `sapling_wallet.py`, `sapling_wallet_nullifiers.py` (Haven't been able to include them here because those are depending on the shielded spend functionality that is introduced after this work and will have its own separate PR).

#### List of commits from 1798:

* Add Sapling notes map to CWalletTx —> 8ae2ea25fb2592378cae939ebba59bb38991b208
* [Sapling] SaplingNoteData class created. —> 6a77b6377f7b38229c63e241d8f030c348d293e1
* Back port IncrementNoteWitnesses & DecrementNoteWitnesses —> 069480a816c943af4b62bdf1324c71a4976e51b8
* [Wallet] Write/Read Sapling witness cache size from db. —> 9d98dd1aa463e20ead8557dd8e8ec1075fe6ac0a
* Wallet: Keep track of the used nullifiers method. —> 68b4ccd0840bea39b40a158f850ac3ea47ecd461
* [Wallet] MarkAffectedTransactionsDirty() for Sapling. —> 7045acff1cc72d5a2eaf0ba6165052663de8f5ae
* [Wallet] Sapling UpdatedNoteData() implemented —> 2c4bab731799061cb3aab85d5e8401a992690e6f
* [Wallet] Back port FindMySaplingNotes(). —> 82714ff899ceff4751034a376e6e3b855e93d9a5
* [Sapling] Create IsSaplingNullifierFromMe . —> 7d8a575cb071f1f45a12c797ad010d72b2cf557e
* [Wallet] Connect tx GetShieldedValueIn —> ed188975da684801ebdd22a43212c8aceafe7862
* Update CWalletTx::GetAmounts() to return COutputEntry for Sapling valueBalance. —> fdfc73cd4f8fb0261c23e2788437af9b0a7454c1
* [Sapling] Update nullifier note map (block & tx) methods back ported. —> 907ae3f731ee4c394f1e0786d05de4c7bfb1c70a
* CWallet::ChainTip slot back ported —> 108162a25254a62168d79b1114f97c239fdace6f
* UpdateNullifierNoteMapWithTx connected to wallet. —> 46ff034a368931156ff0d12759de032b7c694333
* Cleaning compiler warnings —> 14d2d2c2dabdeb0860e410986b252f0187db8f58
* [Wallet] Sapling GetConflicts implemented. —> 46f4f928c40db6ded4b4e18bf9cddfbf92771bb8
* [Wallet] IsSaplingSpent back port. —> 6156b1588baa3ca97d5f138b6bb9f97af1b29640
* [Wallet] Sapling GetSaplingNoteWitnesses back ported. —> 12b7b7bf5ada9b6df0ac9de1d6301d5f156f4cad
* [Wallet] Sapling wallet unit tests back port —> 50e1cfc9a70885655fa0409ffd16076added27a2
* Migration from Purple_Fenix upgrade to v5_dummy —> 6d49e6bad03c823c948b6ede34cf0012906ce72b (PARTIALLY)
* Sapling wallet unit tests, set wallet minimum version to FEATURE_SAPLING. —> 5ed289cf1d37d053fbedc2559e591667a9b2de6f
* wallet: Introduce IsAmountCached to know whether a tx amount has been cached or not.  —> db27b545fe1ec9059d3508b816c0f14727ed8861