### PR TITLE
[Backport] Fix races for strMiscWarning and fLargeWork*Found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,6 +400,7 @@ set(COMMON_SOURCES
         ./src/script/script_error.cpp
         ./src/spork.cpp
         ./src/sporkdb.cpp
+        ./src/warnings.cpp
         )
 add_library(COMMON_A STATIC ${BitcoinHeaders} ${COMMON_SOURCES})
 target_include_directories(COMMON_A PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -289,6 +289,7 @@ BITCOIN_CORE_H = \
   destination_io.h \
   wallet/wallet.h \
   wallet/walletdb.h \
+  warnings.h \
   zpivchain.h \
   zpiv/deterministicmint.h \
   zpiv/mintpool.h \
@@ -511,6 +512,7 @@ libbitcoin_common_a_SOURCES = \
   script/script.cpp \
   script/sign.cpp \
   script/standard.cpp \
+  warnings.cpp \
   script/script_error.cpp \
   spork.cpp \
   sporkdb.cpp \

--- a/src/guiinterface.h
+++ b/src/guiinterface.h
@@ -85,9 +85,6 @@ public:
     /** Progress message during initialization. */
     boost::signals2::signal<void(const std::string& message)> InitMessage;
 
-    /** Translate a message to the native language of the user. */
-    boost::signals2::signal<std::string(const char* psz)> Translate;
-
     /** Number of network connections changed. */
     boost::signals2::signal<void(int newNumConnections)> NotifyNumConnectionsChanged;
 
@@ -111,15 +108,5 @@ public:
 };
 
 extern CClientUIInterface uiInterface;
-
-/**
- * Translation function: Call Translate signal on UI interface, which returns a boost::optional result.
- * If no translation slot is registered, nothing is returned, and simply return the input.
- */
-inline std::string _(const char* psz)
-{
-    Optional<std::string> rv = uiInterface.Translate(psz);
-    return rv ? (*rv) : psz;
-}
 
 #endif // BITCOIN_GUIINTERFACE_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -66,6 +66,7 @@
 #include "wallet/rpcwallet.h"
 
 #endif
+#include "warnings.h"
 
 #include <atomic>
 #include <fstream>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -125,7 +125,7 @@ enum BindFlags {
 };
 
 static const char* FEE_ESTIMATES_FILENAME = "fee_estimates.dat";
-CClientUIInterface uiInterface;
+CClientUIInterface uiInterface;  // Declared but not defined in guiinterface.h
 
 //////////////////////////////////////////////////////////////////////////////
 //

--- a/src/pivx-cli.cpp
+++ b/src/pivx-cli.cpp
@@ -22,8 +22,6 @@
 
 #include <univalue.h>
 
-#define _(x) std::string(x) /* Keep the _() around in case gettext or such will be used later to translate non-UI */
-
 static const char DEFAULT_RPCCONNECT[] = "127.0.0.1";
 static const int DEFAULT_HTTP_CLIENT_TIMEOUT=900;
 

--- a/src/pivx-tx.cpp
+++ b/src/pivx-tx.cpp
@@ -13,7 +13,6 @@
 #include "primitives/transaction.h"
 #include "script/script.h"
 #include "script/sign.h"
-#include "guiinterface.h" // for _(...)
 #include <univalue.h>
 #include "util.h"
 #include "utilmoneystr.h"
@@ -27,7 +26,6 @@
 
 static bool fCreateBlank;
 static std::map<std::string, UniValue> registers;
