### PR TITLE
[BUG] GetLastPaid/SecondsSincePayment locking cs_main

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -178,12 +178,12 @@ CMasternode::state CMasternode::GetActiveState() const
     return MASTERNODE_ENABLED;
 }
 
-int64_t CMasternode::SecondsSincePayment() const
+int64_t CMasternode::SecondsSincePayment(const CBlockIndex* BlockReading) const
 {
     CScript pubkeyScript;
     pubkeyScript = GetScriptForDestination(pubKeyCollateralAddress.GetID());
 
-    int64_t sec = (GetAdjustedTime() - GetLastPaid());
+    int64_t sec = (GetAdjustedTime() - GetLastPaid(BlockReading));
     int64_t month = 60 * 60 * 24 * 30;
     if (sec < month) return sec; //if it's less than 30 days, give seconds
 
@@ -196,9 +196,8 @@ int64_t CMasternode::SecondsSincePayment() const
     return month + hash.GetCompact(false);
 }
 
-int64_t CMasternode::GetLastPaid() const
+int64_t CMasternode::GetLastPaid(const CBlockIndex* BlockReading) const
 {
-    const CBlockIndex* BlockReading = GetChainTip();
     if (BlockReading == nullptr) return false;
 
     CScript mnpayee;

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -202,8 +202,6 @@ public:
         Unserialize(s);
     }
 
-    int64_t SecondsSincePayment(const CBlockIndex* BlockReading) const;
-
     bool UpdateFromNewBroadcast(CMasternodeBroadcast& mnb);
 
     CMasternode::state GetActiveState() const;
@@ -256,7 +254,6 @@ public:
         return strprintf("INVALID_%d", activeState);
     }
 
-    int64_t GetLastPaid(const CBlockIndex* BlockReading) const;
     bool IsValidNetAddr() const;
 
     /// Is the input associated with collateral public key? (and there is 10000 PIV - checking if valid masternode)

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -202,7 +202,7 @@ public:
         Unserialize(s);
     }
 
-    int64_t SecondsSincePayment() const;
+    int64_t SecondsSincePayment(const CBlockIndex* BlockReading) const;
 
     bool UpdateFromNewBroadcast(CMasternodeBroadcast& mnb);
 
@@ -256,7 +256,7 @@ public:
         return strprintf("INVALID_%d", activeState);
     }
 
