### PR TITLE
[BUG] Fix lock order issue with CMMan::CheckAndRemove and CMPayments::CleanPaymentList

### DIFF
--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -52,7 +52,7 @@ public:
 
     CMasternodePaymentDB();
     bool Write(const CMasternodePayments& objToSave);
-    ReadResult Read(CMasternodePayments& objToLoad, bool fDryRun = false);
+    ReadResult Read(CMasternodePayments& objToLoad);
 };
 
 class CMasternodePayee
@@ -251,7 +251,7 @@ public:
     bool ProcessBlock(int nBlockHeight);
 
     void Sync(CNode* node, int nCountNeeded);
-    void CleanPaymentList();
+    void CleanPaymentList(int mnCount, int nHeight);
 
     bool GetBlockPayee(int nBlockHeight, CScript& payee);
     bool IsTransactionValid(const CTransaction& txNew, int nBlockHeight);

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -209,8 +209,9 @@ bool CMasternodeMan::Add(CMasternode& mn)
 
     const auto& it = mapMasternodes.find(mn.vin.prevout);
     if (it == mapMasternodes.end()) {
-        LogPrint(BCLog::MASTERNODE, "CMasternodeMan: Adding new Masternode %s - %i now\n", mn.vin.prevout.hash.ToString(), size() + 1);
+        LogPrint(BCLog::MASTERNODE, "Adding new Masternode %s\n", mn.vin.prevout.ToString());
         mapMasternodes.emplace(mn.vin.prevout, std::make_shared<CMasternode>(mn));
+        LogPrint(BCLog::MASTERNODE, "Masternode added. New total count: %d\n", mapMasternodes.size());
         return true;
     }
 
@@ -246,7 +247,7 @@ int CMasternodeMan::CheckAndRemove(bool forceExpiredRemoval)
             activeState == CMasternode::MASTERNODE_VIN_SPENT ||
             (forceExpiredRemoval && activeState == CMasternode::MASTERNODE_EXPIRED) ||
             mn->protocolVersion < ActiveProtocol()) {
-            LogPrint(BCLog::MASTERNODE, "CMasternodeMan: Removing inactive Masternode %s - %i now\n", it->first.hash.ToString(), size() - 1);
+            LogPrint(BCLog::MASTERNODE, "Removing inactive Masternode %s\n", it->first.ToString());
 
             //erase all of the broadcasts we've seen from this vin
             // -- if we missed a few pings and the node was removed, this will allow is to get it back without them
@@ -272,10 +273,12 @@ int CMasternodeMan::CheckAndRemove(bool forceExpiredRemoval)
             }
 
             it = mapMasternodes.erase(it);
+            LogPrint(BCLog::MASTERNODE, "Masternode removed.\n");
         } else {
             ++it;
         }
     }
+    LogPrint(BCLog::MASTERNODE, "New total masternode count: %d\n", mapMasternodes.size());
 
     // check who's asked for the Masternode list
     std::map<CNetAddr, int64_t>::iterator it1 = mAskedUsForMasternodeList.begin();
@@ -841,9 +844,10 @@ void CMasternodeMan::UpdateMasternodeList(CMasternodeBroadcast mnb)
 std::string CMasternodeMan::ToString() const
 {
     std::ostringstream info;
-
-    info << "Masternodes: " << (int)size() << ", peers who asked us for Masternode list: " << (int)mAskedUsForMasternodeList.size() << ", peers we asked for Masternode list: " << (int)mWeAskedForMasternodeList.size() << ", entries in Masternode list we asked for: " << (int)mWeAskedForMasternodeListEntry.size();
-
+    info << "Masternodes: " << (int)mapMasternodes.size()
+         << ", peers who asked us for Masternode list: " << (int)mAskedUsForMasternodeList.size()
+         << ", peers we asked for Masternode list: " << (int)mWeAskedForMasternodeList.size()
+         << ", entries in Masternode list we asked for: " << (int)mWeAskedForMasternodeListEntry.size();
     return info.str();
 }
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -389,8 +389,9 @@ int CMasternodeMan::CountEnabled(int protocolVersion) const
     return i;
 }
 
-void CMasternodeMan::CountNetworks(int protocolVersion, int& ipv4, int& ipv6, int& onion) const
+int CMasternodeMan::CountNetworks(int& ipv4, int& ipv6, int& onion) const
 {
+    LOCK(cs);
     for (const auto& it : mapMasternodes) {
         const MasternodeRef& mn = it.second;
         std::string strHost;
@@ -411,6 +412,7 @@ void CMasternodeMan::CountNetworks(int protocolVersion, int& ipv4, int& ipv6, in
                 break;
         }
     }
+    return mapMasternodes.size();
 }
 
 void CMasternodeMan::DsegUpdate(CNode* pnode)

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -51,7 +51,7 @@ public:
 
     CMasternodeDB();
     bool Write(const CMasternodeMan& mnodemanToSave);
