### PR TITLE
[Wallet][Sapling] Dummy ECDSA sigs and zk-proofs during fee calculation loop

### DIFF
--- a/src/sapling/sapling_operation.cpp
+++ b/src/sapling/sapling_operation.cpp
@@ -170,7 +170,7 @@ OperationResult SaplingOperation::build()
 
         // Build the transaction
         txBuilder.SetFee(nFeeRet);
-        TransactionBuilderResult txResult = txBuilder.Build();
+        TransactionBuilderResult txResult = txBuilder.Build(true);
         auto opTx = txResult.GetTx();
 
         // Check existent tx
@@ -213,6 +213,16 @@ OperationResult SaplingOperation::build()
     }
     // Done
     fee = nFeeRet;
+
+    // Clear dummy signatures/proofs and add real ones
+    txBuilder.ClearProofsAndSignatures();
+    TransactionBuilderResult txResult = txBuilder.ProveAndSign();
+    auto opTx = txResult.GetTx();
+    // Check existent tx
+    if (!opTx) {
+        return errorOut("Failed to build transaction: " + txResult.GetError());
+    }
+    finalTx = *opTx;
     return OperationResult(true);
 }
 

--- a/src/sapling/transaction_builder.cpp
+++ b/src/sapling/transaction_builder.cpp
@@ -68,6 +68,35 @@ Optional<OutputDescription> OutputDescriptionInfo::Build(void* ctx) {
     return odesc;
 }
 
+// Dummy constants used during fee-calculation loop
+static OutputDescription CreateDummyOD()
+{
+    OutputDescription dummyOD;
+    dummyOD.cv = UINT256_MAX;
+    dummyOD.cmu = UINT256_MAX;
+    dummyOD.ephemeralKey = UINT256_MAX;
+    dummyOD.encCiphertext = {{0xff}};
+    dummyOD.outCiphertext = {{0xff}};
+    dummyOD.zkproof = {{0xff}};
+    return dummyOD;
+}
+static SpendDescription CreateDummySD()
+{
+    SpendDescription dummySD;
+    dummySD.cv = UINT256_MAX;
+    dummySD.anchor = UINT256_MAX;
+    dummySD.nullifier = UINT256_MAX;
+    dummySD.rk = UINT256_MAX;
+    dummySD.zkproof = {{0xff}};
+    dummySD.spendAuthSig = {{0xff}};
+    return dummySD;
+}
+
+const OutputDescription DUMMY_SHIELD_OUT = CreateDummyOD();
+const SpendDescription DUMMY_SHIELD_SPEND = CreateDummySD();
+const SaplingTxData::binding_sig_t DUMMY_SHIELD_BINDSIG = {{0xff}};
+
+
 TransactionBuilderResult::TransactionBuilderResult(const CTransaction& tx) : maybeTx(tx) {}
 
 TransactionBuilderResult::TransactionBuilderResult(const std::string& error) : maybeError(error) {}
@@ -328,29 +357,15 @@ TransactionBuilderResult TransactionBuilder::AddDummySignatures()
 {
     if (!spends.empty() || !outputs.empty()) {
         // Add Dummy Sapling OutputDescriptions
-        OutputDescription dummyOD;
-        dummyOD.cv = UINT256_MAX;
-        dummyOD.cmu = UINT256_MAX;
-        dummyOD.ephemeralKey = UINT256_MAX;
-        dummyOD.encCiphertext = {{0xff}};
-        dummyOD.outCiphertext = {{0xff}};
-        dummyOD.zkproof = {{0xff}};
         for (unsigned int i = 0; i < outputs.size(); i++) {
-            mtx.sapData->vShieldedOutput.push_back(dummyOD);
+            mtx.sapData->vShieldedOutput.push_back(DUMMY_SHIELD_OUT);
         }
         // Add Dummy Sapling SpendDescriptions
-        SpendDescription dummySD;
-        dummySD.cv = UINT256_MAX;
-        dummySD.anchor = UINT256_MAX;
-        dummySD.nullifier = UINT256_MAX;
-        dummySD.rk = UINT256_MAX;
-        dummySD.zkproof = {{0xff}};
-        dummySD.spendAuthSig = {{0xff}};
         for (unsigned int i = 0; i < spends.size(); i++) {
-            mtx.sapData->vShieldedSpend.push_back(dummySD);
+            mtx.sapData->vShieldedSpend.push_back(DUMMY_SHIELD_SPEND);
         }
         // Add Dummy Binding sig
-        mtx.sapData->bindingSig = {{0xff}};
+        mtx.sapData->bindingSig = DUMMY_SHIELD_BINDSIG;
     }
 
     // Add Dummmy Transparent signatures

--- a/src/sapling/transaction_builder.cpp
+++ b/src/sapling/transaction_builder.cpp
@@ -209,6 +209,121 @@ void TransactionBuilder::SendChangeTo(CTxDestination& changeAddr)
     saplingChangeAddr = nullopt;
 }
 
