### PR TITLE
[TierTwo] Missing misbehaving + ban score not introduced on the new msg dispatcher flow

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -476,10 +476,6 @@ bool CMasternodeBroadcast::CheckAndUpdate(int& nDos)
         return false;
     }
 
-    // incorrect ping or its sigTime
-    if(lastPing.IsNull() || !lastPing.CheckAndUpdate(nDos, false, true))
-    return false;
-
     if (protocolVersion < ActiveProtocol()) {
         LogPrint(BCLog::MASTERNODE,"mnb - ignoring outdated Masternode %s protocol version %d\n", vin.prevout.hash.ToString(), protocolVersion);
         return false;
@@ -520,6 +516,11 @@ bool CMasternodeBroadcast::CheckAndUpdate(int& nDos)
         if (addr.GetPort() != 51472) return false;
     } else if (addr.GetPort() == 51472)
         return false;
+
+    // incorrect ping or its sigTime
+    if(lastPing.IsNull() || !lastPing.CheckAndUpdate(nDos, false, true)) {
+        return false;
+    }
 
     //search existing Masternode list, this is where we update existing Masternodes with new mnb broadcasts
     CMasternode* pmn = mnodeman.Find(vin);

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -645,7 +645,6 @@ int CMasternodeMan::ProcessMNBroadcast(CNode* pfrom, CMasternodeBroadcast& mnb)
         masternodeSync.AddedMasternodeList(mnbHash);
         return 0;
     }
-    mapSeenMasternodeBroadcast.emplace(mnbHash, mnb);
 
     int nDoS = 0;
     if (!mnb.CheckAndUpdate(nDoS)) {
@@ -658,6 +657,9 @@ int CMasternodeMan::ProcessMNBroadcast(CNode* pfrom, CMasternodeBroadcast& mnb)
         LogPrintf("CMasternodeMan::ProcessMessage() : mnb - Got mismatched pubkey and vin\n");
         return 33;
     }
+
+    // now that did the basic mnb checks, can add it.
+    mapSeenMasternodeBroadcast.emplace(mnbHash, mnb);
 
     // make sure it's still unspent
     //  - this is checked later by .check() in many places and by ThreadCheckObfuScationPool()

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -677,7 +677,6 @@ int CMasternodeMan::ProcessMNPing(CNode* pfrom, CMasternodePing& mnp)
 {
     const uint256& mnpHash = mnp.GetHash();
     if (mapSeenMasternodePing.count(mnpHash)) return 0; //seen
-    mapSeenMasternodePing.emplace(mnpHash, mnp);
 
     int nDoS = 0;
     if (mnp.CheckAndUpdate(nDoS)) return 0;


### PR DESCRIPTION
Small decoupling from #1935 work.
Focused on the mnb and mnp misbehaving ban score increment.