### PR TITLE
[Refactor] SaplingOperation: support for multisig, cold-staking, and OP_RETURN outputs

### DIFF
--- a/src/sapling/sapling_operation.cpp
+++ b/src/sapling/sapling_operation.cpp
@@ -49,18 +49,14 @@ OperationResult loadKeysFromShieldedFrom(const libzcash::SaplingPaymentAddress &
     return OperationResult(true);
 }
 
-TxValues calculateTarget(std::vector<SendManyRecipient>& taddrRecipients,
-                         std::vector<SendManyRecipient>& shieldedAddrRecipients,
-                         CAmount fee)
+TxValues calculateTarget(const std::vector<SendManyRecipient>& recipients, const CAmount& fee)
 {
     TxValues txValues;
-    for (SendManyRecipient &t : taddrRecipients) {
-        txValues.transOutTotal += t.transparentRecipient->nValue;
-    }
-
-    // Add shielded outputs
-    for (const SendManyRecipient &t : shieldedAddrRecipients) {
-        txValues.shieldedOutTotal += t.shieldedRecipient->amount;
+    for (const SendManyRecipient &t : recipients) {
+        if (t.IsTransparent())
+            txValues.transOutTotal += t.transparentRecipient->nValue;
+        else
+            txValues.shieldedOutTotal += t.shieldedRecipient->amount;
     }
     txValues.target = txValues.shieldedOutTotal + txValues.transOutTotal + fee;
     return txValues;
@@ -87,7 +83,7 @@ OperationResult SaplingOperation::build()
         }
     }
 
-    if (taddrRecipients.empty() && shieldedAddrRecipients.empty()) {
+    if (recipients.empty()) {
         return errorOut("No recipients");
     }
 
@@ -96,7 +92,7 @@ OperationResult SaplingOperation::build()
     }
 
     // First calculate target values
-    TxValues txValues = calculateTarget(taddrRecipients, shieldedAddrRecipients, fee);
+    TxValues txValues = calculateTarget(recipients, fee);
     OperationResult result(false);
     // Necessary keys
     libzcash::SaplingExpandedSpendingKey expsk;
@@ -122,22 +118,21 @@ OperationResult SaplingOperation::build()
         ovk = pwalletMain->GetSaplingScriptPubKeyMan()->getCommonOVKFromSeed();
     }
 
