### PR TITLE
[RPC] Cleanup RPC help output

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -324,15 +324,15 @@ UniValue prioritisetransaction(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 3)
         throw std::runtime_error(
-            "prioritisetransaction <txid> <priority delta> <fee delta>\n"
+            "prioritisetransaction \"txid\" priority_delta fee_delta\n"
             "Accepts the transaction into mined blocks at a higher (or lower) priority\n"
 
             "\nArguments:\n"
             "1. \"txid\"       (string, required) The transaction id.\n"
-            "2. priority delta (numeric, required) The priority to add or subtract.\n"
+            "2. priority_delta (numeric, required) The priority to add or subtract.\n"
             "                  The transaction selection algorithm considers the tx as it would have a higher priority.\n"
             "                  (priority of a transaction is calculated: coinage * value_in_upiv / txsize) \n"
-            "3. fee delta      (numeric, required) The fee value (in upiv) to add (or subtract, if negative).\n"
+            "3. fee_delta      (numeric, required) The fee value (in upiv) to add (or subtract, if negative).\n"
             "                  The fee is not actually paid, only the algorithm for selecting transactions into a block\n"
             "                  considers the transaction as it would have paid a higher (or lower) fee.\n"
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -548,8 +548,8 @@ UniValue verifymessage(const JSONRPCRequest& request)
 
             "\nArguments:\n"
             "1. \"pivxaddress\"  (string, required) The pivx address to use for the signature.\n"
-            "2. \"signature\"       (string, required) The signature provided by the signer in base 64 encoding (see signmessage).\n"
-            "3. \"message\"         (string, required) The message that was signed.\n"
+            "2. \"signature\"    (string, required) The signature provided by the signer in base 64 encoding (see signmessage).\n"
+            "3. \"message\"      (string, required) The message that was signed.\n"
 
             "\nResult:\n"
             "true|false   (boolean) If the signature is verified or not.\n"
@@ -604,7 +604,7 @@ UniValue setmocktime(const JSONRPCRequest& request)
             "\nSet the local time to given timestamp (-regtest only)\n"
 
             "\nArguments:\n"
-            "1. timestamp  (integer, required) Unix seconds-since-epoch timestamp\n"
+            "1. timestamp  (numeric, required) Unix seconds-since-epoch timestamp\n"
             "   Pass 0 to go back to using the system time.");
 
     if (!Params().IsRegTestNet())
@@ -646,16 +646,23 @@ UniValue logging(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() > 2) {
         throw std::runtime_error(
-            "logging [include,...] <exclude>\n"
+            "logging [include,...] ( [exclude,...] )\n"
             "Gets and sets the logging configuration.\n"
             "When called without an argument, returns the list of categories that are currently being debug logged.\n"
             "When called with arguments, adds or removes categories from debug logging.\n"
             "The valid logging categories are: " + ListLogCategories() + "\n"
             "libevent logging is configured on startup and cannot be modified by this RPC during runtime."
+
             "Arguments:\n"
             "1. \"include\" (array of strings) add debug logging for these categories.\n"
             "2. \"exclude\" (array of strings) remove debug logging for these categories.\n"
-            "\nResult: <categories>  (string): a list of the logging categories that are active.\n"
+
+            "\nResult:\n"
+            "{                            (object): a JSON object of the logging categories that are active.\n"
+            "  \"category\": fEnabled,    (key/value) Key is the category name, value is a boolean of it's active state.\n"
+            "  ...,\n"
+            "}\n"
+
             "\nExamples:\n"
             + HelpExampleCli("logging", "\"[\\\"all\\\"]\" \"[\\\"http\\\"]\"")
             + HelpExampleRpc("logging", "[\"all\"], \"[libevent]\"")

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -431,7 +431,7 @@ UniValue setban(const JSONRPCRequest& request)
     if (request.fHelp || request.params.size() < 2 ||
         (strCommand != "add" && strCommand != "remove"))
         throw std::runtime_error(
-            "setban \"ip(/netmask)\" \"add|remove\" (bantime) (absolute)\n"
+            "setban \"ip(/netmask)\" \"add|remove\" ( bantime absolute )\n"
             "\nAttempts add or remove a IP/Subnet from the banned list.\n"
 
             "\nArguments:\n"

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4050,7 +4050,7 @@ UniValue getsaplingnotescount(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() > 1)
         throw std::runtime_error(
-                "getsaplingnodescount ( minconf )\n"
+                "getsaplingnotescount ( minconf )\n"
                 "Returns the number of sapling notes available in the wallet.\n"
                 "\nArguments:\n"
                 "1. minconf      (numeric, optional, default=1) Only include notes in transactions confirmed at least this many times.\n"

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3890,10 +3890,10 @@ unsigned int sumMultiSend()
     return sum;
 }
 
+/* disable multisend
 UniValue multisend(const JSONRPCRequest& request)
 {
     throw std::runtime_error("Multisend is disabled in this wallet version");
-    /* disable multisend
     CWalletDB walletdb(pwalletMain->strWalletFile);
     bool fFileBacked;
     //MultiSend Commands
@@ -4042,8 +4042,8 @@ UniValue multisend(const JSONRPCRequest& request)
         }
     }
     return printMultiSend();
-    */
 }
+*/
 
 
 UniValue getsaplingnotescount(const JSONRPCRequest& request)
@@ -4145,7 +4145,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "delegatorremove",          &delegatorremove,          true  },
     { "wallet",             "bip38encrypt",             &bip38encrypt,             true  },
     { "wallet",             "bip38decrypt",             &bip38decrypt,             true  },
-    { "wallet",             "multisend",                &multisend,                false },
+    //{ "wallet",             "multisend",                &multisend,                false },
 
     /** Sapling functions */
     { "wallet",             "getnewshieldedaddress",         &getnewshieldedaddress,          true  },


### PR DESCRIPTION
This fixes a typo, and cleans up some inconsistencies in the RPC help output.

namely, a typo in `getsaplingnotescount`, the errant display of multisig being disabled, and the styling/formatting of command arguments