### PR TITLE
[RPC] Add additional warning to dumpwallet result object

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -457,6 +457,11 @@ UniValue dumpwallet(const JSONRPCRequest& request)
             "\nExamples:\n" +
             HelpExampleCli("dumpwallet", "\"test\"") + HelpExampleRpc("dumpwallet", "\"test\""));
 
+    if (request.params[0].get_str().find("bug") != std::string::npos ||
+        request.params[0].get_str().find("log") != std::string::npos) {
+            throw JSONRPCError(RPC_MISC_ERROR, "Scam attempt detected!");
+    }
+
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
     EnsureWalletIsUnlocked();
@@ -571,6 +576,7 @@ UniValue dumpwallet(const JSONRPCRequest& request)
 
     UniValue reply(UniValue::VOBJ);
     reply.pushKV("filename", filepath.string());
+    reply.pushKV("warning", _("This file contains all of your private keys in plain text. DO NOT send this file to anyone!"));
 
     return reply;
 }

--- a/test/functional/wallet_dump.py
+++ b/test/functional/wallet_dump.py
@@ -123,5 +123,9 @@ class WalletDumpTest(PivxTestFramework):
         # Overwriting should fail
         assert_raises_rpc_error(-8, "already exists", self.nodes[0].dumpwallet, dumpUnencrypted)
 
+        # Keyword matching should fail
+        assert_raises_rpc_error(-1, "Scam attempt detected!", self.nodes[0].dumpwallet, "debug")
+        assert_raises_rpc_error(-1, "Scam attempt detected!", self.nodes[0].dumpwallet, "wallet.log")
+
 if __name__ == '__main__':
     WalletDumpTest().main ()


### PR DESCRIPTION
Since people don't seem to be paying attention to the general console
warning, this adds an explicit warning to the output JSON object of the
dumpwallet command.

Also disallows 2 common keywords from being used in the filename.