### PR TITLE
[Refactor] Removing prev index pointer from FillBlockPayee flow.

### DIFF
--- a/src/masternode-budget.cpp
+++ b/src/masternode-budget.cpp
@@ -657,18 +657,17 @@ bool CBudgetManager::GetPayeeAndAmount(int chainHeight, CScript& payeeRet, CAmou
     return pfb->GetPayeeAndAmount(chainHeight, payeeRet, nAmountRet);
 }
 
-bool CBudgetManager::FillBlockPayee(CMutableTransaction& txNew, bool fProofOfStake) const
+bool CBudgetManager::FillBlockPayee(CMutableTransaction& txNew, const int nHeight, bool fProofOfStake) const
 {
-    int chainHeight = GetBestHeight();
-    if (chainHeight <= 0) return false;
+    if (nHeight <= 0) return false;
 
     CScript payee;
     CAmount nAmount = 0;
 
-    if (!GetPayeeAndAmount(chainHeight + 1, payee, nAmount))
+    if (!GetPayeeAndAmount(nHeight, payee, nAmount))
         return false;
 
-    CAmount blockValue = GetBlockValue(chainHeight + 1);
+    CAmount blockValue = GetBlockValue(nHeight);
 
     if (fProofOfStake) {
         unsigned int i = txNew.vout.size();

--- a/src/masternode-budget.h
+++ b/src/masternode-budget.h
@@ -297,7 +297,7 @@ public:
     bool UpdateFinalizedBudget(CFinalizedBudgetVote& vote, CNode* pfrom, std::string& strError);
     TrxValidationStatus IsTransactionValid(const CTransaction& txNew, const uint256& nBlockHash, int nBlockHeight) const;
     std::string GetRequiredPaymentsString(int nBlockHeight);
-    bool FillBlockPayee(CMutableTransaction& txNew, bool fProofOfStake) const;
+    bool FillBlockPayee(CMutableTransaction& txNew, const int nHeight, bool fProofOfStake) const;
 
     // Only initialized masternodes: sign and submit votes on valid finalized budgets
     void VoteOnFinalizedBudgets();

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -297,15 +297,15 @@ bool IsBlockPayeeValid(const CBlock& block, int nBlockHeight)
 }
 
 
-void FillBlockPayee(CMutableTransaction& txNew, const CBlockIndex* pindexPrev, bool fProofOfStake)
+void FillBlockPayee(CMutableTransaction& txNew, const int nHeight, bool fProofOfStake)
 {
-    if (!pindexPrev) return;
+    if (nHeight == 0) return;
 
-    if (!sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS) ||       // if superblocks are not enabled
-            !g_budgetman.IsBudgetPaymentBlock(pindexPrev->nHeight + 1) || // or this is not a superblock
+    if (!sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS) ||  // if superblocks are not enabled
+            !g_budgetman.IsBudgetPaymentBlock(nHeight) || // or this is not a superblock
             !g_budgetman.FillBlockPayee(txNew, fProofOfStake) ) {         // or there's no budget with enough votes
         // pay a masternode
-        masternodePayments.FillBlockPayee(txNew, pindexPrev, fProofOfStake);
+        masternodePayments.FillBlockPayee(txNew, nHeight, fProofOfStake);
     }
 }
 
@@ -318,15 +318,15 @@ std::string GetRequiredPaymentsString(int nBlockHeight)
     }
 }
 
