### PR TITLE
[BUG] Fix transaction size limits for sapling version

### DIFF
--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -75,8 +75,8 @@ bool CheckTransaction(const CTransaction& tx, bool fZerocoinActive, bool fReject
     }
 
     // Size limits
-    BOOST_STATIC_ASSERT(MAX_BLOCK_SIZE_CURRENT >= MAX_TX_SIZE_AFTER_SAPLING);   // sanity
-    BOOST_STATIC_ASSERT(MAX_TX_SIZE_AFTER_SAPLING > MAX_ZEROCOIN_TX_SIZE);      // sanity
+    static_assert(MAX_BLOCK_SIZE_CURRENT >= MAX_TX_SIZE_AFTER_SAPLING, "Max block size must be bigger than max TX size");    // sanity
+    static_assert(MAX_TX_SIZE_AFTER_SAPLING > MAX_ZEROCOIN_TX_SIZE, "New max TX size must be bigger than old max TX size");  // sanity
     const unsigned int nMaxSize = tx.IsShieldedTx() ? MAX_TX_SIZE_AFTER_SAPLING : MAX_ZEROCOIN_TX_SIZE;
     if (tx.GetTotalSize() > nMaxSize) {
         return state.DoS(10, false, REJECT_INVALID, "bad-txns-oversize");

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -74,17 +74,19 @@ bool CheckTransaction(const CTransaction& tx, bool fZerocoinActive, bool fReject
                     REJECT_INVALID, "bad-tx-version-too-high");
     }
 
+    // Size limits
+    BOOST_STATIC_ASSERT(MAX_BLOCK_SIZE_CURRENT >= MAX_TX_SIZE_AFTER_SAPLING);   // sanity
+    BOOST_STATIC_ASSERT(MAX_TX_SIZE_AFTER_SAPLING > MAX_ZEROCOIN_TX_SIZE);      // sanity
+    const unsigned int nMaxSize = tx.IsShieldedTx() ? MAX_TX_SIZE_AFTER_SAPLING : MAX_ZEROCOIN_TX_SIZE;
+    if (tx.GetTotalSize() > nMaxSize) {
+        return state.DoS(10, false, REJECT_INVALID, "bad-txns-oversize");
+    }
+
     // Dispatch to Sapling validator
     CAmount nValueOut = 0;
     if (!SaplingValidation::CheckTransaction(tx, state, nValueOut, fSaplingActive)) {
         return false;
     }
-
-    // Size limits
-    unsigned int nMaxSize = MAX_ZEROCOIN_TX_SIZE;
-
-    if (::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION) > nMaxSize)
-        return state.DoS(100, false, REJECT_INVALID, "bad-txns-oversize");
 
     // Check for negative or overflow output values
     const Consensus::Params& consensus = Params().GetConsensus();

--- a/src/sapling/sapling_validation.cpp
+++ b/src/sapling/sapling_validation.cpp
@@ -57,13 +57,6 @@ bool CheckTransactionWithoutProofVerification(const CTransaction& tx, CValidatio
     // If the tx got to this point, must be +v2.
     assert(tx.isSaplingVersion());
 
-    // Size limits
-    BOOST_STATIC_ASSERT(MAX_BLOCK_SIZE_CURRENT >= MAX_TX_SIZE_AFTER_SAPLING); // sanity
-    BOOST_STATIC_ASSERT(MAX_TX_SIZE_AFTER_SAPLING > MAX_ZEROCOIN_TX_SIZE); // sanity
-    if (::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION) > MAX_TX_SIZE_AFTER_SAPLING)
-        return state.DoS(100, error("%s: size limits failed", __func__ ),
-                         REJECT_INVALID, "bad-txns-oversize");
-
     // Check for non-zero valueBalance when there are no Sapling inputs or outputs
     if (tx.sapData->vShieldedSpend.empty() && tx.sapData->vShieldedOutput.empty() && tx.sapData->valueBalance != 0) {
         return state.DoS(100, error("%s: tx.sapData->valueBalance has no sources or sinks", __func__ ),
@@ -157,14 +150,6 @@ bool ContextualCheckTransaction(
                 error("%s: Sapling version too low", __func__ ),
                 REJECT_INVALID, "bad-tx-sapling-version-too-low");
     }
-
-    // Size limits
-    BOOST_STATIC_ASSERT(MAX_BLOCK_SIZE_CURRENT > MAX_TX_SIZE_AFTER_SAPLING); // sanity
-    if (::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION) > MAX_TX_SIZE_AFTER_SAPLING)
-        return state.DoS(
-                dosLevelPotentiallyRelaxing,
-                error("%s: size limits failed", __func__ ),
-                REJECT_INVALID, "bad-txns-oversize");
 
     bool hasShieldedData = tx.hasSaplingData();
     // A coinbase/coinstake transaction cannot have output descriptions nor shielded spends

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -155,9 +155,9 @@ class EstimateFeeTest(PivxTestFramework):
         But first we need to use one node to create a lot of outputs
         which we will use to generate our transactions.
         """
-        self.add_nodes(3, extra_args=[[],
-                                      ["-blockmaxsize=18000"],
-                                      ["-blockmaxsize=9000"]])
+        self.add_nodes(3, extra_args=[["-minrelaytxfee=0.000001"],
+                                      ["-minrelaytxfee=0.000001", "-blockmaxsize=18000"],
+                                      ["-minrelaytxfee=0.000001", "-blockmaxsize=9000"]])
         # Use node0 to mine blocks for input splitting
         # Node1 mines small blocks but that are bigger than the expected transaction rate.
         # NOTE: the CreateNewBlock code starts counting block size at 1,000 bytes,


### PR DESCRIPTION
The size limits for a sapling transaction are currently checked in 3 places:
1- `CheckTransaction` (validation.cpp)
2- `CheckTransactionWithoutProofVerification` (called by `SaplingValidation::CheckTransaction`)
3- `SaplingValidation::ContextualCheckTransaction`

While in (2) and (3) the size is correctly checked against `MAX_TX_SIZE_AFTER_SAPLING`, in (1) it is checked against the old `MAX_ZEROCOIN_TX_SIZE`. 
So a shielded transaction with size greater than `MAX_ZEROCOIN_TX_SIZE` would be wrongly rejected in `CheckTransaction`.

Fix the check in (1), selecting the correct max size for shielded/non-shielded transactions.
Move the size-check before calling SaplingValidation::CheckTransaction (as it's faster).
Remove the checks in (2) and (3) that are just redundant.

Based on top of:
- [x] #1955 
