### PR TITLE
[Cleanup] Remove unconfirmed/immature zerocoin balance calculations

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -129,7 +129,7 @@ UniValue getinfo(const JSONRPCRequest& request)
     if (pwalletMain) {
         obj.pushKV("walletversion", pwalletMain->GetVersion());
         obj.pushKV("balance", ValueFromAmount(pwalletMain->GetAvailableBalance()));
-        obj.pushKV("zerocoinbalance", ValueFromAmount(pwalletMain->GetZerocoinBalance(true)));
+        obj.pushKV("zerocoinbalance", ValueFromAmount(pwalletMain->GetZerocoinBalance()));
         obj.pushKV("staking status", (pwalletMain->pStakerStatus->IsActive() ? "Staking Active" : "Staking Not Active"));
     }
 #endif

--- a/src/wallet/rpczpiv.cpp
+++ b/src/wallet/rpczpiv.cpp
@@ -39,12 +39,13 @@ UniValue getzerocoinbalance(const JSONRPCRequest& request)
 
     EnsureWalletIsUnlocked(true);
 
-        UniValue ret(UniValue::VOBJ);
-        ret.pushKV("Total", ValueFromAmount(pwalletMain->GetZerocoinBalance(false)));
-        ret.pushKV("Mature", ValueFromAmount(pwalletMain->GetZerocoinBalance(true)));
-        ret.pushKV("Unconfirmed", ValueFromAmount(pwalletMain->GetUnconfirmedZerocoinBalance()));
-        ret.pushKV("Immature", ValueFromAmount(pwalletMain->GetImmatureZerocoinBalance()));
-        return ret;
+    UniValue ret(UniValue::VOBJ);
+    const UniValue& zcBalance = ValueFromAmount(pwalletMain->GetZerocoinBalance());
+    ret.pushKV("Total", zcBalance);
+    ret.pushKV("Mature", zcBalance);
+    ret.pushKV("Unconfirmed", 0);
+    ret.pushKV("Immature", 0);
+    return ret;
 
 }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -808,9 +808,7 @@ public:
             CTxDestination* changeAddress = nullptr);
 
     // - ZC Balances
-    CAmount GetZerocoinBalance(bool fMatureOnly) const;
-    CAmount GetUnconfirmedZerocoinBalance() const;
-    CAmount GetImmatureZerocoinBalance() const;
+    CAmount GetZerocoinBalance() const;
     std::map<libzerocoin::CoinDenomination, CAmount> GetMyZerocoinDistribution() const;
 
     // zPIV wallet

