### PR TITLE
[RPC] Add nullifiers to listshieldedunspent output

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -552,6 +552,7 @@ UniValue listshieldedunspent(const JSONRPCRequest& request)
                 "    \"amount\": xxxxx,          (numeric) the amount of value in the note\n"
                 "    \"memo\": xxxxx,            (string) hexademical string representation of memo field\n"
                 "    \"change\": true|false,     (boolean) true if the address that received the note is also one of the sending addresses\n"
+                "    \"nullifier\": xxxxx,       (string) the note's nullifier, hex encoded"
                 "  }\n"
                 "  ,...\n"
                 "]\n"
@@ -638,6 +639,10 @@ UniValue listshieldedunspent(const JSONRPCRequest& request)
             obj.pushKV("memo", HexStrTrimmed(entry.memo));
             if (hasSaplingSpendingKey) {
                 obj.pushKV("change", pwalletMain->GetSaplingScriptPubKeyMan()->IsNoteSaplingChange(nullifierSet, entry.address, entry.op));
+            }
+            const auto& nd = pwalletMain->mapWallet.at(entry.op.hash).mapSaplingNoteData.at(entry.op);
+            if (nd.nullifier) {
+                obj.pushKV("nullifier", nd.nullifier->ToString());
             }
             results.push_back(obj);
         }

--- a/test/functional/sapling_wallet_listreceived.py
+++ b/test/functional/sapling_wallet_listreceived.py
@@ -120,6 +120,11 @@ class ListReceivedTest (PivxTestFramework):
         # Now can check that the information is the same
         assert_equal(r, r2)
 
+        # Get the note nullifier
+        lsu = self.nodes[1].listshieldedunspent();
+        assert_equal(len(lsu), 1)
+        nullifier = lsu[0]["nullifier"]
+
         # Generate some change by sending part of shield_addr1 to shield_addr2
         txidPrev = txid
         shield_addr2 = self.nodes[1].getnewshieldedaddress()
@@ -128,6 +133,10 @@ class ListReceivedTest (PivxTestFramework):
                                                1, fee) # change 0.9
         self.sync_all()
         self.generate_and_sync(height+4)
+
+        # Verify the spent nullifier
+        tx_json = self.nodes[1].getrawtransaction(txid, True)
+        assert_equal(nullifier, tx_json["vShieldedSpend"][0]["nullifier"])
 
         # Decrypted transaction details should be correct
         pt = self.nodes[1].viewshieldedtransaction(txid)


### PR DESCRIPTION
Add the nullifier to the output of `listshieldedunspent`.
Verify it in `sapling_wallet_listreceived` functional test.