### PR TITLE
[BUG][GUI] TxDetail dialog memo: plain text edit + copy button

### DIFF
--- a/src/qt/pivx/forms/sendconfirmdialog.ui
+++ b/src/qt/pivx/forms/sendconfirmdialog.ui
@@ -181,7 +181,7 @@
         <property name="minimumSize">
          <size>
           <width>0</width>
-          <height>0</height>
+          <height>450</height>
          </size>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -217,9 +217,9 @@ background:transparent;
             <property name="geometry">
              <rect>
               <x>0</x>
-              <y>-217</y>
+              <y>0</y>
               <width>586</width>
-              <height>737</height>
+              <height>700</height>
              </rect>
             </property>
             <property name="autoFillBackground">
@@ -931,17 +931,20 @@ background:transparent;
                 <item>
                  <widget class="QWidget" name="contentMemo" native="true">
                   <layout class="QVBoxLayout" name="contentMemo_layout">
+                   <property name="spacing">
+                    <number>0</number>
+                   </property>
                    <property name="leftMargin">
                     <number>0</number>
                    </property>
                    <property name="topMargin">
-                    <number>9</number>
+                    <number>0</number>
                    </property>
                    <property name="rightMargin">
                     <number>0</number>
                    </property>
                    <property name="bottomMargin">
-                    <number>9</number>
+                    <number>0</number>
                    </property>
                    <item>
                     <layout class="QHBoxLayout" name="horizontalLayout_2">

--- a/src/qt/pivx/forms/sendconfirmdialog.ui
+++ b/src/qt/pivx/forms/sendconfirmdialog.ui
@@ -217,9 +217,9 @@ background:transparent;
             <property name="geometry">
              <rect>
               <x>0</x>
-              <y>-130</y>
+              <y>-217</y>
               <width>586</width>
-              <height>650</height>
+              <height>737</height>
              </rect>
             </property>
             <property name="autoFillBackground">
@@ -944,24 +944,77 @@ background:transparent;
                     <number>9</number>
                    </property>
                    <item>
-                    <widget class="QLabel" name="labelMemo">
-                     <property name="maximumSize">
-                      <size>
-                       <width>16777215</width>
-                       <height>16777215</height>
-                      </size>
+                    <layout class="QHBoxLayout" name="horizontalLayout_2">
+                     <property name="spacing">
+                      <number>0</number>
                      </property>
-                     <property name="text">
-                      <string>Memo</string>
-                     </property>
-                    </widget>
+                     <item>
+                      <widget class="QLabel" name="labelMemo">
+                       <property name="maximumSize">
+                        <size>
+                         <width>16777215</width>
+                         <height>16777215</height>
+                        </size>
+                       </property>
+                       <property name="text">
+                        <string>Memo</string>
+                       </property>
+                       <property name="alignment">
+                        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QPushButton" name="pushCopyMemo">
+                       <property name="minimumSize">
+                        <size>
+                         <width>34</width>
+                         <height>34</height>
+                        </size>
+                       </property>
+                       <property name="maximumSize">
+                        <size>
+                         <width>34</width>
+                         <height>34</height>
+                        </size>
+                       </property>
+                       <property name="focusPolicy">
+                        <enum>Qt::NoFocus</enum>
+                       </property>
+                       <property name="text">
+                        <string/>
+                       </property>
+                       <property name="iconSize">
+                        <size>
+                         <width>18</width>
+                         <height>18</height>
+                        </size>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
                    </item>
                    <item>
-                    <widget class="QLabel" name="textMemo">
-                     <property name="text">
-                      <string>No memo</string>
+                    <widget class="QPlainTextEdit" name="textMemo">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
                      </property>
-                     <property name="wordWrap">
+                     <property name="verticalScrollBarPolicy">
+                      <enum>Qt::ScrollBarAsNeeded</enum>
+                     </property>
+                     <property name="horizontalScrollBarPolicy">
+                      <enum>Qt::ScrollBarAlwaysOff</enum>
+                     </property>
+                     <property name="sizeAdjustPolicy">
+                      <enum>QAbstractScrollArea::AdjustToContents</enum>
+                     </property>
+                     <property name="undoRedoEnabled">
+                      <bool>false</bool>
+                     </property>
+                     <property name="readOnly">
                       <bool>true</bool>
                      </property>
                     </widget>

--- a/src/qt/pivx/res/css/style_dark.css
+++ b/src/qt/pivx/res/css/style_dark.css
@@ -1745,6 +1745,13 @@ HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH*/
     color: #FFFFFF;
 }
 
