### PR TITLE
[RPC] Speeding up listmasternodes command

### DIFF
--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -146,8 +146,8 @@ public:
         Check();
         return vMasternodes;
     }
-
-    std::vector<std::pair<int, CMasternode> > GetMasternodeRanks(int64_t nBlockHeight, int minProtocol = 0);
+    // Retrieve the known masternodes ordered by scoring without checking them. (Only used for listmasternodes RPC call)
+    std::vector<std::pair<int64_t, CMasternode>> GetMasternodeRanks(int nBlockHeight);
     int GetMasternodeRank(const CTxIn& vin, int64_t nBlockHeight, int minProtocol = 0, bool fOnlyActive = true);
 
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -85,39 +85,37 @@ UniValue listmasternodes(const JSONRPCRequest& request)
     for (int pos=0; pos < (int) vMasternodeRanks.size(); pos++) {
         const auto& s = vMasternodeRanks[pos];
         UniValue obj(UniValue::VOBJ);
-        std::string strVin = s.second.vin.prevout.ToStringShort();
-        std::string strTxHash = s.second.vin.prevout.hash.ToString();
-        uint32_t oIdx = s.second.vin.prevout.n;
+        CMasternode mn = s.second;
 
-        CMasternode* mn = mnodeman.Find(s.second.vin);
+        std::string strVin = mn.vin.prevout.ToStringShort();
+        std::string strTxHash = mn.vin.prevout.hash.ToString();
+        uint32_t oIdx = mn.vin.prevout.n;
 
-        if (mn != NULL) {
-            if (strFilter != "" && strTxHash.find(strFilter) == std::string::npos &&
-                mn->Status().find(strFilter) == std::string::npos &&
-                EncodeDestination(mn->pubKeyCollateralAddress.GetID()).find(strFilter) == std::string::npos) continue;
+        if (strFilter != "" && strTxHash.find(strFilter) == std::string::npos &&
+            mn.Status().find(strFilter) == std::string::npos &&
+            EncodeDestination(mn.pubKeyCollateralAddress.GetID()).find(strFilter) == std::string::npos) continue;
 
-            std::string strStatus = mn->Status();
-            std::string strHost;
-            int port;
-            SplitHostPort(mn->addr.ToString(), port, strHost);
-            CNetAddr node;
-            LookupHost(strHost.c_str(), node, false);
-            std::string strNetwork = GetNetworkName(node.GetNetwork());
+        std::string strStatus = mn.Status();
+        std::string strHost;
+        int port;
+        SplitHostPort(mn.addr.ToString(), port, strHost);
+        CNetAddr node;
+        LookupHost(strHost.c_str(), node, false);
+        std::string strNetwork = GetNetworkName(node.GetNetwork());
 
-            obj.pushKV("rank", (strStatus == "ENABLED" ? pos : 0));
-            obj.pushKV("network", strNetwork);
-            obj.pushKV("txhash", strTxHash);
-            obj.pushKV("outidx", (uint64_t)oIdx);
-            obj.pushKV("pubkey", HexStr(mn->pubKeyMasternode));
-            obj.pushKV("status", strStatus);
-            obj.pushKV("addr", EncodeDestination(mn->pubKeyCollateralAddress.GetID()));
-            obj.pushKV("version", mn->protocolVersion);
-            obj.pushKV("lastseen", (int64_t)mn->lastPing.sigTime);
-            obj.pushKV("activetime", (int64_t)(mn->lastPing.sigTime - mn->sigTime));
-            obj.pushKV("lastpaid", (int64_t)mn->GetLastPaid());
+        obj.pushKV("rank", (strStatus == "ENABLED" ? pos : 0));
+        obj.pushKV("network", strNetwork);
+        obj.pushKV("txhash", strTxHash);
+        obj.pushKV("outidx", (uint64_t)oIdx);
+        obj.pushKV("pubkey", HexStr(mn.pubKeyMasternode));
+        obj.pushKV("status", strStatus);
+        obj.pushKV("addr", EncodeDestination(mn.pubKeyCollateralAddress.GetID()));
+        obj.pushKV("version", mn.protocolVersion);
+        obj.pushKV("lastseen", (int64_t)mn.lastPing.sigTime);
+        obj.pushKV("activetime", (int64_t)(mn.lastPing.sigTime - mn.sigTime));
+        obj.pushKV("lastpaid", (int64_t)mn.GetLastPaid());
 
-            ret.push_back(obj);
-        }
+        ret.push_back(obj);
     }
 
     return ret;

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -81,8 +81,9 @@ UniValue listmasternodes(const JSONRPCRequest& request)
     int nHeight = WITH_LOCK(cs_main, return chainActive.Height());
     if (nHeight < 0) return "[]";
 
-    std::vector<std::pair<int, CMasternode> > vMasternodeRanks = mnodeman.GetMasternodeRanks(nHeight);
-    for (PAIRTYPE(int, CMasternode) & s : vMasternodeRanks) {
+    std::vector<std::pair<int64_t, CMasternode>> vMasternodeRanks = mnodeman.GetMasternodeRanks(nHeight);
+    for (int pos=0; pos < (int) vMasternodeRanks.size(); pos++) {
+        const auto& s = vMasternodeRanks[pos];
         UniValue obj(UniValue::VOBJ);
         std::string strVin = s.second.vin.prevout.ToStringShort();
         std::string strTxHash = s.second.vin.prevout.hash.ToString();
@@ -103,7 +104,7 @@ UniValue listmasternodes(const JSONRPCRequest& request)
             LookupHost(strHost.c_str(), node, false);
             std::string strNetwork = GetNetworkName(node.GetNetwork());
 
-            obj.pushKV("rank", (strStatus == "ENABLED" ? s.first : 0));
+            obj.pushKV("rank", (strStatus == "ENABLED" ? pos : 0));
             obj.pushKV("network", strNetwork);
             obj.pushKV("txhash", strTxHash);
             obj.pushKV("outidx", (uint64_t)oIdx);


### PR DESCRIPTION
Built on top of #1904 . PR starting on 9123d22.

`listmasternodes` RPC command was taking a considerable amount of time, checked the flow and discovered a lot of redundancies in the process. This PR aims to correct them.

 1) `CMasternodeMan::GetMasternodeRanks` is only used for an RPC call and it was checking and validating each Masternode instead of just retrieve them as it suppose to be doing (the tier two thread is the only one responsible of check and update the masternodes list).

2) `CMasternodeMan::GetMasternodeRanks` had a totally unneeded second vector load. Looping over the entire masternodes list one more time after getting it.

3) `listmasternodes` after calling `GetMasternodeRanks` was looking for each of the retrieved masternodes one more time using the retrieved masternode vin (yes..).