### PR TITLE
[GUI] Workaround to the MN MISSING/REMOVE labeling

### DIFF
--- a/src/qt/pivx/mnmodel.cpp
+++ b/src/qt/pivx/mnmodel.cpp
@@ -87,7 +87,19 @@ QVariant MNModel::data(const QModelIndex &index, int role) const
                 return (isAvailable) ? QString::number(rec->vin.prevout.n) : "Not available";
             case STATUS: {
                 std::pair<QString, CMasternode*> pair = nodes.values().value(row);
-                return (pair.second) ? QString::fromStdString(pair.second->Status()) : "MISSING";
+                std::string status = "MISSING";
+                if (pair.second) {
+                    status = pair.second->Status();
+                    // Quick workaround to the current Masternode status types.
+                    // If the status is REMOVE and there is no pubkey associated to the Masternode
+                    // means that the MN is not in the network list and was created in
+                    // updateMNList(). Which.. denotes a not started masternode.
+                    // This will change in the future with the MasternodeWrapper introduction.
+                    if (status == "REMOVE" && !pair.second->pubKeyCollateralAddress.IsValid()) {
+                        return "MISSING";
+                    }
+                }
+                return QString::fromStdString(status);
             }
             case PRIV_KEY: {
                 for (CMasternodeConfig::CMasternodeEntry mne : masternodeConfig.getEntries()) {


### PR DESCRIPTION
As #2019 got little bit big and we are entering into a freeze period, this is a quick fix to the "MISSING" state invalidly shown as "REMOVE" in the masternodes screen. Introduced by #2006.
 This affects the GUI as it makes masternodes that are not started to appear as "REMOVE" instead of "MISSING" as it was before (could be a MN in the configuration file only or even with the collateral accepted but not started).

