### PR TITLE
[GUI] Fixing export addressbook, shielded addresses missing type

### DIFF
--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -112,6 +112,10 @@ static QString translateTypeToString(AddressTableEntry::Type type)
             return QObject::tr("Cold Staking");
         case AddressTableEntry::ColdStakingSend:
             return QObject::tr("Cold Staking Contact");
+        case AddressTableEntry::ShieldedReceive:
+            return QObject::tr("Receiving Shielded");
+        case AddressTableEntry::ShieldedSend:
+            return QObject::tr("Contact Shielded");
         case AddressTableEntry::Hidden:
             return QObject::tr("Hidden");
         default:


### PR DESCRIPTION
Pretty straightforward, fixing the missing address type in the export address book for shielded addresses. 