### PR TITLE
Coin control dialog utxo processing/update flow large cleanup and improvements

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -55,14 +55,7 @@ bool CAddrInfo::IsTerrible(int64_t nNow) const
 double CAddrInfo::GetChance(int64_t nNow) const
 {
     double fChance = 1.0;
-
-    int64_t nSinceLastSeen = nNow - nTime;
-    int64_t nSinceLastTry = nNow - nLastTry;
-
-    if (nSinceLastSeen < 0)
-        nSinceLastSeen = 0;
-    if (nSinceLastTry < 0)
-        nSinceLastTry = 0;
+    int64_t nSinceLastTry = std::max<int64_t>(nNow - nLastTry, 0);
 
     // deprioritize very recent attempts away
     if (nSinceLastTry < 60 * 10)

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -211,7 +211,6 @@ void CoinControlDialog::setModel(WalletModel* model)
         updateView();
         updateLabelLocked();
         updateLabels();
-        updateDialogLabels();
     }
 }
 
@@ -230,7 +229,6 @@ void CoinControlDialog::buttonSelectAllClicked()
     if (!fSelectAll)
         coinControl->UnSelectAll(); // just to be sure
     updateLabels();
-    updateDialogLabels();
 }
 
 // Toggle lock state
@@ -261,7 +259,6 @@ void CoinControlDialog::buttonToggleLockClicked()
         }
         ui->treeWidget->setEnabled(true);
         updateLabels();
-        updateDialogLabels();
     } else {
         QMessageBox msgBox;
         msgBox.setObjectName("lockMessageBox");
@@ -465,7 +462,6 @@ void CoinControlDialog::viewItemChanged(QTreeWidgetItem* item, int column)
         // selection changed -> update labels
         if (ui->treeWidget->isEnabled()){ // do not update on every click for (un)select all
             updateLabels();
-            updateDialogLabels();
         }
     }
 
@@ -487,38 +483,6 @@ void CoinControlDialog::updateLabelLocked()
         ui->labelLocked->setVisible(true);
     } else
         ui->labelLocked->setVisible(false);
-}
-
-void CoinControlDialog::updateDialogLabels()
-{
-
-    if (this->parentWidget() == nullptr) {
-        updateLabels();
-        return;
-    }
-
-    std::vector<COutPoint> vCoinControl;
-    std::vector<COutput> vOutputs;
-    coinControl->ListSelected(vCoinControl);
-    model->getOutputs(vCoinControl, vOutputs);
-
-    CAmount nAmount = 0;
-    unsigned int nQuantity = 0;
-    for (const COutput& out : vOutputs) {
-        // unselect already spent, very unlikely scenario, this could happen
-        // when selected are spent elsewhere, like rpc or another computer
-        COutPoint outpt(out.tx->GetHash(), out.i);
-        if(model->isSpent(outpt)) {
-            coinControl->UnSelect(outpt);
-            continue;
-        }
-
-        // Quantity
-        nQuantity++;
-
-        // Amount
-        nAmount += out.tx->vout[out.i].nValue;
-    }
 }
 
 void CoinControlDialog::updateLabels()
@@ -837,7 +801,6 @@ void CoinControlDialog::refreshDialog()
     updateView();
     updateLabelLocked();
     updateLabels();
-    updateDialogLabels();
 }
 
 void CoinControlDialog::inform(const QString& text)

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -642,7 +642,8 @@ void CoinControlDialog::loadAvailableCoin(bool treeMode,
                                           const uint32_t outIndex,
                                           const CAmount nValue,
                                           const int64_t nTime,
-                                          const int nDepth)
+                                          const int nDepth,
+                                          const bool isChange)
 {
     CCoinControlWidgetItem* itemOutput;
     if (treeMode)
@@ -660,7 +661,11 @@ void CoinControlDialog::loadAvailableCoin(bool treeMode,
     }
 
     // label
-    if (!treeMode) {
+    if (isChange) {
+        // tooltip stating where the change is being stored.
+        itemOutput->setToolTip(COLUMN_LABEL, tr("change in %1").arg(sWalletAddress));
+        itemOutput->setText(COLUMN_LABEL, tr("(change)"));
+    } else if (!treeMode) {
         itemOutput->setText(COLUMN_LABEL, sWalletLabel);
     }
 
@@ -729,7 +734,7 @@ void CoinControlDialog::updateView()
         itemWalletAddress->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);
         const WalletModel::ListCoinsKey& keys = coins.first;
         const QString& sWalletAddress = keys.address;
-        const Optional<QString>& stakerAddress = keys.stakerAddres;
+        const Optional<QString>& stakerAddress = keys.stakerAddress;
         QString sWalletLabel = model->getAddressTableModel()->labelForAddress(sWalletAddress);
         if (sWalletLabel.isEmpty())
             sWalletLabel = tr("(no label)");
@@ -758,8 +763,9 @@ void CoinControlDialog::updateView()
             nChildren++;
 
             loadAvailableCoin(treeMode, itemWalletAddress, flgCheckbox, flgTristate,
-                            nDisplayUnit, sWalletAddress, stakerAddress, sWalletLabel,
-                              out.txhash, out.outIndex, out.nValue, out.nTime, out.nDepth);
+                              nDisplayUnit, sWalletAddress, stakerAddress, sWalletLabel,
+                              out.txhash, out.outIndex, out.nValue, out.nTime, out.nDepth,
+                              keys.isChange);
         }
 
         // amount

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -165,10 +165,6 @@ CoinControlDialog::CoinControlDialog(QWidget* parent, bool _forDelegation) : QDi
     // Toggle lock state
     connect(ui->pushButtonToggleLock, &QPushButton::clicked, this, &CoinControlDialog::buttonToggleLockClicked);
 
