### PR TITLE
[BUG][Wallet] return unconfirmed balance for all spendable coins by default

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -606,7 +606,7 @@ public:
     CAmount GetDelegatedBalance() const;    // delegated coins for which we have the spending key
     CAmount GetImmatureDelegatedBalance() const;
     CAmount GetLockedCoins() const;
-    CAmount GetUnconfirmedBalance(isminetype filter = ISMINE_SPENDABLE) const;
+    CAmount GetUnconfirmedBalance(isminetype filter = ISMINE_SPENDABLE_ALL) const;
     CAmount GetImmatureBalance() const;
     CAmount GetWatchOnlyBalance() const;
     CAmount GetUnconfirmedWatchOnlyBalance() const;


### PR DESCRIPTION
(thus including also unconfirmed, delegated balance).

One immediate effect is that, this way, delegations are reflected under "Pending balance" in the GUI (owner-side), before being included in a block (so this closes #2072)