### PR TITLE
[RPC][Tests] Memo field for sapling transactions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -173,7 +173,7 @@ jobs:
         BUILD_TIMEOUT=800
 
     - stage: test
-      name: 'x86_64 Linux  [GOAL: install]  [bionic]  [no GUI, no unit tests - only tier two functional tests]'
+      name: 'x86_64 Linux  [GOAL: install]  [bionic]  [no GUI, no unit tests - only tiertwo/sapling functional tests]'
       env: >-
         HOST=x86_64-unknown-linux-gnu
         PACKAGES="python3-zmq protobuf-compiler libdbus-1-dev libharfbuzz-dev libprotobuf-dev"

--- a/src/sapling/sapling_operation.h
+++ b/src/sapling/sapling_operation.h
@@ -98,9 +98,6 @@ public:
 
     CTransaction getFinalTx() { return finalTx; }
 
-    // Public only for unit test coverage
-    bool getMemoFromHexString(const std::string& s, std::array<unsigned char, ZC_MEMO_SIZE> memoRet, std::string& error);
-
 private:
     FromAddress fromAddress;
     // In case of no addressFrom filter selected, it will accept any utxo in the wallet as input.
@@ -125,5 +122,7 @@ private:
                                      uint256& ovk);
     OperationResult checkTxValues(TxValues& txValues, bool isFromtAddress, bool isFromShielded);
 };
+
+OperationResult GetMemoFromString(const std::string& s, std::array<unsigned char, ZC_MEMO_SIZE>& memoRet);
 
 #endif //PIVX_SAPLING_OPERATION_H

--- a/src/test/librust/sapling_rpc_wallet_tests.cpp
+++ b/src/test/librust/sapling_rpc_wallet_tests.cpp
@@ -360,51 +360,33 @@ BOOST_AUTO_TEST_CASE(saplingOperationTests) {
         BOOST_CHECK(res.getError().find("Insufficient funds, no available notes to spend") != std::string::npos);
     }
 
-    // get_memo_from_hex_string())
+    // GetMemoFromString
     {
-        std::vector<SendManyRecipient> recipients = { SendManyRecipient(zaddr1, COIN, "DEADBEEF") };
-        SaplingOperation operation(consensusParams, 1);
-        operation.setFromAddress(zaddr1);
-        operation.setRecipients(recipients);
+        std::string memoStr = "Sapling memo!";
+        std::array<unsigned char, ZC_MEMO_SIZE> memo;
 
-        std::string memo = "DEADBEEF";
-        std::array<unsigned char, ZC_MEMO_SIZE> array;
-
-        std::string error;
-        /* todo: test failing, fix it.
-        BOOST_CHECK(operation.getMemoFromHexString(memo, array, error));
-        BOOST_CHECK_EQUAL(array[0], 0xDE);
-        BOOST_CHECK_EQUAL(array[1], 0xAD);
-        BOOST_CHECK_EQUAL(array[2], 0xBE);
-        BOOST_CHECK_EQUAL(array[3], 0xEF);
-        for (int i=4; i<ZC_MEMO_SIZE; i++) {
-            BOOST_CHECK_EQUAL(array[i], 0x00);  // zero padding
+        BOOST_CHECK(GetMemoFromString(memoStr, memo));
+        BOOST_CHECK_EQUAL(memo[0], 0x53);   // S
+        BOOST_CHECK_EQUAL(memo[1], 0x61);   // a
+        BOOST_CHECK_EQUAL(memo[2], 0x70);   // p
+        BOOST_CHECK_EQUAL(memo[3], 0x6C);   // l
+        BOOST_CHECK_EQUAL(memo[4], 0x69);   // i
+        BOOST_CHECK_EQUAL(memo[5], 0x6E);   // n
+        BOOST_CHECK_EQUAL(memo[6], 0x67);   // g
+        BOOST_CHECK_EQUAL(memo[12], 0x21);  // !
+        for (int i = 13; i < ZC_MEMO_SIZE; i++) {
+            BOOST_CHECK_EQUAL(memo[i], 0x00);  // zero padding
         }
-         */
 
         // memo is longer than allowed
         std::vector<char> v (2 * (ZC_MEMO_SIZE+1));
         std::fill(v.begin(),v.end(), 'A');
         std::string bigmemo(v.begin(), v.end());
 
-        BOOST_CHECK(!operation.getMemoFromHexString(bigmemo, array, error));
-        BOOST_CHECK(error.find("too big") != std::string::npos);
-
-        // invalid hexadecimal string
-        std::fill(v.begin(),v.end(), '@'); // not a hex character
-        std::string badmemo(v.begin(), v.end());
-
-        BOOST_CHECK(!operation.getMemoFromHexString(badmemo, array, error));
-        BOOST_CHECK(error.find("hexadecimal format") != std::string::npos);
-
-        // odd length hexadecimal string
-        std::fill(v.begin(),v.end(), 'A');
-        v.resize(v.size() - 1);
-        assert(v.size() %2 == 1); // odd length
-        std::string oddmemo(v.begin(), v.end());
-
-        BOOST_CHECK(!operation.getMemoFromHexString(oddmemo, array, error));
-        BOOST_CHECK(error.find("hexadecimal format") != std::string::npos);
+        OperationResult res = GetMemoFromString(bigmemo, memo);
+        BOOST_CHECK(!res);
+        const std::string& errStr = res.getError();
+        BOOST_CHECK(errStr.find("too big") != std::string::npos);
     }
     RegtestDeactivateSapling();
 }

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -541,3 +541,26 @@ std::string Capitalize(std::string str)
     str[0] = ToUpper(str.front());
     return str;
 }
