### PR TITLE
[Wallet] Making CWalletTx store TransactionRef.

### DIFF
--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -107,13 +107,8 @@ public:
     COutPoint prevout;
     CScript scriptSig;
     uint32_t nSequence;
-    CScript prevPubKey;
 
-    CTxIn()
-    {
-        nSequence = std::numeric_limits<unsigned int>::max();
-    }
-
+    CTxIn() { nSequence = std::numeric_limits<unsigned int>::max(); }
     explicit CTxIn(COutPoint prevoutIn, CScript scriptSigIn=CScript(), uint32_t nSequenceIn=std::numeric_limits<unsigned int>::max());
     CTxIn(uint256 hashPrevTx, uint32_t nOut, CScript scriptSigIn=CScript(), uint32_t nSequenceIn=std::numeric_limits<uint32_t>::max());
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -216,8 +216,33 @@ public:
 
 struct CMutableTransaction;
 
+/**
+ * Transaction serialization format:
+ * - int32_t nVersion
+ * - std::vector<CTxIn> vin
+ * - std::vector<CTxOut> vout
+ * - uint32_t nLockTime
+ * - Optional<SaplingTxData> sapData
+ * - Optional<std::vector<uint8_t>> extraPayload
+ */
+template<typename Stream, typename Operation, typename TxType>
+inline void SerializeTransaction(TxType& tx, Stream& s, Operation ser_action) {
+    READWRITE(*const_cast<int16_t*>(&tx.nVersion));
+    READWRITE(*const_cast<int16_t*>(&tx.nType));
+    READWRITE(*const_cast<std::vector<CTxIn>*>(&tx.vin));
+    READWRITE(*const_cast<std::vector<CTxOut>*>(&tx.vout));
+    READWRITE(*const_cast<uint32_t*>(&tx.nLockTime));
+
+    if (g_IsSaplingActive && tx.isSaplingVersion()) {
+        READWRITE(*const_cast<Optional<SaplingTxData>*>(&tx.sapData));
+        if (!tx.IsNormalType()) {
+            READWRITE(*const_cast<Optional<std::vector<uint8_t>>*>(&tx.extraPayload));
+        }
+    }
+}
+
 /** The basic transaction that is broadcasted on the network and contained in
- * blocks.  A transaction can contain multiple inputs and outputs.
+ * blocks. A transaction can contain multiple inputs and outputs.
  */
 class CTransaction
 {
@@ -267,20 +292,10 @@ public:
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(*const_cast<int16_t*>(&nVersion));
-        READWRITE(*const_cast<int16_t*>(&nType));
-        READWRITE(*const_cast<std::vector<CTxIn>*>(&vin));
-        READWRITE(*const_cast<std::vector<CTxOut>*>(&vout));
-        READWRITE(*const_cast<uint32_t*>(&nLockTime));
-
-        if (g_IsSaplingActive && isSaplingVersion()) {
-            READWRITE(*const_cast<Optional<SaplingTxData>*>(&sapData));
-            if (nType != TxType::NORMAL)
-                READWRITE(*const_cast<Optional<std::vector<uint8_t> >*>(&extraPayload));
-        }
-
-        if (ser_action.ForRead())
+        SerializeTransaction(*this, s, ser_action);
+        if (ser_action.ForRead()) {
             UpdateHash();
+        }
     }
 
     template <typename Stream>
@@ -322,6 +337,8 @@ public:
     {
         return isSaplingVersion() && nType != TxType::NORMAL && hasExtraPayload();
     }
+
+    bool IsNormalType() const { return nType == TxType::NORMAL; }
 
     // Ensure that special and sapling fields are signed
     SigVersion GetRequiredSigVersion() const
@@ -406,17 +423,7 @@ struct CMutableTransaction
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(nVersion);
-        READWRITE(nType);
-        READWRITE(vin);
-        READWRITE(vout);
-        READWRITE(nLockTime);
-
-        if (g_IsSaplingActive && nVersion >= CTransaction::TxVersion::SAPLING) {
-            READWRITE(*const_cast<Optional<SaplingTxData>*>(&sapData));
-            if (nType != CTransaction::TxType::NORMAL)
-                READWRITE(*const_cast<Optional<std::vector<uint8_t> >*>(&extraPayload));
-        }
+        SerializeTransaction(*this, s, ser_action);
     }
 
     template <typename Stream>
@@ -424,15 +431,13 @@ struct CMutableTransaction
         Unserialize(s);
     }
 
+    bool isSaplingVersion() const { return nVersion >= CTransaction::TxVersion::SAPLING; }
+    bool IsNormalType() const { return nType == CTransaction::TxType::NORMAL; }
+
     /** Compute the hash of this CMutableTransaction. This is computed on the
      * fly, as opposed to GetHash() in CTransaction, which uses a cached result.
      */
     uint256 GetHash() const;
-
-    bool isSaplingVersion() const
-    {
-        return nVersion >= CTransaction::TxVersion::SAPLING;
-    }
 
     // Ensure that special and sapling fields are signed
     SigVersion GetRequiredSigVersion() const

--- a/src/qt/pivx/coldstakingmodel.cpp
+++ b/src/qt/pivx/coldstakingmodel.cpp
@@ -40,7 +40,7 @@ void ColdStakingModel::refresh()
 
             const auto *wtx = utxo.tx;
             const QString txId = QString::fromStdString(wtx->GetHash().GetHex());
-            const CTxOut& out = wtx->vout[utxo.i];
+            const CTxOut& out = wtx->tx->vout[utxo.i];
 
             // First parse the cs delegation
             CSDelegation delegation;

--- a/src/qt/pivx/masternodewizarddialog.cpp
+++ b/src/qt/pivx/masternodewizarddialog.cpp
@@ -260,8 +260,8 @@ bool MasterNodeWizardDialog::createMN()
         CWalletTx* walletTx = currentTransaction.getTransaction();
         std::string txID = walletTx->GetHash().GetHex();
         int indexOut = -1;