-    // change coin control first column label due Qt4 bug.
-    // see https://github.com/bitcoin/bitcoin/issues/5716
-    ui->treeWidget->headerItem()->setText(COLUMN_CHECKBOX, QString());
-
     ui->treeWidget->setColumnWidth(COLUMN_CHECKBOX, 84);
     ui->treeWidget->setColumnWidth(COLUMN_AMOUNT, 120);
     ui->treeWidget->setColumnWidth(COLUMN_LABEL, 170);

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -764,16 +764,15 @@ void CoinControlDialog::updateView()
     QFlags<Qt::ItemFlag> flgTristate = Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsUserCheckable | Qt::ItemIsTristate;
 
     int nDisplayUnit = model->getOptionsModel()->getDisplayUnit();
-//    double mempoolEstimatePriority = mempool.estimateSmartPriority(nTxConfirmTarget);
-
     nSelectableInputs = 0;
-    std::map<QString, std::vector<COutput>> mapCoins;
+    std::map<WalletModel::ListCoinsKey, std::vector<COutput>> mapCoins;
     model->listCoins(mapCoins);
 
-    for (std::pair<QString, std::vector<COutput>> coins : mapCoins) {
+    for (const auto& coins : mapCoins) {
         CCoinControlWidgetItem* itemWalletAddress = new CCoinControlWidgetItem();
         itemWalletAddress->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);
-        QString sWalletAddress = coins.first;
+        WalletModel::ListCoinsKey keys = coins.first;
+        QString sWalletAddress = keys.address;
         QString sWalletLabel = model->getAddressTableModel()->labelForAddress(sWalletAddress);
         if (sWalletLabel.isEmpty())
             sWalletLabel = tr("(no label)");

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -675,9 +675,7 @@ void CoinControlDialog::updateLabels()
         }
 
         // after fee
-        nAfterFee = nAmount - nPayFee;
-        if (nAfterFee < 0)
-            nAfterFee = 0;
+        nAfterFee = std::max<CAmount>(nAmount - nPayFee, 0);
     }
 
     // actually update labels

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -481,9 +481,8 @@ void CoinControlDialog::viewItemChanged(QTreeWidgetItem* item, int column)
 // shows count of locked unspent outputs
 void CoinControlDialog::updateLabelLocked()
 {
-    std::vector<COutPoint> vOutpts;
-    model->listLockedCoins(vOutpts);
-    if (vOutpts.size() > 0) {
+    std::set<COutPoint> vOutpts = model->listLockedCoins();
+    if (!vOutpts.empty()) {
         ui->labelLocked->setText(tr("(%1 locked)").arg(vOutpts.size()));
         ui->labelLocked->setVisible(true);
     } else

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -795,9 +795,7 @@ void CoinControlDialog::updateView()
         }
 
         CAmount nSum = 0;
-        double dPrioritySum = 0;
         int nChildren = 0;
-        int nInputSum = 0;
         for(const COutput& out: coins.second) {
 
             // Basic values used in the entire process
@@ -809,7 +807,6 @@ void CoinControlDialog::updateView()
             const bool isP2CS = out.tx->vout[outIndex].scriptPubKey.IsPayToColdStaking();
 
             ++nSelectableInputs;
-            int nInputSize = 0;
             nSum += nValue;
             nChildren++;
 
@@ -847,11 +844,6 @@ void CoinControlDialog::updateView()
                     itemOutput->setText(COLUMN_ADDRESS, sAddress);
                 else
                     itemOutput->setToolTip(COLUMN_ADDRESS, sAddress);
-
-                CPubKey pubkey;
-                CKeyID* keyid = boost::get<CKeyID>(&outputAddress);
-                if (keyid && model->getPubKey(*keyid, pubkey) && !pubkey.IsCompressed())
-                    nInputSize = 29; // 29 = 180 - 151 (public key is 180 bytes, priority free area is 151 bytes)
             }
 
             // label
@@ -880,10 +872,6 @@ void CoinControlDialog::updateView()
             // confirmations
             itemOutput->setText(COLUMN_CONFIRMATIONS, QString::number(nDepth));
             itemOutput->setData(COLUMN_CONFIRMATIONS, Qt::UserRole, QVariant((qlonglong) nDepth));
-
-            // priority
-            dPrioritySum += (double)nValue * (nDepth + 1);
-            nInputSum += nInputSize;
 
             // transaction hash
             itemOutput->setText(COLUMN_TXHASH, QString::fromStdString(txhash.GetHex()));
@@ -918,7 +906,6 @@ void CoinControlDialog::updateView()
 
         // amount
         if (treeMode) {
-            dPrioritySum = dPrioritySum / (nInputSum + 78);
             itemWalletAddress->setText(COLUMN_CHECKBOX, "(" + QString::number(nChildren) + ")");
             itemWalletAddress->setText(COLUMN_AMOUNT, BitcoinUnits::format(nDisplayUnit, nSum));
             itemWalletAddress->setToolTip(COLUMN_AMOUNT, BitcoinUnits::format(nDisplayUnit, nSum));

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -464,14 +464,6 @@ void CoinControlDialog::viewItemChanged(QTreeWidgetItem* item, int column)
             updateLabels();
         }
     }
