### PR TITLE
[Tests] Fix double bug in sapling_mempool functional test

### DIFF
--- a/test/functional/sapling_mempool.py
+++ b/test/functional/sapling_mempool.py
@@ -65,10 +65,11 @@ class SaplingMempoolTest(PivxTestFramework):
         # Mine tx_B and try to send tx_A again
         self.log.info("Mine a block and verify that tx_B gets on chain")
         miner.generate(1)
-        txB_json = miner.getrawtransaction(txid_B, True)
+        self.sync_all()
+        txB_json = alice.getrawtransaction(txid_B, True)
         assert("blockhash" in txB_json)
         self.log.info("trying to relay tx_A again...")
-        assert_raises_rpc_error(-26, "bad-txns-nullifier-double-spent",
+        assert_raises_rpc_error(-26, "bad-txns-shielded-requirements-not-met",
                                 alice.sendrawtransaction, rawTx['hex'])
         self.log.info("tx_A NOT accepted in the mempool. Good.")
 


### PR DESCRIPTION
Alice should receive the block mined, and expect a different message when trying to spend a note with a nullifier that has already been spent on-chain (rather than spent in the mempool).
These two bugs (not receiving the block, and expecting the wrong error message) nullify each other, so this is usually hidden and the test passes.
Although, sometimes, due to timing differences, Alice **does** receive the mined block, and this bug shows  (as can be seen in https://github.com/PIVX-Project/PIVX/runs/1465681420?check_suite_focus=true).

Fix the expected message, sync the nodes, and check the mined tx with alice.