### PR TITLE
[Consensus][Validation] Dynamic Fee for Shielded Transactions + Max Size.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -299,7 +299,7 @@ jobs:
             unit_tests: false
             functional_tests: true
             goal: install
-            test_runner_extra: "--tiertwo --sapling --skipcache"
+            test_runner_extra: "--tiertwo --sapling"
             BITCOIN_CONFIG: "--enable-zmq --with-gui=no --enable-glibc-back-compat --enable-reduce-exports --disable-online-rust"
 
           - name: x86_64 Linux  [GOAL:install]  [xenial]  [no depends only system libs]

--- a/.travis.yml
+++ b/.travis.yml
@@ -180,7 +180,7 @@ jobs:
         DEP_OPTS="NO_QT=1 NO_UPNP=1 DEBUG=1 ALLOW_HOST_PACKAGES=1"
         RUN_UNIT_TESTS=false
         RUN_FUNCTIONAL_TESTS=true
-        TEST_RUNNER_EXTRA="--tiertwo --sapling --skipcache"   # Run tier two and sapling functional tests only.
+        TEST_RUNNER_EXTRA="--tiertwo --sapling"   # Run tier two and sapling functional tests only.
         GOAL="install"
         BITCOIN_CONFIG="--with-gui=no --enable-glibc-back-compat --enable-reduce-exports --disable-online-rust --with-params-dir=$PARAMS_DIR"
         BUILD_TIMEOUT=800

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -15,7 +15,7 @@ static const unsigned int MAX_BLOCK_SIZE_CURRENT = 2000000;
 static const unsigned int MAX_BLOCK_SIZE_LEGACY = 1000000;
 
 /** The maximum size of a transaction after Sapling activation (network rule) */
-static const unsigned int MAX_TX_SIZE_AFTER_SAPLING = MAX_BLOCK_SIZE_LEGACY;
+static const unsigned int MAX_TX_SIZE_AFTER_SAPLING = 400000;
 
 /** The maximum allowed number of signature check operations in a block (network rule) */
 static const unsigned int MAX_BLOCK_SIGOPS_CURRENT = MAX_BLOCK_SIZE_CURRENT / 50;

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -34,9 +34,23 @@ CAmount GetDustThreshold(const CTxOut& txout, const CFeeRate& dustRelayFee)
     return 3 * dustRelayFee.GetFee(nSize);
 }
 