-
-    // TODO: Remove this temporary qt5 fix after Qt5.3 and Qt5.4 are no longer used.
-    //       Fixed in Qt5.5 and above: https://bugreports.qt.io/browse/QTBUG-43473
-    else if (column == COLUMN_CHECKBOX && item->childCount() > 0)
-    {
-        if (item->checkState(COLUMN_CHECKBOX) == Qt::PartiallyChecked && item->child(0)->checkState(COLUMN_CHECKBOX) == Qt::PartiallyChecked)
-            item->setCheckState(COLUMN_CHECKBOX, Qt::Checked);
-    }
 }
 
 // shows count of locked unspent outputs

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -827,9 +827,7 @@ void CoinControlDialog::updateView()
 
             // label
             if (!treeMode) {
-                QString sLabel = model->getAddressTableModel()->labelForAddress(sWalletAddress);
-                if (sLabel.isEmpty()) sLabel = tr("(no label)");
-                itemOutput->setText(COLUMN_LABEL, sLabel);
+                itemOutput->setText(COLUMN_LABEL, sWalletLabel);
             }
 
             // amount

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -721,7 +721,7 @@ void CoinControlDialog::updateView()
 
     int nDisplayUnit = model->getOptionsModel()->getDisplayUnit();
     nSelectableInputs = 0;
-    std::map<WalletModel::ListCoinsKey, std::vector<COutput>> mapCoins;
+    std::map<WalletModel::ListCoinsKey, std::vector<WalletModel::ListCoinsValue>> mapCoins;
     model->listCoins(mapCoins);
 
     for (const auto& coins : mapCoins) {
@@ -752,22 +752,14 @@ void CoinControlDialog::updateView()
 
         CAmount nSum = 0;
         int nChildren = 0;
-        for(const COutput& out: coins.second) {
-
-            // Basic values used in the entire process
-            const uint256& txhash = out.tx->GetHash();
-            const uint32_t outIndex = out.i;
-            const CAmount nValue = out.tx->vout[out.i].nValue;
-            const int64_t nTime = out.tx->GetTxTime();
-            const int nDepth = out.nDepth;
-
+        for (const WalletModel::ListCoinsValue& out: coins.second) {
             ++nSelectableInputs;
-            nSum += nValue;
+            nSum += out.nValue;
             nChildren++;
 
             loadAvailableCoin(treeMode, itemWalletAddress, flgCheckbox, flgTristate,
                             nDisplayUnit, sWalletAddress, stakerAddress, sWalletLabel,
-                            txhash, outIndex, nValue, nTime, nDepth);
+                              out.txhash, out.outIndex, out.nValue, out.nTime, out.nDepth);
         }
 
         // amount

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -509,7 +509,6 @@ void CoinControlDialog::updateLabels()
     unsigned int nBytes = 0;
     unsigned int nBytesInputs = 0;
     unsigned int nQuantity = 0;
-    int nQuantityUncompressed = 0;
 
     std::vector<COutPoint> vCoinControl;
     std::vector<COutput> vOutputs;
@@ -528,24 +527,10 @@ void CoinControlDialog::updateLabels()
 
         // Quantity
         nQuantity++;
-
         // Amount
         nAmount += out.tx->vout[out.i].nValue;
-
         // Bytes
-        CTxDestination address;
-        if (ExtractDestination(out.tx->vout[out.i].scriptPubKey, address)) {
-            CPubKey pubkey;
-            CKeyID* keyid = boost::get<CKeyID>(&address);
-            if (keyid && model->getPubKey(*keyid, pubkey)) {
-                nBytesInputs += (pubkey.IsCompressed() ? 148 : 180);
-                if (!pubkey.IsCompressed())
-                    nQuantityUncompressed++;
-            } else
-                nBytesInputs += 148; // in all error cases, simply assume 148 here
-        } else
-            nBytesInputs += 148;
-
+        nBytesInputs += 148;
         // Additional byte for P2CS
         if (out.tx->vout[out.i].scriptPubKey.IsPayToColdStaking())
             nBytesInputs++;

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -818,23 +818,17 @@ void CoinControlDialog::updateView()
             itemOutput->setFlags(flgCheckbox);
             itemOutput->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);
 