+TransactionBuilderResult TransactionBuilder::ProveAndSign()
+{
+    //
+    // Sapling spend descriptions
+    //
+    if (!spends.empty() || !outputs.empty()) {
+
+        auto ctx = librustzcash_sapling_proving_ctx_init();
+
+        // Create Sapling OutputDescriptions
+        for (auto output : outputs) {
+            // Check this out here as well to provide better logging.
+            if (!output.note.cmu()) {
+                librustzcash_sapling_proving_ctx_free(ctx);
+                return TransactionBuilderResult("Output is invalid");
+            }
+
+            auto odesc = output.Build(ctx);
+            if (!odesc) {
+                librustzcash_sapling_proving_ctx_free(ctx);
+                return TransactionBuilderResult("Failed to create output description");
+            }
+
+            mtx.sapData->vShieldedOutput.push_back(odesc.get());
+        }
+
+        // Create Sapling SpendDescriptions
+        for (auto spend : spends) {
+            auto cm = spend.note.cmu();
+            auto nf = spend.note.nullifier(
+                    spend.expsk.full_viewing_key(), spend.witness.position());
+            if (!cm || !nf) {
+                librustzcash_sapling_proving_ctx_free(ctx);
+                return TransactionBuilderResult("Spend is invalid");
+            }
+
+            CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+            ss << spend.witness.path();
+            std::vector<unsigned char> witness(ss.begin(), ss.end());
+
+            SpendDescription sdesc;
+            if (!librustzcash_sapling_spend_proof(
+                    ctx,
+                    spend.expsk.full_viewing_key().ak.begin(),
+                    spend.expsk.nsk.begin(),
+                    spend.note.d.data(),
+                    spend.note.r.begin(),
+                    spend.alpha.begin(),
+                    spend.note.value(),
+                    spend.anchor.begin(),
+                    witness.data(),
+                    sdesc.cv.begin(),
+                    sdesc.rk.begin(),
+                    sdesc.zkproof.data())) {
+                librustzcash_sapling_proving_ctx_free(ctx);
+                return TransactionBuilderResult("Spend proof failed");
+            }
+
+            sdesc.anchor = spend.anchor;
+            sdesc.nullifier = *nf;
+            mtx.sapData->vShieldedSpend.push_back(sdesc);
+        }
+
+        //
+        // Signatures
+        //
+
+        // Empty output script.
+        uint256 dataToBeSigned;
+        CScript scriptCode;
+        try {
+            dataToBeSigned = SignatureHash(scriptCode, mtx, NOT_AN_INPUT, SIGHASH_ALL, 0, SIGVERSION_SAPLING);
+        } catch (const std::logic_error& ex) {
+            librustzcash_sapling_proving_ctx_free(ctx);
+            return TransactionBuilderResult("Could not construct signature hash: " + std::string(ex.what()));
+        }
+
+        // Create Sapling spendAuth and binding signatures
+        for (size_t i = 0; i < spends.size(); i++) {
+            librustzcash_sapling_spend_sig(
+                    spends[i].expsk.ask.begin(),
+                    spends[i].alpha.begin(),
+                    dataToBeSigned.begin(),
+                    mtx.sapData->vShieldedSpend[i].spendAuthSig.data());
+        }
+
+        librustzcash_sapling_binding_sig(
+                ctx,
+                mtx.sapData->valueBalance,
+                dataToBeSigned.begin(),
+                mtx.sapData->bindingSig.data());
+
+        librustzcash_sapling_proving_ctx_free(ctx);
+    }
+
+    // Transparent signatures
+    CTransaction txNewConst(mtx);
+    for (int nIn = 0; nIn < (int) mtx.vin.size(); nIn++) {
+        auto tIn = tIns[nIn];
+        SignatureData sigdata;
+        bool signSuccess = ProduceSignature(
+            TransactionSignatureCreator(
+                keystore, &txNewConst, nIn, tIn.value, SIGHASH_ALL),
+            tIn.scriptPubKey, sigdata, SIGVERSION_SAPLING, false);
+
+        if (!signSuccess) {
+            return TransactionBuilderResult("Failed to sign transaction");
+        } else {
+            UpdateTransaction(mtx, nIn, sigdata);
+        }
+    }
+
+    return TransactionBuilderResult(CTransaction(mtx));
+}
+
 TransactionBuilderResult TransactionBuilder::Build()
 {
     //
@@ -263,115 +378,5 @@ TransactionBuilderResult TransactionBuilder::Build()
         }
     }
 