+CAmount GetDustThreshold(const CFeeRate& dustRelayFee)
+{
+    // return the dust threshold for a typical 34 bytes output
+    return 3 * dustRelayFee.GetFee(182);
+}
+
 bool IsDust(const CTxOut& txout, const CFeeRate& dustRelayFee)
 {
     return (txout.nValue < GetDustThreshold(txout, dustRelayFee));
+}
+
+CAmount GetShieldedDustThreshold(const CFeeRate& dustRelayFee)
+{
+    unsigned int K = DEFAULT_SHIELDEDTXFEE_K;   // Fixed (1000) for now
+    return 3 * K * dustRelayFee.GetFee(SPENDDESCRIPTION_SIZE +
+                                       CTXOUT_REGULAR_SIZE +
+                                       BINDINGSIG_SIZE);
 }
 
 /**

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -120,7 +120,7 @@ bool IsStandardTx(const CTransaction& tx, int nBlockHeight, std::string& reason)
     // computing signature hashes is O(ninputs*txsize). Limiting transactions
     // to MAX_STANDARD_TX_SIZE mitigates CPU exhaustion attacks.
     unsigned int sz = tx.GetTotalSize();
-    unsigned int nMaxSize = tx.IsShieldedTx() ? MAX_STANDARD_SHIELDED_TX_SIZE :
+    unsigned int nMaxSize = tx.IsShieldedTx() ? MAX_TX_SIZE_AFTER_SAPLING :
             tx.ContainsZerocoins() ? MAX_ZEROCOIN_TX_SIZE : MAX_STANDARD_TX_SIZE;
     if (sz >= nMaxSize) {
         reason = "tx-size";

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -54,6 +54,9 @@ CAmount GetDustThreshold(const CTxOut& txout, const CFeeRate& dustRelayFee);
 
 bool IsDust(const CTxOut& txout, const CFeeRate& dustRelayFee);
 
+CAmount GetDustThreshold(const CFeeRate& dustRelayFee);
+CAmount GetShieldedDustThreshold(const CFeeRate& dustRelayFee);
+
 bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType);
 
 /** Check for standard transaction types

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -876,7 +876,7 @@ UniValue sendrawtransaction(const JSONRPCRequest& request)
         bool fMissingInputs;
         {
             LOCK(cs_main);
-            if (!AcceptToMemoryPool(mempool, state, MakeTransactionRef(std::move(tx)), false, &fMissingInputs, false, !fOverrideFees)) {
+            if (!AcceptToMemoryPool(mempool, state, MakeTransactionRef(std::move(tx)), true, &fMissingInputs, false, !fOverrideFees)) {
                 if (state.IsInvalid()) {
                     throw JSONRPCError(RPC_TRANSACTION_REJECTED, strprintf("%i: %s", state.GetRejectCode(), state.GetRejectReason()));
                 } else {

--- a/src/sapling/sapling_operation.cpp
+++ b/src/sapling/sapling_operation.cpp
@@ -278,10 +278,16 @@ OperationResult SaplingOperation::loadUtxos(TxValues& txValues)
         }
     }
 
+    // Not enough funds
+    if (selectedUTXOAmount < txValues.target) {
+                return errorOut(strprintf("Insufficient transparent funds, have %s, need %s",
+                                  FormatMoney(selectedUTXOAmount), FormatMoney(txValues.target)));
+    }
+
     // If there is transparent change, is it valid or is it dust?
     if (dustChange < dustThreshold && dustChange != 0) {
         return errorOut(strprintf("Insufficient transparent funds, have %s, need %s more to avoid creating invalid change output %s (dust threshold is %s)",
-                                  FormatMoney(txValues.transInTotal), FormatMoney(dustThreshold - dustChange), FormatMoney(dustChange), FormatMoney(dustThreshold)));
+                                  FormatMoney(selectedUTXOAmount), FormatMoney(dustThreshold - dustChange), FormatMoney(dustChange), FormatMoney(dustThreshold)));
     }
 
     transInputs = selectedTInputs;

--- a/src/sapling/sapling_operation.h
+++ b/src/sapling/sapling_operation.h
@@ -87,6 +87,7 @@ public:
 
     void setFromAddress(const CTxDestination&);
     void setFromAddress(const libzcash::SaplingPaymentAddress&);
+    void clearTx() { txBuilder.Clear(); }
     // In case of no addressFrom filter selected, it will accept any utxo in the wallet as input.
     SaplingOperation* setSelectTransparentCoins(const bool select) { selectFromtaddrs = select; return this; };
     SaplingOperation* setSelectShieldedCoins(const bool select) { selectFromShield = select; return this; };
@@ -107,7 +108,7 @@ private:
     std::vector<COutput> transInputs;
     std::vector<SaplingNoteEntry> shieldedInputs;
     int mindepth{5}; // Min default depth 5.
-    CAmount fee{DEFAULT_SAPLING_FEE}; // Hardcoded fee for now.
+    CAmount fee{0};  // User selected fee.
 
     // transparent change
     CReserveKey* tkeyChange{nullptr};

--- a/src/sapling/sapling_transaction.h
+++ b/src/sapling/sapling_transaction.h
@@ -25,6 +25,7 @@
 // https://zips.z.cash/protocol/protocol.pdf#txnencoding
 #define OUTPUTDESCRIPTION_SIZE  948
 #define SPENDDESCRIPTION_SIZE   384
+#define BINDINGSIG_SIZE          64
 
 namespace libzcash {
     static constexpr size_t GROTH_PROOF_SIZE = (
@@ -130,7 +131,7 @@ public:
 class SaplingTxData
 {
 public:
-    typedef std::array<unsigned char, 64> binding_sig_t;
+    typedef std::array<unsigned char, BINDINGSIG_SIZE> binding_sig_t;
 
     CAmount valueBalance{0};
     std::vector<SpendDescription> vShieldedSpend;

--- a/src/sapling/sapling_transaction.h
+++ b/src/sapling/sapling_transaction.h
@@ -17,10 +17,14 @@
 
 #include <boost/variant.hpp>
 
+// transaction.h comment: spending taddr output requires CTxIn >= 148 bytes and typical taddr txout is 34 bytes
+#define CTXIN_SPEND_DUST_SIZE   148
+#define CTXOUT_REGULAR_SIZE     34
+
 // These constants are defined in the protocol § 7.1:
 // https://zips.z.cash/protocol/protocol.pdf#txnencoding
-#define OUTPUTDESCRIPTION_SIZE 948
-#define SPENDDESCRIPTION_SIZE 384
+#define OUTPUTDESCRIPTION_SIZE  948
+#define SPENDDESCRIPTION_SIZE   384
 
 namespace libzcash {
     static constexpr size_t GROTH_PROOF_SIZE = (

--- a/src/sapling/transaction_builder.cpp
+++ b/src/sapling/transaction_builder.cpp
@@ -8,6 +8,8 @@
 #include "script/sign.h"
 #include "utilmoneystr.h"
 #include "consensus/upgrades.h"
+#include "policy/policy.h"
+#include "validation.h"
 
 #include <librustzcash.h>
 
@@ -234,21 +236,30 @@ TransactionBuilderResult TransactionBuilder::Build()
     //
 
     if (change > 0) {
-        // Send change to the specified change address. If no change address
-        // was set, send change to the first Sapling address given as input
-        // (A t-address can only be used as the change address if explicitly set.)
-        if (saplingChangeAddr) {
-            AddSaplingOutput(saplingChangeAddr->first, saplingChangeAddr->second, change);
-        } else if (tChangeAddr) {
-            // tChangeAddr has already been validated.
-            AddTransparentOutput(*tChangeAddr, change);
-        } else if (!spends.empty()) {
-            auto fvk = spends[0].expsk.full_viewing_key();
-            auto note = spends[0].note;
-            libzcash::SaplingPaymentAddress changeAddr(note.d, note.pk_d);
-            AddSaplingOutput(fvk.ovk, changeAddr, change);
+        // If we get here and the change is dust, add it to the fee
+        CAmount dustThreshold = (spends.empty() && outputs.empty()) ? GetDustThreshold(minRelayTxFee) :
+                                GetShieldedDustThreshold(minRelayTxFee);
+        if (change > dustThreshold) {
+            // Send change to the specified change address. If no change address
+            // was set, send change to the first Sapling address given as input
+            // (A t-address can only be used as the change address if explicitly set.)
+            if (saplingChangeAddr) {
+                AddSaplingOutput(saplingChangeAddr->first, saplingChangeAddr->second, change);
+            } else if (tChangeAddr) {
+                // tChangeAddr has already been validated.
+                AddTransparentOutput(*tChangeAddr, change);
+            } else if (!spends.empty()) {
+                auto fvk = spends[0].expsk.full_viewing_key();
+                auto note = spends[0].note;
+                libzcash::SaplingPaymentAddress changeAddr(note.d, note.pk_d);
+                AddSaplingOutput(fvk.ovk, changeAddr, change);
+            } else {
+                return TransactionBuilderResult("Could not determine change address");
+            }
         } else {
-            return TransactionBuilderResult("Could not determine change address");
+            // Not used after, but update for consistency
+            fee += change;
+            change = 0;
         }
     }
 

--- a/src/sapling/transaction_builder.cpp
+++ b/src/sapling/transaction_builder.cpp
@@ -11,9 +11,6 @@
 
 #include <librustzcash.h>
 
-// Initial fee used when searching for the optimal (GetShieldedTxMinFee)
-CAmount DEFAULT_SAPLING_FEE = 1000000;
-
 SpendDescriptionInfo::SpendDescriptionInfo(
     libzcash::SaplingExpandedSpendingKey expsk,
     libzcash::SaplingNote note,

--- a/src/sapling/transaction_builder.h
+++ b/src/sapling/transaction_builder.h
@@ -19,8 +19,6 @@
 #include "sapling/note.hpp"
 #include "sapling/noteencryption.hpp"
 
-extern CAmount DEFAULT_SAPLING_FEE;
-
 struct SpendDescriptionInfo {
     libzcash::SaplingExpandedSpendingKey expsk;
     libzcash::SaplingNote note;

--- a/src/sapling/transaction_builder.h
+++ b/src/sapling/transaction_builder.h
@@ -79,7 +79,7 @@ private:
     int nHeight;
     const CKeyStore* keystore;
     CMutableTransaction mtx;
-    CAmount fee = DEFAULT_SAPLING_FEE;
+    CAmount fee = -1;   // Verified in Build(). Must be set before.
 
     std::vector<SpendDescriptionInfo> spends;
     std::vector<OutputDescriptionInfo> outputs;
@@ -93,6 +93,8 @@ public:
         const Consensus::Params& consensusParams,
         int nHeight,
         CKeyStore* keyStore = nullptr);
+
+    void Clear();
 
     void SetFee(CAmount _fee);
 

--- a/src/test/librust/sapling_wallet_tests.cpp
+++ b/src/test/librust/sapling_wallet_tests.cpp
@@ -562,8 +562,8 @@ BOOST_AUTO_TEST_CASE(SpentSaplingNoteIsFromMe) {
     BOOST_CHECK_EQUAL(tx2.vin.size(), 0);
     BOOST_CHECK_EQUAL(tx2.vout.size(), 0);
     BOOST_CHECK_EQUAL(tx2.sapData->vShieldedSpend.size(), 1);
-    BOOST_CHECK_EQUAL(tx2.sapData->vShieldedOutput.size(), 2);
-    BOOST_CHECK_EQUAL(tx2.sapData->valueBalance, 10000000);
+    BOOST_CHECK_EQUAL(tx2.sapData->vShieldedOutput.size(), 1);   // 0.025 dust change added to the fee
+    BOOST_CHECK_EQUAL(tx2.sapData->valueBalance, 12500000);      // 0.025 dust change added to the fee
 
     CWalletTx wtx2 {&wallet, tx2};
 
@@ -1112,8 +1112,8 @@ BOOST_AUTO_TEST_CASE(MarkAffectedSaplingTransactionsDirty) {
     BOOST_CHECK_EQUAL(tx2.vin.size(), 0);
     BOOST_CHECK_EQUAL(tx2.vout.size(), 0);
     BOOST_CHECK_EQUAL(tx2.sapData->vShieldedSpend.size(), 1);
-    BOOST_CHECK_EQUAL(tx2.sapData->vShieldedOutput.size(), 2);
-    BOOST_CHECK_EQUAL(tx2.sapData->valueBalance, 10000000);
+    BOOST_CHECK_EQUAL(tx2.sapData->vShieldedOutput.size(), 1); // 0.05 dust change added to the fee
+    BOOST_CHECK_EQUAL(tx2.sapData->valueBalance, 15000000);    // 0.05 dust change added to the fee
 
     CWalletTx wtx2 {&wallet, tx2};
 

--- a/src/test/librust/sapling_wallet_tests.cpp
+++ b/src/test/librust/sapling_wallet_tests.cpp
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(SetSaplingNoteAddrsInCWalletTx) {
     auto ivk = fvk.in_viewing_key();
     auto pk = sk.DefaultAddress();
 
-    libzcash::SaplingNote note(pk, 50000);
+    libzcash::SaplingNote note(pk, 50000000);
     auto cm = note.cmu().get();
     SaplingMerkleTree tree;
     tree.append(cm);
@@ -96,8 +96,8 @@ BOOST_AUTO_TEST_CASE(SetSaplingNoteAddrsInCWalletTx) {
 
     auto builder = TransactionBuilder(consensusParams, 1);
     builder.AddSaplingSpend(expsk, note, anchor, witness);
-    builder.AddSaplingOutput(fvk.ovk, pk, 50000, {});
-    builder.SetFee(0);
+    builder.AddSaplingOutput(fvk.ovk, pk, 40000000, {});
+    builder.SetFee(10000000);
     auto tx = builder.Build().GetTxOrThrow();
 
     CWalletTx wtx {&wallet, tx};
@@ -152,12 +152,13 @@ BOOST_AUTO_TEST_CASE(FindMySaplingNotes) {
     auto extfvk = sk.ToXFVK();
     auto pa = sk.DefaultAddress();
 
-    auto testNote = GetTestSaplingNote(pa, 50000);
+    auto testNote = GetTestSaplingNote(pa, 50000000);
 
     // Generate transaction
     auto builder = TransactionBuilder(consensusParams, 1);
     builder.AddSaplingSpend(expsk, testNote.note, testNote.tree.root(), testNote.tree.witness());
-    builder.AddSaplingOutput(extfvk.fvk.ovk, pa, 25000, {});
+    builder.AddSaplingOutput(extfvk.fvk.ovk, pa, 25000000, {});
+    builder.SetFee(10000000);
     auto tx = builder.Build().GetTxOrThrow();
 
     // No Sapling notes can be found in tx which does not belong to the wallet
@@ -195,7 +196,7 @@ BOOST_AUTO_TEST_CASE(GetConflictedSaplingNotes) {
     BOOST_CHECK(wallet.HaveSaplingSpendingKey(extfvk));
 
     // Generate note A
-    libzcash::SaplingNote note(pk, 50000);
+    libzcash::SaplingNote note(pk, 50000000);
     auto cm = note.cmu().get();
     SaplingMerkleTree saplingTree;
     saplingTree.append(cm);
@@ -205,7 +206,8 @@ BOOST_AUTO_TEST_CASE(GetConflictedSaplingNotes) {
     // Generate tx to create output note B
     auto builder = TransactionBuilder(consensusParams, 1);
     builder.AddSaplingSpend(expsk, note, anchor, witness);
-    builder.AddSaplingOutput(extfvk.fvk.ovk, pk, 35000, {});
+    builder.AddSaplingOutput(extfvk.fvk.ovk, pk, 35000000, {});
+    builder.SetFee(10000000);
     auto tx = builder.Build().GetTxOrThrow();
     CWalletTx wtx {&wallet, tx};
 
@@ -258,14 +260,16 @@ BOOST_AUTO_TEST_CASE(GetConflictedSaplingNotes) {
 
     // Create transaction to spend note B
     auto builder2 = TransactionBuilder(consensusParams, 2);
+    builder2.SetFee(10000000);
     builder2.AddSaplingSpend(expsk, note2, anchor, spend_note_witness);
-    builder2.AddSaplingOutput(extfvk.fvk.ovk, pk, 20000, {});
+    builder2.AddSaplingOutput(extfvk.fvk.ovk, pk, 20000000, {});
     auto tx2 = builder2.Build().GetTxOrThrow();
 
     // Create conflicting transaction which also spends note B
     auto builder3 = TransactionBuilder(consensusParams, 2);
+    builder3.SetFee(10000000);
     builder3.AddSaplingSpend(expsk, note2, anchor, spend_note_witness);
-    builder3.AddSaplingOutput(extfvk.fvk.ovk, pk, 19999, {});
+    builder3.AddSaplingOutput(extfvk.fvk.ovk, pk, 19999000, {});
     auto tx3 = builder3.Build().GetTxOrThrow();
 
     CWalletTx wtx2 {&wallet, tx2};
@@ -309,12 +313,13 @@ BOOST_AUTO_TEST_CASE(SaplingNullifierIsSpent) {
     auto extfvk = sk.ToXFVK();
     auto pa = sk.DefaultAddress();
 
-    auto testNote = GetTestSaplingNote(pa, 50000);
+    auto testNote = GetTestSaplingNote(pa, 50000000);
 
     // Generate transaction
     auto builder = TransactionBuilder(consensusParams, 1);
     builder.AddSaplingSpend(expsk,  testNote.note, testNote.tree.root(), testNote.tree.witness());
-    builder.AddSaplingOutput(extfvk.fvk.ovk, pa, 25000, {});
+    builder.AddSaplingOutput(extfvk.fvk.ovk, pa, 2500000, {});
+    builder.SetFee(10000000);
     auto tx = builder.Build().GetTxOrThrow();
 
     CWalletTx wtx {&wallet, tx};
@@ -370,12 +375,13 @@ BOOST_AUTO_TEST_CASE(NavigateFromSaplingNullifierToNote) {
     auto extfvk = sk.ToXFVK();
     auto pa = sk.DefaultAddress();
 
-    auto testNote = GetTestSaplingNote(pa, 50000);
+    auto testNote = GetTestSaplingNote(pa, 50000000);
 
     // Generate transaction
     auto builder = TransactionBuilder(consensusParams, 1);
     builder.AddSaplingSpend(expsk, testNote.note, testNote.tree.root(), testNote.tree.witness());
-    builder.AddSaplingOutput(extfvk.fvk.ovk, pa, 25000, {});
+    builder.AddSaplingOutput(extfvk.fvk.ovk, pa, 25000000, {});
+    builder.SetFee(10000000);
     auto tx = builder.Build().GetTxOrThrow();
 
     CWalletTx wtx {&wallet, tx};
@@ -468,7 +474,7 @@ BOOST_AUTO_TEST_CASE(SpentSaplingNoteIsFromMe) {
     auto pk = sk.DefaultAddress();
 
     // Generate Sapling note A
-    libzcash::SaplingNote note(pk, 50000);
+    libzcash::SaplingNote note(pk, 50000000);
     auto cm = note.cmu().get();
     SaplingMerkleTree saplingTree;
     saplingTree.append(cm);
@@ -478,7 +484,8 @@ BOOST_AUTO_TEST_CASE(SpentSaplingNoteIsFromMe) {
     // Generate transaction, which sends funds to note B
     auto builder = TransactionBuilder(consensusParams, 1);
     builder.AddSaplingSpend(expsk, note, anchor, witness);
-    builder.AddSaplingOutput(extfvk.fvk.ovk, pk, 25000, {});
+    builder.AddSaplingOutput(extfvk.fvk.ovk, pk, 25000000, {});
+    builder.SetFee(10000000);
     auto tx = builder.Build().GetTxOrThrow();
 
     CWalletTx wtx {&wallet, tx};
@@ -549,13 +556,14 @@ BOOST_AUTO_TEST_CASE(SpentSaplingNoteIsFromMe) {
     // Create transaction to spend note B
     auto builder2 = TransactionBuilder(consensusParams, 2);
     builder2.AddSaplingSpend(expsk, note2, anchor, spend_note_witness);
-    builder2.AddSaplingOutput(extfvk.fvk.ovk, pk, 12500, {});
+    builder2.AddSaplingOutput(extfvk.fvk.ovk, pk, 12500000, {});
+    builder2.SetFee(10000000);
     auto tx2 = builder2.Build().GetTxOrThrow();
     BOOST_CHECK_EQUAL(tx2.vin.size(), 0);
     BOOST_CHECK_EQUAL(tx2.vout.size(), 0);
     BOOST_CHECK_EQUAL(tx2.sapData->vShieldedSpend.size(), 1);
     BOOST_CHECK_EQUAL(tx2.sapData->vShieldedOutput.size(), 2);
-    BOOST_CHECK_EQUAL(tx2.sapData->valueBalance, 10000);
+    BOOST_CHECK_EQUAL(tx2.sapData->valueBalance, 10000000);
 
     CWalletTx wtx2 {&wallet, tx2};
 
@@ -924,12 +932,13 @@ BOOST_AUTO_TEST_CASE(UpdatedSaplingNoteData) {
     auto extfvk2 = sk2.ToXFVK();
     auto pa2 = sk2.DefaultAddress();
 
-    auto testNote = GetTestSaplingNote(pa, 50000);
+    auto testNote = GetTestSaplingNote(pa, 50000000);
 
     // Generate transaction
     auto builder = TransactionBuilder(consensusParams, 1);
     builder.AddSaplingSpend(expsk, testNote.note, testNote.tree.root(), testNote.tree.witness());
-    builder.AddSaplingOutput(extfvk.fvk.ovk, pa2, 25000, {});
+    builder.AddSaplingOutput(extfvk.fvk.ovk, pa2, 25000000, {});
+    builder.SetFee(10000000);
     auto tx = builder.Build().GetTxOrThrow();
 
     // Wallet contains extfvk1 but not extfvk2
@@ -1038,17 +1047,18 @@ BOOST_AUTO_TEST_CASE(MarkAffectedSaplingTransactionsDirty) {
     auto scriptPubKey = GetScriptForDestination(tsk.GetPubKey().GetID());
 
     // Generate shielding tx from transparent to Sapling
-    // 0.0005 t-PIV in, 0.0004 z-PIV out, 0.0001 t-PIV fee
+    // 0.5 t-PIV in, 0.4 z-PIV out, 0.1 t-PIV fee
     auto builder = TransactionBuilder(consensusParams, 1, &keystore);
-    builder.AddTransparentInput(COutPoint(), scriptPubKey, 50000);
-    builder.AddSaplingOutput(extfvk.fvk.ovk, pk, 40000, {});
+    builder.AddTransparentInput(COutPoint(), scriptPubKey, 50000000);
+    builder.AddSaplingOutput(extfvk.fvk.ovk, pk, 40000000, {});
+    builder.SetFee(10000000);
     auto tx1 = builder.Build().GetTxOrThrow();
 
     BOOST_CHECK_EQUAL(tx1.vin.size(), 1);
     BOOST_CHECK_EQUAL(tx1.vout.size(), 0);
     BOOST_CHECK_EQUAL(tx1.sapData->vShieldedSpend.size(), 0);
     BOOST_CHECK_EQUAL(tx1.sapData->vShieldedOutput.size(), 1);
-    BOOST_CHECK_EQUAL(tx1.sapData->valueBalance, -40000);
+    BOOST_CHECK_EQUAL(tx1.sapData->valueBalance, -40000000);
 
     CWalletTx wtx {&wallet, tx1};
 
@@ -1092,17 +1102,18 @@ BOOST_AUTO_TEST_CASE(MarkAffectedSaplingTransactionsDirty) {
     auto witness = saplingTree.witness();
 
     // Create a Sapling-only transaction
-    // 0.0004 z-ZEC in, 0.00025 z-ZEC out, 0.0001 t-ZEC fee, 0.00005 z-ZEC change
+    // 0.4 z-PIV in, 0.25 z-PIV out, 0.1 t-PIV fee, 0.05 z-PIV change
     auto builder2 = TransactionBuilder(consensusParams, 2);
     builder2.AddSaplingSpend(expsk, note, anchor, witness);
-    builder2.AddSaplingOutput(extfvk.fvk.ovk, pk, 25000, {});
+    builder2.AddSaplingOutput(extfvk.fvk.ovk, pk, 25000000, {});
+    builder2.SetFee(10000000);
     auto tx2 = builder2.Build().GetTxOrThrow();
 
     BOOST_CHECK_EQUAL(tx2.vin.size(), 0);
     BOOST_CHECK_EQUAL(tx2.vout.size(), 0);
     BOOST_CHECK_EQUAL(tx2.sapData->vShieldedSpend.size(), 1);
     BOOST_CHECK_EQUAL(tx2.sapData->vShieldedOutput.size(), 2);
-    BOOST_CHECK_EQUAL(tx2.sapData->valueBalance, 10000);
+    BOOST_CHECK_EQUAL(tx2.sapData->valueBalance, 10000000);
 
     CWalletTx wtx2 {&wallet, tx2};
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -263,6 +263,11 @@ CAmount GetMinRelayFee(const CTransaction& tx, const CTxMemPool& pool, unsigned 
     if (dPriorityDelta > 0 || nFeeDelta > 0)
         return 0;
 
+    return GetMinRelayFee(nBytes, fAllowFree);
+}
+
+CAmount GetMinRelayFee(unsigned int nBytes, bool fAllowFree)
+{
     CAmount nMinFee = ::minRelayTxFee.GetFee(nBytes);
 
     if (fAllowFree) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -290,7 +290,8 @@ CAmount GetMinRelayFee(unsigned int nBytes, bool fAllowFree)
 CAmount GetShieldedTxMinFee(const CTransaction& tx)
 {
     assert (tx.IsShieldedTx());
-    CAmount nMinFee = ::minRelayTxFee.GetFee(tx.GetTotalSize()) * 1000;
+    unsigned int K = DEFAULT_SHIELDEDTXFEE_K;   // Fixed (1000) for now
+    CAmount nMinFee = ::minRelayTxFee.GetFee(tx.GetTotalSize()) * K;
     if (!Params().GetConsensus().MoneyRange(nMinFee))
         nMinFee = Params().GetConsensus().nMaxMoneyOut;
     return nMinFee;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -279,6 +279,15 @@ CAmount GetMinRelayFee(const CTransaction& tx, const CTxMemPool& pool, unsigned 
     return nMinFee;
 }
 
+CAmount GetShieldedTxMinFee(const CTransaction& tx)
+{
+    assert (tx.IsShieldedTx());
+    CAmount nMinFee = ::minRelayTxFee.GetFee(tx.GetTotalSize()) * 1000;
+    if (!Params().GetConsensus().MoneyRange(nMinFee))
+        nMinFee = Params().GetConsensus().nMaxMoneyOut;
+    return nMinFee;
+}
+
 /** Convert CValidationState to a human-readable message for logging */
 std::string FormatStateMessage(const CValidationState &state)
 {

--- a/src/validation.h
+++ b/src/validation.h
@@ -112,6 +112,8 @@ static const unsigned int AVG_ADDRESS_BROADCAST_INTERVAL = 30;
 /** Average delay between trickled inventory broadcasts in seconds.
  *  Blocks, whitelisted receivers, and a random 25% of transactions bypass this. */
 static const unsigned int AVG_INVENTORY_BROADCAST_INTERVAL = 5;
+/** Default multiplier used in the computation for shielded txes min fee */
+static const unsigned int DEFAULT_SHIELDEDTXFEE_K = 1000;
 
 /** Enable bloom filter */
  static const bool DEFAULT_PEERBLOOMFILTERS = true;

--- a/src/validation.h
+++ b/src/validation.h
@@ -75,7 +75,6 @@ static const unsigned int DEFAULT_LIMITFREERELAY = 30;
 /** The maximum size for transactions we're willing to relay/mine */
 static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
 static const unsigned int MAX_ZEROCOIN_TX_SIZE = 150000;
-static const unsigned int MAX_STANDARD_SHIELDED_TX_SIZE = MAX_TX_SIZE_AFTER_SAPLING;
 /** Default for -checkblocks */
 static const signed int DEFAULT_CHECKBLOCKS = 10;
 /** The maximum size of a blk?????.dat file (since 0.8) */

--- a/src/validation.h
+++ b/src/validation.h
@@ -226,6 +226,10 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
 std::string FormatStateMessage(const CValidationState &state);
 
 CAmount GetMinRelayFee(const CTransaction& tx, const CTxMemPool& pool, unsigned int nBytes, bool fAllowFree);
+/**
+ * Return the minimum fee for a shielded tx.
+ */
+CAmount GetShieldedTxMinFee(const CTransaction& tx);
 
 /**
  * Check transaction inputs, and make sure any

--- a/src/validation.h
+++ b/src/validation.h
@@ -226,6 +226,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransa
 std::string FormatStateMessage(const CValidationState &state);
 
 CAmount GetMinRelayFee(const CTransaction& tx, const CTxMemPool& pool, unsigned int nBytes, bool fAllowFree);
+CAmount GetMinRelayFee(unsigned int nBytes, bool fAllowFree);
 /**
  * Return the minimum fee for a shielded tx.
  */

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1436,10 +1436,6 @@ UniValue viewshieldedtransaction(const JSONRPCRequest& request)
     return entry;
 }
 
