### PR TITLE
[BUG] g_IsSapling active flag during reindex

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1470,6 +1470,9 @@ bool AppInit2()
 
     fReindex = gArgs.GetBoolArg("-reindex", false);
 
+    // Assume sapling active during reindex for proper v2 deserialization when loading the wallet
+    if (fReindex) g_IsSaplingActive = true;
+
     // Create blocks directory if it doesn't already exist
     fs::create_directories(GetDataDir() / "blocks");
 


### PR DESCRIPTION
**Problem**:
Starting the wallet with `--reindex`  (w/wo `--zapwallettxes`) causes a crash if the wallet has shield transactions.

**Cause**:
`g_IsSaplingActive` is used to select the proper serialization for v2 txes (with or without sapData).
During init, `g_IsSaplingActive` is set to true in `LoadBlockIndexDB` when connecting a post-enforcement block.
When `--reindex`ing, though, `LoadBlockIndexDB` is skipped in `LoadBlockIndex`, and the global flag remains false.
Therefore `g_IsSaplingActive` is false when init gets to `InitLoadWallet` and the deserialization of shield transactions throws.

**Solution**:
Set `g_IsSaplingActive` to true when `--reindex`.
This way the wallet can be loaded, and then the flag switches back to false as soon as the first pre-enforcement block is connected (`ThreadImport` starts only **after** the wallet has been loaded).

*Note*: A wallet would now crash during a reindex, if containing a __pre-enforcement__ v2 transaction (old serialization, no sapData). 
But such transactions are non-standard (afaik there's only one on the whole main-net blockchain).
A wallet with this transaction (if it still exists) would not be able to use `--reindex` and would be forced to `--resync`.