-            const QString& sAddress = sWalletAddress;
             // if listMode or change => show PIVX address. In tree mode, address is not shown again for direct wallet address outputs
-            if (!treeMode)
-                itemOutput->setText(COLUMN_ADDRESS, sAddress);
-            else
-                itemOutput->setToolTip(COLUMN_ADDRESS, sAddress);
+            if (!treeMode) {
+                itemOutput->setText(COLUMN_ADDRESS, sWalletAddress);
+            }else {
+                itemOutput->setToolTip(COLUMN_ADDRESS, sWalletAddress);
+            }
 
             // label
-            if (!(sAddress == sWalletAddress)) // change
-            {
-                // tooltip from where the change comes from
-                itemOutput->setToolTip(COLUMN_LABEL, tr("change from %1 (%2)").arg(sWalletLabel).arg(sWalletAddress));
-                itemOutput->setText(COLUMN_LABEL, tr("(change)"));
-            } else if (!treeMode) {
-                QString sLabel = model->getAddressTableModel()->labelForAddress(sAddress);
-                if (sLabel.isEmpty())
-                    sLabel = tr("(no label)");
+            if (!treeMode) {
+                QString sLabel = model->getAddressTableModel()->labelForAddress(sWalletAddress);
+                if (sLabel.isEmpty()) sLabel = tr("(no label)");
                 itemOutput->setText(COLUMN_LABEL, sLabel);
             }
 

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -8,6 +8,8 @@
 
 #include "amount.h"
 #include "qt/pivx/snackbar.h"
+#include "optional.h"
+#include "uint256.h"
 
 #include <QAbstractButton>
 #include <QAction>
@@ -73,6 +75,21 @@ private:
     void updatePushButtonSelectAll(bool checked);
     void sortView(int, Qt::SortOrder);
     void inform(const QString& text);
+
+    // Load a row with coin's data
+    void loadAvailableCoin(bool treeMode,
+                           CCoinControlWidgetItem* itemWalletAddress,
+                           QFlags<Qt::ItemFlag> flgCheckbox,
+                           QFlags<Qt::ItemFlag> flgTristate,
+                           int nDisplayUnit,
+                           const QString& sWalletAddress,
+                           const Optional<QString>& stakerAddress,
+                           const QString& sWalletLabel,
+                           const uint256& txhash,
+                           const uint32_t outIndex,
+                           const CAmount nValue,
+                           const int64_t nTime,
+                           const int nDepth);
 
     enum {
         COLUMN_CHECKBOX,

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -46,7 +46,6 @@ public:
     ~CoinControlDialog() override;
 
     void setModel(WalletModel* model);
-    void updateDialogLabels();
     void updateLabels();
     void updateView();
     void refreshDialog();

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -19,8 +19,6 @@
 #include <QTreeWidgetItem>
 
 class WalletModel;
-
-class MultisigDialog;
 class CCoinControl;
 class CTxMemPool;
 
@@ -36,7 +34,7 @@ public:
     explicit CCoinControlWidgetItem(int type = Type) : QTreeWidgetItem(type) {}
     explicit CCoinControlWidgetItem(QTreeWidgetItem *parent, int type = Type) : QTreeWidgetItem(parent, type) {}
 
-    bool operator<(const QTreeWidgetItem &other) const;
+    bool operator<(const QTreeWidgetItem &other) const override;
 };
 
 class CoinControlDialog : public QDialog
@@ -45,7 +43,7 @@ class CoinControlDialog : public QDialog
 
 public:
     explicit CoinControlDialog(QWidget* parent = nullptr, bool _forDelegation = false);
-    ~CoinControlDialog();
+    ~CoinControlDialog() override;
 
     void setModel(WalletModel* model);
     void updateDialogLabels();
@@ -54,8 +52,6 @@ public:
     void refreshDialog();
     void clearPayAmounts();
     void addPayAmount(const CAmount& amount);
-
-    static QString getPriorityLabel(double dPriority, double mempoolEstimatePriority);
 
     CCoinControl* coinControl;
 

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -89,7 +89,8 @@ private:
                            const uint32_t outIndex,
                            const CAmount nValue,
                            const int64_t nTime,
-                           const int nDepth);
+                           const int nDepth,
+                           const bool isChange);
 
     enum {
         COLUMN_CHECKBOX,

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -861,19 +861,11 @@ void WalletModel::listCoins(std::map<QString, std::vector<COutput> >& mapCoins) 
     std::vector<COutput> vCoins;
     wallet->AvailableCoins(&vCoins, nullptr, filter);
 
-    LOCK(wallet->cs_wallet);
     for (const COutput& out : vCoins) {
-        COutput cout = out;
-
-        while (wallet->IsChange(cout.tx->vout[cout.i]) && cout.tx->vin.size() > 0 && wallet->IsMine(cout.tx->vin[0])) {
-            if (!wallet->mapWallet.count(cout.tx->vin[0].prevout.hash)) break;
-            cout = COutput(&wallet->mapWallet[cout.tx->vin[0].prevout.hash], cout.tx->vin[0].prevout.n, 0, true, true);
-        }
-
         CTxDestination address;
-        if (!out.fSpendable || !ExtractDestination(cout.tx->vout[cout.i].scriptPubKey, address))
+        if (!out.fSpendable || !ExtractDestination(out.tx->vout[out.i].scriptPubKey, address))
             continue;
-        mapCoins[QString::fromStdString(EncodeDestination(address))].push_back(out);
+        mapCoins[QString::fromStdString(EncodeDestination(address))].emplace_back(out);
     }
 }
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -908,10 +908,10 @@ void WalletModel::unlockCoin(COutPoint& output)
     wallet->UnlockCoin(output);
 }
 