-// transaction.h comment: spending taddr output requires CTxIn >= 148 bytes and typical taddr txout is 34 bytes
-#define CTXIN_SPEND_DUST_SIZE   148
-#define CTXOUT_REGULAR_SIZE     34
-
 static SaplingOperation CreateShieldedTransaction(const JSONRPCRequest& request)
 {
     EnsureWalletIsUnlocked();

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1292,6 +1292,7 @@ UniValue viewshieldedtransaction(const JSONRPCRequest& request)
                 "\nResult:\n"
                 "{\n"
                 "  \"txid\" : \"transactionid\",   (string) The transaction id\n"
+                "  \"fee\"  : x.xxx,               (numeric) The transaction fee in " + CURRENCY_UNIT + "\n"
                 "  \"spends\" : [\n"
                 "    {\n"
                 "      \"spend\" : n,                    (numeric, sapling) the index of the spend within vShieldedSpend\n"
@@ -1430,6 +1431,7 @@ UniValue viewshieldedtransaction(const JSONRPCRequest& request)
         outputs.push_back(entry_);
     }
 
+    entry.pushKV("fee", FormatMoney(pcoinsTip->GetValueIn(wtx) - wtx.GetValueOut()));
     entry.pushKV("spends", spends);
     entry.pushKV("outputs", outputs);
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1075,13 +1075,11 @@ UniValue CreateColdStakeDelegation(const UniValue& params, CWalletTx& wtxNew, CR
         if (!consensus.NetworkUpgradeActive(nextBlockHeight, Consensus::UPGRADE_V5_DUMMY)) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, Sapling not active yet");
         }
