### PR TITLE
[GUI] Settings information, fix missing initial masternodes count value.

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -83,6 +83,17 @@ QString ClientModel::getMasternodeCountString() const
     return tr("Total: %1 (IPv4: %2 / IPv6: %3 / Tor: %4 / Unknown: %5)").arg(QString::number(total)).arg(QString::number((int)ipv4)).arg(QString::number((int)ipv6)).arg(QString::number((int)onion)).arg(QString::number((int)nUnknown));
 }
 
+QString ClientModel::getMasternodesCount()
+{
+    if (!cachedMasternodeCountString.isEmpty()) {
+        return cachedMasternodeCountString;
+    }
+
+    // Force an update
+    cachedMasternodeCountString = getMasternodeCountString();
+    return cachedMasternodeCountString;
+}
+
 int ClientModel::getNumBlocks()
 {
     if (!cacheTip) {
@@ -139,12 +150,8 @@ void ClientModel::updateTimer()
 
 void ClientModel::updateMnTimer()
 {
-    // Get required lock upfront. This avoids the GUI from getting stuck on
-    // periodical polls if the core is holding the locks for a longer time -
-    // for example, during a wallet rescan.
-    TRY_LOCK(cs_main, lockMain);
-    if (!lockMain)
-        return;
+    // Following method is locking the mnmanager mutex for now,
+    // future: move to an event based update.
     QString newMasternodeCountString = getMasternodeCountString();
 
     if (cachedMasternodeCountString != newMasternodeCountString) {

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -89,6 +89,9 @@ public:
     // Start/Stop the masternode polling timer
     void startMasternodesTimer();
     void stopMasternodesTimer();
+    // Force a MN count update calling mnmanager directly locking its internal mutex.
+    // Future todo: implement an event based update and remove the lock requirement.
+    QString getMasternodesCount();
 
 private:
     QString getMasternodeCountString() const;

--- a/src/qt/pivx/settings/settingsinformationwidget.h
+++ b/src/qt/pivx/settings/settingsinformationwidget.h
@@ -19,19 +19,22 @@ class SettingsInformationWidget : public PWidget
 
 public:
     explicit SettingsInformationWidget(PIVXGUI* _window, QWidget *parent = nullptr);
-    ~SettingsInformationWidget();
+    ~SettingsInformationWidget() override;
 
     void loadClientModel() override;
+
+    void run(int type) override;
+    void onError(QString error, int type) override;
 
 private Q_SLOTS:
     void setNumConnections(int count);
     void setNumBlocks(int count);
-    void setMasternodeCount(const QString& strMasternodes);
     void showEvent(QShowEvent* event) override;
     void hideEvent(QHideEvent* event) override;
 
 public Q_SLOTS:
     void openNetworkMonitor();
+    void setMasternodeCount(const QString& strMasternodes);
 
 private:
     Ui::SettingsInformationWidget *ui;


### PR DESCRIPTION
The count isn't updated on every widget show, only via the event (which only happen every 40 minutes as Masternodes updates aren't regular at all).
This PR fixes it updating the masternode count every time that the screen is visible, then the event is in charge of update it if the user stays there long enough.