### PR TITLE
[Validation] Sapling nullifiers mempool connection

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -898,6 +898,11 @@ bool CCoinsViewMemPool::HaveCoin(const COutPoint& outpoint) const
     return mempool.exists(outpoint) || base->HaveCoin(outpoint);
 }
 
+bool CCoinsViewMemPool::GetNullifier(const uint256& nullifier) const
+{
+    return mempool.nullifierExists(nullifier) || base->GetNullifier(nullifier);
+}
+
 size_t CTxMemPool::DynamicMemoryUsage() const
 {
     LOCK(cs);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -818,6 +818,12 @@ void CTxMemPool::ClearPrioritisation(const uint256 hash)
     mapDeltas.erase(hash);
 }
 
+bool CTxMemPool::nullifierExists(const uint256& nullifier) const
+{
+    LOCK(cs);
+    return mapSaplingNullifiers.count(nullifier);
+}
+
 bool CTxMemPool::HasNoInputsOf(const CTransaction &tx) const
 {
     if (tx.HasZerocoinSpendInputs())
@@ -856,8 +862,14 @@ bool CCoinsViewMemPool::HaveCoin(const COutPoint& outpoint) const
 size_t CTxMemPool::DynamicMemoryUsage() const
 {
     LOCK(cs);
-    // Estimate the overhead of mapTx to be 12 pointers + an allocation, as no exact formula for boost::multi_index_contained is implemented.
-    return memusage::MallocUsage(sizeof(CTxMemPoolEntry) + 12 * sizeof(void*)) * mapTx.size() + memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(mapDeltas) + memusage::DynamicUsage(mapLinks) + cachedInnerUsage;
+    // Estimate the overhead of mapTx to be 12 pointers + an allocation, as no exact formula for
+    // boost::multi_index_contained is implemented.
+    return memusage::MallocUsage(sizeof(CTxMemPoolEntry) + 12 * sizeof(void*)) * mapTx.size() +
+            memusage::DynamicUsage(mapNextTx) +
+            memusage::DynamicUsage(mapDeltas) +
+            memusage::DynamicUsage(mapLinks) +
+            cachedInnerUsage +
+            memusage::DynamicUsage(mapSaplingNullifiers);
 }
 
 void CTxMemPool::RemoveStaged(setEntries &stage)

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -407,7 +407,7 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry,
     // Save spent nullifiers
     if (tx.IsShieldedTx()) {
         for (const SpendDescription& sd : tx.sapData->vShieldedSpend) {
-            mapSaplingNullifiers[sd.nullifier] = &tx;
+            mapSaplingNullifiers[sd.nullifier] = newit->GetSharedTx();
         }
     }
 
@@ -550,7 +550,7 @@ void CTxMemPool::removeWithAnchor(const uint256& invalidRoot)
         if (!tx.IsShieldedTx()) continue;
         for (const auto& sd : tx.sapData->vShieldedSpend) {
             if (sd.anchor == invalidRoot) {
-                transactionsToRemove.push_back(tx);
+                transactionsToRemove.emplace_back(tx);
                 break;
             }
         }
@@ -773,8 +773,8 @@ void CTxMemPool::checkNullifiers() const
         const uint256& hash = it.second->GetHash();
         const auto& findTx = mapTx.find(hash);
         assert(findTx != mapTx.end());
-        const CTransaction& tx = findTx->GetTx();
-        assert(&tx == it.second);
+        const CTransactionRef& tx = findTx->GetSharedTx();
+        assert(*tx == *it.second);
     }
 }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -550,6 +550,18 @@ void CTxMemPool::removeConflicts(const CTransaction& tx, std::list<CTransactionR
             }
         }
     }
