### PR TITLE
[GUI] Transaction detail, scroll memo fix, starting from the top.

### DIFF
--- a/src/qt/pivx/sendconfirmdialog.cpp
+++ b/src/qt/pivx/sendconfirmdialog.cpp
@@ -140,6 +140,8 @@ void TxDetailDialog::setData(WalletModel *_model, const QModelIndex &index)
             ui->contentMemo->setVisible(true);
             ui->labelDividerMemo->setVisible(true);
             ui->textMemo->adjustSize();
+            ui->textMemo->moveCursor(QTextCursor::Start);
+            ui->textMemo->ensureCursorVisible();
         } else {
             ui->contentMemo->setVisible(false);
             ui->labelDividerMemo->setVisible(false);
@@ -211,6 +213,8 @@ void TxDetailDialog::setData(WalletModel *_model, WalletModelTransaction* _tx)
             ui->textMemo->insertPlainText(recipient.message);
             ui->contentMemo->setVisible(true);
             ui->labelDividerMemo->setVisible(true);
+            ui->textMemo->moveCursor(QTextCursor::Start);
+            ui->textMemo->ensureCursorVisible();
         } else {
             ui->contentMemo->setVisible(false);
             ui->labelDividerMemo->setVisible(false);


### PR DESCRIPTION
`QPlainTextEdit` cursor always scroll down up to the bottom if the view is scrollable, this force it to start from the top in the transaction detail screen over the memo field so it can be read properly.