-    //
-    // Sapling spends and outputs
-    //
-    if (!spends.empty() || !outputs.empty()) {
-
-        auto ctx = librustzcash_sapling_proving_ctx_init();
-
-        // Create Sapling SpendDescriptions
-        for (auto spend : spends) {
-            auto cm = spend.note.cmu();
-            auto nf = spend.note.nullifier(
-                    spend.expsk.full_viewing_key(), spend.witness.position());
-            if (!cm || !nf) {
-                librustzcash_sapling_proving_ctx_free(ctx);
-                return TransactionBuilderResult("Spend is invalid");
-            }
-
-            CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-            ss << spend.witness.path();
-            std::vector<unsigned char> witness(ss.begin(), ss.end());
-
-            SpendDescription sdesc;
-            if (!librustzcash_sapling_spend_proof(
-                    ctx,
-                    spend.expsk.full_viewing_key().ak.begin(),
-                    spend.expsk.nsk.begin(),
-                    spend.note.d.data(),
-                    spend.note.r.begin(),
-                    spend.alpha.begin(),
-                    spend.note.value(),
-                    spend.anchor.begin(),
-                    witness.data(),
-                    sdesc.cv.begin(),
-                    sdesc.rk.begin(),
-                    sdesc.zkproof.data())) {
-                librustzcash_sapling_proving_ctx_free(ctx);
-                return TransactionBuilderResult("Spend proof failed");
-            }
-
-            sdesc.anchor = spend.anchor;
-            sdesc.nullifier = *nf;
-            mtx.sapData->vShieldedSpend.push_back(sdesc);
-        }
-
-        // Create Sapling OutputDescriptions
-        for (auto output : outputs) {
-            // Check this out here as well to provide better logging.
-            if (!output.note.cmu()) {
-                librustzcash_sapling_proving_ctx_free(ctx);
-                return TransactionBuilderResult("Output is invalid");
-            }
-
-            auto odesc = output.Build(ctx);
-            if (!odesc) {
-                librustzcash_sapling_proving_ctx_free(ctx);
-                return TransactionBuilderResult("Failed to create output description");
-            }
-
-            mtx.sapData->vShieldedOutput.push_back(odesc.get());
-        }
-
-        //
-        // Signatures
-        //
-
-        // Empty output script.
-        uint256 dataToBeSigned;
-        CScript scriptCode;
-        try {
-            dataToBeSigned = SignatureHash(scriptCode, mtx, NOT_AN_INPUT, SIGHASH_ALL, 0, SIGVERSION_SAPLING);
-        } catch (const std::logic_error& ex) {
-            librustzcash_sapling_proving_ctx_free(ctx);
-            return TransactionBuilderResult("Could not construct signature hash: " + std::string(ex.what()));
-        }
-
-        // Create Sapling spendAuth and binding signatures
-        for (size_t i = 0; i < spends.size(); i++) {
-            librustzcash_sapling_spend_sig(
-                    spends[i].expsk.ask.begin(),
-                    spends[i].alpha.begin(),
-                    dataToBeSigned.begin(),
-                    mtx.sapData->vShieldedSpend[i].spendAuthSig.data());
-        }
-
-        librustzcash_sapling_binding_sig(
-                ctx,
-                mtx.sapData->valueBalance,
-                dataToBeSigned.begin(),
-                mtx.sapData->bindingSig.data());
-
-        librustzcash_sapling_proving_ctx_free(ctx);
-    }
-
-    // Transparent signatures
-    CTransaction txNewConst(mtx);
-    for (int nIn = 0; nIn < (int) mtx.vin.size(); nIn++) {
-        auto tIn = tIns[nIn];
-        SignatureData sigdata;
-        bool signSuccess = ProduceSignature(
-            TransactionSignatureCreator(
-                keystore, &txNewConst, nIn, tIn.value, SIGHASH_ALL),
-            tIn.scriptPubKey, sigdata, SIGVERSION_SAPLING, false);
-
-        if (!signSuccess) {
-            return TransactionBuilderResult("Failed to sign transaction");
-        } else {
-            UpdateTransaction(mtx, nIn, sigdata);
-        }
-    }
-
-    return TransactionBuilderResult(CTransaction(mtx));
+    return ProveAndSign();
 }

