### PR TITLE
[Net] Socks5 netbase back ports, less scary failures.

### DIFF
--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -312,7 +312,7 @@ struct ProxyCredentials
 bool static Socks5(std::string strDest, int port, const ProxyCredentials *auth, SOCKET& hSocket)
 {
     IntrRecvError recvr;
-    LogPrintf("SOCKS5 connecting %s\n", strDest);
+    LogPrint(BCLog::NET, "SOCKS5 connecting %s\n", strDest);
     if (strDest.size() > 255) {
         CloseSocket(hSocket);
         return error("Hostname too long");
@@ -454,7 +454,7 @@ bool static Socks5(std::string strDest, int port, const ProxyCredentials *auth, 
         CloseSocket(hSocket);
         return error("Error reading from proxy");
     }
-    LogPrintf("SOCKS5 connected %s\n", strDest);
+    LogPrint(BCLog::NET, "SOCKS5 connected %s\n", strDest);
     return true;
 }
 

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -404,27 +404,21 @@ bool static Socks5(std::string strDest, int port, const ProxyCredentials *auth, 
         return error("Proxy failed to accept request");
     }
     if (pchRet2[1] != 0x00) {
+        // Failures to connect to a peer that are not proxy errors
         CloseSocket(hSocket);
-        switch (pchRet2[1]) {
-        case 0x01:
-            return error("Proxy error: general failure");
-        case 0x02:
-            return error("Proxy error: connection not allowed");
-        case 0x03:
-            return error("Proxy error: network unreachable");
-        case 0x04:
-            return error("Proxy error: host unreachable");
-        case 0x05:
-            return error("Proxy error: connection refused");
-        case 0x06:
-            return error("Proxy error: TTL expired");
-        case 0x07:
-            return error("Proxy error: protocol error");
-        case 0x08:
-            return error("Proxy error: address type not supported");
-        default:
-            return error("Proxy error: unknown");
+        switch (pchRet2[1])
+        {
+            case 0x01: LogPrintf("Socks5() connect to %s:%d failed: general failure\n", strDest, port); break;
+            case 0x02: LogPrintf("Socks5() connect to %s:%d failed: connection not allowed\n", strDest, port); break;
+            case 0x03: LogPrintf("Socks5() connect to %s:%d failed: network unreachable\n", strDest, port); break;
+            case 0x04: LogPrintf("Socks5() connect to %s:%d failed: host unreachable\n", strDest, port); break;
+            case 0x05: LogPrintf("Socks5() connect to %s:%d failed: connection refused\n", strDest, port); break;
+            case 0x06: LogPrintf("Socks5() connect to %s:%d failed: TTL expired\n", strDest, port); break;
+            case 0x07: LogPrintf("Socks5() connect to %s:%d failed: protocol error\n", strDest, port); break;
+            case 0x08: LogPrintf("Socks5() connect to %s:%d failed: address type not supported\n", strDest, port); break;
+            default:   LogPrintf("Socks5() connect to %s:%d failed: unknown\n", strDest, port);
         }
+        return false;
     }
     if (pchRet2[2] != 0x00) {
         CloseSocket(hSocket);

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -663,13 +663,14 @@ std::string NetworkErrorString(int err)
 std::string NetworkErrorString(int err)
 {
     char buf[256];
-    const char* s = buf;
     buf[0] = 0;
 /* Too bad there are two incompatible implementations of the
      * thread-safe strerror. */
+    const char *s;
 #ifdef STRERROR_R_CHAR_P /* GNU variant can return a pointer outside the passed buffer */
     s = strerror_r(err, buf, sizeof(buf));
 #else                    /* POSIX variant always returns message in buffer */
+    s = buf;
     if (strerror_r(err, buf, sizeof(buf)))
         buf[0] = 0;
 #endif

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -336,7 +336,8 @@ bool static Socks5(std::string strDest, int port, const ProxyCredentials *auth, 
     char pchRet1[2];
     if ((recvr = InterruptibleRecv(pchRet1, 2, SOCKS5_RECV_TIMEOUT, hSocket)) != IntrRecvError::OK) {
         CloseSocket(hSocket);
-        return error("Error reading proxy response");
+        LogPrintf("Socks5() connect to %s:%d failed: InterruptibleRecv() timeout or other failure\n", strDest, port);
+        return false;
     }
     if (pchRet1[0] != 0x05) {
         CloseSocket(hSocket);

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -94,30 +94,9 @@ bool static LookupIntern(const char* pszName, std::vector<CNetAddr>& vIP, unsign
         }
     }
 
-#ifdef HAVE_GETADDRINFO_A
-    struct in_addr ipv4_addr;
-#ifdef HAVE_INET_PTON
-    if (inet_pton(AF_INET, pszName, &ipv4_addr) > 0) {
-        vIP.emplace_back(ipv4_addr);
-        return true;
-    }
-
-    struct in6_addr ipv6_addr;
-    if (inet_pton(AF_INET6, pszName, &ipv6_addr) > 0) {
-        vIP.emplace_back(ipv6_addr);
-        return true;
-    }
-#else
-    ipv4_addr.s_addr = inet_addr(pszName);
-    if (ipv4_addr.s_addr != INADDR_NONE) {
-        vIP.emplace_back(ipv4_addr);
-        return true;
-    }
-#endif
-#endif
-
     struct addrinfo aiHint;
     memset(&aiHint, 0, sizeof(struct addrinfo));
+
     aiHint.ai_socktype = SOCK_STREAM;
     aiHint.ai_protocol = IPPROTO_TCP;
     aiHint.ai_family = AF_UNSPEC;
@@ -126,33 +105,8 @@ bool static LookupIntern(const char* pszName, std::vector<CNetAddr>& vIP, unsign
 #else
     aiHint.ai_flags = fAllowLookup ? AI_ADDRCONFIG : AI_NUMERICHOST;
 #endif
-
     struct addrinfo* aiRes = NULL;
-#ifdef HAVE_GETADDRINFO_A
-    struct gaicb gcb, *query = &gcb;
-    memset(query, 0, sizeof(struct gaicb));
-    gcb.ar_name = pszName;
-    gcb.ar_request = &aiHint;
-    int nErr = getaddrinfo_a(GAI_NOWAIT, &query, 1, NULL);
-    if (nErr)
-        return false;
-
-    do {
-        // Should set the timeout limit to a resonable value to avoid
-        // generating unnecessary checking call during the polling loop,
-        // while it can still response to stop request quick enough.
-        // 2 seconds looks fine in our situation.
-        struct timespec ts = {2, 0};
-        gai_suspend(&query, 1, &ts);
-        boost::this_thread::interruption_point();
-
-        nErr = gai_error(query);
-        if (0 == nErr)
-            aiRes = query->ar_result;
-    } while (nErr == EAI_INPROGRESS);
-#else
     int nErr = getaddrinfo(pszName, NULL, &aiHint, &aiRes);
-#endif
     if (nErr)
         return false;
 

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -308,6 +308,21 @@ struct ProxyCredentials
     std::string password;
 };
 
+std::string static Socks5ErrorString(int err)
+{
+    switch(err) {
+        case 0x01: return "general failure";
+        case 0x02: return "connection not allowed";
+        case 0x03: return "network unreachable";
+        case 0x04: return "host unreachable";
+        case 0x05: return "connection refused";
+        case 0x06: return "TTL expired";
+        case 0x07: return "protocol error";
+        case 0x08: return "address type not supported";
+        default:   return "unknown";
+    }
+}
+
 /** Connect using SOCKS5 (as described in RFC1928) */
 bool static Socks5(std::string strDest, int port, const ProxyCredentials *auth, SOCKET& hSocket)
 {
@@ -407,18 +422,7 @@ bool static Socks5(std::string strDest, int port, const ProxyCredentials *auth, 
     if (pchRet2[1] != 0x00) {
         // Failures to connect to a peer that are not proxy errors
         CloseSocket(hSocket);
-        switch (pchRet2[1])
-        {
-            case 0x01: LogPrintf("Socks5() connect to %s:%d failed: general failure\n", strDest, port); break;
-            case 0x02: LogPrintf("Socks5() connect to %s:%d failed: connection not allowed\n", strDest, port); break;
-            case 0x03: LogPrintf("Socks5() connect to %s:%d failed: network unreachable\n", strDest, port); break;
-            case 0x04: LogPrintf("Socks5() connect to %s:%d failed: host unreachable\n", strDest, port); break;
-            case 0x05: LogPrintf("Socks5() connect to %s:%d failed: connection refused\n", strDest, port); break;
-            case 0x06: LogPrintf("Socks5() connect to %s:%d failed: TTL expired\n", strDest, port); break;
-            case 0x07: LogPrintf("Socks5() connect to %s:%d failed: protocol error\n", strDest, port); break;
-            case 0x08: LogPrintf("Socks5() connect to %s:%d failed: address type not supported\n", strDest, port); break;
-            default:   LogPrintf("Socks5() connect to %s:%d failed: unknown\n", strDest, port);
-        }
+        LogPrintf("Socks5() connect to %s:%d failed: %s\n", strDest, port, Socks5ErrorString(pchRet2[1]));
         return false;
     }
     if (pchRet2[2] != 0x00) {


### PR DESCRIPTION
Made a set of back ports to make Socks5 connection failures less noisy and less unnecessarily scary.
Plus added a straightforward removal of `getaddrinfo_a` which was never available at configure time.

Back ported PRs list:
#8033
#9229
#9539