### PR TITLE
[Build] CMake pivxd and unit tests: fixing missing MacOS framework.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -570,6 +570,10 @@ if(MINIUPNP_FOUND)
     target_include_directories(pivxd PUBLIC ${MINIUPNP_INCLUDE_DIR})
 endif()
 
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    target_link_libraries(pivxd "-framework Cocoa")
+endif()
+
 target_link_libraries(pivxd ${sodium_LIBRARY_RELEASE} -ldl -lpthread)
 
 add_subdirectory(src/qt)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -173,6 +173,10 @@ if(MINIUPNP_FOUND)
     target_include_directories(test_pivx PRIVATE ${MINIUPNP_INCLUDE_DIR})
 endif()
 
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    target_link_libraries(test_pivx PRIVATE "-framework Cocoa")
+endif()
+
 target_link_libraries(test_pivx PRIVATE ${sodium_LIBRARY_RELEASE} -ldl -lpthread)
 
 enable_testing()


### PR DESCRIPTION
Without the framework include, CMake isn't able to find the `CFBundleGetMainBundle` and relative classes/functions. Thus why isn't compiling pivxd and the unit test target. Dependency included due #2022 changes.