### PR TITLE
[P2P] When clearing addrman clear mapInfo and mapAddr

### DIFF
--- a/src/addrman.h
+++ b/src/addrman.h
@@ -480,6 +480,8 @@ public:
         nTried = 0;
         nNew = 0;
         nLastGood = 1; //Initially at 1 so that "never" is strictly worse.
+        mapInfo.clear();
+        mapAddr.clear();
     }
 
     CAddrMan()


### PR DESCRIPTION
Another quick one, from bitcoin/bitcoin#11252

> Power failure on my machine resulted in a corrupted addrman that would hit bad assertions when trying to serialize the "cleared" addrman to disk: