### PR TITLE
[GUI] Dashboard, fix type filtering disappearance.

### DIFF
--- a/src/qt/pivx/dashboardwidget.cpp
+++ b/src/qt/pivx/dashboardwidget.cpp
@@ -242,7 +242,7 @@ void DashboardWidget::onTxArrived(const QString& hash, const bool& isCoinStake, 
 
 void DashboardWidget::showList()
 {
-    if (filter->rowCount() == 0) {
+    if (txModel->size() == 0) {
         ui->emptyContainer->setVisible(true);
         ui->listTransactions->setVisible(false);
         ui->comboBoxSortType->setVisible(false);


### PR DESCRIPTION
The combobox shouldn't get hide when there are transactions in the wallet, independently on the selected filter. If the user selects a type that it isn't in the wallet, the filter combobox will disappear, leaving the tx list empty and not allowing any other movement.