-        CAmount nFee = DEFAULT_SAPLING_FEE;
         std::vector<SendManyRecipient> recipients = {SendManyRecipient(ownerKey, *stakeKey, nValue)};
         TransactionBuilder txBuilder = TransactionBuilder(consensus, nextBlockHeight, pwalletMain);
         SaplingOperation operation(txBuilder);
         OperationResult res = operation.setSelectShieldedCoins(true)
                                        ->setRecipients(recipients)
-                                       ->setFee(nFee)
                                        ->build();
         if (!res) throw JSONRPCError(RPC_WALLET_ERROR, res.getError());
         wtxNew = CWalletTx(pwalletMain, operation.getFinalTx());

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3068,7 +3068,7 @@ CWallet::CommitResult CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey*
 
         // Try ATMP. This must not fail. The transaction has already been signed and recorded.
         CValidationState state;
-        if (!AcceptToMemoryPool(mempool, state, MakeTransactionRef(std::move(wtxNew)), false, nullptr, false, true, false)) {
+        if (!AcceptToMemoryPool(mempool, state, MakeTransactionRef(std::move(wtxNew)), true, nullptr, false, true, false)) {
             res.state = state;
             // Abandon the transaction
             if (AbandonTransaction(res.hashTx)) {

--- a/test/functional/mining_pos_coldStaking.py
+++ b/test/functional/mining_pos_coldStaking.py
@@ -124,7 +124,7 @@ class PIVX_ColdStakingTest(PivxTestFramework):
         # create shielded balance for node 0
         self.log.info("Shielding some coins for node0...")
         self.nodes[0].shieldedsendmany("from_transparent", [{"address": self.nodes[0].getnewshieldedaddress(),
-                                                             "amount": Decimal('250.00')}], 1, 1)
+                                                             "amount": Decimal('250.00')}], 1)
         self.sync_all()
         for i in range(6):
             self.mocktime = self.generate_pow(0, self.mocktime)
