### PR TITLE
[BUG][RPC] Save collateral errors into proposals/budgets strInvalid

### DIFF
--- a/src/budget/budgetmanager.cpp
+++ b/src/budget/budgetmanager.cpp
@@ -206,6 +206,7 @@ bool CBudgetManager::AddFinalizedBudget(CFinalizedBudget& finalizedBudget)
     if (!CheckCollateral(feeTxId, nHash, strError, finalizedBudget.nTime, nCurrentHeight, true)) {
         LogPrint(BCLog::MNBUDGET,"%s: invalid finalized budget (%s) collateral id=%s - %s\n",
                 __func__, nHash.ToString(), feeTxId.ToString(), strError);
+        finalizedBudget.SetStrInvalid(strError);
         return false;
     }
 
@@ -251,6 +252,7 @@ bool CBudgetManager::AddProposal(CBudgetProposal& budgetProposal)
     if (!CheckCollateral(feeTxId, nHash, strError, budgetProposal.nTime, nCurrentHeight, false)) {
         LogPrint(BCLog::MNBUDGET,"%s: invalid budget proposal (%s) collateral id=%s - %s\n",
                 __func__, nHash.ToString(), feeTxId.ToString(), strError);
+        budgetProposal.SetStrInvalid(strError);
         return false;
     }
 

--- a/src/budget/budgetproposal.h
+++ b/src/budget/budgetproposal.h
@@ -62,6 +62,7 @@ public:
     // Static checks that should be done only once - sets strInvalid
     bool IsWellFormed(const CAmount& nTotalBudget);
     bool IsValid() const  { return fValid; }
+    void SetStrInvalid(const std::string& _strInvalid) { strInvalid = _strInvalid; }
     std::string IsInvalidReason() const { return strInvalid; }
     std::string IsInvalidLogStr() const { return strprintf("[%s]: %s", GetName(), IsInvalidReason()); }
 

--- a/src/budget/finalizedbudget.h
+++ b/src/budget/finalizedbudget.h
@@ -67,6 +67,7 @@ public:
     // Static checks that should be done only once - sets strInvalid
     bool IsWellFormed(const CAmount& nTotalBudget);
     bool IsValid() const  { return fValid; }
+    void SetStrInvalid(const std::string& _strInvalid) { strInvalid = _strInvalid; }
     std::string IsInvalidReason() const { return strInvalid; }
     std::string IsInvalidLogStr() const { return strprintf("[%s (%s)]: %s", GetName(), GetProposalsStr(), IsInvalidReason()); }
 


### PR DESCRIPTION
If `submitbudget` RPC fails for an issue with the collateral (e.g. not enough confirmations), it returns a generic (and confusing) 
```
invalid budget proposal - (code -1)
```

Fix: save the error returned by `CheckCollateral` inside the invalid-reason-string of the budget/proposal object (so it is returned in the RPC with `IsInvalidReason()`.