### PR TITLE
[Trivial] Rename placeholder for v5 network upgrade info

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -479,7 +479,7 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_V3_4].nActivationHeight          = 251;
         consensus.vUpgrades[Consensus::UPGRADE_V4_0].nActivationHeight          =
                 Consensus::NetworkUpgrade::ALWAYS_ACTIVE;
-        consensus.vUpgrades[Consensus::UPGRADE_V5_0].nActivationHeight       = 300;
+        consensus.vUpgrades[Consensus::UPGRADE_V5_0].nActivationHeight          = 300;
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -197,7 +197,7 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_ZC_PUBLIC].nActivationHeight     = 1880000;
         consensus.vUpgrades[Consensus::UPGRADE_V3_4].nActivationHeight          = 1967000;
         consensus.vUpgrades[Consensus::UPGRADE_V4_0].nActivationHeight          = 2153200;
-        consensus.vUpgrades[Consensus::UPGRADE_V5_DUMMY].nActivationHeight =
+        consensus.vUpgrades[Consensus::UPGRADE_V5_0].nActivationHeight =
                 Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
 
         consensus.vUpgrades[Consensus::UPGRADE_ZC].hashActivationBlock =
@@ -336,7 +336,7 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_ZC_PUBLIC].nActivationHeight     = 1106100;
         consensus.vUpgrades[Consensus::UPGRADE_V3_4].nActivationHeight          = 1214000;
         consensus.vUpgrades[Consensus::UPGRADE_V4_0].nActivationHeight          = 1347000;
-        consensus.vUpgrades[Consensus::UPGRADE_V5_DUMMY].nActivationHeight =
+        consensus.vUpgrades[Consensus::UPGRADE_V5_0].nActivationHeight =
                 Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
 
         consensus.vUpgrades[Consensus::UPGRADE_ZC].hashActivationBlock =
@@ -479,7 +479,7 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_V3_4].nActivationHeight          = 251;
         consensus.vUpgrades[Consensus::UPGRADE_V4_0].nActivationHeight          =
                 Consensus::NetworkUpgrade::ALWAYS_ACTIVE;