-void WalletModel::listLockedCoins(std::vector<COutPoint>& vOutpts)
+std::set<COutPoint> WalletModel::listLockedCoins()
 {
-    LOCK2(cs_main, wallet->cs_wallet);
-    wallet->ListLockedCoins(vOutpts);
+    LOCK(wallet->cs_wallet);
+    return wallet->ListLockedCoins();
 }
 
 void WalletModel::loadReceiveRequests(std::vector<std::string>& vReceiveRequests)

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -854,7 +854,7 @@ bool WalletModel::isSpent(const COutPoint& outpoint) const
 }
 
 // AvailableCoins + LockedCoins grouped by wallet address (put change in one group with wallet address)
-void WalletModel::listCoins(std::map<ListCoinsKey, std::vector<COutput> >& mapCoins) const
+void WalletModel::listCoins(std::map<ListCoinsKey, std::vector<ListCoinsValue>>& mapCoins) const
 {
     CWallet::AvailableCoinsFilter filter;
     filter.fIncludeLocked = true;
@@ -886,7 +886,14 @@ void WalletModel::listCoins(std::map<ListCoinsKey, std::vector<COutput> >& mapCo
             nullopt;
 
         ListCoinsKey key{address, stakerAddr};
-        mapCoins[key].emplace_back(out);
+        ListCoinsValue value{
+                out.tx->GetHash(),
+                out.i,
+                out.tx->vout[out.i].nValue,
+                out.tx->GetTxTime(),
+                out.nDepth
+        };
+        mapCoins[key].emplace_back(value);
     }
 }
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -820,12 +820,12 @@ void WalletModel::getOutputs(const std::vector<COutPoint>& vOutpoints, std::vect
 {
     LOCK2(cs_main, wallet->cs_wallet);
     for (const COutPoint& outpoint : vOutpoints) {
-        if (!wallet->mapWallet.count(outpoint.hash)) continue;
+        const auto* tx = wallet->GetWalletTx(outpoint.hash);
+        if (!tx) continue;
         bool fConflicted;
-        const int nDepth = wallet->mapWallet[outpoint.hash].GetDepthAndMempool(fConflicted);
+        const int nDepth = tx->GetDepthAndMempool(fConflicted);
         if (nDepth < 0 || fConflicted) continue;
-        COutput out(&wallet->mapWallet[outpoint.hash], outpoint.n, nDepth, true, true);
-        vOutputs.push_back(out);
+        vOutputs.emplace_back(tx, outpoint.n, nDepth, true, true);
     }
 }
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -885,7 +885,7 @@ void WalletModel::listCoins(std::map<ListCoinsKey, std::vector<ListCoinsValue>>&
             Optional<QString>(QString::fromStdString(EncodeDestination(outputAddressStaker, CChainParams::STAKING_ADDRESS))) :
             nullopt;
 
-        ListCoinsKey key{address, stakerAddr};
+        ListCoinsKey key{address, wallet->IsChange(outputAddress), stakerAddr};
         ListCoinsValue value{
                 out.tx->GetHash(),
                 out.i,

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -97,8 +97,10 @@ CAmount WalletModel::getBalance(const CCoinControl* coinControl, bool fIncludeDe
 {
     if (coinControl) {
         CAmount nBalance = 0;
+        CWallet::AvailableCoinsFilter coinsFilter;
+        coinsFilter.fIncludeDelegated = fIncludeDelegated;
         std::vector<COutput> vCoins;
-        wallet->AvailableCoins(&vCoins, coinControl, fIncludeDelegated);
+        wallet->AvailableCoins(&vCoins, coinControl, coinsFilter);
         for (const COutput& out : vCoins) {
             bool fSkip = fUnlockedOnly && isLockedCoin(out.tx->GetHash(), out.i);
             if (out.fSpendable && !fSkip)
@@ -830,8 +832,11 @@ void WalletModel::getOutputs(const std::vector<COutPoint>& vOutpoints, std::vect
 // returns a COutPoint of 10000 PIV if found
 bool WalletModel::getMNCollateralCandidate(COutPoint& outPoint)
 {
+    CWallet::AvailableCoinsFilter coinsFilter;
+    coinsFilter.fIncludeDelegated = false;
+    coinsFilter.nCoinType = ONLY_10000;
     std::vector<COutput> vCoins;
-    wallet->AvailableCoins(&vCoins, nullptr, false, false, ONLY_10000);
+    wallet->AvailableCoins(&vCoins, nullptr, coinsFilter);
     for (const COutput& out : vCoins) {
         // skip locked collaterals
         if (!isLockedCoin(out.tx->GetHash(), out.i)) {

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -262,7 +262,22 @@ public:
     void getOutputs(const std::vector<COutPoint>& vOutpoints, std::vector<COutput>& vOutputs);
     bool getMNCollateralCandidate(COutPoint& outPoint);
     bool isSpent(const COutPoint& outpoint) const;
-    void listCoins(std::map<QString, std::vector<COutput> >& mapCoins) const;
+
+    class ListCoinsKey {
+    public:
+        QString address;
+        Optional<QString> stakerAddress; // used only for P2CS utxo
+
+        bool operator==(const ListCoinsKey& key2) const {
+            return address == key2.address && stakerAddress == key2.stakerAddress;
+        }
+
+        bool operator<(const ListCoinsKey& key2) const {
+            return this->address < key2.address;
+        }
+    };
+
+    void listCoins(std::map<ListCoinsKey, std::vector<COutput> >& mapCoins) const;
 
     bool isLockedCoin(uint256 hash, unsigned int n) const;
     void lockCoin(COutPoint& output);

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -266,6 +266,7 @@ public:
     class ListCoinsKey {
     public:
         QString address;
+        bool isChange;
         Optional<QString> stakerAddress; // used only for P2CS utxo
 
         bool operator==(const ListCoinsKey& key2) const {

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -277,7 +277,16 @@ public:
         }
     };
 
-    void listCoins(std::map<ListCoinsKey, std::vector<COutput> >& mapCoins) const;
+    class ListCoinsValue {
+    public:
+        const uint256& txhash;
+        int outIndex;
+        CAmount nValue;
+        int64_t nTime;
+        int nDepth;
+    };
+
+    void listCoins(std::map<ListCoinsKey, std::vector<ListCoinsValue>>& mapCoins) const;
 
     bool isLockedCoin(uint256 hash, unsigned int n) const;
     void lockCoin(COutPoint& output);

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -282,9 +282,8 @@ public:
     bool isLockedCoin(uint256 hash, unsigned int n) const;
     void lockCoin(COutPoint& output);
     void unlockCoin(COutPoint& output);
-    void listLockedCoins(std::vector<COutPoint>& vOutpts);
+    std::set<COutPoint> listLockedCoins();
 
-    std::string GetUniqueWalletBackupName();
     void loadReceiveRequests(std::vector<std::string>& vReceiveRequests);
     bool saveReceiveRequest(const std::string& sAddress, const int64_t nId, const std::string& sRequest);
 

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -489,8 +489,11 @@ UniValue getmasternodeoutputs (const JSONRPCRequest& request)
             HelpExampleCli("getmasternodeoutputs", "") + HelpExampleRpc("getmasternodeoutputs", ""));
 
     // Find possible candidates
+    CWallet::AvailableCoinsFilter coinsFilter;
+    coinsFilter.fIncludeDelegated = false;
+    coinsFilter.nCoinType = ONLY_10000;
     std::vector<COutput> possibleCoins;
-    pwalletMain->AvailableCoins(&possibleCoins, nullptr, false, false, ONLY_10000);
+    pwalletMain->AvailableCoins(&possibleCoins, nullptr, coinsFilter);
 
     UniValue ret(UniValue::VARR);
     for (COutput& out : possibleCoins) {

--- a/src/sapling/sapling_operation.cpp
+++ b/src/sapling/sapling_operation.cpp
@@ -211,16 +211,14 @@ OperationResult SaplingOperation::loadUtxos(TxValues& txValues)
 {
     std::set<CTxDestination> destinations;
     if (fromAddress.isFromTAddress()) destinations.insert(fromAddress.fromTaddr);
-    if (!pwalletMain->AvailableCoins(
-            &transInputs,
-            nullptr,
-            false,
-            false,
-            ALL_COINS,
-            true,
-            true,
-            &destinations,
-            mindepth)) {
+    CWallet::AvailableCoinsFilter coinsFilter(false,
+                                              false,
+                                              ALL_COINS,
+                                              true,
+                                              true,
+                                              &destinations,
+                                              mindepth);
+    if (!pwalletMain->AvailableCoins(&transInputs, nullptr, coinsFilter)) {
         return errorOut("Insufficient funds, no available UTXO to spend");
     }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3257,13 +3257,9 @@ UniValue listunspent(const JSONRPCRequest& request)
     std::vector<COutput> vecOutputs;
     assert(pwalletMain != NULL);
     LOCK2(cs_main, pwalletMain->cs_wallet);
-    pwalletMain->AvailableCoins(&vecOutputs,
-                                &coinControl,    // coin control
-                                true,       // include delegated
-                                false,      // include cold staking
-                                ALL_COINS,  // coin type
-                                false       // only confirmed
-                                );
+    CWallet::AvailableCoinsFilter coinFilter;
+    coinFilter.fOnlyConfirmed = false;
+    pwalletMain->AvailableCoins(&vecOutputs, &coinControl, coinFilter);
     for (const COutput& out : vecOutputs) {
         if (out.nDepth < nMinDepth || out.nDepth > nMaxDepth)
             continue;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3453,12 +3453,10 @@ UniValue listlockunspent(const JSONRPCRequest& request)
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
-    std::vector<COutPoint> vOutpts;
-    pwalletMain->ListLockedCoins(vOutpts);
-
+    std::set<COutPoint> vOutpts = pwalletMain->ListLockedCoins();
     UniValue ret(UniValue::VARR);
 
-    for (COutPoint& outpt : vOutpts) {
+    for (const COutPoint& outpt : vOutpts) {
         UniValue o(UniValue::VOBJ);
 
         o.pushKV("txid", outpt.hash.GetHex());

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1310,11 +1310,16 @@ bool CWallet::IsChange(const CTxOut& txout) const
         if (!ExtractDestination(txout.scriptPubKey, address))
             return true;
 
-        LOCK(cs_wallet);
-        if (!HasAddressBook(address))
-            return true;
+        return IsChange(address);
     }
     return false;
+}
+
+bool CWallet::IsChange(const CTxDestination& address) const
+{
+    // Read the current assumptions in IsChange(const CTxOut&)
+    // this can definitely be different in the short future.
+    return WITH_LOCK(cs_wallet, return !HasAddressBook(address));
 }
 
 int64_t CWalletTx::GetTxTime() const

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2168,7 +2168,8 @@ CWallet::OutputAvailabilityResult CWallet::CheckOutputAvailability(
         const CCoinControl* coinControl,
         const bool fCoinsSelected,
         const bool fIncludeColdStaking,
-        const bool fIncludeDelegated) const
+        const bool fIncludeDelegated,
+        const bool fIncludeLocked) const
 {
     OutputAvailabilityResult res;
 
@@ -2190,7 +2191,7 @@ CWallet::OutputAvailabilityResult CWallet::CheckOutputAvailability(
     if (mine == ISMINE_WATCH_ONLY && coinControl && !coinControl->fAllowWatchOnly) return res;
 
     // Skip locked utxo
-    if (IsLockedCoin(wtxid, outIndex) && nCoinType != ONLY_10000) return res;
+    if (!fIncludeLocked && IsLockedCoin(wtxid, outIndex) && nCoinType != ONLY_10000) return res;
 
     // Check if we should include zero value utxo
     if (output.nValue <= 0) return res;
@@ -2264,7 +2265,8 @@ bool CWallet::AvailableCoins(std::vector<COutput>* pCoins,      // --> populates
                         coinControl,
                         fCoinsSelected,
                         coinsFilter.fIncludeColdStaking,
-                        coinsFilter.fIncludeDelegated);
+                        coinsFilter.fIncludeDelegated,
+                        coinsFilter.fIncludeLocked);
 
                 if (!res.available) continue;
                 if (coinsFilter.fOnlySpendable && !res.spendable) continue;
@@ -2376,7 +2378,8 @@ bool CWallet::StakeableCoins(std::vector<CStakeableOutput>* pCoins)
                     nullptr, // coin control
                     false,   // fIncludeDelegated
                     fIncludeColdStaking,
-                    false);
+                    false,
+                    false);   // fIncludeLocked
 
             if (!res.available) continue;
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3520,14 +3520,10 @@ bool CWallet::IsLockedCoin(const uint256& hash, unsigned int n) const
     return (setLockedCoins.count(outpt) > 0);
 }
 
-void CWallet::ListLockedCoins(std::vector<COutPoint>& vOutpts)
+std::set<COutPoint> CWallet::ListLockedCoins()
 {
-    AssertLockHeld(cs_wallet); // setLockedCoins
-    for (std::set<COutPoint>::iterator it = setLockedCoins.begin();
-         it != setLockedCoins.end(); it++) {
-        COutPoint outpt = (*it);
-        vOutpts.push_back(outpt);
-    }
+    AssertLockHeld(cs_wallet);
+    return setLockedCoins;
 }
 
 /** @} */ // end of Actions

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -441,16 +441,37 @@ public:
     //! check whether we are allowed to upgrade (or already support) to the named feature
     bool CanSupportFeature(enum WalletFeature wf);
 
+    struct AvailableCoinsFilter {
+        public:
+        AvailableCoinsFilter() {}
+        AvailableCoinsFilter(bool _fIncludeDelegated,
+                             bool _fIncludeColdStaking,
+                             AvailableCoinsType _nCoinType,
+                             bool _fOnlyConfirmed,
+                             bool _fOnlySpendable,
+                             std::set<CTxDestination>* _onlyFilteredDest,
+                             int _minDepth) :
+                fIncludeDelegated(_fIncludeDelegated),
+                fIncludeColdStaking(_fIncludeColdStaking),
+                nCoinType(_nCoinType),
+                fOnlyConfirmed(_fOnlyConfirmed),
+                fOnlySpendable(_fOnlySpendable),
+                onlyFilteredDest(_onlyFilteredDest),
+                minDepth(_minDepth) {}
+
+        bool fIncludeDelegated{true};
+        bool fIncludeColdStaking{false};
+        AvailableCoinsType nCoinType{ALL_COINS};
+        bool fOnlyConfirmed{true};
+        bool fOnlySpendable{false};
+        std::set<CTxDestination>* onlyFilteredDest{nullptr};
+        int minDepth{0};
+    };
+
     //! >> Available coins (generic)
     bool AvailableCoins(std::vector<COutput>* pCoins,   // --> populates when != nullptr
                         const CCoinControl* coinControl = nullptr,
-                        bool fIncludeDelegated          = true,
-                        bool fIncludeColdStaking        = false,
-                        AvailableCoinsType nCoinType    = ALL_COINS,
-                        bool fOnlyConfirmed             = true,
-                        bool fOnlySpendable             = false,
-                        std::set<CTxDestination>*       = nullptr,
-                        int minDepth                    = 0
+                        AvailableCoinsFilter coinsFilter = AvailableCoinsFilter()
                         ) const;
     //! >> Available coins (spending)
     bool SelectCoinsToSpend(const std::vector<COutput>& vAvailableCoins, const CAmount& nTargetValue, std::set<std::pair<const CWalletTx*, unsigned int> >& setCoinsRet, CAmount& nValueRet, const CCoinControl* coinControl = nullptr) const;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -58,7 +58,6 @@ extern CAmount maxTxFee;
 extern unsigned int nTxConfirmTarget;
 extern bool bSpendZeroConfChange;
 extern bool bdisableSystemnotifications;
-extern bool fSendFreeTransactions;
 extern bool fPayAtLeastCustomFee;
 
 //! -paytxfee default

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -340,7 +340,8 @@ private:
                                                      const CCoinControl* coinControl,
                                                      const bool fCoinsSelected,
                                                      const bool fIncludeColdStaking,
-                                                     const bool fIncludeDelegated) const;
+                                                     const bool fIncludeDelegated,
+                                                     const bool fIncludeLocked) const;
 
     // Zerocoin wallet
     CzPIVWallet* zwallet{nullptr};
@@ -450,14 +451,16 @@ public:
                              bool _fOnlyConfirmed,
                              bool _fOnlySpendable,
                              std::set<CTxDestination>* _onlyFilteredDest,
-                             int _minDepth) :
+                             int _minDepth,
+                             bool _fIncludeLocked = false) :
                 fIncludeDelegated(_fIncludeDelegated),
                 fIncludeColdStaking(_fIncludeColdStaking),
                 nCoinType(_nCoinType),
                 fOnlyConfirmed(_fOnlyConfirmed),
                 fOnlySpendable(_fOnlySpendable),
                 onlyFilteredDest(_onlyFilteredDest),
-                minDepth(_minDepth) {}
+                minDepth(_minDepth),
+                fIncludeLocked(_fIncludeLocked) {}
 
         bool fIncludeDelegated{true};
         bool fIncludeColdStaking{false};
@@ -466,6 +469,7 @@ public:
         bool fOnlySpendable{false};
         std::set<CTxDestination>* onlyFilteredDest{nullptr};
         int minDepth{0};
+        bool fIncludeLocked{false};
     };
 
     //! >> Available coins (generic)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -709,6 +709,7 @@ public:
     isminetype IsMine(const CTxOut& txout) const;
     CAmount GetCredit(const CTxOut& txout, const isminefilter& filter) const;
     bool IsChange(const CTxOut& txout) const;
+    bool IsChange(const CTxDestination& address) const;
     CAmount GetChange(const CTxOut& txout) const;
     bool IsMine(const CTransaction& tx) const;
     /** should probably be renamed to IsRelevantToMe */

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -499,7 +499,7 @@ public:
     void LockCoin(const COutPoint& output);
     void UnlockCoin(const COutPoint& output);
     void UnlockAllCoins();
-    void ListLockedCoins(std::vector<COutPoint>& vOutpts);
+    std::set<COutPoint> ListLockedCoins();
 
     //  keystore implementation
     PairResult getNewAddress(CTxDestination& ret, const std::string addressLabel, const std::string purpose,


### PR DESCRIPTION
Base initial work in order to be able to generalize `CoinControlDialog` up to the point of introducing shielded notes selection (being developed in the Sapling GUI PR #1963).

Found several redundancies and not so good code over the overall `CoinControlDialog` class.  So.. have re-structured it in a large percentage, aiming to improve the performance and clean all of the inefficiencies.