### PR TITLE
[Backport] P2P open network connection, fix race condition

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1869,11 +1869,11 @@ bool CConnman::OpenNetworkConnection(const CAddress& addrConnect, bool fCountFai
     if (fFeeler)
         pnode->fFeeler = true;
 
+    GetNodeSignals().InitializeNode(pnode, *this);
     {
         LOCK(cs_vNodes);
         vNodes.push_back(pnode);
     }
-    GetNodeSignals().InitializeNode(pnode, *this);
 
     return true;
 }


### PR DESCRIPTION
Coming from [btc/9671 ](https://github.com/bitcoin/bitcoin/pull/9671)

> Once the CNode has been added to vNodes, it is possible that it is
> disconnected+deleted in the socket handler thread. However, after
> that we now call InitializeNode, which accesses the pnode.
> 
> helgrind managed to tickle this case (somehow), but I suspect it
> requires in immensely braindead scheduler.
