### PR TITLE
[Consensus] Budget: Fix instant killing of proposals

### DIFF
--- a/src/budget/budgetproposal.h
+++ b/src/budget/budgetproposal.h
@@ -27,7 +27,7 @@ private:
     std::string strInvalid;
 
     // Functions used inside UpdateValid()/IsWellFormed - setting strInvalid
-    bool IsHeavilyDownvoted();
+    bool IsHeavilyDownvoted(bool fNewRules);
     bool IsExpired(int nCurrentHeight);
     bool CheckStartEnd();
     bool CheckAmount(const CAmount& nTotalBudget);


### PR DESCRIPTION
- raise the threshold required to 30%
- never kill a proposal before its first superblock.

Closes #1852 