### PR TITLE
[Consensus] Bump TxVersion::SAPLING to 3

### DIFF
--- a/src/consensus/upgrades.cpp
+++ b/src/consensus/upgrades.cpp
@@ -51,7 +51,7 @@ const struct NUInfo NetworkUpgradeInfo[Consensus::MAX_NETWORK_UPGRADES] = {
         },
         {
                 /*.strName =*/ "v5_shield",
-                /*.strInfo =*/ "Sapling Shield - start block v8 - start transaction v2",
+                /*.strInfo =*/ "Sapling Shield - start block v8 - start transaction v3",
         },
         {
                 /*.strName =*/ "Test_dummy",

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1464,9 +1464,6 @@ bool AppInit2()
 
     fReindex = gArgs.GetBoolArg("-reindex", false);
 
-    // Assume sapling active during reindex for proper v2 deserialization when loading the wallet
-    if (fReindex) g_IsSaplingActive = true;
-
     // Create blocks directory if it doesn't already exist
     fs::create_directories(GetDataDir() / "blocks");
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -229,7 +229,7 @@ public:
     /** Transaction Versions */
     enum TxVersion: int16_t {
         LEGACY      = 1,
-        SAPLING     = 2,
+        SAPLING     = 3,
         TOOHIGH
     };
 

--- a/src/sapling/sapling_validation.cpp
+++ b/src/sapling/sapling_validation.cpp
@@ -32,7 +32,7 @@ bool CheckTransaction(const CTransaction& tx, CValidationState& state, CAmount& 
         return true;
     }
 
-    // From here, all of the checks are done in +v2 transactions.
+    // From here, all of the checks are done in v3+ transactions.
 
     // if the tx has shielded data, cannot be a coinstake, coinbase, zcspend and zcmint
     if (tx.IsCoinStake() || tx.IsCoinBase() || tx.HasZerocoinSpendInputs() || tx.HasZerocoinMintOutputs())
@@ -53,7 +53,7 @@ bool CheckTransactionWithoutProofVerification(const CTransaction& tx, CValidatio
 {
     // Basic checks that don't depend on any context
     const Consensus::Params& consensus = Params().GetConsensus();
-    // If the tx got to this point, must be +v2.
+    // If the tx got to this point, must be v3+.
     assert(tx.isSaplingVersion());
 
     // Check for non-zero valueBalance when there are no Sapling inputs or outputs

--- a/src/sapling/sapling_validation.h
+++ b/src/sapling/sapling_validation.h
@@ -14,7 +14,7 @@ class CValidationState;
 namespace SaplingValidation {
 
 /** Context-independent validity checks */
-// Note: for +v2, if the tx has no shielded data, this method returns true.
+// Note: for v3+, if the tx has no shielded data, this method returns true.
 // Note2: This function only performs shielded data related checks, it does NOT checks regular inputs and outputs.
 bool CheckTransaction(const CTransaction& tx, CValidationState& state, CAmount& nValueOut, bool fIsSaplingActive);
 bool CheckTransactionWithoutProofVerification(const CTransaction& tx, CValidationState &state, CAmount& nValueOut);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4122,6 +4122,11 @@ bool CWallet::InitLoadWallet()
         return true;
     }
 
+    // Assume sapling active during initialization of the wallet for proper v3 deserialization
+    // before reindex/resync
+    const bool wasSaplingActive = g_IsSaplingActive;
+    if (!wasSaplingActive) g_IsSaplingActive = true;
+
     std::string walletFile = gArgs.GetArg("-wallet", DEFAULT_WALLET_DAT);
 
     CWallet * const pwallet = CreateWalletFromFile(walletFile);
@@ -4130,6 +4135,8 @@ bool CWallet::InitLoadWallet()
     }
     pwalletMain = pwallet;
 
+    // restore global flag to previous state
+    g_IsSaplingActive = wasSaplingActive;
     return true;
 }
 


### PR DESCRIPTION

To hopefully clean up the tx serialization from the contextual flag after v5 enforcement.

Note: This PR marks the end of `testnet4` (clients compiled from master branch would no longer be able to run there) so it should be merged last, before starting `testnet5` alongside.