### PR TITLE
[BUG][GUI] CControl: cache utxo amount values properly

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -457,8 +457,7 @@ void CoinControlDialog::viewItemChanged(QTreeWidgetItem* item, int column)
         else if (item->isDisabled()) // locked (this happens if "check all" through parent node)
             item->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);
         else {
-            CAmount value = 0;
-            ParseFixedPoint(item->text(COLUMN_AMOUNT).toStdString(), 8, &value);
+            const CAmount value = static_cast<CAmount>(item->data(CoinControlDialog::COLUMN_AMOUNT, Qt::UserRole).toLongLong());
             bool isP2CS = item->data(COLUMN_CHECKBOX, Qt::UserRole) == QString("Delegated");
             coinControl->Select(outpt, value, isP2CS);
         }


### PR DESCRIPTION
**Problem:**
The total selected and "after fee" amounts in coin control are not updated when selecting utxos (or shield notes) that have value greater than 10K PIV.
Bug found by @NoobieDev12 

**Cause:**
Bug  introduced with the coin-control wrapper enhancement.
In `CoinControlDialog::viewItemChanged`, we are taking the text __string__ of the amount, and passing it to `ParseFixedPoint`, which of course craps out when it finds a white space (which is added as thousands separator for values > 9999).

**Solution:**
Consider directly the data of the `QTreeWidgetItem` (at `COLUMN_AMOUNT`), rather than taking the text and parsing it (it's also faster).

Before:
![Screenshot from 2020-11-30 00-02-03](https://user-images.githubusercontent.com/18186894/100556074-df270f80-329f-11eb-809a-3869e75a18a4.png)

After:
![Screenshot from 2020-11-29 23-55-32](https://user-images.githubusercontent.com/18186894/100556079-e5b58700-329f-11eb-8543-4de0234fa9b3.png)
