### PR TITLE
[RPC] shielded supply in getsupplyinfo and getinfo

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -651,6 +651,7 @@ UniValue getsupplyinfo(const JSONRPCRequest& request)
             "  \"updateheight\" : n,       (numeric) The chain height when the transparent supply was updated\n"
             "  \"transparentsupply\" : n   (numeric) The sum of all spendable transaction outputs at height updateheight\n"
             "  \"shieldedsupply\": n       (numeric) Chain tip shielded pool value\n"
+            "  \"totalsupply\": n          (numeric) The sum of transparentsupply and shieldedsupply\n"
             "}\n"
 
             "\nExamples:\n" +
@@ -665,10 +666,13 @@ UniValue getsupplyinfo(const JSONRPCRequest& request)
     }
 
     UniValue ret(UniValue::VOBJ);
+    const CAmount tSupply = MoneySupply.Get();
     ret.pushKV("updateheight", MoneySupply.GetCacheHeight());
-    ret.pushKV("transparentsupply", ValueFromAmount(MoneySupply.Get()));
+    ret.pushKV("transparentsupply", ValueFromAmount(tSupply));
     Optional<CAmount> shieldedPoolValue = WITH_LOCK(cs_main, return (chainActive.Tip() ? chainActive.Tip()->nChainSaplingValue : nullopt); );
     ret.pushKV("shieldedsupply", ValuePoolDesc(shieldedPoolValue, nullopt)["chainValue"]);
+    const CAmount totalSupply = tSupply + (shieldedPoolValue ? *shieldedPoolValue : 0);
+    ret.pushKV("totalsupply", ValueFromAmount(totalSupply));
 
     return ret;
 }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -648,8 +648,9 @@ UniValue getsupplyinfo(const JSONRPCRequest& request)
 
             "\nResult:\n"
             "{\n"
-            "  \"updateheight\" : n, (numeric) The chain height when the supply was updated\n"
-            "  \"supply\" :       n   (numeric) The sum of all spendable transaction outputs at height updateheight\n"
+            "  \"updateheight\" : n,       (numeric) The chain height when the transparent supply was updated\n"
+            "  \"transparentsupply\" : n   (numeric) The sum of all spendable transaction outputs at height updateheight\n"
+            "  \"shieldedsupply\": n       (numeric) Chain tip shielded pool value\n"
             "}\n"
 
             "\nExamples:\n" +
@@ -665,7 +666,9 @@ UniValue getsupplyinfo(const JSONRPCRequest& request)
 
     UniValue ret(UniValue::VOBJ);
     ret.pushKV("updateheight", MoneySupply.GetCacheHeight());
-    ret.pushKV("supply", ValueFromAmount(MoneySupply.Get()));
+    ret.pushKV("transparentsupply", ValueFromAmount(MoneySupply.Get()));
+    Optional<CAmount> shieldedPoolValue = WITH_LOCK(cs_main, return (chainActive.Tip() ? chainActive.Tip()->nChainSaplingValue : nullopt); );
+    ret.pushKV("shieldedsupply", ValuePoolDesc(shieldedPoolValue, nullopt)["chainValue"]);
 
     return ret;
 }

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -60,7 +60,6 @@ UniValue getinfo(const JSONRPCRequest& request)
             "  \"protocolversion\": xxxxx,     (numeric) the protocol version\n"
             "  \"walletversion\": xxxxx,       (numeric) the wallet version\n"
             "  \"balance\": xxxxxxx,           (numeric) the total pivx balance of the wallet (excluding zerocoins)\n"
-            "  \"zerocoinbalance\": xxxxxxx,   (numeric) the total zerocoin balance of the wallet\n"
             "  \"staking status\": true|false, (boolean) if the wallet is staking or not\n"
             "  \"blocks\": xxxxxx,             (numeric) the current number of blocks processed in the server\n"
             "  \"timeoffset\": xxxxx,          (numeric) the time offset\n"
@@ -72,18 +71,6 @@ UniValue getinfo(const JSONRPCRequest& request)
             "                                            last flushed to disk (use getsupplyinfo to know the update-height, or\n"
             "                                            to trigger the money supply update/recalculation)"
             "  \"shieldedsupply\": n           (numeric) Chain tip shielded pool value\n"
-            "  \"zPIVsupply\" :\n"
-            "  {\n"
-            "     \"1\" : n,            (numeric) supply of 1 zPIV denomination\n"
-            "     \"5\" : n,            (numeric) supply of 5 zPIV denomination\n"
-            "     \"10\" : n,           (numeric) supply of 10 zPIV denomination\n"
-            "     \"50\" : n,           (numeric) supply of 50 zPIV denomination\n"
-            "     \"100\" : n,          (numeric) supply of 100 zPIV denomination\n"
-            "     \"500\" : n,          (numeric) supply of 500 zPIV denomination\n"
-            "     \"1000\" : n,         (numeric) supply of 1000 zPIV denomination\n"
-            "     \"5000\" : n,         (numeric) supply of 5000 zPIV denomination\n"
-            "     \"total\" : n,        (numeric) The total supply of all zPIV denominations\n"
-            "  }\n"
             "  \"keypoololdest\": xxxxxx,      (numeric) the timestamp (seconds since GMT epoch) of the oldest pre-generated key in the key pool\n"
             "  \"keypoolsize\": xxxx,          (numeric) how many new keys are pre-generated\n"
             "  \"unlocked_until\": ttt,        (numeric) the timestamp in seconds since epoch (midnight Jan 1 1970 GMT) that the wallet is unlocked for transfers, or 0 if the wallet is locked\n"
