### PR TITLE
[Refactor] Strip out cs_main lock for misbehaving from Masternodeman:ProcessMessage

### DIFF
--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -641,11 +641,12 @@ std::vector<std::pair<int64_t, CMasternode>> CMasternodeMan::GetMasternodeRanks(
 
 int CMasternodeMan::ProcessMNBroadcast(CNode* pfrom, CMasternodeBroadcast& mnb)
 {
-    if (mapSeenMasternodeBroadcast.count(mnb.GetHash())) { //seen
-        masternodeSync.AddedMasternodeList(mnb.GetHash());
+    const uint256& mnbHash = mnb.GetHash();
+    if (mapSeenMasternodeBroadcast.count(mnbHash)) { //seen
+        masternodeSync.AddedMasternodeList(mnbHash);
         return 0;
     }
-    mapSeenMasternodeBroadcast.emplace(mnb.GetHash(), mnb);
+    mapSeenMasternodeBroadcast.emplace(mnbHash, mnb);
 
     int nDoS = 0;
     if (!mnb.CheckAndUpdate(nDoS)) {
@@ -664,7 +665,7 @@ int CMasternodeMan::ProcessMNBroadcast(CNode* pfrom, CMasternodeBroadcast& mnb)
     if (mnb.CheckInputsAndAdd(nDoS)) {
         // use this as a peer
         g_connman->AddNewAddress(CAddress(mnb.addr, NODE_NETWORK), pfrom->addr, 2 * 60 * 60);
-        masternodeSync.AddedMasternodeList(mnb.GetHash());
+        masternodeSync.AddedMasternodeList(mnbHash);
     } else {
         LogPrint(BCLog::MASTERNODE,"mnb - Rejected Masternode entry %s\n", mnb.vin.prevout.hash.ToString());
         return nDoS;
@@ -675,8 +676,9 @@ int CMasternodeMan::ProcessMNBroadcast(CNode* pfrom, CMasternodeBroadcast& mnb)
 
 int CMasternodeMan::ProcessMNPing(CNode* pfrom, CMasternodePing& mnp)
 {
-    if (mapSeenMasternodePing.count(mnp.GetHash())) return 0; //seen
-    mapSeenMasternodePing.emplace(mnp.GetHash(), mnp);
+    const uint256& mnpHash = mnp.GetHash();
+    if (mapSeenMasternodePing.count(mnpHash)) return 0; //seen
+    mapSeenMasternodePing.emplace(mnpHash, mnp);
 
     int nDoS = 0;
     if (mnp.CheckAndUpdate(nDoS)) return 0;

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -156,8 +156,8 @@ public:
 
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
 
-    // Process GETMNLIST message
-    void ProcessGetMNList(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
+    // Process GETMNLIST message, returning the banning score (if 0, no ban score increase is needed)
+    int ProcessGetMNList(CNode* pfrom, CTxIn& vin);
 
     /// Return the number of (unique) Masternodes
     int size() { return vMasternodes.size(); }

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -81,6 +81,7 @@ private:
     // Return the banning score (0 if no ban score increase is needed).
     int ProcessMNBroadcast(CNode* pfrom, CMasternodeBroadcast& mnb);
     int ProcessMNPing(CNode* pfrom, CMasternodePing& mnp);
+    int ProcessMessageInner(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
 
 public:
     // Keep track of all broadcasts I've seen

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -78,6 +78,10 @@ private:
     // Memory Only. Cache last block hashes. Used to verify mn pings and winners.
     CyclingVector<uint256> cvLastBlockHashes;
 
+    // Return the banning score (0 if no ban score increase is needed).
+    int ProcessMNBroadcast(CNode* pfrom, CMasternodeBroadcast& mnb);
+    int ProcessMNPing(CNode* pfrom, CMasternodePing& mnp);
+
 public:
     // Keep track of all broadcasts I've seen
     std::map<uint256, CMasternodeBroadcast> mapSeenMasternodeBroadcast;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -118,10 +118,8 @@ public:
         READWRITE(nSequence);
     }
 
-    bool IsFinal() const
-    {
-        return (nSequence == std::numeric_limits<uint32_t>::max());
-    }
+    bool IsFinal() const { return nSequence == std::numeric_limits<uint32_t>::max(); }
+    bool IsNull() const { return prevout.IsNull() && scriptSig.empty() && IsFinal(); }
 
     bool IsZerocoinSpend() const;
     bool IsZerocoinPublicSpend() const;

--- a/src/tiertwo_networksync.cpp
+++ b/src/tiertwo_networksync.cpp
@@ -43,7 +43,10 @@ bool CMasternodeSync::MessageDispatcher(CNode* pfrom, std::string& strCommand, C
 
     if (strCommand == NetMsgType::GETMNLIST) {
         // Get Masternode list or specific entry
-        mnodeman.ProcessGetMNList(pfrom, strCommand, vRecv);
+        CTxIn vin;
+        vRecv >> vin;
+        mnodeman.ProcessGetMNList(pfrom, vin);
+        // todo result ban score misbehaving..
         return true;
     }
 


### PR DESCRIPTION
Built on top of #1845.

Refactored `Masternodeman:ProcessMessage` decoupling in different methods and stripped out every `cs_main` lock for a `Misbehaving` function call.