### PR TITLE
[Build] Replicate TravisCI tests in Github Actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,437 @@
+name: CI Actions for PIVX
+
+on: [push, pull_request]
+jobs:
+  lint:
+    env:
+      SHELLCHECK_VERSION: v0.6.0
+      LC_ALL: C
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v2
+      - name: Checkout Repo
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.5
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install codespell==1.13.0
+          pip install flake8==3.5.0
+          pip install vulture==0.29
+
+          curl -s "https://storage.googleapis.com/shellcheck/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar --xz -xf - --directory /tmp/
+          export PATH="/tmp/shellcheck-${SHELLCHECK_VERSION}:${PATH}"
+          echo $PATH
+
+          echo ::group::Fetch
+          git fetch --unshallow
+          echo ::endgroup::
+      - name: Lint
+        run: |
+          contrib/devtools/git-subtree-check.sh src/secp256k1
+          contrib/devtools/git-subtree-check.sh src/univalue
+          contrib/devtools/git-subtree-check.sh src/leveldb
+          contrib/devtools/git-subtree-check.sh src/crc32c
+          contrib/devtools/check-doc.py
+          contrib/devtools/logprint-scanner.py
+
+          echo "${{ github.event_name }}"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            contrib/devtools/lint-whitespace.sh
+            contrib/devtools/commit-script-check.sh $TRAVIS_COMMIT_RANGE
+            test/lint/lint-qt.sh
+          fi
+
+  cmake:
+    name: CMake-${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    needs: lint
+    continue-on-error: true
+    env:
+      APT_BASE: ccache
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_SIZE: 500M
+      CCACHE_COMPRESS: 1
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: Linux
+            os: ubuntu-16.04
+            packages: python3-zmq qtbase5-dev qttools5-dev-tools libqt5svg5-dev libssl-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libprotobuf-dev protobuf-compiler libqrencode-dev libgmp-dev libsodium-dev cargo
+            cc: gcc
+            cxx: g++
+
+          # macOS disabled for now due to a compiler error
+          #- name: macOS
+          #  os: macos-10.15
+          #  packages: python3 autoconf automake berkeley-db4 libtool boost miniupnpc pkg-config protobuf qt5 zmq libevent qrencode gmp libsodium
+          #  cc: clang
+          #  cxx: clang++
+
+    steps:
+      - name: Get Source
+        uses: actions/checkout@v2
+
+      - name: Setup Environment
+        run: |
+          if [[ ${{ matrix.config.os }} = ubuntu* ]]; then
+            sudo apt-get update
+            sudo apt-get install --no-install-recommends --no-upgrade -qq "$APT_BASE" ${{ matrix.config.packages }}
+          fi
+          if [[ ${{ matrix.config.os }} = macos* ]]; then
+            brew install "$APT_BASE" ${{ matrix.config.packages }}
+          fi
+
+      - name: Prepare ccache timestamp
+        id: ccache_cache_timestamp
+        shell: cmake -P {0}
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+          message("::set-output name=timestamp::${current_date}")
+
+      - name: ccache cache files
+        uses: actions/cache@v2
+        with:
+          path: .ccache
+          key: cmake-${{ matrix.config.name }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          restore-keys: |
+            cmake-${{ matrix.config.name }}-ccache-
+
+      - name: build
+        run: |
+          CC=${{ matrix.config.cc }}
+          CXX=${{ matrix.config.cxx }}
+          export CC
+          export CXX
+          mkdir -p ${{ github.workspace }}/cmake-build-debug && cd ${{ github.workspace }}/cmake-build-debug
+          cmake -DCMAKE_BUILD_TYPE=Debug -G "CodeBlocks - Unix Makefiles" ${{ github.workspace }}
+          cmake --build ${{ github.workspace }}/cmake-build-debug --target all -- -j 2
+
+  build_depends:
+    name: Depends-${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    needs: lint
+    env:
+      APT_BASE: ccache
+      SDK_URL: https://bitcoincore.org/depends-sources/sdks
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: ARM 32-bit
+            os: ubuntu-18.04
+            host: arm-linux-gnueabihf
+            apt_get: python3 g++-arm-linux-gnueabihf
+
+          - name: AARCH64
+            os: ubuntu-18.04
+            host: aarch64-linux-gnu
+            apt_get: python3 g++-aarch64-linux-gnu
+
+          - name: Win64
+            os: ubuntu-18.04
+            host: x86_64-w64-mingw32
+            apt_get: python3 nsis g++-mingw-w64-x86-64 wine-binfmt wine64
+
+          - name: 32-bit + dash
+            os: ubuntu-18.04
+            host: i686-pc-linux-gnu
+            apt_get: g++-multilib python3-zmq
+
+          - name: x86_64 Linux
+            os: ubuntu-18.04
+            host: x86_64-unknown-linux-gnu
+            apt_get: python3-zmq qtbase5-dev qttools5-dev-tools libqt5svg5-dev libqt5charts5-dev libqrencode-dev protobuf-compiler libdbus-1-dev libharfbuzz-dev libprotobuf-dev
+            dep_opts: NO_QT=1 NO_UPNP=1 DEBUG=1 ALLOW_HOST_PACKAGES=1
+
+          - name: macOS 10.10
+            os: ubuntu-18.04
+            host: x86_64-apple-darwin14
+            apt_get: cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python3-dev python3-setuptools
+            OSX_SDK: 10.11
+
+    steps:
+      - name: Get Source
+        uses: actions/checkout@v2
+
+      - name: Setup Environment
+        run: sudo apt-get install --no-install-recommends --no-upgrade -qq "$APT_BASE" ${{ matrix.config.apt_get }}
+
+      - name: Prepare Depends timestamp
+        id: depends_cache_timestamp
+        shell: cmake -P {0}
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+          message("::set-output name=timestamp::${current_date}")
+
+      - name: depends cache files
+        uses: actions/cache@v2
+        with:
+          path: |
+            depends/built
+            depends/sdk-sources
+            depends/${{ matrix.config.host }}
+          key: ${{ runner.os }}-depends-${{ matrix.config.host }}-${{ steps.depends_cache_timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ runner.os }}-depends-${{ matrix.config.host }}-
+
+      - name: Build Depends
+        run: |
+          export LC_ALL=C.UTF-8
+
+          PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
+          # Add llvm-symbolizer directory to PATH. Needed to get symbolized stack traces from the sanitizers.
+          PATH=$PATH:/usr/lib/llvm-6.0/bin/
+          export PATH
+
+          mkdir -p depends/SDKs depends/sdk-sources
+
+          if [ -n "${{ matrix.config.OSX_SDK }}" -a ! -f depends/sdk-sources/MacOSX${{ matrix.config.OSX_SDK }}.sdk.tar.gz ]; then
+            curl --location --fail $SDK_URL/MacOSX${{ matrix.config.OSX_SDK }}.sdk.tar.gz -o depends/sdk-sources/MacOSX${{ matrix.config.OSX_SDK }}.sdk.tar.gz
+          fi
+
+          if [ -n "${{ matrix.config.OSX_SDK }}" -a -f depends/sdk-sources/MacOSX${{ matrix.config.OSX_SDK }}.sdk.tar.gz ]; then
+            tar -C depends/SDKs -xf depends/sdk-sources/MacOSX${{ matrix.config.OSX_SDK }}.sdk.tar.gz
+          fi
+
+          if [[ ${{ matrix.config.host }} = *-mingw32 ]]; then
+            BIN=$(which ${{ matrix.config.host }}-g++-posix)
+            sudo update-alternatives --set ${{ matrix.config.host }}-g++ $BIN
+          fi
+
+          if [ -z "${{ matrix.config.no_depends }}" ]; then
+            make -j2 -C depends HOST=${{ matrix.config.host }} ${{ matrix.config.dep_opts }}
+          fi
+
+  build_wallet:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    needs: [lint, build_depends]
+    env:
+      APT_BASE: ccache
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_SIZE: 500M
+      CCACHE_COMPRESS: 1
+      PARAMS_DIR: ${{ github.workspace }}/.pivx-params
+      WINEDEBUG: fixme-all
+      BOOST_TEST_RANDOM: 1${{ github.run_id }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: ARM 32-bit [GOAL:install]  [no unit or functional tests]
+            os: ubuntu-18.04
+            host: arm-linux-gnueabihf
+            apt_get: python3 g++-arm-linux-gnueabihf
+            unit_tests: false
+            functional_tests: false
+            goal: install
+            # -Wno-psabi is to disable ABI warnings: "note: parameter passing for argument of type ... changed in GCC 7.1"
+            # This could be removed once the ABI change warning does not show up by default
+            BITCOIN_CONFIG: "--with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports --disable-online-rust CXXFLAGS=-Wno-psabi"
+
+          - name: AARCH64 [GOAL:install] [no unit or functional tests]
+            os: ubuntu-18.04
+            host: aarch64-linux-gnu
+            apt_get: python3 g++-aarch64-linux-gnu
+            unit_tests: false
+            functional_tests: false
+            goal: install
+            BITCOIN_CONFIG: "--with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports --disable-online-rust"
+
+          - name: Win64  [GOAL:deploy] [no functional tests]
+            os: ubuntu-18.04
+            host: x86_64-w64-mingw32
+            apt_get: python3 nsis g++-mingw-w64-x86-64 wine-binfmt wine64
+            unit_tests: true
+            functional_tests: false
+            goal: deploy
+            BITCOIN_CONFIG: "--with-gui=auto --enable-reduce-exports --disable-online-rust"
+
+          - name: x86_64 Linux  [GOAL:install]  [bionic]
+            os: ubuntu-18.04
+            host: x86_64-unknown-linux-gnu
+            apt_get: python3-zmq qtbase5-dev qttools5-dev-tools libqt5svg5-dev libqt5charts5-dev libqrencode-dev protobuf-compiler libdbus-1-dev libharfbuzz-dev libprotobuf-dev
+            unit_tests: true
+            functional_tests: true
+            goal: install
+            test_runner_extra: "--coverage --extended"
+            BITCOIN_CONFIG: "--enable-zmq --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports --disable-online-rust"
+
+          - name: x86_64 Linux  [GOAL:install]  [bionic] [no GUI no unit tests - only functional tests on legacy pre-HD wallets]
+            os: ubuntu-18.04
+            host: x86_64-unknown-linux-gnu
+            apt_get: python3-zmq qtbase5-dev qttools5-dev-tools libqt5svg5-dev libqt5charts5-dev libqrencode-dev protobuf-compiler libdbus-1-dev libharfbuzz-dev libprotobuf-dev
+            unit_tests: false
+            functional_tests: true
+            goal: install
+            test_runner_extra: "--legacywallet"
+            BITCOIN_CONFIG: "--enable-zmq --with-gui=no --enable-glibc-back-compat --enable-reduce-exports --disable-online-rust"
+
+          - name: x86_64 Linux  [GOAL:install]  [bionic] [no GUI no unit tests - only tiertwo/sapling functional tests]
+            os: ubuntu-18.04
+            host: x86_64-unknown-linux-gnu
+            apt_get: python3-zmq qtbase5-dev qttools5-dev-tools libqt5svg5-dev libqt5charts5-dev libqrencode-dev protobuf-compiler libdbus-1-dev libharfbuzz-dev libprotobuf-dev
+            unit_tests: false
+            functional_tests: true
+            goal: install
+            test_runner_extra: "--tiertwo --sapling --skipcache"
+            BITCOIN_CONFIG: "--enable-zmq --with-gui=no --enable-glibc-back-compat --enable-reduce-exports --disable-online-rust"
+
+          - name: x86_64 Linux  [GOAL:install]  [xenial]  [no depends only system libs]
+            os: ubuntu-16.04
+            host: x86_64-unknown-linux-gnu
+            apt_get: python3-zmq qtbase5-dev qttools5-dev-tools libqt5svg5-dev libssl-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libprotobuf-dev protobuf-compiler libqrencode-dev libgmp-dev libsodium-dev cargo
+            unit_tests: true
+            functional_tests: true
+            no_depends: 1
+            BITCOIN_CONFIG: "--enable-zmq --with-incompatible-bdb --with-gui=qt5 CPPFLAGS=-DDEBUG_LOCKORDER --disable-hardening --disable-asm"
+
+          - name: x86_64 Linux  [GOAL:install]  [bionic]  [no depends only system libs]
+            os: ubuntu-18.04
+            host: x86_64-unknown-linux-gnu
+            apt_get: python3-zmq qtbase5-dev qttools5-dev-tools libqt5svg5-dev libqt5charts5-dev libssl1.0-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libprotobuf-dev protobuf-compiler libqrencode-dev libgmp-dev libsodium-dev cargo
+            unit_tests: true
+            no_depends: 1
+            BITCOIN_CONFIG: "--enable-zmq --with-incompatible-bdb --with-gui=qt5 CPPFLAGS=-DDEBUG_LOCKORDER"
+
+          - name: macOS 10.10  [GOAL:deploy] [no functional tests]
+            os: ubuntu-18.04
+            host: x86_64-apple-darwin14
+            apt-get: cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python3-dev python3-setuptools
+            OSX_SDK: 10.11
+            unit_tests: false
+            functional_tests: false
+            BITCOIN_CONFIG: "--enable-gui --enable-reduce-exports --enable-werror --disable-online-rust"
+
+    steps:
+      - name: Get Source
+        uses: actions/checkout@v2
+
+      - name: Setup Environment
+        run: |
+          if [ "${{ matrix.config.no_depends }}" = 1 ]; then
+            sudo apt-get update
+          fi
+          sudo apt-get install --no-install-recommends --no-upgrade -qq "$APT_BASE" ${{ matrix.config.apt_get }}
+
+      - name: depends cache files
+        if: matrix.config.no_depends != 1
+        uses: actions/cache@v2
+        with:
+          path: |
+            depends/built
+            depends/sdk-sources
+            depends/${{ matrix.config.host }}
+          key: ${{ runner.os }}-depends-${{ matrix.config.host }}-
+          restore-keys: |
+            ${{ runner.os }}-depends-${{ matrix.config.host }}-
+
+      - name: Prepare ccache timestamp
+        id: ccache_cache_timestamp
+        shell: cmake -P {0}
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+          message("::set-output name=timestamp::${current_date}")
+
+      - name: ccache cache files
+        uses: actions/cache@v2
+        with:
+          path: |
+            .ccache
+            .pivx-params
+          key: ${{ matrix.config.name }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ matrix.config.name }}-ccache-
+
+      - name: Build Wallet
+        run: |
+          export LC_ALL=C.UTF-8
+
+          echo $CCACHE_DIR
+          echo $PARAMS_DIR
+
+          PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
+          # Add llvm-symbolizer directory to PATH. Needed to get symbolized stack traces from the sanitizers.
+          PATH=$PATH:/usr/lib/llvm-6.0/bin/
+          export PATH
+
+          mkdir -p depends/SDKs depends/sdk-sources
+
+          if [ -n "${{ matrix.config.OSX_SDK }}" -a ! -f depends/sdk-sources/MacOSX${{ matrix.config.OSX_SDK }}.sdk.tar.gz ]; then
+            curl --location --fail $SDK_URL/MacOSX${{ matrix.config.OSX_SDK }}.sdk.tar.gz -o depends/sdk-sources/MacOSX${{ matrix.config.OSX_SDK }}.sdk.tar.gz
+          fi
+
+          if [ -n "${{ matrix.config.OSX_SDK }}" -a -f depends/sdk-sources/MacOSX${{ matrix.config.OSX_SDK }}.sdk.tar.gz ]; then
+            tar -C depends/SDKs -xf depends/sdk-sources/MacOSX${{ matrix.config.OSX_SDK }}.sdk.tar.gz
+          fi
+
+          if [[ ${{ matrix.config.host }} = *-mingw32 ]]; then
+            BIN=$(which ${{ matrix.config.host }}-g++-posix)
+            sudo update-alternatives --set ${{ matrix.config.host }}-g++ $BIN
+            sudo update-binfmts --import /usr/share/binfmts/wine
+          fi
+
+          OUTDIR_PATH="$GITHUB_WORKSPACE/$GITHUB_RUN_NUMBER-${{ matrix.config.host }}"
+          BITCOIN_CONFIG_ALL="--disable-dependency-tracking --prefix=$GITHUB_WORKSPACE/depends/${{ matrix.config.host }} --bindir=$OUTDIR_PATH/bin --libdir=$OUTDIR_PATH/lib"
+
+          if [ "${{ matrix.config.unit_tests }}" = "true" ] || [ "${{ matrix.config.functional_tests }}" = "true" ]; then
+            mkdir -p $PARAMS_DIR
+            PARAMS_FLAGS="--with-params-dir=$PARAMS_DIR"
+          fi
+
+          echo ::group::Autogen
+          ./autogen.sh
+          echo ::endgroup::
+
+          mkdir build && cd build
+
+          echo ::group::Configure
+          ../configure --cache-file=config.cache $BITCOIN_CONFIG_ALL ${{ matrix.config.BITCOIN_CONFIG }} $PARAMS_FLAGS || ( cat config.log && false)
+          echo ::endgroup::
+
+          echo ::group::Distdir
+          make distdir VERSION=${{ matrix.config.host }}
+          echo ::endgroup::
+
+          cd pivx-${{ matrix.config.host }}
+
+          echo ::group::Configure
+          ./configure --cache-file=../config.cache $BITCOIN_CONFIG_ALL ${{ matrix.config.BITCOIN_CONFIG }} $PARAMS_FLAGS || ( cat config.log && false)
+          echo ::endgroup
+
+          echo ::group::Build
+          make -j2 ${{ matrix.config.goal }} || ( echo "Build failure. Verbose build follows." && make ${{ matrix.config.goal }} V=1 ; false )
+          echo ::endgroup::
+
+          if [ "${{ matrix.config.unit_tests }}" = "true" ] || [ "${{ matrix.config.functional_tests }}" = "true" ]; then
+            echo ::group::Params
+            util/fetch-params.sh $PARAMS_DIR
+            echo ::endgroup::
+          fi
+
+          if [ "${{ matrix.config.unit_tests }}" = "true" ]; then
+            echo ::group::Unit-Tests
+            LD_LIBRARY_PATH=$GITHUB_WORKSPACE/depends/"${{ matrix.config.host }}"/lib make -j2 check VERBOSE=1
+            echo ::endgroup::
+          fi
+
+          if [ "${{ matrix.config.functional_tests }}" = "true" ]; then
+            echo ::group::Functional-Tests
+            test/functional/test_runner.py --combinedlogslen=4000 ${{ matrix.config.test_runner_extra }}
+            echo ::endgroup::
+          fi


### PR DESCRIPTION
This is a near 1:1 re-creation of our TravisCI workflow implemented in Github Actions.

TravisCI recently rolled out un-announced changes that have made it extremely difficult for open source projects to continue using the free build jobs they are supposed to able to use.

No artifacts are made available here due to the need to use a specific zk-params path at configure time so our unit/functional tests can run properly. The resulting binaries would not be easily portable to other systems.

See the workflow results in my repo to view the build logs for this: https://github.com/Fuzzbawls/PIVX/actions/runs/378462901