+    // Remove txes with conflicting nullifier
+    if (tx.IsShieldedTx()) {
+        for (const SpendDescription& sd : tx.sapData->vShieldedSpend) {
+            const auto& it = mapSaplingNullifiers.find(sd.nullifier);
+            if (it != mapSaplingNullifiers.end()) {
+                const CTransaction& txConflict = *it->second;
+                if (txConflict != tx) {
+                    remove(txConflict, removed, true);
+                }
+            }
+        }
+    }
 }
 
 /**

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -727,8 +727,22 @@ void CTxMemPool::check(const CCoinsViewCache* pcoins) const
         assert(it->first == it->second.ptx->vin[it->second.n].prevout);
     }
 
+    // Consistency check for sapling nullifiers
+    checkNullifiers();
+
     assert(totalTxSize == checkTotal);
     assert(innerUsage == cachedInnerUsage);
+}
+
+void CTxMemPool::checkNullifiers() const
+{
+    for (const auto& it : mapSaplingNullifiers) {
+        const uint256& hash = it.second->GetHash();
+        const auto& findTx = mapTx.find(hash);
+        assert(findTx != mapTx.end());
+        const CTransaction& tx = findTx->GetTx();
+        assert(&tx == it.second);
+    }
 }
 
 void CTxMemPool::queryHashes(std::vector<uint256>& vtxid)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -364,7 +364,7 @@ private:
     void trackPackageRemoved(const CFeeRate& rate);
 
     // Shielded txes
-    std::map<uint256, const CTransaction*> mapSaplingNullifiers;
+    std::map<uint256, CTransactionRef> mapSaplingNullifiers;
     void checkNullifiers() const;
 
 public:

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -479,6 +479,7 @@ public:
     bool addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry, setEntries &setAncestors, bool fCurrentEstimate = true);
     void remove(const CTransaction& tx, std::list<CTransactionRef>& removed, bool fRecursive = false);
     void removeForReorg(const CCoinsViewCache* pcoins, unsigned int nMemPoolHeight, int flags);
+    void removeWithAnchor(const uint256& invalidRoot);
     void removeConflicts(const CTransaction& tx, std::list<CTransactionRef>& removed);
     void removeForBlock(const std::vector<CTransactionRef>& vtx, unsigned int nBlockHeight, std::list<CTransactionRef>& conflicts, bool fCurrentEstimate = true);
     void clear();

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -365,6 +365,7 @@ private:
 
     // Shielded txes
     std::map<uint256, const CTransaction*> mapSaplingNullifiers;
+    void checkNullifiers() const;
 
 public:
 
@@ -469,7 +470,6 @@ public:
      */
     void check(const CCoinsViewCache *pcoins) const;
     void setSanityCheck(double dFrequency = 1.0) { nCheckFrequency = dFrequency * 4294967295.0; }
-    void checkNullifiers() const;
 
     // addUnchecked must updated state for all ancestors of a given transaction,
     // to track size/count of descendant transactions.  First version of

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -363,6 +363,9 @@ private:
 
     void trackPackageRemoved(const CFeeRate& rate);
 
+    // Shielded txes
+    std::map<uint256, const CTransaction*> mapSaplingNullifiers;
+
 public:
 
     static const int ROLLING_FEE_HALFLIFE = 60 * 60 * 12; // public only for testing
@@ -494,6 +497,8 @@ public:
     void PrioritiseTransaction(const uint256 hash, const std::string strHash, double dPriorityDelta, const CAmount& nFeeDelta);
     void ApplyDeltas(const uint256 hash, double& dPriorityDelta, CAmount& nFeeDelta) const;
     void ClearPrioritisation(const uint256 hash);
+
+    bool nullifierExists(const uint256& nullifier) const;
 
     /** Remove a set of transactions from the mempool.
      *  If a transaction is in this set, then all in-mempool descendants must

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -652,6 +652,7 @@ public:
     CCoinsViewMemPool(CCoinsView* baseIn, CTxMemPool& mempoolIn);
     bool GetCoin(const COutPoint& outpoint, Coin& coin) const;
     bool HaveCoin(const COutPoint& outpoint) const;
+    bool GetNullifier(const uint256& nullifier) const;
 };
 
 // We want to sort transactions by coin age priority

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -469,6 +469,7 @@ public:
      */
     void check(const CCoinsViewCache *pcoins) const;
     void setSanityCheck(double dFrequency = 1.0) { nCheckFrequency = dFrequency * 4294967295.0; }
+    void checkNullifiers() const;
 
     // addUnchecked must updated state for all ancestors of a given transaction,
     // to track size/count of descendant transactions.  First version of


### PR DESCRIPTION
Keep track of nullifiers of notes spent by mempool transactions (preventing in-mempool double spends).
Add consistency checks with coins view nullifiers.

Also, if the sapling anchor changes after a disconnection, we must evict from mempool any transaction that spends from the now-invalid root.

Built on top of:
- [x] #1955 