### PR TITLE
doc: Windows WSL build recommendation to temporarily disable Win32 PE support

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -92,15 +92,22 @@ Note that for WSL the Pivx Core source path MUST be somewhere in the default mou
 example /usr/src/pivx, AND not under /mnt/d/. If this is not the case the dependency autoconf scripts will fail.
 This means you cannot use a directory that is located directly on the host Windows file system to perform the build.
 
+Additional WSL Note: WSL support for [launching Win32 applications](https://docs.microsoft.com/en-us/archive/blogs/wsl/windows-and-ubuntu-interoperability#launching-win32-applications-from-within-wsl)
+results in `Autoconf` configure scripts being able to execute Windows Portable Executable files. This can cause
+unexpected behaviour during the build, such as Win32 error dialogs for missing libraries. The recommended approach
+is to temporarily disable WSL support for Win32 applications.
+
 Build using:
 
     PATH=$(echo "$PATH" | sed -e 's/:\/mnt.*//g') # strip out problematic Windows %PATH% imported var
+    sudo bash -c "echo 0 > /proc/sys/fs/binfmt_misc/status" # Disable WSL support for Win32 applications.
     cd depends
     make HOST=x86_64-w64-mingw32
     cd ..
     ./autogen.sh # not required when building from tarball
     CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site ./configure --prefix=/
     make
+    sudo bash -c "echo 1 > /proc/sys/fs/binfmt_misc/status" # Enable WSL support for Win32 applications.
 
 ## Depends system
 


### PR DESCRIPTION
This is a cherry-pick from Bitcoin upstream. 

bitcoin/bitcoin#19408
```
This is a solution for the issues described in #17277 and #18348

When cross compiling Bitcoin Code for Windows the Autoconf configure scripts attempt to execute Win32 PE files. The configure scripts expect the attempt to fail, however, WSL supports forking the execution of Win32 PE files out to the underlying Windows OS. This can result in the executions failing for unanticipated reasons, which is the case in the two referenced issues.

This PR adds an explanatory note and additional instructions to temporarily disable WLS's Win32 support.
```

Anyways I am making a pull request for this as it would be nice to be able to cross-compile pivx using the docs in the repo instead of checking bitcoin upstream for fixes and such.