-        consensus.vUpgrades[Consensus::UPGRADE_V5_DUMMY].nActivationHeight       = 300;
+        consensus.vUpgrades[Consensus::UPGRADE_V5_0].nActivationHeight       = 300;
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -33,7 +33,7 @@ enum UpgradeIndex : uint32_t {
     UPGRADE_ZC_PUBLIC,
     UPGRADE_V3_4,
     UPGRADE_V4_0,
-    UPGRADE_V5_DUMMY,
+    UPGRADE_V5_0,
     UPGRADE_TESTDUMMY,
     // NOTE: Also add new upgrades to NetworkUpgradeInfo in upgrades.cpp
     MAX_NETWORK_UPGRADES

--- a/src/consensus/upgrades.cpp
+++ b/src/consensus/upgrades.cpp
@@ -51,7 +51,7 @@ const struct NUInfo NetworkUpgradeInfo[Consensus::MAX_NETWORK_UPGRADES] = {
         },
         {
                 /*.strName =*/ "v5_shield",
-                /*.strInfo =*/ "Placeholder for future PIVX version 5.0 upgrade",
+                /*.strInfo =*/ "Sapling Shield - start block v8 - start transaction v2",
         },
         {
                 /*.strName =*/ "Test_dummy",

--- a/src/consensus/upgrades.cpp
+++ b/src/consensus/upgrades.cpp
@@ -50,7 +50,7 @@ const struct NUInfo NetworkUpgradeInfo[Consensus::MAX_NETWORK_UPGRADES] = {
                 /*.strInfo =*/ "new message sigs - start block v7 - time protocol - zc spend v4",
         },
         {
-                /*.strName =*/ "v5_dummy",
+                /*.strName =*/ "v5_shield",
                 /*.strInfo =*/ "Placeholder for future PIVX version 5.0 upgrade",
         },
         {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -448,7 +448,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, 
         LogPrintf("%s : total size %u\n", __func__, nBlockSize);
 
         // Sapling
-        if (NetworkUpgradeActive(nHeight, consensus, Consensus::UPGRADE_V5_DUMMY)) {
+        if (NetworkUpgradeActive(nHeight, consensus, Consensus::UPGRADE_V5_0)) {
             pblock->nVersion = 8;
             SaplingMerkleTree sapling_tree;
             assert(view.GetSaplingAnchorAt(view.GetBestAnchor(), sapling_tree));

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -98,7 +98,7 @@ bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType)
 bool IsStandardTx(const CTransaction& tx, int nBlockHeight, std::string& reason)
 {
     AssertLockHeld(cs_main);
-    if (!Params().GetConsensus().NetworkUpgradeActive(nBlockHeight, Consensus::UPGRADE_V5_DUMMY)) {
+    if (!Params().GetConsensus().NetworkUpgradeActive(nBlockHeight, Consensus::UPGRADE_V5_0)) {
         // Before v5, all txes with version other than STANDARD_VERSION (1) are considered non-standard
         if (tx.nVersion != CTransaction::TxVersion::LEGACY) {
             reason = "version";

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -460,7 +460,7 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(WalletModelTransaction& tran
     }
 
     bool fColdStakingActive = isColdStakingNetworkelyEnabled();
-    bool fSaplingActive = Params().GetConsensus().NetworkUpgradeActive(cachedNumBlocks, Consensus::UPGRADE_V5_DUMMY);
+    bool fSaplingActive = Params().GetConsensus().NetworkUpgradeActive(cachedNumBlocks, Consensus::UPGRADE_V5_0);
 
     // Double check the tx before doing anything
     CWalletTx* newTx = transaction.getTransaction();
@@ -526,7 +526,7 @@ OperationResult WalletModel::PrepareShieldedTransaction(WalletModelTransaction* 
 
     // Check network status
     int nextBlockHeight = cachedNumBlocks + 1;
-    if (!Params().GetConsensus().NetworkUpgradeActive(nextBlockHeight, Consensus::UPGRADE_V5_DUMMY)) {
+    if (!Params().GetConsensus().NetworkUpgradeActive(nextBlockHeight, Consensus::UPGRADE_V5_0)) {
         return errorOut("Error, cannot send transaction. Sapling is not activated");
     }
 

--- a/src/sapling/sapling_validation.cpp
+++ b/src/sapling/sapling_validation.cpp
@@ -138,7 +138,7 @@ bool ContextualCheckTransaction(
 
     // If Sapling is not active return quickly and don't perform any check here.
     // basic data checks are performed in CheckTransaction which is ALWAYS called before ContextualCheckTransaction.
-    if (!chainparams.GetConsensus().NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V5_DUMMY)) {
+    if (!chainparams.GetConsensus().NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V5_0)) {
         return true;
     }
 

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -928,7 +928,7 @@ KeyAddResult SaplingScriptPubKeyMan::AddSpendingKeyToWallet(
 
             int64_t nTimeToSet;
             // Sapling addresses can't have been used in transactions prior to activation.
-            if (params.vUpgrades[Consensus::UPGRADE_V5_DUMMY].nActivationHeight == Consensus::NetworkUpgrade::ALWAYS_ACTIVE) {
+            if (params.vUpgrades[Consensus::UPGRADE_V5_0].nActivationHeight == Consensus::NetworkUpgrade::ALWAYS_ACTIVE) {
                 nTimeToSet = nTime;
             } else {
                 // TODO: Update epoch before release v5.

--- a/src/sapling/transaction_builder.cpp
+++ b/src/sapling/transaction_builder.cpp
@@ -101,7 +101,7 @@ std::string TransactionBuilderResult::GetError() {
 CMutableTransaction CreateNewContextualCMutableTransaction(const Consensus::Params& consensusParams, int nHeight)
 {
     CMutableTransaction mtx;
-    bool isSapling = consensusParams.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V5_DUMMY);
+    bool isSapling = consensusParams.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V5_0);
     mtx.nVersion = isSapling ? CTransaction::TxVersion::SAPLING : CTransaction::TxVersion::LEGACY;
     return mtx;
 }

--- a/src/test/librust/utiltest.cpp
+++ b/src/test/librust/utiltest.cpp
@@ -15,13 +15,13 @@ static const std::string T_SECRET_REGTEST = "cND2ZvtabDbJ1gucx9GWH6XT9kgTAqfb6co
 
 const Consensus::Params& RegtestActivateSapling() {
     SelectParams(CBaseChainParams::REGTEST);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_V5_DUMMY, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_V5_0, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     g_IsSaplingActive = true;
     return Params().GetConsensus();
 }
 
 void RegtestDeactivateSapling() {
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_V5_DUMMY, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_V5_0, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
     g_IsSaplingActive = false;
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -327,7 +327,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState &state, const C
     const CChainParams& params = Params();
     const Consensus::Params& consensus = params.GetConsensus();
     int chainHeight = chainActive.Height();
-    bool fSaplingActive = consensus.NetworkUpgradeActive(chainHeight, Consensus::UPGRADE_V5_DUMMY);
+    bool fSaplingActive = consensus.NetworkUpgradeActive(chainHeight, Consensus::UPGRADE_V5_0);
 
     // If v5 is active, bye bye zerocoin
     if (fSaplingActive && hasTxZerocoins) {
@@ -1390,7 +1390,7 @@ DisconnectResult DisconnectBlock(CBlock& block, CBlockIndex* pindex, CCoinsViewC
     // However, this is only reliable if the last block was on or after
     // the Sapling activation height. Otherwise, the last anchor was the
     // empty root.
-    if (consensus.NetworkUpgradeActive(pindex->pprev->nHeight, Consensus::UPGRADE_V5_DUMMY)) {
+    if (consensus.NetworkUpgradeActive(pindex->pprev->nHeight, Consensus::UPGRADE_V5_0)) {
         view.PopAnchor(pindex->pprev->hashFinalSaplingRoot);
     } else {
         view.PopAnchor(SaplingMerkleTree::empty_root());
@@ -1534,7 +1534,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     assert(view.GetSaplingAnchorAt(view.GetBestAnchor(), sapling_tree));
 
     //
-    bool isV5UpgradeEnforced = consensus.NetworkUpgradeActive(pindex->nHeight, Consensus::UPGRADE_V5_DUMMY);
+    bool isV5UpgradeEnforced = consensus.NetworkUpgradeActive(pindex->nHeight, Consensus::UPGRADE_V5_0);
 
     std::vector<PrecomputedTransactionData> precomTxData;
     precomTxData.reserve(block.vtx.size()); // Required so that pointers to individual precomTxData don't get invalidated
@@ -1687,7 +1687,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     view.PushAnchor(sapling_tree);
 
     // Verify header correctness
-    if (consensus.NetworkUpgradeActive(pindex->nHeight, Consensus::UPGRADE_V5_DUMMY)) {
+    if (consensus.NetworkUpgradeActive(pindex->nHeight, Consensus::UPGRADE_V5_0)) {
         // If Sapling is active, block.hashFinalSaplingRoot must be the
         // same as the root of the Sapling tree
         if (block.hashFinalSaplingRoot != sapling_tree.root()) {
@@ -1939,7 +1939,7 @@ void static UpdateTip(CBlockIndex* pindexNew)
 {
     AssertLockHeld(cs_main);
     chainActive.SetTip(pindexNew);
-    g_IsSaplingActive = Params().GetConsensus().NetworkUpgradeActive(pindexNew->nHeight, Consensus::UPGRADE_V5_DUMMY);
+    g_IsSaplingActive = Params().GetConsensus().NetworkUpgradeActive(pindexNew->nHeight, Consensus::UPGRADE_V5_0);
 
     // New best block
     mempool.AddTransactionsUpdated(1);
@@ -2043,7 +2043,7 @@ bool static DisconnectTip(CValidationState& state, const CChainParams& chainpara
         GetMainSignals().SyncTransaction(*tx, pindexDelete->pprev, CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK);
     }
 
-    if (chainparams.GetConsensus().NetworkUpgradeActive(pindexDelete->nHeight, Consensus::UPGRADE_V5_DUMMY)) {
+    if (chainparams.GetConsensus().NetworkUpgradeActive(pindexDelete->nHeight, Consensus::UPGRADE_V5_0)) {
         // Update Sapling cached incremental witnesses
         GetMainSignals().ChainTip(pindexDelete, &block, nullopt);
     }
@@ -2400,7 +2400,7 @@ bool ActivateBestChain(CValidationState& state, std::shared_ptr<const CBlock> pb
                 SaplingMerkleTree oldSaplingTree;
                 bool isSaplingActive = (pprev) != nullptr &&
                                        Params().GetConsensus().NetworkUpgradeActive(pprev->nHeight,
-                                                                                    Consensus::UPGRADE_V5_DUMMY);
+                                                                                    Consensus::UPGRADE_V5_0);
                 if (isSaplingActive) {
                     assert(pcoinsTip->GetSaplingAnchorAt(pprev->hashFinalSaplingRoot, oldSaplingTree));
                 } else {
@@ -2875,7 +2875,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
     // TODO: Check if this is ok... blockHeight is always the tip or should we look for the prevHash and get the height?
     int blockHeight = chainActive.Height() + 1;
     const Consensus::Params& consensus = Params().GetConsensus();
-    bool fSaplingActive = consensus.NetworkUpgradeActive(blockHeight, Consensus::UPGRADE_V5_DUMMY);
+    bool fSaplingActive = consensus.NetworkUpgradeActive(blockHeight, Consensus::UPGRADE_V5_0);
     for (const auto& txIn : block.vtx) {
         const CTransaction& tx = *txIn;
         if (!CheckTransaction(
@@ -3472,7 +3472,7 @@ bool ProcessNewBlock(CValidationState& state, CNode* pfrom, const std::shared_pt
     // For now, we need the tip to know whether p2pkh block signatures are accepted or not.
     // After 5.0, this can be removed and replaced by the enforcement block time.
     const int newHeight = chainActive.Height() + 1;
-    const bool enableP2PKH = consensus.NetworkUpgradeActive(newHeight, Consensus::UPGRADE_V5_DUMMY);
+    const bool enableP2PKH = consensus.NetworkUpgradeActive(newHeight, Consensus::UPGRADE_V5_0);
     if (!CheckBlockSignature(*pblock, enableP2PKH))
         return error("%s : bad proof-of-stake block signature", __func__);
 
@@ -3742,7 +3742,7 @@ bool static LoadBlockIndexDB(std::string& strError)
     const CBlockIndex* pChainTip = chainActive.Tip();
 
     // initial global flag update
-    g_IsSaplingActive = Params().GetConsensus().NetworkUpgradeActive(pChainTip->nHeight, Consensus::UPGRADE_V5_DUMMY);
+    g_IsSaplingActive = Params().GetConsensus().NetworkUpgradeActive(pChainTip->nHeight, Consensus::UPGRADE_V5_0);
 
     LogPrintf("LoadBlockIndexDB(): hashBestChain=%s height=%d date=%s progress=%f\n",
             pChainTip->GetBlockHash().GetHex(), pChainTip->nHeight,

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1074,7 +1074,7 @@ UniValue CreateColdStakeDelegation(const UniValue& params, CWalletTx& wtxNew, CR
         const Consensus::Params& consensus = Params().GetConsensus();
         // Check network status
         int nextBlockHeight = chainActive.Height() + 1;
-        if (!consensus.NetworkUpgradeActive(nextBlockHeight, Consensus::UPGRADE_V5_DUMMY)) {
+        if (!consensus.NetworkUpgradeActive(nextBlockHeight, Consensus::UPGRADE_V5_0)) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, Sapling not active yet");
         }
         std::vector<SendManyRecipient> recipients = {SendManyRecipient(ownerKey, *stakeKey, nValue)};
@@ -1556,7 +1556,7 @@ static SaplingOperation CreateShieldedTransaction(const JSONRPCRequest& request)
     }
 
     // Check network status
-    if (!Params().GetConsensus().NetworkUpgradeActive(nextBlockHeight, Consensus::UPGRADE_V5_DUMMY) ||
+    if (!Params().GetConsensus().NetworkUpgradeActive(nextBlockHeight, Consensus::UPGRADE_V5_0) ||
             sporkManager.IsSporkActive(SPORK_20_SAPLING_MAINTENANCE)) {
         // If Sapling is not active, do not allow sending from or sending to Sapling addresses.
         if (fromSapling || containsSaplingOutput) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1731,7 +1731,7 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate, b
             // This should never fail: we should always be able to get the tree
             // state on the path to the tip of our chain
             if (pindex->pprev) {
-                if (Params().GetConsensus().NetworkUpgradeActive(pindex->pprev->nHeight,  Consensus::UPGRADE_V5_DUMMY)) {
+                if (Params().GetConsensus().NetworkUpgradeActive(pindex->pprev->nHeight,  Consensus::UPGRADE_V5_0)) {
                     SaplingMerkleTree saplingTree;
                     assert(pcoinsTip->GetSaplingAnchorAt(pindex->pprev->hashFinalSaplingRoot, saplingTree));
                     // Increment note witness caches
@@ -2955,7 +2955,7 @@ bool CWallet::CreateCoinStake(
     pStakerStatus->SetLastCoins((int) availableCoins->size());
 
     // P2PKH block signatures were not accepted before v5 update.
-    bool onlyP2PK = !consensus.NetworkUpgradeActive(pindexPrev->nHeight + 1, Consensus::UPGRADE_V5_DUMMY);
+    bool onlyP2PK = !consensus.NetworkUpgradeActive(pindexPrev->nHeight + 1, Consensus::UPGRADE_V5_0);
 
     // Kernel Search
     CAmount nCredit;

--- a/test/functional/mining_pos_coldStaking.py
+++ b/test/functional/mining_pos_coldStaking.py
@@ -34,7 +34,7 @@ class PIVX_ColdStakingTest(PivxTestFramework):
 
     def set_test_params(self):
         self.num_nodes = 3
-        self.extra_args = [['-nuparams=v5_dummy:201']] * self.num_nodes
+        self.extra_args = [['-nuparams=v5_shield:201']] * self.num_nodes
         self.extra_args[0].append('-sporkkey=932HEevBSujW2ud7RfB1YF91AFygbBRQj3de3LyaCRqNzKKgWXi')
 
     def setup_chain(self):

--- a/test/functional/mining_v5_upgrade.py
+++ b/test/functional/mining_v5_upgrade.py
@@ -15,11 +15,11 @@ class MiningV5UpgradeTest(PivxTestFramework):
         self.setup_clean_chain = True
 
     def run_test(self):
-        assert_equal(self.nodes[0].getblockchaininfo()['upgrades']['v5 dummy']['status'], 'pending')
+        assert_equal(self.nodes[0].getblockchaininfo()['upgrades']['v5 shield']['status'], 'pending')
         self.nodes[0].generate(300) # v5 activation height
-        assert_equal(self.nodes[0].getblockchaininfo()['upgrades']['v5 dummy']['status'], 'active')
+        assert_equal(self.nodes[0].getblockchaininfo()['upgrades']['v5 shield']['status'], 'active')
         self.nodes[0].generate(25) # 25 more to check chain movement
-        assert_equal(self.nodes[0].getblockchaininfo()['upgrades']['v5 dummy']['status'], 'active')
+        assert_equal(self.nodes[0].getblockchaininfo()['upgrades']['v5 shield']['status'], 'active')
         assert_equal(self.nodes[0].getblockcount(), 325)
 
 

--- a/test/functional/sapling_changeaddresses.py
+++ b/test/functional/sapling_changeaddresses.py
@@ -15,7 +15,7 @@ class WalletChangeAddressesTest(PivxTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
         self.setup_clean_chain = True
-        saplingUpgrade = ['-nuparams=v5_dummy:1']
+        saplingUpgrade = ['-nuparams=v5_shield:1']
         self.extra_args = [saplingUpgrade, saplingUpgrade]
 
     def run_test(self):

--- a/test/functional/sapling_key_import_export.py
+++ b/test/functional/sapling_key_import_export.py
@@ -14,7 +14,7 @@ class SaplingkeyImportExportTest (PivxTestFramework):
     def set_test_params(self):
         self.num_nodes = 5
         self.setup_clean_chain = True
-        saplingUpgrade = ['-nuparams=v5_dummy:1']
+        saplingUpgrade = ['-nuparams=v5_shield:1']
         self.extra_args = [saplingUpgrade, saplingUpgrade, saplingUpgrade, saplingUpgrade, saplingUpgrade]
 
     def run_test(self):

--- a/test/functional/sapling_mempool.py
+++ b/test/functional/sapling_mempool.py
@@ -18,7 +18,7 @@ class SaplingMempoolTest(PivxTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
         self.setup_clean_chain = True
-        self.extra_args = [['-nuparams=v5_dummy:1']] * self.num_nodes
+        self.extra_args = [['-nuparams=v5_shield:1']] * self.num_nodes
 
     def run_test(self):
         miner = self.nodes[0]

--- a/test/functional/sapling_supply.py
+++ b/test/functional/sapling_supply.py
@@ -14,7 +14,7 @@ class SaplingSupplyTest(PivxTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True
-        self.extra_args = [['-nuparams=v5_dummy:1']]
+        self.extra_args = [['-nuparams=v5_shield:1']]
 
     def generate_and_sync(self, count):
         assert(count > 0)

--- a/test/functional/sapling_wallet.py
+++ b/test/functional/sapling_wallet.py
@@ -23,7 +23,7 @@ class WalletSaplingTest(PivxTestFramework):
 
     def set_test_params(self):
         self.num_nodes = 4
-        saplingUpgrade = ['-nuparams=v5_dummy:201']
+        saplingUpgrade = ['-nuparams=v5_shield:201']
         self.extra_args = [saplingUpgrade, saplingUpgrade, saplingUpgrade, saplingUpgrade]
         self.extra_args[0].append('-sporkkey=932HEevBSujW2ud7RfB1YF91AFygbBRQj3de3LyaCRqNzKKgWXi')
 

--- a/test/functional/sapling_wallet_anchorfork.py
+++ b/test/functional/sapling_wallet_anchorfork.py
@@ -13,13 +13,13 @@ class WalletAnchorForkTest(PivxTestFramework):
     def set_test_params(self):
         self.num_nodes = 3
         self.setup_clean_chain = True
-        saplingUpgrade = ['-nuparams=v5_dummy:1']
+        saplingUpgrade = ['-nuparams=v5_shield:1']
         self.extra_args = [saplingUpgrade, saplingUpgrade, saplingUpgrade]
 
     def run_test (self):
         self.nodes[0].generate(4) # generate blocks to activate sapling in regtest
         # verify sapling activation.
-        assert(self.nodes[0].getblockchaininfo()['upgrades']['v5 dummy']['activationheight'] == 1)
+        assert(self.nodes[0].getblockchaininfo()['upgrades']['v5 shield']['activationheight'] == 1)
 
         self.sync_all()
 

--- a/test/functional/sapling_wallet_listreceived.py
+++ b/test/functional/sapling_wallet_listreceived.py
@@ -23,7 +23,7 @@ class ListReceivedTest (PivxTestFramework):
 
     def set_test_params(self):
         self.num_nodes = 4
-        saplingUpgrade = ['-nuparams=v5_dummy:201']
+        saplingUpgrade = ['-nuparams=v5_shield:201']
         self.extra_args = [saplingUpgrade, saplingUpgrade, saplingUpgrade, saplingUpgrade]
 
     def generate_and_sync(self, new_height):

--- a/test/functional/sapling_wallet_nullifiers.py
+++ b/test/functional/sapling_wallet_nullifiers.py
@@ -16,7 +16,7 @@ class WalletNullifiersTest (PivxTestFramework):
 
     def set_test_params(self):
         self.num_nodes = 4
-        saplingUpgrade = ['-nuparams=v5_dummy:201']
+        saplingUpgrade = ['-nuparams=v5_shield:201']
         self.extra_args = [saplingUpgrade, saplingUpgrade, saplingUpgrade, saplingUpgrade]
 
     def run_test (self):

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -755,7 +755,7 @@ class PivxTestFramework():
             fDoubleSpend=False):
         """ Calls stake_block appending to the current tip"""
         assert_greater_than(len(self.nodes), node_id)
-        saplingActive = self.nodes[node_id].getblockchaininfo()['upgrades']['v5 dummy']['status'] == 'active'
+        saplingActive = self.nodes[node_id].getblockchaininfo()['upgrades']['v5 shield']['status'] == 'active'
         blockVersion = 8 if saplingActive else 7
         nHeight = self.nodes[node_id].getblockcount()
         prevHhash = self.nodes[node_id].getblockhash(nHeight)


### PR DESCRIPTION
Rename the NU param info/index removing the "dummy" label.
```
-BEGIN VERIFY SCRIPT-
sed -i 's/v5_dummy/v5_shield/g' src/*.h src/*.cpp src/*/*.h src/*/*.cpp src/*/*/*.h src/*/*/*.cpp test/functional/*.py ;
sed -i 's/v5 dummy/v5 shield/g' test/functional/*.py test/functional/*/*.py;
sed -i 's/UPGRADE_V5_DUMMY/UPGRADE_V5_0/g' src/*.h src/*.cpp src/*/*.h src/*/*.cpp src/*/*/*.h src/*/*/*.cpp ;
-END VERIFY SCRIPT-
```