### PR TITLE
[Trivial] Remove unused var in SaplingSPKM::AddSaplingSpendingKey

### DIFF
--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -167,7 +167,6 @@ bool SaplingScriptPubKeyMan::AddSaplingSpendingKey(
         CSecureDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
         ss << sk;
         CKeyingMaterial vchSecret(ss.begin(), ss.end());
-        auto address = sk.DefaultAddress();
         auto extfvk = sk.ToXFVK();
         if (!EncryptSecret(wallet->GetEncryptionKey(), vchSecret, extfvk.fvk.GetFingerprint(), vchCryptedSecret)) {
             return false;


### PR DESCRIPTION
Extremely trivial thing. Just to remove an annoying compiler warning.