-    int64_t GetLastPaid() const;
+    int64_t GetLastPaid(const CBlockIndex* BlockReading) const;
     bool IsValidNetAddr() const;
 
     /// Is the input associated with collateral public key? (and there is 10000 PIV - checking if valid masternode)

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -43,8 +43,8 @@ struct CompareScoreTxIn {
 };
 
 struct CompareScoreMN {
-    bool operator()(const std::pair<int64_t, CMasternode>& t1,
-        const std::pair<int64_t, CMasternode>& t2) const
+    bool operator()(const std::pair<int64_t, MasternodeRef>& t1,
+        const std::pair<int64_t, MasternodeRef>& t2) const
     {
         return t1.first < t2.first;
     }
@@ -636,9 +636,9 @@ int CMasternodeMan::GetMasternodeRank(const CTxIn& vin, int64_t nBlockHeight, in
     return -1;
 }
 
-std::vector<std::pair<int64_t, CMasternode>> CMasternodeMan::GetMasternodeRanks(int nBlockHeight) const
+std::vector<std::pair<int64_t, MasternodeRef>> CMasternodeMan::GetMasternodeRanks(int nBlockHeight) const
 {
-    std::vector<std::pair<int64_t, CMasternode>> vecMasternodeScores;
+    std::vector<std::pair<int64_t, MasternodeRef>> vecMasternodeScores;
     const uint256& hash = GetHashAtHeight(nBlockHeight - 1);
     // height outside range
     if (!hash) return vecMasternodeScores;
@@ -648,12 +648,12 @@ std::vector<std::pair<int64_t, CMasternode>> CMasternodeMan::GetMasternodeRanks(
         for (const auto& it : mapMasternodes) {
             const MasternodeRef& mn = it.second;
             if (!mn->IsEnabled()) {
-                vecMasternodeScores.emplace_back(9999, *mn);
+                vecMasternodeScores.emplace_back(9999, mn);
                 continue;
             }
 
             int64_t n2 = mn->CalculateScore(hash).GetCompact(false);
-            vecMasternodeScores.emplace_back(n2, *mn);
+            vecMasternodeScores.emplace_back(n2, mn);
         }
     }
     sort(vecMasternodeScores.rbegin(), vecMasternodeScores.rend(), CompareScoreMN());

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -478,6 +478,8 @@ void CMasternodeMan::CheckSpentCollaterals(const std::vector<CTransactionRef>& v
 //
 const CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight, bool fFilterSigTime, int& nCount) const
 {
+    AssertLockNotHeld(cs_main);
+    const CBlockIndex* BlockReading = GetChainTip();
     LOCK(cs);
 
     const CMasternode* pBestMasternode = nullptr;
@@ -504,7 +506,7 @@ const CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlock
         //make sure it has as many confirmations as there are masternodes
         if (pcoinsTip->GetCoinDepthAtHeight(mn->vin.prevout, nBlockHeight) < nMnCount) continue;
 
-        vecMasternodeLastPaid.emplace_back(mn->SecondsSincePayment(), mn->vin);
+        vecMasternodeLastPaid.emplace_back(mn->SecondsSincePayment(BlockReading), mn->vin);
     }
 
     nCount = (int)vecMasternodeLastPaid.size();

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -153,7 +153,7 @@ public:
     std::vector<std::pair<MasternodeRef, int>> GetMnScores(int nLast) const;
 
     // Retrieve the known masternodes ordered by scoring without checking them. (Only used for listmasternodes RPC call)
-    std::vector<std::pair<int64_t, CMasternode>> GetMasternodeRanks(int nBlockHeight) const;
+    std::vector<std::pair<int64_t, MasternodeRef>> GetMasternodeRanks(int nBlockHeight) const;
     int GetMasternodeRank(const CTxIn& vin, int64_t nBlockHeight, int minProtocol = 0, bool fOnlyActive = true) const;
 
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -174,6 +174,10 @@ public:
     /// Update masternode list and maps using provided CMasternodeBroadcast
     void UpdateMasternodeList(CMasternodeBroadcast mnb);
 
+    /// Get the time a masternode was last paid
+    int64_t GetLastPaid(const MasternodeRef& mn, const CBlockIndex* BlockReading) const;
+    int64_t SecondsSincePayment(const MasternodeRef& mn, const CBlockIndex* BlockReading) const;
+
     // Block hashes cycling vector management
     void CacheBlockHash(const CBlockIndex* pindex);
     void UncacheBlockHash(const CBlockIndex* pindex);

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -138,11 +138,12 @@ UniValue listmasternodes(const JSONRPCRequest& request)
     if (!chainTip) return "[]";
     int nHeight = chainTip->nHeight;
 
+    // !todo: return masternodeRef with ranks
     std::vector<std::pair<int64_t, CMasternode>> vMasternodeRanks = mnodeman.GetMasternodeRanks(nHeight);
     for (int pos=0; pos < (int) vMasternodeRanks.size(); pos++) {
         const auto& s = vMasternodeRanks[pos];
         UniValue obj(UniValue::VOBJ);
-        CMasternode mn = s.second;
+        const CMasternode& mn = s.second;
 
         std::string strVin = mn.vin.prevout.ToStringShort();
         std::string strTxHash = mn.vin.prevout.hash.ToString();
@@ -170,7 +171,7 @@ UniValue listmasternodes(const JSONRPCRequest& request)
         obj.pushKV("version", mn.protocolVersion);
         obj.pushKV("lastseen", (int64_t)mn.lastPing.sigTime);
         obj.pushKV("activetime", (int64_t)(mn.lastPing.sigTime - mn.sigTime));
-        obj.pushKV("lastpaid", (int64_t)mn.GetLastPaid(chainTip));
+        obj.pushKV("lastpaid", (int64_t)mnodeman.GetLastPaid(std::make_shared<CMasternode>(mn), chainTip));
 
         ret.push_back(obj);
     }

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -138,12 +138,11 @@ UniValue listmasternodes(const JSONRPCRequest& request)
     if (!chainTip) return "[]";
     int nHeight = chainTip->nHeight;
 
-    // !todo: return masternodeRef with ranks
-    std::vector<std::pair<int64_t, CMasternode>> vMasternodeRanks = mnodeman.GetMasternodeRanks(nHeight);
+    std::vector<std::pair<int64_t, MasternodeRef>> vMasternodeRanks = mnodeman.GetMasternodeRanks(nHeight);
     for (int pos=0; pos < (int) vMasternodeRanks.size(); pos++) {
         const auto& s = vMasternodeRanks[pos];
         UniValue obj(UniValue::VOBJ);
-        const CMasternode& mn = s.second;
+        const CMasternode& mn = *(s.second);
 
         std::string strVin = mn.vin.prevout.ToStringShort();
         std::string strTxHash = mn.vin.prevout.hash.ToString();
@@ -171,7 +170,7 @@ UniValue listmasternodes(const JSONRPCRequest& request)
         obj.pushKV("version", mn.protocolVersion);
         obj.pushKV("lastseen", (int64_t)mn.lastPing.sigTime);
         obj.pushKV("activetime", (int64_t)(mn.lastPing.sigTime - mn.sigTime));
-        obj.pushKV("lastpaid", (int64_t)mnodeman.GetLastPaid(std::make_shared<CMasternode>(mn), chainTip));
+        obj.pushKV("lastpaid", (int64_t)mnodeman.GetLastPaid(s.second, chainTip));
 
         ret.push_back(obj);
     }

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -134,8 +134,9 @@ UniValue listmasternodes(const JSONRPCRequest& request)
             HelpExampleCli("listmasternodes", "") + HelpExampleRpc("listmasternodes", ""));
 
     UniValue ret(UniValue::VARR);
-    int nHeight = WITH_LOCK(cs_main, return chainActive.Height());
-    if (nHeight < 0) return "[]";
+    const CBlockIndex* chainTip = GetChainTip();
+    if (!chainTip) return "[]";
+    int nHeight = chainTip->nHeight;
 
     std::vector<std::pair<int64_t, CMasternode>> vMasternodeRanks = mnodeman.GetMasternodeRanks(nHeight);
     for (int pos=0; pos < (int) vMasternodeRanks.size(); pos++) {
@@ -169,7 +170,7 @@ UniValue listmasternodes(const JSONRPCRequest& request)
         obj.pushKV("version", mn.protocolVersion);
         obj.pushKV("lastseen", (int64_t)mn.lastPing.sigTime);
         obj.pushKV("activetime", (int64_t)(mn.lastPing.sigTime - mn.sigTime));
-        obj.pushKV("lastpaid", (int64_t)mn.GetLastPaid());
+        obj.pushKV("lastpaid", (int64_t)mn.GetLastPaid(chainTip));
 
         ret.push_back(obj);
     }


### PR DESCRIPTION
Fixing
```
2019-10-31 22:53:22 POTENTIAL DEADLOCK DETECTED
2019-10-31 22:53:22 Previous lock order was:
2019-10-31 22:53:22  (1) cs masternodeman.cpp:481 (in thread pivx-msghand)
2019-10-31 22:53:22  (2) cs_main validation.cpp:193 (in thread pivx-msghand)
2019-10-31 22:53:22 Current lock order is:
2019-10-31 22:53:22  (2) cs_main validation.cpp:2318 (TRY) (in thread )
2019-10-31 22:53:22  (1) cs masternodeman.cpp:465 (in thread )
```

Move `GetLastPaid`/`SecondsSincePayment` to the manager and clean up.