+
+// Based on http://www.zedwood.com/article/cpp-is-valid-utf8-string-function
+bool IsValidUTF8(const std::string& str)
+{
+    const unsigned int strLen = str.length();
+    int c,n;
+    for (unsigned i = 0; i < strLen; i++) {
+        c = (unsigned char) str[i];
+        if (0x00 <= c && c <= 0x7f)     n=0;      // 0bbbbbbb (ASCII)
+        else if ((c & 0xE0) == 0xC0)    n=1;      // 110bbbbb
+        else if ( c == 0xED && i < (strLen - 1) && ((unsigned char)str[i+1] & 0xA0) == 0xA0)
+            return false;                         //U+d800 to U+dfff
+        else if ((c & 0xF0) == 0xE0)    n=2;      // 1110bbbb
+        else if ((c & 0xF8) == 0xF0)    n=3;      // 11110bbb
+        else return false;
+        for (int j=0; j < n && i < strLen; j++) { // n bytes matching 10bbbbbb follow ?
+            if ((++i == strLen) || (( (unsigned char)str[i] & 0xC0) != 0x80))
+                return false;
+        }
+    }
+    return true;
+}
+

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -99,6 +99,13 @@ bool ParseInt64(const std::string& str, int64_t *out);
  */
 bool ParseDouble(const std::string& str, double *out);
 
+/* Return iterator to first non zero element, or itend */
+template <typename T>
+T FindFirstNonZero(T itbegin, T itend)
+{
+    return std::find_if(itbegin, itend, [](unsigned char v) { return v != 0; });
+}
+
 template <typename T>
 std::string HexStr(const T itbegin, const T itend, bool fSpaces = false)
 {
@@ -121,6 +128,12 @@ template <typename T>
 inline std::string HexStr(const T& vch, bool fSpaces = false)
 {
     return HexStr(vch.begin(), vch.end(), fSpaces);
+}
+
+template <typename T>
+inline std::string HexStrTrimmed(const T& vch, bool fSpaces = false)
+{
+    return HexStr(vch.begin(), FindFirstNonZero(vch.rbegin(), vch.rend()).base(), fSpaces);
 }
 
 /** Reverse the endianess of a string */

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -241,4 +241,11 @@ constexpr unsigned char ToUpper(unsigned char c)
  */
 std::string Capitalize(std::string str);
 
+/**
+ * Checks for valid 4-byte UTF-8 encoding in a string
+ * @param[in] str   the string to check.
+ * @return          boolean. true for valid UTF-8 encoding.
+ */
+bool IsValidUTF8(const std::string& str);
+
 #endif // BITCOIN_UTILSTRENCODINGS_H

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1670,7 +1670,7 @@ UniValue raw_shielded_sendmany(const JSONRPCRequest& request)
                 "    [{\n"
                 "      \"address\":address  (string, required) The address is a transparent addr or shielded addr\n"
                 "      \"amount\":amount    (numeric, required) The numeric amount in " + "PIV" + " is the value\n"
-                "      \"memo\":memo        (string, optional) If the address is a shielded addr, raw data represented in hexadecimal string format\n"
+                "      \"memo\":memo        (string, optional) If the address is a shielded addr, message string of max 512 bytes\n"
                 "    }, ... ]\n"
                 "3. minconf               (numeric, optional, default=1) Only use funds confirmed at least this many times.\n"
                 "4. fee                   (numeric, optional, default=" + strprintf("%s", FormatMoney(DEFAULT_SAPLING_FEE)) +

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1509,8 +1509,6 @@ static SaplingOperation CreateShieldedTransaction(const JSONRPCRequest& request)
             memo = memoValue.get_str();
             if (!saddr) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "Memo cannot be used with a taddr. It can only be used with a shielded addr.");
