### PR TITLE
[Core] Masternode collateral index

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -188,7 +188,7 @@ bool CActiveMasternode::SendMasternodePing(std::string& errorMessage)
     }
 
     // Update lastPing for our masternode in Masternode list
-    CMasternode* pmn = mnodeman.Find(*vin);
+    CMasternode* pmn = mnodeman.Find(vin->prevout);
     if (pmn != NULL) {
         if (pmn->IsPingedWithin(MasternodePingSeconds(), mnp.sigTime)) {
             errorMessage = "Too early to send Masternode Ping";

--- a/src/budget/budgetmanager.cpp
+++ b/src/budget/budgetmanager.cpp
@@ -971,7 +971,7 @@ void CBudgetManager::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         }
 
         const CTxIn& voteVin = vote.GetVin();
-        CMasternode* pmn = mnodeman.Find(voteVin);
+        CMasternode* pmn = mnodeman.Find(voteVin.prevout);
         if (pmn == NULL) {
             LogPrint(BCLog::MNBUDGET,"mvote - unknown masternode - vin: %s\n", voteVin.ToString());
             mnodeman.AskForMN(pfrom, voteVin);
@@ -1034,7 +1034,7 @@ void CBudgetManager::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         }
 
         const CTxIn& voteVin = vote.GetVin();
-        CMasternode* pmn = mnodeman.Find(voteVin);
+        CMasternode* pmn = mnodeman.Find(voteVin.prevout);
         if (pmn == NULL) {
             LogPrint(BCLog::MNBUDGET, "fbvote - unknown masternode - vin: %s\n", voteVin.prevout.hash.ToString());
             mnodeman.AskForMN(pfrom, voteVin);

--- a/src/budget/budgetproposal.cpp
+++ b/src/budget/budgetproposal.cpp
@@ -262,7 +262,7 @@ void CBudgetProposal::CleanAndRemove()
     std::map<uint256, CBudgetVote>::iterator it = mapVotes.begin();
 
     while (it != mapVotes.end()) {
-        CMasternode* pmn = mnodeman.Find((*it).second.GetVin());
+        CMasternode* pmn = mnodeman.Find(it->second.GetVin().prevout);
         (*it).second.SetValid(pmn != nullptr);
         ++it;
     }

--- a/src/budget/finalizedbudget.cpp
+++ b/src/budget/finalizedbudget.cpp
@@ -169,7 +169,7 @@ void CFinalizedBudget::CleanAndRemove()
     std::map<uint256, CFinalizedBudgetVote>::iterator it = mapVotes.begin();
 
     while (it != mapVotes.end()) {
-        CMasternode* pmn = mnodeman.Find((*it).second.GetVin());
+        CMasternode* pmn = mnodeman.Find(it->second.GetVin().prevout);
         (*it).second.SetValid(pmn != nullptr);
         ++it;
     }

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -164,7 +164,7 @@ std::string CMasternodePaymentWinner::GetStrMessage() const
 
 bool CMasternodePaymentWinner::IsValid(CNode* pnode, std::string& strError)
 {
-    CMasternode* pmn = mnodeman.Find(vinMasternode);
+    CMasternode* pmn = mnodeman.Find(vinMasternode.prevout);
 
     if (!pmn) {
         strError = strprintf("Unknown Masternode %s", vinMasternode.prevout.hash.ToString());

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -76,10 +76,7 @@ CMasternode::CMasternode() :
     activeState = MASTERNODE_ENABLED;
     sigTime = GetAdjustedTime();
     lastPing = CMasternodePing();
-    unitTest = false;
-    allowFreeTx = true;
     protocolVersion = PROTOCOL_VERSION;
-    nLastDsq = 0;
     nScanningErrorCount = 0;
     nLastScanningErrorBlockHeight = 0;
     lastTimeChecked = 0;
@@ -96,10 +93,7 @@ CMasternode::CMasternode(const CMasternode& other) :
     activeState = other.activeState;
     sigTime = other.sigTime;
     lastPing = other.lastPing;
-    unitTest = other.unitTest;
-    allowFreeTx = other.allowFreeTx;
     protocolVersion = other.protocolVersion;
-    nLastDsq = other.nLastDsq;
     nScanningErrorCount = other.nScanningErrorCount;
     nLastScanningErrorBlockHeight = other.nLastScanningErrorBlockHeight;
     lastTimeChecked = 0;

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -523,7 +523,7 @@ bool CMasternodeBroadcast::CheckAndUpdate(int& nDos)
     }
 
     //search existing Masternode list, this is where we update existing Masternodes with new mnb broadcasts
-    CMasternode* pmn = mnodeman.Find(vin);
+    CMasternode* pmn = mnodeman.Find(vin.prevout);
 
     // no such masternode, nothing to update
     if (pmn == NULL) return true;
@@ -571,14 +571,14 @@ bool CMasternodeBroadcast::CheckInputsAndAdd(int& nDoS)
     }
 
     // search existing Masternode list
-    CMasternode* pmn = mnodeman.Find(vin);
+    CMasternode* pmn = mnodeman.Find(vin.prevout);
 
     if (pmn != NULL) {
         // nothing to do here if we already know about this masternode and it's enabled
         if (pmn->IsEnabled()) return true;
         // if it's not enabled, remove old MN first and continue
         else
-            mnodeman.Remove(pmn->vin);
+            mnodeman.Remove(pmn->vin.prevout);
     }
 
     if (pcoinsTip->AccessCoin(vin.prevout).IsSpent()) {
@@ -697,7 +697,7 @@ bool CMasternodePing::CheckAndUpdate(int& nDos, bool fRequireEnabled, bool fChec
     }
 
     // see if we have this Masternode
-    CMasternode* pmn = mnodeman.Find(vin);
+    CMasternode* pmn = mnodeman.Find(vin.prevout);
     const bool isMasternodeFound = (pmn != nullptr);
     const bool isSignatureValid = (isMasternodeFound && CheckSignature(pmn->pubKeyMasternode));
 

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -180,10 +180,8 @@ void CMasternode::Check(bool forceCheck)
     if (!forceCheck && (GetTime() - lastTimeChecked < MASTERNODE_CHECK_SECONDS)) return;
     lastTimeChecked = GetTime();
 
-
     //once spent, stop doing the checks
     if (activeState == MASTERNODE_VIN_SPENT) return;
-
 
     if (!IsPingedWithin(MasternodeRemovalSeconds())) {
         activeState = MASTERNODE_REMOVE;
@@ -198,13 +196,6 @@ void CMasternode::Check(bool forceCheck)
     if(lastPing.sigTime - sigTime < MasternodeMinPingSeconds()){
         activeState = MASTERNODE_PRE_ENABLED;
         return;
-    }
-
-    if (!unitTest) {
-        if (pcoinsTip->AccessCoin(vin.prevout).IsSpent()) {
-            activeState = MASTERNODE_VIN_SPENT;
-            return;
-        }
     }
 
     activeState = MASTERNODE_ENABLED; // OK

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -126,10 +126,7 @@ public:
     CPubKey pubKeyMasternode;
     int activeState;
     int64_t sigTime; //mnb message time
-    bool unitTest;
-    bool allowFreeTx;
     int protocolVersion;
-    int64_t nLastDsq; //the dsq count from the last dsq broadcast of this node
     int nScanningErrorCount;
     int nLastScanningErrorBlockHeight;
     CMasternodePing lastPing;
@@ -161,10 +158,7 @@ public:
         swap(first.activeState, second.activeState);
         swap(first.sigTime, second.sigTime);
         swap(first.lastPing, second.lastPing);
-        swap(first.unitTest, second.unitTest);
-        swap(first.allowFreeTx, second.allowFreeTx);
         swap(first.protocolVersion, second.protocolVersion);
-        swap(first.nLastDsq, second.nLastDsq);
         swap(first.nScanningErrorCount, second.nScanningErrorCount);
         swap(first.nLastScanningErrorBlockHeight, second.nLastScanningErrorBlockHeight);
     }
@@ -201,9 +195,6 @@ public:
         READWRITE(protocolVersion);
         READWRITE(activeState);
         READWRITE(lastPing);
-        READWRITE(unitTest);
-        READWRITE(allowFreeTx);
-        READWRITE(nLastDsq);
         READWRITE(nScanningErrorCount);
         READWRITE(nLastScanningErrorBlockHeight);
     }
@@ -300,9 +291,7 @@ public:
         READWRITE(sigTime);
         READWRITE(protocolVersion);
         READWRITE(lastPing);
-        READWRITE(nMessVersion);    // abuse nLastDsq (which will be removed) for old serialization
-        if (ser_action.ForRead())
-            nLastDsq = 0;
+        READWRITE(nMessVersion);
     }
 
     /// Create Masternode broadcast, needs to be relayed manually after that

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -10,6 +10,7 @@
 #include "key.h"
 #include "messagesigner.h"
 #include "net.h"
+#include "serialize.h"
 #include "sync.h"
 #include "timedata.h"
 #include "util.h"
@@ -131,7 +132,7 @@ public:
     int nLastScanningErrorBlockHeight;
     CMasternodePing lastPing;
 
-    CMasternode();
+    explicit CMasternode();
     CMasternode(const CMasternode& other);
 
     // override CSignedMessage functions
@@ -197,6 +198,11 @@ public:
         READWRITE(lastPing);
         READWRITE(nScanningErrorCount);
         READWRITE(nLastScanningErrorBlockHeight);
+    }
+
+    template <typename Stream>
+    CMasternode(deserialize_type, Stream& s) {
+        Unserialize(s);
     }
 
     int64_t SecondsSincePayment();

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -117,11 +117,7 @@ public:
         MASTERNODE_ENABLED,
         MASTERNODE_EXPIRED,
         MASTERNODE_REMOVE,
