### PR TITLE
[Sapling] Try to recover corruption of notes cache during send operation

### DIFF
--- a/src/sapling/sapling_operation.cpp
+++ b/src/sapling/sapling_operation.cpp
@@ -364,7 +364,7 @@ static CacheCheckResult CheckCachedNote(const SaplingNoteEntry& t, const libzcas
             LogPrintf("ERROR: Unable to recover nullifier for note %s.\n", noteStr);
             return CacheCheckResult::INVALID;
         }
-        sspkm->UpdateSaplingNullifierNoteMap(nd, t.op, nf);
+        WITH_LOCK(pwalletMain->cs_wallet, sspkm->UpdateSaplingNullifierNoteMap(nd, t.op, nf));
         // re-check the spent status
         if (sspkm->IsSaplingSpent(*(nd.nullifier))) {
             LogPrintf("Removed note %s as it appears to be already spent.\n", noteStr);

--- a/src/sapling/sapling_operation.cpp
+++ b/src/sapling/sapling_operation.cpp
@@ -368,6 +368,9 @@ static CacheCheckResult CheckCachedNote(const SaplingNoteEntry& t, const libzcas
         // re-check the spent status
         if (sspkm->IsSaplingSpent(*(nd.nullifier))) {
             LogPrintf("Removed note %s as it appears to be already spent.\n", noteStr);
+            prevTx.MarkDirty();
+            CWalletDB(pwalletMain->strWalletFile, "r+").WriteTx(prevTx);
+            pwalletMain->NotifyTransactionChanged(pwalletMain, t.op.hash, CT_UPDATED);
             return CacheCheckResult::SPENT;
         }
     }

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -46,6 +46,7 @@ void SaplingScriptPubKeyMan::UpdateSaplingNullifierNoteMapForBlock(const CBlock 
 // Updates noteData and mapSaplingNullifiersToNotes directly
 void SaplingScriptPubKeyMan::UpdateSaplingNullifierNoteMap(SaplingNoteData& nd, const SaplingOutPoint& op, const Optional<uint256>& nullifier)
 {
+    AssertLockHeld(wallet->cs_wallet);
     nd.nullifier = nullifier;
     if (nullifier) mapSaplingNullifiersToNotes[*nullifier] = op;
 }

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -43,6 +43,13 @@ void SaplingScriptPubKeyMan::UpdateSaplingNullifierNoteMapForBlock(const CBlock 
     }
 }
 
+// Updates noteData and mapSaplingNullifiersToNotes directly
+void SaplingScriptPubKeyMan::UpdateSaplingNullifierNoteMap(SaplingNoteData& nd, const SaplingOutPoint& op, const Optional<uint256>& nullifier)
+{
+    nd.nullifier = nullifier;
+    if (nullifier) mapSaplingNullifiersToNotes[*nullifier] = op;
+}
+
 /**
  * Update mapSaplingNullifiersToNotes, computing the nullifier from a cached witness if necessary.
  */
@@ -50,15 +57,15 @@ void SaplingScriptPubKeyMan::UpdateSaplingNullifierNoteMapWithTx(CWalletTx& wtx)
     LOCK(wallet->cs_wallet);
 
     for (mapSaplingNoteData_t::value_type &item : wtx.mapSaplingNoteData) {
-        SaplingOutPoint op = item.first;
-        SaplingNoteData nd = item.second;
+        const SaplingOutPoint& op = item.first;
+        SaplingNoteData& nd = item.second;
 
         if (nd.witnesses.empty() || !nd.IsMyNote()) {
             // If there are no witnesses, erase the nullifier and associated mapping.
-            if (item.second.nullifier) {
+            if (nd.nullifier) {
                 mapSaplingNullifiersToNotes.erase(item.second.nullifier.get());
             }
-            item.second.nullifier = boost::none;
+            nd.nullifier = boost::none;
         } else {
             const libzcash::SaplingIncomingViewingKey& ivk = *(nd.ivk);
             uint64_t position = nd.witnesses.front().position();
@@ -79,9 +86,7 @@ void SaplingScriptPubKeyMan::UpdateSaplingNullifierNoteMapWithTx(CWalletTx& wtx)
                 // This should not happen.  If it does, maybe the position has been corrupted or miscalculated?
                 assert(false);
             }
-            uint256 nullifier = optNullifier.get();
-            mapSaplingNullifiersToNotes[nullifier] = op;
-            item.second.nullifier = nullifier;
+            UpdateSaplingNullifierNoteMap(nd, op, optNullifier.get());
         }
     }
 }

--- a/src/sapling/saplingscriptpubkeyman.h
+++ b/src/sapling/saplingscriptpubkeyman.h
@@ -174,6 +174,12 @@ public:
     void UpdateNullifierNoteMapWithTx(const CWalletTx& wtx);
 
     /**
+     *  Update mapSaplingNullifiersToNotes, and NoteData of a specific outpoint,
+     *  directly with nullifier provided by the caller.
+     */
+    void UpdateSaplingNullifierNoteMap(SaplingNoteData& nd, const SaplingOutPoint& op, const Optional<uint256>& nullifier);
+
+    /**
      *  Update mapSaplingNullifiersToNotes, computing the nullifier
      *  from a cached witness if necessary.
      */

--- a/src/test/librust/sapling_rpc_wallet_tests.cpp
+++ b/src/test/librust/sapling_rpc_wallet_tests.cpp
@@ -27,9 +27,6 @@
 
 extern UniValue CallRPC(std::string args); // Implemented in rpc_tests.cpp
 
-// Remember: this method will be moved to an utility file in the short future. For now, it's in sapling_keystore_tests.cpp
-extern libzcash::SaplingExtendedSpendingKey GetTestMasterSaplingSpendingKey();
-
 namespace {
 
     /** Set the working directory for the duration of the scope. */

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1446,7 +1446,7 @@ CAmount CWalletTx::GetCredit(const isminefilter& filter, bool recalculate) const
         credit += GetCachableAmount(CREDIT, ISMINE_SPENDABLE_DELEGATED, recalculate);
     }
     if (filter & ISMINE_SPENDABLE_SHIELDED) {
-        credit += GetCachableAmount(CREDIT, ISMINE_SPENDABLE_SHIELDED);
+        credit += GetCachableAmount(CREDIT, ISMINE_SPENDABLE_SHIELDED, recalculate);
     }
     return credit;
 }


### PR DESCRIPTION
This is a contingency plan, in case of missing cached nullifier of a spent note in the wallet.
Since, during the spend, the wallet is unlocked, and we have the spending key, we can directly recover the nullifier from the note (provided that we have a valid cached witness) and fix the issue in the background, without requiring any user intervention.

If we don't have the witness, we can still provide a better log and error message in the gui, than a generic, and probably obscure
```
bad-txns-shielded-requirements-not-met
```