-    // Add transparent outputs
-    for (SendManyRecipient &t : taddrRecipients) {
-        txBuilder.AddTransparentOutput(*t.transparentRecipient);
-    }
-
-    // Add shielded outputs
-    for (const SendManyRecipient &t : shieldedAddrRecipients) {
-        const auto& address = t.shieldedRecipient->address;
-        const CAmount& amount = t.shieldedRecipient->amount;
-        const std::string& memo = t.shieldedRecipient->memo;
-        assert(IsValidPaymentAddress(address));
-        std::array<unsigned char, ZC_MEMO_SIZE> vMemo = {};
-        std::string error;
-        if (!getMemoFromHexString(memo, vMemo, error))
-            return errorOut(error);
-        txBuilder.AddSaplingOutput(ovk, address, amount, vMemo);
+    // Add outputs
+    for (const SendManyRecipient &t : recipients) {
+        if (t.IsTransparent()) {
+            txBuilder.AddTransparentOutput(*t.transparentRecipient);
+        } else {
+            const auto& address = t.shieldedRecipient->address;
+            const CAmount& amount = t.shieldedRecipient->amount;
+            const std::string& memo = t.shieldedRecipient->memo;
+            assert(IsValidPaymentAddress(address));
+            std::array<unsigned char, ZC_MEMO_SIZE> vMemo = {};
+            std::string error;
+            if (!getMemoFromHexString(memo, vMemo, error))
+                return errorOut(error);
+            txBuilder.AddSaplingOutput(ovk, address, amount, vMemo);
+        }
     }
 
     // If from address is a taddr, select UTXOs to spend

--- a/src/sapling/sapling_operation.h
+++ b/src/sapling/sapling_operation.h
@@ -83,8 +83,7 @@ public:
     // In case of no addressFrom filter selected, it will accept any utxo in the wallet as input.
     SaplingOperation* setSelectTransparentCoins(const bool select) { selectFromtaddrs = select; return this; };
     SaplingOperation* setSelectShieldedCoins(const bool select) { selectFromShield = select; return this; };
-    SaplingOperation* setTransparentRecipients(std::vector<SendManyRecipient>& vec) { taddrRecipients = std::move(vec); return this; };
-    SaplingOperation* setShieldedRecipients(std::vector<SendManyRecipient>& vec) { shieldedAddrRecipients = std::move(vec); return this; } ;
+    SaplingOperation* setRecipients(std::vector<SendManyRecipient>& vec) { recipients = std::move(vec); return this; };
     SaplingOperation* setFee(CAmount _fee) { fee = _fee; return this; }
     SaplingOperation* setMinDepth(int _mindepth) { assert(_mindepth >= 0); mindepth = _mindepth; return this; }
     SaplingOperation* setTxBuilder(TransactionBuilder& builder) { txBuilder = builder; return this; }
@@ -100,8 +99,7 @@ private:
     // In case of no addressFrom filter selected, it will accept any utxo in the wallet as input.
     bool selectFromtaddrs{false};
     bool selectFromShield{false};
-    std::vector<SendManyRecipient> taddrRecipients;
-    std::vector<SendManyRecipient> shieldedAddrRecipients;
+    std::vector<SendManyRecipient> recipients;
     std::vector<COutput> transInputs;
     std::vector<SaplingNoteEntry> shieldedInputs;
     int mindepth{5}; // Min default depth 5.

--- a/src/sapling/sapling_operation.h
+++ b/src/sapling/sapling_operation.h
@@ -31,7 +31,6 @@ struct SendManyRecipient
     const Optional<CTxOut> transparentRecipient;
 
     bool IsTransparent() const { return transparentRecipient != nullopt; }
-    bool IsShielded() const { return !IsTransparent(); }
 
     // Prevent default empty initialization
     SendManyRecipient() = delete;
@@ -39,7 +38,7 @@ struct SendManyRecipient
     // Shielded recipient
     SendManyRecipient(const libzcash::SaplingPaymentAddress& address, const CAmount& amount, const std::string& memo):
         shieldedRecipient(ShieldedRecipient(address, amount, memo))
-    { }
+    {}
 
     // Transparent recipient: P2PKH
     SendManyRecipient(const CTxDestination& dest, const CAmount& amount):
@@ -51,7 +50,15 @@ struct SendManyRecipient
         transparentRecipient(CTxOut(amount, GetScriptForStakeDelegation(stakerKey, ownerKey)))
     {}
 
-    // !TODO: Transparent recipient: multisig and OP_RETURN
+    // Transparent recipient: multisig
+    SendManyRecipient(int nRequired, const std::vector<CPubKey>& keys, const CAmount& amount):
+        transparentRecipient(CTxOut(amount, GetScriptForMultisig(nRequired, keys)))
+    {}
+
+    // Transparent recipient: OP_RETURN
+    SendManyRecipient(const uint256& message):
+        transparentRecipient(CTxOut(0, GetScriptForOpReturn(message)))
+    {}
 };
 
 class FromAddress {

--- a/src/sapling/sapling_operation.h
+++ b/src/sapling/sapling_operation.h
@@ -27,8 +27,8 @@ struct ShieldedRecipient
 
 struct SendManyRecipient
 {
-    const Optional<ShieldedRecipient> shieldedRecipient;
-    const Optional<CTxOut> transparentRecipient;
+    const Optional<ShieldedRecipient> shieldedRecipient{nullopt};
+    const Optional<CTxOut> transparentRecipient{nullopt};
 
     bool IsTransparent() const { return transparentRecipient != nullopt; }
 

--- a/src/sapling/transaction_builder.h
+++ b/src/sapling/transaction_builder.h
@@ -111,9 +111,10 @@ public:
         std::array<unsigned char, ZC_MEMO_SIZE> memo = {{0xF6}});
 
     // Assumes that the value correctly corresponds to the provided UTXO.
-    void AddTransparentInput(COutPoint utxo, CScript scriptPubKey, CAmount value);
+    void AddTransparentInput(const COutPoint& utxo, const CScript& scriptPubKey, const CAmount& value);
 
-    void AddTransparentOutput(const CTxDestination& to, CAmount value);
+    void AddTransparentOutput(const CTxOut& out);
+    void AddTransparentOutput(const CTxDestination& dest, const CAmount& value);
 
     void SendChangeTo(libzcash::SaplingPaymentAddress changeAddr, uint256 ovk);
 

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -329,6 +329,13 @@ CScript GetScriptForMultisig(int nRequired, const std::vector<CPubKey>& keys)
     return script;
 }
 