--- a/src/sapling/transaction_builder.h
+++ b/src/sapling/transaction_builder.h
@@ -121,6 +121,8 @@ public:
     void SendChangeTo(CTxDestination& changeAddr);
 
     TransactionBuilderResult Build();
+    // Add Sapling Spend/Output descriptions, binding sig, and transparent signatures
+    TransactionBuilderResult ProveAndSign();
 };
 
 #endif /* TRANSACTION_BUILDER_H */

--- a/src/sapling/transaction_builder.h
+++ b/src/sapling/transaction_builder.h
@@ -120,9 +120,13 @@ public:
 
     void SendChangeTo(CTxDestination& changeAddr);
 
-    TransactionBuilderResult Build();
+    TransactionBuilderResult Build(bool fDummySig = false);
     // Add Sapling Spend/Output descriptions, binding sig, and transparent signatures
     TransactionBuilderResult ProveAndSign();
+    // Add dummy Sapling Spend/Output descriptions, binding sig, and transparent signatures
+    TransactionBuilderResult AddDummySignatures();
+    // Remove Sapling Spend/Output descriptions, binding sig, and transparent signatures
+    void ClearProofsAndSignatures();
 };
 
 #endif /* TRANSACTION_BUILDER_H */

--- a/src/sapling/transaction_builder.h
+++ b/src/sapling/transaction_builder.h
@@ -55,6 +55,11 @@ struct TransparentInputInfo {
         CAmount value) : scriptPubKey(scriptPubKey), value(value) {}
 };
 
+// Dummy constants used during fee-calculation loop
+extern const OutputDescription DUMMY_SHIELD_OUT;
+extern const SpendDescription DUMMY_SHIELD_SPEND;
+extern const SaplingTxData::binding_sig_t DUMMY_SHIELD_BINDSIG;
+
 class TransactionBuilderResult {
 private:
     Optional<CTransaction> maybeTx;

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -139,5 +139,6 @@ arith_uint512 UintToArith512(const uint512 &);
 /** constant uint256 instances */
 const uint256 UINT256_ZERO = uint256();
 const uint256 UINT256_ONE = uint256("0000000000000000000000000000000000000000000000000000000000000001");
+const uint256 UINT256_MAX = uint256("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 
 #endif // PIVX_UINT256_H


### PR DESCRIPTION
First commit backports bitcoin/bitcoin#9465.
Following commits adapt the same idea to sapling transactions, including also the spend/output descriptors.

This gives a **huge** speed-up in the transaction-creation process (especially with many inuputs and/or outputs).

Down-side: less time for the awesome shield animation in the GUI :)

~~Built on top of #2064 to remove the conflicts.~~