### PR TITLE
Sapling operation new spend from several different sources feature + send/build decoupling.

### DIFF
--- a/src/sapling/address.hpp
+++ b/src/sapling/address.hpp
@@ -193,6 +193,7 @@ public:
     }
 
     SaplingFullViewingKey full_viewing_key() const;
+    bool IsNull() { return ask.IsNull() && nsk.IsNull() && ovk.IsNull(); }
 
     friend inline bool operator==(const SaplingExpandedSpendingKey& a, const SaplingExpandedSpendingKey& b) {
         return a.ask == b.ask && a.nsk == b.nsk && a.ovk == b.ovk;

--- a/src/sapling/key_io_sapling.cpp
+++ b/src/sapling/key_io_sapling.cpp
@@ -146,6 +146,13 @@ namespace KeyIO {
         return libzcash::InvalidEncoding();
     }
 
+    Optional<libzcash::SaplingPaymentAddress> DecodeSaplingPaymentAddress(const std::string& strAddress)
+    {
+        libzcash::PaymentAddress addr = KeyIO::DecodePaymentAddress(strAddress);
+        const auto dest = boost::get<libzcash::SaplingPaymentAddress>(&addr);
+        return (dest) ? Optional<libzcash::SaplingPaymentAddress>(*dest) : nullopt;
+    }
+
     bool IsValidPaymentAddressString(const std::string& str) {
         return IsValidPaymentAddress(DecodePaymentAddress(str));
     }

--- a/src/sapling/key_io_sapling.h
+++ b/src/sapling/key_io_sapling.h
@@ -13,6 +13,7 @@ namespace KeyIO {
 
     std::string EncodePaymentAddress(const libzcash::PaymentAddress& zaddr);
     libzcash::PaymentAddress DecodePaymentAddress(const std::string& str);
+    Optional<libzcash::SaplingPaymentAddress> DecodeSaplingPaymentAddress(const std::string& str);
     bool IsValidPaymentAddressString(const std::string& str);
 
     std::string EncodeViewingKey(const libzcash::ViewingKey& vk);

--- a/src/sapling/sapling_operation.cpp
+++ b/src/sapling/sapling_operation.cpp
@@ -35,7 +35,7 @@ OperationResult SaplingOperation::checkTxValues(TxValues& txValues, bool isFromt
     return OperationResult(true);
 }
 
-OperationResult SaplingOperation::send(std::string& retTxHash)
+OperationResult SaplingOperation::build()
 {
 
     bool isFromtAddress = fromAddress.isFromTAddress();
@@ -139,7 +139,11 @@ OperationResult SaplingOperation::send(std::string& retTxHash)
     // Build the transaction
     txBuilder.SetFee(fee);
     finalTx = txBuilder.Build().GetTxOrThrow();
+    return OperationResult(true);
+}
 
+OperationResult SaplingOperation::send(std::string& retTxHash)
+{
     if (!testMode) {
         CWalletTx wtx(pwalletMain, finalTx);
         const CWallet::CommitResult& res = pwalletMain->CommitTransaction(wtx, tkeyChange, g_connman.get());
@@ -150,6 +154,12 @@ OperationResult SaplingOperation::send(std::string& retTxHash)
 
     retTxHash = finalTx.GetHash().ToString();
     return OperationResult(true);
+}
+
+OperationResult SaplingOperation::buildAndSend(std::string& retTxHash)
+{
+    OperationResult res = build();
+    return (res) ? send(retTxHash) : res;
 }
 
 void SaplingOperation::setFromAddress(const CTxDestination& _dest)

--- a/src/sapling/sapling_operation.cpp
+++ b/src/sapling/sapling_operation.cpp
@@ -138,7 +138,15 @@ OperationResult SaplingOperation::build()
 
     // Build the transaction
     txBuilder.SetFee(fee);
-    finalTx = txBuilder.Build().GetTxOrThrow();
+    TransactionBuilderResult txResult = txBuilder.Build();
+    auto opTx = txResult.GetTx();
+
+    // Check existent tx
+    if (!opTx) {
+        return errorOut("Failed to build transaction: " + txResult.GetError());
+    }
+
+    finalTx = *opTx;
     return OperationResult(true);
 }
 

--- a/src/sapling/sapling_operation.cpp
+++ b/src/sapling/sapling_operation.cpp
@@ -38,7 +38,7 @@ OperationResult SaplingOperation::checkTxValues(TxValues& txValues, bool isFromt
 OperationResult SaplingOperation::build()
 {
 
-    bool isFromtAddress = fromAddress.isFromTAddress();
+    bool isFromtAddress = fromAddress.isFromTAddress() || selectFromtaddrs;
     bool isFromShielded = fromAddress.isFromSapAddress();
 
     // It needs to have a from (for now at least)
@@ -175,7 +175,7 @@ void SaplingOperation::setFromAddress(const libzcash::SaplingPaymentAddress& _pa
 OperationResult SaplingOperation::loadUtxos(TxValues& txValues)
 {
     std::set<CTxDestination> destinations;
-    destinations.insert(fromAddress.fromTaddr);
+    if (fromAddress.isFromTAddress()) destinations.insert(fromAddress.fromTaddr);
     if (!pwalletMain->AvailableCoins(
             &transInputs,
             nullptr,

--- a/src/sapling/sapling_operation.cpp
+++ b/src/sapling/sapling_operation.cpp
@@ -35,15 +35,56 @@ OperationResult SaplingOperation::checkTxValues(TxValues& txValues, bool isFromt
     return OperationResult(true);
 }
 
+OperationResult loadKeysFromShieldedFrom(const libzcash::SaplingPaymentAddress &addr,
+                                         libzcash::SaplingExpandedSpendingKey& expskOut,
+                                         uint256& ovkOut)
+{
+    // Get spending key for address
+    libzcash::SaplingExtendedSpendingKey sk;
+    if (!pwalletMain->GetSaplingExtendedSpendingKey(addr, sk)) {
+        return errorOut("Spending key not in the wallet");
+    }
+    expskOut = sk.expsk;
+    ovkOut = expskOut.full_viewing_key().ovk;
+    return OperationResult(true);
+}
+
+TxValues calculateTarget(std::vector<SendManyRecipient>& taddrRecipients,
+                         std::vector<SendManyRecipient>& shieldedAddrRecipients,
+                         CAmount fee)
+{
+    TxValues txValues;
+    for (SendManyRecipient &t : taddrRecipients) {
+        txValues.transOutTotal += t.amount;
+    }
+
+    // Add shielded outputs
+    for (const SendManyRecipient &t : shieldedAddrRecipients) {
+        txValues.shieldedOutTotal += t.amount;
+    }
+    txValues.target = txValues.shieldedOutTotal + txValues.transOutTotal + fee;
+    return txValues;
+}
+
 OperationResult SaplingOperation::build()
 {
 
-    bool isFromtAddress = fromAddress.isFromTAddress() || selectFromtaddrs;
+    bool isFromtAddress = fromAddress.isFromTAddress();
     bool isFromShielded = fromAddress.isFromSapAddress();
 
-    // It needs to have a from (for now at least)
     if (!isFromtAddress && !isFromShielded) {
-        return errorOut("From address parameter missing");
+        isFromtAddress = selectFromtaddrs;
+        isFromShielded = selectFromShield;
+
+        // It needs to have a from.
+        if (!isFromtAddress && !isFromShielded) {
+            return errorOut("From address parameter missing");
+        }
+
+        // Cannot be from both
+        if (isFromtAddress && isFromShielded) {
+            return errorOut("From address type cannot be shielded and transparent");
+        }
     }
 
     if (taddrRecipients.empty() && shieldedAddrRecipients.empty()) {
@@ -54,17 +95,25 @@ OperationResult SaplingOperation::build()
         return errorOut("Minconf cannot be zero when sending from shielded address");
     }
 
-    // Get necessary keys
+    // First calculate target values
+    TxValues txValues = calculateTarget(taddrRecipients, shieldedAddrRecipients, fee);
+    OperationResult result(false);
+    // Necessary keys
     libzcash::SaplingExpandedSpendingKey expsk;
     uint256 ovk;
     if (isFromShielded) {
-        // Get spending key for address
-        libzcash::SaplingExtendedSpendingKey sk;
-        if (!pwalletMain->GetSaplingExtendedSpendingKey(fromAddress.fromSapAddr.get(), sk)) {
-            return errorOut("Spending key not in the wallet");
+        // Try to get the sk and ovk if we know the address from, if we don't know it then this will be loaded in loadUnspentNotes
+        // using the sk of the first note input of the transaction.
+        if (fromAddress.isFromSapAddress()) {
+            // Get spending key for address
+            auto loadKeyRes = loadKeysFromShieldedFrom(fromAddress.fromSapAddr.get(), expsk, ovk);
+            if (!loadKeyRes) return loadKeyRes;
         }
-        expsk = sk.expsk;
-        ovk = expsk.full_viewing_key().ovk;
+
+        // Load and select notes to spend
+        if (!(result = loadUnspentNotes(txValues, expsk, ovk))) {
+            return result;
+        }
     } else {
         // Sending from a t-address, which we don't have an ovk for. Instead,
         // generate a common one from the HD seed. This ensures the data is
@@ -73,17 +122,13 @@ OperationResult SaplingOperation::build()
         ovk = pwalletMain->GetSaplingScriptPubKeyMan()->getCommonOVKFromSeed();
     }
 
-    // Results
-    TxValues txValues;
     // Add transparent outputs
     for (SendManyRecipient &t : taddrRecipients) {
-        txValues.transOutTotal += t.amount;
         txBuilder.AddTransparentOutput(DecodeDestination(t.address), t.amount);
     }
 
     // Add shielded outputs
     for (const SendManyRecipient &t : shieldedAddrRecipients) {
-        txValues.shieldedOutTotal += t.amount;
         auto addr = KeyIO::DecodePaymentAddress(t.address);
         assert(IsValidPaymentAddress(addr));
         auto to = boost::get<libzcash::SaplingPaymentAddress>(addr);
@@ -94,23 +139,11 @@ OperationResult SaplingOperation::build()
         txBuilder.AddSaplingOutput(ovk, to, t.amount, memo);
     }
 
-    // Load total
-    txValues.target = txValues.shieldedOutTotal + txValues.transOutTotal + fee;
-    OperationResult result(false);
-
     // If from address is a taddr, select UTXOs to spend
     // note: when spending coinbase utxos, you can only specify a single shielded addr as the change must go somewhere
     // and if there are multiple shielded addrs, we don't know where to send it.
     if (isFromtAddress && !(result = loadUtxos(txValues))) {
         return result;
-    }
-
-    // If from a shielded addr, select notes to spend
-    if (isFromShielded) {
-        // Load notes
-        if (!(result = loadUnspentNotes(txValues, expsk))) {
-            return result;
-        }
     }
 
     const auto& retCalc = checkTxValues(txValues, isFromtAddress, isFromShielded);
@@ -245,11 +278,12 @@ OperationResult SaplingOperation::loadUtxos(TxValues& txValues)
     return OperationResult(true);
 }
 
-OperationResult SaplingOperation::loadUnspentNotes(TxValues& txValues, const libzcash::SaplingExpandedSpendingKey& expsk)
+OperationResult SaplingOperation::loadUnspentNotes(TxValues& txValues,
+                                                   libzcash::SaplingExpandedSpendingKey& expsk,
+                                                   uint256& ovk)
 {
     std::vector<SaplingNoteEntry> saplingEntries;
-    libzcash::PaymentAddress paymentAddress(fromAddress.fromSapAddr.get());
-    pwalletMain->GetSaplingScriptPubKeyMan()->GetFilteredNotes(saplingEntries, paymentAddress, mindepth);
+    pwalletMain->GetSaplingScriptPubKeyMan()->GetFilteredNotes(saplingEntries, fromAddress.fromSapAddr, mindepth);
 
     for (const auto& entry : saplingEntries) {
         shieldedInputs.emplace_back(entry);
@@ -277,6 +311,11 @@ OperationResult SaplingOperation::loadUnspentNotes(TxValues& txValues, const lib
     std::vector<libzcash::SaplingNote> notes;
     CAmount sum = 0;
     for (const auto& t : shieldedInputs) {
+        // if null, load the first input sk
+        if (expsk.IsNull()) {
+            auto resLoadKeys = loadKeysFromShieldedFrom(t.address, expsk, ovk);
+            if (!resLoadKeys) return resLoadKeys;
+        }
         ops.emplace_back(t.op);
         notes.emplace_back(t.note);
         sum += t.note.value();

--- a/src/sapling/sapling_operation.h
+++ b/src/sapling/sapling_operation.h
@@ -41,6 +41,8 @@ public:
     explicit SaplingOperation(const Consensus::Params& consensusParams, int chainHeight) : txBuilder(consensusParams, chainHeight) {};
     explicit SaplingOperation(TransactionBuilder& _builder) : txBuilder(_builder) {};
 
+    ~SaplingOperation() { delete tkeyChange; }
+
     OperationResult send(std::string& retTxHash);
 
     void setFromAddress(const CTxDestination&);
@@ -50,6 +52,7 @@ public:
     SaplingOperation* setFee(CAmount _fee) { fee = _fee; return this; }
     SaplingOperation* setMinDepth(int _mindepth) { assert(_mindepth >= 0); mindepth = _mindepth; return this; }
     SaplingOperation* setTxBuilder(TransactionBuilder& builder) { txBuilder = builder; return this; }
+    SaplingOperation* setTransparentKeyChange(CReserveKey* reserveKey) { tkeyChange = reserveKey; return this; }
 
     CTransaction getFinalTx() { return finalTx; }
 
@@ -66,7 +69,10 @@ private:
     std::vector<COutput> transInputs;
     std::vector<SaplingNoteEntry> shieldedInputs;
     int mindepth{5}; // Min default depth 5.
-    CAmount fee{0};
+    CAmount fee{DEFAULT_SAPLING_FEE}; // Hardcoded fee for now.
+
+    // transparent change
+    CReserveKey* tkeyChange{nullptr};
 
     // Builder
     TransactionBuilder txBuilder;

--- a/src/sapling/sapling_operation.h
+++ b/src/sapling/sapling_operation.h
@@ -49,6 +49,8 @@ public:
 
     void setFromAddress(const CTxDestination&);
     void setFromAddress(const libzcash::SaplingPaymentAddress&);
+    // In case of no addressFrom filter selected, it will accept any utxo in the wallet as input.
+    SaplingOperation* setSelectTransparentCoins(const bool select) { selectFromtaddrs = select; return this; };
     SaplingOperation* setTransparentRecipients(std::vector<SendManyRecipient>& vec) { taddrRecipients = std::move(vec); return this; };
     SaplingOperation* setShieldedRecipients(std::vector<SendManyRecipient>& vec) { shieldedAddrRecipients = std::move(vec); return this; } ;
     SaplingOperation* setFee(CAmount _fee) { fee = _fee; return this; }
@@ -66,6 +68,8 @@ public:
 
 private:
     FromAddress fromAddress;
+    // In case of no addressFrom filter selected, it will accept any utxo in the wallet as input.
+    bool selectFromtaddrs{false};
     std::vector<SendManyRecipient> taddrRecipients;
     std::vector<SendManyRecipient> shieldedAddrRecipients;
     std::vector<COutput> transInputs;

--- a/src/sapling/sapling_operation.h
+++ b/src/sapling/sapling_operation.h
@@ -51,6 +51,7 @@ public:
     void setFromAddress(const libzcash::SaplingPaymentAddress&);
     // In case of no addressFrom filter selected, it will accept any utxo in the wallet as input.
     SaplingOperation* setSelectTransparentCoins(const bool select) { selectFromtaddrs = select; return this; };
+    SaplingOperation* setSelectShieldedCoins(const bool select) { selectFromShield = select; return this; };
     SaplingOperation* setTransparentRecipients(std::vector<SendManyRecipient>& vec) { taddrRecipients = std::move(vec); return this; };
     SaplingOperation* setShieldedRecipients(std::vector<SendManyRecipient>& vec) { shieldedAddrRecipients = std::move(vec); return this; } ;
     SaplingOperation* setFee(CAmount _fee) { fee = _fee; return this; }
@@ -70,6 +71,7 @@ private:
     FromAddress fromAddress;
     // In case of no addressFrom filter selected, it will accept any utxo in the wallet as input.
     bool selectFromtaddrs{false};
+    bool selectFromShield{false};
     std::vector<SendManyRecipient> taddrRecipients;
     std::vector<SendManyRecipient> shieldedAddrRecipients;
     std::vector<COutput> transInputs;
@@ -85,7 +87,9 @@ private:
     CTransaction finalTx;
 
     OperationResult loadUtxos(TxValues& values);
-    OperationResult loadUnspentNotes(TxValues& txValues, const libzcash::SaplingExpandedSpendingKey& expsk);
+    OperationResult loadUnspentNotes(TxValues& txValues,
+                                     libzcash::SaplingExpandedSpendingKey& expsk,
+                                     uint256& ovk);
     OperationResult checkTxValues(TxValues& txValues, bool isFromtAddress, bool isFromShielded);
 };
 

--- a/src/sapling/sapling_operation.h
+++ b/src/sapling/sapling_operation.h
@@ -43,7 +43,9 @@ public:
 
     ~SaplingOperation() { delete tkeyChange; }
 
+    OperationResult build();
     OperationResult send(std::string& retTxHash);
+    OperationResult buildAndSend(std::string& retTxHash);
 
     void setFromAddress(const CTxDestination&);
     void setFromAddress(const libzcash::SaplingPaymentAddress&);

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -379,15 +379,15 @@ std::vector<libzcash::SaplingPaymentAddress> SaplingScriptPubKeyMan::FindMySapli
  */
 void SaplingScriptPubKeyMan::GetFilteredNotes(
         std::vector<SaplingNoteEntry>& saplingEntries,
-        const libzcash::PaymentAddress& address,
+        Optional<libzcash::SaplingPaymentAddress>& address,
         int minDepth,
         bool ignoreSpent,
         bool requireSpendingKey)
 {
     std::set<libzcash::PaymentAddress> filterAddresses;
 
-    if (IsValidPaymentAddress(address)) {
-        filterAddresses.insert(address);
+    if (address && IsValidPaymentAddress(*address)) {
+        filterAddresses.insert(*address);
     }
 
     GetFilteredNotes(saplingEntries, filterAddresses, minDepth, INT_MAX, ignoreSpent, requireSpendingKey);

--- a/src/sapling/saplingscriptpubkeyman.h
+++ b/src/sapling/saplingscriptpubkeyman.h
@@ -235,7 +235,7 @@ public:
 
     /* Find notes filtered by payment address, min depth, ability to spend */
     void GetFilteredNotes(std::vector<SaplingNoteEntry>& saplingEntries,
-                          const libzcash::PaymentAddress& address,
+                          Optional<libzcash::SaplingPaymentAddress>& address,
                           int minDepth=1,
                           bool ignoreSpent=true,
                           bool requireSpendingKey=true);

--- a/src/test/librust/sapling_rpc_wallet_tests.cpp
+++ b/src/test/librust/sapling_rpc_wallet_tests.cpp
@@ -336,7 +336,7 @@ BOOST_AUTO_TEST_CASE(saplingOperationTests) {
         std::vector<SendManyRecipient> recipients = { SendManyRecipient(zaddr1,100.0, "DEADBEEF") };
         SaplingOperation operation(consensusParams, 1);
         operation.setFromAddress(DecodeDestination(taddr1));
-        auto res = operation.setShieldedRecipients(recipients)->send(ret);
+        auto res = operation.setShieldedRecipients(recipients)->buildAndSend(ret);
         BOOST_CHECK(!res);
         BOOST_CHECK(res.getError().find("Insufficient funds, no available UTXO to spend") != std::string::npos);
     }
@@ -346,7 +346,7 @@ BOOST_AUTO_TEST_CASE(saplingOperationTests) {
         std::vector<SendManyRecipient> recipients = { SendManyRecipient(zaddr1,100.0, "DEADBEEF") };
         SaplingOperation operation(consensusParams, 1);
         operation.setFromAddress(pa);
-        auto res = operation.setShieldedRecipients(recipients)->setMinDepth(0)->send(ret);
+        auto res = operation.setShieldedRecipients(recipients)->setMinDepth(0)->buildAndSend(ret);
         BOOST_CHECK(!res);
         BOOST_CHECK(res.getError().find("Minconf cannot be zero when sending from shielded address") != std::string::npos);
     }
@@ -356,7 +356,7 @@ BOOST_AUTO_TEST_CASE(saplingOperationTests) {
         std::vector<SendManyRecipient> recipients = { SendManyRecipient(taddr1,100.0, "DEADBEEF") };
         SaplingOperation operation(consensusParams, 1);
         operation.setFromAddress(pa);
-        auto res = operation.setTransparentRecipients(recipients)->send(ret);
+        auto res = operation.setTransparentRecipients(recipients)->buildAndSend(ret);
         BOOST_CHECK(!res);
         BOOST_CHECK(res.getError().find("Insufficient funds, no available notes to spend") != std::string::npos);
     }
@@ -464,7 +464,7 @@ BOOST_AUTO_TEST_CASE(rpc_shielded_sendmany_taddr_to_sapling)
     operation.testMode = true; // To not commit the transaction
     BOOST_CHECK(operation.setShieldedRecipients(recipients)
                         ->setMinDepth(0)
-                        ->send(txFinalHash));
+                        ->buildAndSend(txFinalHash));
 
     // Get the transaction
     // Test mode does not send the transaction to the network.

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1636,8 +1636,7 @@ UniValue shielded_sendmany(const JSONRPCRequest& request) {
             ->setMinDepth(nMinDepth)
             ->setShieldedRecipients(shieldAddrRecipients)
             ->setTransparentRecipients(taddrRecipients)
-            ->send(txHash);
-
+            ->buildAndSend(txHash);
     if (!res) throw JSONRPCError(RPC_WALLET_ERROR, res.getError());
     return txHash;
 }

--- a/src/wallet/test/wallet_shielded_balances_tests.cpp
+++ b/src/wallet/test/wallet_shielded_balances_tests.cpp
@@ -350,9 +350,9 @@ BOOST_AUTO_TEST_CASE(GetShieldedAvailableCredit)
 
     // 3) Now can spend one output and recalculate the shielded credit.
     std::vector<SaplingNoteEntry> saplingEntries;
-    libzcash::PaymentAddress paymentAddress(pa);
+    Optional<libzcash::SaplingPaymentAddress> opPa(pa);
     wallet.GetSaplingScriptPubKeyMan()->GetFilteredNotes(saplingEntries,
-                                                         paymentAddress,
+                                                         opPa,
                                                          0);
 
     std::vector<SaplingOutPoint> ops = {saplingEntries[0].op};

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3050,10 +3050,15 @@ std::string CWallet::CommitResult::ToString() const
     return strErrRet;
 }
 
+CWallet::CommitResult CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey& opReservekey, CConnman* connman)
+{
+    return CommitTransaction(wtxNew, &opReservekey, connman);
+}
+
 /**
  * Call after CreateTransaction unless you want to abort
  */
-CWallet::CommitResult CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey, CConnman* connman)
+CWallet::CommitResult CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey* opReservekey, CConnman* connman)
 {
     CommitResult res;
     {
@@ -3061,7 +3066,7 @@ CWallet::CommitResult CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey&
         LogPrintf("%s:\n%s", __func__, wtxNew.ToString());
         {
             // Take key pair from key pool so it won't be used again
-            reservekey.KeepKey();
+            if (opReservekey) opReservekey->KeepKey();
 
             // Add tx to wallet, because if it has change it's also ours,
             // otherwise just for transaction history.
@@ -3092,7 +3097,7 @@ CWallet::CommitResult CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey&
             if (AbandonTransaction(res.hashTx)) {
                 res.status = CWallet::CommitStatus::Abandoned;
                 // Return the change key
-                reservekey.ReturnKey();
+                if (opReservekey) opReservekey->ReturnKey();
             }
 
             LogPrintf("%s: ERROR: %s\n", __func__, res.ToString());

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -640,7 +640,8 @@ public:
         // converts CommitResult in human-readable format
         std::string ToString() const;
     };
-    CWallet::CommitResult CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey, CConnman* connman);
+    CWallet::CommitResult CommitTransaction(CWalletTx& wtxNew, CReserveKey& opReservekey, CConnman* connman);
+    CWallet::CommitResult CommitTransaction(CWalletTx& wtxNew, CReserveKey* reservekey, CConnman* connman);
     bool CreateCoinStake(const CKeyStore& keystore,
                          const CBlockIndex* pindexPrev,
                          unsigned int nBits,


### PR DESCRIPTION
Up until now, the sapling operation flow (shielded transaction building) only was allowing to create a transaction from a single address source (transparent or shielded). This means that the user needed to select from which address the wallet should take funds from to spend.

This PR introduces two main new features and several improvements over the sapling operation class.

Main features:
 (1) spending from several transparent sources and (2) spending from several shielded sources. Both selected by the operation process automatically, no user input needed.

Secondary improvements:
(1) making the change address key optional, (2) decoupling sapling operation build and send process (this is needed in order to be able to create the tx on the GUI and raw shielded txs using the command line).

Refactoring:
(1) `GetFilteredNotes` SaplingPaymentAddress argument moved to optional so it can be omitted in the shielded funds selection process.