### PR TITLE
[Wallet] HD wallets automatic upgrade to sapling features.

### DIFF
--- a/src/qt/pivx/topbar.h
+++ b/src/qt/pivx/topbar.h
@@ -37,7 +37,6 @@ public:
 
     void openPassPhraseDialog(AskPassphraseDialog::Mode mode, AskPassphraseDialog::Context ctx);
     void encryptWallet();
-    void showUpgradeDialog();
 
     void run(int type) override;
     void onError(QString error, int type) override;
@@ -52,6 +51,7 @@ public Q_SLOTS:
     void setStakingStatusActive(bool fActive);
     void updateStakingStatus();
     void updateHDState(const bool& upgraded, const QString& upgradeError);
+    void showUpgradeDialog(const QString& message);
 
 Q_SIGNALS:
     void themeChanged(bool isLight);
@@ -85,6 +85,7 @@ private:
     BalanceBubble* balanceBubble = nullptr;
 
     void updateTorIcon();
+    void connectUpgradeBtnAndDialogTimer(const QString& message);
 };
 
 #endif // TOPBAR_H

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -86,6 +86,11 @@ bool WalletModel::isHDEnabled() const
     return wallet->IsHDEnabled();
 }
 
+bool WalletModel::isSaplingWalletEnabled() const
+{
+    return wallet->IsSaplingUpgradeEnabled();
+}
+
 bool WalletModel::upgradeWallet(std::string& upgradeError)
 {
     // This action must be performed in a separate thread and not the main one.

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -158,6 +158,7 @@ public:
     bool hasWallet() { return wallet; };
 
     bool isHDEnabled() const;
+    bool isSaplingWalletEnabled() const;
     bool upgradeWallet(std::string& upgradeError);
 
     interfaces::WalletBalances GetWalletBalances() { return m_cached_balances; };

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -96,6 +96,11 @@ bool CWallet::IsHDEnabled() const
     return m_spk_man->IsHDEnabled();
 }
 
+bool CWallet::IsSaplingUpgradeEnabled() const
+{
+    return m_sspk_man->IsEnabled();
+}
+
 const CWalletTx* CWallet::GetWalletTx(const uint256& hash) const
 {
     LOCK(cs_wallet);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4020,7 +4020,9 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
     }
 
     // Upgrade to HD only if explicit upgrade was requested
-    if (gArgs.GetBoolArg("-upgradewallet", false)) {
+    // or if we are running an HD wallet and need to upgrade to Sapling.
+    if (gArgs.GetBoolArg("-upgradewallet", false) ||
+        (!walletInstance->IsLocked() && prev_version == FEATURE_PRE_SPLIT_KEYPOOL)) {
         std::string upgradeError;
         if (!walletInstance->Upgrade(upgradeError, prev_version)) {
             UIError(upgradeError);
@@ -4435,6 +4437,10 @@ int CWallet::GetVersion()
 ////////////////////////////////////////////////////////////
 
 libzcash::SaplingPaymentAddress CWallet::GenerateNewSaplingZKey(std::string label) {
+    if (!m_sspk_man->IsEnabled()) {
+        throw std::runtime_error("Cannot generate shielded addresses. Start with -upgradewallet in order to upgrade a non-HD wallet to HD and Sapling features");
+    }
+
     auto address = m_sspk_man->GenerateNewSaplingZKey();
     SetAddressBook(address, label, AddressBook::AddressBookPurpose::SHIELDED_RECEIVE);
     return address;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -332,6 +332,8 @@ public:
     bool SetupSPKM(bool newKeypool = true, bool memOnly = false);
     //! Whether the wallet is hd or not //
     bool IsHDEnabled() const;
+    //! Whether the wallet supports Sapling or not //
+    bool IsSaplingUpgradeEnabled() const;
 
     /* SPKM Helpers */
     const CKeyingMaterial& GetEncryptionKey() const;


### PR DESCRIPTION
HD wallets (`FEATURE_PRE_SPLIT_KEYPOOL`) automatic upgrade to `FEATURE_SAPLING` to support shielded functionality by default.

This is an straightforward version bump because only the seed is needed to generate the sapling keys tree. More info in #1553.

Plus added a version guard in the shielded addresses generation method, so pre-HD wallets show the proper error when they cannot generate shielded addresses (essentially, will notify the user that he/she needs to upgrade their wallet to support shielded operations).

As an extra information, pre-HD wallets who upgrade to HD running v5, will automatically be upgraded to support sapling features. This was done in #1553 as well.