### PR TITLE
[Core] Lock cs_vSend and cs_inventory in a consistent order even in TRY

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1149,11 +1149,12 @@ void CConnman::ThreadSocketHandler()
                 if (pnode->GetRefCount() <= 0) {
                     bool fDelete = false;
                     {
-                        TRY_LOCK(pnode->cs_vSend, lockSend);
-                        if (lockSend) {
-                                TRY_LOCK(pnode->cs_inventory, lockInv);
-                                if (lockInv)
-                                    fDelete = true;
+                        TRY_LOCK(pnode->cs_inventory, lockInv);
+                        if (lockInv) {
+                            TRY_LOCK(pnode->cs_vSend, lockSend);
+                            if (lockSend) {
+                                fDelete = true;
+                            }
                         }
                     }
                     if (fDelete) {


### PR DESCRIPTION
Fixes another inconsistency found with #1920 :
```
2020-10-15 23:43:11 POTENTIAL DEADLOCK DETECTED
2020-10-15 23:43:11 Previous lock order was:
2020-10-15 23:43:11  (1) pnode->cs_vSend net.cpp:1152 (TRY) (in thread pivx-net)
2020-10-15 23:43:11  (2) pnode->cs_inventory net.cpp:1154 (TRY) (in thread pivx-net)
2020-10-15 23:43:11 Current lock order is:
2020-10-15 23:43:11  pnode->cs_sendProcessing net.cpp:1898 (in thread pivx-msghand)
2020-10-15 23:43:11  cs_main net_processing.cpp:1992 (TRY) (in thread pivx-msghand)
2020-10-15 23:43:11  (2) pto->cs_inventory net_processing.cpp:2081 (in thread pivx-msghand)
2020-10-15 23:43:11  (1) pnode->cs_vSend net.cpp:2568 (in thread pivx-msghand)
```

backporting the only missing commit from upstream bitcoin/bitcoin#9674