### PR TITLE
[BUG][Wallet] Lock cs_main before accessing CheckFinalTx

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -495,6 +495,7 @@ void CTxMemPool::remove(const CTransaction& origTx, std::list<CTransactionRef>& 
 
 void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMemPoolHeight, int flags)
 {
+    AssertLockHeld(cs_main);
     // Remove transactions spending a coinbase which are now immature and no-longer-final transactions
     LOCK(cs);
     std::list<CTransaction> transactionsToRemove;


### PR DESCRIPTION
Bug introduced in #1698 .
The LockHeld assertion in `CheckFinalTx` fails when it is called from `GetMasternodeVinAndKeys` (via `CheckTXAvailability`).

This  PR adds an assertion to the functions calling `CheckFinalTx`
- `removeForReorg`
- `CheckTXAvailability`

And acquires `cs_main` mutex in `GetMasternodeVinAndKeys`.