### PR TITLE
[Validation] Introducing Sapling transaction network connection and validations.

### DIFF
--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -14,6 +14,9 @@
 static const unsigned int MAX_BLOCK_SIZE_CURRENT = 2000000;
 static const unsigned int MAX_BLOCK_SIZE_LEGACY = 1000000;
 
+/** The maximum size of a transaction after Sapling activation (network rule) */
+static const unsigned int MAX_TX_SIZE_AFTER_SAPLING = MAX_BLOCK_SIZE_LEGACY;
+
 /** The maximum allowed number of signature check operations in a block (network rule) */
 static const unsigned int MAX_BLOCK_SIGOPS_CURRENT = MAX_BLOCK_SIZE_CURRENT / 50;
 static const unsigned int MAX_BLOCK_SIGOPS_LEGACY = MAX_BLOCK_SIZE_LEGACY / 50;

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -16,7 +16,7 @@ class CValidationState;
 /** Transaction validation functions */
 
 /** Context-independent validity checks */
-bool CheckTransaction(const CTransaction& tx, bool fZerocoinActive, bool fRejectBadUTXO, CValidationState& state, bool fFakeSerialAttack = false, bool fColdStakingActive=false);
+bool CheckTransaction(const CTransaction& tx, bool fZerocoinActive, bool fRejectBadUTXO, CValidationState& state, bool fFakeSerialAttack = false, bool fColdStakingActive=false, bool fSaplingActive=false);
 
 /**
  * Count ECDSA signature operations the old-fashioned (pre-0.6) way

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -93,7 +93,8 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason)
     // computing signature hashes is O(ninputs*txsize). Limiting transactions
     // to MAX_STANDARD_TX_SIZE mitigates CPU exhaustion attacks.
     unsigned int sz = GetSerializeSize(tx, SER_NETWORK, CTransaction::CURRENT_VERSION);
-    unsigned int nMaxSize = tx.ContainsZerocoins() ? MAX_ZEROCOIN_TX_SIZE : MAX_STANDARD_TX_SIZE;
+    unsigned int nMaxSize = tx.hasSaplingData() ? MAX_STANDARD_SHIELDED_TX_SIZE :
+            tx.ContainsZerocoins() ? MAX_ZEROCOIN_TX_SIZE : MAX_STANDARD_TX_SIZE;
     if (sz >= nMaxSize) {
         reason = "tx-size";
         return false;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -305,7 +305,9 @@ public:
     {
         return sapData != nullopt &&
             (!sapData->vShieldedOutput.empty() ||
-            !sapData->vShieldedSpend.empty());
+            !sapData->vShieldedSpend.empty() ||
+            sapData->valueBalance != 0 ||
+            sapData->hasBindingSig());
     };
 
     bool isSapling() const

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -454,7 +454,7 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(WalletModelTransaction& tran
     bool fColdStakingActive = sporkManager.IsSporkActive(SPORK_17_COLDSTAKING_ENFORCEMENT);
 
     // Double check tx before do anything
-    CValidationState state;
+    CValidationState state; // TODO: Add sapling network active flag check
     if (!CheckTransaction(*transaction.getTransaction(), true, true, state, true, fColdStakingActive)) {
         return TransactionCheckFailed;
     }

--- a/src/sapling/sapling_transaction.h
+++ b/src/sapling/sapling_transaction.h
@@ -146,6 +146,12 @@ public:
 
     explicit SaplingTxData() : valueBalance(0), vShieldedSpend(), vShieldedOutput() { }
     explicit SaplingTxData(const SaplingTxData& from) : valueBalance(from.valueBalance), vShieldedSpend(from.vShieldedSpend), vShieldedOutput(from.vShieldedOutput), bindingSig(from.bindingSig) {}
+
+    bool hasBindingSig() const
+    {
+        return std::any_of(bindingSig.begin(), bindingSig.end(),
+                          [](const unsigned char& c){ return c != 0; });
+    }
 };
 
 

--- a/src/sapling/sapling_validation.cpp
+++ b/src/sapling/sapling_validation.cpp
@@ -57,15 +57,6 @@ bool CheckTransactionWithoutProofVerification(const CTransaction& tx, CValidatio
     // If the tx got to this point, must be +v2.
     assert(tx.nVersion >= CTransaction::SAPLING_VERSION);
 
-    // Transactions containing empty `vin` must have non-empty `vShieldedSpend`.
-    if (tx.vin.empty() && tx.sapData->vShieldedSpend.empty())
-        return state.DoS(10, error("%s: vin empty", __func__ ),
-                         REJECT_INVALID, "bad-txns-vin-empty");
-    // Transactions containing empty `vout` must have non-empty `vShieldedOutput`.
-    if (tx.vout.empty() && tx.sapData->vShieldedOutput.empty())
-        return state.DoS(10, error("%s: vout empty", __func__ ),
-                         REJECT_INVALID, "bad-txns-vout-empty");
-
     // Size limits
     BOOST_STATIC_ASSERT(MAX_BLOCK_SIZE_CURRENT >= MAX_TX_SIZE_AFTER_SAPLING); // sanity
     BOOST_STATIC_ASSERT(MAX_TX_SIZE_AFTER_SAPLING > MAX_ZEROCOIN_TX_SIZE); // sanity

--- a/src/sapling/sapling_validation.h
+++ b/src/sapling/sapling_validation.h
@@ -13,6 +13,12 @@ class CValidationState;
 
 namespace SaplingValidation {
 
+/** Context-independent validity checks */
+// Note: for +v2, if the tx has no shielded data, this method returns true.
+// Note2: This function only performs shielded data related checks, it does NOT checks regular inputs and outputs.
+bool CheckTransaction(const CTransaction& tx, CValidationState& state, CAmount& nValueOut, bool fIsSaplingActive);
+bool CheckTransactionWithoutProofVerification(const CTransaction& tx, CValidationState &state, CAmount& nValueOut);
+
 /** Check a transaction contextually against a set of consensus rules */
 bool ContextualCheckTransaction(const CTransaction &tx, CValidationState &state,
                                 const CChainParams &chainparams, int nHeight, bool isMined,

--- a/src/sapling/sapling_validation.h
+++ b/src/sapling/sapling_validation.h
@@ -20,6 +20,7 @@ bool CheckTransaction(const CTransaction& tx, CValidationState& state, CAmount& 
 bool CheckTransactionWithoutProofVerification(const CTransaction& tx, CValidationState &state, CAmount& nValueOut);
 
 /** Check a transaction contextually against a set of consensus rules */
+// Note: if v5 upgrade wasn't enforced, this method returns true without performing any check.
 bool ContextualCheckTransaction(const CTransaction &tx, CValidationState &state,
                                 const CChainParams &chainparams, int nHeight, bool isMined,
                                 bool sInitBlockDownload);

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -94,6 +94,9 @@ static bool MatchMultisig(const CScript& script, unsigned int& required, std::ve
  */
 bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, std::vector<std::vector<unsigned char> >& vSolutionsRet)
 {
+    if (scriptPubKey.empty())
+        return false;
+
     vSolutionsRet.clear();
 
     // Shortcut for pay-to-script-hash, which are more constrained than the other types:

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -515,10 +515,21 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState &state, const C
             }
         }
 
-        if (fRejectAbsurdFee && nFees > ::minRelayTxFee.GetFee(nSize) * 10000)
-            return state.Invalid(false,
-                REJECT_HIGHFEE, "absurdly-high-fee",
-                strprintf("%d > %d", nFees, ::minRelayTxFee.GetFee(nSize) * 10000));
+        if (!tx.hasSaplingData()) { // Sapling fee could be higher. Review it properly
+            if (fRejectAbsurdFee && nFees > ::minRelayTxFee.GetFee(nSize) * 10000) {
+                return state.Invalid(false,
+                                     REJECT_HIGHFEE, "absurdly-high-fee",
+                                     strprintf("%d > %d", nFees, ::minRelayTxFee.GetFee(nSize) * 10000));
+            }
+        } else {
+            // Accept a tx if it contains sapling and has at least the default fee specified (0.0001 PIV).
+            // todo: this is a initial step, we can definitely be more accurate with the fee calculation and use the regular fee flow.
+            if (nFees < 10000) {
+                return state.Invalid(false,
+                                     REJECT_HIGHFEE, "sapling-invalid-fee",
+                                     strprintf("sapling fee: %d < %d", nFees, 10000));
+            }
+        }
 
         // As zero fee transactions are not going to be accepted in the near future (4.0) and the code will be fully refactored soon.
         // This is just a quick inline towards that goal, the mempool by default will not accept them. Blocking

--- a/src/validation.h
+++ b/src/validation.h
@@ -74,6 +74,7 @@ static const unsigned int DEFAULT_LIMITFREERELAY = 30;
 /** The maximum size for transactions we're willing to relay/mine */
 static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
 static const unsigned int MAX_ZEROCOIN_TX_SIZE = 150000;
+static const unsigned int MAX_STANDARD_SHIELDED_TX_SIZE = MAX_TX_SIZE_AFTER_SAPLING;
 /** Default for -checkblocks */
 static const signed int DEFAULT_CHECKBLOCKS = 10;
 /** The maximum size of a blk?????.dat file (since 0.8) */


### PR DESCRIPTION
Hopefully the last decouple from #1798.

Focused on introducing network flow connection and validations for shielded transactions (primitives and contextual checks), coins cache nullifier and anchor and a test case covering the invalid paths.

This work can be verified running 1798 functional tests suite. `sapling_wallet_nullifiers.py`, `sapling_wallet.py`, `sapling_wallet_anchorfork.py` , `sapling_key_import_export.py` are all running on top of this work, creating shielded txs, checking balances and generating blocks.

-- A future to do in the area is the mempool validations (nullifiers) connection (stated in 1798 but a little bit of redundancy here doesn't hurt) and continue adding more test coverage for the validation area. Plus, discuss the fee topic further on its own PR, can be dynamic and not fixed as is now. --


#### Commits coming from 1798:

* PR decoupled from 1798, focused on introducing Sapling transaction network validations.
* TransactionBuilder: Do not set the binding signature if there is no shielded spends/outs. —> 096b0ed04d3806784bf606b557c4bb9341ad644f 
* Validation: Connecting Sapling ContextualCheckTransaction. —> b37998cdf7577555c0648454b2b12a1c5810c499
* Sapling transaction fixed fee check. —> cda336e6affe7a64bb71ead876f2e96243360f89
* Add HaveShieldedRequirements checks in mempool, connectBlock and checkTxInputs —> 3dbd3191570066f7d27e42a4ba6c2b96a3bc116e
* validation: sapling merkle tree and view state update connection. —> 382a99b5afd96f6fbd3a1c7ad506329fba196ca6
* Sapling CheckTransaction connection. —> 3b40c6e328166f71eb49e2d6bc49f25272e38101
* Sapling validation, CheckTransaction implemented. —> 7fd17eece9cc881a416ce13b56cfec54459804f4
* Solver return false for empty scripts. —> 3622a0dd8df71dce908b4d2d12fe20fdd55ad750