### PR TITLE
[BUG][MN] Immediately detect forked masternodes

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -177,7 +177,7 @@ bool CActiveMasternode::SendMasternodePing(std::string& errorMessage)
     LogPrintf("CActiveMasternode::SendMasternodePing() - Relay Masternode Ping vin = %s\n", vin->ToString());
 
     const uint256& nBlockHash = mnodeman.GetBlockHashToPing();
-    CMasternodePing mnp(*vin, nBlockHash);
+    CMasternodePing mnp(*vin, nBlockHash, GetAdjustedTime());
     if (!mnp.Sign(privKeyMasternode, pubKeyMasternode)) {
         errorMessage = "Couldn't sign Masternode Ping";
         return false;

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -602,6 +602,14 @@ bool CMasternodePing::CheckAndUpdate(int& nDos, bool fRequireAvailable, bool fCh
         return false;
     }
 
+    // Check if the ping block hash exists and it's within 24 blocks from the tip
+    if (!mnodeman.IsWithinDepth(blockHash, 2 * MNPING_DEPTH)) {
+        LogPrint(BCLog::MNPING,"%s: Masternode %s block hash %s is too old or has an invalid block hash\n",
+                                        __func__, vin.prevout.hash.ToString(), blockHash.ToString());
+        nDos = 33;
+        return false;
+    }
+
     // see if we have this Masternode
     CMasternode* pmn = mnodeman.Find(vin.prevout);
     const bool isMasternodeFound = (pmn != nullptr);
@@ -629,14 +637,6 @@ bool CMasternodePing::CheckAndUpdate(int& nDos, bool fRequireAvailable, bool fCh
         // last ping was more then MASTERNODE_MIN_MNP_SECONDS-60 ago comparing to this one
         if (!pmn->IsPingedWithin(MasternodeMinPingSeconds() - 60, sigTime)) {
             if (!isSignatureValid) {
-                nDos = 33;
-                return false;
-            }
-
-            // Check if the ping block hash exists and it's within 24 blocks from the tip
-            if (!mnodeman.IsWithinDepth(blockHash, 2 * MNPING_DEPTH)) {
-                LogPrint(BCLog::MNPING,"%s: Masternode %s block hash %s is too old or has an invalid block hash\n",
-                                                __func__, vin.prevout.hash.ToString(), blockHash.ToString());
                 nDos = 33;
                 return false;
             }

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -73,7 +73,7 @@ CMasternode::CMasternode() :
     addr = CService();
     pubKeyCollateralAddress = CPubKey();
     pubKeyMasternode = CPubKey();
-    sigTime = GetAdjustedTime();
+    sigTime = 0;
     lastPing = CMasternodePing();
     protocolVersion = PROTOCOL_VERSION;
     nScanningErrorCount = 0;
@@ -288,7 +288,7 @@ bool CMasternodeBroadcast::Create(const CTxIn& txin,
 
     // Get block hash to ping (TODO: move outside of this function)
     const uint256& nBlockHashToPing = mnodeman.GetBlockHashToPing();
-    CMasternodePing mnp(txin, nBlockHashToPing);
+    CMasternodePing mnp(txin, nBlockHashToPing, GetAdjustedTime());
     if (!mnp.Sign(keyMasternodeNew, pubKeyMasternodeNew)) {
         strErrorRet = strprintf("Failed to sign ping, masternode=%s", txin.prevout.hash.ToString());
         LogPrint(BCLog::MASTERNODE,"CMasternodeBroadcast::Create -- %s\n", strErrorRet);
@@ -564,14 +564,14 @@ CMasternodePing::CMasternodePing() :
         CSignedMessage(),
         vin(),
         blockHash(),
-        sigTime(GetAdjustedTime())
+        sigTime(0)
 { }
 
-CMasternodePing::CMasternodePing(const CTxIn& newVin, const uint256& nBlockHash) :
+CMasternodePing::CMasternodePing(const CTxIn& newVin, const uint256& nBlockHash, uint64_t _sigTime) :
         CSignedMessage(),
         vin(newVin),
         blockHash(nBlockHash),
-        sigTime(GetAdjustedTime())
+        sigTime(_sigTime)
 { }
 
 uint256 CMasternodePing::GetHash() const

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -206,7 +206,7 @@ CMasternodeBroadcast::CMasternodeBroadcast() :
         CMasternode()
 { }
 
-CMasternodeBroadcast::CMasternodeBroadcast(CService newAddr, CTxIn newVin, CPubKey pubKeyCollateralAddressNew, CPubKey pubKeyMasternodeNew, int protocolVersionIn) :
+CMasternodeBroadcast::CMasternodeBroadcast(CService newAddr, CTxIn newVin, CPubKey pubKeyCollateralAddressNew, CPubKey pubKeyMasternodeNew, int protocolVersionIn, const CMasternodePing& _lastPing) :
         CMasternode()
 {
     vin = newVin;
@@ -214,6 +214,8 @@ CMasternodeBroadcast::CMasternodeBroadcast(CService newAddr, CTxIn newVin, CPubK
     pubKeyCollateralAddress = pubKeyCollateralAddressNew;
     pubKeyMasternode = pubKeyMasternodeNew;
     protocolVersion = protocolVersionIn;
+    lastPing = _lastPing;
+    sigTime = lastPing.sigTime;
 }
 
 CMasternodeBroadcast::CMasternodeBroadcast(const CMasternode& mn) :
@@ -294,7 +296,7 @@ bool CMasternodeBroadcast::Create(const CTxIn& txin,
         return false;
     }
 
-    mnbRet = CMasternodeBroadcast(service, txin, pubKeyCollateralAddressNew, pubKeyMasternodeNew, PROTOCOL_VERSION);
+    mnbRet = CMasternodeBroadcast(service, txin, pubKeyCollateralAddressNew, pubKeyMasternodeNew, PROTOCOL_VERSION, mnp);
 
     if (!mnbRet.IsValidNetAddr()) {
         strErrorRet = strprintf("Invalid IP address %s, masternode=%s", mnbRet.addr.ToStringIP (), txin.prevout.hash.ToString());
@@ -303,7 +305,6 @@ bool CMasternodeBroadcast::Create(const CTxIn& txin,
         return false;
     }
 
-    mnbRet.lastPing = mnp;
     if (!mnbRet.Sign(keyCollateralAddressNew, pubKeyCollateralAddressNew)) {
         strErrorRet = strprintf("Failed to sign broadcast, masternode=%s", txin.prevout.hash.ToString());
         LogPrint(BCLog::MASTERNODE,"CMasternodeBroadcast::Create -- %s\n", strErrorRet);

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -268,7 +268,7 @@ class CMasternodeBroadcast : public CMasternode
 {
 public:
     CMasternodeBroadcast();
-    CMasternodeBroadcast(CService newAddr, CTxIn newVin, CPubKey newPubkey, CPubKey newPubkey2, int protocolVersionIn);
+    CMasternodeBroadcast(CService newAddr, CTxIn newVin, CPubKey newPubkey, CPubKey newPubkey2, int protocolVersionIn, const CMasternodePing& _lastPing);
     CMasternodeBroadcast(const CMasternode& mn);
 
     bool CheckAndUpdate(int& nDoS);

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -41,7 +41,7 @@ public:
     int64_t sigTime; //mnb message times
 
     CMasternodePing();
-    CMasternodePing(const CTxIn& newVin, const uint256& nBlockHash);
+    CMasternodePing(const CTxIn& newVin, const uint256& nBlockHash, uint64_t _sigTime);
 
     ADD_SERIALIZE_METHODS;
 


### PR DESCRIPTION
Check the pinged blockhash at the beginning of `CMasternodePing::CheckAndUpdate`.
So we don't ask new broadcasts when it's wrong, and we can immediately detect stale mnbs.

Also, explicitly pass the signature time when constructing `CMasternode` and `CMasternodePing` objects (instead of automatically setting it to the current time, which might be error prone, leading to unintended updates).