+*[cssClass="edit-primary-no-border"] {
+    border: 0px;
+    background-color:#0f0b16;
+    font-size:15px;
+    color: #B3FFFFFF;
+}
+
 QPushButton[cssClass="btn-expand"] {
     background-image: url("://ic-expand");
     background-position:center;

--- a/src/qt/pivx/res/css/style_light.css
+++ b/src/qt/pivx/res/css/style_light.css
@@ -1753,6 +1753,13 @@ QPushButton[cssClass="btn-expand"] {
     background-color:#FFFFFF;
 }
 
+*[cssClass="edit-primary-no-border"] {
+    border: 0px;
+    background-color:#ffffff;
+    font-size:15px;
+    color: #707070;
+}
+
 
 /*HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH
 HH      SPLASH

--- a/src/qt/pivx/send.cpp
+++ b/src/qt/pivx/send.cpp
@@ -496,7 +496,7 @@ bool SendWidget::sendFinalStep()
     dialog->setDisplayUnit(walletModel->getOptionsModel()->getDisplayUnit());
     dialog->setData(walletModel, ptrModelTx);
     dialog->adjustSize();
-    openDialogWithOpaqueBackgroundY(dialog, window, 3, 5);
+    openDialogWithOpaqueBackgroundY(dialog, window, 3, 15);
 
     if (dialog->isConfirm()) {
         // now send the prepared transaction

--- a/src/qt/pivx/sendconfirmdialog.cpp
+++ b/src/qt/pivx/sendconfirmdialog.cpp
@@ -139,9 +139,11 @@ void TxDetailDialog::setData(WalletModel *_model, const QModelIndex &index)
             ui->textMemo->insertPlainText(QString::fromStdString(*rec->memo));
             ui->contentMemo->setVisible(true);
             ui->labelDividerMemo->setVisible(true);
+            ui->textMemo->adjustSize();
         } else {
             ui->contentMemo->setVisible(false);
             ui->labelDividerMemo->setVisible(false);
+            adjustSize();
         }
 
         connect(ui->pushCopy, &QPushButton::clicked, [this](){

--- a/src/qt/pivx/sendconfirmdialog.cpp
+++ b/src/qt/pivx/sendconfirmdialog.cpp
@@ -33,7 +33,7 @@ TxDetailDialog::TxDetailDialog(QWidget *parent, bool _isConfirmDialog, const QSt
     setCssProperty({ui->labelDividerID, ui->labelDividerOutputs, ui->labelDividerPrevtx, ui->labelDividerFeeSize, ui->labelDividerChange, ui->labelDividerConfs, ui->labelDividerMemo}, "container-divider");
     setCssProperty({ui->textAmount, ui->textSendLabel, ui->textInputs, ui->textFee, ui->textChange, ui->textId, ui->textSize, ui->textStatus, ui->textConfirmations, ui->textDate, ui->textMemo} , "text-body3-dialog");
 
-    setCssProperty(ui->pushCopy, "ic-copy-big");
+    setCssProperty({ui->pushCopy, ui->pushCopyMemo}, "ic-copy-big");
     setCssProperty({ui->pushInputs, ui->pushOutputs}, "ic-arrow-down");
     setCssProperty(ui->btnEsc, "ic-close");
 
@@ -44,6 +44,9 @@ TxDetailDialog::TxDetailDialog(QWidget *parent, bool _isConfirmDialog, const QSt
     // hide change address for now
     ui->contentChangeAddress->setVisible(false);
     ui->labelDividerChange->setVisible(false);
+
+    // Memo text
+    ui->textMemo->setProperty("cssClass","edit-primary-no-border");
 
     setCssProperty({ui->labelOutputIndex, ui->textSend, ui->labelTitlePrevTx}, "text-body2-dialog");
 
@@ -133,7 +136,7 @@ void TxDetailDialog::setData(WalletModel *_model, const QModelIndex &index)
 
         // If there is a memo in this record
         if (rec->memo) {
-            ui->textMemo->setText(QString::fromStdString(*rec->memo));
+            ui->textMemo->insertPlainText(QString::fromStdString(*rec->memo));
             ui->contentMemo->setVisible(true);
             ui->labelDividerMemo->setVisible(true);
         } else {
@@ -145,6 +148,14 @@ void TxDetailDialog::setData(WalletModel *_model, const QModelIndex &index)
             GUIUtil::setClipboard(QString::fromStdString(this->txHash.GetHex()));
             if (!snackBar) snackBar = new SnackBar(nullptr, this);
             snackBar->setText(tr("ID copied"));
+            snackBar->resize(this->width(), snackBar->height());
+            openDialog(snackBar, this);
+        });
+
+        connect(ui->pushCopyMemo, &QPushButton::clicked, [this, rec](){
+            GUIUtil::setClipboard(QString::fromStdString(*rec->memo));
+            if (!snackBar) snackBar = new SnackBar(nullptr, this);
+            snackBar->setText(tr("Memo copied"));
             snackBar->resize(this->width(), snackBar->height());
             openDialog(snackBar, this);
         });
@@ -195,7 +206,7 @@ void TxDetailDialog::setData(WalletModel *_model, WalletModelTransaction* _tx)
 
         // If there is a single output, then show the memo.
         if (!recipient.message.isEmpty()) {
-            ui->textMemo->setText(recipient.message);
+            ui->textMemo->insertPlainText(recipient.message);
             ui->contentMemo->setVisible(true);
             ui->labelDividerMemo->setVisible(true);
         } else {


### PR DESCRIPTION
**Problem:**
Memo word-wrap in the txdetails dialog works only with white-spaces.
But with a single too-long word the frame is stretched, messing up the layout:

<img src="https://user-images.githubusercontent.com/18186894/101272965-6dfcc600-3791-11eb-830d-fd1e14508ef2.png" width=500>

**Fix:** 
switch from QLabel to QPlainTextEdit (read-only), so the text is properly wrapped, and can also be conveniently selected for copying specific parts.
To copy the whole message, a copy-to-clipboard button is also added:

<img src="https://user-images.githubusercontent.com/18186894/101274159-13b53280-379c-11eb-9b8b-b08176951039.png" width=500>


Big thanks to @NoobieDev12 for his extensive testing of all the features :pray: 
