### PR TITLE
[BUG][GUI] Receive widget: check typeRole before refreshing view

### DIFF
--- a/src/qt/pivx/receivewidget.cpp
+++ b/src/qt/pivx/receivewidget.cpp
@@ -135,6 +135,9 @@ void ReceiveWidget::loadWalletModel()
 void ReceiveWidget::refreshView(const QModelIndex& tl, const QModelIndex& br)
 {
     const QModelIndex& index = tl.sibling(tl.row(), AddressTableModel::Address);
+    const QString& typeRole = index.data(AddressTableModel::TypeRole).toString();
+    if (shieldedMode && typeRole != AddressTableModel::ShieldedReceive) return;
+    if (!shieldedMode && typeRole != AddressTableModel::Receive) return;
     return refreshView(index.data(Qt::DisplayRole).toString());
 }
 


### PR DESCRIPTION
Fix a nice bug found by @vampyren.

If `AddressTableModel::dataChanged` is fired, check the address `TypeRole` inside `ReceiveWidget::refreshView`, and skip the update for un-related roles.