### PR TITLE
[RPC] redirect sendmany to shieldedsendmany when recipient is shielded

### DIFF
--- a/src/sapling/sapling_operation.cpp
+++ b/src/sapling/sapling_operation.cpp
@@ -244,6 +244,13 @@ void SaplingOperation::setFromAddress(const libzcash::SaplingPaymentAddress& _pa
     fromAddress = FromAddress(_payment);
 }
 
+SaplingOperation* SaplingOperation::setSelectTransparentCoins(const bool select, const bool _fIncludeDelegated)
+{
+    selectFromtaddrs = select;
+    if (selectFromtaddrs) fIncludeDelegated = _fIncludeDelegated;
+    return this;
+};
+
 OperationResult SaplingOperation::loadUtxos(TxValues& txValues)
 {
     // If the user has selected coins to spend then, directly load them.
@@ -267,7 +274,7 @@ OperationResult SaplingOperation::loadUtxos(TxValues& txValues)
     // No coin control selected, let's find the utxo by our own.
     std::set<CTxDestination> destinations;
     if (fromAddress.isFromTAddress()) destinations.insert(fromAddress.fromTaddr);
-    CWallet::AvailableCoinsFilter coinsFilter(false,
+    CWallet::AvailableCoinsFilter coinsFilter(fIncludeDelegated,
                                               false,
                                               ALL_COINS,
                                               true,

--- a/src/sapling/sapling_operation.h
+++ b/src/sapling/sapling_operation.h
@@ -94,7 +94,7 @@ public:
     void setFromAddress(const libzcash::SaplingPaymentAddress&);
     void clearTx() { txBuilder.Clear(); }
     // In case of no addressFrom filter selected, it will accept any utxo in the wallet as input.
-    SaplingOperation* setSelectTransparentCoins(const bool select) { selectFromtaddrs = select; return this; };
+    SaplingOperation* setSelectTransparentCoins(const bool select, const bool _fIncludeDelegated = false);
     SaplingOperation* setSelectShieldedCoins(const bool select) { selectFromShield = select; return this; };
     SaplingOperation* setRecipients(std::vector<SendManyRecipient>& vec) { recipients = std::move(vec); return this; };
     SaplingOperation* setFee(CAmount _fee) { fee = _fee; return this; }
@@ -111,6 +111,7 @@ private:
     // In case of no addressFrom filter selected, it will accept any utxo in the wallet as input.
     bool selectFromtaddrs{false};
     bool selectFromShield{false};
+    bool fIncludeDelegated{false};
     const CCoinControl* coinControl{nullptr};
     std::vector<SendManyRecipient> recipients;
     std::vector<COutput> transInputs;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2075,14 +2075,16 @@ UniValue sendmany(const JSONRPCRequest& request)
     if (request.fHelp || request.params.size() < 2 || request.params.size() > 5)
         throw std::runtime_error(
             "sendmany \"\" {\"address\":amount,...} ( minconf \"comment\" includeDelegated )\n"
-            "\nSend multiple times. Amounts are double-precision floating point numbers.\n"
+            "\nSend to multiple destinations. Recipients are transparent or shielded PIVX addresses.\n"
+            "\nAmounts are double-precision floating point numbers.\n"
             + HelpRequiringPassphrase() + "\n"
 
             "\nArguments:\n"
             "1. \"dummy\"               (string, required) Must be set to \"\" for backwards compatibility.\n"
             "2. \"amounts\"             (string, required) A json object with addresses and amounts\n"
             "    {\n"
-            "      \"address\":amount   (numeric) The pivx address is the key, the numeric amount in PIV is the value\n"
+            "      \"address\":amount   (numeric) The pivx address (either transparent or shielded) is the key,\n"
+            "                                     the numeric amount in PIV is the value\n"
             "      ,...\n"
             "    }\n"
             "3. minconf                 (numeric, optional, default=1) Only use the balance confirmed at least this many times.\n"
@@ -2098,6 +2100,8 @@ UniValue sendmany(const JSONRPCRequest& request)
             HelpExampleCli("sendmany", "\"\" \"{\\\"DMJRSsuU9zfyrvxVaAEFQqK4MxZg6vgeS6\\\":0.01,\\\"DAD3Y6ivr8nPQLT1NEPX84DxGCw9jz9Jvg\\\":0.02}\"") +
             "\nSend two amounts to two different addresses setting the confirmation and comment:\n" +
             HelpExampleCli("sendmany", "\"\" \"{\\\"DMJRSsuU9zfyrvxVaAEFQqK4MxZg6vgeS6\\\":0.01,\\\"DAD3Y6ivr8nPQLT1NEPX84DxGCw9jz9Jvg\\\":0.02}\" 6 \"testing\"") +
+            "\nSend to shielded address:\n" +
+            HelpExampleCli("sendmany", "\"\" \"{\\\"ps1u87kylcmn28yclnx2uy0psnvuhs2xn608ukm6n2nshrpg2nzyu3n62ls8j77m9cgp40dx40evej\\\":10}\"") +
             "\nAs a json rpc call\n" +
             HelpExampleRpc("sendmany", "\"\", \"{\\\"DMJRSsuU9zfyrvxVaAEFQqK4MxZg6vgeS6\\\":0.01,\\\"DAD3Y6ivr8nPQLT1NEPX84DxGCw9jz9Jvg\\\":0.02}\", 6, \"testing\"")
         );

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -146,8 +146,8 @@ TIERTWO_SCRIPTS = [
 SAPLING_SCRIPTS = [
     # Longest test should go first, to favor running tests in parallel
     'sapling_key_import_export.py',             # ~ 378 sec
+    'sapling_wallet.py',                        # ~ 350 sec
     'sapling_wallet_anchorfork.py',             # ~ 345 sec
-    'sapling_wallet.py',                        # ~ 274 sec
     'sapling_wallet_nullifiers.py',             # ~ 190 sec
     'sapling_wallet_listreceived.py',           # ~ 157 sec
     'sapling_changeaddresses.py',               # ~ 151 sec


### PR DESCRIPTION
Instead of throwing an error, let's repack the json request and send it to `shieldedsendmany`.
This makes the integration of send-to-shield-address much easier for third-party services.

We keep the old implementation of `sendmany` for `t->t` transactions, until the two flows are properly abstracted.

Also fix a minor bug found in `sendmany` (not properly considering the `fIncludeDelegated` flag), and add capability to spend P2CS inside `SaplingOperation`.

Note:  the same thing proposed here, could be done with the RPC `sendtoaddress` (future).