### PR TITLE
[Consensus][Validation] Reject outdated block version after v5 enforcement

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -169,8 +169,16 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, CWallet* pwallet, 
     if (fSaplingActive) {
         //!> Block v8: Sapling / tx v2
         pblock->nVersion = CBlockHeader::CURRENT_VERSION;
-    } else {
+    } else if (consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V4_0)) {
         pblock->nVersion = 7;
+    } else if (consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V3_4)) {
+        pblock->nVersion = 6;
+    } else if (consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_BIP65)) {
+        pblock->nVersion = 5;
+    } else if (consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_ZC)) {
+        pblock->nVersion = 4;
+    } else {
+        pblock->nVersion = 3;
     }
     // -regtest only: allow overriding block.nVersion with
     // -blockversion=N to test forking scenarios

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2953,11 +2953,12 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
         return state.DoS(0, error("%s : forked chain older than last checkpoint (height %d)", __func__, nHeight));
 
     // Reject outdated version blocks
-    if((block.nVersion < 3 && nHeight >= 1) ||
+    if ((block.nVersion < 3 && nHeight >= 1) ||
         (block.nVersion < 4 && consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_ZC)) ||
         (block.nVersion < 5 && consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_BIP65)) ||
         (block.nVersion < 6 && consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V3_4)) ||
-        (block.nVersion < 7 && consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V4_0)))
+        (block.nVersion < 7 && consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V4_0)) ||
+        (block.nVersion < 8 && consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V5_0)))
     {
         std::string stringErr = strprintf("rejected block version %d at height %d", block.nVersion, nHeight);
         return state.Invalid(false, REJECT_OBSOLETE, "bad-version", stringErr);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2703,7 +2703,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
 
     // Check that the header is valid (particularly PoW).  This is mostly
     // redundant with the call in AcceptBlockHeader.
-    if (!CheckBlockHeader(block, state, !IsPoS))
+    if (!CheckBlockHeader(block, state, !IsPoS && fCheckPOW))
         return false;
 
     // All potential-corruption validation must be done before we do any

--- a/src/validation.h
+++ b/src/validation.h
@@ -323,7 +323,6 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex);
 bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pindex, CCoinsViewCache& coins, bool fJustCheck, bool fAlreadyChecked = false);
 
 /** Context-independent validity checks */
-bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, bool fCheckPOW = true);
 bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW = true, bool fCheckMerkleRoot = true, bool fCheckSig = true);
 bool CheckWork(const CBlock block, CBlockIndex* const pindexPrev);
 


### PR DESCRIPTION
1) fix a bug in `CreateNewBlock` where we check the PoW before mining the correct nonce (only for upcoming testnet5, no effect on main-net or testnet4)
2) Reject blocks with version below 8 after v5 enforcement (same as we do for the other block versions)
3) Set the proper block version in `CreateNewBlock` based on the current chain height (only for upcoming testnet5, no effect on main-net or testnet4)
4) Remove unneded check for block-version-4 based on zerocoin activation time, and cleanup `CheckBlockHeader`.