-        for (int i=0; i < (int)walletTx->vout.size(); i++) {
-            CTxOut& out = walletTx->vout[i];
+        for (int i=0; i < (int)walletTx->tx->vout.size(); i++) {
+            const CTxOut& out = walletTx->tx->vout[i];
             if (out.nValue == 10000 * COIN) {
                 indexOut = i;
                 break;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -123,7 +123,7 @@ CAmount WalletModel::getBalance(const CCoinControl* coinControl, bool fIncludeDe
         for (const COutput& out : vCoins) {
             bool fSkip = fUnlockedOnly && isLockedCoin(out.tx->GetHash(), out.i);
             if (out.fSpendable && !fSkip)
-                nBalance += out.tx->vout[out.i].nValue;
+                nBalance += out.tx->tx->vout[out.i].nValue;
         }
 
         return nBalance;
@@ -571,7 +571,7 @@ OperationResult WalletModel::PrepareShieldedTransaction(WalletModelTransaction* 
     }
 
     // load the transaction and key change (if needed)
-    modelTransaction->setTransaction(new CWalletTx(wallet, operation.getFinalTx()));
+    modelTransaction->setTransaction(new CWalletTx(wallet, MakeTransactionRef(operation.getFinalTx())));
     modelTransaction->setTransactionFee(operation.getFee()); // in the future, fee will be dynamically calculated.
     return operationResult;
 }
@@ -978,7 +978,7 @@ void WalletModel::listCoins(std::map<ListCoinsKey, std::vector<ListCoinsValue>>&
     for (const COutput& out : vCoins) {
         if (!out.fSpendable) continue;
 
-        const CScript& scriptPubKey = out.tx->vout[out.i].scriptPubKey;
+        const CScript& scriptPubKey = out.tx->tx->vout[out.i].scriptPubKey;
         const bool isP2CS = scriptPubKey.IsPayToColdStaking();
 
         CTxDestination outputAddress;
@@ -1003,7 +1003,7 @@ void WalletModel::listCoins(std::map<ListCoinsKey, std::vector<ListCoinsValue>>&
         ListCoinsValue value{
                 out.tx->GetHash(),
                 out.i,
-                out.tx->vout[out.i].nValue,
+                out.tx->tx->vout[out.i].nValue,
                 out.tx->GetTxTime(),
                 out.nDepth
         };

--- a/src/sapling/sapling_operation.cpp
+++ b/src/sapling/sapling_operation.cpp
@@ -228,7 +228,7 @@ OperationResult SaplingOperation::build()
 
 OperationResult SaplingOperation::send(std::string& retTxHash)
 {
-    CWalletTx wtx(pwalletMain, finalTx);
+    CWalletTx wtx(pwalletMain, MakeTransactionRef(finalTx));
     const CWallet::CommitResult& res = pwalletMain->CommitTransaction(wtx, tkeyChange, g_connman.get());
     if (res.status != CWallet::CommitStatus::OK) {
         return errorOut(res.ToString());
@@ -275,7 +275,7 @@ OperationResult SaplingOperation::loadUtxos(TxValues& txValues)
         for (const auto& outpoint : vCoins) {
             const auto* tx = pwalletMain->GetWalletTx(outpoint.outPoint.hash);
             if (!tx) continue;
-            nSelectedValue += tx->vout[outpoint.outPoint.n].nValue;
+            nSelectedValue += tx->tx->vout[outpoint.outPoint.n].nValue;
             selectedUTXOInputs.emplace_back(tx, outpoint.outPoint.n, 0, true, true);
         }
         return loadUtxos(txValues, selectedUTXOInputs, nSelectedValue);
@@ -309,7 +309,7 @@ OperationResult SaplingOperation::loadUtxos(TxValues& txValues)
     CAmount selectedUTXOAmount = 0;
     std::vector<COutput> selectedTInputs;
     for (const COutput& t : transInputs) {
-        const auto& outPoint = t.tx->vout[t.i];
+        const auto& outPoint = t.tx->tx->vout[t.i];
         selectedUTXOAmount += outPoint.nValue;
         selectedTInputs.emplace_back(t);
         if (selectedUTXOAmount >= txValues.target) {
@@ -343,7 +343,7 @@ OperationResult SaplingOperation::loadUtxos(TxValues& txValues, const std::vecto
 
     // update the transaction with these inputs
     for (const auto& t : transInputs) {
-        const auto& outPoint = t.tx->vout[t.i];
+        const auto& outPoint = t.tx->tx->vout[t.i];
         txBuilder.AddTransparentInput(COutPoint(t.tx->GetHash(), t.i), outPoint.scriptPubKey, outPoint.nValue);
     }
     return OperationResult(true);

--- a/src/test/librust/sapling_rpc_wallet_tests.cpp
+++ b/src/test/librust/sapling_rpc_wallet_tests.cpp
@@ -408,7 +408,7 @@ BOOST_AUTO_TEST_CASE(rpc_shieldsendmany_taddr_to_sapling)
     // Add a fake transaction to the wallet
     CMutableTransaction mtx;
     mtx.vout.emplace_back(5 * COIN, GetScriptForDestination(taddr));
-    CWalletTx wtx(pwalletMain, mtx);
+    CWalletTx wtx(pwalletMain, MakeTransactionRef(mtx));
     pwalletMain->LoadToWallet(wtx);
 
     // Fake-mine the transaction

--- a/src/test/librust/sapling_wallet_tests.cpp
+++ b/src/test/librust/sapling_wallet_tests.cpp
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE(SetSaplingNoteAddrsInCWalletTx) {
     builder.SetFee(10000000);
     auto tx = builder.Build().GetTxOrThrow();
 
-    CWalletTx wtx {&wallet, tx};
+    CWalletTx wtx {&wallet, MakeTransactionRef(tx)};
 
     BOOST_CHECK_EQUAL(0, wtx.mapSaplingNoteData.size());
     mapSaplingNoteData_t noteData;
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE(FindMySaplingNotes) {
     auto tx = builder.Build().GetTxOrThrow();
 
     // No Sapling notes can be found in tx which does not belong to the wallet
-    CWalletTx wtx {&wallet, tx};
+    CWalletTx wtx {&wallet, MakeTransactionRef(tx)};
     BOOST_CHECK(!wallet.HaveSaplingSpendingKey(extfvk));
     auto noteMap = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(wtx).first;
     BOOST_CHECK_EQUAL(0, noteMap.size());
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE(GetConflictedSaplingNotes) {
     builder.AddSaplingOutput(extfvk.fvk.ovk, pk, 35000000, {});
     builder.SetFee(10000000);
     auto tx = builder.Build().GetTxOrThrow();
-    CWalletTx wtx {&wallet, tx};
+    CWalletTx wtx {&wallet, MakeTransactionRef(tx)};
 
     // Fake-mine the transaction
     BOOST_CHECK_EQUAL(0, chainActive.Height());
@@ -245,10 +245,10 @@ BOOST_AUTO_TEST_CASE(GetConflictedSaplingNotes) {
 
     // Decrypt output note B
     auto maybe_pt = libzcash::SaplingNotePlaintext::decrypt(
-            wtx.sapData->vShieldedOutput[0].encCiphertext,
+            wtx.tx->sapData->vShieldedOutput[0].encCiphertext,
             ivk,
-            wtx.sapData->vShieldedOutput[0].ephemeralKey,
-            wtx.sapData->vShieldedOutput[0].cmu);
+            wtx.tx->sapData->vShieldedOutput[0].ephemeralKey,
+            wtx.tx->sapData->vShieldedOutput[0].cmu);
     BOOST_CHECK(static_cast<bool>(maybe_pt) == true);
     auto maybe_note = maybe_pt.get().note(ivk);
     BOOST_CHECK(static_cast<bool>(maybe_note) == true);
@@ -275,8 +275,8 @@ BOOST_AUTO_TEST_CASE(GetConflictedSaplingNotes) {
     builder3.AddSaplingOutput(extfvk.fvk.ovk, pk, 19999000, {});
     auto tx3 = builder3.Build().GetTxOrThrow();
 
-    CWalletTx wtx2 {&wallet, tx2};
-    CWalletTx wtx3 {&wallet, tx3};
+    CWalletTx wtx2 {&wallet, MakeTransactionRef(tx2)};
+    CWalletTx wtx3 {&wallet, MakeTransactionRef(tx3)};
 
     const auto& hash2 = wtx2.GetHash();
     const auto& hash3 = wtx3.GetHash();
@@ -325,7 +325,7 @@ BOOST_AUTO_TEST_CASE(SaplingNullifierIsSpent) {
     builder.SetFee(10000000);
     auto tx = builder.Build().GetTxOrThrow();
 
-    CWalletTx wtx {&wallet, tx};
+    CWalletTx wtx {&wallet, MakeTransactionRef(tx)};
     BOOST_CHECK(wallet.AddSaplingZKey(sk));
     BOOST_CHECK(wallet.HaveSaplingSpendingKey(extfvk));
 
@@ -387,7 +387,7 @@ BOOST_AUTO_TEST_CASE(NavigateFromSaplingNullifierToNote) {
     builder.SetFee(10000000);
     auto tx = builder.Build().GetTxOrThrow();
 
-    CWalletTx wtx {&wallet, tx};
+    CWalletTx wtx {&wallet, MakeTransactionRef(tx)};
     BOOST_CHECK(wallet.AddSaplingZKey(sk));
     BOOST_CHECK(wallet.HaveSaplingSpendingKey(extfvk));
 
@@ -491,7 +491,7 @@ BOOST_AUTO_TEST_CASE(SpentSaplingNoteIsFromMe) {
     builder.SetFee(10000000);
     auto tx = builder.Build().GetTxOrThrow();
 
-    CWalletTx wtx {&wallet, tx};
+    CWalletTx wtx {&wallet, MakeTransactionRef(tx)};
     BOOST_CHECK(wallet.AddSaplingZKey(sk));
     BOOST_CHECK(wallet.HaveSaplingSpendingKey(extfvk));
 
@@ -536,10 +536,10 @@ BOOST_AUTO_TEST_CASE(SpentSaplingNoteIsFromMe) {
 
     // Decrypt note B
     auto maybe_pt = libzcash::SaplingNotePlaintext::decrypt(
-            wtx.sapData->vShieldedOutput[0].encCiphertext,
+            wtx.tx->sapData->vShieldedOutput[0].encCiphertext,
             ivk,
-            wtx.sapData->vShieldedOutput[0].ephemeralKey,
-            wtx.sapData->vShieldedOutput[0].cmu);
+            wtx.tx->sapData->vShieldedOutput[0].ephemeralKey,
+            wtx.tx->sapData->vShieldedOutput[0].cmu);
     BOOST_CHECK_EQUAL(static_cast<bool>(maybe_pt), true);
     auto maybe_note = maybe_pt.get().note(ivk);
     BOOST_CHECK_EQUAL(static_cast<bool>(maybe_note), true);
@@ -568,7 +568,7 @@ BOOST_AUTO_TEST_CASE(SpentSaplingNoteIsFromMe) {
     BOOST_CHECK_EQUAL(tx2.sapData->vShieldedOutput.size(), 2);
     BOOST_CHECK_EQUAL(tx2.sapData->valueBalance, 10000000);
 
-    CWalletTx wtx2 {&wallet, tx2};
+    CWalletTx wtx2 {&wallet, MakeTransactionRef(tx2)};
 
     // Fake-mine this tx into the next block
     BOOST_CHECK_EQUAL(0, chainActive.Height());
@@ -945,7 +945,7 @@ BOOST_AUTO_TEST_CASE(UpdatedSaplingNoteData) {
     auto tx = builder.Build().GetTxOrThrow();
 
     // Wallet contains extfvk1 but not extfvk2
-    CWalletTx wtx {&wallet, tx};
+    CWalletTx wtx {&wallet, MakeTransactionRef(tx)};
     BOOST_CHECK(wallet.AddSaplingZKey(sk));
     BOOST_CHECK(wallet.HaveSaplingSpendingKey(extfvk));
     BOOST_CHECK(!wallet.HaveSaplingSpendingKey(extfvk2));
@@ -1063,7 +1063,7 @@ BOOST_AUTO_TEST_CASE(MarkAffectedSaplingTransactionsDirty) {
     BOOST_CHECK_EQUAL(tx1.sapData->vShieldedOutput.size(), 1);
     BOOST_CHECK_EQUAL(tx1.sapData->valueBalance, -40000000);
 
-    CWalletTx wtx {&wallet, tx1};
+    CWalletTx wtx {&wallet, MakeTransactionRef(tx1)};
 
     // Fake-mine the transaction
     BOOST_CHECK_EQUAL(0, chainActive.Height());
@@ -1118,7 +1118,7 @@ BOOST_AUTO_TEST_CASE(MarkAffectedSaplingTransactionsDirty) {
     BOOST_CHECK_EQUAL(tx2.sapData->vShieldedOutput.size(), 2);
     BOOST_CHECK_EQUAL(tx2.sapData->valueBalance, 10000000);
 
-    CWalletTx wtx2 {&wallet, tx2};
+    CWalletTx wtx2 {&wallet, MakeTransactionRef(tx2)};
 
     wallet.MarkAffectedTransactionsDirty(wtx);
 

--- a/src/test/librust/utiltest.cpp
+++ b/src/test/librust/utiltest.cpp
@@ -76,7 +76,7 @@ CWalletTx GetValidSaplingReceive(const Consensus::Params& consensusParams,
     }
 
     CTransaction tx = builder.Build().GetTxOrThrow();
-    CWalletTx wtx {pwalletIn, tx};
+    CWalletTx wtx {pwalletIn, MakeTransactionRef(tx)};
     return wtx;
 }
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -43,7 +43,7 @@ static void add_coin(const CAmount& nValue, int nAge = 6*24, bool fIsFromMe = fa
         // so stop vin being empty, and cache a non-zero Debit to fake out IsFromMe()
         tx.vin.resize(1);
     }
-    CWalletTx* wtx = new CWalletTx(pwalletMain, tx);
+    CWalletTx* wtx = new CWalletTx(pwalletMain, MakeTransactionRef(tx));
     if (fIsFromMe) {
         wtx->m_amounts[CWalletTx::DEBIT].Set(ISMINE_SPENDABLE, 1);
     }
@@ -352,7 +352,7 @@ CWalletTx& BuildAndLoadTxToWallet(const std::vector<CTxIn>& vin,
     mTx.vin = vin;
     mTx.vout = vout;
     CTransaction tx(mTx);
-    wallet.LoadToWallet({&wallet, tx});
+    wallet.LoadToWallet({&wallet, MakeTransactionRef(tx)});
     return wallet.mapWallet[tx.GetHash()];
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -66,7 +66,7 @@ struct CompareValueOnly {
 
 std::string COutput::ToString() const
 {
-    return strprintf("COutput(%s, %d, %d) [%s]", tx->GetHash().ToString(), i, nDepth, FormatMoney(tx->vout[i].nValue));
+    return strprintf("COutput(%s, %d, %d) [%s]", tx->GetHash().ToString(), i, nDepth, FormatMoney(tx->tx->vout[i].nValue));
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -495,7 +495,7 @@ void CWallet::SetBestChainInternal(CWalletDB& walletdb, const CBlockLocator& loc
         // transactions in which we only have transparent addresses involved.
         if (!wtx.mapSaplingNoteData.empty()) {
             // Sanity check
-            if (!wtx.isSaplingVersion()) {
+            if (!wtx.tx->isSaplingVersion()) {
                 LogPrintf("SetBestChain(): ERROR, Invalid tx version found with sapling data\n");
                 walletdb.TxnAbort();
                 uiInterface.ThreadSafeMessageBox(
@@ -584,8 +584,8 @@ std::set<uint256> CWallet::GetConflicts(const uint256& txid) const
 
     std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range;
 
-    for (const CTxIn& txin : wtx.vin) {
-        if (mapTxSpends.count(txin.prevout) <= 1 || wtx.HasZerocoinSpendInputs())
+    for (const CTxIn& txin : wtx.tx->vin) {
+        if (mapTxSpends.count(txin.prevout) <= 1 || wtx.tx->HasZerocoinSpendInputs())
             continue; // No conflict if zero or one spends
         range = mapTxSpends.equal_range(txin.prevout);
         for (TxSpends::const_iterator it = range.first; it != range.second; ++it)
@@ -761,11 +761,11 @@ void CWallet::AddToSpends(const uint256& wtxid)
     if (thisTx.IsCoinBase()) // Coinbases don't spend anything!
         return;
 
-    for (const CTxIn& txin : thisTx.vin)
+    for (const CTxIn& txin : thisTx.tx->vin)
         AddToSpends(txin.prevout, wtxid);
 
-    if (CanSupportFeature(FEATURE_SAPLING) && thisTx.sapData) {
-        for (const SpendDescription &spend : thisTx.sapData->vShieldedSpend) {
+    if (CanSupportFeature(FEATURE_SAPLING) && thisTx.tx->sapData) {
+        for (const SpendDescription &spend : thisTx.tx->sapData->vShieldedSpend) {
             GetSaplingScriptPubKeyMan()->AddToSaplingSpends(spend.nullifier, wtxid);
         }
     }
@@ -779,7 +779,7 @@ bool CWallet::GetVinAndKeysFromOutput(COutput out, CTxIn& txinRet, CPubKey& pubK
     CScript pubScript;
 
     txinRet = CTxIn(out.tx->GetHash(), out.i);
-    pubScript = out.tx->vout[out.i].scriptPubKey; // the inputs PubKey
+    pubScript = out.tx->tx->vout[out.i].scriptPubKey; // the inputs PubKey
 
     CTxDestination address1;
     ExtractDestination(pubScript, address1, fColdStake);
@@ -909,7 +909,7 @@ bool CWallet::IsKeyUsed(const CPubKey& vchPubKey) {
              it != mapWallet.end() && vchPubKey.IsValid();
              ++it) {
             const CWalletTx& wtx = (*it).second;
-            for (const CTxOut& txout : wtx.vout)
+            for (const CTxOut& txout : wtx.tx->vout)
                 if (txout.scriptPubKey == scriptPubKey)
                     return true;
         }
@@ -1010,7 +1010,7 @@ bool CWallet::LoadToWallet(const CWalletTx& wtxIn)
     m_sspk_man->UpdateNullifierNoteMapWithTx(mapWallet[hash]);
     wtxOrdered.emplace(wtx.nOrderPos, &wtx);
     AddToSpends(hash);
-    for (const CTxIn& txin : wtx.vin) {
+    for (const CTxIn& txin : wtx.tx->vin) {
         if (mapWallet.count(txin.prevout.hash)) {
             CWalletTx& prevtx = mapWallet[txin.prevout.hash];
             if (prevtx.nIndex == -1 && !prevtx.hashUnset()) {
@@ -1037,11 +1037,11 @@ bool CWallet::FindNotesDataAndAddMissingIVKToKeystore(const CTransaction& tx, Op
 
 void CWallet::AddExternalNotesDataToTx(CWalletTx& wtx) const
 {
-    if (HasSaplingSPKM() && wtx.IsShieldedTx()) {
+    if (HasSaplingSPKM() && wtx.tx->IsShieldedTx()) {
         const uint256& txId = wtx.GetHash();
         // Add the external outputs.
         SaplingOutPoint op {txId, 0};
-        for (unsigned int i = 0; i < wtx.sapData->vShieldedOutput.size(); i++) {
+        for (unsigned int i = 0; i < wtx.tx->sapData->vShieldedOutput.size(); i++) {
             op.n = i;
             if (wtx.mapSaplingNoteData.count(op)) continue;     // internal output
             auto recovered = GetSaplingScriptPubKeyMan()->TryToRecoverNote(wtx, op);
@@ -1107,8 +1107,8 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransaction& tx, const uint256& bl
                 m_spk_man->MarkUnusedAddresses(txout.scriptPubKey);
             }
 
-            CWalletTx wtx(this, tx);
-            if (wtx.IsShieldedTx()) {
+            CWalletTx wtx(this, MakeTransactionRef(tx));
+            if (wtx.tx->IsShieldedTx()) {
                 if (saplingNoteData && !saplingNoteData->empty()) {
                     wtx.SetSaplingNoteData(*saplingNoteData);
                 }
@@ -1173,7 +1173,7 @@ bool CWallet::AbandonTransaction(const uint256& hashTx)
             }
             // If a transaction changes 'conflicted' state, that changes the balance
             // available of the outputs it spends. So force those to be recomputed
-            for (const CTxIn& txin: wtx.vin)
+            for (const CTxIn& txin: wtx.tx->vin)
             {
                 if (mapWallet.count(txin.prevout.hash))
                     mapWallet[txin.prevout.hash].MarkDirty();
@@ -1235,7 +1235,7 @@ void CWallet::MarkConflicted(const uint256& hashBlock, const uint256& hashTx)
             }
             // If a transaction changes 'conflicted' state, that changes the balance
             // available of the outputs it spends. So force those to be recomputed
-            for (const CTxIn& txin: wtx.vin)
+            for (const CTxIn& txin: wtx.tx->vin)
             {
                 if (mapWallet.count(txin.prevout.hash))
                     mapWallet[txin.prevout.hash].MarkDirty();
@@ -1295,8 +1295,8 @@ isminetype CWallet::IsMine(const CTxIn& txin) const
         std::map<uint256, CWalletTx>::const_iterator mi = mapWallet.find(txin.prevout.hash);
         if (mi != mapWallet.end()) {
             const CWalletTx& prev = (*mi).second;
-            if (txin.prevout.n < prev.vout.size())
-                return IsMine(prev.vout[txin.prevout.n]);
+            if (txin.prevout.n < prev.tx->vout.size())
+                return IsMine(prev.tx->vout[txin.prevout.n]);
         }
     }
     return ISMINE_NO;
@@ -1315,7 +1315,7 @@ bool CWallet::IsUsed(const CTxDestination address) const
         if (wtx.IsCoinBase()) {
             continue;
         }
-        for (const CTxOut& txout : wtx.vout) {
+        for (const CTxOut& txout : wtx.tx->vout) {
             if (txout.scriptPubKey == scriptPubKey)
                 return true;
         }
@@ -1330,9 +1330,9 @@ CAmount CWallet::GetDebit(const CTxIn& txin, const isminefilter& filter) const
         std::map<uint256, CWalletTx>::const_iterator mi = mapWallet.find(txin.prevout.hash);
         if (mi != mapWallet.end()) {
             const CWalletTx& prev = (*mi).second;
-            if (txin.prevout.n < prev.vout.size())
-                if (IsMine(prev.vout[txin.prevout.n]) & filter)
-                    return prev.vout[txin.prevout.n].nValue;
+            if (txin.prevout.n < prev.tx->vout.size())
+                if (IsMine(prev.tx->vout[txin.prevout.n]) & filter)
+                    return prev.tx->vout[txin.prevout.n].nValue;
         }
     }
     return 0;
@@ -1405,7 +1405,7 @@ bool CWalletTx::IsAmountCached(AmountType type, const isminefilter& filter) cons
 //! filter decides which addresses will count towards the debit
 CAmount CWalletTx::GetDebit(const isminefilter& filter) const
 {
-    if (vin.empty() && (sapData && sapData->vShieldedSpend.empty())) {
+    if (tx->vin.empty() && (tx->sapData && tx->sapData->vShieldedSpend.empty())) {
         return 0;
     }
 
@@ -1493,9 +1493,9 @@ CAmount CWalletTx::GetAvailableCredit(bool fUseCache, const isminefilter& filter
     if (filter != ISMINE_SPENDABLE_SHIELDED && filter != ISMINE_WATCH_ONLY_SHIELDED) {
 
         const uint256& hashTx = GetHash();
-        for (unsigned int i = 0; i < vout.size(); i++) {
+        for (unsigned int i = 0; i < tx->vout.size(); i++) {
             if (!pwallet->IsSpent(hashTx, i)) {
-                const CTxOut &txout = vout[i];
+                const CTxOut &txout = tx->vout[i];
                 nCredit += pwallet->GetCredit(txout, filter);
                 if (!Params().GetConsensus().MoneyRange(nCredit))
                     throw std::runtime_error(std::string(__func__) + " : value out of range");
@@ -1540,8 +1540,8 @@ CAmount CWalletTx::GetLockedCredit() const
 
     CAmount nCredit = 0;
     uint256 hashTx = GetHash();
-    for (unsigned int i = 0; i < vout.size(); i++) {
-        const CTxOut& txout = vout[i];
+    for (unsigned int i = 0; i < tx->vout.size(); i++) {
+        const CTxOut& txout = tx->vout[i];
 
         // Skip spent coins
         if (pwallet->IsSpent(hashTx, i)) continue;
@@ -1552,7 +1552,7 @@ CAmount CWalletTx::GetLockedCredit() const
         }
 
         // Add masternode collaterals which are handled like locked coins
-        else if (fMasterNode && vout[i].nValue == 10000 * COIN) {
+        else if (fMasterNode && tx->vout[i].nValue == 10000 * COIN) {
             nCredit += pwallet->GetCredit(txout, ISMINE_SPENDABLE);
         }
 
@@ -1592,27 +1592,27 @@ void CWalletTx::GetAmounts(std::list<COutputEntry>& listReceived,
     bool isFromMyTaddr = nDebit > 0; // debit>0 means we signed/sent this transaction
 
     if (isFromMyTaddr) {// debit>0 means we signed/sent this transaction
-        CAmount nValueOut = GetValueOut(); // transasparent outputs plus the negative Sapling valueBalance
-        CAmount nValueIn = GetShieldedValueIn();
+        CAmount nValueOut = tx->GetValueOut(); // transasparent outputs plus the negative Sapling valueBalance
+        CAmount nValueIn = tx->GetShieldedValueIn();
         nFee = nDebit - nValueOut + nValueIn;
 
         // If we sent utxos from this transaction, create output for value taken from (negative valueBalance)
         // or added (positive valueBalance) to the transparent value pool by Sapling shielding and unshielding.
-        if (sapData) {
-            if (sapData->valueBalance < 0) {
-                COutputEntry output = {CNoDestination(), -sapData->valueBalance, (int) vout.size()};
+        if (tx->sapData) {
+            if (tx->sapData->valueBalance < 0) {
+                COutputEntry output = {CNoDestination(), -tx->sapData->valueBalance, (int) tx->vout.size()};
                 listSent.push_back(output);
-            } else if (sapData->valueBalance > 0) {
-                COutputEntry output = {CNoDestination(), sapData->valueBalance, (int) vout.size()};
+            } else if (tx->sapData->valueBalance > 0) {
+                COutputEntry output = {CNoDestination(), tx->sapData->valueBalance, (int) tx->vout.size()};
                 listReceived.push_back(output);
             }
         }
     }
 
     // Sent/received.
-    bool hasZerocoinSpends = HasZerocoinSpendInputs();
-    for (unsigned int i = 0; i < vout.size(); ++i) {
-        const CTxOut& txout = vout[i];
+    bool hasZerocoinSpends = tx->HasZerocoinSpendInputs();
+    for (unsigned int i = 0; i < tx->vout.size(); ++i) {
+        const CTxOut& txout = tx->vout[i];
         isminetype fIsMine = pwallet->IsMine(txout);
         // Only need to handle txouts if AT LEAST one of these is true:
         //   1) they debit from us (sent)
@@ -1944,7 +1944,7 @@ CAmount CWallet::GetAvailableBalance(isminefilter& filter, bool useCache, int mi
 CAmount CWallet::GetColdStakingBalance() const
 {
     return loopTxsBalance([](const uint256& id, const CWalletTx& pcoin, CAmount& nTotal) {
-        if (pcoin.HasP2CSOutputs() && pcoin.IsTrusted())
+        if (pcoin.tx->HasP2CSOutputs() && pcoin.IsTrusted())
             nTotal += pcoin.GetColdStakingCredit();
     });
 }
@@ -1966,7 +1966,7 @@ CAmount CWallet::GetStakingBalance(const bool fIncludeColdStaking) const
 CAmount CWallet::GetDelegatedBalance() const
 {
     return loopTxsBalance([](const uint256& id, const CWalletTx& pcoin, CAmount& nTotal) {
-            if (pcoin.HasP2CSOutputs() && pcoin.IsTrusted())
+            if (pcoin.tx->HasP2CSOutputs() && pcoin.IsTrusted())
                 nTotal += pcoin.GetStakeDelegationCredit();
     });
 }
@@ -2056,7 +2056,7 @@ CAmount CWallet::GetLegacyBalance(const isminefilter& filter, int minDepth) cons
         // treat change outputs specially, as part of the amount debited.
         CAmount debit = wtx.GetDebit(filter);
         const bool outgoing = debit > 0;
-        for (const CTxOut& out : wtx.vout) {
+        for (const CTxOut& out : wtx.tx->vout) {
             if (outgoing && IsChange(out)) {
                 debit -= out.nValue;
             } else if (IsMine(out) & filter && depth >= minDepth) {
@@ -2099,9 +2099,9 @@ void CWallet::GetAvailableP2CSCoins(std::vector<COutput>& vCoins) const {
             if (fConflicted || nDepth < 0)
                 continue;
 
-            if (pcoin->HasP2CSOutputs()) {
-                for (int i = 0; i < (int) pcoin->vout.size(); i++) {
-                    const auto &utxo = pcoin->vout[i];
+            if (pcoin->tx->HasP2CSOutputs()) {
+                for (int i = 0; i < (int) pcoin->tx->vout.size(); i++) {
+                    const auto &utxo = pcoin->tx->vout[i];
 
                     if (IsSpent(wtxid, i))
                         continue;
@@ -2172,12 +2172,12 @@ bool CWallet::GetMasternodeVinAndKeys(CTxIn& txinRet, CPubKey& pubKeyRet, CKey& 
     }
 
     // Verify index limits
-    if (nOutputIndex < 0 || nOutputIndex >= (int) wtx->vout.size()) {
+    if (nOutputIndex < 0 || nOutputIndex >= (int) wtx->tx->vout.size()) {
         strError = "Invalid masternode output index";
         return error("%s: output index %d not found in %s", __func__, nOutputIndex, strTxHash);
     }
 
-    CTxOut txOut = wtx->vout[nOutputIndex];
+    CTxOut txOut = wtx->tx->vout[nOutputIndex];
 
     // Masternode collateral value
     if (txOut.nValue != 10000 * COIN) {
@@ -2305,8 +2305,8 @@ bool CWallet::AvailableCoins(std::vector<COutput>* pCoins,      // --> populates
             // Check min depth filtering requirements
             if (nDepth < coinsFilter.minDepth) continue;
 
-            for (unsigned int i = 0; i < pcoin->vout.size(); i++) {
-                const auto& output = pcoin->vout[i];
+            for (unsigned int i = 0; i < pcoin->tx->vout.size(); i++) {
+                const auto& output = pcoin->tx->vout[i];
 
                 // Filter by specific destinations if needed
                 if (coinsFilter.onlyFilteredDest && !coinsFilter.onlyFilteredDest->empty()) {
@@ -2351,16 +2351,16 @@ std::map<CTxDestination , std::vector<COutput> > CWallet::AvailableCoinsByAddres
 
     std::map<CTxDestination, std::vector<COutput> > mapCoins;
     for (COutput& out : vCoins) {
-        if (maxCoinValue > 0 && out.tx->vout[out.i].nValue > maxCoinValue)
+        if (maxCoinValue > 0 && out.tx->tx->vout[out.i].nValue > maxCoinValue)
             continue;
 
         CTxDestination address;
         bool fColdStakeAddr = false;
-        if (!ExtractDestination(out.tx->vout[out.i].scriptPubKey, address, fColdStakeAddr)) {
+        if (!ExtractDestination(out.tx->tx->vout[out.i].scriptPubKey, address, fColdStakeAddr)) {
             // if this is a P2CS we don't have the owner key - check if we have the staking key
             fColdStakeAddr = true;
-            if ( !out.tx->vout[out.i].scriptPubKey.IsPayToColdStaking() ||
-                    !ExtractDestination(out.tx->vout[out.i].scriptPubKey, address, fColdStakeAddr) )
+            if ( !out.tx->tx->vout[out.i].scriptPubKey.IsPayToColdStaking() ||
+                    !ExtractDestination(out.tx->tx->vout[out.i].scriptPubKey, address, fColdStakeAddr) )
                 continue;
         }
 
@@ -2430,10 +2430,10 @@ bool CWallet::StakeableCoins(std::vector<CStakeableOutput>* pCoins)
         // Check min depth requirement for stake inputs
         if (nDepth < Params().GetConsensus().nStakeMinDepth) continue;
 
-        for (unsigned int index = 0; index < pcoin->vout.size(); index++) {
+        for (unsigned int index = 0; index < pcoin->tx->vout.size(); index++) {
 
             auto res = CheckOutputAvailability(
-                    pcoin->vout[index],
+                    pcoin->tx->vout[index],
                     index,
                     wtxid,
                     STAKEABLE_COINS,
@@ -2477,7 +2477,7 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int
             continue;
 
         int i = output.i;
-        CAmount n = pcoin->vout[i].nValue;
+        CAmount n = pcoin->tx->vout[i].nValue;
 
         std::pair<CAmount, std::pair<const CWalletTx*, unsigned int> > coin = std::make_pair(n, std::make_pair(pcoin, i));
 
@@ -2550,7 +2550,7 @@ bool CWallet::SelectCoinsToSpend(const std::vector<COutput>& vAvailableCoins, co
             if (!out.fSpendable)
                 continue;
 
-            nValueRet += out.tx->vout[out.i].nValue;
+            nValueRet += out.tx->tx->vout[out.i].nValue;
             setCoinsRet.emplace(out.tx, out.i);
         }
         return (nValueRet >= nTargetValue);
@@ -2568,9 +2568,9 @@ bool CWallet::SelectCoinsToSpend(const std::vector<COutput>& vAvailableCoins, co
         if (it != mapWallet.end()) {
             const CWalletTx* pcoin = &it->second;
             // Clearly invalid input, fail
-            if (pcoin->vout.size() <= outpoint.outPoint.n)
+            if (pcoin->tx->vout.size() <= outpoint.outPoint.n)
                 return false;
-            nValueFromPresetInputs += pcoin->vout[outpoint.outPoint.n].nValue;
+            nValueFromPresetInputs += pcoin->tx->vout[outpoint.outPoint.n].nValue;
             setPresetCoins.emplace(pcoin, outpoint.outPoint.n);
         } else
             return false; // TODO: Allow non-wallet inputs
@@ -2645,10 +2645,10 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, bool ov
         return false;
 
     if (nChangePosInOut != -1)
-        tx.vout.insert(tx.vout.begin() + nChangePosInOut, wtx.vout[nChangePosInOut]);
+        tx.vout.insert(tx.vout.begin() + nChangePosInOut, wtx.tx->vout[nChangePosInOut]);
 
     // Add new txins (keeping original txin scriptSig/order)
-    for (const CTxIn& txin : wtx.vin) {
+    for (const CTxIn& txin : wtx.tx->vin) {
         if (!coinControl.IsSelected(txin.prevout)) {
             tx.vin.push_back(txin);
 
@@ -2806,7 +2806,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend,
 
                 // Fill vin
                 for (const std::pair<const CWalletTx*, unsigned int>& coin : setCoins) {
-                    if(coin.first->vout[coin.second].scriptPubKey.IsPayToColdStaking()) {
+                    if(coin.first->tx->vout[coin.second].scriptPubKey.IsPayToColdStaking()) {
                         wtxNew->fStakeDelegationVoided = true;
                     }
                     txNew.vin.emplace_back(coin.first->GetHash(), coin.second);
@@ -2815,7 +2815,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend,
                 // Fill in dummy signatures for fee calculation.
                 int nIn = 0;
                 for (const auto & coin : setCoins) {
-                    const CScript& scriptPubKey = coin.first->vout[coin.second].scriptPubKey;
+                    const CScript& scriptPubKey = coin.first->tx->vout[coin.second].scriptPubKey;
                     SignatureData sigdata;
                     if (!ProduceSignature(DummySignatureCreator(this), scriptPubKey, sigdata, txNew.GetRequiredSigVersion(), false)) {
                         strFailReason = _("Signing transaction failed");
@@ -2865,12 +2865,12 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend,
             CTransaction txNewConst(txNew);
             int nIn = 0;
             for (const auto& coin : setCoins) {
-                const CScript& scriptPubKey = coin.first->vout[coin.second].scriptPubKey;
+                const CScript& scriptPubKey = coin.first->tx->vout[coin.second].scriptPubKey;
                 SignatureData sigdata;
                 bool haveKey = coin.first->GetStakeDelegationCredit() > 0;
 
                 if (!ProduceSignature(
-                        TransactionSignatureCreator(this, &txNewConst, nIn, coin.first->vout[coin.second].nValue, SIGHASH_ALL),
+                        TransactionSignatureCreator(this, &txNewConst, nIn, coin.first->tx->vout[coin.second].nValue, SIGHASH_ALL),
                         scriptPubKey,
                         sigdata,
                         txNewConst.GetRequiredSigVersion(),
@@ -2892,7 +2892,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend,
         }
 
         // Embed the constructed transaction data in wtxNew.
-        *static_cast<CTransaction*>(wtxNew) = CTransaction(txNew);
+        wtxNew->SetTx(MakeTransactionRef(std::move(txNew)));
     }
     return true;
 }
@@ -2935,7 +2935,7 @@ bool CWallet::CreateCoinStake(
     int nAttempts = 0;
     for (auto it = availableCoins->begin(); it != availableCoins->end();) {
         COutPoint outPoint = COutPoint(it->tx->GetHash(), it->i);
-        CPivStake stakeInput(it->tx->vout[it->i],
+        CPivStake stakeInput(it->tx->tx->vout[it->i],
                              outPoint,
                              it->pindex);
 
@@ -3076,7 +3076,7 @@ CWallet::CommitResult CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey*
     CommitResult res;
     {
         LOCK2(cs_main, cs_wallet);
-        LogPrintf("%s:\n%s", __func__, wtxNew.ToString());
+        LogPrintf("%s:\n%s", __func__, wtxNew.tx->ToString());
         {
             // Take key pair from key pool so it won't be used again
             if (opReservekey) opReservekey->KeepKey();
@@ -3086,9 +3086,9 @@ CWallet::CommitResult CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey*
             AddToWallet(wtxNew);
 
             // Notify that old coins are spent
-            if (!wtxNew.HasZerocoinSpendInputs()) {
+            if (!wtxNew.tx->HasZerocoinSpendInputs()) {
                 std::set<uint256> updated_hashes;
-                for (const CTxIn& txin : wtxNew.vin) {
+                for (const CTxIn& txin : wtxNew.tx->vin) {
                     // notify only once
                     if (updated_hashes.find(txin.prevout.hash) != updated_hashes.end()) continue;
 
@@ -3358,15 +3358,15 @@ std::map<CTxDestination, CAmount> CWallet::GetAddressBalances()
             if (nDepth < (pcoin->IsFromMe(ISMINE_ALL) ? 0 : 1))
                 continue;
 
-            for (unsigned int i = 0; i < pcoin->vout.size(); i++) {
+            for (unsigned int i = 0; i < pcoin->tx->vout.size(); i++) {
                 CTxDestination addr;
-                if (!IsMine(pcoin->vout[i]))
+                if (!IsMine(pcoin->tx->vout[i]))
                     continue;
-                if ( !ExtractDestination(pcoin->vout[i].scriptPubKey, addr) &&
-                        !ExtractDestination(pcoin->vout[i].scriptPubKey, addr, true) )
+                if ( !ExtractDestination(pcoin->tx->vout[i].scriptPubKey, addr) &&
+                        !ExtractDestination(pcoin->tx->vout[i].scriptPubKey, addr, true) )
                     continue;
 
-                CAmount n = IsSpent(walletEntry.first, i) ? 0 : pcoin->vout[i].nValue;
+                CAmount n = IsSpent(walletEntry.first, i) ? 0 : pcoin->tx->vout[i].nValue;
 
                 if (!balances.count(addr))
                     balances[addr] = 0;
@@ -3387,14 +3387,14 @@ std::set<std::set<CTxDestination> > CWallet::GetAddressGroupings()
     for (std::pair<uint256, CWalletTx> walletEntry : mapWallet) {
         CWalletTx* pcoin = &walletEntry.second;
 
-        if (pcoin->vin.size() > 0) {
+        if (pcoin->tx->vin.size() > 0) {
             bool any_mine = false;
             // group all input addresses with each other
-            for (CTxIn txin : pcoin->vin) {
+            for (CTxIn txin : pcoin->tx->vin) {
                 CTxDestination address;
                 if (!IsMine(txin)) /* If this input isn't mine, ignore it */
                     continue;
-                if (!ExtractDestination(mapWallet[txin.prevout.hash].vout[txin.prevout.n].scriptPubKey, address))
+                if (!ExtractDestination(mapWallet[txin.prevout.hash].tx->vout[txin.prevout.n].scriptPubKey, address))
                     continue;
                 grouping.insert(address);
                 any_mine = true;
@@ -3402,7 +3402,7 @@ std::set<std::set<CTxDestination> > CWallet::GetAddressGroupings()
 
             // group change with input addresses
             if (any_mine) {
-                for (CTxOut txout : pcoin->vout)
+                for (CTxOut txout : pcoin->tx->vout)
                     if (IsChange(txout)) {
                         CTxDestination txoutAddr;
                         if (!ExtractDestination(txout.scriptPubKey, txoutAddr))
@@ -3417,10 +3417,10 @@ std::set<std::set<CTxDestination> > CWallet::GetAddressGroupings()
         }
 
         // group lone addrs by themselves
-        for (unsigned int i = 0; i < pcoin->vout.size(); i++)
-            if (IsMine(pcoin->vout[i])) {
+        for (unsigned int i = 0; i < pcoin->tx->vout.size(); i++)
+            if (IsMine(pcoin->tx->vout[i])) {
                 CTxDestination address;
-                if (!ExtractDestination(pcoin->vout[i].scriptPubKey, address))
+                if (!ExtractDestination(pcoin->tx->vout[i].scriptPubKey, address))
                     continue;
                 grouping.insert(address);
                 groupings.insert(grouping);
@@ -3652,7 +3652,7 @@ void CWallet::GetKeyBirthTimes(std::map<CKeyID, int64_t>& mapKeyBirth) const
         if (blit != mapBlockIndex.end() && chainActive.Contains(blit->second)) {
             // ... which are already in a block
             int nHeight = blit->second->nHeight;
-            for (const CTxOut& txout : wtx.vout) {
+            for (const CTxOut& txout : wtx.tx->vout) {
                 // iterate over all their outputs
                 CAffectedKeysVisitor(*this, vAffected).Process(txout.scriptPubKey);
                 for (const CKeyID& keyid : vAffected) {
@@ -3728,7 +3728,7 @@ void CWallet::AutoCombineDust(CConnman* connman)
                 continue;
 
             // no p2cs accepted, those coins are "locked"
-            if (out.tx->vout[out.i].scriptPubKey.IsPayToColdStaking())
+            if (out.tx->tx->vout[out.i].scriptPubKey.IsPayToColdStaking())
                 continue;
 
             COutPoint outpt(out.tx->GetHash(), out.i);
@@ -4418,13 +4418,13 @@ CAmount CWallet::GetDebit(const CTransaction& tx, const isminefilter& filter) co
 CAmount CWallet::GetCredit(const CWalletTx& tx, const isminefilter& filter) const
 {
     CAmount nCredit = 0;
-    for (unsigned int i = 0; i < tx.vout.size(); i++) {
-        nCredit += GetCredit(tx.vout[i], filter);
+    for (unsigned int i = 0; i < tx.tx->vout.size(); i++) {
+        nCredit += GetCredit(tx.tx->vout[i], filter);
     }
 
     // Shielded credit
     if (filter & ISMINE_SPENDABLE_SHIELDED || filter & ISMINE_WATCH_ONLY_SHIELDED) {
-        if (tx.hasSaplingData()) {
+        if (tx.tx->hasSaplingData()) {
             nCredit += m_sspk_man->GetCredit(tx, filter, false);
         }
     }
@@ -4503,23 +4503,14 @@ bool CWallet::LoadSaplingPaymentAddress(
 ///////////////// End Sapling Methods //////////////////////
 ////////////////////////////////////////////////////////////
 
-CWalletTx::CWalletTx()
+CWalletTx::CWalletTx() : CMerkleTx()
 {
     Init(NULL);
 }
 
-CWalletTx::CWalletTx(const CWallet* pwalletIn)
+CWalletTx::CWalletTx(const CWallet* pwalletIn, CTransactionRef arg) : CMerkleTx(std::move(arg))
 {
-    Init(pwalletIn);
-}
-
-CWalletTx::CWalletTx(const CWallet* pwalletIn, const CMerkleTx& txIn) : CMerkleTx(txIn)
-{
-    Init(pwalletIn);
-}
-
-CWalletTx::CWalletTx(const CWallet* pwalletIn, const CTransaction& txIn) : CMerkleTx(txIn)
-{
+    // todo: set tx ref
     Init(pwalletIn);
 }
 
@@ -4566,12 +4557,12 @@ bool CWalletTx::IsTrusted(int& nDepth, bool& fConflicted) const
         return false;
 
     // Trusted if all inputs are from us and are in the mempool:
-    for (const CTxIn& txin : vin) {
+    for (const CTxIn& txin : tx->vin) {
         // Transactions not sent by us: not trusted
         const CWalletTx* parent = pwallet->GetWalletTx(txin.prevout.hash);
         if (parent == nullptr)
             return false;
-        const CTxOut& parentOut = parent->vout[txin.prevout.n];
+        const CTxOut& parentOut = parent->tx->vout[txin.prevout.n];
         if (pwallet->IsMine(parentOut) != ISMINE_SPENDABLE)
             return false;
     }
@@ -4617,7 +4608,7 @@ void CWalletTx::SetSaplingNoteData(mapSaplingNoteData_t &noteData)
 {
     mapSaplingNoteData.clear();
     for (const std::pair<SaplingOutPoint, SaplingNoteData> nd : noteData) {
-        if (nd.first.n < sapData->vShieldedOutput.size()) {
+        if (nd.first.n < tx->sapData->vShieldedOutput.size()) {
             mapSaplingNoteData[nd.first] = nd.second;
         } else {
             throw std::logic_error("CWalletTx::SetSaplingNoteData(): Invalid note");
@@ -4635,7 +4626,7 @@ Optional<std::pair<
         return nullopt;
     }
 
-    auto output = this->sapData->vShieldedOutput[op.n];
+    auto output = this->tx->sapData->vShieldedOutput[op.n];
     auto nd = this->mapSaplingNoteData.at(op);
 
     auto maybe_pt = libzcash::SaplingNotePlaintext::decrypt(
@@ -4658,7 +4649,7 @@ Optional<std::pair<
         libzcash::SaplingPaymentAddress>> CWalletTx::RecoverSaplingNote(
         SaplingOutPoint op, std::set<uint256>& ovks) const
 {
-    auto output = this->sapData->vShieldedOutput[op.n];
+    auto output = this->tx->sapData->vShieldedOutput[op.n];
 
     for (auto ovk : ovks) {
         auto outPt = libzcash::SaplingOutgoingPlaintext::decrypt(


### PR DESCRIPTION
Instead of inheriting from `CTransaction`, now `CWalletTx` will store it as member. Another step forward over the transaction complete immutability goal.

An adaptation of c3f5673a6304e3ea9fa56fff66b6ea1cb73cc98f with further needed changes, essentially:

> it makes it actually fully immutable and never modifies any of its elements (apart from wit) after construction.
> 
> To do so, we heavily rely on C++11. CTransaction gets a (CMutableTransaction&&) constructor that efficiently converts a CMutableTransaction into a CTransaction without copying. In addition, CTransaction gets a deserializing constructors.
> 
> One downside is that CWalletTx cannot easily inherent from CTransaction anymore, as CWalletTx needs a way to modify the CTransaction data inside. By turning the superclass into a CTransactionRef field, it can take advantage (not implemented yet) of sharing CTransactions with the mempool.

