### PR TITLE
[Cleanup] Remove Q_FOREACH, PAIRTYPE, and BOOST_REVERSE_FOREACH

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -23,7 +23,6 @@ ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 DerivePointerAlignment: false
 DisableFormat:   false
-ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH, BOOST_REVERSE_FOREACH ]
 IndentCaseLabels: false
 IndentFunctionDeclarationAfterType: false
 IndentWidth:     4

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -14,7 +14,6 @@
 
 #include <stdint.h>
 
-#include <boost/foreach.hpp>
 
 namespace Checkpoints
 {

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -92,7 +92,7 @@ CBlockIndex* GetLastCheckpoint()
 
     const MapCheckpoints& checkpoints = *Params().Checkpoints().mapCheckpoints;
 
-    BOOST_REVERSE_FOREACH (const MapCheckpoints::value_type& i, checkpoints) {
+    for (const MapCheckpoints::value_type& i : reverse_iterate(checkpoints)) {
         const uint256& hash = i.second;
         BlockMap::const_iterator t = mapBlockIndex.find(hash);
         if (t != mapBlockIndex.end())

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -8,6 +8,7 @@
 
 #include "chain.h"
 #include "chainparams.h"
+#include "reverse_iterate.h"
 #include "uint256.h"
 #include "validation.h"
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1260,7 +1260,7 @@ bool AppInit2()
                 }
                 // Loop backward through backup files and keep the N newest ones (1 <= N <= 10)
                 int counter = 0;
-                BOOST_REVERSE_FOREACH (PAIRTYPE(const std::time_t, fs::path) file, folder_set) {
+                BOOST_REVERSE_FOREACH (std::pair<const std::time_t, fs::path> file, folder_set) {
                     counter++;
                     if (counter > nWalletBackups) {
                         // More than nWalletBackups backups: delete oldest one(s)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -82,7 +82,6 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/interprocess/sync/file_lock.hpp>
 #include <boost/thread.hpp>
-#include <boost/foreach.hpp>
 
 #if ENABLE_ZMQ
 #include "zmq/zmqnotificationinterface.h"

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1260,7 +1260,7 @@ bool AppInit2()
                 }
                 // Loop backward through backup files and keep the N newest ones (1 <= N <= 10)
                 int counter = 0;
-                BOOST_REVERSE_FOREACH (std::pair<const std::time_t, fs::path> file, folder_set) {
+                for (std::pair<const std::time_t, fs::path> file : reverse_iterate(folder_set)) {
                     counter++;
                     if (counter > nWalletBackups) {
                         // More than nWalletBackups backups: delete oldest one(s)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -35,6 +35,7 @@
 #include "netbase.h"
 #include "net_processing.h"
 #include "policy/policy.h"
+#include "reverse_iterate.h"
 #include "rpc/server.h"
 #include "script/sigcache.h"
 #include "script/standard.h"

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -529,7 +529,7 @@ CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight
     int nCountTenth = 0;
     uint256 nHigh;
     const uint256& hash = GetHashAtHeight(nBlockHeight - 101);
-    for (PAIRTYPE(int64_t, CTxIn) & s : vecMasternodeLastPaid) {
+    for (std::pair<int64_t, CTxIn> & s : vecMasternodeLastPaid) {
         CMasternode* pmn = Find(s.second);
         if (!pmn) break;
 
@@ -606,7 +606,7 @@ int CMasternodeMan::GetMasternodeRank(const CTxIn& vin, int64_t nBlockHeight, in
     sort(vecMasternodeScores.rbegin(), vecMasternodeScores.rend(), CompareScoreTxIn());
 
     int rank = 0;
-    for (PAIRTYPE(int64_t, CTxIn) & s : vecMasternodeScores) {
+    for (std::pair<int64_t, CTxIn> & s : vecMasternodeScores) {
         rank++;
         if (s.second.prevout == vin.prevout) {
             return rank;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -841,8 +841,7 @@ void static ProcessGetData(CNode* pfrom, CConnman& connman, std::atomic<bool>& i
                             // they must either disconnect and retry or request the full block.
                             // Thus, the protocol spec specified allows for us to provide duplicate txn here,
                             // however we MUST always provide at least what the remote peer needs
-                            typedef std::pair<unsigned int, uint256> PairType;
-                            for (PairType& pair : merkleBlock.vMatchedTxn)
+                            for (std::pair<unsigned int, uint256>& pair : merkleBlock.vMatchedTxn)
                                 connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::TX, *block.vtx[pair.first]));
                         }
                         // else

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -13,7 +13,6 @@
 #include "utilstrencodings.h"
 #include "validation.h"
 
-#include <boost/foreach.hpp>
 
 bool fIsBareMultisigStd = DEFAULT_PERMIT_BAREMULTISIG;
 

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -132,7 +132,7 @@ public:
         typedef const T* pointer;
         typedef const T& reference;
         typedef std::bidirectional_iterator_tag iterator_category;
-        const_reverse_iterator(T* ptr_) : ptr(ptr_) {}
+        const_reverse_iterator(const T* ptr_) : ptr(ptr_) {}
         const_reverse_iterator(reverse_iterator x) : ptr(&(*x)) {}
         const T& operator*() const { return *ptr; }
         const T* operator->() const { return ptr; }

--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -243,7 +243,7 @@ void AddressBookPage::done(int retval)
     // Figure out which address was selected, and return it
     QModelIndexList indexes = table->selectionModel()->selectedRows(AddressTableModel::Address);
 
-    Q_FOREACH (QModelIndex index, indexes) {
+    for (QModelIndex index : indexes) {
         QVariant address = table->model()->data(index);
         returnValue = address.toString();
     }

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -777,7 +777,7 @@ void CoinControlDialog::updateView()
     std::map<QString, std::vector<COutput>> mapCoins;
     model->listCoins(mapCoins);
 
-    for (PAIRTYPE(QString, std::vector<COutput>) coins : mapCoins) {
+    for (std::pair<QString, std::vector<COutput>> coins : mapCoins) {
         CCoinControlWidgetItem* itemWalletAddress = new CCoinControlWidgetItem();
         itemWalletAddress->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);
         QString sWalletAddress = coins.first;

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -562,7 +562,7 @@ void CoinControlDialog::updateLabels()
     // nPayAmount
     CAmount nPayAmount = 0;
     bool fDust = false;
-    Q_FOREACH (const CAmount& amount, payAmounts) {
+    for (const CAmount& amount : payAmounts) {
         nPayAmount += amount;
         if (amount > 0) {
             CTxOut txout(amount, (CScript)std::vector<unsigned char>(24, 0));

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -108,7 +108,7 @@ OptionsDialog::OptionsDialog(QWidget* parent, bool enableWallet) : QDialog(paren
     /* Language selector */
     QDir translations(":translations");
     ui->lang->addItem(QString("(") + tr("default") + QString(")"), QVariant(""));
-    Q_FOREACH (const QString& langStr, translations.entryList()) {
+    for (const QString& langStr : translations.entryList()) {
         QLocale locale(langStr);
 
         /** check if the locale name consists of 2 parts (language_country) */

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -131,7 +131,7 @@ void PaymentServer::LoadRootCAs(X509_STORE* _store)
 
     int nRootCerts = 0;
     const QDateTime currentTime = QDateTime::currentDateTime();
-    Q_FOREACH (const QSslCertificate& cert, certList) {
+    for (const QSslCertificate& cert : certList) {
         if (currentTime < cert.effectiveDate() || currentTime > cert.expiryDate()) {
             ReportInvalidCertificate(cert);
             continue;
@@ -228,7 +228,7 @@ void PaymentServer::ipcParseCommandLine(int argc, char* argv[])
 bool PaymentServer::ipcSendCommandLine()
 {
     bool fResult = false;
-    Q_FOREACH (const QString& r, savedPaymentRequests) {
+    for (const QString& r : savedPaymentRequests) {
         QLocalSocket* socket = new QLocalSocket();
         socket->connectToServer(ipcServerName(), QIODevice::WriteOnly);
         if (!socket->waitForConnected(BITCOIN_IPC_CONNECT_TIMEOUT)) {
@@ -345,7 +345,7 @@ void PaymentServer::uiReady()
     initNetManager();
 
     saveURIs = false;
-    Q_FOREACH (const QString& s, savedPaymentRequests) {
+    for (const QString& s : savedPaymentRequests) {
         handleURIOrFile(s);
     }
     savedPaymentRequests.clear();
@@ -497,7 +497,7 @@ bool PaymentServer::processPaymentRequest(PaymentRequestPlus& request, SendCoins
     QList<std::pair<CScript, CAmount> > sendingTos = request.getPayTo();
     QStringList addresses;
 
-    Q_FOREACH (const PAIRTYPE(CScript, CAmount) & sendingTo, sendingTos) {
+    for (const PAIRTYPE(CScript, CAmount) & sendingTo : sendingTos) {
         // Extract and check destination addresses
         CTxDestination dest;
         if (ExtractDestination(sendingTo.first, dest)) {
@@ -649,7 +649,7 @@ void PaymentServer::reportSslErrors(QNetworkReply* reply, const QList<QSslError>
     Q_UNUSED(reply);
 
     QString errString;
-    Q_FOREACH (const QSslError& err, errs) {
+    for (const QSslError& err : errs) {
         qWarning() << "PaymentServer::reportSslErrors : " << err;
         errString += err.errorString() + "\n";
     }

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -497,7 +497,7 @@ bool PaymentServer::processPaymentRequest(PaymentRequestPlus& request, SendCoins
     QList<std::pair<CScript, CAmount> > sendingTos = request.getPayTo();
     QStringList addresses;
 
-    for (const PAIRTYPE(CScript, CAmount) & sendingTo : sendingTos) {
+    for (const std::pair<CScript, CAmount> & sendingTo : sendingTos) {
         // Extract and check destination addresses
         CTxDestination dest;
         if (ExtractDestination(sendingTo.first, dest)) {

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -89,7 +89,7 @@ public:
         // build index map
         mapNodeRows.clear();
         int row = 0;
-        Q_FOREACH (const CNodeCombinedStats& stats, cachedNodeStats)
+        for (const CNodeCombinedStats& stats : cachedNodeStats)
             mapNodeRows.emplace(stats.nodeStats.nodeid, row++);
     }
 

--- a/src/qt/pivx/navmenuwidget.cpp
+++ b/src/qt/pivx/navmenuwidget.cpp
@@ -118,7 +118,7 @@ void NavMenuWidget::onReceiveClicked(){
 
 void NavMenuWidget::onNavSelected(QWidget* active, bool startup) {
     QString start = "btn-nav-";
-    Q_FOREACH (QWidget* w, btns) {
+    for (QWidget* w : btns) {
         QString clazz = start + w->property("name").toString();
         if (w == active) {
             clazz += "-active";

--- a/src/qt/pivx/qtutils.cpp
+++ b/src/qt/pivx/qtutils.cpp
@@ -301,7 +301,7 @@ void setCssBtnSecondary(QPushButton* btn, bool forceUpdate)
 
 void setCssTextBodyDialog(std::initializer_list<QWidget*> args)
 {
-    Q_FOREACH (QWidget* w, args) {
+    for (QWidget* w : args) {
         setCssTextBodyDialog(w);
     }
 }
@@ -323,7 +323,7 @@ void setCssSubtitleScreen(QWidget* wid)
 
 void setCssProperty(std::initializer_list<QWidget*> args, QString value)
 {
-    Q_FOREACH (QWidget* w, args) {
+    for (QWidget* w : args) {
         setCssProperty(w, value);
     }
 }
@@ -342,7 +342,7 @@ void forceUpdateStyle(QWidget* widget, bool forceUpdate)
 
 void forceUpdateStyle(std::initializer_list<QWidget*> args)
 {
-    Q_FOREACH (QWidget* w, args) {
+    for (QWidget* w : args) {
         forceUpdateStyle(w, true);
     }
 }

--- a/src/qt/pivx/settings/settingsconsolewidget.cpp
+++ b/src/qt/pivx/settings/settingsconsolewidget.cpp
@@ -123,7 +123,7 @@ bool parseCommandLineSettings(std::vector<std::string>& args, const std::string&
         STATE_ESCAPE_DOUBLEQUOTED
     } state = STATE_EATING_SPACES;
     std::string curarg;
-    Q_FOREACH (char ch, strCommand) {
+    for (char ch : strCommand) {
         switch (state) {
             case STATE_ARGUMENT:      // In or after argument
             case STATE_EATING_SPACES: // Handle runs of whitespace

--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -48,7 +48,7 @@ TopBar::TopBar(PIVXGUI* _mainWindow, QWidget *parent) :
     setCssProperty(lblTitles, "text-title-topbar");
     QFont font;
     font.setWeight(QFont::Light);
-    Q_FOREACH (QWidget* w, lblTitles) { w->setFont(font); }
+    for (QWidget* w : lblTitles) { w->setFont(font); }
 
     // Amount information top
     ui->widgetTopAmount->setVisible(false);

--- a/src/qt/pivx/welcomecontentwidget.cpp
+++ b/src/qt/pivx/welcomecontentwidget.cpp
@@ -176,7 +176,7 @@ void WelcomeContentWidget::initLanguages()
     /* Language selector */
     QDir translations(":translations");
     ui->comboBoxLanguage->addItem(QString("(") + tr("default") + QString(")"), QVariant(""));
-    Q_FOREACH (const QString& langStr, translations.entryList()) {
+    for (const QString& langStr : translations.entryList()) {
         QLocale locale(langStr);
 
         /** check if the locale name consists of 2 parts (language_country) */

--- a/src/qt/platformstyle.cpp
+++ b/src/qt/platformstyle.cpp
@@ -47,7 +47,7 @@ void MakeSingleColorImage(QImage& img, const QColor& colorbase)
 QIcon ColorizeIcon(const QIcon& ico, const QColor& colorbase)
 {
     QIcon new_ico;
-    Q_FOREACH (const QSize sz, ico.availableSizes()) {
+    for (const QSize sz : ico.availableSizes()) {
         QImage img(ico.pixmap(sz).toImage());
         MakeSingleColorImage(img, colorbase);
         new_ico.addPixmap(QPixmap::fromImage(img));

--- a/src/qt/platformstyle.cpp
+++ b/src/qt/platformstyle.cpp
@@ -47,8 +47,7 @@ void MakeSingleColorImage(QImage& img, const QColor& colorbase)
 QIcon ColorizeIcon(const QIcon& ico, const QColor& colorbase)
 {
     QIcon new_ico;
-    QSize sz;
-    Q_FOREACH (sz, ico.availableSizes()) {
+    Q_FOREACH (const QSize sz, ico.availableSizes()) {
         QImage img(ico.pixmap(sz).toImage());
         MakeSingleColorImage(img, colorbase);
         new_ico.addPixmap(QPixmap::fromImage(img));

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -136,7 +136,7 @@ bool parseCommandLine(std::vector<std::string>& args, const std::string& strComm
         STATE_ESCAPE_DOUBLEQUOTED
     } state = STATE_EATING_SPACES;
     std::string curarg;
-    Q_FOREACH (char ch, strCommand) {
+    for (char ch : strCommand) {
         switch (state) {
         case STATE_ARGUMENT:      // In or after argument
         case STATE_EATING_SPACES: // Handle runs of whitespace

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -140,10 +140,10 @@ void TrafficGraphWidget::updateRates()
     }
 
     float tmax = 0.0f;
-    Q_FOREACH (float f, vSamplesIn) {
+    for (float f : vSamplesIn) {
         if (f > tmax) tmax = f;
     }
-    Q_FOREACH (float f, vSamplesOut) {
+    for (float f : vSamplesOut) {
         if (f > tmax) tmax = f;
     }
     fMax = tmax;

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -98,7 +98,7 @@ HelpMessageDialog::HelpMessageDialog(QWidget* parent, bool about) : QDialog(pare
         QTextCharFormat bold;
         bold.setFontWeight(QFont::Bold);
 
-        Q_FOREACH (const QString &line, coreOptions.split("\n")) {
+        for (const QString &line : coreOptions.split("\n")) {
             if (line.startsWith("  -"))
             {
                 cursor.currentTable()->appendRows(1);

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -927,7 +927,7 @@ void WalletModel::loadReceiveRequests(std::vector<std::string>& vReceiveRequests
 {
     LOCK(wallet->cs_wallet);
     for (auto it = wallet->NewAddressBookIterator(); it.IsValid(); it.Next()) {
-        for (const PAIRTYPE(std::string, std::string) &item2 : it.GetValue().destdata)
+        for (const std::pair<std::string, std::string> &item2 : it.GetValue().destdata)
             if (item2.first.size() > 2 && item2.first.substr(0, 2) == "rr") // receive request
                 vReceiveRequests.push_back(item2.second);
     }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -319,7 +319,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
     int nAddresses = 0;
 
     // Pre-check input data for validity
-    Q_FOREACH (const SendCoinsRecipient& rcp, recipients) {
+    for (const SendCoinsRecipient& rcp : recipients) {
         if (rcp.paymentRequest.IsInitialized()) { // PaymentRequest...
             CAmount subtotal = 0;
             const payments::PaymentDetails& details = rcp.paymentRequest.getDetails();
@@ -465,7 +465,7 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(WalletModelTransaction& tran
         QList<SendCoinsRecipient> recipients = transaction.getRecipients();
 
         // Store PaymentRequests in wtx.vOrderForm in wallet.
-        Q_FOREACH (const SendCoinsRecipient& rcp, recipients) {
+        for (const SendCoinsRecipient& rcp : recipients) {
             if (rcp.paymentRequest.IsInitialized()) {
                 std::string key("PaymentRequest");
                 std::string value;
@@ -491,7 +491,7 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(WalletModelTransaction& tran
 
     // Add addresses / update labels that we've sent to to the address book,
     // and emit coinsSent signal for each recipient
-    Q_FOREACH (const SendCoinsRecipient& rcp, transaction.getRecipients()) {
+    for (const SendCoinsRecipient& rcp : transaction.getRecipients()) {
         // Don't touch the address book when we have a payment request
         if (!rcp.paymentRequest.IsInitialized()) {
             bool isStaking = false;

--- a/src/qt/walletmodeltransaction.cpp
+++ b/src/qt/walletmodeltransaction.cpp
@@ -49,7 +49,7 @@ void WalletModelTransaction::setTransactionFee(const CAmount& newFee)
 CAmount WalletModelTransaction::getTotalTransactionAmount()
 {
     CAmount totalTransactionAmount = 0;
-    Q_FOREACH (const SendCoinsRecipient& rcp, recipients) {
+    for (const SendCoinsRecipient& rcp : recipients) {
         totalTransactionAmount += rcp.amount;
     }
     return totalTransactionAmount;

--- a/src/reverse_iterate.h
+++ b/src/reverse_iterate.h
@@ -2,36 +2,40 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#pragma once
-/*
-    Template used for reverse iteration in C++11 range-based for loops.
-    std::vector<int> v = {1, 2, 3, 4, 5};
-    for (auto x : reverse_iterate(v))
-        std::cout << x << " ";
+#ifndef BITCOIN_REVERSE_ITERATE_H
+#define BITCOIN_REVERSE_ITERATE_H
+
+/**
+ * Template used for reverse iteration in C++11 range-based for loops.
+ *
+ *   std::vector<int> v = {1, 2, 3, 4, 5};
+ *   for (auto x : reverse_iterate(v))
+ *       std::cout << x << " ";
  */
 
 template <typename T>
 class reverse_range
 {
-    T &x;
-    
+    T &m_x;
+
 public:
-    reverse_range(T &x) : x(x) {}
-    
-    auto begin() const -> decltype(this->x.rbegin())
+    reverse_range(T &x) : m_x(x) {}
+
+    auto begin() const -> decltype(this->m_x.rbegin())
     {
-        return x.rbegin();
+        return m_x.rbegin();
     }
-    
-    auto end() const -> decltype(this->x.rend())
+
+    auto end() const -> decltype(this->m_x.rend())
     {
-        return x.rend();
+        return m_x.rend();
     }
 };
- 
+
 template <typename T>
 reverse_range<T> reverse_iterate(T &x)
 {
     return reverse_range<T>(x);
 }
 
+#endif // BITCOIN_REVERSE_ITERATE_H

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1063,9 +1063,9 @@ UniValue getchaintips(const JSONRPCRequest& request)
        known blocks, and successively remove blocks that appear as pprev
        of another block.  */
     std::set<const CBlockIndex*, CompareBlocksByHeight> setTips;
-    for (const PAIRTYPE(const uint256, CBlockIndex*) & item : mapBlockIndex)
+    for (const std::pair<const uint256, CBlockIndex*> & item : mapBlockIndex)
         setTips.insert(item.second);
-    for (const PAIRTYPE(const uint256, CBlockIndex*) & item : mapBlockIndex) {
+    for (const std::pair<const uint256, CBlockIndex*> & item : mapBlockIndex) {
         const CBlockIndex* pprev = item.second->pprev;
         if (pprev)
             setTips.erase(pprev);

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -94,7 +94,7 @@ void RPCTypeCheckObj(const UniValue& o,
                   bool fAllowNull,
                   bool fStrict)
 {
-    for (const PAIRTYPE(std::string, UniValue::VType)& t : typesExpected) {
+    for (const std::pair<std::string, UniValue::VType>& t : typesExpected) {
         const UniValue& v = find_value(o, t.first);
         if (!fAllowNull && v.isNull())
             throw JSONRPCError(RPC_TYPE_ERROR, strprintf("Missing %s", t.first));

--- a/src/swifttx.cpp
+++ b/src/swifttx.cpp
@@ -226,7 +226,7 @@ int64_t CreateNewLock(CTransaction tx)
 {
     int nChainHeight = WITH_LOCK(cs_main, return chainActive.Height(); );
     int64_t nTxAge = 0;
-    BOOST_REVERSE_FOREACH (CTxIn i, tx.vin) {
+    for (CTxIn i : reverse_iterate(tx.vin)) {
         nTxAge = pcoinsTip->GetCoinDepthAtHeight(i.prevout, nChainHeight);
         if (nTxAge < 5) //1 less than the "send IX" gui requires, incase of a block propagating the network at the time
         {

--- a/src/swifttx.cpp
+++ b/src/swifttx.cpp
@@ -18,7 +18,6 @@
 #include "sync.h"
 #include "util.h"
 #include "validationinterface.h"
-#include <boost/foreach.hpp>
 
 
 std::map<uint256, CTransaction> mapTxLockReq;

--- a/src/swifttx.cpp
+++ b/src/swifttx.cpp
@@ -13,6 +13,7 @@
 #include "messagesigner.h"
 #include "net.h"
 #include "protocol.h"
+#include "reverse_iterate.h"
 #include "spork.h"
 #include "sync.h"
 #include "util.h"

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -145,7 +145,7 @@ void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256> &vHashes
     // This maximizes the benefit of the descendant cache and guarantees that
     // setMemPoolChildren will be updated, an assumption made in
     // UpdateForDescendants.
-    BOOST_REVERSE_FOREACH(const uint256 &hash, vHashesToUpdate) {
+    for (const uint256 &hash : reverse_iterate(vHashesToUpdate)) {
         // we cache the in-mempool children to avoid duplicate updates
         setEntries setChildren;
         // calculate children from mapNextTx

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -8,6 +8,7 @@
 
 #include "clientversion.h"
 #include "policy/fees.h"
+#include "reverse_iterate.h"
 #include "streams.h"
 #include "timedata.h"
 #include "util.h"

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -17,7 +17,6 @@
 #include "version.h"
 #include "validation.h"
 
-#include <boost/foreach.hpp>
 
 
 CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& _tx, const CAmount& _nFee,

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -20,7 +20,6 @@
 #define UBEGIN(a) ((unsigned char*)&(a))
 #define UEND(a) ((unsigned char*)&((&(a))[1]))
 #define ARRAYLEN(array) (sizeof(array) / sizeof((array)[0]))
-#define PAIRTYPE(t1, t2) std::pair<t1, t2>
 
 /** Used by SanitizeString() */
 enum SafeChars

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -20,8 +20,6 @@
 #define UBEGIN(a) ((unsigned char*)&(a))
 #define UEND(a) ((unsigned char*)&((&(a))[1]))
 #define ARRAYLEN(array) (sizeof(array) / sizeof((array)[0]))
-
-/** This is needed because the foreach macro can't get over the comma in pair<t1, t2> */
 #define PAIRTYPE(t1, t2) std::pair<t1, t2>
 
 /** Used by SanitizeString() */

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2194,7 +2194,7 @@ static bool ActivateBestChainStep(CValidationState& state, CBlockIndex* pindexMo
         nHeight = nTargetHeight;
 
         // Connect new blocks.
-        BOOST_REVERSE_FOREACH (CBlockIndex* pindexConnect, vpindexToConnect) {
+        for (CBlockIndex* pindexConnect : reverse_iterate(vpindexToConnect)) {
             if (!ConnectTip(state, pindexConnect, (pindexConnect == pindexMostWork) ? pblock : std::shared_ptr<const CBlock>(), fAlreadyChecked, connectTrace)) {
                 if (state.IsInvalid()) {
                     // The block violates a consensus rule.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -37,6 +37,7 @@
 #include "net_processing.h"
 #include "policy/policy.h"
 #include "pow.h"
+#include "reverse_iterate.h"
 #include "script/sigcache.h"
 #include "spork.h"
 #include "sporkdb.h"

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -53,7 +53,6 @@
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/thread.hpp>
-#include <boost/foreach.hpp>
 #include <atomic>
 #include <queue>
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3551,7 +3551,7 @@ bool static LoadBlockIndexDB(std::string& strError)
         vSortedByHeight.emplace_back(pindex->nHeight, pindex);
     }
     std::sort(vSortedByHeight.begin(), vSortedByHeight.end());
-    for (const PAIRTYPE(int, CBlockIndex*) & item : vSortedByHeight) {
+    for (const std::pair<int, CBlockIndex*> & item : vSortedByHeight) {
         // Stop if shutdown was requested
         if (ShutdownRequested()) return false;
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -78,7 +78,7 @@ void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
     entry.pushKV("walletconflicts", conflicts);
     entry.pushKV("time", wtx.GetTxTime());
     entry.pushKV("timereceived", (int64_t)wtx.nTimeReceived);
-    for (const PAIRTYPE(std::string, std::string) & item : wtx.mapValue)
+    for (const std::pair<std::string, std::string> & item : wtx.mapValue)
         entry.pushKV(item.first, item.second);
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -880,7 +880,7 @@ void CWallet::MarkDirty()
 {
     {
         LOCK(cs_wallet);
-        for (PAIRTYPE(const uint256, CWalletTx) & item : mapWallet)
+        for (std::pair<const uint256, CWalletTx> & item : mapWallet)
             item.second.MarkDirty();
     }
 }
@@ -1636,7 +1636,7 @@ void CWallet::ReacceptWalletTransactions(bool fFirstLoad)
     std::map<int64_t, CWalletTx*> mapSorted;
 
     // Sort pending wallet transactions based on their initial wallet insertion order
-    for (PAIRTYPE(const uint256, CWalletTx)& item: mapWallet) {
+    for (std::pair<const uint256, CWalletTx>& item: mapWallet) {
         const uint256& wtxid = item.first;
         CWalletTx& wtx = item.second;
         assert(wtx.GetHash() == wtxid);
@@ -1648,7 +1648,7 @@ void CWallet::ReacceptWalletTransactions(bool fFirstLoad)
     }
 
     // Try to add wallet transactions to memory pool
-    for (PAIRTYPE(const int64_t, CWalletTx*)& item: mapSorted)
+    for (std::pair<const int64_t, CWalletTx*>& item: mapSorted)
     {
         CWalletTx& wtx = *(item.second);
 
@@ -1784,14 +1784,14 @@ void CWallet::ResendWalletTransactions(CConnman* connman)
         LOCK(cs_wallet);
         // Sort them in chronological order
         std::multimap<unsigned int, CWalletTx*> mapSorted;
-        for (PAIRTYPE(const uint256, CWalletTx) & item : mapWallet) {
+        for (std::pair<const uint256, CWalletTx> & item : mapWallet) {
             CWalletTx& wtx = item.second;
             // Don't rebroadcast until it's had plenty of time that
             // it should have gotten in already by now.
             if (nTimeBestReceived - (int64_t)wtx.nTimeReceived > 5 * 60)
                 mapSorted.emplace(wtx.nTimeReceived, &wtx);
         }
-        for (PAIRTYPE(const unsigned int, CWalletTx*) & item : mapSorted) {
+        for (std::pair<const unsigned int, CWalletTx*> & item : mapSorted) {
             CWalletTx& wtx = *item.second;
             wtx.RelayWalletTransaction(connman);
         }
@@ -2636,7 +2636,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend,
                 }
 
 
-                for (PAIRTYPE(const CWalletTx*, unsigned int) pcoin : setCoins) {
+                for (std::pair<const CWalletTx*, unsigned int> pcoin : setCoins) {
                     if(pcoin.first->vout[pcoin.second].scriptPubKey.IsPayToColdStaking())
                         wtxNew.fStakeDelegationVoided = true;
                     CAmount nCredit = pcoin.first->vout[pcoin.second].nValue;
@@ -2721,13 +2721,13 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend,
                     reservekey.ReturnKey();
 
                 // Fill vin
-                for (const PAIRTYPE(const CWalletTx*, unsigned int) & coin : setCoins)
+                for (const std::pair<const CWalletTx*, unsigned int> & coin : setCoins)
                     txNew.vin.emplace_back(coin.first->GetHash(), coin.second);
 
                 // Sign
                 int nIn = 0;
                 CTransaction txNewConst(txNew);
-                for (const PAIRTYPE(const CWalletTx*, unsigned int) & coin : setCoins) {
+                for (const std::pair<const CWalletTx*, unsigned int> & coin : setCoins) {
                     bool signSuccess;
                     const CScript& scriptPubKey = coin.first->vout[coin.second].scriptPubKey;
                     SignatureData sigdata;
@@ -3135,7 +3135,7 @@ bool CWallet::DelAddressBook(const CTxDestination& address, const CChainParams::
 
         if (fFileBacked) {
             // Delete destdata tuples associated with address
-            for (const PAIRTYPE(std::string, std::string) & item : mapAddressBook[address].destdata) {
+            for (const std::pair<std::string, std::string> & item : mapAddressBook[address].destdata) {
                 CWalletDB(strWalletFile).EraseDestData(strAddress, item.first);
             }
         }
@@ -3239,7 +3239,7 @@ std::map<CTxDestination, CAmount> CWallet::GetAddressBalances()
 
     {
         LOCK(cs_wallet);
-        for (PAIRTYPE(uint256, CWalletTx) walletEntry : mapWallet) {
+        for (std::pair<uint256, CWalletTx> walletEntry : mapWallet) {
             CWalletTx* pcoin = &walletEntry.second;
 
             if (!IsFinalTx(*pcoin) || !pcoin->IsTrusted())
@@ -3281,7 +3281,7 @@ std::set<std::set<CTxDestination> > CWallet::GetAddressGroupings()
     std::set<std::set<CTxDestination> > groupings;
     std::set<CTxDestination> grouping;
 
-    for (PAIRTYPE(uint256, CWalletTx) walletEntry : mapWallet) {
+    for (std::pair<uint256, CWalletTx> walletEntry : mapWallet) {
         CWalletTx* pcoin = &walletEntry.second;
 
         if (pcoin->vin.size() > 0) {

--- a/src/wallet/wallet_zerocoin.cpp
+++ b/src/wallet/wallet_zerocoin.cpp
@@ -345,7 +345,7 @@ bool CWallet::CreateZerocoinMintTransaction(const CAmount nValue,
     // Sign
     int nIn = 0;
     CTransaction txNewConst(txNew);
-    for (const PAIRTYPE(const CWalletTx*, unsigned int) & coin : setCoins) {
+    for (const std::pair<const CWalletTx*, unsigned int> & coin : setCoins) {
         bool signSuccess;
         const CScript& scriptPubKey = coin.first->vout[coin.second].scriptPubKey;
         SignatureData sigdata;


### PR DESCRIPTION
Replaces ForEachMacros with native c++11 for loops and replaces the PARTYPE macro with `std::pair`

Most of the changes are scripted (scripts are in commit messages where applicable), with a few self-explanatory manual commits