### PR TITLE
[Wallet] Initial cleanup to the v1 transparent CreateTransaction flow.

### DIFF
--- a/src/coincontrol.h
+++ b/src/coincontrol.h
@@ -32,8 +32,6 @@ class CCoinControl
 {
 public:
     CTxDestination destChange = CNoDestination();
-    bool fSplitBlock;
-    int nSplitBlock;
     //! If false, allows unselected inputs, but requires all selected inputs be used
     bool fAllowOtherInputs;
     //! Includes watch only addresses which are solvable
@@ -59,8 +57,6 @@ public:
         nMinimumTotalFee = 0;
         nFeeRate = CFeeRate(0);
         fOverrideFeeRate = false;
-        fSplitBlock = false;
-        nSplitBlock = 1;
     }
 
     bool HasSelected() const

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2740,22 +2740,8 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend,
                     return false;
                 }
 
-
-                for (std::pair<const CWalletTx*, unsigned int> pcoin : setCoins) {
-                    if(pcoin.first->vout[pcoin.second].scriptPubKey.IsPayToColdStaking())
-                        wtxNew->fStakeDelegationVoided = true;
-                    //The coin age after the next block (depth+1) is used instead of the current,
-                    //reflecting an assumption the user would accept a bit more delay for
-                    //a chance at a free transaction.
-                    //But mempool inputs might still be in the mempool, so their age stays 0
-                    int age = pcoin.first->GetDepthInMainChain();
-                    assert(age >= 0);
-                    if (age != 0)
-                        age += 1;
-                }
-
+                // Change
                 CAmount nChange = nValueIn - nValue - nFeeRet;
-
                 if (nChange > 0) {
                     // Fill a vout to ourself
                     // TODO: pass in scriptChange instead of reservekey so
@@ -2824,8 +2810,12 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend,
                     reservekey.ReturnKey();
 
                 // Fill vin
-                for (const std::pair<const CWalletTx*, unsigned int> & coin : setCoins)
+                for (const std::pair<const CWalletTx*, unsigned int>& coin : setCoins) {
+                    if(coin.first->vout[coin.second].scriptPubKey.IsPayToColdStaking()) {
+                        wtxNew->fStakeDelegationVoided = true;
+                    }
                     txNew.vin.emplace_back(coin.first->GetHash(), coin.second);
+                }
 
                 // Sign
                 int nIn = 0;


### PR DESCRIPTION
Removed unused and redundant flows from `CWallet::CreateTransaction`. Like the utxo splitter that isn't used anywhere and the coin age calculation that was previously being used for free transaction calculation (which we don't have anymore).

It will speedup the transaction creation process for v1 transactions removing one loop over all of the available utxo and help on the v1-v2 transaction creation processes unification goal.