### PR TITLE
[Masternode] Encapsulate global and do not parse privkey redundantly everywhere.

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -56,11 +56,12 @@ OperationResult initMasternode(const std::string& _strMasterNodePrivKey, const s
 
     CKey key;
     CPubKey pubkey;
-
     if (!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, key, pubkey)) {
         return errorOut(_("Invalid masternodeprivkey. Please see the documentation."));
     }
+
     activeMasternode.pubKeyMasternode = pubkey;
+    activeMasternode.privKeyMasternode = key;
     fMasterNode = true;
     return OperationResult(true);
 }

--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -232,3 +232,13 @@ bool CActiveMasternode::EnableHotColdMasterNode(CTxIn& newVin, CService& newServ
 
     return true;
 }
+
+bool CActiveMasternode::GetKeys(CKey& _privKeyMasternode, CPubKey& _pubKeyMasternode)
+{
+    if (!privKeyMasternode.IsValid() || !pubKeyMasternode.IsValid()) {
+        return error("Error trying to get masternode keys");
+    }
+    _privKeyMasternode = privKeyMasternode;
+    _pubKeyMasternode = pubKeyMasternode;
+    return true;
+}

--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -170,11 +170,8 @@ bool CActiveMasternode::SendMasternodePing(std::string& errorMessage)
         return false;
     }
 
-    CPubKey pubKeyMasternode;
-    CKey keyMasternode;
-
-    if (!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, keyMasternode, pubKeyMasternode)) {
-        errorMessage = "Error upon calling GetKeysFromSecret.\n";
+    if (!privKeyMasternode.IsValid() || !pubKeyMasternode.IsValid()) {
+        errorMessage = "Error upon masternode key.\n";
         return false;
     }
 
@@ -182,7 +179,7 @@ bool CActiveMasternode::SendMasternodePing(std::string& errorMessage)
 
     const uint256& nBlockHash = mnodeman.GetBlockHashToPing();
     CMasternodePing mnp(*vin, nBlockHash);
-    if (!mnp.Sign(keyMasternode, pubKeyMasternode)) {
+    if (!mnp.Sign(privKeyMasternode, pubKeyMasternode)) {
         errorMessage = "Couldn't sign Masternode Ping";
         return false;
     }

--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -33,7 +33,6 @@ OperationResult initMasternode(const std::string& _strMasterNodePrivKey, const s
 
     // Global params set
     strMasterNodeAddr = _strMasterNodeAddr;
-    strMasterNodePrivKey = _strMasterNodePrivKey;
 
     // Address parsing.
     const CChainParams& params = Params();
@@ -56,7 +55,7 @@ OperationResult initMasternode(const std::string& _strMasterNodePrivKey, const s
 
     CKey key;
     CPubKey pubkey;
-    if (!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, key, pubkey)) {
+    if (!CMessageSigner::GetKeysFromSecret(_strMasterNodePrivKey, key, pubkey)) {
         return errorOut(_("Invalid masternodeprivkey. Please see the documentation."));
     }
 

--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -232,12 +232,11 @@ bool CActiveMasternode::EnableHotColdMasterNode(CTxIn& newVin, CService& newServ
     return true;
 }
 
-bool CActiveMasternode::GetKeys(CKey& _privKeyMasternode, CPubKey& _pubKeyMasternode)
+void CActiveMasternode::GetKeys(CKey& _privKeyMasternode, CPubKey& _pubKeyMasternode)
 {
     if (!privKeyMasternode.IsValid() || !pubKeyMasternode.IsValid()) {
-        return error("Error trying to get masternode keys");
+        throw std::runtime_error("Error trying to get masternode keys");
     }
     _privKeyMasternode = privKeyMasternode;
     _pubKeyMasternode = pubKeyMasternode;
-    return true;
 }

--- a/src/activemasternode.h
+++ b/src/activemasternode.h
@@ -57,7 +57,7 @@ public:
     /// Enable cold wallet mode (run a Masternode with no funds)
     bool EnableHotColdMasterNode(CTxIn& vin, CService& addr);
 
-    bool GetKeys(CKey& privKeyMasternode, CPubKey& pubKeyMasternode);
+    void GetKeys(CKey& privKeyMasternode, CPubKey& pubKeyMasternode);
 };
 
 #endif

--- a/src/activemasternode.h
+++ b/src/activemasternode.h
@@ -56,6 +56,8 @@ public:
     bool SendMasternodePing(std::string& errorMessage);
     /// Enable cold wallet mode (run a Masternode with no funds)
     bool EnableHotColdMasterNode(CTxIn& vin, CService& addr);
+
+    bool GetKeys(CKey& privKeyMasternode, CPubKey& pubKeyMasternode);
 };
 
 #endif

--- a/src/activemasternode.h
+++ b/src/activemasternode.h
@@ -40,6 +40,7 @@ public:
     // Initialized by init.cpp
     // Keys for the main Masternode
     CPubKey pubKeyMasternode;
+    CKey privKeyMasternode;
 
     // Initialized while registering Masternode
     Optional<CTxIn> vin;

--- a/src/budget/budgetmanager.cpp
+++ b/src/budget/budgetmanager.cpp
@@ -500,8 +500,7 @@ void CBudgetManager::VoteOnFinalizedBudgets()
     // Get masternode keys
     CPubKey pubKeyMasternode;
     CKey keyMasternode;
-    if (!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, keyMasternode, pubKeyMasternode)) {
-        LogPrintf("%s: Unable to get masternode keys\n", __func__);
+    if (!activeMasternode.GetKeys(keyMasternode, pubKeyMasternode)) {
         return;
     }
     // Sign finalized budgets

--- a/src/budget/budgetmanager.cpp
+++ b/src/budget/budgetmanager.cpp
@@ -500,9 +500,8 @@ void CBudgetManager::VoteOnFinalizedBudgets()
     // Get masternode keys
     CPubKey pubKeyMasternode;
     CKey keyMasternode;
-    if (!activeMasternode.GetKeys(keyMasternode, pubKeyMasternode)) {
-        return;
-    }
+    activeMasternode.GetKeys(keyMasternode, pubKeyMasternode);
+
     // Sign finalized budgets
     for (const uint256& budgetHash: vBudgetHashes) {
         CFinalizedBudgetVote vote(*(activeMasternode.vin), budgetHash);

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -681,10 +681,7 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight)
     }
 
     CPubKey pubKeyMasternode; CKey keyMasternode;
-    if (!activeMasternode.GetKeys(keyMasternode, pubKeyMasternode)) {
-        LogPrint(BCLog::MASTERNODE,"CMasternodePayments::ProcessBlock() - Error upon calling GetKeysFromSecret.\n");
-        return false;
-    }
+    activeMasternode.GetKeys(keyMasternode, pubKeyMasternode);
 
     LogPrint(BCLog::MASTERNODE,"CMasternodePayments::ProcessBlock() - Signing Winner\n");
     if (newWinner.Sign(keyMasternode, pubKeyMasternode)) {

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -680,11 +680,8 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight)
         }
     }
 