+CScript GetScriptForOpReturn(const uint256& message)
+{
+    CScript script;
+    script << OP_RETURN << ToByteVector(message);
+    return script;
+}
+
 bool IsValidDestination(const CTxDestination& dest) {
     return dest.which() != 0;
 }

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -84,5 +84,6 @@ CScript GetScriptForDestination(const CTxDestination& dest);
 CScript GetScriptForRawPubKey(const CPubKey& pubKey);
 CScript GetScriptForMultisig(int nRequired, const std::vector<CPubKey>& keys);
 CScript GetScriptForStakeDelegation(const CKeyID& stakingKey, const CKeyID& spendingKey);
+CScript GetScriptForOpReturn(const uint256& message);
 
 #endif // BITCOIN_SCRIPT_STANDARD_H

--- a/src/test/librust/sapling_rpc_wallet_tests.cpp
+++ b/src/test/librust/sapling_rpc_wallet_tests.cpp
@@ -335,7 +335,7 @@ BOOST_AUTO_TEST_CASE(saplingOperationTests) {
         std::vector<SendManyRecipient> recipients = { SendManyRecipient(zaddr1, COIN, "DEADBEEF") };
         SaplingOperation operation(consensusParams, 1);
         operation.setFromAddress(taddr1);
-        auto res = operation.setShieldedRecipients(recipients)->buildAndSend(ret);
+        auto res = operation.setRecipients(recipients)->buildAndSend(ret);
         BOOST_CHECK(!res);
         BOOST_CHECK(res.getError().find("Insufficient funds, no available UTXO to spend") != std::string::npos);
     }
@@ -345,7 +345,7 @@ BOOST_AUTO_TEST_CASE(saplingOperationTests) {
         std::vector<SendManyRecipient> recipients = { SendManyRecipient(zaddr1, COIN, "DEADBEEF") };
         SaplingOperation operation(consensusParams, 1);
         operation.setFromAddress(zaddr1);
-        auto res = operation.setShieldedRecipients(recipients)->setMinDepth(0)->buildAndSend(ret);
+        auto res = operation.setRecipients(recipients)->setMinDepth(0)->buildAndSend(ret);
         BOOST_CHECK(!res);
         BOOST_CHECK(res.getError().find("Minconf cannot be zero when sending from shielded address") != std::string::npos);
     }
@@ -355,7 +355,7 @@ BOOST_AUTO_TEST_CASE(saplingOperationTests) {
         std::vector<SendManyRecipient> recipients = { SendManyRecipient(taddr1, COIN) };
         SaplingOperation operation(consensusParams, 1);
         operation.setFromAddress(zaddr1);
-        auto res = operation.setTransparentRecipients(recipients)->buildAndSend(ret);
+        auto res = operation.setRecipients(recipients)->buildAndSend(ret);
         BOOST_CHECK(!res);
         BOOST_CHECK(res.getError().find("Insufficient funds, no available notes to spend") != std::string::npos);
     }
