### PR TITLE
[Build] Proper coverage for ppa, local, and snapcraft

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -14,6 +14,7 @@ description: |
   - [Download](https://pivx.org/wp-content/uploads/2018/10/PIVX-White.pdf) PIVX White Paper PDF
 grade: devel
 confinement: strict
+
 apps:
   daemon:
     command: pivxd
@@ -30,7 +31,7 @@ apps:
       XDG_DATA_DIRS: $SNAP_USER_DATA:$SNAP/usr/share:$XDG_DATA_DIRS
       HOME: $SNAP_USER_COMMON
   qt:
-    command: pivx-qt
+    command: desktop-launch pivx-qt
     plugs: [network, network-bind, network-status, unity7, desktop, desktop-legacy, wayland, x11, mir, opengl, home, gsettings, removable-media, screen-inhibit-control, pulseaudio, media-hub]
     desktop: pivx-qt.desktop
     environment:
@@ -38,7 +39,7 @@ apps:
       XDG_DATA_DIRS: $SNAP_USER_DATA:$SNAP/usr/share:$XDG_DATA_DIRS
       HOME: $SNAP_USER_COMMON
   qt-testnet:
-    command: pivx-qt --testnet
+    command: desktop-launch pivx-qt --testnet
     plugs: [network, network-bind, network-status, unity7, desktop, desktop-legacy, wayland, x11, mir, opengl, home, gsettings, removable-media, screen-inhibit-control, pulseaudio, media-hub]
     desktop: pivx-qt_testnet.desktop
     environment:
@@ -66,7 +67,44 @@ apps:
   testqt:
     command: test_pivx-qt
     plugs: [home]
+
+layout:
+  /usr/share/pivx/sapling-spend.params:
+    bind-file: $SNAP/share/pivx/sapling-spend.params
+  /usr/share/pivx/sapling-output.params:
+    bind-file: $SNAP/share/pivx/sapling-output.params
+
 parts:
+
+  # Remote part for support of various desktop technologies
+  # Refer: https://github.com/ubuntu/snapcraft-desktop-helpers/blob/master/snapcraft.yaml
+  desktop-qt5:
+    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
+    source-depth: 1
+    source-subdir: qt
+
+    plugin: make
+    make-parameters: [ "FLAVOR=qt5" ]
+    build-packages:
+      - build-essential
+      - qtbase5-dev
+      - dpkg-dev
+    stage-packages:
+      - libxkbcommon0
+      - ttf-ubuntu-font-family
+      - dmz-cursor-theme
+      - light-themes
+      - adwaita-icon-theme
+      - gnome-themes-standard
+      - shared-mime-info
+      - libqt5gui5
+      - libgdk-pixbuf2.0-0
+      - libqt5svg5 # for loading icon themes which are svg
+      - try: [ appmenu-qt5 ] # not available on core18
+      - locales-all
+      - xdg-user-dirs
+      - fcitx-frontend-qt5
+
   pivx-core:
     source: https://github.com/PIVX-Project/PIVX
     source-type: git
@@ -82,7 +120,6 @@ parts:
       #    default value is "false", to enable it, use your projects binary prefix
       OVERRIDEBINPREFIX="pivx"
       OVERRIDEDATADIR="false"
-      PARAMSDIR=".pivx-params"
       OVERRIDECONF="${OVERRIDEDATADIR}"
       COPYCONF=0    # copy example config into users data folder, 1 = enabled
       JOBS=4        # 0 means off and make will run without -j
@@ -90,7 +127,7 @@ parts:
       SPLASHPNGS=0  # patch pngs to differ visaully from those installed from self compilation or other source like deb
       FIXPPCBUILD=1 # if ppc builds fail due to failed qt, apps part will return error and build will fail, 1 = enabled
       EXTRALOG=0    # prints env and all installed files at the end of current script
-      RUNTESTS=1    # run make check after post install part
+      RUNTESTS=0    # run make check after post install part
       DEPENDS=0     # use the depends system instead of syslibs
       echo "-----------------------------------------------"
       echo "+++++++++++++++++++++++++++++++++++++++++++++++"
@@ -170,9 +207,6 @@ parts:
       echo "+++++++++++++++++++++++++++++++++++++++++++++++"
       cd ${SNAPCRAFT_PART_BUILD}
       echo "Configure and build ${BINPREF}"
-      if [ $RUNTESTS = 1 ]; then
-        mkdir -p ${SNAP_USER_COMMON}/${PARAMSDIR}
-      fi
       ./autogen.sh
       if [ $DEPENDS = 1 ]; then
         ./configure --prefix=`pwd`/depends/${HOST}
@@ -231,13 +265,11 @@ parts:
       echo "CONFIG FILE" # create .pivx folder and copy example config - !!!warning!!!: do not copy as pivx.conf
       echo "+++++++++++++++++++++++++++++++++++++++++++++++"
       mkdir -p ${SNAP_USER_COMMON}/.${DATADIR}
-      mkdir -p ${SNAP_USER_COMMON}/${PARAMSDIR}
       if [ $COPYCONF = 1 ]; then
-        cp ${SNAPCRAFT_PART_BUILD}/contrib/debian/manpages/${CONF}.conf.5 ${SNAP_USER_COMMON}/.${DATADIR}/${CONF}-example.conf
+        cp ${SNAPCRAFT_PART_BUILD}/contrib/debian/examples/${CONF}.conf ${SNAP_USER_COMMON}/.${DATADIR}/${CONF}-example.conf
       else
         echo "COPY CONFIG FILE disabled, skipping"
       fi
-      cp ${SNAPCRAFT_PART_BUILD}/params/*.params ${SNAP_USER_COMMON}/${PARAMSDIR}/
       echo "-----------------------------------------------"
       echo "+++++++++++++++++++++++++++++++++++++++++++++++"
       echo "RUN TESTS" # if tests fail to pass, build and release will fail

--- a/params/Makefile.am
+++ b/params/Makefile.am
@@ -1,3 +1,3 @@
-dist_data_DATA =
+dist_pkgdata_DATA =
 
-dist_data_DATA+=sapling-output.params sapling-spend.params
+dist_pkgdata_DATA+=sapling-output.params sapling-spend.params

--- a/params/install-params.sh
+++ b/params/install-params.sh
@@ -41,7 +41,7 @@ function install_params {
     # if the params don't exist in the current directory, assume we're running from release tarballs
     if ! [ -f "$filename" ]
     then
-        filename="share/$filename"
+        filename="share/pivx/$filename"
     fi
 
     if ! [ -f "$output" ]

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -472,8 +472,15 @@ void initZKSNARKS()
         CFRelease(mainBundle);
 #else
         // Linux fallback path for debuild/ppa based installs
-        sapling_spend = "/usr/local/share/sapling-spend.params";
-        sapling_output = "/usr/local/share/sapling-output.params";
+        sapling_spend = "/usr/share/pivx/sapling-spend.params";
+        sapling_output = "/usr/share/pivx/sapling-output.params";
+        if (fs::exists(sapling_spend) && fs::exists(sapling_output)) {
+            fParamsFound = true;
+        } else {
+            // Linux fallback for local installs
+            sapling_spend = "/usr/local/share/pivx/sapling-spend.params";
+            sapling_output = "/usr/local/share/pivx/sapling-output.params";
+        }
 #endif
         if (fs::exists(sapling_spend) && fs::exists(sapling_output))
             fParamsFound = true;


### PR DESCRIPTION
Followup to #2022 to resolve the lingering issues with ppa/snapcraft builds.

build-log of a PPA build can be seen [here](https://launchpadlibrarian.net/510054528/buildlog_ubuntu-bionic-amd64.pivx_4.3.99~202012060757+gitdc5ad4478~ubuntu18.04.1_BUILDING.txt.gz)

This also introduces proper `desktop-launch` wrapping for the nightly snapcraft builds, which is required to successfully open the GUI wallet from the snap commands.