### PR TITLE
[Refactor] Masternode activeState on-demand

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -87,7 +87,6 @@ void CActiveMasternode::ManageStatus()
         CMasternode* pmn;
         pmn = mnodeman.Find(pubKeyMasternode);
         if (pmn != nullptr) {
-            pmn->Check();
             if (pmn->IsEnabled() && pmn->protocolVersion == PROTOCOL_VERSION)
                 EnableHotColdMasterNode(pmn->vin, pmn->addr);
         }

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -328,7 +328,7 @@ void CMasternodePayments::FillBlockPayee(CMutableTransaction& txNew, const int n
     //spork
     if (!masternodePayments.GetBlockPayee(nHeight, payee)) {
         //no masternode detected
-        CMasternode* winningNode = mnodeman.GetCurrentMasterNode(1);
+        const CMasternode* winningNode = mnodeman.GetCurrentMasterNode(1);
         if (winningNode) {
             payee = GetScriptForDestination(winningNode->pubKeyCollateralAddress.GetID());
         } else {
@@ -478,7 +478,7 @@ bool CMasternodePayments::GetBlockPayee(int nBlockHeight, CScript& payee)
 
 // Is this masternode scheduled to get paid soon?
 // -- Only look ahead up to 8 blocks to allow for propagation of the latest 2 winners
-bool CMasternodePayments::IsScheduled(CMasternode& mn, int nNotBlockHeight)
+bool CMasternodePayments::IsScheduled(const CMasternode& mn, int nNotBlockHeight)
 {
     LOCK(cs_mapMasternodeBlocks);
 
@@ -669,9 +669,9 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight)
 
         // pay to the oldest MN that still had no payment but its input is old enough and it was active long enough
         int nCount = 0;
-        CMasternode* pmn = mnodeman.GetNextMasternodeInQueueForPayment(nBlockHeight, true, nCount);
+        const CMasternode* pmn = mnodeman.GetNextMasternodeInQueueForPayment(nBlockHeight, true, nCount);
 
-        if (pmn != NULL) {
+        if (pmn != nullptr) {
             LogPrint(BCLog::MASTERNODE,"CMasternodePayments::ProcessBlock() Found by FindOldestNotInVec \n");
 
             newWinner.nBlockHeight = nBlockHeight;

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -255,7 +255,7 @@ public:
 
     bool GetBlockPayee(int nBlockHeight, CScript& payee);
     bool IsTransactionValid(const CTransaction& txNew, int nBlockHeight);
-    bool IsScheduled(CMasternode& mn, int nNotBlockHeight);
+    bool IsScheduled(const CMasternode& mn, int nNotBlockHeight);
 
     bool CanVote(const COutPoint& outMasternode, int nBlockHeight)
     {

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -73,13 +73,11 @@ CMasternode::CMasternode() :
     addr = CService();
     pubKeyCollateralAddress = CPubKey();
     pubKeyMasternode = CPubKey();
-    activeState = MASTERNODE_ENABLED;
     sigTime = GetAdjustedTime();
     lastPing = CMasternodePing();
     protocolVersion = PROTOCOL_VERSION;
     nScanningErrorCount = 0;
     nLastScanningErrorBlockHeight = 0;
-    lastTimeChecked = 0;
 }
 
 CMasternode::CMasternode(const CMasternode& other) :
@@ -90,13 +88,11 @@ CMasternode::CMasternode(const CMasternode& other) :
     addr = other.addr;
     pubKeyCollateralAddress = other.pubKeyCollateralAddress;
     pubKeyMasternode = other.pubKeyMasternode;
-    activeState = other.activeState;
     sigTime = other.sigTime;
     lastPing = other.lastPing;
     protocolVersion = other.protocolVersion;
     nScanningErrorCount = other.nScanningErrorCount;
     nLastScanningErrorBlockHeight = other.nLastScanningErrorBlockHeight;
-    lastTimeChecked = 0;
 }
 
 uint256 CMasternode::GetSignatureHash() const
@@ -134,7 +130,6 @@ bool CMasternode::UpdateFromNewBroadcast(CMasternodeBroadcast& mnb)
         vchSig = mnb.vchSig;
         protocolVersion = mnb.protocolVersion;
         addr = mnb.addr;
-        lastTimeChecked = 0;
         int nDoS = 0;
         if (mnb.lastPing.IsNull() || (!mnb.lastPing.IsNull() && mnb.lastPing.CheckAndUpdate(nDoS, false))) {
             lastPing = mnb.lastPing;
@@ -165,37 +160,24 @@ uint256 CMasternode::CalculateScore(const uint256& hash) const
     return (hash3 > hash2 ? hash3 - hash2 : hash2 - hash3);
 }
 
-void CMasternode::Check(bool forceCheck)
+CMasternode::state CMasternode::GetActiveState() const
 {
-    if (ShutdownRequested()) return;
-
-    LOCK(cs);
-
-    if (!forceCheck && (GetTime() - lastTimeChecked < MASTERNODE_CHECK_SECONDS)) return;
-    lastTimeChecked = GetTime();
-
-    //once spent, stop doing the checks
-    if (activeState == MASTERNODE_VIN_SPENT) return;
-
+    if (fCollateralSpent) {
+        return MASTERNODE_VIN_SPENT;
+    }
     if (!IsPingedWithin(MasternodeRemovalSeconds())) {
-        activeState = MASTERNODE_REMOVE;
-        return;
+        return MASTERNODE_REMOVE;
     }
-
     if (!IsPingedWithin(MasternodeExpirationSeconds())) {
-        activeState = MASTERNODE_EXPIRED;
-        return;
+        return MASTERNODE_EXPIRED;
     }
-
     if(lastPing.sigTime - sigTime < MasternodeMinPingSeconds()){
-        activeState = MASTERNODE_PRE_ENABLED;
-        return;
+        return MASTERNODE_PRE_ENABLED;
     }
-
-    activeState = MASTERNODE_ENABLED; // OK
+    return MASTERNODE_ENABLED;
 }
 
-int64_t CMasternode::SecondsSincePayment()
+int64_t CMasternode::SecondsSincePayment() const
 {
     CScript pubkeyScript;
     pubkeyScript = GetScriptForDestination(pubKeyCollateralAddress.GetID());
@@ -213,7 +195,7 @@ int64_t CMasternode::SecondsSincePayment()
     return month + hash.GetCompact(false);
 }
 
-int64_t CMasternode::GetLastPaid()
+int64_t CMasternode::GetLastPaid() const
 {
     const CBlockIndex* BlockReading = GetChainTip();
     if (BlockReading == nullptr) return false;
@@ -257,7 +239,7 @@ int64_t CMasternode::GetLastPaid()
     return 0;
 }
 
-bool CMasternode::IsValidNetAddr()
+bool CMasternode::IsValidNetAddr() const
 {
     // TODO: regtest is fine with any addresses for now,
     // should probably be a bit smarter if one day we start to implement tests for this
@@ -530,7 +512,6 @@ bool CMasternodeBroadcast::CheckAndUpdate(int& nDos)
         //take the newest entry
         LogPrint(BCLog::MASTERNODE,"mnb - Got updated entry for %s\n", vin.prevout.hash.ToString());
         if (pmn->UpdateFromNewBroadcast((*this))) {
-            pmn->Check();
             if (pmn->IsEnabled()) Relay();
         }
         masternodeSync.AddedMasternodeList(GetHash());
@@ -728,12 +709,11 @@ bool CMasternodePing::CheckAndUpdate(int& nDos, bool fRequireEnabled, bool fChec
 
             //mnodeman.mapSeenMasternodeBroadcast.lastPing is probably outdated, so we'll update it
             CMasternodeBroadcast mnb(*pmn);
-            uint256 hash = mnb.GetHash();
+            const uint256& hash = mnb.GetHash();
             if (mnodeman.mapSeenMasternodeBroadcast.count(hash)) {
                 mnodeman.mapSeenMasternodeBroadcast[hash].lastPing = *this;
             }
 
-            pmn->Check(true);
             if (!pmn->IsEnabled()) return false;
 
             LogPrint(BCLog::MNPING, "%s: Masternode ping accepted, vin: %s\n", __func__, vin.prevout.hash.ToString());

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -68,7 +68,7 @@ public:
     const CTxIn GetVin() const override  { return vin; };
     bool IsNull() const { return blockHash.IsNull() || vin.prevout.IsNull(); }
 
-    bool CheckAndUpdate(int& nDos, bool fRequireEnabled = true, bool fCheckSigTimeOnly = false);
+    bool CheckAndUpdate(int& nDos, bool fRequireAvailable = true, bool fCheckSigTimeOnly = false);
     void Relay();
 
     void swap(CMasternodePing& first, CMasternodePing& second) // nothrow
@@ -230,12 +230,18 @@ public:
 
     bool IsEnabled() const
     {
-        return WITH_LOCK(cs, return GetActiveState() == MASTERNODE_ENABLED);
+        return GetActiveState() == MASTERNODE_ENABLED;
     }
 
     bool IsPreEnabled() const
     {
-        return WITH_LOCK(cs, return GetActiveState() == MASTERNODE_PRE_ENABLED );
+        return GetActiveState() == MASTERNODE_PRE_ENABLED;
+    }
+
+    bool IsAvailableState() const
+    {
+        state s = GetActiveState();
+        return s == MASTERNODE_ENABLED || s == MASTERNODE_PRE_ENABLED;
     }
 
     std::string Status() const

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -66,7 +66,7 @@ public:
     uint256 GetSignatureHash() const override { return GetHash(); }
     std::string GetStrMessage() const override;
     const CTxIn GetVin() const override  { return vin; };
-    bool IsNull() { return blockHash.IsNull() || vin.prevout.IsNull(); }
+    bool IsNull() const { return blockHash.IsNull() || vin.prevout.IsNull(); }
 
     bool CheckAndUpdate(int& nDos, bool fRequireEnabled = true, bool fCheckSigTimeOnly = false);
     void Relay();
@@ -110,7 +110,7 @@ class CMasternode : public CSignedMessage
 private:
     // critical section to protect the inner data structures
     mutable RecursiveMutex cs;
-    int64_t lastTimeChecked;
+    bool fCollateralSpent{false};
 
 public:
     enum state {
@@ -125,7 +125,6 @@ public:
     CService addr;
     CPubKey pubKeyCollateralAddress;
     CPubKey pubKeyMasternode;
-    int activeState;
     int64_t sigTime; //mnb message time
     int protocolVersion;
     int nScanningErrorCount;
@@ -156,7 +155,6 @@ public:
         swap(first.addr, second.addr);
         swap(first.pubKeyCollateralAddress, second.pubKeyCollateralAddress);
         swap(first.pubKeyMasternode, second.pubKeyMasternode);
-        swap(first.activeState, second.activeState);
         swap(first.sigTime, second.sigTime);
         swap(first.lastPing, second.lastPing);
         swap(first.protocolVersion, second.protocolVersion);
@@ -194,7 +192,6 @@ public:
         READWRITE(vchSig);
         READWRITE(sigTime);
         READWRITE(protocolVersion);
-        READWRITE(activeState);
         READWRITE(lastPing);
         READWRITE(nScanningErrorCount);
         READWRITE(nLastScanningErrorBlockHeight);
@@ -205,25 +202,24 @@ public:
         Unserialize(s);
     }
 
-    int64_t SecondsSincePayment();
+    int64_t SecondsSincePayment() const;
 
     bool UpdateFromNewBroadcast(CMasternodeBroadcast& mnb);
 
-    void Check(bool forceCheck = false);
+    CMasternode::state GetActiveState() const;
 
     bool IsBroadcastedWithin(int seconds)
     {
         return (GetAdjustedTime() - sigTime) < seconds;
     }
 
-    bool IsPingedWithin(int seconds, int64_t now = -1)
+    bool IsPingedWithin(int seconds, int64_t now = -1) const
     {
         now == -1 ? now = GetAdjustedTime() : now;
-
         return lastPing.IsNull() ? false : now - lastPing.sigTime < seconds;
     }
 
-    void SetSpent() { LOCK(cs); activeState = CMasternode::MASTERNODE_VIN_SPENT; }
+    void SetSpent() { fCollateralSpent = true; }
 
     void Disable()
     {
@@ -232,19 +228,20 @@ public:
         lastPing = CMasternodePing();
     }
 
-    bool IsEnabled()
+    bool IsEnabled() const
     {
-        return WITH_LOCK(cs, return activeState == MASTERNODE_ENABLED);
+        return WITH_LOCK(cs, return GetActiveState() == MASTERNODE_ENABLED);
     }
 
-    bool IsPreEnabled()
+    bool IsPreEnabled() const
     {
-        return WITH_LOCK(cs, return activeState == MASTERNODE_PRE_ENABLED );
+        return WITH_LOCK(cs, return GetActiveState() == MASTERNODE_PRE_ENABLED );
     }
 
     std::string Status() const
     {
         LOCK(cs);
+        auto activeState = GetActiveState();
         if (activeState == CMasternode::MASTERNODE_PRE_ENABLED) return "PRE_ENABLED";
         if (activeState == CMasternode::MASTERNODE_ENABLED)     return "ENABLED";
         if (activeState == CMasternode::MASTERNODE_EXPIRED)     return "EXPIRED";
@@ -253,8 +250,8 @@ public:
         return strprintf("INVALID_%d", activeState);
     }
 
-    int64_t GetLastPaid();
-    bool IsValidNetAddr();
+    int64_t GetLastPaid() const;
+    bool IsValidNetAddr() const;
 
     /// Is the input associated with collateral public key? (and there is 10000 PIV - checking if valid masternode)
     bool IsInputAssociatedWithPubkey() const;

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -210,7 +210,7 @@ bool CMasternodeMan::Add(CMasternode& mn)
 {
     LOCK(cs);
 
-    if (!mn.IsEnabled() && !mn.IsPreEnabled())
+    if (!mn.IsAvailableState())
         return false;
 
     const auto& it = mapMasternodes.find(mn.vin.prevout);

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -120,9 +120,6 @@ public:
     /// Ask (source) node for mnb
     void AskForMN(CNode* pnode, const CTxIn& vin);
 
-    /// Check all Masternodes
-    void Check();
-
     /// Check all Masternodes and remove inactive
     void CheckAndRemove(bool forceExpiredRemoval = false);
 
@@ -132,31 +129,32 @@ public:
     void SetBestHeight(int height) { nBestHeight.store(height, std::memory_order_release); };
     int GetBestHeight() const { return nBestHeight.load(std::memory_order_acquire); }
 
-    int CountEnabled(int protocolVersion = -1);
+    int CountEnabled(int protocolVersion = -1) const;
 
-    void CountNetworks(int protocolVersion, int& ipv4, int& ipv6, int& onion);
+    void CountNetworks(int protocolVersion, int& ipv4, int& ipv6, int& onion) const;
 
     void DsegUpdate(CNode* pnode);
 
     /// Find an entry
     CMasternode* Find(const COutPoint& collateralOut);
+    const CMasternode* Find(const COutPoint& collateralOut) const;
     CMasternode* Find(const CPubKey& pubKeyMasternode);
 
-    /// Check all transactions in a block, for spent masternode collateral outpoints.
+    /// Check all transactions in a block, for spent masternode collateral outpoints (marking them as spent)
     void CheckSpentCollaterals(const std::vector<CTransactionRef>& vtx);
 
     /// Find an entry in the masternode list that is next to be paid
-    CMasternode* GetNextMasternodeInQueueForPayment(int nBlockHeight, bool fFilterSigTime, int& nCount);
+    const CMasternode* GetNextMasternodeInQueueForPayment(int nBlockHeight, bool fFilterSigTime, int& nCount) const;
 
     /// Get the current winner for this block
-    CMasternode* GetCurrentMasterNode(int mod = 1, int64_t nBlockHeight = 0, int minProtocol = 0);
+    const CMasternode* GetCurrentMasterNode(int mod = 1, int64_t nBlockHeight = 0, int minProtocol = 0) const;
 
     /// vector of pairs <masternode winner, height>
-    std::vector<std::pair<MasternodeRef, int>> GetMnScores(int nLast);
+    std::vector<std::pair<MasternodeRef, int>> GetMnScores(int nLast) const;
 
     // Retrieve the known masternodes ordered by scoring without checking them. (Only used for listmasternodes RPC call)
-    std::vector<std::pair<int64_t, CMasternode>> GetMasternodeRanks(int nBlockHeight);
-    int GetMasternodeRank(const CTxIn& vin, int64_t nBlockHeight, int minProtocol = 0, bool fOnlyActive = true);
+    std::vector<std::pair<int64_t, CMasternode>> GetMasternodeRanks(int nBlockHeight) const;
+    int GetMasternodeRank(const CTxIn& vin, int64_t nBlockHeight, int minProtocol = 0, bool fOnlyActive = true) const;
 
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
 
@@ -167,7 +165,7 @@ public:
     int size() const { LOCK(cs); return mapMasternodes.size(); }
 
     /// Return the number of Masternodes older than (default) 8000 seconds
-    int stable_size ();
+    int stable_size() const;
 
     std::string ToString() const;
 

--- a/src/qt/pivx/mnmodel.cpp
+++ b/src/qt/pivx/mnmodel.cpp
@@ -158,7 +158,7 @@ bool MNModel::addMn(CMasternodeConfig::CMasternodeEntry* mne)
 int MNModel::getMNState(QString mnAlias)
 {
     QMap<QString, std::pair<QString, CMasternode*>>::const_iterator it = nodes.find(mnAlias);
-    if (it != nodes.end()) return it.value().second->activeState;
+    if (it != nodes.end()) return it.value().second->GetActiveState();
     throw std::runtime_error(std::string("Masternode alias not found"));
 }
 

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -237,7 +237,7 @@ UniValue masternodecurrent (const JSONRPCRequest& request)
 
     const int nHeight = WITH_LOCK(cs_main, return chainActive.Height() + 1);
     int nCount = 0;
-    CMasternode* winner = mnodeman.GetNextMasternodeInQueueForPayment(nHeight, true, nCount);
+    const CMasternode* winner = mnodeman.GetNextMasternodeInQueueForPayment(nHeight, true, nCount);
     if (winner) {
         UniValue obj(UniValue::VOBJ);
         obj.pushKV("protocol", (int64_t)winner->protocolVersion);


### PR DESCRIPTION
This is the second part of #2000 , and it's based on top of it.
Here we remove `CMasternode::check()` and `CMasternode::activeState`, replacing it with a function `GetActiveState()`, which returns the state in real time.
