### PR TITLE
[RPC][Tests] Add sapling mempool test + getbestsaplinganchor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -180,10 +180,10 @@ jobs:
         DEP_OPTS="NO_QT=1 NO_UPNP=1 DEBUG=1 ALLOW_HOST_PACKAGES=1"
         RUN_UNIT_TESTS=false
         RUN_FUNCTIONAL_TESTS=true
-        TEST_RUNNER_EXTRA="--tiertwo"  # Run tier two functional tests only.
+        TEST_RUNNER_EXTRA="--tiertwo --sapling --skipcache"   # Run tier two and sapling functional tests only.
         GOAL="install"
         BITCOIN_CONFIG="--with-gui=no --enable-glibc-back-compat --enable-reduce-exports --disable-online-rust --with-params-dir=$PARAMS_DIR"
-        BUILD_TIMEOUT=1800
+        BUILD_TIMEOUT=800
 
     - stage: test
       name: 'x86_64 Linux  [GOAL: install]  [xenial]  [no depends, only system libs]'

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -207,6 +207,22 @@ UniValue getbestblockhash(const JSONRPCRequest& request)
     return chainActive.Tip()->GetBlockHash().GetHex();
 }
 
+UniValue getbestsaplinganchor(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() != 0)
+        throw std::runtime_error(
+            "getbestsaplinganchor\n"
+            "\nReturns the most recent SaplingMerkleTree root.\n"
+
+            "\nResult\n"
+            "\"hex\"      (string) the sapling anchor hex encoded\n"
+
+            "\nExamples\n" +
+            HelpExampleCli("getbestsaplinganchor", "") + HelpExampleRpc("getbestsaplinganchor", ""));
+
+    return pcoinsTip->GetBestAnchor().ToString();
+}
+
 void RPCNotifyBlockChange(bool fInitialDownload, const CBlockIndex* pindex)
 {
     if(pindex) {
@@ -1621,6 +1637,7 @@ static const CRPCCommand commands[] =
     { "blockchain",         "getblockindexstats",     &getblockindexstats,     true  },
     { "blockchain",         "getblockchaininfo",      &getblockchaininfo,      true  },
     { "blockchain",         "getbestblockhash",       &getbestblockhash,       true  },
+    { "blockchain",         "getbestsaplinganchor",   &getbestsaplinganchor,   true  },
     { "blockchain",         "getblockcount",          &getblockcount,          true  },
     { "blockchain",         "getblock",               &getblock,               true  },
     { "blockchain",         "getblockhash",           &getblockhash,           true  },

--- a/test/functional/sapling_mempool.py
+++ b/test/functional/sapling_mempool.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The PIVX Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import PivxTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+    sync_mempools,
+)
+
+from decimal import Decimal
+
+# Test mempool interaction with Sapling transactions
+class SaplingMempoolTest(PivxTestFramework):
+
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+        self.extra_args = [['-nuparams=v5_dummy:1']] * self.num_nodes
+
+    def run_test(self):
+        miner = self.nodes[0]
+        alice = self.nodes[1]
+
+        # Fixed fee
+        fee = 1
+
+        self.log.info("Mining 120 blocks...")
+        miner.generate(120)
+        self.sync_all()
+        # Sanity-check the test harness
+        assert_equal([x.getblockcount() for x in self.nodes], [120] * self.num_nodes)
+
+        # miner sends a 10 PIV note to Alice
+        self.log.info("Shielding some coins for Alice...")
+        alice_zaddr = alice.getnewshieldedaddress()
+        miner.shielded_sendmany("from_transparent", [{"address": alice_zaddr, "amount": Decimal('10.00')}], 1, fee)
+        miner.generate(1)
+        self.sync_all()
+        assert_equal(alice.getshieldedbalance(alice_zaddr), Decimal('10.00'))
+
+        # Alice creates (but doesn't send) tx_A to transparent address tadd_A
+        self.log.info("Alice creating tx_A...")
+        tadd_A = alice.getnewaddress()
+        rawTx = alice.raw_shielded_sendmany(alice_zaddr, [{"address": tadd_A, "amount": Decimal('9.00')}], 1, fee)
+
+        # Alice creates and sends tx_B, unshielding the same note to tadd_B
+        self.log.info("Alice creating and sending tx_B...")
+        tadd_B = alice.getnewaddress()
+        txid_B = alice.shielded_sendmany(alice_zaddr, [{"address": tadd_B, "amount": Decimal('9.00')}], 1, fee)
+
+        # Miner receives tx_B and accepts it in the mempool
+        assert (txid_B in alice.getrawmempool())
+        sync_mempools(self.nodes)
+        assert(txid_B in miner.getrawmempool())
+        self.log.info("tx_B accepted in the memory pool.")
+
+        # Now tx_A would double-spend the sapling note in the memory pool
+        assert_raises_rpc_error(-26, "bad-txns-nullifier-double-spent",
+                                alice.sendrawtransaction, rawTx['hex'])
+        self.log.info("tx_A NOT accepted in the mempool. Good.")
+
+        # Mine tx_B and try to send tx_A again
+        self.log.info("Mine a block and verify that tx_B gets on chain")
+        miner.generate(1)
+        txB_json = miner.getrawtransaction(txid_B, True)
+        assert("blockhash" in txB_json)
+        self.log.info("trying to relay tx_A again...")
+        assert_raises_rpc_error(-26, "bad-txns-nullifier-double-spent",
+                                alice.sendrawtransaction, rawTx['hex'])
+        self.log.info("tx_A NOT accepted in the mempool. Good.")
+
+        # miner sends another 10 PIV note to Alice
+        self.log.info("Shielding some more coins for Alice...")
+        miner.shielded_sendmany("from_transparent", [{"address": alice_zaddr, "amount": Decimal('10.00')}], 1, fee)
+        miner.generate(1)
+        self.sync_all()
+        assert_equal(alice.getshieldedbalance(alice_zaddr), Decimal('10.00'))
+
+        # Alice creates and sends tx_C, unshielding the note to tadd_C
+        self.log.info("Alice creating and sending tx_C...")
+        tadd_C = alice.getnewaddress()
+        txC_json = alice.raw_shielded_sendmany(alice_zaddr, [{"address": tadd_C, "amount": Decimal('9.00')}], 1, fee)
+        txid_C = alice.sendrawtransaction(txC_json['hex'])
+
+        # Miner receives tx_C and accepts it in the mempool
+        sync_mempools(self.nodes)
+        assert(txid_C in miner.getrawmempool())
+        self.log.info("tx_C accepted in the memory pool.")
+
+        # Now disconnect the block with the note's anchor,
+        # and check that the tx is removed from the mempool
+        self.log.info("Disconnect the last block to change the sapling anchor")
+        anchor = txC_json['vShieldedSpend'][0]['anchor']
+        assert_equal(anchor, miner.getbestsaplinganchor())
+        miner.invalidateblock(miner.getbestblockhash())
+        assert (anchor != miner.getbestsaplinganchor())
+        assert(txid_C not in miner.getrawmempool())
+        self.log.info("Good. tx_C removed from the memory pool.")
+
+
+if __name__ == '__main__':
+    SaplingMempoolTest().main()

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -129,6 +129,8 @@ class PivxTestFramework():
                           help='create pre-HD wallets only')
         parser.add_option('--tiertwo', dest="tiertwo", default=False, action="store_true",
                           help='run tier two tests only')