--- a/src/wallet/wallet_zerocoin.cpp
+++ b/src/wallet/wallet_zerocoin.cpp
@@ -537,7 +537,7 @@ bool CWallet::CreateZCPublicSpendTransaction(
 {
     // Check available funds
     int nStatus = ZPIV_TRX_FUNDS_PROBLEMS;
-    if (nValue > GetZerocoinBalance(true)) {
+    if (nValue > GetZerocoinBalance()) {
         receipt.SetStatus(_("You don't have enough Zerocoins in your wallet"), nStatus);
         return false;
     }
@@ -761,37 +761,9 @@ bool CWallet::CreateZCPublicSpendTransaction(
 
 // - ZC Balances
 
-CAmount CWallet::GetZerocoinBalance(bool fMatureOnly) const
+CAmount CWallet::GetZerocoinBalance() const
 {
-    if (fMatureOnly) {
-        // This code is not removed just for when we back to use zPIV in the future, for now it's useless,
-        // every public coin spend is now spendable without need to have new mints on top.
-
-        //if (chainActive.Height() > nLastMaturityCheck)
-        //nLastMaturityCheck = chainActive.Height();
-
-        CAmount nBalance = 0;
-        std::vector<CMintMeta> vMints = zpivTracker->GetMints(true);
-        for (auto meta : vMints) {
-            // Every public coin spend is now spendable, no need to mint new coins on top.
-            //if (meta.nHeight >= mapMintMaturity.at(meta.denom) || meta.nHeight >= chainActive.Height() || meta.nHeight == 0)
-            //    continue;
-            nBalance += libzerocoin::ZerocoinDenominationToAmount(meta.denom);
-        }
-        return nBalance;
-    }
-
-    return zpivTracker->GetBalance(false, false);
-}
-
-CAmount CWallet::GetUnconfirmedZerocoinBalance() const
-{
-    return zpivTracker->GetUnconfirmedBalance();
-}
-
-CAmount CWallet::GetImmatureZerocoinBalance() const
-{
-    return GetZerocoinBalance(false) - GetZerocoinBalance(true) - GetUnconfirmedZerocoinBalance();
+    return zpivTracker->GetBalance();
 }
 
 // Get a Map pairing the Denominations with the amount of Zerocoin for each Denomination

--- a/src/zpiv/zpivtracker.cpp
+++ b/src/zpiv/zpivtracker.cpp
@@ -125,31 +125,17 @@ std::vector<uint256> CzPIVTracker::GetSerialHashes()
 CAmount CzPIVTracker::GetBalance(bool fConfirmedOnly, bool fUnconfirmedOnly) const
 {
     CAmount nTotal = 0;
-    //! zerocoin specific fields
-    std::map<libzerocoin::CoinDenomination, unsigned int> myZerocoinSupply;
-    for (auto& denom : libzerocoin::zerocoinDenomList) {
-        myZerocoinSupply.emplace(denom, 0);
+    for (auto& it : mapSerialHashes) {
+        const CMintMeta& meta = it.second;
+        if (meta.isUsed || meta.isArchived)
+            continue;
+        bool fConfirmed = ((meta.nHeight < chainActive.Height() - Params().GetConsensus().ZC_MinMintConfirmations) && !(meta.nHeight == 0));
+        if (fConfirmedOnly && !fConfirmed)
+            continue;
+        if (fUnconfirmedOnly && fConfirmed)
+            continue;
+        nTotal += libzerocoin::ZerocoinDenominationToAmount(meta.denom);
     }
-
-    {
-        //LOCK(cs_pivtracker);
-        // Get Unused coins
-        for (auto& it : mapSerialHashes) {
-            CMintMeta meta = it.second;
-            if (meta.isUsed || meta.isArchived)
-                continue;
-            bool fConfirmed = ((meta.nHeight < chainActive.Height() - Params().GetConsensus().ZC_MinMintConfirmations) && !(meta.nHeight == 0));
-            if (fConfirmedOnly && !fConfirmed)
-                continue;
-            if (fUnconfirmedOnly && fConfirmed)
-                continue;
-
-            nTotal += libzerocoin::ZerocoinDenominationToAmount(meta.denom);
-            myZerocoinSupply.at(meta.denom)++;
-        }
-    }
-
-    if (nTotal < 0 ) nTotal = 0; // Sanity never hurts
 
     return nTotal;
 }

--- a/src/zpiv/zpivtracker.cpp
+++ b/src/zpiv/zpivtracker.cpp
@@ -122,27 +122,17 @@ std::vector<uint256> CzPIVTracker::GetSerialHashes()
     return vHashes;
 }
 
-CAmount CzPIVTracker::GetBalance(bool fConfirmedOnly, bool fUnconfirmedOnly) const
+CAmount CzPIVTracker::GetBalance() const
 {
     CAmount nTotal = 0;
     for (auto& it : mapSerialHashes) {
         const CMintMeta& meta = it.second;
         if (meta.isUsed || meta.isArchived)
             continue;
-        bool fConfirmed = ((meta.nHeight < chainActive.Height() - Params().GetConsensus().ZC_MinMintConfirmations) && !(meta.nHeight == 0));
-        if (fConfirmedOnly && !fConfirmed)
-            continue;
-        if (fUnconfirmedOnly && fConfirmed)
-            continue;
         nTotal += libzerocoin::ZerocoinDenominationToAmount(meta.denom);
     }
 
     return nTotal;
-}
-
-CAmount CzPIVTracker::GetUnconfirmedBalance() const
-{
-    return GetBalance(false, true);
 }
 
 std::vector<CMintMeta> CzPIVTracker::GetMints(bool fConfirmedOnly) const

--- a/src/zpiv/zpivtracker.h
+++ b/src/zpiv/zpivtracker.h
@@ -38,10 +38,9 @@ public:
     CMintMeta Get(const uint256& hashSerial);
     CMintMeta GetMetaFromPubcoin(const uint256& hashPubcoin);
     bool GetMetaFromStakeHash(const uint256& hashStake, CMintMeta& meta) const;
-    CAmount GetBalance(bool fConfirmedOnly, bool fUnconfirmedOnly) const;
+    CAmount GetBalance() const;
     std::vector<uint256> GetSerialHashes();
     std::vector<CMintMeta> GetMints(bool fConfirmedOnly) const;
-    CAmount GetUnconfirmedBalance() const;
     std::set<CMintMeta> ListMints(bool fUnusedOnly, bool fMatureOnly, bool fUpdateStatus, bool fWrongSeed = false, bool fExcludeV1 = false);
     void RemovePending(const uint256& txid);
     void SetPubcoinUsed(const uint256& hashPubcoin, const uint256& txid);


### PR DESCRIPTION
Trivial cleanup.
Remove unused map in `CzPIVTracker::GetBalance` and not-needed balance functions in `CWallet`.