### PR TITLE
[Wallet] fix GetShieldedChange, tx isSapling renamed to isSaplingVersion

### DIFF
--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -582,7 +582,7 @@ CAmount SaplingScriptPubKeyMan::GetDebit(const CTransaction& tx, const isminefil
 
 CAmount SaplingScriptPubKeyMan::GetShieldedChange(const CWalletTx& wtx)
 {
-    if (!wtx.isSapling() || wtx.sapData->vShieldedOutput.empty()) {
+    if (!wtx.isSaplingVersion() || wtx.sapData->vShieldedOutput.empty()) {
         return 0;
     }
     const uint256& txHash = wtx.GetHash();


### PR DESCRIPTION
Small and quick fix, master is currently not compiling due #1955 and #1952 getting merged without being based one on the other. the first PR renamed the tx `isSapling` method to `isSaplingVersion` and in the second PR, a new function was implemented `GetShieldedChange` that was using using `isSapling`. 