### PR TITLE
[Cleanup] Remove duplicate header includes

### DIFF
--- a/src/qt/pivx/furabstractlistitemdelegate.h
+++ b/src/qt/pivx/furabstractlistitemdelegate.h
@@ -8,13 +8,12 @@
 #include "qt/pivx/furlistrow.h"
 
 #include <QAbstractItemDelegate>
-#include <QPainter>
-#include <QObject>
-#include <QWidget>
 #include <QColor>
 #include <QModelIndex>
 #include <QObject>
 #include <QPaintEngine>
+#include <QPainter>
+#include <QWidget>
 
 QT_BEGIN_NAMESPACE
 class QModelIndex;

--- a/src/qt/pivx/settings/settingsbackupwallet.cpp
+++ b/src/qt/pivx/settings/settingsbackupwallet.cpp
@@ -3,13 +3,15 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "qt/pivx/settings/settingsbackupwallet.h"
+
 #include "qt/pivx/settings/forms/ui_settingsbackupwallet.h"
-#include <QFile>
-#include <QGraphicsDropShadowEffect>
+
+#include "guiinterface.h"
 #include "guiutil.h"
 #include "qt/pivx/qtutils.h"
-#include "guiinterface.h"
-#include "qt/pivx/qtutils.h"
+
+#include <QGraphicsDropShadowEffect>
+
 SettingsBackupWallet::SettingsBackupWallet(PIVXGUI* _window, QWidget *parent) :
     PWidget(_window, parent),
     ui(new Ui::SettingsBackupWallet)

--- a/src/qt/pivx/settings/settingsconsolewidget.cpp
+++ b/src/qt/pivx/settings/settingsconsolewidget.cpp
@@ -4,7 +4,7 @@
 
 #include "qt/pivx/settings/settingsconsolewidget.h"
 #include "qt/pivx/settings/forms/ui_settingsconsolewidget.h"
-#include "QGraphicsDropShadowEffect"
+
 #include "qt/pivx/qtutils.h"
 
 #include "clientmodel.h"
@@ -14,6 +14,8 @@
 #include "rpc/client.h"
 #include "rpc/server.h"
 #include "util.h"
+#include "utilitydialog.h"
+
 #ifdef ENABLE_WALLET
 #include "wallet/wallet.h"
 #endif // ENABLE_WALLET
@@ -27,6 +29,7 @@
 #endif
 
 #include <QDir>
+#include <QGraphicsDropShadowEffect>
 #include <QKeyEvent>
 #include <QMenu>
 #include <QScrollBar>
@@ -35,8 +38,6 @@
 #include <QTime>
 #include <QTimer>
 #include <QStringList>
-#include "qt/pivx/qtutils.h"
-#include "utilitydialog.h"
 
 const int CONSOLE_HISTORY = 50;
 

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -9,14 +9,12 @@
 #include "ui_helpmessagedialog.h"
 
 #include "clientmodel.h"
+#include "clientversion.h"
 #include "guiconstants.h"
+#include "init.h"
 #include "intro.h"
 #include "guiutil.h"
-
-#include "qt/pivx/qtutils.cpp"
-
-#include "clientversion.h"
-#include "init.h"
+#include "qt/pivx/qtutils.h"
 #include "util.h"
 
 #include <stdio.h>

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -24,10 +24,8 @@
 #include <boost/algorithm/string/split.hpp>
 #include <boost/assign/list_of.hpp>
 #include <boost/test/unit_test.hpp>
-#include <boost/assign/list_of.hpp>
 
 #include <univalue.h>
-
 
 // In script_tests.cpp
 extern UniValue read_json(const std::string& jsondata);


### PR DESCRIPTION
Also removes a few unused includes and cleans up the include ordering in
affected files.

This is part of a larger header include cleanup, but i'm keeping PRs narrowly
focused so as to avoid conflicts with existing PRs