### PR TITLE
[WIP] [GUI] Fixing invalid masternode presented status. 

### DIFF
--- a/src/masternodeconfig.h
+++ b/src/masternodeconfig.h
@@ -6,6 +6,7 @@
 #ifndef SRC_MASTERNODECONFIG_H_
 #define SRC_MASTERNODECONFIG_H_
 
+#include "key.h"
 #include "sync.h"
 #include <string>
 #include <vector>
@@ -21,27 +22,39 @@ public:
     private:
         std::string alias;
         std::string ip;
-        std::string privKey;
+        std::string privkeyStr;
+        std::string pubkeyStr;
         std::string txHash;
         std::string outputIndex;
 
     public:
-        CMasternodeEntry(std::string& _alias, std::string& _ip, std::string& _privKey, std::string& _txHash, std::string& _outputIndex) :
-            alias(_alias), ip(_ip), privKey(_privKey), txHash(_txHash), outputIndex(_outputIndex) { }
+        CMasternodeEntry(std::string& _alias,
+                         std::string& _ip,
+                         std::string& _privkeyStr,
+                         std::string& _pubkeyStr,
+                         std::string& _txHash,
+                         std::string& _outputIndex) :
+            alias(_alias), ip(_ip), privkeyStr(_privkeyStr), pubkeyStr(_pubkeyStr), txHash(_txHash), outputIndex(_outputIndex) { }
 
-        const std::string& getAlias() const { return alias; }
-        const std::string& getOutputIndex() const { return outputIndex; }
+        std::string getAlias() const { return alias; }
+        std::string getOutputIndex() const { return outputIndex; }
         bool castOutputIndex(int& n) const;
-        const std::string& getPrivKey() const { return privKey; }
-        const std::string& getTxHash() const { return txHash; }
-        const std::string& getIp() const { return ip; }
+        std::string getPrivKeyStr() const { return privkeyStr; }
+        std::string getPubKeyStr() const { return pubkeyStr; }
+        std::string getTxHash() const { return txHash; }
+        std::string getIp() const { return ip; }
     };
 
     CMasternodeConfig() { entries = std::vector<CMasternodeEntry>(); }
 
     void clear() { LOCK(cs_entries); entries.clear(); }
     bool read(std::string& strErr);
-    CMasternodeConfig::CMasternodeEntry* add(std::string alias, std::string ip, std::string privKey, std::string txHash, std::string outputIndex);
+    CMasternodeConfig::CMasternodeEntry* add(std::string alias,
+                                             std::string ip,
+                                             std::string privKeyStr,
+                                             std::string pubKeyStr,
+                                             std::string txHash,
+                                             std::string outputIndex);
     void remove(std::string alias);
 
     std::vector<CMasternodeEntry> getEntries() { LOCK(cs_entries); return entries; }

