### PR TITLE
[Build] Address more issues with GA

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -324,7 +324,7 @@ jobs:
           - name: macOS 10.10  [GOAL:deploy] [no functional tests]
             os: ubuntu-18.04
             host: x86_64-apple-darwin14
-            apt-get: cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python3-dev python3-setuptools
+            apt_get: cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python3-dev python3-setuptools
             OSX_SDK: 10.11
             unit_tests: false
             functional_tests: false

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -309,6 +309,7 @@ jobs:
             unit_tests: true
             functional_tests: true
             no_depends: 1
+            goal: install
             BITCOIN_CONFIG: "--enable-zmq --with-incompatible-bdb --with-gui=qt5 CPPFLAGS=-DDEBUG_LOCKORDER --disable-hardening --disable-asm"
 
           - name: x86_64 Linux  [GOAL:install]  [bionic]  [no depends only system libs]
@@ -317,6 +318,7 @@ jobs:
             apt_get: python3-zmq qtbase5-dev qttools5-dev-tools libqt5svg5-dev libqt5charts5-dev libssl1.0-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libprotobuf-dev protobuf-compiler libqrencode-dev libgmp-dev libsodium-dev cargo
             unit_tests: true
             no_depends: 1
+            goal: install
             BITCOIN_CONFIG: "--enable-zmq --with-incompatible-bdb --with-gui=qt5 CPPFLAGS=-DDEBUG_LOCKORDER"
 
           - name: macOS 10.10  [GOAL:deploy] [no functional tests]
@@ -326,6 +328,7 @@ jobs:
             OSX_SDK: 10.11
             unit_tests: false
             functional_tests: false
+            goal: deploy
             BITCOIN_CONFIG: "--enable-gui --enable-reduce-exports --enable-werror --disable-online-rust"
 
     steps:


### PR DESCRIPTION
A few build jobs weren't using the expected "goal" config parameter, most notably the macOS job, which is supposed to test `make deploy` to create a `.dmg` file.

Further, there was a typo in the macOS config area that incorrectly used `apt-get` instead of `apt_get`