-    std::string errorMessage;
-    CPubKey pubKeyMasternode;
-    CKey keyMasternode;
-
-    if (!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, keyMasternode, pubKeyMasternode)) {
+    CPubKey pubKeyMasternode; CKey keyMasternode;
+    if (!activeMasternode.GetKeys(keyMasternode, pubKeyMasternode)) {
         LogPrint(BCLog::MASTERNODE,"CMasternodePayments::ProcessBlock() - Error upon calling GetKeysFromSecret.\n");
         return false;
     }

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -26,7 +26,6 @@ class CActiveMasternode;
 
 extern CMasternodeMan mnodeman;
 extern CActiveMasternode activeMasternode;
-extern std::string strMasterNodePrivKey;
 
 void DumpMasternodes();
 

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -273,14 +273,8 @@ UniValue mnbudgetvote(const JSONRPCRequest& request)
         UniValue statusObj(UniValue::VOBJ);
 
         while (true) {
-            if (!activeMasternode.GetKeys(keyMasternode, pubKeyMasternode)) {
-                failed++;
-                statusObj.pushKV("node", "local");
-                statusObj.pushKV("result", "failed");
-                statusObj.pushKV("error", "Masternode signing error, GetKeysFromSecret failed.");
-                resultsObj.push_back(statusObj);
-                break;
-            }
+            // Get MN keys
+            activeMasternode.GetKeys(keyMasternode, pubKeyMasternode);
 
             CMasternode* pmn = mnodeman.Find(activeMasternode.vin->prevout);
             if (pmn == NULL) {
@@ -817,9 +811,7 @@ UniValue mnfinalbudget(const JSONRPCRequest& request)
         uint256 hash(uint256S(strHash));
 
         CPubKey pubKeyMasternode; CKey keyMasternode;
-        if (!activeMasternode.GetKeys(keyMasternode, pubKeyMasternode)) {
-            return "Error upon calling GetKeysFromSecret";
-        }
+        activeMasternode.GetKeys(keyMasternode, pubKeyMasternode);
 
         CMasternode* pmn = mnodeman.Find(activeMasternode.vin->prevout);
         if (pmn == NULL) {

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -273,7 +273,7 @@ UniValue mnbudgetvote(const JSONRPCRequest& request)
         UniValue statusObj(UniValue::VOBJ);
 
         while (true) {
-            if (!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, keyMasternode, pubKeyMasternode)) {
+            if (!activeMasternode.GetKeys(keyMasternode, pubKeyMasternode)) {
                 failed++;
                 statusObj.pushKV("node", "local");
                 statusObj.pushKV("result", "failed");
@@ -816,11 +816,10 @@ UniValue mnfinalbudget(const JSONRPCRequest& request)
         std::string strHash = request.params[1].get_str();
         uint256 hash(uint256S(strHash));
 
-        CPubKey pubKeyMasternode;
-        CKey keyMasternode;
-
-        if (!CMessageSigner::GetKeysFromSecret(strMasterNodePrivKey, keyMasternode, pubKeyMasternode))
+        CPubKey pubKeyMasternode; CKey keyMasternode;
+        if (!activeMasternode.GetKeys(keyMasternode, pubKeyMasternode)) {
             return "Error upon calling GetKeysFromSecret";
+        }
 
         CMasternode* pmn = mnodeman.Find(activeMasternode.vin->prevout);
         if (pmn == NULL) {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -90,7 +90,6 @@ const char * const PIVX_MASTERNODE_CONF_FILENAME = "masternode.conf";
 // PIVX only features
 // Masternode
 std::atomic<bool> fMasterNode{false};
-std::string strMasterNodePrivKey = "";
 std::string strMasterNodeAddr = "";
 bool fLiteMode = false;
 


### PR DESCRIPTION
Performance improvement for masternodes, instead of having to parse the global private key string, decode it once and cache it on the active masternode class, plus remove the global mn privkey string.
As this was decoded and re-decoded everywhere, this will have a direct effect on the ping send process, vote on finalized budgets, masternode payments block processing, and budget proposal vote flow.