### PR TITLE
[BUG][Masternode] Miner not paying valid finalized budget if <20 active masternodes

### DIFF
--- a/src/budget/budgetmanager.cpp
+++ b/src/budget/budgetmanager.cpp
@@ -401,17 +401,12 @@ int CBudgetManager::GetHighestVoteCount(int chainHeight) const
 
 bool CBudgetManager::GetPayeeAndAmount(int chainHeight, CScript& payeeRet, CAmount& nAmountRet) const
 {
-    const CFinalizedBudget* pfb = GetBudgetWithHighestVoteCount(chainHeight);
-    if (!pfb) return false;
-
-    // Check that there are enough votes
-    int mnCount = mnodeman.CountEnabled(ActiveProtocol());
-    int nFivePercent = mnCount / 20;
-    if ((nFivePercent == 0 && !(Params().IsRegTestNet() && mnCount > 0) ) ||
-        pfb->GetVoteCount() < nFivePercent)
+    int nCountThreshold;
+    if (!IsBudgetPaymentBlock(chainHeight, nCountThreshold))
         return false;
 
-    return pfb->GetPayeeAndAmount(chainHeight, payeeRet, nAmountRet);
+    const CFinalizedBudget* pfb = GetBudgetWithHighestVoteCount(chainHeight);
+    return pfb && pfb->GetPayeeAndAmount(chainHeight, payeeRet, nAmountRet) && pfb->GetVoteCount() > nCountThreshold;
 }
 
 bool CBudgetManager::FillBlockPayee(CMutableTransaction& txNew, const int nHeight, bool fProofOfStake) const

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -295,10 +295,9 @@ void FillBlockPayee(CMutableTransaction& txNew, const int nHeight, bool fProofOf
 {
     if (nHeight == 0) return;
 
-    if (!sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS) ||  // if superblocks are not enabled
-            !g_budgetman.IsBudgetPaymentBlock(nHeight) || // or this is not a superblock
-            !g_budgetman.FillBlockPayee(txNew, nHeight, fProofOfStake) ) {    // or there's no budget with enough votes
-        // pay a masternode
+    if (!sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS) ||           // if superblocks are not enabled
+            !g_budgetman.FillBlockPayee(txNew, nHeight, fProofOfStake) ) {    // or this is not a superblock,
+        // ... or there's no budget with enough votes, then pay a masternode
         masternodePayments.FillBlockPayee(txNew, nHeight, fProofOfStake);
     }
 }


### PR DESCRIPTION
Edge case where the consensus is not aligned between the block producer and the block verifier.

Verifier: (`CheckBlock` --> `IsBlockPayeeValid` --> `IsBudgetPaymentBlock`), during a superblock, expects a payment to a budget proposal, even with the case of N<20 active masternodes on the network, provided that all N voted on the finalized budget (the threshold is N-1).

The block producer, instead, is paying a masternode (`GetPayeeAndAmount`). 
Fix it, using the same flow of the verifier: first check the threshold, adjusting it for the case of N<20 (5% = 0), setting it to N-1, and then check that there is a finalized budget with enough votes. 

Also remove the extra call to `IsBudgetPaymentBlock` directly from `FillBlockPayee` (now called by `CBudgetManager::FillBlockPayee` --> `GetPayeeAndAmount`).