@@ -191,6 +191,7 @@ class PIVX_ColdStakingTest(PivxTestFramework):
         assert (res != None and res["txid"] != None and res["txid"] != "")
         assert_equal(res["owner_address"], owner_address)
         assert_equal(res["staker_address"], staker_address)
+        fee = self.nodes[0].viewshieldedtransaction(res["txid"])['fee']
         # sync and mine 2 blocks
         sync_mempools(self.nodes)
         self.mocktime = self.generate_pos(2, self.mocktime)
@@ -200,8 +201,8 @@ class PIVX_ColdStakingTest(PivxTestFramework):
         self.expected_balance = NUM_OF_INPUTS * INPUT_VALUE
         self.expected_immature_balance = 0
         self.checkBalances()
-        # also shielded balance of node 0 (250 - 249 - minimum fee 0.0001)
-        assert_equal(self.nodes[0].getshieldedbalance(), Decimal('0.9999'))
+        # also shielded balance of node 0 (250 - 249 - fee)
+        assert_equal(self.nodes[0].getshieldedbalance(), round(Decimal(1)-Decimal(fee), 8))
 
         # 6) check that the owner (nodes[0]) can spend the coins.
         # -------------------------------------------------------

--- a/test/functional/sapling_changeaddresses.py
+++ b/test/functional/sapling_changeaddresses.py
@@ -39,13 +39,12 @@ class WalletChangeAddressesTest(PivxTestFramework):
 
         def check_change_taddr_reuse(target, isTargetShielded):
             recipients = [{"address": target, "amount": Decimal('1')}]
