### PR TITLE
[Core] Introduce --lockorderabort to abort if inconsistent lock order is detected

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -45,6 +45,7 @@
 #include "torcontrol.h"
 #include "guiinterface.h"
 #include "guiinterfaceutil.h"
+#include "sync.h"
 #include "util.h"
 #include "utilmoneystr.h"
 #include "util/threadnames.h"
@@ -409,6 +410,9 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-disablesystemnotifications", strprintf(_("Disable OS notifications for incoming transactions (default: %u)"), 0));
     strUsage += HelpMessageOpt("-dbcache=<n>", strprintf(_("Set database cache size in megabytes (%d to %d, default: %d)"), nMinDbCache, nMaxDbCache, nDefaultDbCache));
     strUsage += HelpMessageOpt("-loadblock=<file>", _("Imports blocks from external blk000??.dat file") + " " + _("on startup"));
+#ifdef DEBUG_LOCKORDER
+    strUsage += HelpMessageOpt("-lockorderabort", _("Abort if a lock-order inconsistency is detected"));
+#endif
     strUsage += HelpMessageOpt("-maxreorg=<n>", strprintf(_("Set the Maximum reorg depth (default: %u)"), DEFAULT_MAX_REORG_DEPTH));
     strUsage += HelpMessageOpt("-maxorphantx=<n>", strprintf(_("Keep at most <n> unconnectable transactions in memory (default: %u)"), DEFAULT_MAX_ORPHAN_TRANSACTIONS));
     strUsage += HelpMessageOpt("-maxmempool=<n>", strprintf(_("Keep the transaction memory pool below <n> megabytes (default: %u)"), DEFAULT_MAX_MEMPOOL_SIZE));
@@ -1014,7 +1018,9 @@ bool AppInit2()
             }
         }
     }
-
+#ifdef DEBUG_LOCKORDER
+    g_debug_lockorder_abort = GetBoolArg("-lockorderabort", false);
+#endif
     // Check for -debugnet
     if (GetBoolArg("-debugnet", false))
         UIWarning(_("Warning: Unsupported argument -debugnet ignored, use -debug=net."));

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -112,11 +112,13 @@ static void potential_deadlock_detected(const std::pair<void*, void*>& mismatch,
         }
         LogPrintf(" %s\n", i.second.ToString());
     }
+    if (g_debug_lockorder_unittest) {
+        throw std::logic_error("potential deadlock detected");
+    }
     if (g_debug_lockorder_abort) {
         tfm::format(std::cerr, "Assertion failed: detected inconsistent lock order at %s:%i, details in debug log.\n", __FILE__, __LINE__);
         abort();
     }
-    throw std::logic_error("potential deadlock detected");
 }
 
 static void push_lock(void* c, const CLockLocation& locklocation)
@@ -207,6 +209,7 @@ void DeleteLock(void* cs)
     }
 }
 
-bool g_debug_lockorder_abort = true;
+bool g_debug_lockorder_abort = false;
+bool g_debug_lockorder_unittest = false;
 
 #endif /* DEBUG_LOCKORDER */

--- a/src/sync.h
+++ b/src/sync.h
@@ -58,10 +58,14 @@ void DeleteLock(void* cs);
 
 /**
  * Call abort() if a potential lock order deadlock bug is detected, instead of
- * just logging information and throwing a logic_error. Defaults to true, and
- * set to false in DEBUG_LOCKORDER unit tests.
+ * just logging information. Defaults to false, and set to true with --lockorderabort.
  */
 extern bool g_debug_lockorder_abort;
+/**
+ * Throw logic error if a potential lock order deadlock bug is detected, instead of
+ * just logging information or aborting. Defaults to false, and set to true in the unit tests.
+ */
+extern bool g_debug_lockorder_unittest;
 #else
 void static inline EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs, bool fTry = false) {}
 void static inline LeaveCritical() {}

--- a/src/test/sync_tests.cpp
+++ b/src/test/sync_tests.cpp
@@ -33,20 +33,17 @@ BOOST_FIXTURE_TEST_SUITE(sync_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(potential_deadlock_detected)
 {
-    #ifdef DEBUG_LOCKORDER
-    bool prev = g_debug_lockorder_abort;
-    g_debug_lockorder_abort = false;
-    #endif
-
+#ifdef DEBUG_LOCKORDER
+    g_debug_lockorder_unittest = true;
+#endif
     RecursiveMutex rmutex1, rmutex2;
     TestPotentialDeadLockDetected(rmutex1, rmutex2);
 
     Mutex mutex1, mutex2;
     TestPotentialDeadLockDetected(mutex1, mutex2);
-
-    #ifdef DEBUG_LOCKORDER
-    g_debug_lockorder_abort = prev;
-    #endif
+#ifdef DEBUG_LOCKORDER
+    g_debug_lockorder_unittest = false;
+#endif
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Otherwise change the default behavior to only log the inconsistency, without aborting.
This way we can run `--enable-debug` nodes, without having to fix one inconsistency at a time.