### PR TITLE
[Core] Sapling transaction version

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -365,7 +365,7 @@ double CCoinsViewCache::GetPriority(const CTransaction& tx, int nHeight, CAmount
     // cannot apply the priority algorithm used for transparent utxos.  Instead, we just
     // use the maximum priority for all (partially or fully) shielded transactions.
     // (Note that coinbase/coinstakes transactions cannot contain Sapling shielded Spends or Outputs.)
-    if (tx.hasSaplingData()) {
+    if (tx.IsShieldedTx()) {
         return INF_PRIORITY;
     }
 
@@ -582,7 +582,7 @@ uint256 CCoinsViewCache::GetBestAnchor() const {
 
 bool CCoinsViewCache::HaveShieldedRequirements(const CTransaction& tx) const
 {
-    if (tx.hasSaplingData()) {
+    if (tx.IsShieldedTx()) {
         for (const SpendDescription &spendDescription : tx.sapData->vShieldedSpend) {
             if (GetNullifier(spendDescription.nullifier)) // Prevent double spends
                 return false;

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -65,6 +65,15 @@ bool CheckTransaction(const CTransaction& tx, bool fZerocoinActive, bool fReject
     if (tx.vout.empty() && (tx.sapData && tx.sapData->vShieldedOutput.empty()))
         return state.DoS(10, false, REJECT_INVALID, "bad-txns-vout-empty");
 
+    // Version check
+    if (fSaplingActive) {
+        // After sapling activation we require 1 <= tx.nVersion < TxVersion::TOOHIGH
+        if (tx.nVersion < 1 || tx.nVersion >= CTransaction::TxVersion::TOOHIGH)
+            return state.DoS(10,
+                    error("%s: Transaction version (%d) too high. Max: %d", __func__, tx.nVersion, int(CTransaction::TxVersion::TOOHIGH) - 1),
+                    REJECT_INVALID, "bad-tx-version-too-high");
+    }
+
     // Dispatch to Sapling validator
     CAmount nValueOut = 0;
     if (!SaplingValidation::CheckTransaction(tx, state, nValueOut, fSaplingActive)) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -452,7 +452,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, 
 
             // Update the Sapling commitment tree.
             for (const auto &tx : pblock->vtx) {
-                if (tx->isSapling() && tx->hasSaplingData()) {
+                if (tx->IsShieldedTx()) {
                     for (const OutputDescription &odesc : tx->sapData->vShieldedOutput) {
                         sapling_tree.append(odesc.cmu);
                     }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -523,7 +523,7 @@ bool AddOrphanTx(const CTransactionRef& tx, NodeId peer) EXCLUSIVE_LOCKS_REQUIRE
     // have been mined or received.
     // 10,000 orphans, each of which is at most 5,000 bytes big is
     // at most 500 megabytes of orphans:
-    unsigned int sz = GetSerializeSize(*tx, SER_NETWORK, CTransaction::CURRENT_VERSION);
+    unsigned int sz = tx->GetTotalSize();
     if (sz > 5000) {
         LogPrint(BCLog::MEMPOOL, "ignoring large orphan tx (size: %u, hash: %s)\n", sz, hash.ToString());
         return false;

--- a/src/pivx-tx.cpp
+++ b/src/pivx-tx.cpp
@@ -159,7 +159,7 @@ static void RegisterLoad(const std::string& strInput)
 static void MutateTxVersion(CMutableTransaction& tx, const std::string& cmdVal)
 {
     int64_t newVersion = atoi64(cmdVal);
-    if (newVersion < 1 || newVersion > CTransaction::CURRENT_VERSION)
+    if (newVersion < 1 || newVersion >= CTransaction::TxVersion::TOOHIGH)
         throw std::runtime_error("Invalid TX version requested");
 
     tx.nVersion = (int)newVersion;

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -116,7 +116,7 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason)
     // computing signature hashes is O(ninputs*txsize). Limiting transactions
     // to MAX_STANDARD_TX_SIZE mitigates CPU exhaustion attacks.
     unsigned int sz = GetSerializeSize(tx, SER_NETWORK, CTransaction::CURRENT_VERSION);
-    unsigned int nMaxSize = tx.hasSaplingData() ? MAX_STANDARD_SHIELDED_TX_SIZE :
+    unsigned int nMaxSize = tx.IsShieldedTx() ? MAX_STANDARD_SHIELDED_TX_SIZE :
             tx.ContainsZerocoins() ? MAX_ZEROCOIN_TX_SIZE : MAX_STANDARD_TX_SIZE;
     if (sz >= nMaxSize) {
         reason = "tx-size";

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -115,7 +115,7 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason)
     // almost as much to process as they cost the sender in fees, because
     // computing signature hashes is O(ninputs*txsize). Limiting transactions
     // to MAX_STANDARD_TX_SIZE mitigates CPU exhaustion attacks.
-    unsigned int sz = GetSerializeSize(tx, SER_NETWORK, CTransaction::CURRENT_VERSION);
+    unsigned int sz = tx.GetTotalSize();
     unsigned int nMaxSize = tx.IsShieldedTx() ? MAX_STANDARD_SHIELDED_TX_SIZE :
             tx.ContainsZerocoins() ? MAX_ZEROCOIN_TX_SIZE : MAX_STANDARD_TX_SIZE;
     if (sz >= nMaxSize) {

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -59,7 +59,7 @@ bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType);
 /** Check for standard transaction types
  * @return True if all outputs (scriptPubKeys) use only standard transaction forms
  */
-bool IsStandardTx(const CTransaction& tx, std::string& reason);
+bool IsStandardTx(const CTransaction& tx, int nBlockHeight, std::string& reason);
 
 /**
  * Check for standard transaction types

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -263,9 +263,9 @@ CAmount CTransaction::GetValueOut() const
         // NB: negative valueBalance "takes" money from the transparent value pool just as outputs do
         nValueOut += -sapData->valueBalance;
 
-        // Verify Sapling
-        if (!isSapling())
-            throw std::runtime_error("GetValueOut(): sapData valueBalance invalid");
+        // Verify Sapling version
+        if (!isSaplingVersion())
+            throw std::runtime_error("GetValueOut(): invalid tx version");
     }
 
     return nValueOut;
@@ -280,8 +280,8 @@ CAmount CTransaction::GetShieldedValueIn() const
         nValue += sapData->valueBalance;
 
         // Verify Sapling
-        if (!isSapling())
-            throw std::runtime_error("GetValueOut(): sapData valueBalance invalid");
+        if (!isSaplingVersion())
+            throw std::runtime_error("GetValueOut(): invalid tx version");
     }
 
     return nValue;

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -264,7 +264,7 @@ CAmount CTransaction::GetValueOut() const
         nValueOut += -sapData->valueBalance;
 
         // Verify Sapling
-        if (nVersion < SAPLING_VERSION)
+        if (!isSapling())
             throw std::runtime_error("GetValueOut(): sapData valueBalance invalid");
     }
 
@@ -280,7 +280,7 @@ CAmount CTransaction::GetShieldedValueIn() const
         nValue += sapData->valueBalance;
 
         // Verify Sapling
-        if (nVersion < SAPLING_VERSION)
+        if (!isSapling())
             throw std::runtime_error("GetValueOut(): sapData valueBalance invalid");
     }
 
@@ -334,7 +334,7 @@ unsigned int CTransaction::GetTotalSize() const
 std::string CTransaction::ToString() const
 {
     std::string str;
-    if (nVersion == CTransaction::SAPLING_VERSION && sapData) {
+    if (isSapling() && sapData) {
         str += strprintf("CTransaction(hash=%s, ver=%d, vin.size=%u, vout.size=%u, nLockTime=%u, valueBalance=%u, vShieldedSpend.size=%u, vShieldedOutput.size=%u)\n",
                          GetHash().ToString().substr(0,10),
                          nVersion,

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -334,7 +334,7 @@ unsigned int CTransaction::GetTotalSize() const
 std::string CTransaction::ToString() const
 {
     std::string str;
-    if (isSapling() && sapData) {
+    if (IsShieldedTx()) {
         str += strprintf("CTransaction(hash=%s, ver=%d, vin.size=%u, vout.size=%u, nLockTime=%u, valueBalance=%u, vShieldedSpend.size=%u, vShieldedOutput.size=%u)\n",
                          GetHash().ToString().substr(0,10),
                          nVersion,

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -224,10 +224,13 @@ private:
     void UpdateHash() const;
 
 public:
-    static const int32_t STANDARD_VERSION = 1;
-    static const int32_t SAPLING_VERSION = 2;
+    enum TxVersion {
+        LEGACY      = 1,
+        SAPLING     = 2,
+        TOOHIGH
+    };
 
-    static const int32_t CURRENT_VERSION = STANDARD_VERSION;
+    static const int32_t CURRENT_VERSION = static_cast<int32_t>(TxVersion::LEGACY);
 
     // The local variables are made const to prevent unintended modification
     // without updating the cached hash value. However, CTransaction is not
@@ -288,7 +291,7 @@ public:
 
     bool isSaplingVersion() const
     {
-        return nVersion >= SAPLING_VERSION;
+        return nVersion >= TxVersion::SAPLING;
     }
 
     bool IsShieldedTx() const
@@ -376,7 +379,7 @@ struct CMutableTransaction
         READWRITE(vout);
         READWRITE(nLockTime);
 
-        if (g_IsSaplingActive && nVersion >= CTransaction::SAPLING_VERSION) {
+        if (g_IsSaplingActive && nVersion >= CTransaction::TxVersion::SAPLING) {
             READWRITE(*const_cast<Optional<SaplingTxData>*>(&sapData));
         }
     }

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -291,6 +291,11 @@ public:
         return nVersion >= SAPLING_VERSION;
     }
 
+    bool IsShieldedTx() const
+    {
+        return isSapling() && hasSaplingData();
+    }
+
     /*
      * Context for the two methods below:
      * We can think of the Sapling shielded part of the transaction as an input

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -258,7 +258,7 @@ public:
         READWRITE(*const_cast<std::vector<CTxOut>*>(&vout));
         READWRITE(*const_cast<uint32_t*>(&nLockTime));
 
-        if (g_IsSaplingActive && nVersion == CTransaction::SAPLING_VERSION) {
+        if (g_IsSaplingActive && isSapling()) {
             READWRITE(*const_cast<Optional<SaplingTxData>*>(&sapData));
         }
 
@@ -288,7 +288,7 @@ public:
 
     bool isSapling() const
     {
-        return nVersion == SAPLING_VERSION;
+        return nVersion >= SAPLING_VERSION;
     }
 
     /*
@@ -371,7 +371,7 @@ struct CMutableTransaction
         READWRITE(vout);
         READWRITE(nLockTime);
 
-        if (g_IsSaplingActive && nVersion == CTransaction::SAPLING_VERSION) {
+        if (g_IsSaplingActive && nVersion >= CTransaction::SAPLING_VERSION) {
             READWRITE(*const_cast<Optional<SaplingTxData>*>(&sapData));
         }
     }

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -258,7 +258,7 @@ public:
         READWRITE(*const_cast<std::vector<CTxOut>*>(&vout));
         READWRITE(*const_cast<uint32_t*>(&nLockTime));
 
-        if (g_IsSaplingActive && isSapling()) {
+        if (g_IsSaplingActive && isSaplingVersion()) {
             READWRITE(*const_cast<Optional<SaplingTxData>*>(&sapData));
         }
 
@@ -286,14 +286,14 @@ public:
             sapData->hasBindingSig());
     };
 
-    bool isSapling() const
+    bool isSaplingVersion() const
     {
         return nVersion >= SAPLING_VERSION;
     }
 
     bool IsShieldedTx() const
     {
-        return isSapling() && hasSaplingData();
+        return isSaplingVersion() && hasSaplingData();
     }
 
     /*

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -313,7 +313,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet* 
     }
 
     // TODO: Add shielded transactions parsing.
-    if (wtx.hasSaplingData()) {
+    if (wtx.IsShieldedTx()) {
         return parts;
     }
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -68,7 +68,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
     TxToUniv(tx, uint256(), entry);
 
     // Sapling
-    if (pwalletMain && tx.nVersion >= CTransaction::SAPLING_VERSION && tx.hasSaplingData()) {
+    if (pwalletMain && tx.isSapling() && tx.hasSaplingData()) {
         // Add information that only this wallet knows about the transaction if is possible
         if (pwalletMain->HasSaplingSPKM()) {
             std::vector<libzcash::SaplingPaymentAddress> addresses =

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -68,7 +68,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
     TxToUniv(tx, uint256(), entry);
 
     // Sapling
-    if (pwalletMain && tx.isSapling() && tx.hasSaplingData()) {
+    if (pwalletMain && tx.IsShieldedTx()) {
         // Add information that only this wallet knows about the transaction if is possible
         if (pwalletMain->HasSaplingSPKM()) {
             std::vector<libzcash::SaplingPaymentAddress> addresses =

--- a/src/sapling/sapling_core_write.cpp
+++ b/src/sapling/sapling_core_write.cpp
@@ -42,7 +42,7 @@ static UniValue TxShieldedOutputsToJSON(const CTransaction& tx) {
 }
 
 void TxSaplingToJSON(const CTransaction& tx, UniValue& entry) {
-    if (tx.isSapling() && tx.sapData) {
+    if (tx.IsShieldedTx()) {
         entry.pushKV("valueBalance", FormatMoney(tx.sapData->valueBalance));
         entry.pushKV("valueBalanceSat", tx.sapData->valueBalance);
         UniValue vspenddesc = TxShieldedSpendsToJSON(tx);

--- a/src/sapling/sapling_core_write.cpp
+++ b/src/sapling/sapling_core_write.cpp
@@ -42,7 +42,7 @@ static UniValue TxShieldedOutputsToJSON(const CTransaction& tx) {
 }
 
 void TxSaplingToJSON(const CTransaction& tx, UniValue& entry) {
-    if (tx.nVersion >= CTransaction::SAPLING_VERSION && tx.sapData) {
+    if (tx.isSapling() && tx.sapData) {
         entry.pushKV("valueBalance", FormatMoney(tx.sapData->valueBalance));
         entry.pushKV("valueBalanceSat", tx.sapData->valueBalance);
         UniValue vspenddesc = TxShieldedSpendsToJSON(tx);

--- a/src/sapling/sapling_validation.cpp
+++ b/src/sapling/sapling_validation.cpp
@@ -22,7 +22,7 @@ bool CheckTransaction(const CTransaction& tx, CValidationState& state, CAmount& 
     bool hasSaplingData = tx.hasSaplingData();
 
     // v1 must not have shielded data.
-    if (!tx.isSapling() && hasSaplingData) {
+    if (!tx.isSaplingVersion() && hasSaplingData) {
         return state.DoS(100, error("%s: Not Sapling version with Sapling data", __func__ ),
                          REJECT_INVALID, "bad-txns-form-not-sapling");
     }
@@ -55,7 +55,7 @@ bool CheckTransactionWithoutProofVerification(const CTransaction& tx, CValidatio
     // Basic checks that don't depend on any context
     const Consensus::Params& consensus = Params().GetConsensus();
     // If the tx got to this point, must be +v2.
-    assert(tx.isSapling());
+    assert(tx.isSaplingVersion());
 
     // Size limits
     BOOST_STATIC_ASSERT(MAX_BLOCK_SIZE_CURRENT >= MAX_TX_SIZE_AFTER_SAPLING); // sanity
@@ -151,7 +151,7 @@ bool ContextualCheckTransaction(
     }
 
     // Reject transactions with invalid version
-    if (!tx.isSapling() && tx.hasSaplingData()) {
+    if (!tx.isSaplingVersion() && tx.hasSaplingData()) {
         return state.DoS(
                 dosLevelConstricting,
                 error("%s: Sapling version too low", __func__ ),

--- a/src/sapling/sapling_validation.cpp
+++ b/src/sapling/sapling_validation.cpp
@@ -22,7 +22,7 @@ bool CheckTransaction(const CTransaction& tx, CValidationState& state, CAmount& 
     bool hasSaplingData = tx.hasSaplingData();
 
     // v1 must not have shielded data.
-    if (tx.nVersion < CTransaction::SAPLING_VERSION && hasSaplingData) {
+    if (!tx.isSapling() && hasSaplingData) {
         return state.DoS(100, error("%s: Not Sapling version with Sapling data", __func__ ),
                          REJECT_INVALID, "bad-txns-form-not-sapling");
     }
@@ -55,7 +55,7 @@ bool CheckTransactionWithoutProofVerification(const CTransaction& tx, CValidatio
     // Basic checks that don't depend on any context
     const Consensus::Params& consensus = Params().GetConsensus();
     // If the tx got to this point, must be +v2.
-    assert(tx.nVersion >= CTransaction::SAPLING_VERSION);
+    assert(tx.isSapling());
 
     // Size limits
     BOOST_STATIC_ASSERT(MAX_BLOCK_SIZE_CURRENT >= MAX_TX_SIZE_AFTER_SAPLING); // sanity
@@ -151,19 +151,11 @@ bool ContextualCheckTransaction(
     }
 
     // Reject transactions with invalid version
-    if (tx.nVersion < CTransaction::SAPLING_VERSION && tx.hasSaplingData()) {
+    if (!tx.isSapling() && tx.hasSaplingData()) {
         return state.DoS(
                 dosLevelConstricting,
                 error("%s: Sapling version too low", __func__ ),
                 REJECT_INVALID, "bad-tx-sapling-version-too-low");
-    }
-
-    // Reject transactions with invalid version
-    if (tx.nVersion > CTransaction::SAPLING_VERSION) {
-        return state.DoS(
-                dosLevelPotentiallyRelaxing,
-                error("%s: Sapling version too high", __func__),
-                REJECT_INVALID, "bad-tx-sapling-version-too-high");
     }
 
     // Size limits

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -209,7 +209,7 @@ void SaplingScriptPubKeyMan::IncrementNoteWitnesses(const CBlockIndex* pindex,
     }
 
     for (const auto& tx : pblock->vtx) {
-        if (!tx->hasSaplingData()) continue;
+        if (!tx->IsShieldedTx()) continue;
 
         const uint256& hash = tx->GetHash();
         bool txIsOurs = wallet->mapWallet.count(hash);
@@ -311,8 +311,8 @@ void SaplingScriptPubKeyMan::DecrementNoteWitnesses(const CBlockIndex* pindex)
  */
 std::pair<mapSaplingNoteData_t, SaplingIncomingViewingKeyMap> SaplingScriptPubKeyMan::FindMySaplingNotes(const CTransaction &tx) const
 {
-    // First check that this tx is a Sapling tx.
-    if (!tx.isSapling() || !tx.hasSaplingData()) {
+    // First check that this tx is a Shielded tx.
+    if (!tx.IsShieldedTx()) {
         return {};
     }
 
@@ -664,7 +664,7 @@ void SaplingScriptPubKeyMan::GetConflicts(const CWalletTx& wtx, std::set<uint256
     AssertLockHeld(wallet->cs_wallet);
     std::pair<TxNullifiers::const_iterator, TxNullifiers::const_iterator> range_o;
 
-    if (wtx.hasSaplingData()) {
+    if (wtx.IsShieldedTx()) {
         for (const SpendDescription& spend : wtx.sapData->vShieldedSpend) {
             const uint256& nullifier = spend.nullifier;
             if (mapTxSaplingNullifiers.count(nullifier) <= 1) {

--- a/src/sapling/transaction_builder.cpp
+++ b/src/sapling/transaction_builder.cpp
@@ -103,7 +103,7 @@ CMutableTransaction CreateNewContextualCMutableTransaction(const Consensus::Para
 {
     CMutableTransaction mtx;
     bool isSapling = consensusParams.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V5_DUMMY);
-    mtx.nVersion = isSapling ? CTransaction::SAPLING_VERSION : CTransaction::STANDARD_VERSION;
+    mtx.nVersion = isSapling ? CTransaction::TxVersion::SAPLING : CTransaction::TxVersion::LEGACY;
     return mtx;
 }
 
@@ -125,7 +125,7 @@ void TransactionBuilder::AddSaplingSpend(
     SaplingWitness witness)
 {
     // Sanity check: cannot add Sapling spend to pre-Sapling transaction
-    if (mtx.nVersion < CTransaction::SAPLING_VERSION) {
+    if (mtx.nVersion < CTransaction::TxVersion::SAPLING) {
         throw std::runtime_error("TransactionBuilder cannot add Sapling spend to pre-Sapling transaction");
     }
 
@@ -145,7 +145,7 @@ void TransactionBuilder::AddSaplingOutput(
     std::array<unsigned char, ZC_MEMO_SIZE> memo)
 {
     // Sanity check: cannot add Sapling output to pre-Sapling transaction
-    if (mtx.nVersion < CTransaction::SAPLING_VERSION) {
+    if (mtx.nVersion < CTransaction::TxVersion::SAPLING) {
         throw std::runtime_error("TransactionBuilder cannot add Sapling output to pre-Sapling transaction");
     }
 

--- a/src/test/script_P2SH_tests.cpp
+++ b/src/test/script_P2SH_tests.cpp
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE(sign)
         txFrom.vout[i+4].scriptPubKey = standardScripts[i];
         txFrom.vout[i+4].nValue = COIN;
     }
-    BOOST_CHECK(IsStandardTx(txFrom, reason));
+    BOOST_CHECK(IsStandardTx(txFrom, 0, reason));
 
     CMutableTransaction txTo[8]; // Spending transactions
     for (int i = 0; i < 8; i++)
@@ -186,7 +186,7 @@ BOOST_AUTO_TEST_CASE(set)
         txFrom.vout[i].scriptPubKey = outer[i];
         txFrom.vout[i].nValue = CENT;
     }
-    BOOST_CHECK(IsStandardTx(txFrom, reason));
+    BOOST_CHECK(IsStandardTx(txFrom, 0, reason));
 
     CMutableTransaction txTo[4]; // Spending transactions
     for (int i = 0; i < 4; i++)
@@ -202,7 +202,7 @@ BOOST_AUTO_TEST_CASE(set)
     for (int i = 0; i < 4; i++)
     {
         BOOST_CHECK_MESSAGE(SignSignature(keystore, txFrom, txTo[i], 0, SIGHASH_ALL), strprintf("SignSignature %d", i));
-        BOOST_CHECK_MESSAGE(IsStandardTx(txTo[i], reason), strprintf("txTo[%d].IsStandard", i));
+        BOOST_CHECK_MESSAGE(IsStandardTx(txTo[i], 0, reason), strprintf("txTo[%d].IsStandard", i));
     }
 }
 

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE(sighash_test)
         }
         std::cout << "\n";
         #endif
-        if (txTo.nVersion != CTransaction::SAPLING_VERSION) { // Sapling has a different signature.
+        if (txTo.nVersion < CTransaction::SAPLING_VERSION) { // Sapling has a different signature.
             BOOST_CHECK(sh == sho);
         }
     }

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE(sighash_test)
         }
         std::cout << "\n";
         #endif
-        if (txTo.nVersion < CTransaction::SAPLING_VERSION) { // Sapling has a different signature.
+        if (txTo.nVersion < CTransaction::TxVersion::SAPLING) { // Sapling has a different signature.
             BOOST_CHECK(sh == sho);
         }
     }

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -421,60 +421,60 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.vout[0].scriptPubKey = GetScriptForDestination(key.GetPubKey().GetID());
 
     std::string reason;
-    BOOST_CHECK(IsStandardTx(t, reason));
+    BOOST_CHECK(IsStandardTx(t, 0, reason));
 
     t.vout[0].nValue = 5011; // dust
-    BOOST_CHECK(!IsStandardTx(t, reason));
+    BOOST_CHECK(!IsStandardTx(t, 0, reason));
 
     t.vout[0].nValue = 6011; // not dust
-    BOOST_CHECK(IsStandardTx(t, reason));
+    BOOST_CHECK(IsStandardTx(t, 0, reason));
 
     t.vout[0].scriptPubKey = CScript() << OP_1;
-    BOOST_CHECK(!IsStandardTx(t, reason));
+    BOOST_CHECK(!IsStandardTx(t, 0, reason));
 
     // MAX_OP_RETURN_RELAY-byte TX_NULL_DATA (standard)
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38");
     BOOST_CHECK_EQUAL(MAX_OP_RETURN_RELAY, t.vout[0].scriptPubKey.size());
-    BOOST_CHECK(IsStandardTx(t, reason));
+    BOOST_CHECK(IsStandardTx(t, 0, reason));
 
     // MAX_OP_RETURN_RELAY+1-byte TX_NULL_DATA (non-standard)
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3800");
     BOOST_CHECK_EQUAL(MAX_OP_RETURN_RELAY + 1, t.vout[0].scriptPubKey.size());
-    BOOST_CHECK(!IsStandardTx(t, reason));
+    BOOST_CHECK(!IsStandardTx(t, 0, reason));
 
     // Data payload can be encoded in any way...
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("");
-    BOOST_CHECK(IsStandardTx(t, reason));
+    BOOST_CHECK(IsStandardTx(t, 0, reason));
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("00") << ParseHex("01");
-    BOOST_CHECK(IsStandardTx(t, reason));
+    BOOST_CHECK(IsStandardTx(t, 0, reason));
     // OP_RESERVED *is* considered to be a PUSHDATA type opcode by IsPushOnly()!
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << OP_RESERVED << -1 << 0 << ParseHex("01") << 2 << 3 << 4 << 5 << 6 << 7 << 8 << 9 << 10 << 11 << 12 << 13 << 14 << 15 << 16;
-    BOOST_CHECK(IsStandardTx(t, reason));
+    BOOST_CHECK(IsStandardTx(t, 0, reason));
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << 0 << ParseHex("01") << 2 << ParseHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-    BOOST_CHECK(IsStandardTx(t, reason));
+    BOOST_CHECK(IsStandardTx(t, 0, reason));
 
     // ...so long as it only contains PUSHDATA's
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << OP_RETURN;
-    BOOST_CHECK(!IsStandardTx(t, reason));
+    BOOST_CHECK(!IsStandardTx(t, 0, reason));
 
     // TX_NULL_DATA w/o PUSHDATA
     t.vout.resize(1);
     t.vout[0].scriptPubKey = CScript() << OP_RETURN;
-    BOOST_CHECK(IsStandardTx(t, reason));
+    BOOST_CHECK(IsStandardTx(t, 0, reason));
 
     // Only one TX_NULL_DATA permitted in all cases
     t.vout.resize(2);
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38");
     t.vout[1].scriptPubKey = CScript() << OP_RETURN << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38");
-    BOOST_CHECK(!IsStandardTx(t, reason));
+    BOOST_CHECK(!IsStandardTx(t, 0, reason));
 
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38");
     t.vout[1].scriptPubKey = CScript() << OP_RETURN;
-    BOOST_CHECK(!IsStandardTx(t, reason));
+    BOOST_CHECK(!IsStandardTx(t, 0, reason));
 
     t.vout[0].scriptPubKey = CScript() << OP_RETURN;
     t.vout[1].scriptPubKey = CScript() << OP_RETURN;
-    BOOST_CHECK(!IsStandardTx(t, reason));
+    BOOST_CHECK(!IsStandardTx(t, 0, reason));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -29,7 +29,7 @@ CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& _tx, const CAmount& _nFe
     nModSize = _tx->CalculateModifiedSize(nTxSize);
     nUsageSize = _tx->DynamicMemoryUsage();
     hasZerocoins = _tx->ContainsZerocoins();
-    m_isShielded = _tx->hasSaplingData();
+    m_isShielded = _tx->IsShieldedTx();
 
     nCountWithDescendants = 1;
     nSizeWithDescendants = nTxSize;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -498,7 +498,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState &state, const C
             }
         }
 
-        if (!tx.hasSaplingData()) { // Sapling fee could be higher. Review it properly
+        if (!tx.IsShieldedTx()) { // Sapling fee could be higher. Review it properly
             if (fRejectAbsurdFee && nFees > ::minRelayTxFee.GetFee(nSize) * 10000) {
                 return state.Invalid(false,
                                      REJECT_HIGHFEE, "absurdly-high-fee",
@@ -2526,7 +2526,7 @@ bool ReceivedBlockTransactions(const CBlock& block, CValidationState& state, CBl
     // Sapling
     CAmount saplingValue = 0;
     for (const auto& tx : block.vtx) {
-        if (tx->isSapling() && tx->hasSaplingData()) {
+        if (tx->IsShieldedTx()) {
             // Negative valueBalance "takes" money from the transparent value pool
             // and adds it to the Sapling value pool. Positive valueBalance "gives"
             // money to the transparent value pool, removing from the Sapling value

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -336,7 +336,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState &state, const C
 
     // Rather not work on nonstandard transactions (unless regtest)
     std::string reason;
-    if (!Params().IsRegTestNet() && !IsStandardTx(tx, reason))
+    if (!Params().IsRegTestNet() && !IsStandardTx(tx, nextBlockHeight, reason))
         return state.DoS(0, false, REJECT_NONSTANDARD, reason);
     // is it already in the memory pool?
     uint256 hash = tx.GetHash();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -334,9 +334,9 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState &state, const C
     if (!CheckFinalTx(tx, STANDARD_LOCKTIME_VERIFY_FLAGS))
         return state.DoS(0, false, REJECT_NONSTANDARD, "non-final");
 
-    // Rather not work on nonstandard transactions (unless regtest)
+    // Rather not work on nonstandard transactions
     std::string reason;
-    if (!Params().IsRegTestNet() && !IsStandardTx(tx, nextBlockHeight, reason))
+    if (!IsStandardTx(tx, nextBlockHeight, reason))
         return state.DoS(0, false, REJECT_NONSTANDARD, reason);
     // is it already in the memory pool?
     uint256 hash = tx.GetHash();

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1311,7 +1311,7 @@ UniValue viewshieldedtransaction(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid or non-wallet transaction id");
     const CWalletTx& wtx = pwalletMain->mapWallet[hash];
 
-    if (!wtx.isSapling() || !wtx.hasSaplingData()) {
+    if (!wtx.IsShieldedTx()) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid transaction, no shielded data available");
     }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1311,7 +1311,7 @@ UniValue viewshieldedtransaction(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid or non-wallet transaction id");
     const CWalletTx& wtx = pwalletMain->mapWallet[hash];
 
-    if (wtx.nVersion < CTransaction::SAPLING_VERSION || !wtx.hasSaplingData()) {
+    if (!wtx.isSapling() || !wtx.hasSaplingData()) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid transaction, no shielded data available");
     }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1553,7 +1553,7 @@ UniValue shielded_sendmany(const JSONRPCRequest& request) {
 
     // Now check the transaction
     CMutableTransaction mtx;
-    mtx.nVersion = CTransaction::SAPLING_VERSION;
+    mtx.nVersion = CTransaction::TxVersion::SAPLING;
     unsigned int max_tx_size = MAX_TX_SIZE_AFTER_SAPLING;
 
     // As a sanity check, estimate and verify that the size of the transaction will be valid.

--- a/src/wallet/rpczpiv.cpp
+++ b/src/wallet/rpczpiv.cpp
@@ -386,7 +386,7 @@ UniValue DoZpivSpend(const CAmount nAmount, std::vector<CZerocoinMint>& vMintsSe
     //construct JSON to return
     UniValue ret(UniValue::VOBJ);
     ret.pushKV("txid", wtx.GetHash().ToString());
-    ret.pushKV("bytes", (int64_t)GetSerializeSize(wtx, SER_NETWORK, CTransaction::CURRENT_VERSION));
+    ret.pushKV("bytes", (int64_t)wtx.GetTotalSize());
     ret.pushKV("fee", ValueFromAmount(nValueIn - nValueOut));
     ret.pushKV("duration_millis", (GetTimeMillis() - nTimeStart));
     ret.pushKV("spends", arrSpends);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -483,7 +483,7 @@ void CWallet::SetBestChainInternal(CWalletDB& walletdb, const CBlockLocator& loc
         // transactions in which we only have transparent addresses involved.
         if (!wtx.mapSaplingNoteData.empty()) {
             // Sanity check
-            if (wtx.nVersion < CTransaction::SAPLING_VERSION) {
+            if (!wtx.isSapling()) {
                 LogPrintf("SetBestChain(): ERROR, Invalid tx version found with sapling data\n");
                 walletdb.TxnAbort();
                 uiInterface.ThreadSafeMessageBox(

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1211,7 +1211,7 @@ void CWallet::MarkAffectedTransactionsDirty(const CTransaction& tx)
     }
 
     // Sapling
-    if (HasSaplingSPKM() && tx.isSapling() && tx.hasSaplingData()) {
+    if (HasSaplingSPKM() && tx.IsShieldedTx()) {
         for (const SpendDescription &spend : tx.sapData->vShieldedSpend) {
             uint256 nullifier = spend.nullifier;
             if (m_sspk_man->mapSaplingNullifiersToNotes.count(nullifier) &&
@@ -4346,7 +4346,7 @@ bool CWallet::IsFromMe(const CTransaction& tx) const
         return true;
     }
 
-    if (tx.hasSaplingData()) {
+    if (tx.IsShieldedTx()) {
         for (const SpendDescription& spend : tx.sapData->vShieldedSpend) {
             if (m_sspk_man->IsSaplingNullifierFromMe(spend.nullifier)) {
                 return true;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -483,7 +483,7 @@ void CWallet::SetBestChainInternal(CWalletDB& walletdb, const CBlockLocator& loc
         // transactions in which we only have transparent addresses involved.
         if (!wtx.mapSaplingNoteData.empty()) {
             // Sanity check
-            if (!wtx.isSapling()) {
+            if (!wtx.isSaplingVersion()) {
                 LogPrintf("SetBestChain(): ERROR, Invalid tx version found with sapling data\n");
                 walletdb.TxnAbort();
                 uiInterface.ThreadSafeMessageBox(

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1012,7 +1012,7 @@ public:
         READWRITE(fFromMe);
         READWRITE(fSpent);
 
-        if (this->isSapling()) {
+        if (this->isSaplingVersion()) {
             READWRITE(mapSaplingNoteData);
         }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1012,7 +1012,7 @@ public:
         READWRITE(fFromMe);
         READWRITE(fSpent);
 
-        if (this->nVersion >= CTransaction::SAPLING_VERSION) {
+        if (this->isSapling()) {
             READWRITE(mapSaplingNoteData);
         }
 


### PR DESCRIPTION
Uniform the definition of `isSapling` transaction, which originally was meant only for txes with version equal to 2, and it was later changed to include also txes with version greater than 2 (but not updated everywhere).

Add a `IsShieldedTx` utility function defining "shielded tx" any transaction with isSapling version and with non-empty sapData.

Use `GetTotalSize` to get the serialized size of a transaction (instead of calling GetSerializeSize with `CTransaction::CURRENT_VERSION`).

Remove the possibility of having non-standard txes due to their version, after v5 enforcement.
Transactions with invalid version are now directly rejected in CheckTransaction.

Re-enables the IsStandardTx check on regtest.