-CClientUIInterface uiInterface;
 
 static bool AppInitRawTx(int argc, char* argv[])
 {

--- a/src/pivxd.cpp
+++ b/src/pivxd.cpp
@@ -3,19 +3,16 @@
 // Copyright (c) 2014-2015 The Dash developers
 // Copyright (c) 2015-2019 The PIVX developers
 // Distributed under the MIT/X11 software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
+#include "chainparams.h"
 #include "clientversion.h"
 #include "fs.h"
 #include "init.h"
 #include "masternodeconfig.h"
 #include "noui.h"
 #include "rpc/server.h"
-#include "guiinterface.h"
 #include "util.h"
-#include "httpserver.h"
-#include "httprpc.h"
-#include "validation.h"
 
 #include <stdio.h>
 

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -20,6 +20,7 @@
 #include "netbase.h"
 #include "guiinterface.h"
 #include "util.h"
+#include "warnings.h"
 
 #include <stdint.h>
 

--- a/src/qt/pivx.cpp
+++ b/src/qt/pivx.cpp
@@ -247,7 +247,7 @@ BitcoinCore::BitcoinCore() : QObject()
 void BitcoinCore::handleRunawayException(const std::exception* e)
 {
     PrintExceptionContinue(e, "Runaway exception");
-    Q_EMIT runawayException(QString::fromStdString(strMiscWarning));
+    Q_EMIT runawayException(QString::fromStdString(GetWarnings("gui")));
 }
 
 void BitcoinCore::initialize()
@@ -696,10 +696,10 @@ int main(int argc, char* argv[])
         app.exec();
     } catch (const std::exception& e) {
         PrintExceptionContinue(&e, "Runaway exception");
-        app.handleRunawayException(QString::fromStdString(strMiscWarning));
+        app.handleRunawayException(QString::fromStdString(GetWarnings("gui")));
     } catch (...) {
         PrintExceptionContinue(NULL, "Runaway exception");
-        app.handleRunawayException(QString::fromStdString(strMiscWarning));
+        app.handleRunawayException(QString::fromStdString(GetWarnings("gui")));
     }
     return app.getReturnValue();
 }

--- a/src/qt/pivx.cpp
+++ b/src/qt/pivx.cpp
@@ -567,7 +567,7 @@ int main(int argc, char* argv[])
     // Now that QSettings are accessible, initialize translations
     //initTranslations(qtTranslatorBase, qtTranslator, translatorBase, translator);
     app.updateTranslation();
-    uiInterface.Translate.connect(Translate);
+    translationInterface.Translate.connect(Translate);
 
     // Show help message immediately after parsing command-line options (for "-lang") and setting locale,
     // but before showing splash screen.

--- a/src/qt/pivx.cpp
+++ b/src/qt/pivx.cpp
@@ -33,6 +33,7 @@
 #include "rpc/server.h"
 #include "guiinterface.h"
 #include "util.h"
+#include "warnings.h"
 
 #ifdef ENABLE_WALLET
 #include "wallet/wallet.h"

--- a/src/qt/pivx/pivxgui.cpp
+++ b/src/qt/pivx/pivxgui.cpp
@@ -239,9 +239,9 @@ void PIVXGUI::handleRestart(QStringList args)
 }
 
 
-void PIVXGUI::setClientModel(ClientModel* clientModel)
+void PIVXGUI::setClientModel(ClientModel* _clientModel)
 {
-    this->clientModel = clientModel;
+    this->clientModel = _clientModel;
     if (this->clientModel) {
         // Create system tray menu (or setup the dock menu) that late to prevent users from calling actions,
         // while the client has not yet fully loaded
@@ -254,6 +254,9 @@ void PIVXGUI::setClientModel(ClientModel* clientModel)
 
         // Receive and report messages from client model
         connect(clientModel, &ClientModel::message, this, &PIVXGUI::message);
+        connect(clientModel, &ClientModel::alertsChanged, [this](const QString& _alertStr) {
+            message(tr("Alert!"), _alertStr, CClientUIInterface::MSG_WARNING);
+        });
         connect(topBar, &TopBar::walletSynced, dashboard, &DashboardWidget::walletSynced);
         connect(topBar, &TopBar::walletSynced, coldStakingWidget, &ColdStakingWidget::walletSynced);
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -7,10 +7,6 @@
 
 #include "rpc/client.h"
 
-#include "rpc/protocol.h"
-#include "guiinterface.h"
-#include "util.h"
-
 #include <set>
 #include <stdint.h>
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -20,6 +20,7 @@
 #include "wallet/db.h"
 #include "wallet/wallet.h"
 #endif
+#include "warnings.h"
 
 #include <stdint.h>
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -21,6 +21,7 @@
 #include "wallet/wallet.h"
 #include "wallet/walletdb.h"
 #endif
+#include "warnings.h"
 
 #include <stdint.h>
 

--- a/src/test/test_pivx.cpp
+++ b/src/test/test_pivx.cpp
@@ -21,7 +21,7 @@
 
 std::unique_ptr<CConnman> g_connman;
 
-CClientUIInterface uiInterface;
+CClientUIInterface uiInterface;  // Declared but not defined in guiinterface.h
 
 uint256 insecure_rand_seed = GetRandHash();
 FastRandomContext insecure_rand_ctx(insecure_rand_seed);

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -10,7 +10,7 @@
 #include "netaddress.h"
 #include "sync.h"
 #include "util.h"
-#include "utilstrencodings.h"
+#include "warnings.h"
 
 
 static RecursiveMutex cs_nTimeOffset;

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -74,11 +74,11 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample, int nOffsetLimit)
         // Only let other nodes change our time by so much
         if (abs64(nMedian) < nOffsetLimit) {
             nTimeOffset = nMedian;
-            strMiscWarning = "";
+            SetMiscWarning("");
         } else {
             nTimeOffset = (nMedian > 0 ? 1 : -1) * nOffsetLimit;
             std::string strMessage = _("Warning: Please check that your computer's date and time are correct! If your clock is wrong PIVX Core will not work properly.");
-            strMiscWarning = strMessage;
+            SetMiscWarning(strMessage);
             LogPrintf("*** %s\n", strMessage);
             uiInterface.ThreadSafeMessageBox(strMessage, "", CClientUIInterface::MSG_ERROR);
         }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -100,6 +100,7 @@ ArgsManager gArgs;
 bool fDaemon = false;
 CTranslationInterface translationInterface;
 
+RecursiveMutex cs_warnings;
 std::string strMiscWarning;
 bool fLargeWorkForkFound = false;
 bool fLargeWorkInvalidChainFound = false;
@@ -843,10 +844,42 @@ int GetNumCores()
     return std::thread::hardware_concurrency();
 }
 
