### PR TITLE
[SSPKM] Crash fix, external notes witness decrement

### DIFF
--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -263,6 +263,8 @@ void DecrementNoteWitnesses(NoteDataMap& noteDataMap, int indexHeight, int64_t n
 {
     for (auto& item : noteDataMap) {
         auto* nd = &(item.second);
+        // skip externally sent notes
+        if (!nd->IsMyNote()) continue;
         // Only decrement witnesses that are not above the current height
         if (nd->witnessHeight <= indexHeight) {
             // Check the validity of the cache


### PR DESCRIPTION
On block disconnection, notes that aren't from the wallet are currently passing through the witness decrement process causing a crash on reorgs. The note data cached height will be different than the disconnected block height, `witnessHeight` is never updated for external notes as them don't need a witness at all.