### PR TITLE
[BUG][GUI] memo not reset after hitting reset button

### DIFF
--- a/src/qt/pivx/sendmemodialog.cpp
+++ b/src/qt/pivx/sendmemodialog.cpp
@@ -72,6 +72,8 @@ void SendMemoDialog::reset()
         ui->textEdit->clear();
         ui->btnCancel->setText(tr("CANCEL"));
     }
+    // caller reset memo on the recipient
+    operationResult = true;
     close();
 }
 


### PR DESCRIPTION
bug found by @jakimanboy (https://github.com/PIVX-Project/PIVX/pull/1999#issuecomment-736984982)
>  Click `Add encrypted memo`, enter some text, then click save, then click `Update memo`, and now `RESET` doesn't actually clear the memo content, and the `Update memo` button also does not change back to `Add encrypted memo`.

cause: operationResult not set to true in `SendMemoDialog::reset()`, thus entry never updated in the send widget.