### PR TITLE
[GUI] Double confirmation dialog for dumpwallet command.

### DIFF
--- a/src/qt/pivx/settings/settingsconsolewidget.h
+++ b/src/qt/pivx/settings/settingsconsolewidget.h
@@ -44,8 +44,8 @@ public:
 
 public Q_SLOTS:
     void clear(bool clearHistory = true);
-    void message(int category, const QString &msg) { message(category, msg, false); }
-    void message(int category, const QString &message, bool html);
+    void response(int category, const QString &message) { messageInternal(category, message); };
+    void messageInternal(int category, const QString &message, bool html = false);
     /** Go forward or back in history */
     void browseHistory(int offset);
     /** Scroll console view to end */

--- a/src/qt/pivx/settings/settingswidget.cpp
+++ b/src/qt/pivx/settings/settingswidget.cpp
@@ -165,6 +165,8 @@ SettingsWidget::SettingsWidget(PIVXGUI* parent) :
     connect(settingsWalletOptionsWidget, &SettingsWalletOptionsWidget::saveSettings, this, &SettingsWidget::onSaveOptionsClicked);
     connect(settingsWalletOptionsWidget, &SettingsWalletOptionsWidget::discardSettings, this, &SettingsWidget::onDiscardChanges);
 
+    connect(settingsConsoleWidget, &SettingsConsoleWidget::message,this, &SettingsWidget::message);
+
     /* Widget-to-option mapper */
     mapper = new QDataWidgetMapper(this);
     mapper->setSubmitPolicy(QDataWidgetMapper::ManualSubmit);


### PR DESCRIPTION
Another attempt to alert users about scams, added a second confirmation dialog after requesting a `dumpwallet` or `dumpprivkey` in the internal GUI wallet console. 
Want to emphasize that this is a GUI only change, command line RPC call will continue exactly as before.

After typing `dumpwallet`, the application will launch the following confirmation dialog:
<img width="1224" alt="dumpwallet" src="https://user-images.githubusercontent.com/5377650/96373757-f32a0e00-1144-11eb-8c8b-1bc569366d64.png">

So, in other words, the command will only be executed if the user presses "OK" on this "**DON'T DO THIS**" warning