### PR TITLE
[Miner] Update block header's current version to v8

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -164,8 +164,14 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, 
     // Make sure to create the correct block version
     const Consensus::Params& consensus = Params().GetConsensus();
 
-    //!> Block v7: Removes accumulator checkpoints
-    pblock->nVersion = CBlockHeader::CURRENT_VERSION;
+    bool fSaplingActive = NetworkUpgradeActive(nHeight, consensus, Consensus::UPGRADE_V5_0);
+
+    if (fSaplingActive) {
+        //!> Block v8: Sapling / tx v2
+        pblock->nVersion = CBlockHeader::CURRENT_VERSION;
+    } else {
+        pblock->nVersion = 7;
+    }
     // -regtest only: allow overriding block.nVersion with
     // -blockversion=N to test forking scenarios
     if (Params().IsRegTestNet()) {
@@ -391,8 +397,7 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, 
         LogPrintf("%s : total size %u\n", __func__, nBlockSize);
 
         // Sapling
-        if (NetworkUpgradeActive(nHeight, consensus, Consensus::UPGRADE_V5_0)) {
-            pblock->nVersion = 8;
+        if (fSaplingActive) {
             SaplingMerkleTree sapling_tree;
             assert(view.GetSaplingAnchorAt(view.GetBestAnchor(), sapling_tree));
 

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -23,7 +23,7 @@ class CBlockHeader
 {
 public:
     // header
-    static const int32_t CURRENT_VERSION=7;     //!> Version 7 removes nAccumulatorCheckpoint from serialization
+    static const int32_t CURRENT_VERSION=8;     //!> Version 8 Sapling feature and tx v2
     int32_t nVersion;
     uint256 hashPrevBlock;
     uint256 hashMerkleRoot;


### PR DESCRIPTION
Avoids an upgrade warning from being triggered after 100 v8 blocks are
on chain. Moved the network upgrade consensus check further up too.