### PR TITLE
[Trivial][Refactor] Pass caught logic_error by reference in CreateSig

### DIFF
--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -27,7 +27,7 @@ bool TransactionSignatureCreator::CreateSig(std::vector<unsigned char>& vchSig, 
     uint256 hash;
     try {
         hash = SignatureHash(scriptCode, *txTo, nIn, nHashType, amount, sigversion);
-    } catch (std::logic_error ex) {
+    } catch (const std::logic_error& ex) {
         return false;
     }
 


### PR DESCRIPTION
Exceptions/errors caught should be passed by reference.
If the catch-block is not modifying the exception/error, the reference should be `const` (same as we did way back in #979)

Fix one instance in `TransactionSignatureCreator::CreateSig` where we are passing a logic_error by copy, causing the `catching polymorphic type` warning reported in #2076 