### PR TITLE
[GUI][Trivial] Adjust CoinControl column widths for readability

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -165,12 +165,12 @@ CoinControlDialog::CoinControlDialog(QWidget* parent, bool _forDelegation) : QDi
     // Toggle lock state
     connect(ui->pushButtonToggleLock, &QPushButton::clicked, this, &CoinControlDialog::buttonToggleLockClicked);
 
-    ui->treeWidget->setColumnWidth(COLUMN_CHECKBOX, 84);
-    ui->treeWidget->setColumnWidth(COLUMN_AMOUNT, 120);
-    ui->treeWidget->setColumnWidth(COLUMN_LABEL, 170);
+    ui->treeWidget->setColumnWidth(COLUMN_CHECKBOX, 100);
+    ui->treeWidget->setColumnWidth(COLUMN_AMOUNT, 110);
+    ui->treeWidget->setColumnWidth(COLUMN_LABEL, 160);
     ui->treeWidget->setColumnWidth(COLUMN_ADDRESS, 310);
-    ui->treeWidget->setColumnWidth(COLUMN_DATE, 100);
-    ui->treeWidget->setColumnWidth(COLUMN_CONFIRMATIONS, 100);
+    ui->treeWidget->setColumnWidth(COLUMN_DATE, 145);
+    ui->treeWidget->setColumnWidth(COLUMN_CONFIRMATIONS, 65);
     ui->treeWidget->setColumnHidden(COLUMN_TXHASH, true);         // store transacton hash in this column, but dont show it
     ui->treeWidget->setColumnHidden(COLUMN_VOUT_INDEX, true);     // store vout index in this column, but dont show it
 


### PR DESCRIPTION
For example, if user is running a masternode, after 100+ days of receiving rewards and not moving them, there will be more than 100 different UTXOs. Default column width when starting a wallet is currently not wide enough to show 3 digit amount of UTXOs. This PR fixes it.

**Before:**
![before01](https://user-images.githubusercontent.com/57232689/101265971-61ee1580-374b-11eb-9874-b4cd791bcad2.JPG)

**After:**
![After01](https://user-images.githubusercontent.com/57232689/101265975-64e90600-374b-11eb-9b24-e5034d3c418a.JPG)