+        parser.add_option('--sapling', dest="sapling", default=False, action="store_true",
+                          help='run tier two tests only')
         parser.add_option("--pdbonfailure", dest="pdbonfailure", default=False, action="store_true",
                           help="Attach a python debugger if test fails")
         parser.add_option("--usecli", dest="usecli", default=False, action="store_true",

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -58,6 +58,8 @@ BASE_SCRIPTS= [
     # Longest test should go first, to favor running tests in parallel
     'wallet_basic.py',                          # ~ 498 sec
     'wallet_backup.py',                         # ~ 477 sec
+    'sapling_key_import_export.py',             # ~ 356 sec
+    'sapling_wallet_anchorfork.py',             # ~ 345 sec
 
     # vv Tests less than 5m vv
     'wallet_zapwallettxes.py',                  # ~ 300 sec
@@ -68,19 +70,17 @@ BASE_SCRIPTS= [
     'wallet_abandonconflict.py',                # ~ 212 sec
     'wallet_hd.py',                             # ~ 210 sec
     'wallet_zerocoin_publicspends.py',          # ~ 202 sec
+    'sapling_wallet_nullifiers.py',             # ~ 201 sec
     'feature_logging.py',                       # ~ 200 sec
     'rpc_rawtransaction.py',                    # ~ 193 sec
     'wallet_keypool_topup.py',                  # ~ 174 sec
+    'sapling_wallet_listreceived.py',           # ~ 169
     'sapling_wallet.py',                        # ~ 164 sec
-    'sapling_changeaddresses.py',
-    'sapling_wallet_anchorfork.py',
-    'sapling_wallet_nullifiers.py',
-    'sapling_key_import_export.py',
-    'sapling_wallet_listreceived.py',
     'wallet_txn_doublespend.py --mineblock',    # ~ 157 sec
     'wallet_txn_clone.py --mineblock',          # ~ 157 sec
     'rpc_spork.py',                             # ~ 156 sec
     'interface_rest.py',                        # ~ 154 sec
+    'sapling_changeaddresses.py',               # ~ 151 sec
     'feature_proxy.py',                         # ~ 143 sec
     'feature_uacomment.py',                     # ~ 130 sec
     'wallet_upgrade.py',                        # ~ 124 sec
@@ -93,6 +93,7 @@ BASE_SCRIPTS= [
     'feature_reindex.py',                       # ~ 110 sec
     'interface_http.py',                        # ~ 105 sec
     'feature_blockhashcache.py',                # ~ 100 sec
+    'sapling_mempool.py',                       # ~ 98 sec
     'wallet_listtransactions.py',               # ~ 97 sec
     'mempool_reorg.py',                         # ~ 92 sec
     'sapling_wallet_persistence.py',            # ~ 90 sec
@@ -200,6 +201,7 @@ LEGACY_SKIP_TESTS = [
     'sapling_wallet_anchorfork.py',
     'sapling_wallet_listreceived.py',
     'sapling_wallet_nullifiers.py',
+    'sapling_mempool.py',
 ]
 
 # Place EXTENDED_SCRIPTS first since it has the 3 longest running tests


### PR DESCRIPTION
Based on top of:
- [x] #1958 
- [x] #1964 

This adds a functional test to check the bahavior of sapling transactions with the mempool.
Specifically, it verifies the nullifiers/anchor management introduced in #1958:
- If a transaction spends a sapling note, already spent by another in-mempool transaction, it's not accepted in the mempool.
- Same if it tries to double-spend a note already spent on chain.
- If, after disconnecting a block, the sapling merkle tree root changes, any transaction that spends a note referencing the old root must be evicted from the mempool.

In order to verify the last point, a simple RPC `getbestsaplinganchor` is introduced in the "blockchain" category.
It returns the `pcoinsTip` best anchor.

Note: without 1958, the test crashes the node, as two transactions spending the same note can both enter the mempool, but then the assertions in the memory pool consistency checks fail during block creation.