### PR TITLE
[wallet] CWalletTx: missing fStakeDelegationVoided initialization

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4457,6 +4457,7 @@ void CWalletTx::Init(const CWallet* pwalletIn)
     fFromMe = false;
     fChangeCached = false;
     nChangeCached = 0;
+    fStakeDelegationVoided = false;
     nOrderPos = -1;
 }
 


### PR DESCRIPTION
Missing initialization for `fStakeDelegationVoided` flag in `CWalletTx`.