### PR TITLE
[Cleanup] Remove ZLNP remnants in bloom.h/bloom.cpp

### DIFF
--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -5,11 +5,7 @@
 
 #include "bloom.h"
 
-
-#include "chainparams.h"
 #include "hash.h"
-#include "libzerocoin/bignum.h"
-#include "libzerocoin/CoinSpend.h"
 #include "primitives/transaction.h"
 #include "script/script.h"
 #include "script/standard.h"
@@ -59,11 +55,6 @@ inline unsigned int CBloomFilter::Hash(unsigned int nHashNum, const std::vector<
 {
     // 0xFBA4C795 chosen as it guarantees a reasonable bit difference between nHashNum values.
     return MurmurHash3(nHashNum * 0xFBA4C795 + nTweak, vDataToHash) % (vData.size() * 8);
-}
-
-void CBloomFilter::setNotFull()
-{
-    isFull = false;
 }
 
 void CBloomFilter::insert(const std::vector<unsigned char>& vKey)
@@ -200,10 +191,6 @@ bool CBloomFilter::IsRelevantAndUpdate(const CTransaction& tx)
                 break;
             }
 
-            if (txout.IsZerocoinMint()){
-                data = std::vector<unsigned char>(txout.scriptPubKey.begin() + 6, txout.scriptPubKey.begin() + txout.scriptPubKey.size());
-            }
-
             if (data.size() != 0 && contains(data)) {
                 fFound = true;
                 if ((nFlags & BLOOM_UPDATE_MASK) == BLOOM_UPDATE_ALL)
@@ -235,12 +222,6 @@ bool CBloomFilter::IsRelevantAndUpdate(const CTransaction& tx)
             opcodetype opcode;
             if (!txin.scriptSig.GetOp(pc, opcode, data))
                 break;
-            if (txin.IsZerocoinSpend()) {
-                CDataStream s(std::vector<unsigned char>(txin.scriptSig.begin() + 44, txin.scriptSig.end()),
-                        SER_NETWORK, PROTOCOL_VERSION);
-
-                data = libzerocoin::CoinSpend::ParseSerial(s);
-            }
             if (data.size() != 0 && contains(data)) {
                 return true;
             }

--- a/src/bloom.h
+++ b/src/bloom.h
@@ -6,7 +6,6 @@
 #ifndef BITCOIN_BLOOM_H
 #define BITCOIN_BLOOM_H
 
-#include "libzerocoin/bignum.h"
 #include "serialize.h"
 
 #include <vector>
@@ -81,8 +80,6 @@ public:
         READWRITE(nTweak);
         READWRITE(nFlags);
     }
-
-    void setNotFull();
 
     void insert(const std::vector<unsigned char>& vKey);
     void insert(const COutPoint& outpoint);


### PR DESCRIPTION
Since the `--peerbloomfilterszc` is no longer available, we can remove the dependency on libzerocoin/bignum from `bloom.h` (which is implicitly carried over to a huge number of files, via `net.h` inclusion).