-            } else if (!IsHex(memo)) {
-                throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, expected memo data in hexadecimal format.");
             }
             if (memo.length() > ZC_MEMO_SIZE*2) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER,  strprintf("Invalid parameter, size of memo is larger than maximum allowed %d", ZC_MEMO_SIZE ));
@@ -1638,7 +1636,7 @@ UniValue shielded_sendmany(const JSONRPCRequest& request)
                 "    [{\n"
                 "      \"address\":address  (string, required) The address is a transparent addr or shielded addr\n"
                 "      \"amount\":amount    (numeric, required) The numeric amount in " + "PIV" + " is the value\n"
-                "      \"memo\":memo        (string, optional) If the address is a shielded addr, raw data represented in hexadecimal string format\n"
+                "      \"memo\":memo        (string, optional) If the address is a shielded addr, message string of max 512 bytes\n"
                 "    }, ... ]\n"
                 "3. minconf               (numeric, optional, default=1) Only use funds confirmed at least this many times.\n"
                 "4. fee                   (numeric, optional, default=" + strprintf("%s", FormatMoney(DEFAULT_SAPLING_FEE)) +

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1322,7 +1322,6 @@ UniValue viewshieldedtransaction(const JSONRPCRequest& request)
 
     auto addMemo = [](UniValue &entry, std::array<unsigned char, ZC_MEMO_SIZE> &memo) {
         entry.pushKV("memo", HexStr(memo));
-        /*
         // If the leading byte is 0xF4 or lower, the memo field should be interpreted as a
         // UTF-8-encoded text string.
         if (memo[0] <= 0xf4) {
@@ -1332,11 +1331,10 @@ UniValue viewshieldedtransaction(const JSONRPCRequest& request)
                     memo.rend(),
                     [](unsigned char v) { return v != 0; });
             std::string memoStr(memo.begin(), end.base());
-            if (utf8::is_valid(memoStr)) { // todo: Add utf8 validation.
-                entry.pushKV("memoStr", memoStr));
+            if (IsValidUTF8(memoStr)) {
+                entry.pushKV("memoStr", memoStr);
             }
         }
-         */
     };
 
     auto sspkm = pwalletMain->GetSaplingScriptPubKeyMan();

--- a/test/functional/sapling_wallet_listreceived.py
+++ b/test/functional/sapling_wallet_listreceived.py
@@ -11,8 +11,7 @@ from decimal import Decimal
 my_memo_str = "What, so everyone’s supposed to sleep every single night now?\n"\
               "You realize that nighttime makes up half of all time?"
 my_memo_hex = bytes_to_hex_str(my_memo_str.encode('utf-8'))
-my_memo_hex += '0' * (1024-len(my_memo_hex))
-no_memo = 'f6' + ('0'*1022)
+no_memo = 'f6'
 
 fee = Decimal('0.0001')
 

--- a/test/functional/sapling_wallet_listreceived.py
+++ b/test/functional/sapling_wallet_listreceived.py
@@ -53,47 +53,24 @@ class ListReceivedTest (PivxTestFramework):
         assert_equal(len(pt['spends']), 0)
         assert_equal(len(pt['outputs']), 2)
 