@@ -130,7 +117,6 @@ UniValue getinfo(const JSONRPCRequest& request)
     if (pwalletMain) {
         obj.pushKV("walletversion", pwalletMain->GetVersion());
         obj.pushKV("balance", ValueFromAmount(pwalletMain->GetAvailableBalance()));
-        obj.pushKV("zerocoinbalance", ValueFromAmount(pwalletMain->GetZerocoinBalance()));
         obj.pushKV("staking status", (pwalletMain->pStakerStatus->IsActive() ? "Staking Active" : "Staking Not Active"));
     }
 #endif
@@ -146,16 +132,6 @@ UniValue getinfo(const JSONRPCRequest& request)
     UniValue supply_info = getsupplyinfo(JSONRPCRequest());
     obj.pushKV("transparentsupply", supply_info["transparentsupply"]);
     obj.pushKV("shieldedsupply", supply_info["shieldedsupply"]);
-
-    UniValue zpivObj(UniValue::VOBJ);
-    for (auto denom : libzerocoin::zerocoinDenomList) {
-        if (mapZerocoinSupply.empty())
-            zpivObj.pushKV(std::to_string(denom), ValueFromAmount(0));
-        else
-            zpivObj.pushKV(std::to_string(denom), ValueFromAmount(mapZerocoinSupply.at(denom) * (denom*COIN)));
-    }
-    zpivObj.pushKV("total", ValueFromAmount(GetZerocoinSupply()));
-    obj.pushKV("zPIVsupply", zpivObj);
 
 #ifdef ENABLE_WALLET
     if (pwalletMain) {

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -67,6 +67,7 @@ UniValue getinfo(const JSONRPCRequest& request)
             "  \"proxy\": \"host:port\",       (string, optional) the proxy used by the server\n"
             "  \"difficulty\": xxxxxx,         (numeric) the current difficulty\n"
             "  \"testnet\": true|false,        (boolean) if the server is using testnet or not\n"
+            "  \"moneysupply\": n              (numeric) The sum of transparentsupply and shieldedsupply\n"
             "  \"transparentsupply\" : n       (numeric) The sum of the value of all unspent outputs when the chainstate was\n"
             "                                            last flushed to disk (use getsupplyinfo to know the update-height, or\n"
             "                                            to trigger the money supply update/recalculation)"
@@ -130,6 +131,7 @@ UniValue getinfo(const JSONRPCRequest& request)
 
     // Add (cached) money supply via getsupplyinfo RPC
     UniValue supply_info = getsupplyinfo(JSONRPCRequest());
+    obj.pushKV("moneysupply", supply_info["totalsupply"]);
     obj.pushKV("transparentsupply", supply_info["transparentsupply"]);
     obj.pushKV("shieldedsupply", supply_info["shieldedsupply"]);
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -68,9 +68,10 @@ UniValue getinfo(const JSONRPCRequest& request)
             "  \"proxy\": \"host:port\",       (string, optional) the proxy used by the server\n"
             "  \"difficulty\": xxxxxx,         (numeric) the current difficulty\n"
             "  \"testnet\": true|false,        (boolean) if the server is using testnet or not\n"
-            "  \"moneysupply\" : \"supply\"    (numeric) The sum of the value of all unspent outputs when the chainstate was\n"
+            "  \"transparentsupply\" : n       (numeric) The sum of the value of all unspent outputs when the chainstate was\n"
             "                                            last flushed to disk (use getsupplyinfo to know the update-height, or\n"
             "                                            to trigger the money supply update/recalculation)"
+            "  \"shieldedsupply\": n           (numeric) Chain tip shielded pool value\n"
             "  \"zPIVsupply\" :\n"
             "  {\n"
             "     \"1\" : n,            (numeric) supply of 1 zPIV denomination\n"
@@ -143,7 +144,8 @@ UniValue getinfo(const JSONRPCRequest& request)
 
     // Add (cached) money supply via getsupplyinfo RPC
     UniValue supply_info = getsupplyinfo(JSONRPCRequest());
-    obj.pushKV("moneysupply", supply_info["supply"]);
+    obj.pushKV("transparentsupply", supply_info["transparentsupply"]);
+    obj.pushKV("shieldedsupply", supply_info["shieldedsupply"]);
 
     UniValue zpivObj(UniValue::VOBJ);
     for (auto denom : libzerocoin::zerocoinDenomList) {

--- a/test/functional/mining_pos_reorg.py
+++ b/test/functional/mining_pos_reorg.py
@@ -53,7 +53,7 @@ class ReorgStakeTest(PivxTestFramework):
 
     def check_money_supply(self, expected_piv):
         # verify that nodes have the expected PIV supply
-        piv_supply = [self.nodes[i].getsupplyinfo(True)['supply']
+        piv_supply = [self.nodes[i].getsupplyinfo(True)['transparentsupply']
                       for i in range(self.num_nodes)]
         assert_equal(piv_supply, [DecimalAmt(expected_piv)] * self.num_nodes)
 


### PR DESCRIPTION
Add the shielded pool value (at the chain tip) to `getsupplyinfo`/`getinfo` output.
Rename `moneysupply` --> `transparentsupply`
Remove `zPIVsupply`/`zerocoinbalance` from `getinfo` output.

Based on top of:
- [x] #1983 