--- a/src/qt/pivx/masternodeswidget.cpp
+++ b/src/qt/pivx/masternodeswidget.cpp
@@ -247,7 +247,7 @@ void MasterNodesWidget::updateModelAndInform(QString informText)
 bool MasterNodesWidget::startMN(CMasternodeConfig::CMasternodeEntry mne, std::string& strError)
 {
     CMasternodeBroadcast mnb;
-    if (!CMasternodeBroadcast::Create(mne.getIp(), mne.getPrivKey(), mne.getTxHash(), mne.getOutputIndex(), strError, mnb))
+    if (!CMasternodeBroadcast::Create(mne.getIp(), mne.getPrivKeyStr(), mne.getTxHash(), mne.getOutputIndex(), strError, mnb))
         return false;
 
     mnodeman.UpdateMasternodeList(mnb);

--- a/src/qt/pivx/masternodewizarddialog.cpp
+++ b/src/qt/pivx/masternodewizarddialog.cpp
@@ -358,7 +358,12 @@ bool MasterNodeWizardDialog::createMN()
     fs::path pathNewConfFile = AbsPathForConfigVal(fs::path("masternode.conf"));
     rename(pathConfigFile, pathNewConfFile);
 
-    mnEntry = masternodeConfig.add(alias, ipAddress+":"+port, mnKeyString, txID, indexOutStr);
+    mnEntry = masternodeConfig.add(alias,
+                                   ipAddress+":"+port,
+                                   mnKeyString,
+                                   secret.GetPubKey().GetHash().GetHex(),
+                                   txID,
+                                   indexOutStr);
 
     // Lock collateral output
     walletModel->lockCoin(collateralOut);

--- a/src/qt/pivx/mnmodel.cpp
+++ b/src/qt/pivx/mnmodel.cpp
@@ -4,7 +4,6 @@
 
 #include "qt/pivx/mnmodel.h"
 
-#include "activemasternode.h"
 #include "masternode-sync.h"
 #include "masternodeman.h"
 #include "net.h"        // for validateMasternodeIP
@@ -29,7 +28,13 @@ void MNModel::updateMNList()
         uint256 txHash(mne.getTxHash());
         CTxIn txIn(txHash, uint32_t(nIndex));
         CMasternode* pmn = mnodeman.Find(txIn.prevout);
-        nodes.insert(QString::fromStdString(mne.getAlias()), std::make_pair(QString::fromStdString(mne.getIp()), pmn));
+        nodes.append(MasternodeWrapper(
+                     QString::fromStdString(mne.getAlias()),
+                     QString::fromStdString(mne.getIp()),
+                     pmn,
+                     pmn ? pmn->vin.prevout : txIn.prevout,
+                     Optional<QString>(QString::fromStdString(mne.getPubKeyStr())))
+                     );
         if (pwalletMain) {
             bool txAccepted = false;
             {
@@ -65,42 +70,41 @@ QVariant MNModel::data(const QModelIndex &index, int role) const
     if (!index.isValid())
             return QVariant();
 
-    // rec could be null, always verify it.
-    CMasternode* rec = static_cast<CMasternode*>(index.internalPointer());
-    bool isAvailable = rec;
     int row = index.row();
+    const MasternodeWrapper& mnWrapper = nodes.at(row);
     if (role == Qt::DisplayRole || role == Qt::EditRole) {
         switch (index.column()) {
             case ALIAS:
-                return nodes.uniqueKeys().value(row);
+                return mnWrapper.label;
             case ADDRESS:
-                return nodes.values().value(row).first;
+                return mnWrapper.ipPort;
             case PUB_KEY:
-                return (isAvailable) ? QString::fromStdString(nodes.values().value(row).second->pubKeyMasternode.GetHash().GetHex()) : "Not available";
+                return mnWrapper.mnPubKey ? *mnWrapper.mnPubKey : "Not available";
             case COLLATERAL_ID:
-                return (isAvailable) ? QString::fromStdString(rec->vin.prevout.hash.GetHex()) : "Not available";
+                return mnWrapper.collateralId ? QString::fromStdString(mnWrapper.collateralId->hash.GetHex()) : "Not available";
             case COLLATERAL_OUT_INDEX:
-                return (isAvailable) ? QString::number(rec->vin.prevout.n) : "Not available";
+                return mnWrapper.collateralId ? QString::number(mnWrapper.collateralId->n) : "Not available";
             case STATUS: {
-                std::pair<QString, CMasternode*> pair = nodes.values().value(row);
-                return (pair.second) ? QString::fromStdString(pair.second->Status()) : "MISSING";
+                return mnWrapper.masternode ? QString::fromStdString(mnWrapper.masternode->Status()) : "MISSING";
             }
             case PRIV_KEY: {
-                for (const CMasternodeConfig::CMasternodeEntry& mne : masternodeConfig.getEntries()) {
-                    if (mne.getTxHash().compare(rec->vin.prevout.hash.GetHex()) == 0) {
-                        return QString::fromStdString(mne.getPrivKey());
+                if (mnWrapper.collateralId) {
+                    for (const CMasternodeConfig::CMasternodeEntry& mne : masternodeConfig.getEntries()) {
+                        if (mne.getTxHash() == mnWrapper.collateralId->hash.GetHex()) {
+                            return QString::fromStdString(mne.getPrivKeyStr());
+                        }
                     }
                 }
                 return "Not available";
             }
             case WAS_COLLATERAL_ACCEPTED:{
-                if (!isAvailable) return false;
-                std::string txHash = rec->vin.prevout.hash.GetHex();
+                if (!mnWrapper.masternode) return false;
+                std::string txHash = mnWrapper.collateralId->hash.GetHex();
                 if (!collateralTxAccepted.value(txHash)) {
                     bool txAccepted = false;
                     {
                         LOCK2(cs_main, pwalletMain->cs_wallet);
-                        const CWalletTx *walletTx = pwalletMain->GetWalletTx(rec->vin.prevout.hash);
+                        const CWalletTx *walletTx = pwalletMain->GetWalletTx(mnWrapper.collateralId->hash);
                         txAccepted = walletTx && walletTx->GetDepthInMainChain() > 0;
                     }
                     return txAccepted;
@@ -112,27 +116,11 @@ QVariant MNModel::data(const QModelIndex &index, int role) const
     return QVariant();
 }
 
-QModelIndex MNModel::index(int row, int column, const QModelIndex& parent) const
-{
-    Q_UNUSED(parent);
-    std::pair<QString, CMasternode*> pair = nodes.values().value(row);
-    CMasternode* data = pair.second;
-    if (data) {
-        return createIndex(row, column, data);
-    } else if (!pair.first.isEmpty()) {
-        return createIndex(row, column, nullptr);
-    } else {
-        return QModelIndex();
-    }
-}
-
-
 bool MNModel::removeMn(const QModelIndex& modelIndex)
 {
-    QString alias = modelIndex.data(Qt::DisplayRole).toString();
     int idx = modelIndex.row();
     beginRemoveRows(QModelIndex(), idx, idx);
-    nodes.take(alias);
+    nodes.removeAt(idx);
     endRemoveRows();
     Q_EMIT dataChanged(index(idx, 0, QModelIndex()), index(idx, 5, QModelIndex()) );
     return true;
@@ -145,17 +133,35 @@ bool MNModel::addMn(CMasternodeConfig::CMasternodeEntry* mne)
     if (!mne->castOutputIndex(nIndex))
         return false;
 
-    CMasternode* pmn = mnodeman.Find(COutPoint(uint256S(mne->getTxHash()), uint32_t(nIndex)));
-    nodes.insert(QString::fromStdString(mne->getAlias()), std::make_pair(QString::fromStdString(mne->getIp()), pmn));
+    COutPoint collateralId = COutPoint(uint256S(mne->getTxHash()), uint32_t(nIndex));
+    CMasternode* pmn = mnodeman.Find(collateralId);
+    nodes.append(MasternodeWrapper(
+                 QString::fromStdString(mne->getAlias()),
+                 QString::fromStdString(mne->getIp()),
+                 pmn, pmn ? pmn->vin.prevout : collateralId,
+                 Optional<QString>(QString::fromStdString(mne->getPubKeyStr())))
+                 );
     endInsertRows();
     return true;
 }
 
+const MasternodeWrapper* MNModel::getMNWrapper(QString mnAlias)
+{
+    for (const auto& it : nodes) {
+        if (it.label == mnAlias) {
+            return &it;
+        }
+    }
+    return nullptr;
+}
+
 int MNModel::getMNState(QString mnAlias)
 {
-    QMap<QString, std::pair<QString, CMasternode*>>::const_iterator it = nodes.find(mnAlias);
-    if (it != nodes.end()) return it.value().second->GetActiveState();
-    throw std::runtime_error(std::string("Masternode alias not found"));
+    const MasternodeWrapper* mn = getMNWrapper(mnAlias);
+    if (!mn) {
+        throw std::runtime_error(std::string("Masternode alias not found"));
+    }
+    return mn->masternode ? mn->masternode->GetActiveState() : -1;
 }
 
 bool MNModel::isMNInactive(QString mnAlias)
@@ -172,9 +178,11 @@ bool MNModel::isMNActive(QString mnAlias)
 
 bool MNModel::isMNCollateralMature(QString mnAlias)
 {
-    QMap<QString, std::pair<QString, CMasternode*>>::const_iterator it = nodes.find(mnAlias);
-    if (it != nodes.end()) return collateralTxAccepted.value(it.value().second->vin.prevout.hash.GetHex());
-    throw std::runtime_error(std::string("Masternode alias not found"));
+    const MasternodeWrapper* mn = getMNWrapper(mnAlias);
+    if (!mn) {
+        throw std::runtime_error(std::string("Masternode alias not found"));
+    }
+    return mn->masternode ? collateralTxAccepted.value(mn->masternode->vin.prevout.hash.GetHex()) : false;
 }
 
 bool MNModel::isMNsNetworkSynced()

--- a/src/qt/pivx/mnmodel.cpp
+++ b/src/qt/pivx/mnmodel.cpp
@@ -22,17 +22,13 @@ void MNModel::updateMNList()
     int end = nodes.size();
     nodes.clear();
     collateralTxAccepted.clear();
-    for (CMasternodeConfig::CMasternodeEntry mne : masternodeConfig.getEntries()) {
+    for (const CMasternodeConfig::CMasternodeEntry& mne : masternodeConfig.getEntries()) {
         int nIndex;
         if (!mne.castOutputIndex(nIndex))
             continue;
         uint256 txHash(mne.getTxHash());
         CTxIn txIn(txHash, uint32_t(nIndex));
         CMasternode* pmn = mnodeman.Find(txIn.prevout);
-        if (!pmn) {
-            pmn = new CMasternode();
-            pmn->vin = txIn;
-        }
         nodes.insert(QString::fromStdString(mne.getAlias()), std::make_pair(QString::fromStdString(mne.getIp()), pmn));
         if (pwalletMain) {
             bool txAccepted = false;
@@ -90,7 +86,7 @@ QVariant MNModel::data(const QModelIndex &index, int role) const
                 return (pair.second) ? QString::fromStdString(pair.second->Status()) : "MISSING";
             }
             case PRIV_KEY: {
-                for (CMasternodeConfig::CMasternodeEntry mne : masternodeConfig.getEntries()) {
+                for (const CMasternodeConfig::CMasternodeEntry& mne : masternodeConfig.getEntries()) {
                     if (mne.getTxHash().compare(rec->vin.prevout.hash.GetHex()) == 0) {
                         return QString::fromStdString(mne.getPrivKey());
                     }

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -80,7 +80,6 @@ bool TransactionRecord::decomposeZcSpendTx(const CWallet* wallet, const CWalletT
     int64_t nTime = wtx.GetTxTime();
 
     //zerocoin spend outputs
-    bool fFeeAssigned = false;
     for (unsigned int nOut = 0; nOut < wtx.vout.size(); nOut++) {
         const CTxOut& txout = wtx.vout[nOut];
         // change that was reminted as zerocoins

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -337,7 +337,7 @@ UniValue mnbudgetvote(const JSONRPCRequest& request)
 
             UniValue statusObj(UniValue::VOBJ);
 
-            if (!CMessageSigner::GetKeysFromSecret(mne.getPrivKey(), keyMasternode, pubKeyMasternode)) {
+            if (!CMessageSigner::GetKeysFromSecret(mne.getPrivKeyStr(), keyMasternode, pubKeyMasternode)) {
                 failed++;
                 statusObj.pushKV("node", mne.getAlias());
                 statusObj.pushKV("result", "failed");
@@ -408,7 +408,7 @@ UniValue mnbudgetvote(const JSONRPCRequest& request)
 
             UniValue statusObj(UniValue::VOBJ);
 
-            if(!CMessageSigner::GetKeysFromSecret(mne.getPrivKey(), keyMasternode, pubKeyMasternode)){
+            if(!CMessageSigner::GetKeysFromSecret(mne.getPrivKeyStr(), keyMasternode, pubKeyMasternode)){
                 failed++;
                 statusObj.pushKV("node", mne.getAlias());
                 statusObj.pushKV("result", "failed");
@@ -755,7 +755,7 @@ UniValue mnfinalbudget(const JSONRPCRequest& request)
 
             UniValue statusObj(UniValue::VOBJ);
 
-            if (!CMessageSigner::GetKeysFromSecret(mne.getPrivKey(), keyMasternode, pubKeyMasternode)) {
+            if (!CMessageSigner::GetKeysFromSecret(mne.getPrivKeyStr(), keyMasternode, pubKeyMasternode)) {
                 failed++;
                 statusObj.pushKV("result", "failed");
                 statusObj.pushKV("errorMessage", "Masternode signing error, could not set key correctly.");

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -265,7 +265,7 @@ bool StartMasternodeEntry(UniValue& statusObjRet, CMasternodeBroadcast& mnbRet, 
         if (strCommand == "disabled" && pmn->IsEnabled()) return false;
     }
 
-    fSuccessRet = CMasternodeBroadcast::Create(mne.getIp(), mne.getPrivKey(), mne.getTxHash(), mne.getOutputIndex(), errorMessage, mnbRet);
+    fSuccessRet = CMasternodeBroadcast::Create(mne.getIp(), mne.getPrivKeyStr(), mne.getTxHash(), mne.getOutputIndex(), errorMessage, mnbRet);
 
     statusObjRet.pushKV("alias", mne.getAlias());
     statusObjRet.pushKV("result", fSuccessRet ? "success" : "failed");
@@ -558,7 +558,7 @@ UniValue listmasternodeconf (const JSONRPCRequest& request)
         UniValue mnObj(UniValue::VOBJ);
         mnObj.pushKV("alias", mne.getAlias());
         mnObj.pushKV("address", mne.getIp());
-        mnObj.pushKV("privateKey", mne.getPrivKey());
+        mnObj.pushKV("privateKey", mne.getPrivKeyStr());
         mnObj.pushKV("txHash", mne.getTxHash());
         mnObj.pushKV("outputIndex", mne.getOutputIndex());
         mnObj.pushKV("status", strStatus);


### PR DESCRIPTION
Since #2006, the "MISSING" state doesn't exists anymore in the `CMasternode` class. This affected the GUI as it was using such value to describe masternodes that are in the configuration file but not initialized. The uninitialized masternodes are shown with a "REMOVE" state which isn't the correct one, this PR fixes it.