### PR TITLE
[Bug] Updated stakeable coins in staker thread

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -468,6 +468,7 @@ public:
     /// Extract txin information and keys from output
     bool GetVinAndKeysFromOutput(COutput out, CTxIn& txinRet, CPubKey& pubKeyRet, CKey& keyRet, bool fColdStake = false);
 
+    bool IsSpent(const COutPoint& outpoint) const;
     bool IsSpent(const uint256& hash, unsigned int n) const;
 
     bool IsLockedCoin(const uint256& hash, unsigned int n) const;


### PR DESCRIPTION
Currently, during the staking thread, the list of available coins is updated every 5 minutes.
This can lead to two problems:
- If a coin is not included due to low confirmations number, when it matures, it cannot be staked immediately: it gets included only after the full 5 minutes.
- If a coin is spent, it is not removed immediately from the list. So, if a valid kernel is found with said coin, the following two things happen.
First, the newly created block fails `TestBlockValidity` (as it contains essentially a double spend) and gets discarded by the staker, who also clears his mempool (thus removing the transaction that was spending the coin). 
Then, after few seconds, the staker tries again with the same coin, finding again a valid kernel with it, but this time creating a (valid) empty block. The wallet transaction, originally spending the stake input, and later removed from the memory pool, is now marked conflicted.

For now, let's address the issue by:
- reloading the list of available coins whenever the tip hash changes (so, at least, at every block).
- checking for in-wallet spent-status before staking (as the list of coins is updated only when a new block arrives, a certain coin could have been spent in the mempool afterwards).

Closes #1923 

A better approach (future work), would be to implement an interface in the miner, subscribing to the wallet signals and updating the stakeable coins cache only when a coin is added, or is spent (or matures).