-        MASTERNODE_WATCHDOG_EXPIRED,
-        MASTERNODE_POSE_BAN,
         MASTERNODE_VIN_SPENT,
-        MASTERNODE_POS_ERROR,
-        MASTERNODE_MISSING
     };
 
     CTxIn vin;
@@ -257,9 +253,6 @@ public:
         if (activeState == CMasternode::MASTERNODE_EXPIRED)     return "EXPIRED";
         if (activeState == CMasternode::MASTERNODE_VIN_SPENT)   return "VIN_SPENT";
         if (activeState == CMasternode::MASTERNODE_REMOVE)      return "REMOVE";
-        if (activeState == CMasternode::MASTERNODE_POS_ERROR)   return "POS_ERROR";
-        if (activeState == CMasternode::MASTERNODE_MISSING)     return "MISSING";
-
         return strprintf("INVALID_%d", activeState);
     }
 

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -230,6 +230,8 @@ public:
         return lastPing.IsNull() ? false : now - lastPing.sigTime < seconds;
     }
 
+    void SetSpent() { LOCK(cs); activeState = CMasternode::MASTERNODE_VIN_SPENT; }
+
     void Disable()
     {
         LOCK(cs);

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -574,6 +574,31 @@ CMasternode* CMasternodeMan::GetCurrentMasterNode(int mod, int64_t nBlockHeight,
     return winner;
 }
 
+std::vector<std::pair<CMasternode, int>> CMasternodeMan::GetMnScores(int nLast)
+{
+    std::vector<std::pair<CMasternode, int>> ret;
+    int nChainHeight = GetBestHeight();
+    if (nChainHeight < 0) return ret;
+
+    Check();
+    for (int nHeight = nChainHeight - nLast; nHeight < nChainHeight + 20; nHeight++) {
+        const uint256& hash = GetHashAtHeight(nHeight - 101);
+        uint256 nHigh = UINT256_ZERO;
+        CMasternode pBestMasternode;
+        for (const auto& it : mapMasternodes) {
+            const uint256& n = it.second.CalculateScore(hash);
+            if (n > nHigh) {
+                nHigh = n;
+                pBestMasternode = it.second;
+            }
+        }
+        if (nHigh > UINT256_ZERO) {
+            ret.emplace_back(pBestMasternode, nHeight);
+        }
+    }
+    return ret;
+}
+
 int CMasternodeMan::GetMasternodeRank(const CTxIn& vin, int64_t nBlockHeight, int minProtocol, bool fOnlyActive)
 {
     std::vector<std::pair<int64_t, CTxIn> > vecMasternodeScores;

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -453,20 +453,6 @@ CMasternode* CMasternodeMan::Find(const COutPoint& collateralOut)
     return it != mapMasternodes.end() ? it->second.get() : nullptr;
 }
 
-CMasternode* CMasternodeMan::Find(const CScript& payee)
-{
-    LOCK(cs);
-    CScript payee2;
-
-    for (auto& it : mapMasternodes) {
-        MasternodeRef& mn = it.second;
-        payee2 = GetScriptForDestination(mn->pubKeyCollateralAddress.GetID());
-        if (payee2 == payee)
-            return mn.get();
-    }
-    return nullptr;
-}
-
 CMasternode* CMasternodeMan::Find(const CPubKey& pubKeyMasternode)
 {
     LOCK(cs);

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -213,10 +213,10 @@ bool CMasternodeMan::Add(CMasternode& mn)
     if (!mn.IsEnabled())
         return false;
 
-    CMasternode* pmn = Find(mn.vin);
-    if (pmn == NULL) {
+    const auto& it = mapMasternodes.find(mn.vin.prevout);
+    if (it == mapMasternodes.end()) {
         LogPrint(BCLog::MASTERNODE, "CMasternodeMan: Adding new Masternode %s - %i now\n", mn.vin.prevout.hash.ToString(), size() + 1);
-        vMasternodes.push_back(mn);
+        mapMasternodes.emplace(mn.vin.prevout, mn);
         return true;
     }
 
@@ -243,8 +243,8 @@ void CMasternodeMan::Check()
 {
     LOCK(cs);
 
-    for (CMasternode& mn : vMasternodes) {
-        mn.Check();
+    for (auto& mnIt : mapMasternodes) {
+        mnIt.second.Check();
     }
 }
 
@@ -255,20 +255,21 @@ void CMasternodeMan::CheckAndRemove(bool forceExpiredRemoval)
     LOCK(cs);
 
     //remove inactive and outdated
-    std::vector<CMasternode>::iterator it = vMasternodes.begin();
-    while (it != vMasternodes.end()) {
-        if ((*it).activeState == CMasternode::MASTERNODE_REMOVE ||
-            (*it).activeState == CMasternode::MASTERNODE_VIN_SPENT ||
-            (forceExpiredRemoval && (*it).activeState == CMasternode::MASTERNODE_EXPIRED) ||
-            (*it).protocolVersion < ActiveProtocol()) {
-            LogPrint(BCLog::MASTERNODE, "CMasternodeMan: Removing inactive Masternode %s - %i now\n", (*it).vin.prevout.hash.ToString(), size() - 1);
+    auto it = mapMasternodes.begin();
+    while (it != mapMasternodes.end()) {
+        CMasternode& mn = it->second;
+        if (mn.activeState == CMasternode::MASTERNODE_REMOVE ||
+            mn.activeState == CMasternode::MASTERNODE_VIN_SPENT ||
+            (forceExpiredRemoval && mn.activeState == CMasternode::MASTERNODE_EXPIRED) ||
+            mn.protocolVersion < ActiveProtocol()) {
+            LogPrint(BCLog::MASTERNODE, "CMasternodeMan: Removing inactive Masternode %s - %i now\n", it->first.hash.ToString(), size() - 1);
 
             //erase all of the broadcasts we've seen from this vin
             // -- if we missed a few pings and the node was removed, this will allow is to get it back without them
             //    sending a brand new mnb
             std::map<uint256, CMasternodeBroadcast>::iterator it3 = mapSeenMasternodeBroadcast.begin();
             while (it3 != mapSeenMasternodeBroadcast.end()) {
-                if ((*it3).second.vin == (*it).vin) {
+                if (it3->second.vin == it->second.vin) {
                     masternodeSync.mapSeenSyncMNB.erase((*it3).first);
                     it3 = mapSeenMasternodeBroadcast.erase(it3);
                 } else {
@@ -279,14 +280,14 @@ void CMasternodeMan::CheckAndRemove(bool forceExpiredRemoval)
             // allow us to ask for this masternode again if we see another ping
             std::map<COutPoint, int64_t>::iterator it2 = mWeAskedForMasternodeListEntry.begin();
             while (it2 != mWeAskedForMasternodeListEntry.end()) {
-                if ((*it2).first == (*it).vin.prevout) {
+                if (it2->first == it->first) {
                     it2 = mWeAskedForMasternodeListEntry.erase(it2);
                 } else {
                     ++it2;
                 }
             }
 
-            it = vMasternodes.erase(it);
+            it = mapMasternodes.erase(it);
         } else {
             ++it;
         }
@@ -347,7 +348,7 @@ void CMasternodeMan::CheckAndRemove(bool forceExpiredRemoval)
 void CMasternodeMan::Clear()
 {
     LOCK(cs);
-    vMasternodes.clear();
+    mapMasternodes.clear();
     mAskedUsForMasternodeList.clear();
     mWeAskedForMasternodeList.clear();
     mWeAskedForMasternodeListEntry.clear();
@@ -363,7 +364,8 @@ int CMasternodeMan::stable_size ()
     int64_t nMasternode_Min_Age = MN_WINNER_MINIMUM_AGE;
     int64_t nMasternode_Age = 0;
 
-    for (CMasternode& mn : vMasternodes) {
+    for (auto& it : mapMasternodes) {
+        CMasternode& mn = it.second;
         if (mn.protocolVersion < nMinProtocol) {
             continue; // Skip obsolete versions
         }
@@ -388,7 +390,8 @@ int CMasternodeMan::CountEnabled(int protocolVersion)
     int i = 0;
     protocolVersion = protocolVersion == -1 ? ActiveProtocol() : protocolVersion;
 
-    for (CMasternode& mn : vMasternodes) {
+    for (auto& it : mapMasternodes) {
+        CMasternode& mn = it.second;
         mn.Check();
         if (mn.protocolVersion < protocolVersion || !mn.IsEnabled()) continue;
         i++;
@@ -399,7 +402,8 @@ int CMasternodeMan::CountEnabled(int protocolVersion)
 
 void CMasternodeMan::CountNetworks(int protocolVersion, int& ipv4, int& ipv6, int& onion)
 {
-    for (CMasternode& mn : vMasternodes) {
+    for (auto& it : mapMasternodes) {
+        CMasternode& mn = it.second;
         mn.Check();
         std::string strHost;
         int port;
@@ -442,40 +446,40 @@ void CMasternodeMan::DsegUpdate(CNode* pnode)
     mWeAskedForMasternodeList[pnode->addr] = askAgain;
 }
 
+CMasternode* CMasternodeMan::Find(const COutPoint& collateralOut)
+{
+    LOCK(cs);
+    if (mapMasternodes.count(collateralOut)) {
+        // todo: move to a const pointer or copy
+        return &mapMasternodes.at(collateralOut);
+    }
+    return nullptr;
+}
+
 CMasternode* CMasternodeMan::Find(const CScript& payee)
 {
     LOCK(cs);
     CScript payee2;
 
-    for (CMasternode& mn : vMasternodes) {
+    for (auto& it : mapMasternodes) {
+        CMasternode& mn = it.second;
         payee2 = GetScriptForDestination(mn.pubKeyCollateralAddress.GetID());
         if (payee2 == payee)
             return &mn;
     }
-    return NULL;
+    return nullptr;
 }
-
-CMasternode* CMasternodeMan::Find(const CTxIn& vin)
-{
-    LOCK(cs);
-
-    for (CMasternode& mn : vMasternodes) {
-        if (mn.vin.prevout == vin.prevout)
-            return &mn;
-    }
-    return NULL;
-}
-
 
 CMasternode* CMasternodeMan::Find(const CPubKey& pubKeyMasternode)
 {
     LOCK(cs);
 
-    for (CMasternode& mn : vMasternodes) {
+    for (auto& it : mapMasternodes) {
+        CMasternode& mn = it.second;
         if (mn.pubKeyMasternode == pubKeyMasternode)
             return &mn;
     }
-    return NULL;
+    return nullptr;
 }
 
 //
@@ -493,7 +497,8 @@ CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight
     */
 
     int nMnCount = CountEnabled();
-    for (CMasternode& mn : vMasternodes) {
+    for (auto& it : mapMasternodes) {
+        CMasternode& mn = it.second;
         mn.Check();
         if (!mn.IsEnabled()) continue;
 
@@ -529,7 +534,7 @@ CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight
     uint256 nHigh;
     const uint256& hash = GetHashAtHeight(nBlockHeight - 101);
     for (std::pair<int64_t, CTxIn> & s : vecMasternodeLastPaid) {
-        CMasternode* pmn = Find(s.second);
+        CMasternode* pmn = Find(s.second.prevout);
         if (!pmn) break;
 
         const uint256& n = pmn->CalculateScore(hash);
@@ -550,7 +555,8 @@ CMasternode* CMasternodeMan::GetCurrentMasterNode(int mod, int64_t nBlockHeight,
     const uint256& hash = GetHashAtHeight(nBlockHeight - 1);
 
     // scan for winner
-    for (CMasternode& mn : vMasternodes) {
+    for (auto& it : mapMasternodes) {
+        CMasternode& mn = it.second;
         mn.Check();
         if (mn.protocolVersion < minProtocol || !mn.IsEnabled()) continue;
 
@@ -579,7 +585,8 @@ int CMasternodeMan::GetMasternodeRank(const CTxIn& vin, int64_t nBlockHeight, in
     if (!hash) return -1;
 
     // scan for winner
-    for (CMasternode& mn : vMasternodes) {
+    for (auto& it : mapMasternodes) {
+        CMasternode& mn = it.second;
         if (mn.protocolVersion < minProtocol) {
             LogPrint(BCLog::MASTERNODE,"Skipping Masternode with obsolete version %d\n", mn.protocolVersion);
             continue;                                                       // Skip obsolete versions
@@ -624,7 +631,8 @@ std::vector<std::pair<int64_t, CMasternode>> CMasternodeMan::GetMasternodeRanks(
     {
         LOCK(cs);
         // scan for winner
-        for (CMasternode& mn : vMasternodes) {
+        for (auto& it : mapMasternodes) {
+            CMasternode& mn = it.second;
             if (!mn.IsEnabled()) {
                 vecMasternodeScores.emplace_back(9999, mn);
                 continue;
@@ -688,7 +696,7 @@ int CMasternodeMan::ProcessMNPing(CNode* pfrom, CMasternodePing& mnp)
         return nDoS;
     } else {
         // if nothing significant failed, search existing Masternode list
-        CMasternode* pmn = Find(mnp.vin);
+        CMasternode* pmn = Find(mnp.vin.prevout);
         // if it's known, don't ask for the mnb, just return
         if (pmn != NULL) return 0;
     }
@@ -724,7 +732,8 @@ int CMasternodeMan::ProcessGetMNList(CNode* pfrom, CTxIn& vin)
     int nInvCount = 0;
     {
         LOCK(cs);
-        for (CMasternode& mn : vMasternodes) {
+        for (auto& it : mapMasternodes) {
+            CMasternode& mn = it.second;
             if (mn.addr.IsRFC1918()) continue; //local network
 
             if (mn.IsEnabled()) {
@@ -793,18 +802,12 @@ int CMasternodeMan::ProcessMessageInner(CNode* pfrom, std::string& strCommand, C
     return 0;
 }
 
-void CMasternodeMan::Remove(CTxIn vin)
+void CMasternodeMan::Remove(const COutPoint& collateralOut)
 {
     LOCK(cs);
-
-    std::vector<CMasternode>::iterator it = vMasternodes.begin();
-    while (it != vMasternodes.end()) {
-        if ((*it).vin == vin) {
-            LogPrint(BCLog::MASTERNODE, "CMasternodeMan: Removing Masternode %s - %i now\n", (*it).vin.prevout.hash.ToString(), size() - 1);
-            vMasternodes.erase(it);
-            break;
-        }
-        ++it;
+    const auto it = mapMasternodes.find(collateralOut);
+    if (it != mapMasternodes.end()) {
+        mapMasternodes.erase(it);
     }
 }
 
@@ -816,7 +819,7 @@ void CMasternodeMan::UpdateMasternodeList(CMasternodeBroadcast mnb)
 
     LogPrint(BCLog::MASTERNODE,"CMasternodeMan::UpdateMasternodeList() -- masternode=%s\n", mnb.vin.prevout.ToString());
 
-    CMasternode* pmn = Find(mnb.vin);
+    CMasternode* pmn = Find(mnb.vin.prevout);
     if (pmn == NULL) {
         CMasternode mn(mnb);
         Add(mn);
@@ -829,7 +832,7 @@ std::string CMasternodeMan::ToString() const
 {
     std::ostringstream info;
 
-    info << "Masternodes: " << (int)vMasternodes.size() << ", peers who asked us for Masternode list: " << (int)mAskedUsForMasternodeList.size() << ", peers we asked for Masternode list: " << (int)mWeAskedForMasternodeList.size() << ", entries in Masternode list we asked for: " << (int)mWeAskedForMasternodeListEntry.size();
+    info << "Masternodes: " << (int)size() << ", peers who asked us for Masternode list: " << (int)mAskedUsForMasternodeList.size() << ", peers we asked for Masternode list: " << (int)mWeAskedForMasternodeList.size() << ", entries in Masternode list we asked for: " << (int)mWeAskedForMasternodeListEntry.size();
 
     return info.str();
 }

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -210,7 +210,7 @@ bool CMasternodeMan::Add(CMasternode& mn)
 {
     LOCK(cs);
 
-    if (!mn.IsEnabled())
+    if (!mn.IsEnabled() && !mn.IsPreEnabled())
         return false;
 
     const auto& it = mapMasternodes.find(mn.vin.prevout);

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -482,6 +482,19 @@ CMasternode* CMasternodeMan::Find(const CPubKey& pubKeyMasternode)
     return nullptr;
 }
 
+void CMasternodeMan::CheckSpentCollaterals(const std::vector<CTransactionRef>& vtx)
+{
+    LOCK(cs);
+    for (const auto& tx : vtx) {
+        for (const auto& in : tx->vin) {
+            const auto& it = mapMasternodes.find(in.prevout);
+            if (it != mapMasternodes.end()) {
+                it->second.SetSpent();
+            }
+        }
+    }
+}
+
 //
 // Deterministically select the oldest/best masternode to pay on the network
 //

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -140,6 +140,9 @@ public:
     CMasternode* Find(const CScript& payee);
     CMasternode* Find(const CPubKey& pubKeyMasternode);
 
+    /// Check all transactions in a block, for spent masternode collateral outpoints.
+    void CheckSpentCollaterals(const std::vector<CTransactionRef>& vtx);
+
     /// Find an entry in the masternode list that is next to be paid
     CMasternode* GetNextMasternodeInQueueForPayment(int nBlockHeight, bool fFilterSigTime, int& nCount);
 

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -146,16 +146,9 @@ public:
     /// Get the current winner for this block
     CMasternode* GetCurrentMasterNode(int mod = 1, int64_t nBlockHeight = 0, int minProtocol = 0);
 
-    // !todo: remove this
-    std::vector<CMasternode> GetFullMasternodeVector()
-    {
-        Check();
-        std::vector<CMasternode> vMasternodes;
-        for (const auto it : mapMasternodes) {
-            vMasternodes.emplace_back(it.second);
-        }
-        return vMasternodes;
-    }
+    /// vector of pairs <masternode winner, height>
+    std::vector<std::pair<CMasternode, int>> GetMnScores(int nLast);
+
     // Retrieve the known masternodes ordered by scoring without checking them. (Only used for listmasternodes RPC call)
     std::vector<std::pair<int64_t, CMasternode>> GetMasternodeRanks(int nBlockHeight);
     int GetMasternodeRank(const CTxIn& vin, int64_t nBlockHeight, int minProtocol = 0, bool fOnlyActive = true);

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -54,6 +54,9 @@ public:
     ReadResult Read(CMasternodeMan& mnodemanToLoad, bool fDryRun = false);
 };
 
+//
+typedef std::shared_ptr<CMasternode> MasternodeRef;
+
 class CMasternodeMan
 {
 private:
@@ -64,7 +67,7 @@ private:
     mutable RecursiveMutex cs_process_message;
 
     // map to hold all MNs (indexed by collateral outpoint)
-    std::map<COutPoint, CMasternode> mapMasternodes;
+    std::map<COutPoint, MasternodeRef> mapMasternodes;
     // who's asked for the Masternode list and the last time
     std::map<CNetAddr, int64_t> mAskedUsForMasternodeList;
     // who we asked for the Masternode list and the last time
@@ -150,7 +153,7 @@ public:
     CMasternode* GetCurrentMasterNode(int mod = 1, int64_t nBlockHeight = 0, int minProtocol = 0);
 
     /// vector of pairs <masternode winner, height>
-    std::vector<std::pair<CMasternode, int>> GetMnScores(int nLast);
+    std::vector<std::pair<MasternodeRef, int>> GetMnScores(int nLast);
 
     // Retrieve the known masternodes ordered by scoring without checking them. (Only used for listmasternodes RPC call)
     std::vector<std::pair<int64_t, CMasternode>> GetMasternodeRanks(int nBlockHeight);

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -140,7 +140,6 @@ public:
 
     /// Find an entry
     CMasternode* Find(const COutPoint& collateralOut);
-    CMasternode* Find(const CScript& payee);
     CMasternode* Find(const CPubKey& pubKeyMasternode);
 
     /// Check all transactions in a block, for spent masternode collateral outpoints.

--- a/src/messagesigner.cpp
+++ b/src/messagesigner.cpp
@@ -130,8 +130,8 @@ bool CSignedMessage::CheckSignature() const
 
 const CPubKey CSignedMessage::GetPublicKey(std::string& strErrorRet) const
 {
-    const CTxIn vin = GetVin();
-    CMasternode* pmn = mnodeman.Find(vin);
+    const CTxIn& vin = GetVin();
+    CMasternode* pmn = mnodeman.Find(vin.prevout);
     if(pmn) {
         return pmn->pubKeyMasternode;
     }

--- a/src/qt/pivx/mnmodel.cpp
+++ b/src/qt/pivx/mnmodel.cpp
@@ -26,10 +26,9 @@ void MNModel::updateMNList()
         int nIndex;
         if (!mne.castOutputIndex(nIndex))
             continue;
-
         uint256 txHash(mne.getTxHash());
         CTxIn txIn(txHash, uint32_t(nIndex));
-        CMasternode* pmn = mnodeman.Find(txIn);
+        CMasternode* pmn = mnodeman.Find(txIn.prevout);
         if (!pmn) {
             pmn = new CMasternode();
             pmn->vin = txIn;
@@ -151,7 +150,7 @@ bool MNModel::addMn(CMasternodeConfig::CMasternodeEntry* mne)
     if (!mne->castOutputIndex(nIndex))
         return false;
 
-    CMasternode* pmn = mnodeman.Find(CTxIn(uint256S(mne->getTxHash()), uint32_t(nIndex)));
+    CMasternode* pmn = mnodeman.Find(COutPoint(uint256S(mne->getTxHash()), uint32_t(nIndex)));
     nodes.insert(QString::fromStdString(mne->getAlias()), std::make_pair(QString::fromStdString(mne->getIp()), pmn));
     endInsertRows();
     return true;

--- a/src/qt/pivx/mnmodel.cpp
+++ b/src/qt/pivx/mnmodel.cpp
@@ -32,7 +32,6 @@ void MNModel::updateMNList()
         if (!pmn) {
             pmn = new CMasternode();
             pmn->vin = txIn;
-            pmn->activeState = CMasternode::MASTERNODE_MISSING;
         }
         nodes.insert(QString::fromStdString(mne.getAlias()), std::make_pair(QString::fromStdString(mne.getIp()), pmn));
         if (pwalletMain) {
@@ -166,7 +165,7 @@ int MNModel::getMNState(QString mnAlias)
 bool MNModel::isMNInactive(QString mnAlias)
 {
     int activeState = getMNState(mnAlias);
-    return activeState == CMasternode::MASTERNODE_MISSING || activeState == CMasternode::MASTERNODE_EXPIRED || activeState == CMasternode::MASTERNODE_REMOVE;
+    return activeState == CMasternode::MASTERNODE_EXPIRED || activeState == CMasternode::MASTERNODE_REMOVE;
 }
 
 bool MNModel::isMNActive(QString mnAlias)

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -282,7 +282,7 @@ UniValue mnbudgetvote(const JSONRPCRequest& request)
                 break;
             }
 
-            CMasternode* pmn = mnodeman.Find(*(activeMasternode.vin));
+            CMasternode* pmn = mnodeman.Find(activeMasternode.vin->prevout);
             if (pmn == NULL) {
                 failed++;
                 statusObj.pushKV("node", "local");
@@ -675,7 +675,7 @@ UniValue mnbudgetrawvote(const JSONRPCRequest& request)
     if (fInvalid)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Malformed base64 encoding");
 
-    CMasternode* pmn = mnodeman.Find(vin);
+    CMasternode* pmn = mnodeman.Find(vin.prevout);
     if (pmn == NULL) {
         return "Failure to find masternode in list : " + vin.ToString();
     }
@@ -822,7 +822,7 @@ UniValue mnfinalbudget(const JSONRPCRequest& request)
         if (!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, keyMasternode, pubKeyMasternode))
             return "Error upon calling GetKeysFromSecret";
 
-        CMasternode* pmn = mnodeman.Find(*(activeMasternode.vin));
+        CMasternode* pmn = mnodeman.Find(activeMasternode.vin->prevout);
         if (pmn == NULL) {
             return "Failure to find masternode in list : " + activeMasternode.vin->ToString();
         }

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -736,14 +736,14 @@ UniValue getmasternodescores (const JSONRPCRequest& request)
         }
     }
 
-    std::vector<std::pair<CMasternode, int>> vMnScores = mnodeman.GetMnScores(nLast);
+    std::vector<std::pair<MasternodeRef, int>> vMnScores = mnodeman.GetMnScores(nLast);
     if (vMnScores.empty()) return "unknown";
 
     UniValue obj(UniValue::VOBJ);
     for (const auto& p : vMnScores) {
-        const CMasternode& mn = p.first;
+        const MasternodeRef& mn = p.first;
         const int nHeight = p.second;
-        obj.pushKV(strprintf("%d", nHeight), mn.vin.prevout.hash.ToString().c_str());
+        obj.pushKV(strprintf("%d", nHeight), mn->vin.prevout.hash.ToString().c_str());
     }
     return obj;
 }

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -735,25 +735,16 @@ UniValue getmasternodescores (const JSONRPCRequest& request)
             throw std::runtime_error("Exception on param 2");
         }
     }
-    int nChainHeight = mnodeman.GetBestHeight();
-    if (nChainHeight < 0) return "unknown";
-    UniValue obj(UniValue::VOBJ);
-    std::vector<CMasternode> vMasternodes = mnodeman.GetFullMasternodeVector();
-    for (int nHeight = nChainHeight - nLast; nHeight < nChainHeight + 20; nHeight++) {
-        const uint256& hash = mnodeman.GetHashAtHeight(nHeight - 101);
-        uint256 nHigh;
-        CMasternode* pBestMasternode = NULL;
-        for (CMasternode& mn : vMasternodes) {
-            const uint256& n = mn.CalculateScore(hash);
-            if (n > nHigh) {
-                nHigh = n;
-                pBestMasternode = &mn;
-            }
-        }
-        if (pBestMasternode)
-            obj.pushKV(strprintf("%d", nHeight), pBestMasternode->vin.prevout.hash.ToString().c_str());
-    }
 
+    std::vector<std::pair<CMasternode, int>> vMnScores = mnodeman.GetMnScores(nLast);
+    if (vMnScores.empty()) return "unknown";
+
+    UniValue obj(UniValue::VOBJ);
+    for (const auto& p : vMnScores) {
+        const CMasternode& mn = p.first;
+        const int nHeight = p.second;
+        obj.pushKV(strprintf("%d", nHeight), mn.vin.prevout.hash.ToString().c_str());
+    }
     return obj;
 }
 

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -259,7 +259,7 @@ bool StartMasternodeEntry(UniValue& statusObjRet, CMasternodeBroadcast& mnbRet, 
     }
 
     CTxIn vin = CTxIn(uint256S(mne.getTxHash()), uint32_t(nIndex));
-    CMasternode* pmn = mnodeman.Find(vin);
+    CMasternode* pmn = mnodeman.Find(vin.prevout);
     if (pmn != NULL) {
         if (strCommand == "missing") return false;
         if (strCommand == "disabled" && pmn->IsEnabled()) return false;
@@ -546,7 +546,7 @@ UniValue listmasternodeconf (const JSONRPCRequest& request)
         if(!mne.castOutputIndex(nIndex))
             continue;
         CTxIn vin = CTxIn(uint256S(mne.getTxHash()), uint32_t(nIndex));
-        CMasternode* pmn = mnodeman.Find(vin);
+        CMasternode* pmn = mnodeman.Find(vin.prevout);
 
         std::string strStatus = pmn ? pmn->Status() : "MISSING";
 
@@ -594,7 +594,7 @@ UniValue getmasternodestatus (const JSONRPCRequest& request)
     if (activeMasternode.vin == nullopt)
         throw JSONRPCError(RPC_MISC_ERROR, _("Active Masternode not initialized."));
 
-    CMasternode* pmn = mnodeman.Find(*(activeMasternode.vin));
+    CMasternode* pmn = mnodeman.Find(activeMasternode.vin->prevout);
 
     if (pmn) {
         UniValue mnObj(UniValue::VOBJ);

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -893,7 +893,6 @@ UniValue decodemasternodebroadcast(const JSONRPCRequest& request)
             "  \"sigtime\": \"nnn\"             (numeric) Signature timestamp\n"
             "  \"sigvalid\": \"xxx\"            (string) \"true\"/\"false\" whether or not the mnb signature checks out.\n"
             "  \"protocolversion\": \"nnn\"     (numeric) Masternode's protocol version\n"
-            "  \"nlastdsq\": \"nnn\"            (numeric) The last time the masternode sent a DSQ message (for mixing) (DEPRECATED)\n"
             "  \"nMessVersion\": \"nnn\"        (numeric) MNB Message version number\n"
             "  \"lastping\" : {                 (object) JSON object with information about the masternode's last ping\n"
             "      \"vin\": \"xxxx\"            (string) The unspent output of the masternode which is signing the message\n"
@@ -923,7 +922,6 @@ UniValue decodemasternodebroadcast(const JSONRPCRequest& request)
     resultObj.pushKV("sigtime", mnb.sigTime);
     resultObj.pushKV("sigvalid", mnb.CheckSignature() ? "true" : "false");
     resultObj.pushKV("protocolversion", mnb.protocolVersion);
-    resultObj.pushKV("nlastdsq", mnb.nLastDsq);
     resultObj.pushKV("nMessVersion", mnb.nMessVersion);
 
     UniValue lastPingObj(UniValue::VOBJ);

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -682,6 +682,9 @@ template<typename Stream, typename K, typename Pred, typename A> void Unserializ
 template<typename Stream, typename T> void Serialize(Stream& os, const std::shared_ptr<const T>& p);
 template<typename Stream, typename T> void Unserialize(Stream& os, std::shared_ptr<const T>& p);
 
+template<typename Stream, typename T> void Serialize(Stream& os, const std::shared_ptr<T>& p);
+template<typename Stream, typename T> void Unserialize(Stream& os, std::shared_ptr<T>& p);
+
 /**
  * unique_ptr
  */
@@ -999,7 +1002,17 @@ void Unserialize(Stream& is, std::shared_ptr<const T>& p)
     p = std::make_shared<const T>(deserialize, is);
 }
 
+template<typename Stream, typename T> void
+Serialize(Stream& os, const std::shared_ptr<T>& p)
+{
+    Serialize(os, *p);
+}
 
+template<typename Stream, typename T>
+void Unserialize(Stream& is, std::shared_ptr<T>& p)
+{
+    p = std::make_shared<T>(deserialize, is);
+}
 
 /**
  * Support for ADD_SERIALIZE_METHODS and READWRITE macro

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2132,6 +2132,7 @@ bool static ConnectTip(CValidationState& state, CBlockIndex* pindexNew, const st
     UpdateTip(pindexNew);
     // Update MN manager cache
     mnodeman.CacheBlockHash(pindexNew);
+    mnodeman.CheckSpentCollaterals(blockConnecting.vtx);
 
     int64_t nTime6 = GetTimeMicros();
     nTimePostConnect += nTime6 - nTime5;


### PR DESCRIPTION
Currently we check whether a masternode collateral is spent, in `CMasternode::Check()`, which is called in a time-based polling fashion, looking for the collateral outpoint in the coins view cache (and countless other times on-demand, when we want an up-to-date status).
This is highly expensive, and inconsistent (peers check masternodes at different times, thus have slightly different masternode states).

Collaterals, as all coins/outpoints, can only be spent inside blocks.

So we should do this check only when connecting new blocks, not *every x seconds*, or **every time that we need to count the number of enabled masternodes**, just to name the most glaring example (`CMasternodeMan::CountEnabled`).
This can be done very efficiently if we change the data-structure to store them inside the manager, from a vector, to a map, indexed by collateral outpoints.

----
Second part, to be addressed in a follow-up PR:

After this change, `CMasternode::Check()` includes only the ping-checks, which are so fast that can be done in "real-time", thus completely removing the need to cache the `activeState` inside the CMasternode class, and to call `Check()` every time that we want to update it.