-    ReadResult Read(CMasternodeMan& mnodemanToLoad, bool fDryRun = false);
+    ReadResult Read(CMasternodeMan& mnodemanToLoad);
 };
 
 //
@@ -120,8 +120,8 @@ public:
     /// Ask (source) node for mnb
     void AskForMN(CNode* pnode, const CTxIn& vin);
 
-    /// Check all Masternodes and remove inactive
-    void CheckAndRemove(bool forceExpiredRemoval = false);
+    /// Check all Masternodes and remove inactive. Return the total masternode count.
+    int CheckAndRemove(bool forceExpiredRemoval = false);
 
     /// Clear Masternode vector
     void Clear();

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -131,7 +131,8 @@ public:
 
     int CountEnabled(int protocolVersion = -1) const;
 
-    void CountNetworks(int protocolVersion, int& ipv4, int& ipv6, int& onion) const;
+    /// Count the number of nodes with a specific proto version for each network. Return the total.
+    int CountNetworks(int& ipv4, int& ipv6, int& onion) const;
 
     void DsegUpdate(CNode* pnode);
 

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -162,9 +162,6 @@ public:
     // Process GETMNLIST message, returning the banning score (if 0, no ban score increase is needed)
     int ProcessGetMNList(CNode* pfrom, CTxIn& vin);
 
-    /// Return the number of (unique) Masternodes
-    int size() const { LOCK(cs); return mapMasternodes.size(); }
-
     /// Return the number of Masternodes older than (default) 8000 seconds
     int stable_size() const;
 

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -76,10 +76,10 @@ int ClientModel::getNumConnections(unsigned int flags) const
 QString ClientModel::getMasternodeCountString() const
 {
     int ipv4 = 0, ipv6 = 0, onion = 0;
-    mnodeman.CountNetworks(ActiveProtocol(), ipv4, ipv6, onion);
-    int nUnknown = mnodeman.size() - ipv4 - ipv6 - onion;
+    int total = mnodeman.CountNetworks(ipv4, ipv6, onion);
+    int nUnknown = total - ipv4 - ipv6 - onion;
     if(nUnknown < 0) nUnknown = 0;
-    return tr("Total: %1 (IPv4: %2 / IPv6: %3 / Tor: %4 / Unknown: %5)").arg(QString::number((int)mnodeman.size())).arg(QString::number((int)ipv4)).arg(QString::number((int)ipv6)).arg(QString::number((int)onion)).arg(QString::number((int)nUnknown));
+    return tr("Total: %1 (IPv4: %2 / IPv6: %3 / Tor: %4 / Unknown: %5)").arg(QString::number(total)).arg(QString::number((int)ipv4)).arg(QString::number((int)ipv6)).arg(QString::number((int)onion)).arg(QString::number((int)nUnknown));
 }
 
 int ClientModel::getNumBlocks()

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -203,9 +203,9 @@ UniValue getmasternodecount (const JSONRPCRequest& request)
     if (nChainHeight < 0) return "unknown";
 
     mnodeman.GetNextMasternodeInQueueForPayment(nChainHeight, true, nCount);
-    mnodeman.CountNetworks(ActiveProtocol(), ipv4, ipv6, onion);
+    int total = mnodeman.CountNetworks(ipv4, ipv6, onion);
 
-    obj.pushKV("total", mnodeman.size());
+    obj.pushKV("total", total);
     obj.pushKV("stable", mnodeman.stable_size());
     obj.pushKV("enabled", mnodeman.CountEnabled());
     obj.pushKV("inqueue", nCount);


### PR DESCRIPTION
Fixes the following inconsistency (https://github.com/PIVX-Project/PIVX/runs/1491040884):
```
  2020-12-03 07:55:03 POTENTIAL DEADLOCK DETECTED
  2020-12-03 07:55:03 Previous lock order was:
  2020-12-03 07:55:03  (1) cs masternodeman.cpp:481 (in thread pivx-msghand)
  2020-12-03 07:55:03  (2) cs_mapMasternodeBlocks masternode-payments.cpp:483 (in thread pivx-msghand)
  2020-12-03 07:55:03 Current lock order is:
  2020-12-03 07:55:03  cs_mapMasternodePayeeVotes masternode-payments.cpp:619 (in thread pivx-masternodeman)
  2020-12-03 07:55:03  (2) cs_mapMasternodeBlocks masternode-payments.cpp:619 (in thread pivx-masternodeman)
```

Remove the "cleanup" during DB read (move it at the beginning of the thread).
Pass the masternode-count and current-height to `CleanPaymentList`, so there is no call to the masternode manager from within it.

Note: GA will keep failing as there are other locking issues. They will be addressed in separate PR(s).