### PR TITLE
[GUI] Address generation error on locked wallets fix plus extra corrections.

### DIFF
--- a/src/qt/pivx/receivewidget.cpp
+++ b/src/qt/pivx/receivewidget.cpp
@@ -75,6 +75,8 @@ ReceiveWidget::ReceiveWidget(PIVXGUI* parent) :
     ui->pushButtonCopy->setLayoutDirection(Qt::RightToLeft);
     setCssProperty(ui->pushButtonCopy, "btn-secundary-copy");
 
+    setCssProperty(ui->labelQrImg, "text-subtitle");
+
     // List Addresses
     setCssProperty(ui->listViewAddress, "container");
     ui->listViewAddress->setItemDelegate(delegate);
@@ -143,7 +145,7 @@ void ReceiveWidget::refreshView(QString refreshAddress)
 
         if (latestAddress.isEmpty()) {
             // Check for generation errors
-            ui->labelQrImg->setText(tr("No available address, try unlocking the wallet"));
+            ui->labelQrImg->setText(tr("No available address\ntry unlocking the wallet"));
             inform(tr("Error generating address"));
             return;
         }
@@ -159,7 +161,7 @@ void ReceiveWidget::refreshView(QString refreshAddress)
         updateQr(latestAddress);
         updateLabel();
     } catch (const std::runtime_error& error) {
-        ui->labelQrImg->setText(tr("No available address, try unlocking the wallet"));
+        ui->labelQrImg->setText(tr("No available address\ntry unlocking the wallet"));
         inform(tr("Error generating address"));
     }
 }

--- a/src/qt/pivx/send.cpp
+++ b/src/qt/pivx/send.cpp
@@ -722,6 +722,7 @@ void SendWidget::onShieldCoinsClicked()
                 return false;
             }
             recipients.back().address = strAddress;
+            resetCoinControl();
             return true;
         });
     } else {

--- a/src/qt/pivx/send.cpp
+++ b/src/qt/pivx/send.cpp
@@ -674,7 +674,7 @@ void SendWidget::onShieldCoinsClicked()
     }
 
     auto balances = walletModel->GetWalletBalances();
-    CAmount availableBalance = balances.balance - balances.shielded_balance;
+    CAmount availableBalance = balances.balance - balances.shielded_balance - walletModel->getLockedBalance();
     if (walletModel && availableBalance > 0) {
 
         // Calculate the required fee first. TODO future: Unify this code with the code in coincontroldialog into the model.

--- a/src/qt/pivx/send.cpp
+++ b/src/qt/pivx/send.cpp
@@ -24,8 +24,7 @@
 SendWidget::SendWidget(PIVXGUI* parent) :
     PWidget(parent),
     ui(new Ui::send),
-    coinIcon(new QPushButton()),
-    btnContacts(new QPushButton())
+    coinIcon(new QPushButton())
 {
     ui->setupUi(this);
 
@@ -552,15 +551,6 @@ void SendWidget::onError(QString error, int type)
 {
     isProcessing = false;
     processingResultError = error;
-}
-
-QString SendWidget::recipientsToString(QList<SendCoinsRecipient> recipients)
-{
-    QString s = "";
-    for (SendCoinsRecipient rec : recipients) {
-        s += rec.address + " -> " + BitcoinUnits::formatWithUnit(walletModel->getOptionsModel()->getDisplayUnit(), rec.amount, false, BitcoinUnits::separatorAlways) + "\n";
-    }
-    return s;
 }
 
 void SendWidget::updateEntryLabels(QList<SendCoinsRecipient> recipients)

--- a/src/qt/pivx/send.h
+++ b/src/qt/pivx/send.h
@@ -109,7 +109,8 @@ private:
     void resizeMenu();
     QString recipientsToString(QList<SendCoinsRecipient> recipients);
     SendMultiRow* createEntry();
-    void ProcessSend(const QList<SendCoinsRecipient>& recipients, bool hasShieldedOutput);
+    void ProcessSend(QList<SendCoinsRecipient>& recipients, bool hasShieldedOutput,
+                     const std::function<bool(QList<SendCoinsRecipient>&)>& func = nullptr);
     OperationResult prepareShielded(WalletModelTransaction* tx, bool fromTransparent);
     OperationResult prepareTransparent(WalletModelTransaction* tx);
     bool sendFinalStep();

--- a/src/qt/pivx/send.h
+++ b/src/qt/pivx/send.h
@@ -83,7 +83,6 @@ private Q_SLOTS:
 private:
     Ui::send *ui;
     QPushButton *coinIcon;
-    QPushButton *btnContacts;
 
     SendCustomFeeDialog* customFeeDialog = nullptr;
     bool isCustomFeeSelected = false;
@@ -107,7 +106,6 @@ private:
 
     bool isTransparent = true;
     void resizeMenu();
-    QString recipientsToString(QList<SendCoinsRecipient> recipients);
     SendMultiRow* createEntry();
     void ProcessSend(QList<SendCoinsRecipient>& recipients, bool hasShieldedOutput,
                      const std::function<bool(QList<SendCoinsRecipient>&)>& func = nullptr);

--- a/src/qt/pivx/settings/forms/settingsfaqwidget.ui
+++ b/src/qt/pivx/settings/forms/settingsfaqwidget.ui
@@ -527,7 +527,7 @@
                            that can be easily transferred globally, instantly, and with near
                            zero fees.  PIVX incorporates market leading security &amp;
                            privacy and is also the first PoS (Proof of Stake) Cryptocurrency
-                           to implement ZeroCoin(zPIV) and Zerocoin staking.
+                           to implement Sapling(SHIELD), a zk-SNARKs based privacy protocol.
                            &lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;
                            PIVX utilizes a Proof of Stake (PoS) consensus system algorithm,
                            allowing all owners of PIVX to participate in earning block rewards


### PR DESCRIPTION
Gathered a crash fix with some GUI corrections in the PR.
Covering the following points:

1) Fixed a runtime error when the GUI tries to generate a shielded address with the wallet locked.
2) Cleaned an unused member and function in the send screen.
3) Corrected the total available that can be shielded on the shield all process (subtracting the locked coins).
4) Added text styling for the "No available address" error text in the receive widget (could happen only if the wallet is locked and there is no other shielded address to show).
5) Remove zerocoin mention from the FAQ.