@@ -365,7 +365,7 @@ BOOST_AUTO_TEST_CASE(saplingOperationTests) {
         std::vector<SendManyRecipient> recipients = { SendManyRecipient(zaddr1, COIN, "DEADBEEF") };
         SaplingOperation operation(consensusParams, 1);
         operation.setFromAddress(zaddr1);
-        operation.setShieldedRecipients(recipients);
+        operation.setRecipients(recipients);
 
         std::string memo = "DEADBEEF";
         std::array<unsigned char, ZC_MEMO_SIZE> array;
@@ -458,7 +458,7 @@ BOOST_AUTO_TEST_CASE(rpc_shielded_sendmany_taddr_to_sapling)
     std::vector<SendManyRecipient> recipients = { SendManyRecipient(zaddr1, 1 * COIN, "ABCD") };
     SaplingOperation operation(builder);
     operation.setFromAddress(taddr);
-    BOOST_CHECK(operation.setShieldedRecipients(recipients)
+    BOOST_CHECK(operation.setRecipients(recipients)
                          ->setMinDepth(0)
                          ->build());
 
@@ -466,7 +466,7 @@ BOOST_AUTO_TEST_CASE(rpc_shielded_sendmany_taddr_to_sapling)
     std::vector<SendManyRecipient> recipients2 = { SendManyRecipient(zaddr1, 1 * COIN, "ABCD") };
     SaplingOperation operation2(builder);
     BOOST_CHECK(operation2.setSelectTransparentCoins(true)
-                          ->setShieldedRecipients(recipients2)
+                          ->setRecipients(recipients2)
                           ->setMinDepth(0)
                           ->build());
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1471,8 +1471,7 @@ static SaplingOperation CreateShieldedTransaction(const JSONRPCRequest& request)
     // Keep track of addresses to spot duplicates
     std::set<std::string> setAddress;
     // Recipients
-    std::vector<SendManyRecipient> taddrRecipients;
-    std::vector<SendManyRecipient> shieldAddrRecipients;
+    std::vector<SendManyRecipient> recipients;
     CAmount nTotalOut = 0;
     bool containsSaplingOutput = false;
 
@@ -1524,9 +1523,9 @@ static SaplingOperation CreateShieldedTransaction(const JSONRPCRequest& request)
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, amount must be positive");
 
         if (saddr) {
-            shieldAddrRecipients.emplace_back(*saddr, nAmount, memo);
+            recipients.emplace_back(*saddr, nAmount, memo);
         } else {
-            taddrRecipients.emplace_back(taddr, nAmount);
+            recipients.emplace_back(taddr, nAmount);
         }
 
         nTotalOut += nAmount;
@@ -1547,8 +1546,12 @@ static SaplingOperation CreateShieldedTransaction(const JSONRPCRequest& request)
 
     // As a sanity check, estimate and verify that the size of the transaction will be valid.
     // Depending on the input notes, the actual tx size may turn out to be larger and perhaps invalid.
-    size_t txsize = 0;
-    for (const auto& t : shieldAddrRecipients) {
+    size_t nTransparentOuts = 0;
+    for (const auto& t : recipients) {
+        if (t.IsTransparent()) {
+            nTransparentOuts++;
+            continue;
+        }
         if (IsValidPaymentAddress(t.shieldedRecipient->address)) {
             mtx.sapData->vShieldedOutput.emplace_back();
         } else {
@@ -1557,12 +1560,11 @@ static SaplingOperation CreateShieldedTransaction(const JSONRPCRequest& request)
         }
     }
     CTransaction tx(mtx);
-    txsize += GetSerializeSize(tx, SER_NETWORK, tx.nVersion);
+    size_t txsize = GetSerializeSize(tx, SER_NETWORK, tx.nVersion) + CTXOUT_REGULAR_SIZE * nTransparentOuts;
     if (!fromSapling) {
         txsize += CTXIN_SPEND_DUST_SIZE;
         txsize += CTXOUT_REGULAR_SIZE;      // There will probably be taddr change
     }
-    txsize += CTXOUT_REGULAR_SIZE * taddrRecipients.size();
     if (txsize > max_tx_size) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Too many outputs, size of raw transaction would be larger than limit of %d bytes", max_tx_size ));
     }
@@ -1613,8 +1615,7 @@ static SaplingOperation CreateShieldedTransaction(const JSONRPCRequest& request)
     // Build the send operation
     OperationResult res = operation.setFee(nFee)
             ->setMinDepth(nMinDepth)
-            ->setShieldedRecipients(shieldAddrRecipients)
-            ->setTransparentRecipients(taddrRecipients)
+            ->setRecipients(recipients)
             ->build();
     if (!res) throw JSONRPCError(RPC_WALLET_ERROR, res.getError());
     return operation;


### PR DESCRIPTION
Refactor `SaplingOperation`, abstracting the separation between shielded and transparent outputs inside `SendManyRecipient`.
Instead of using strings for the internal representation, save the recipients as either `CTxOut` (for transparent outputs) or a tuple comprising SaplingAddress, Amount and Memo (for sapling outputs).

This has the following pros:
- __Cleaner__: No extra "dummy" variables (such as the memo field for transparent outputs). Plus, as the separation between shielded/transparent recipients is implemented only in the TransactionBuilder, SaplingOperation effectively has an higher level of abstraction. 
- __Faster__: removes the need for extra encoding-decoding operations to go back and forth between strings and scripts.
- __More flexible__: since a `CTxOut` can be any kind of transaction output, we can easily integrate other use-cases. 
For example, in this PR we add support for multisig, P2CS and op_return outputs.