-            fee = 1.0 if isTargetShielded else 0.001 # hardcoded for now
 
             # Send funds to recipient address twice
-            txid1 = self.nodes[0].shieldedsendmany(taddrSource, recipients, 1, fee)
+            txid1 = self.nodes[0].shieldedsendmany(taddrSource, recipients, 1)
             self.nodes[1].generate(1)
             self.sync_all()
-            txid2 = self.nodes[0].shieldedsendmany(taddrSource, recipients, 1, fee)
+            txid2 = self.nodes[0].shieldedsendmany(taddrSource, recipients, 1)
             self.nodes[1].generate(1)
             self.sync_all()
 

--- a/test/functional/sapling_wallet_nullifiers.py
+++ b/test/functional/sapling_wallet_nullifiers.py
@@ -84,8 +84,8 @@ class WalletNullifiersTest (PivxTestFramework):
 
         # check shielded addr balance
         zsendmany2notevalue = Decimal('2.0')
-        zsendmanyfee = Decimal('0.0001')
-        zaddrremaining = zsendmanynotevalue - zsendmany2notevalue - zsendmanyfee # 7 - 3 = 4 shielded PIV
+        zsendmanyfee = Decimal(self.nodes[2].viewshieldedtransaction(txid)['fee'])
+        zaddrremaining = zsendmanynotevalue - zsendmany2notevalue - zsendmanyfee
         assert_equal(self.nodes[3].getshieldedbalance(myzaddr3), zsendmany2notevalue)
         assert_equal(self.nodes[2].getshieldedbalance(myzaddr), zaddrremaining)
         assert_equal(self.nodes[1].getshieldedbalance(myzaddr), zaddrremaining)