-void CMasternodePayments::FillBlockPayee(CMutableTransaction& txNew, const CBlockIndex* pindexPrev, bool fProofOfStake)
+void CMasternodePayments::FillBlockPayee(CMutableTransaction& txNew, const int nHeight, bool fProofOfStake)
 {
-    if (!pindexPrev) return;
+    if (nHeight == 0) return;
 
     bool hasPayment = true;
     CScript payee;
 
     //spork
-    if (!masternodePayments.GetBlockPayee(pindexPrev->nHeight + 1, payee)) {
+    if (!masternodePayments.GetBlockPayee(nHeight, payee)) {
         //no masternode detected
         CMasternode* winningNode = mnodeman.GetCurrentMasterNode(1);
         if (winningNode) {
@@ -371,7 +371,7 @@ void CMasternodePayments::FillBlockPayee(CMutableTransaction& txNew, const CBloc
             txNew.vout.resize(2);
             txNew.vout[1].scriptPubKey = payee;
             txNew.vout[1].nValue = masternodePayment;
-            txNew.vout[0].nValue = GetBlockValue(pindexPrev->nHeight + 1) - masternodePayment;
+            txNew.vout[0].nValue = GetBlockValue(nHeight) - masternodePayment;
         }
 
         CTxDestination address1;

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -303,7 +303,7 @@ void FillBlockPayee(CMutableTransaction& txNew, const int nHeight, bool fProofOf
 
     if (!sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS) ||  // if superblocks are not enabled
             !g_budgetman.IsBudgetPaymentBlock(nHeight) || // or this is not a superblock
-            !g_budgetman.FillBlockPayee(txNew, fProofOfStake) ) {         // or there's no budget with enough votes
+            !g_budgetman.FillBlockPayee(txNew, nHeight, fProofOfStake) ) {    // or there's no budget with enough votes
         // pay a masternode
         masternodePayments.FillBlockPayee(txNew, nHeight, fProofOfStake);
     }

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -27,7 +27,7 @@ void ProcessMessageMasternodePayments(CNode* pfrom, std::string& strCommand, CDa
 bool IsBlockPayeeValid(const CBlock& block, int nBlockHeight);
 std::string GetRequiredPaymentsString(int nBlockHeight);
 bool IsBlockValueValid(int nHeight, CAmount nExpectedValue, CAmount nMinted);
-void FillBlockPayee(CMutableTransaction& txNew, const CBlockIndex* pindexPrev, bool fProofOfStake);
+void FillBlockPayee(CMutableTransaction& txNew, const int nHeight, bool fProofOfStake);
 
 void DumpMasternodePayments();
 
@@ -274,7 +274,7 @@ public:
 
     void ProcessMessageMasternodePayments(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
     std::string GetRequiredPaymentsString(int nBlockHeight);
-    void FillBlockPayee(CMutableTransaction& txNew, const CBlockIndex* pindexPrev, bool fProofOfStake);
+    void FillBlockPayee(CMutableTransaction& txNew, const int nHeight, bool fProofOfStake);
     std::string ToString() const;
 
     ADD_SERIALIZE_METHODS;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -158,7 +158,7 @@ bool CreateCoinbaseTx(CBlock* pblock, const CScript& scriptPubKeyIn, CBlockIndex
     txNew.vout[0].scriptPubKey = scriptPubKeyIn;
 
     //Masternode and general budget payments
-    FillBlockPayee(txNew, pindexPrev, false);
+    FillBlockPayee(txNew, pindexPrev ? pindexPrev->nHeight + 1 : 0, false);
 
     txNew.vin[0].scriptSig = CScript() << pindexPrev->nHeight + 1 << OP_0;
     // If no payee was detected, then the whole block value goes to the first output.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2969,7 +2969,7 @@ bool CWallet::CreateCoinStake(
             return error("%s : exceeded coinstake size limit", __func__);
 
         // Masternode payment
-        FillBlockPayee(txNew, pindexPrev, true);
+        FillBlockPayee(txNew, pindexPrev->nHeight + 1, true);
 
         const uint256& hashTxOut = txNew.GetHash();
         CTxIn in;


### PR DESCRIPTION
Made the following changes:

1) Refactored `FillBlockPayee` flow to not have to input the previous index pointer, only the chain height.
2) Added chain height argument to `BudgetManager::FillBlockPayee` function to not have to use the internal budget manager cached height. The cached height could or not be on the previous block to the one that we are trying to fill in this function.