### PR TITLE
[Refactor] Move CFeeRate out of the consensus module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -366,7 +366,6 @@ target_include_directories(ZEROCOIN_A PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src
 
 set(COMMON_SOURCES
         ./src/allocators.cpp
-        ./src/amount.cpp
         ./src/base58.cpp
         ./src/bip38.cpp
         ./src/consensus/params.cpp
@@ -390,6 +389,7 @@ set(COMMON_SOURCES
         ./src/keystore.cpp
         ./src/netaddress.cpp
         ./src/netbase.cpp
+        ./src/policy/feerate.cpp
         ./src/protocol.cpp
         ./src/pubkey.cpp
         ./src/scheduler.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -221,6 +221,7 @@ BITCOIN_CORE_H = \
   netbase.h \
   netmessagemaker.h \
   noui.h \
+  policy/feerate.h \
   policy/fees.h \
   policy/policy.h \
   optional.h \
@@ -477,7 +478,6 @@ libbitcoin_common_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 libbitcoin_common_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_common_a_SOURCES = \
   allocators.cpp \
-  amount.cpp \
   base58.cpp \
   bip38.cpp \
   chainparams.cpp \
@@ -497,6 +497,7 @@ libbitcoin_common_a_SOURCES = \
   keystore.cpp \
   netaddress.cpp \
   netbase.cpp \
+  policy/feerate.cpp \
   protocol.cpp \
   pubkey.cpp \
   scheduler.cpp \

--- a/src/amount.h
+++ b/src/amount.h
@@ -1,18 +1,13 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2014 The Bitcoin developers
+// Copyright (c) 2009-2017 The Bitcoin developers
 // Copyright (c) 2017-2020 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_AMOUNT_H
-#define BITCOIN_AMOUNT_H
+#ifndef PIVX_AMOUNT_H
+#define PIVX_AMOUNT_H
 
-#include "serialize.h"
-
-#include <stdlib.h>
-#include <string>
-
-extern const std::string CURRENCY_UNIT;
+#include <stdint.h>
 
 /** Amount in PIV (Can be negative) */
 typedef int64_t CAmount;
@@ -20,37 +15,4 @@ typedef int64_t CAmount;
 static const CAmount COIN = 100000000;
 static const CAmount CENT = 1000000;
 
-/**
- * Fee rate in PIV per kilobyte: CAmount / kB
- */
-class CFeeRate
-{
-private:
-    CAmount nSatoshisPerK; // unit is satoshis-per-1,000-bytes
-public:
-    CFeeRate() : nSatoshisPerK(0) {}
-    explicit CFeeRate(const CAmount& _nSatoshisPerK) : nSatoshisPerK(_nSatoshisPerK) {}
-    CFeeRate(const CAmount& nFeePaid, size_t nSize);
-    CFeeRate(const CFeeRate& other) { nSatoshisPerK = other.nSatoshisPerK; }
-
-    CAmount GetFee(size_t size) const;                  // unit returned is satoshis
-    CAmount GetFeePerK() const { return GetFee(1000); } // satoshis-per-1000-bytes
-
-    friend bool operator<(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK < b.nSatoshisPerK; }
-    friend bool operator>(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK > b.nSatoshisPerK; }
-    friend bool operator==(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK == b.nSatoshisPerK; }
-    friend bool operator<=(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK <= b.nSatoshisPerK; }
-    friend bool operator>=(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK >= b.nSatoshisPerK; }
-    CFeeRate& operator+=(const CFeeRate& a) { nSatoshisPerK += a.nSatoshisPerK; return *this; }
-    std::string ToString() const;
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(nSatoshisPerK);
-    }
-};
-
-#endif //  BITCOIN_AMOUNT_H
+#endif //  PIVX_AMOUNT_H

--- a/src/coincontrol.h
+++ b/src/coincontrol.h
@@ -7,6 +7,7 @@
 #ifndef BITCOIN_COINCONTROL_H
 #define BITCOIN_COINCONTROL_H
 
+#include "policy/feerate.h"
 #include "primitives/transaction.h"
 #include "script/standard.h"
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -34,6 +34,7 @@
 #include "miner.h"
 #include "netbase.h"
 #include "net_processing.h"
+#include "policy/feerate.h"
 #include "policy/policy.h"
 #include "reverse_iterate.h"
 #include "rpc/register.h"

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -5,9 +5,12 @@
 #ifndef BITCOIN_MEMUSAGE_H
 #define BITCOIN_MEMUSAGE_H
 
+#include "prevector.h"
+
 #include <stdlib.h>
 
 #include <map>
+#include <memory>
 #include <set>
 #include <vector>
 #include <unordered_map>

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -19,6 +19,7 @@
 #include "masternode-sync.h"
 #include "net.h"
 #include "pow.h"
+#include "policy/feerate.h"
 #include "primitives/block.h"
 #include "primitives/transaction.h"
 #include "timedata.h"

--- a/src/policy/feerate.cpp
+++ b/src/policy/feerate.cpp
@@ -1,10 +1,10 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2014 The Bitcoin developers
-// Copyright (c) 2017-2019 The PIVX developers
+// Copyright (c) 2009-2017 The Bitcoin developers
+// Copyright (c) 2017-2020 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "amount.h"
+#include "feerate.h"
 
 #include "tinyformat.h"
 

--- a/src/policy/feerate.h
+++ b/src/policy/feerate.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2009-2017 The Bitcoin Core developers
+// Copyright (c) 2017-2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef PIVX_POLICY_FEERATE_H
+#define PIVX_POLICY_FEERATE_H
+
+#include "amount.h"
+#include "serialize.h"
+
+#include <string>
+
+extern const std::string CURRENCY_UNIT;
+
+/**
+ * Fee rate in PIV per kilobyte: CAmount / kB
+ */
+class CFeeRate
+{
+private:
+    CAmount nSatoshisPerK; // unit is satoshis-per-1,000-bytes
+public:
+    CFeeRate() : nSatoshisPerK(0) {}
+    explicit CFeeRate(const CAmount& _nSatoshisPerK) : nSatoshisPerK(_nSatoshisPerK) {}
+    CFeeRate(const CAmount& nFeePaid, size_t nSize);
+    CFeeRate(const CFeeRate& other) { nSatoshisPerK = other.nSatoshisPerK; }
+
+    CAmount GetFee(size_t size) const;                  // unit returned is satoshis
+    CAmount GetFeePerK() const { return GetFee(1000); } // satoshis-per-1000-bytes
+
+    friend bool operator<(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK < b.nSatoshisPerK; }
+    friend bool operator>(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK > b.nSatoshisPerK; }
+    friend bool operator==(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK == b.nSatoshisPerK; }
+    friend bool operator<=(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK <= b.nSatoshisPerK; }
+    friend bool operator>=(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK >= b.nSatoshisPerK; }
+    CFeeRate& operator+=(const CFeeRate& a) { nSatoshisPerK += a.nSatoshisPerK; return *this; }
+    std::string ToString() const;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(nSatoshisPerK);
+    }
+};
+
+#endif //  PIVX_POLICY_FEERATE_H

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -6,6 +6,7 @@
 #define BITCOIN_POLICYESTIMATOR_H
 
 #include "amount.h"
+#include "feerate.h"
 #include "uint256.h"
 
 #include <map>

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -7,6 +7,7 @@
 #define BITCOIN_POLICY_H
 
 #include "consensus/consensus.h"
+#include "feerate.h"
 #include "script/interpreter.h"
 #include "script/standard.h"
 

--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -6,6 +6,7 @@
 
 #include "bitcoinunits.h"
 #include "chainparams.h"
+#include "policy/feerate.h"
 #include "primitives/transaction.h"
 
 #include <QSettings>

--- a/src/qt/pivx/sendcustomfeedialog.h
+++ b/src/qt/pivx/sendcustomfeedialog.h
@@ -5,7 +5,7 @@
 #ifndef SENDCUSTOMFEEDIALOG_H
 #define SENDCUSTOMFEEDIALOG_H
 
-#include "amount.h"
+#include "policy/feerate.h"
 #include "qt/pivx/focuseddialog.h"
 #include "qt/pivx/snackbar.h"
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -12,6 +12,7 @@
 #include "kernel.h"
 #include "masternode-budget.h"
 #include "masternodeman.h"
+#include "policy/feerate.h"
 #include "policy/policy.h"
 #include "rpc/server.h"
 #include "sync.h"

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -4,6 +4,7 @@
 
 #include "test/test_pivx.h"
 
+#include "policy/feerate.h"
 #include "txmempool.h"
 #include "util.h"
 

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "policy/feerate.h"
 #include "policy/fees.h"
 #include "txmempool.h"
 #include "uint256.h"

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -13,6 +13,7 @@
 
 #include "amount.h"
 #include "coins.h"
+#include "policy/feerate.h"
 #include "primitives/transaction.h"
 #include "sync.h"
 #include "random.h"

--- a/src/validation.h
+++ b/src/validation.h
@@ -21,6 +21,7 @@
 #include "consensus/validation.h"
 #include "fs.h"
 #include "moneysupply.h"
+#include "policy/feerate.h"
 #include "script/script_error.h"
 #include "sync.h"
 #include "txmempool.h"

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -14,6 +14,7 @@
 #include "key_io.h"
 #include "masternode-sync.h"
 #include "net.h"
+#include "policy/feerate.h"
 #include "rpc/server.h"
 #include "timedata.h"
 #include "util.h"

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -18,6 +18,7 @@
 #include "key.h"
 #include "keystore.h"
 #include "pairresult.h"
+#include "policy/feerate.h"
 #include "primitives/block.h"
 #include "primitives/transaction.h"
 #include "sapling/address.hpp"


### PR DESCRIPTION
After #1950, this PR completes the backport of bitcoin/bitcoin#9279 to move CFeeRate out of libconsensus.

> CTxOut and CTransaction shouldn't depend on CFeeRate, which is something for policy checks and not consensus checks.