### PR TITLE
CMasternode::GetLastPaid cleaning another strange piece of "code"

### DIFF
--- a/src/masternode.h
+++ b/src/masternode.h
@@ -210,7 +210,7 @@ public:
         READWRITE(nLastScanningErrorBlockHeight);
     }
 
-    int64_t SecondsSincePayment();
+    int64_t SecondsSincePayment(int nChainHeight);
 
     bool UpdateFromNewBroadcast(CMasternodeBroadcast& mnb);
 
@@ -260,7 +260,7 @@ public:
         return strStatus;
     }
 
-    int64_t GetLastPaid();
+    int64_t GetLastPaid(int nChainHeight);
     bool IsValidNetAddr();
 
     /// Is the input associated with collateral public key? (and there is 10000 PIV - checking if valid masternode)

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -510,7 +510,7 @@ CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight
         //make sure it has as many confirmations as there are masternodes
         if (pcoinsTip->GetCoinDepthAtHeight(mn.vin.prevout, nBlockHeight) < nMnCount) continue;
 
-        vecMasternodeLastPaid.emplace_back(mn.SecondsSincePayment(), mn.vin);
+        vecMasternodeLastPaid.emplace_back(mn.SecondsSincePayment(nBlockHeight), mn.vin);
     }
 
     nCount = (int)vecMasternodeLastPaid.size();

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -113,7 +113,7 @@ UniValue listmasternodes(const JSONRPCRequest& request)
         obj.pushKV("version", mn.protocolVersion);
         obj.pushKV("lastseen", (int64_t)mn.lastPing.sigTime);
         obj.pushKV("activetime", (int64_t)(mn.lastPing.sigTime - mn.sigTime));
-        obj.pushKV("lastpaid", (int64_t)mn.GetLastPaid());
+        obj.pushKV("lastpaid", (int64_t)mn.GetLastPaid(nHeight));
 
         ret.push_back(obj);
     }


### PR DESCRIPTION
`CMasternode::GetLastPaid`, instead of using the chain tip index, and loop backwards to **only** obtain the block height, use the cached height.