### PR TITLE
[GUI] Tx detail, don't show inputs if there is no information for them.

### DIFF
--- a/src/qt/pivx/sendconfirmdialog.h
+++ b/src/qt/pivx/sendconfirmdialog.h
@@ -51,6 +51,8 @@ private:
     WalletModel::SendCoinsReturn sendStatus;
     WalletModelTransaction* tx{nullptr};
     uint256 txHash;
+    // Shielded tx with not inputs data
+    bool isShieldedToShieldedRecv{false};
 
     bool inputsLoaded = false;
     bool outputsLoaded = false;


### PR DESCRIPTION
The transaction detail dialog was trying to show the shielded inputs of a transaction when the tx was not from the wallet. Which is impossible as it has no information about them. This fixes it.