### PR TITLE
[BUG][GUI] guarding wallet ptr access in WalletModel:getEncryptionStatus .

### DIFF
--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -583,7 +583,7 @@ void TopBar::updateTorIcon()
 void TopBar::refreshStatus()
 {
     // Check lock status
-    if (!this->walletModel)
+    if (!walletModel || !walletModel->hasWallet())
         return;
 
     WalletModel::EncryptionStatus encStatus = walletModel->getEncryptionStatus();

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -144,6 +144,7 @@ bool WalletModel::isColdStaking() const
 
 void WalletModel::updateStatus()
 {
+    if (!wallet) return;
     EncryptionStatus newEncryptionStatus = getEncryptionStatus();
 
     if (cachedEncryptionStatus != newEncryptionStatus)
@@ -152,12 +153,14 @@ void WalletModel::updateStatus()
 
 bool WalletModel::isWalletUnlocked() const
 {
+    if (!wallet) return false;
     EncryptionStatus status = getEncryptionStatus();
     return (status == Unencrypted || status == Unlocked);
 }
 
 bool WalletModel::isWalletLocked(bool fFullUnlocked) const
 {
+    if (!wallet) return false;
     EncryptionStatus status = getEncryptionStatus();
     return (status == Locked || (!fFullUnlocked && status == UnlockedForStaking));
 }
@@ -531,6 +534,7 @@ RecentRequestsTableModel* WalletModel::getRecentRequestsTableModel()
 
 WalletModel::EncryptionStatus WalletModel::getEncryptionStatus() const
 {
+    if (!wallet) throw std::runtime_error("Error, cannot get encryption status. Wallet doesn't exist");
     if (!wallet->IsCrypted()) {
         return Unencrypted;
     } else if (wallet->fWalletUnlockStaking) {

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -151,6 +151,8 @@ public:
     /* current staking status from the miner thread **/
     bool isStakingStatusActive() const;
 
+    bool hasWallet() { return wallet; };
+
     bool isHDEnabled() const;
     bool upgradeWallet(std::string& upgradeError);
 


### PR DESCRIPTION
Solving a crash due an `exc_bad_access`. Happened to me running the wallet with the debugger attached. 
At shutdown, the wallet ptr was already released and the GUI tried to access it from the `updateStakingStatus` function triggered by the timer.