-        # Output orders can be randomized, so we check the output
-        # positions and contents separately
-        outputs = []
-
-        if pt['outputs'][0]['address'] == shield_addr1:
-            assert_equal(pt['outputs'][0]['outgoing'], False)
-            assert_equal(pt['outputs'][0]['memoStr'], my_memo_str)
-        else:
-            assert_equal(pt['outputs'][0]['outgoing'], True)
-        outputs.append({
-            'address': pt['outputs'][0]['address'],
-            'value': pt['outputs'][0]['value'],
-            'valueSat': pt['outputs'][0]['valueSat'],
-            'memo': pt['outputs'][0]['memo'],
-        })
-
-        if pt['outputs'][1]['address'] == shield_addr1:
-            assert_equal(pt['outputs'][1]['outgoing'], False)
-            assert_equal(pt['outputs'][1]['memoStr'], my_memo_str)
-        else:
-            assert_equal(pt['outputs'][1]['outgoing'], True)
-        outputs.append({
-            'address': pt['outputs'][1]['address'],
-            'value': pt['outputs'][1]['value'],
-            'valueSat': pt['outputs'][1]['valueSat'],
-            'memo': pt['outputs'][1]['memo'],
-        })
-
-        assert({
-                   'address': shield_addr1,
-                   'value': Decimal('2'),
-                   'valueSat': 200000000,
-                   'memo': my_memo_hex,
-               } in outputs)
-
-        assert({
-                   'address': shield_addrExt,
-                   'value': Decimal('3'),
-                   'valueSat': 300000000,
-                   'memo': no_memo,
-               } in outputs)
+        found = [False, False]
+        for out in pt['outputs']:
+            assert_equal(pt['outputs'].index(out), out['output'])
+            if out['address'] == shield_addr1:
+                assert_equal(out['outgoing'], False)
+                assert_equal(out['memo'], my_memo_hex)
+                assert_equal(out['memoStr'], my_memo_str)
+                assert_equal(out['value'], Decimal('2'))
+                assert_equal(out['valueSat'], 200000000)
+                found[0] = True
+            else:
+                assert_equal(out['address'], shield_addrExt)
+                assert_equal(out['outgoing'], True)
+                assert_equal(out['memo'], no_memo)
+                assert_equal(out['value'], Decimal('3'))
+                assert_equal(out['valueSat'], 300000000)
+                found[1] = True
+        assert_equal(found, [True] * 2)
 
         r = self.nodes[1].listreceivedbyshieldedaddress(shield_addr1)
         assert_true(0 == len(r), "Should have received no confirmed note")
@@ -154,40 +131,23 @@ class ListReceivedTest (PivxTestFramework):
         assert_equal(pt['spends'][0]['value'], Decimal('2.0'))
         assert_equal(pt['spends'][0]['valueSat'], 200000000)
 
-        # Output orders can be randomized, so we check the output
-        # positions and contents separately
-        outputs = []
-
-        assert_equal(pt['outputs'][0]['output'], 0)
-        assert_equal(pt['outputs'][0]['outgoing'], False)
-        outputs.append({
-            'address': pt['outputs'][0]['address'],
-            'value': pt['outputs'][0]['value'],
-            'valueSat': pt['outputs'][0]['valueSat'],
-            'memo': pt['outputs'][0]['memo'],
-        })
-
-        assert_equal(pt['outputs'][1]['output'], 1)
-        assert_equal(pt['outputs'][1]['outgoing'], False)
-        outputs.append({
-            'address': pt['outputs'][1]['address'],
-            'value': pt['outputs'][1]['value'],
-            'valueSat': pt['outputs'][1]['valueSat'],
-            'memo': pt['outputs'][1]['memo'],
-        })
-
-        assert({
-                   'address': shield_addr2,
-                   'value': Decimal('0.6'),
-                   'valueSat': 60000000,
-                   'memo': no_memo,
-               } in outputs)
-        assert({
-                   'address': shield_addr1,
-                   'value': Decimal('1.3999'),
-                   'valueSat': 139990000,
-                   'memo': no_memo,
-               } in outputs)
+        found = [False, False]
+        for out in pt['outputs']:
+            assert_equal(pt['outputs'].index(out), out['output'])
+            if out['address'] == shield_addr2:
+                assert_equal(out['outgoing'], False)
+                assert_equal(out['memo'], no_memo)
+                assert_equal(out['value'], Decimal('0.6'))
+                assert_equal(out['valueSat'], 60000000)
+                found[0] = True
+            else:
+                assert_equal(out['address'], shield_addr1)
+                assert_equal(out['outgoing'], False)
+                assert_equal(out['memo'], no_memo)
+                assert_equal(out['value'], Decimal('1.3999'))
+                assert_equal(out['valueSat'], 139990000)
+                found[1] = True
+        assert_equal(found, [True] * 2)
 
         # shield_addr1 should have a note with change
         r = self.nodes[1].listreceivedbyshieldedaddress(shield_addr1, 0)


### PR DESCRIPTION
- Don't require to input the memo in hexadecimal format in `shielded_sendmany`/`raw_shielded_sendmany`, accept human readable strings.
- Add a simple function to check valid UTF-8 encoded strings.
- Re-enable `memoStr` field in `viewshieldedtransaction` output (skip if not valid utf-8)
- Trim trailing zeros for the raw `memo` field in `listshieldedunspent`/`viewshieldedtransaction` output.
- Update unit and functional tests