+void SetMiscWarning(const std::string& strWarning)
+{
+    LOCK(cs_warnings);
+    strMiscWarning = strWarning;
+}
+
+void SetfLargeWorkForkFound(bool flag)
+{
+    LOCK(cs_warnings);
+    fLargeWorkForkFound = flag;
+}
+
+bool GetfLargeWorkForkFound()
+{
+    LOCK(cs_warnings);
+    return fLargeWorkForkFound;
+}
+
+void SetfLargeWorkInvalidChainFound(bool flag)
+{
+    LOCK(cs_warnings);
+    fLargeWorkInvalidChainFound = flag;
+}
+
+bool GetfLargeWorkInvalidChainFound()
+{
+    LOCK(cs_warnings);
+    return fLargeWorkInvalidChainFound;
+}
+
 std::string GetWarnings(const std::string& strFor)
 {
     std::string strStatusBar;
     std::string strRPC;
+
+    LOCK(cs_warnings);
 
     if (!CLIENT_VERSION_IS_RELEASE)
         strStatusBar = _("This is a pre-release test build - use at your own risk - do not use for staking or merchant applications!");

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -878,27 +878,36 @@ std::string GetWarnings(const std::string& strFor)
 {
     std::string strStatusBar;
     std::string strRPC;
+    std::string strGUI;
+    const std::string uiAlertSeperator = "<hr />";
 
     LOCK(cs_warnings);
 
-    if (!CLIENT_VERSION_IS_RELEASE)
-        strStatusBar = _("This is a pre-release test build - use at your own risk - do not use for staking or merchant applications!");
+    if (!CLIENT_VERSION_IS_RELEASE) {
+        strStatusBar = "This is a pre-release test build - use at your own risk - do not use for staking or merchant applications";
+        strGUI = _("This is a pre-release test build - use at your own risk - do not use for staking or merchant applications");
+    }
 
     if (gArgs.GetBoolArg("-testsafemode", DEFAULT_TESTSAFEMODE))
-        strStatusBar = strRPC = "testsafemode enabled";
+        strStatusBar = strRPC = strGUI = "testsafemode enabled";
 
     // Misc warnings like out of disk space and clock is wrong
-    if (strMiscWarning != "") {
+    if (!strMiscWarning.empty()) {
         strStatusBar = strMiscWarning;
+        strGUI += (strGUI.empty() ? "" : uiAlertSeperator) + strMiscWarning;
     }
 
     if (fLargeWorkForkFound) {
-        strStatusBar = strRPC = _("Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.");
+        strStatusBar = strRPC = "Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.";
+        strGUI += (strGUI.empty() ? "" : uiAlertSeperator) + _("Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.");
     } else if (fLargeWorkInvalidChainFound) {
-        strStatusBar = strRPC = _("Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.");
+        strStatusBar = strRPC = "Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.";
+        strGUI += (strGUI.empty() ? "" : uiAlertSeperator) + _("Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.");
     }
 
-    if (strFor == "statusbar")
+    if (strFor == "gui")
+        return strGUI;
+    else if (strFor == "statusbar")
         return strStatusBar;
     else if (strFor == "rpc")
         return strRPC;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -98,8 +98,11 @@ std::string strBudgetMode = "";
 ArgsManager gArgs;
 
 bool fDaemon = false;
-std::string strMiscWarning;
 CTranslationInterface translationInterface;
+
+std::string strMiscWarning;
+bool fLargeWorkForkFound = false;
+bool fLargeWorkInvalidChainFound = false;
 
 /** Init OpenSSL library multithreading support */
 static RecursiveMutex** ppmutexOpenSSL;
@@ -838,4 +841,34 @@ void SetThreadPriority(int nPriority)
 int GetNumCores()
 {
     return std::thread::hardware_concurrency();
+}
+
+std::string GetWarnings(const std::string& strFor)
+{
+    std::string strStatusBar;
+    std::string strRPC;
+
+    if (!CLIENT_VERSION_IS_RELEASE)
+        strStatusBar = _("This is a pre-release test build - use at your own risk - do not use for staking or merchant applications!");
+
+    if (gArgs.GetBoolArg("-testsafemode", DEFAULT_TESTSAFEMODE))
+        strStatusBar = strRPC = "testsafemode enabled";
+
+    // Misc warnings like out of disk space and clock is wrong
+    if (strMiscWarning != "") {
+        strStatusBar = strMiscWarning;
+    }
+
+    if (fLargeWorkForkFound) {
+        strStatusBar = strRPC = _("Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.");
+    } else if (fLargeWorkInvalidChainFound) {
+        strStatusBar = strRPC = _("Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.");
+    }
+
+    if (strFor == "statusbar")
+        return strStatusBar;
+    else if (strFor == "rpc")
+        return strRPC;
+    assert(!"GetWarnings() : invalid parameter");
+    return "error";
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -92,11 +92,7 @@ const char * const PIVX_MASTERNODE_CONF_FILENAME = "masternode.conf";
 std::atomic<bool> fMasterNode{false};
 std::string strMasterNodeAddr = "";
 bool fLiteMode = false;
-
-
-/** Spork enforcement enabled time */
-int64_t enforceMasternodePaymentsTime = 4085657524;
-bool fSucessfullyLoaded = false;
+// budget finalization
 std::string strBudgetMode = "";
 
 ArgsManager gArgs;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -100,11 +100,6 @@ ArgsManager gArgs;
 bool fDaemon = false;
 CTranslationInterface translationInterface;
 
-RecursiveMutex cs_warnings;
-std::string strMiscWarning;
-bool fLargeWorkForkFound = false;
-bool fLargeWorkInvalidChainFound = false;
-
 /** Init OpenSSL library multithreading support */
 static RecursiveMutex** ppmutexOpenSSL;
 void locking_callback(int mode, int i, const char* file, int line) NO_THREAD_SAFETY_ANALYSIS
@@ -346,7 +341,6 @@ void PrintExceptionContinue(const std::exception* pex, const char* pszThread)
     std::string message = FormatException(pex, pszThread);
     LogPrintf("\n\n************************\n%s\n", message);
     fprintf(stderr, "\n\n************************\n%s\n", message.c_str());
-    strMiscWarning = message;
 }
 
 fs::path GetDefaultDataDir()
@@ -844,73 +838,3 @@ int GetNumCores()
     return std::thread::hardware_concurrency();
 }
 
-void SetMiscWarning(const std::string& strWarning)
-{
-    LOCK(cs_warnings);
-    strMiscWarning = strWarning;
-}
-
-void SetfLargeWorkForkFound(bool flag)
-{
-    LOCK(cs_warnings);
-    fLargeWorkForkFound = flag;
-}
-
-bool GetfLargeWorkForkFound()
-{
-    LOCK(cs_warnings);
-    return fLargeWorkForkFound;
-}
-
-void SetfLargeWorkInvalidChainFound(bool flag)
-{
-    LOCK(cs_warnings);
-    fLargeWorkInvalidChainFound = flag;
-}
-
-bool GetfLargeWorkInvalidChainFound()
-{
-    LOCK(cs_warnings);
-    return fLargeWorkInvalidChainFound;
-}
-
-std::string GetWarnings(const std::string& strFor)
-{
-    std::string strStatusBar;
-    std::string strRPC;
-    std::string strGUI;
-    const std::string uiAlertSeperator = "<hr />";
-
-    LOCK(cs_warnings);
-
-    if (!CLIENT_VERSION_IS_RELEASE) {
-        strStatusBar = "This is a pre-release test build - use at your own risk - do not use for staking or merchant applications";
-        strGUI = _("This is a pre-release test build - use at your own risk - do not use for staking or merchant applications");
-    }
-
-    if (gArgs.GetBoolArg("-testsafemode", DEFAULT_TESTSAFEMODE))
-        strStatusBar = strRPC = strGUI = "testsafemode enabled";
-
-    // Misc warnings like out of disk space and clock is wrong
-    if (!strMiscWarning.empty()) {
-        strStatusBar = strMiscWarning;
-        strGUI += (strGUI.empty() ? "" : uiAlertSeperator) + strMiscWarning;
-    }
-
-    if (fLargeWorkForkFound) {
-        strStatusBar = strRPC = "Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.";
-        strGUI += (strGUI.empty() ? "" : uiAlertSeperator) + _("Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.");
-    } else if (fLargeWorkInvalidChainFound) {
-        strStatusBar = strRPC = "Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.";
-        strGUI += (strGUI.empty() ? "" : uiAlertSeperator) + _("Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.");
-    }
-
-    if (strFor == "gui")
-        return strGUI;
-    else if (strFor == "statusbar")
-        return strStatusBar;
-    else if (strFor == "rpc")
-        return strRPC;
-    assert(!"GetWarnings() : invalid parameter");
-    return "error";
-}

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -99,6 +99,7 @@ ArgsManager gArgs;
 
 bool fDaemon = false;
 std::string strMiscWarning;
+CTranslationInterface translationInterface;
 
 /** Init OpenSSL library multithreading support */
 static RecursiveMutex** ppmutexOpenSSL;

--- a/src/util.h
+++ b/src/util.h
@@ -32,7 +32,16 @@
 #include <unordered_set>
 #include <vector>
 
+#include <boost/signals2/signal.hpp>
 #include <boost/thread/condition_variable.hpp> // for boost::thread_interrupted
+
+/** Signals for translation. */
+class CTranslationInterface
+{
+public:
+    /** Translate a message to the native language of the user. */
+    boost::signals2::signal<std::string (const char* psz)> Translate;
+};
 
 extern const char * const PIVX_CONF_FILENAME;
 extern const char * const PIVX_PID_FILENAME;
@@ -47,6 +56,18 @@ extern std::string strMasterNodeAddr;
 extern std::string strBudgetMode;
 
 extern std::string strMiscWarning;
+extern CTranslationInterface translationInterface;
+
+/**
+ * Translation function: Call Translate signal on UI interface, which returns a Optional result.
+ * If no translation slot is registered, nothing is returned, and simply return the input.
+ */
+inline std::string _(const char* psz)
+{
+    // todo: this boost::optional is needed for now. Will get removed moving forward
+    boost::optional<std::string> rv = translationInterface.Translate(psz);
+    return rv ? (*rv) : psz;
+}
 
 
 void SetupEnvironment();

--- a/src/util.h
+++ b/src/util.h
@@ -58,9 +58,6 @@ extern std::string strBudgetMode;
 extern CTranslationInterface translationInterface;
 
 static const bool DEFAULT_TESTSAFEMODE = false;
-extern std::string strMiscWarning;
-extern bool fLargeWorkForkFound;
-extern bool fLargeWorkInvalidChainFound;
 
 /**
  * Translation function: Call Translate signal on UI interface, which returns a Optional result.
@@ -266,6 +263,11 @@ void TraceThread(const char* name, Callable func)
 
 fs::path AbsPathForConfigVal(const fs::path& path, bool net_specific = true);
 
+void SetMiscWarning(const std::string& strWarning);
+void SetfLargeWorkForkFound(bool flag);
+bool GetfLargeWorkForkFound();
+void SetfLargeWorkInvalidChainFound(bool flag);
+bool GetfLargeWorkInvalidChainFound();
 std::string GetWarnings(const std::string& strFor);
 
 #endif // BITCOIN_UTIL_H

--- a/src/util.h
+++ b/src/util.h
@@ -43,10 +43,7 @@ extern const char * const DEFAULT_DEBUGLOGFILE;
 
 extern std::atomic<bool> fMasterNode;
 extern bool fLiteMode;
-extern int64_t enforceMasternodePaymentsTime;
 extern std::string strMasterNodeAddr;
-extern int keysLoaded;
-extern bool fSucessfullyLoaded;
 extern std::string strBudgetMode;
 
 extern std::string strMiscWarning;

--- a/src/util.h
+++ b/src/util.h
@@ -57,8 +57,6 @@ extern std::string strBudgetMode;
 
 extern CTranslationInterface translationInterface;
 
-static const bool DEFAULT_TESTSAFEMODE = false;
-
 /**
  * Translation function: Call Translate signal on UI interface, which returns a Optional result.
  * If no translation slot is registered, nothing is returned, and simply return the input.
@@ -262,12 +260,5 @@ void TraceThread(const char* name, Callable func)
 }
 
 fs::path AbsPathForConfigVal(const fs::path& path, bool net_specific = true);
-
-void SetMiscWarning(const std::string& strWarning);
-void SetfLargeWorkForkFound(bool flag);
-bool GetfLargeWorkForkFound();
-void SetfLargeWorkInvalidChainFound(bool flag);
-bool GetfLargeWorkInvalidChainFound();
-std::string GetWarnings(const std::string& strFor);
 
 #endif // BITCOIN_UTIL_H

--- a/src/util.h
+++ b/src/util.h
@@ -55,8 +55,12 @@ extern bool fLiteMode;
 extern std::string strMasterNodeAddr;
 extern std::string strBudgetMode;
 
-extern std::string strMiscWarning;
 extern CTranslationInterface translationInterface;
+
+static const bool DEFAULT_TESTSAFEMODE = false;
+extern std::string strMiscWarning;
+extern bool fLargeWorkForkFound;
+extern bool fLargeWorkInvalidChainFound;
 
 /**
  * Translation function: Call Translate signal on UI interface, which returns a Optional result.
@@ -261,5 +265,7 @@ void TraceThread(const char* name, Callable func)
 }
 
 fs::path AbsPathForConfigVal(const fs::path& path, bool net_specific = true);
+
+std::string GetWarnings(const std::string& strFor);
 
 #endif // BITCOIN_UTIL_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -48,6 +48,7 @@
 #include "util.h"
 #include "utilmoneystr.h"
 #include "validationinterface.h"
+#include "warnings.h"
 #include "zpivchain.h"
 #include "zpiv/zerocoin.h"
 #include "zpiv/zpivmodule.h"

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -836,8 +836,6 @@ bool IsInitialBlockDownload()
     return state;
 }
 
-bool fLargeWorkForkFound = false;
-bool fLargeWorkInvalidChainFound = false;
 CBlockIndex *pindexBestForkTip = NULL, *pindexBestForkBase = NULL;
 
 static void AlertNotify(const std::string& strMessage)
@@ -4068,37 +4066,6 @@ void static CheckBlockIndex()
 
     // Check that we actually traversed the entire map.
     assert(nNodes == forward.size());
-}
-
-
-std::string GetWarnings(std::string strFor)
-{
-    std::string strStatusBar;
-    std::string strRPC;
-
-    if (!CLIENT_VERSION_IS_RELEASE)
-        strStatusBar = _("This is a pre-release test build - use at your own risk - do not use for staking or merchant applications!");
-
-    if (gArgs.GetBoolArg("-testsafemode", DEFAULT_TESTSAFEMODE))
-        strStatusBar = strRPC = "testsafemode enabled";
-
-    // Misc warnings like out of disk space and clock is wrong
-    if (strMiscWarning != "") {
-        strStatusBar = strMiscWarning;
-    }
-
-    if (fLargeWorkForkFound) {
-        strStatusBar = strRPC = _("Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.");
-    } else if (fLargeWorkInvalidChainFound) {
-        strStatusBar = strRPC = _("Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.");
-    }
-
-    if (strFor == "statusbar")
-        return strStatusBar;
-    else if (strFor == "rpc")
-        return strRPC;
-    assert(!"GetWarnings() : invalid parameter");
-    return "error";
 }
 
 // Note: whenever a protocol update is needed toggle between both implementations (comment out the formerly active one)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -874,7 +874,7 @@ void CheckForkWarningConditions()
         pindexBestForkTip = nullptr;
 
     if (pindexBestForkTip || (pindexBestInvalid && pindexBestInvalid->nChainWork > pChainTip->nChainWork + (GetBlockProof(*pChainTip) * 6))) {
-        if (!fLargeWorkForkFound && pindexBestForkBase) {
+        if (!GetfLargeWorkForkFound() && pindexBestForkBase) {
             if (pindexBestForkBase->phashBlock) {
                 std::string warning = std::string("'Warning: Large-work fork detected, forking after block ") +
                                       pindexBestForkBase->phashBlock->ToString() + std::string("'");
@@ -886,15 +886,15 @@ void CheckForkWarningConditions()
                 LogPrintf("CheckForkWarningConditions: Warning: Large valid fork found\n  forking the chain at height %d (%s)\n  lasting to height %d (%s).\nChain state database corruption likely.\n",
                     pindexBestForkBase->nHeight, pindexBestForkBase->phashBlock->ToString(),
                     pindexBestForkTip->nHeight, pindexBestForkTip->phashBlock->ToString());
-                fLargeWorkForkFound = true;
+                SetfLargeWorkForkFound(true);
             }
         } else {
             LogPrintf("CheckForkWarningConditions: Warning: Found invalid chain at least ~6 blocks longer than our best chain.\nChain state database corruption likely.\n");
-            fLargeWorkInvalidChainFound = true;
+            SetfLargeWorkInvalidChainFound(true);
         }
     } else {
-        fLargeWorkForkFound = false;
-        fLargeWorkInvalidChainFound = false;
+        SetfLargeWorkForkFound(false);
+        SetfLargeWorkInvalidChainFound(false);
     }
 }
 
@@ -1184,7 +1184,7 @@ bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsVi
 /** Abort with a message */
 static bool AbortNode(const std::string& strMessage, const std::string& userMessage="")
 {
-    strMiscWarning = strMessage;
+    SetMiscWarning(strMessage);
     LogPrintf("*** %s\n", strMessage);
     uiInterface.ThreadSafeMessageBox(
         userMessage.empty() ? _("Error: A fatal internal error occured, see debug.log for details") : userMessage,
@@ -1922,10 +1922,12 @@ void static UpdateTip(CBlockIndex* pindexNew)
         if (nUpgraded > 0)
             LogPrintf("SetBestChain: %d of last 100 blocks above version %d\n", nUpgraded, (int)CBlock::CURRENT_VERSION);
         if (nUpgraded > 100 / 2) {
-            // strMiscWarning is read by GetWarnings(), called by Qt and the JSON-RPC code to warn the user:
-            strMiscWarning = _("Warning: This version is obsolete, upgrade required!");
-            AlertNotify(strMiscWarning);
-            fWarned = true;
+            std::string strWarning = _("Warning: This version is obsolete, upgrade required!");
+            SetMiscWarning(strWarning);
+            if (!fWarned) {
+                AlertNotify(strWarning);
+                fWarned = true;
+            }
         }
     }
 }

--- a/src/validation.h
+++ b/src/validation.h
@@ -66,8 +66,6 @@ static const unsigned int DEFAULT_MEMPOOL_EXPIRY = 72;
 /** Default for -txindex */
 static const bool DEFAULT_TXINDEX = true;
 static const bool DEFAULT_CHECKPOINTS_ENABLED = true;
-/** Default for -testsafemode */
-static const bool DEFAULT_TESTSAFEMODE = false;
 /** Default for -relaypriority */
 static const bool DEFAULT_RELAYPRIORITY = true;
 /** Default for -limitfeerelay */
@@ -200,8 +198,6 @@ void ThreadScriptCheck();
 
 /** Check whether we are doing an initial block download (synchronizing from disk or network) */
 bool IsInitialBlockDownload();
-/** Format a string that describes several potential problems detected by the core */
-std::string GetWarnings(std::string strFor);
 /** Retrieve a transaction (from memory pool, or from disk, if possible) */
 bool GetTransaction(const uint256& hash, CTransaction& tx, uint256& hashBlock, bool fAllowSlow = false, CBlockIndex* blockIndex = nullptr);
 /** Retrieve an output (from memory pool, or from disk, if possible) */

--- a/src/warnings.cpp
+++ b/src/warnings.cpp
@@ -1,0 +1,87 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "warnings.h"
+
+#include "sync.h"
+#include "clientversion.h"
+#include "util.h"
+
+RecursiveMutex cs_warnings;
+std::string strMiscWarning;
+bool fLargeWorkForkFound = false;
+bool fLargeWorkInvalidChainFound = false;
+
+void SetMiscWarning(const std::string& strWarning)
+{
+    LOCK(cs_warnings);
+    strMiscWarning = strWarning;
+}
+
+void SetfLargeWorkForkFound(bool flag)
+{
+    LOCK(cs_warnings);
+    fLargeWorkForkFound = flag;
+}
+
+bool GetfLargeWorkForkFound()
+{
+    LOCK(cs_warnings);
+    return fLargeWorkForkFound;
+}
+
+void SetfLargeWorkInvalidChainFound(bool flag)
+{
+    LOCK(cs_warnings);
+    fLargeWorkInvalidChainFound = flag;
+}
+
+bool GetfLargeWorkInvalidChainFound()
+{
+    LOCK(cs_warnings);
+    return fLargeWorkInvalidChainFound;
+}
+
+std::string GetWarnings(const std::string& strFor)
+{
+    std::string strStatusBar;
+    std::string strRPC;
+    std::string strGUI;
+    const std::string uiAlertSeperator = "\n";
+
+    LOCK(cs_warnings);
+
+    if (!CLIENT_VERSION_IS_RELEASE) {
+        strStatusBar = "This is a pre-release test build - use at your own risk - do not use for staking or merchant applications!";
+        strGUI = _("This is a pre-release test build - use at your own risk - do not use for staking or merchant applications!");
+    }
+
+    if (gArgs.GetBoolArg("-testsafemode", DEFAULT_TESTSAFEMODE))
+        strStatusBar = strRPC = strGUI = "testsafemode enabled";
+
+    // Misc warnings like out of disk space and clock is wrong
+    if (!strMiscWarning.empty()) {
+        strStatusBar = strMiscWarning;
+        strGUI += (strGUI.empty() ? "" : uiAlertSeperator) + strMiscWarning;
+    }
+
+    if (fLargeWorkForkFound) {
+        strStatusBar = strRPC = "Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.";
+        strGUI += (strGUI.empty() ? "" : uiAlertSeperator) + _("Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.");
+    } else if (fLargeWorkInvalidChainFound) {
+        strStatusBar = strRPC = "Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.";
+        strGUI += (strGUI.empty() ? "" : uiAlertSeperator) + _("Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.");
+    }
+
+    if (strFor == "gui")
+        return strGUI;
+    else if (strFor == "statusbar")
+        return strStatusBar;
+    else if (strFor == "rpc")
+        return strRPC;
+    assert(!"GetWarnings() : invalid parameter");
+    return "error";
+}
+

--- a/src/warnings.h
+++ b/src/warnings.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#ifndef PIVX_WARNINGS_H
+#define PIVX_WARNINGS_H
+
+#include <stdlib.h>
+#include <string>
+
+void SetMiscWarning(const std::string& strWarning);
+void SetfLargeWorkForkFound(bool flag);
+bool GetfLargeWorkForkFound();
+void SetfLargeWorkInvalidChainFound(bool flag);
+bool GetfLargeWorkInvalidChainFound();
+std::string GetWarnings(const std::string& strFor);
+
+static const bool DEFAULT_TESTSAFEMODE = false;
+
+#endif //PIVX_WARNINGS_H


### PR DESCRIPTION
Back ported two different PRs from upstream to solve possible races over the `strMiscWarning` and `fLargeWork*Found` global fields plus some small cleanup.

#6022: to not depend on `guiinterface.h` every time that a back end text needs translations.
#9236: eliminating data races for strMiscWarning and fLargeWork*Found and making QT `runawayException` call `GetWarnings("gui")` instead of directly access `strMiscWarning`.

Extra information:
This work is part of a larger rabbit hole that i'm working on to be able to solve #1973 current issues and compile the project in macOS again (solving the newer boost version errors).