### PR TITLE
[Sapling] Remove Sprout parameters

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -440,11 +440,9 @@ void initZKSNARKS()
     const fs::path& path = ZC_GetParamsDir();
     fs::path sapling_spend = path / "sapling-spend.params";
     fs::path sapling_output = path / "sapling-output.params";
-    fs::path sprout_groth16 = path / "sprout-groth16.params";
 
     if (!(fs::exists(sapling_spend) &&
-          fs::exists(sapling_output) &&
-          fs::exists(sprout_groth16)
+          fs::exists(sapling_output)
     )) {
         throw std::runtime_error("Sapling params don't exist");
     }
@@ -454,7 +452,6 @@ void initZKSNARKS()
         "librustzcash not configured correctly");
     auto sapling_spend_str = sapling_spend.native();
     auto sapling_output_str = sapling_output.native();
-    auto sprout_groth16_str = sprout_groth16.native();
 
     //LogPrintf("Loading Sapling (Spend) parameters from %s\n", sapling_spend.string().c_str());
 
@@ -465,9 +462,9 @@ void initZKSNARKS()
         reinterpret_cast<const codeunit*>(sapling_output_str.c_str()),
         sapling_output_str.length(),
         "657e3d38dbb5cb5e7dd2970e8b03d69b4787dd907285b5a7f0790dcc8072f60bf593b32cc2d1c030e00ff5ae64bf84c5c3beb84ddc841d48264b4a171744d028",
-        reinterpret_cast<const codeunit*>(sprout_groth16_str.c_str()),
-        sprout_groth16_str.length(),
-        "e9b238411bd6c0ec4791e9d04245ec350c9c5744f5610dfcce4365d5ca49dfefd5054e371842b3f88fa1b9d7e8e075249b3ebabd167fa8b0f3161292d36c180a"
+        nullptr,    // sprout_path
+        0,          // sprout_path_len
+        ""          // sprout_hash
     );
 
     //std::cout << "### Sapling params initialized ###" << std::endl;

--- a/util/fetch-params.sh
+++ b/util/fetch-params.sh
@@ -19,11 +19,8 @@ else
     fi
 fi
 
-SPROUT_PKEY_NAME='sprout-proving.key'
-SPROUT_VKEY_NAME='sprout-verifying.key'
 SAPLING_SPEND_NAME='sapling-spend.params'
 SAPLING_OUTPUT_NAME='sapling-output.params'
-SAPLING_SPROUT_GROTH16_NAME='sprout-groth16.params'
 DOWNLOAD_URL="https://download.z.cash/downloads"
 IPFS_HASH="/ipfs/QmXRHVGLQBiKwvNq7c2vPxAKz1zRVmMYbmt7G5TQss7tY7"
 
@@ -207,10 +204,7 @@ EOF
         # This may be the first time the user's run this script, so give
         # them some info, especially about bandwidth usage:
         cat <<EOF
-The complete parameters are currently just under 1.7GB in size, so plan
-accordingly for your bandwidth constraints. If the Sprout parameters are
-already present the additional Sapling parameters required are just under
-800MB in size. If the files are already present and have the correct
+If the files are already present and have the correct
 sha256sum, no networking is used.
 
 Creating params directory. For details about this directory, see:
@@ -224,7 +218,6 @@ EOF
     # Sapling parameters:
     fetch_params "$SAPLING_SPEND_NAME" "$PARAMS_DIR/$SAPLING_SPEND_NAME" "8e48ffd23abb3a5fd9c5589204f32d9c31285a04b78096ba40a79b75677efc13"
     fetch_params "$SAPLING_OUTPUT_NAME" "$PARAMS_DIR/$SAPLING_OUTPUT_NAME" "2f0ebbcbb9bb0bcffe95a397e7eba89c29eb4dde6191c339db88570e3f3fb0e4"
-    fetch_params "$SAPLING_SPROUT_GROTH16_NAME" "$PARAMS_DIR/$SAPLING_SPROUT_GROTH16_NAME" "b685d700c60328498fbde589c8c7c484c722b788b265b72af448a5bf0ee55b50"
 }
 
 if [ "x${1:-}" = 'x--testnet' ]


### PR DESCRIPTION
Don't initialize the sprout circuit. Don't load sprout parameters. Don't download them (saving 692 MB on disk).