### PR TITLE
[Cleanup] Removing unused DisconnectBlocks and ReprocessBlocks

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2108,37 +2108,6 @@ bool DisconnectBlocks(int nBlocks, const CChainParams& chainparams)
     return true;
 }
 
-void ReprocessBlocks(int nBlocks, const CChainParams& chainparams)
-{
-    std::map<uint256, int64_t>::iterator it = mapRejectedBlocks.begin();
-    while (it != mapRejectedBlocks.end()) {
-        //use a window twice as large as is usual for the nBlocks we want to reset
-        if ((*it).second > GetTime() - (nBlocks * Params().GetConsensus().nTargetSpacing * 2)) {
-            BlockMap::iterator mi = mapBlockIndex.find((*it).first);
-            if (mi != mapBlockIndex.end() && (*mi).second) {
-                LOCK(cs_main);
-
-                CBlockIndex* pindex = (*mi).second;
-                LogPrintf("%s - %s\n", __func__, (*it).first.ToString());
-
-                CValidationState state;
-                ReconsiderBlock(state, pindex);
-            }
-        }
-        ++it;
-    }
-
-    CValidationState state;
-    {
-        LOCK(cs_main);
-        DisconnectBlocks(nBlocks, chainparams);
-    }
-
-    if (state.IsValid()) {
-        ActivateBestChain(state);
-    }
-}
-
 /**
  * Return the tip of the chain with the most work in it, that isn't
  * known to be invalid (it's however far from certain to be valid).

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2095,19 +2095,6 @@ bool static ConnectTip(CValidationState& state, CBlockIndex* pindexNew, const st
     return true;
 }
 
-bool DisconnectBlocks(int nBlocks, const CChainParams& chainparams)
-{
-    LOCK(cs_main);
-
-    CValidationState state;
-
-    LogPrintf("%s: Got command to replay %d blocks\n", __func__, nBlocks);
-    for (int i = 0; i <= nBlocks; i++)
-        DisconnectTip(state, chainparams);
-
-    return true;
-}
-
 /**
  * Return the tip of the chain with the most work in it, that isn't
  * known to be invalid (it's however far from certain to be valid).

--- a/src/validation.h
+++ b/src/validation.h
@@ -323,12 +323,6 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex);
 
 /** Functions for validating blocks and updating the block tree */
 
-/** Undo the effects of this block (with given index) on the UTXO set represented by coins.
- *  In case pfClean is provided, operation will try to be tolerant about errors, and *pfClean
- *  will be true if no problems were found. Otherwise, the return value will be false in case
- *  of problems. Note that in any case, coins may be modified. */
-bool DisconnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex, CCoinsViewCache& coins, bool* pfClean = NULL);
-
 /** Apply the effects of this block (with given index) on the UTXO set represented by coins */
 bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pindex, CCoinsViewCache& coins, bool fJustCheck, bool fAlreadyChecked = false);
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -329,9 +329,6 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex);
  *  of problems. Note that in any case, coins may be modified. */
 bool DisconnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex, CCoinsViewCache& coins, bool* pfClean = NULL);
 
-/** Reprocess a number of blocks to try and get on the correct chain again **/
-bool DisconnectBlocks(int nBlocks, const CChainParams& chainparams);
-
 /** Apply the effects of this block (with given index) on the UTXO set represented by coins */
 bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pindex, CCoinsViewCache& coins, bool fJustCheck, bool fAlreadyChecked = false);
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -331,7 +331,6 @@ bool DisconnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex
 
 /** Reprocess a number of blocks to try and get on the correct chain again **/
 bool DisconnectBlocks(int nBlocks, const CChainParams& chainparams);
-void ReprocessBlocks(int nBlocks, const CChainParams& chainparams);
 
 /** Apply the effects of this block (with given index) on the UTXO set represented by coins */
 bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pindex, CCoinsViewCache& coins, bool fJustCheck, bool fAlreadyChecked = false);


### PR DESCRIPTION
Cleaning up two unused functions in the validation area. `DisconnectBlocks` and `ReprocessBlocks`.