@@ -109,6 +109,7 @@ class WalletNullifiersTest (PivxTestFramework):
         # have been cached and spent notes can be detected. Thus the two wallets
         # are in agreement once more.
         zsendmany3notevalue = Decimal('1.0')
+        zsendmanyfee = Decimal(self.nodes[1].viewshieldedtransaction(txid)['fee'])
         zaddrremaining2 = zaddrremaining - zsendmany3notevalue - zsendmanyfee
         assert_equal(self.nodes[1].getshieldedbalance(myzaddr), zaddrremaining2)
         assert_equal(self.nodes[2].getshieldedbalance(myzaddr), zaddrremaining2)

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -145,11 +145,11 @@ TIERTWO_SCRIPTS = [
 
 SAPLING_SCRIPTS = [
     # Longest test should go first, to favor running tests in parallel
-    'sapling_key_import_export.py',             # ~ 356 sec
+    'sapling_key_import_export.py',             # ~ 378 sec
     'sapling_wallet_anchorfork.py',             # ~ 345 sec
-    'sapling_wallet_nullifiers.py',             # ~ 201 sec
-    'sapling_wallet_listreceived.py',           # ~ 169 sec
-    'sapling_wallet.py',                        # ~ 164 sec
+    'sapling_wallet.py',                        # ~ 274 sec
+    'sapling_wallet_nullifiers.py',             # ~ 190 sec
+    'sapling_wallet_listreceived.py',           # ~ 157 sec
     'sapling_changeaddresses.py',               # ~ 151 sec
     'sapling_mempool.py',                       # ~ 98 sec
     'sapling_wallet_persistence.py',            # ~ 90 sec


### PR DESCRIPTION
This PR proposes a mitigation for the attack known as "Sapling Woodchipper" (CVE-2019-11636).
Some references:
- https://nvd.nist.gov/vuln/detail/CVE-2019-11636
- https://github.com/zcash/zcash/issues/3983

Here we:
1) Define a dynamic minimum fee for shielded txes, based on the value of `minRelayTxFee` and the transaction size.
The minRelayTxFee is multiplied by a factor `K` (currently set to `1000`, and in the future could be variable based on the number of transactions in the mempool).

With the default value for minrelaytxfee (0.0001 PIV/kB), a shielded tx costs 0.0064 PIV plus:
- 0.0148 PIV per transparent input (P2PKH spend)
- 0.0384 PIV per shielded spend
- 0.0034 PIV per transparent output
- 0.0948 PIV per shielded output

A simple shielded-to-shielded transaction (with shielded change) thus, for example, requires a minimum fee of 0.2344 PIV (~0.06 USD at the time of writing). A "mint" transaction (transparent to shielded, with transparent change) requires 0.1194 PIV.
Transactions with a fee higher than 100 times the minimum fee are not accepted in the mempool.

2) Update the RPC `shieldedsendmany`/`rawshieldedsendmany` to automatically compute the minimum possible fee as default, when the fee parameter is not set.

3) Lower the maximum allowed size for a shielded transaction to 400 kB.
It would require ~40 PIVs in fees, and in order to fill a block, 5 of such transactions would be needed.

The total cost of the attack is thus raised (from **0.0001 PIV/min**) to **200 PIV/min** (~3600 USD/h).

Update the unit and functional tests where needed (and add test cases for fee too high, or too low).