### PR TITLE
[Travis] Set stricter timeout for Dash 32bit job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -132,6 +132,7 @@ jobs:
         GOAL="install"
         BITCOIN_CONFIG="--enable-zmq --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports --disable-online-rust --with-params-dir=$PARAMS_DIR LDFLAGS=-static-libstdc++"
         CONFIG_SHELL="/bin/dash"
+        BUILD_TIMEOUT=600
 
     - stage: test
       name: 'x86_64 Linux  [GOAL: install]  [bionic]  [uses qt5 dev package instead of depends Qt to speed up build and avoid timeout]'

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -180,10 +180,8 @@ check-zerocoin: $(ZEROCOIN_TESTS:.cpp=.cpp.test)
 check-local: check-sapling check-zerocoin check-standard
 
 %.cpp.test: %.cpp
-	@echo "" && echo Running tests: `cat $< | grep -E "(BOOST_FIXTURE_TEST_SUITE\\(|BOOST_AUTO_TEST_SUITE\\()" | cut -d '(' -f 2 | cut -d ',' -f 1 | cut -d ')' -f 1` from $<
-	$(AM_V_at)$(TEST_BINARY) -l test_suite -t "`cat $< | grep -E "(BOOST_FIXTURE_TEST_SUITE\\(|BOOST_AUTO_TEST_SUITE\\()" | cut -d '(' -f 2 | cut -d ',' -f 1 | cut -d ')' -f 1`" > $<.log 2>&1 || (cat $<.log && false) & echo "$$!" > "$<.pid"
-	@while kill -0 `cat $<.pid` > /dev/null 2>&1; do echo -n "." >&2 | sleep 0.5; done
-	@echo -e "\r\033[1A\033[0K" | rm $<.pid
+	@echo Running tests: `cat $< | grep -E "(BOOST_FIXTURE_TEST_SUITE\\(|BOOST_AUTO_TEST_SUITE\\()" | cut -d '(' -f 2 | cut -d ',' -f 1 | cut -d ')' -f 1` from $<
+	$(AM_V_at)$(TEST_BINARY) -l test_suite -t "`cat $< | grep -E "(BOOST_FIXTURE_TEST_SUITE\\(|BOOST_AUTO_TEST_SUITE\\()" | cut -d '(' -f 2 | cut -d ',' -f 1 | cut -d ')' -f 1`" > $<.log 2>&1 || (cat $<.log && false)
 
 %.json.h: %.json
 	@$(MKDIR_P) $(@D)


### PR DESCRIPTION
The unit tests for this job take upwards of 35 minutes due to 32-bit
performance restrictions, so set a stricter build timeout.

A build timeout of 600 seconds (10 minutes) was chosen as it is roughly double what a (currently) fully ccache'd build requires, so some leeway is left over to avoid unnecessary job restarts when a PR's changeset has a minimal impact on the build time.

Additionally, revert the workaround "hack" to continuously output `.`'s to the console when running the unit tests as #1944's reordering to run longer tests towards the beginning of the process has made it unnecessary. This also restores the easier to read output formatting.