### PR TITLE
[Core] Migrate uint160 (CKeyID/CScriptID) to opaque blobs

### DIFF
--- a/src/blob_uint256.h
+++ b/src/blob_uint256.h
@@ -113,17 +113,6 @@ public:
     explicit blob88(const std::vector<unsigned char>& vch) : base_blob<88>(vch) {}
 };
 
-/** 160-bit opaque blob.
- * @note This type is called uint160 for historical reasons only. It is an opaque
- * blob of 160 bits and has no integer operations.
- */
-class blob_uint160 : public base_blob<160> {
-public:
-    blob_uint160() {}
-    blob_uint160(const base_blob<160>& b) : base_blob<160>(b) {}
-    explicit blob_uint160(const std::vector<unsigned char>& vch) : base_blob<160>(vch) {}
-};
-
 /** 256-bit opaque blob.
  * @note This type is called uint256 for historical reasons only. It is an
  * opaque blob of 256 bits and has no integer operations. Use arith_uint256 if

--- a/src/qt/pivx/settings/settingsbittoolwidget.cpp
+++ b/src/qt/pivx/settings/settingsbittoolwidget.cpp
@@ -150,7 +150,7 @@ void SettingsBitToolWidget::onEncryptKeyButtonENCClicked()
         return;
     }
 
-    CKeyID keyID = *boost::get<CKeyID>(&dest);
+    const CKeyID* keyID = boost::get<CKeyID>(&dest);
     if (!keyID) {
         //ui->addressIn_ENC->setValid(false);
         ui->statusLabel_ENC->setStyleSheet("QLabel { color: red; }");
@@ -166,7 +166,7 @@ void SettingsBitToolWidget::onEncryptKeyButtonENCClicked()
     }
 
     CKey key;
-    if (!pwalletMain->GetKey(keyID, key)) {
+    if (!pwalletMain->GetKey(*keyID, key)) {
         ui->statusLabel_ENC->setStyleSheet("QLabel { color: red; }");
         ui->statusLabel_ENC->setText(tr("Private key for the entered address is not available."));
         return;

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -23,14 +23,14 @@ const char R1ArrayHex[] = "7D1DE5EAF9B156D53208F033B5AA8122D2d2355d5e12292b12115
 const double R1Ldouble = 0.4887374590559308955; // R1L equals roughly R1Ldouble * 2^256
 const double R1Sdouble = 0.7096329412477836074;
 const uint256 R1L = uint256(std::vector<unsigned char>(R1Array,R1Array+32));
-const uint160 R1S = uint160(std::vector<unsigned char>(R1Array,R1Array+20));
+const arith_uint160 R1S = arith_uint160(std::vector<unsigned char>(R1Array,R1Array+20));
 const uint64_t R1LLow64 = 0x121156cfdb4a529cULL;
 
 const unsigned char R2Array[] =
     "\x70\x32\x1d\x7c\x47\xa5\x6b\x40\x26\x7e\x0a\xc3\xa6\x9c\xb6\xbf"
     "\x13\x30\x47\xa3\x19\x2d\xda\x71\x49\x13\x72\xf0\xb4\xca\x81\xd7";
 const uint256 R2L = uint256(std::vector<unsigned char>(R2Array,R2Array+32));
-const uint160 R2S = uint160(std::vector<unsigned char>(R2Array,R2Array+20));
+const arith_uint160 R2S = arith_uint160(std::vector<unsigned char>(R2Array,R2Array+20));
 
 const char R1LplusR2L[] = "549FB09FEA236A1EA3E31D4D58F1B1369288D204211CA751527CFC175767850C";
 
@@ -38,22 +38,22 @@ const unsigned char ZeroArray[] =
     "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
     "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
 const uint256 ZeroL = uint256(std::vector<unsigned char>(ZeroArray,ZeroArray+32));
-const uint160 ZeroS = uint160(std::vector<unsigned char>(ZeroArray,ZeroArray+20));
+const arith_uint160 ZeroS = arith_uint160(std::vector<unsigned char>(ZeroArray,ZeroArray+20));
 
 const unsigned char OneArray[] =
     "\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
     "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
 const uint256 OneL = uint256(std::vector<unsigned char>(OneArray,OneArray+32));
-const uint160 OneS = uint160(std::vector<unsigned char>(OneArray,OneArray+20));
+const arith_uint160 OneS = arith_uint160(std::vector<unsigned char>(OneArray,OneArray+20));
 
 const unsigned char MaxArray[] =
     "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
     "\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff";
 const uint256 MaxL = uint256(std::vector<unsigned char>(MaxArray,MaxArray+32));
-const uint160 MaxS = uint160(std::vector<unsigned char>(MaxArray,MaxArray+20));
+const arith_uint160 MaxS = arith_uint160(std::vector<unsigned char>(MaxArray,MaxArray+20));
 
 const uint256 HalfL = (OneL << 255);
-const uint160 HalfS = (OneS << 159);
+const arith_uint160 HalfS = (OneS << 159);
 std::string ArrayToString(const unsigned char A[], unsigned int width)
 {
     std::stringstream Stream;
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE( basics ) // constructors, equality, inequality
         BOOST_CHECK(ZeroS != (OneS << i));
         BOOST_CHECK((OneS << i) != ZeroS);
         BOOST_CHECK(R1S != (R1S ^ (OneS << i)));
-        BOOST_CHECK(((uint160(Tmp64) ^ (OneS << i) ) != Tmp64 ));
+        BOOST_CHECK(((arith_uint160(Tmp64) ^ (OneS << i) ) != Tmp64 ));
     }
     BOOST_CHECK(ZeroS == (OneS << 256));
 
@@ -125,30 +125,30 @@ BOOST_AUTO_TEST_CASE( basics ) // constructors, equality, inequality
     BOOST_CHECK(uint256(ZeroL) == ZeroL);
     BOOST_CHECK(uint256(OneL) == OneL);
 
-    BOOST_CHECK(uint160("0x"+R1S.ToString()) == R1S);
-    BOOST_CHECK(uint160("0x"+R2S.ToString()) == R2S);
-    BOOST_CHECK(uint160("0x"+ZeroS.ToString()) == ZeroS);
-    BOOST_CHECK(uint160("0x"+OneS.ToString()) == OneS);
-    BOOST_CHECK(uint160("0x"+MaxS.ToString()) == MaxS);
-    BOOST_CHECK(uint160(R1S.ToString()) == R1S);
-    BOOST_CHECK(uint160("   0x"+R1S.ToString()+"   ") == R1S);
-    BOOST_CHECK(uint160("") == ZeroS);
-    BOOST_CHECK(R1S == uint160(R1ArrayHex));
+    BOOST_CHECK(arith_uint160("0x"+R1S.ToString()) == R1S);
+    BOOST_CHECK(arith_uint160("0x"+R2S.ToString()) == R2S);
+    BOOST_CHECK(arith_uint160("0x"+ZeroS.ToString()) == ZeroS);
+    BOOST_CHECK(arith_uint160("0x"+OneS.ToString()) == OneS);
+    BOOST_CHECK(arith_uint160("0x"+MaxS.ToString()) == MaxS);
+    BOOST_CHECK(arith_uint160(R1S.ToString()) == R1S);
+    BOOST_CHECK(arith_uint160("   0x"+R1S.ToString()+"   ") == R1S);
+    BOOST_CHECK(arith_uint160("") == ZeroS);
+    BOOST_CHECK(R1S == arith_uint160(R1ArrayHex));
 
-    BOOST_CHECK(uint160(R1S) == R1S);
-    BOOST_CHECK((uint160(R1S^R2S)^R2S) == R1S);
-    BOOST_CHECK(uint160(ZeroS) == ZeroS);
-    BOOST_CHECK(uint160(OneS) == OneS);
+    BOOST_CHECK(arith_uint160(R1S) == R1S);
+    BOOST_CHECK((arith_uint160(R1S^R2S)^R2S) == R1S);
+    BOOST_CHECK(arith_uint160(ZeroS) == ZeroS);
+    BOOST_CHECK(arith_uint160(OneS) == OneS);
 
     // uint64_t constructor
     BOOST_CHECK( (R1L & uint256("0xffffffffffffffff")) == uint256(R1LLow64));
     BOOST_CHECK(ZeroL.IsNull());
     BOOST_CHECK(OneL == uint256(1));
     BOOST_CHECK(uint256("0xffffffffffffffff") = uint256(0xffffffffffffffffULL));
-    BOOST_CHECK( (R1S & uint160("0xffffffffffffffff")) == uint160(R1LLow64));
-    BOOST_CHECK(ZeroS == uint160(0));
-    BOOST_CHECK(OneS == uint160(1));
-    BOOST_CHECK(uint160("0xffffffffffffffff") = uint160(0xffffffffffffffffULL));
+    BOOST_CHECK( (R1S & arith_uint160("0xffffffffffffffff")) == arith_uint160(R1LLow64));
+    BOOST_CHECK(ZeroS == arith_uint160(0));
+    BOOST_CHECK(OneS == arith_uint160(1));
+    BOOST_CHECK(arith_uint160("0xffffffffffffffff") = arith_uint160(0xffffffffffffffffULL));
 
     // Assignment (from base_uint)
     uint256 tmpL = ~ZeroL; BOOST_CHECK(tmpL == ~ZeroL);
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE( basics ) // constructors, equality, inequality
     tmpL = ~R1L; BOOST_CHECK(tmpL == ~R1L);
     tmpL = ~R2L; BOOST_CHECK(tmpL == ~R2L);
     tmpL = ~MaxL; BOOST_CHECK(tmpL == ~MaxL);
-    uint160 tmpS = ~ZeroS; BOOST_CHECK(tmpS == ~ZeroS);
+    arith_uint160 tmpS = ~ZeroS; BOOST_CHECK(tmpS == ~ZeroS);
     tmpS = ~OneS; BOOST_CHECK(tmpS == ~OneS);
     tmpS = ~R1S; BOOST_CHECK(tmpS == ~R1S);
     tmpS = ~R2S; BOOST_CHECK(tmpS == ~R2S);
@@ -165,8 +165,8 @@ BOOST_AUTO_TEST_CASE( basics ) // constructors, equality, inequality
     // Wrong length must throw exception.
     BOOST_CHECK_THROW(uint256(std::vector<unsigned char>(OneArray,OneArray+31)), uint_error);
     BOOST_CHECK_THROW(uint256(std::vector<unsigned char>(OneArray,OneArray+20)), uint_error);
-    BOOST_CHECK_THROW(uint160(std::vector<unsigned char>(OneArray,OneArray+32)), uint_error);
-    BOOST_CHECK_THROW(uint160(std::vector<unsigned char>(OneArray,OneArray+19)), uint_error);
+    BOOST_CHECK_THROW(arith_uint160(std::vector<unsigned char>(OneArray,OneArray+32)), uint_error);
+    BOOST_CHECK_THROW(arith_uint160(std::vector<unsigned char>(OneArray,OneArray+19)), uint_error);
 }
 
 void shiftArrayRight(unsigned char* to, const unsigned char* from, unsigned int arrayLength, unsigned int bitsToShift)
@@ -242,11 +242,11 @@ BOOST_AUTO_TEST_CASE( shifts ) { // "<<"  ">>"  "<<="  ">>="
         BOOST_CHECK((c1L << i) == (c2L << (i-128)));
     }
 
-    uint160 TmpS;
+    arith_uint160 TmpS;
     for (unsigned int i = 0; i < 160; ++i)
     {
         shiftArrayLeft(TmpArray, OneArray, 20, i);
-        BOOST_CHECK(uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (OneS << i));
+        BOOST_CHECK(arith_uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (OneS << i));
         TmpS = OneS; TmpS <<= i;
         BOOST_CHECK(TmpS == (OneS << i));
         BOOST_CHECK((HalfS >> (159-i)) == (OneS << i));
@@ -254,27 +254,27 @@ BOOST_AUTO_TEST_CASE( shifts ) { // "<<"  ">>"  "<<="  ">>="
         BOOST_CHECK(TmpS == (OneS << i));
 
         shiftArrayLeft(TmpArray, R1Array, 20, i);
-        BOOST_CHECK(uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (R1S << i));
+        BOOST_CHECK(arith_uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (R1S << i));
         TmpS = R1S; TmpS <<= i;
         BOOST_CHECK(TmpS == (R1S << i));
 
         shiftArrayRight(TmpArray, R1Array, 20, i);
-        BOOST_CHECK(uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (R1S >> i));
+        BOOST_CHECK(arith_uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (R1S >> i));
         TmpS = R1S; TmpS >>= i;
         BOOST_CHECK(TmpS == (R1S >> i));
 
         shiftArrayLeft(TmpArray, MaxArray, 20, i);
-        BOOST_CHECK(uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (MaxS << i));
+        BOOST_CHECK(arith_uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (MaxS << i));
         TmpS = MaxS; TmpS <<= i;
         BOOST_CHECK(TmpS == (MaxS << i));
 
         shiftArrayRight(TmpArray, MaxArray, 20, i);
-        BOOST_CHECK(uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (MaxS >> i));
+        BOOST_CHECK(arith_uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (MaxS >> i));
         TmpS = MaxS; TmpS >>= i;
         BOOST_CHECK(TmpS == (MaxS >> i));
     }
-    uint160 c1S = uint160(0x0123456789abcdefULL);
-    uint160 c2S = c1S << 80;
+    arith_uint160 c1S = arith_uint160(0x0123456789abcdefULL);
+    arith_uint160 c2S = c1S << 80;
     for (unsigned int i = 0; i < 80; ++i) {
         BOOST_CHECK((c1S << i) == (c2S >> (80-i)));
     }
@@ -300,7 +300,7 @@ BOOST_AUTO_TEST_CASE( unaryOperators ) // !    ~    -
     unsigned char TmpArray[32];
     for (unsigned int i = 0; i < 32; ++i) { TmpArray[i] = ~R1Array[i]; }
     BOOST_CHECK(uint256(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (~R1L));
-    BOOST_CHECK(uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (~R1S));
+    BOOST_CHECK(arith_uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (~R1S));
 
     BOOST_CHECK(-ZeroL == ZeroL); BOOST_CHECK(-ZeroS == ZeroS);
     BOOST_CHECK(-R1L == (~R1L)+1);
@@ -318,7 +318,7 @@ BOOST_AUTO_TEST_CASE( unaryOperators ) // !    ~    -
     for (unsigned int i = 0; i < 32; ++i) { TmpArray[i] = _A_##Array[i] _OP_ _B_##Array[i]; } \
     BOOST_CHECK(uint256(std::vector<unsigned char>(TmpArray,TmpArray+32)) == (_A_##L _OP_ _B_##L)); \
     for (unsigned int i = 0; i < 20; ++i) { TmpArray[i] = _A_##Array[i] _OP_ _B_##Array[i]; } \
-    BOOST_CHECK(uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (_A_##S _OP_ _B_##S));
+    BOOST_CHECK(arith_uint160(std::vector<unsigned char>(TmpArray,TmpArray+20)) == (_A_##S _OP_ _B_##S));
 
 #define CHECKASSIGNMENTOPERATOR(_A_,_B_,_OP_)                           \
     TmpL = _A_##L; TmpL _OP_##= _B_##L; BOOST_CHECK(TmpL == (_A_##L _OP_ _B_##L)); \
@@ -345,7 +345,7 @@ BOOST_AUTO_TEST_CASE( bitwiseOperators )
     CHECKBITWISEOPERATOR(Max,R1,&)
 
     uint256 TmpL;
-    uint160 TmpS;
+    arith_uint160 TmpS;
     CHECKASSIGNMENTOPERATOR(R1,R2,|)
     CHECKASSIGNMENTOPERATOR(R1,R2,^)
     CHECKASSIGNMENTOPERATOR(R1,R2,&)
@@ -364,13 +364,13 @@ BOOST_AUTO_TEST_CASE( bitwiseOperators )
 
     uint64_t Tmp64 = 0xe1db685c9a0b47a2ULL;
     TmpL = R1L; TmpL |= Tmp64;  BOOST_CHECK(TmpL == (R1L | uint256(Tmp64)));
-    TmpS = R1S; TmpS |= Tmp64;  BOOST_CHECK(TmpS == (R1S | uint160(Tmp64)));
+    TmpS = R1S; TmpS |= Tmp64;  BOOST_CHECK(TmpS == (R1S | arith_uint160(Tmp64)));
     TmpL = R1L; TmpL |= 0; BOOST_CHECK(TmpL == R1L);
     TmpS = R1S; TmpS |= 0; BOOST_CHECK(TmpS == R1S);
     TmpL ^= 0; BOOST_CHECK(TmpL == R1L);
     TmpS ^= 0; BOOST_CHECK(TmpS == R1S);
     TmpL ^= Tmp64;  BOOST_CHECK(TmpL == (R1L ^ uint256(Tmp64)));
-    TmpS ^= Tmp64;  BOOST_CHECK(TmpS == (R1S ^ uint160(Tmp64)));
+    TmpS ^= Tmp64;  BOOST_CHECK(TmpS == (R1S ^ arith_uint160(Tmp64)));
 }
 
 BOOST_AUTO_TEST_CASE( comparison ) // <= >= < >
@@ -385,7 +385,7 @@ BOOST_AUTO_TEST_CASE( comparison ) // <= >= < >
         BOOST_CHECK( R1L <= TmpL ); BOOST_CHECK( (R1L == TmpL) != (R1L < TmpL)); BOOST_CHECK( (TmpL == R1L) || !( R1L >= TmpL));
         BOOST_CHECK(! (TmpL < R1L)); BOOST_CHECK(! (R1L > TmpL));
     }
-    uint160 TmpS;
+    arith_uint160 TmpS;
     for (unsigned int i = 0; i < 160; ++i) {
         TmpS= OneS<< i;
         BOOST_CHECK( TmpS >= ZeroS && TmpS > ZeroS && ZeroS < TmpS && ZeroS <= TmpS);
@@ -441,8 +441,8 @@ BOOST_AUTO_TEST_CASE( plusMinus )
     BOOST_CHECK(--TmpL == R1L-1);
 
     // 160-bit; copy-pasted
-    uint160 TmpS = 0;
-    BOOST_CHECK(R1S+R2S == uint160(R1LplusR2L));
+    arith_uint160 TmpS = 0;
+    BOOST_CHECK(R1S+R2S == arith_uint160(R1LplusR2L));
     TmpS += R1S;
     BOOST_CHECK(TmpS == R1S);
     TmpS += R2S;
@@ -460,9 +460,9 @@ BOOST_AUTO_TEST_CASE( plusMinus )
         BOOST_CHECK( TmpS++ == (MaxS>>i) );
         BOOST_CHECK( TmpS == (HalfS >> (i-1)));
     }
-    BOOST_CHECK(uint160(0xbedc77e27940a7ULL) + 0xee8d836fce66fbULL == uint160(0xbedc77e27940a7ULL + 0xee8d836fce66fbULL));
-    TmpS = uint160(0xbedc77e27940a7ULL); TmpS += 0xee8d836fce66fbULL;
-    BOOST_CHECK(TmpS == uint160(0xbedc77e27940a7ULL+0xee8d836fce66fbULL));
+    BOOST_CHECK(arith_uint160(0xbedc77e27940a7ULL) + 0xee8d836fce66fbULL == arith_uint160(0xbedc77e27940a7ULL + 0xee8d836fce66fbULL));
+    TmpS = arith_uint160(0xbedc77e27940a7ULL); TmpS += 0xee8d836fce66fbULL;
+    BOOST_CHECK(TmpS == arith_uint160(0xbedc77e27940a7ULL+0xee8d836fce66fbULL));
     TmpS -= 0xee8d836fce66fbULL;  BOOST_CHECK(TmpS == 0xbedc77e27940a7ULL);
     TmpS = R1S;
     BOOST_CHECK(++TmpS == R1S+1);
@@ -538,8 +538,8 @@ BOOST_AUTO_TEST_CASE( divide )
     BOOST_CHECK(MaxL / R2L == 1);
     BOOST_CHECK_THROW(R2L / ZeroL, uint_error);
 
-    uint160 D1S("D3C5EDCDEA54EB92679F0A4B4");
-    uint160 D2S("13037");
+    arith_uint160 D1S("D3C5EDCDEA54EB92679F0A4B4");
+    arith_uint160 D2S("13037");
     BOOST_CHECK((R1S / D1S).ToString() == "0000000000000000000000000db9af3beade6c02");
     BOOST_CHECK((R1S / D2S).ToString() == "000098dfb6cc40ca592bf74366794f298ada205c");
     BOOST_CHECK(R1S / OneS == R1S);
@@ -614,7 +614,7 @@ BOOST_AUTO_TEST_CASE( methods ) // GetHex SetHex begin() end() size() GetLow64 G
     BOOST_CHECK(R2S.GetHex() == R2S.ToString());
     BOOST_CHECK(OneS.GetHex() == OneS.ToString());
     BOOST_CHECK(MaxS.GetHex() == MaxS.ToString());
-    uint160 TmpS(R1S);
+    arith_uint160 TmpS(R1S);
     BOOST_CHECK(TmpS == R1S);
     TmpS.SetHex(R2S.ToString());   BOOST_CHECK(TmpS == R2S);
     TmpS.SetHex(ZeroS.ToString()); BOOST_CHECK(TmpS == 0);

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -22,15 +22,15 @@
 // with the blob_uint256 file.
 //
 
-/** 160-bit unsigned big integer. */
-class uint160 : public base_uint<160>
-{
+/** 160-bit opaque blob.
+ * @note This type is called uint160 for historical reasons only. It is an opaque
+ * blob of 160 bits and has no integer operations.
+ */
+class uint160 : public base_blob<160> {
 public:
     uint160() {}
-    uint160(const base_uint<160>& b) : base_uint<160>(b) {}
-    uint160(uint64_t b) : base_uint<160>(b) {}
-    explicit uint160(const std::string& str) : base_uint<160>(str) {}
-    explicit uint160(const std::vector<unsigned char>& vch) : base_uint<160>(vch) {}
+    uint160(const base_blob<160>& b) : base_blob<160>(b) {}
+    explicit uint160(const std::vector<unsigned char>& vch) : base_blob<160>(vch) {}
 };
 
 /** 256-bit unsigned big integer. */

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -434,11 +434,11 @@ UniValue dumpprivkey(const JSONRPCRequest& request)
     CTxDestination dest = DecodeDestination(strAddress);
     if (!IsValidDestination(dest))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid PIVX address");
-    CKeyID keyID = *boost::get<CKeyID>(&dest);
+    const CKeyID* keyID = boost::get<CKeyID>(&dest);
     if (!keyID)
         throw JSONRPCError(RPC_TYPE_ERROR, "Address does not refer to a key");
     CKey vchSecret;
-    if (!pwalletMain->GetKey(keyID, vchSecret))
+    if (!pwalletMain->GetKey(*keyID, vchSecret))
         throw JSONRPCError(RPC_WALLET_ERROR, "Private key for address " + strAddress + " is not known");
     return EncodeSecret(vchSecret);
 }
@@ -610,11 +610,11 @@ UniValue bip38encrypt(const JSONRPCRequest& request)
     CTxDestination address = DecodeDestination(strAddress);
     if (!IsValidDestination(address))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid PIVX address");
-    CKeyID keyID = *boost::get<CKeyID>(&address);
+    const CKeyID* keyID = boost::get<CKeyID>(&address);
     if (!keyID)
         throw JSONRPCError(RPC_TYPE_ERROR, "Address does not refer to a key");
     CKey vchSecret;
-    if (!pwalletMain->GetKey(keyID, vchSecret))
+    if (!pwalletMain->GetKey(*keyID, vchSecret))
         throw JSONRPCError(RPC_WALLET_ERROR, "Private key for address " + strAddress + " is not known");
 
     uint256 privKey = vchSecret.GetPrivKey_256();

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -679,11 +679,11 @@ UniValue delegatoradd(const JSONRPCRequest& request)
 
     const std::string strLabel = (request.params.size() > 1 ? request.params[1].get_str() : "");
 
-    CKeyID keyID = boost::get<CKeyID>(DecodeDestination(request.params[0].get_str()));
+    const CKeyID* keyID = boost::get<CKeyID>(&dest);
     if (!keyID)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Unable to get KeyID from PIVX address");
 
-    return pwalletMain->SetAddressBook(keyID, strLabel, AddressBook::AddressBookPurpose::DELEGATOR);
+    return pwalletMain->SetAddressBook(*keyID, strLabel, AddressBook::AddressBookPurpose::DELEGATOR);
 }
 
 UniValue delegatorremove(const JSONRPCRequest& request)
@@ -709,11 +709,11 @@ UniValue delegatorremove(const JSONRPCRequest& request)
     if (!IsValidDestination(dest) || isStakingAddress)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid PIVX address");
 
-    CKeyID keyID = *boost::get<CKeyID>(&dest);
+    const CKeyID* keyID = boost::get<CKeyID>(&dest);
     if (!keyID)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Unable to get KeyID from PIVX address");
 
-    if (!pwalletMain->HasAddressBook(keyID))
+    if (!pwalletMain->HasAddressBook(*keyID))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Unable to get PIVX address from addressBook");
 
     std::string label = "";
@@ -722,7 +722,7 @@ UniValue delegatorremove(const JSONRPCRequest& request)
         label = optAdd->name;
     }
 
-    return pwalletMain->SetAddressBook(keyID, label, AddressBook::AddressBookPurpose::DELEGABLE);
+    return pwalletMain->SetAddressBook(*keyID, label, AddressBook::AddressBookPurpose::DELEGABLE);
 }
 
 UniValue ListaddressesForPurpose(const std::string strPurpose)
@@ -1103,8 +1103,6 @@ UniValue CreateColdStakeDelegation(const UniValue& params, CWalletTx& wtxNew, CR
         if (!IsValidDestination(dest) || isStaking)
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid PIVX spending address");
         ownerKey = *boost::get<CKeyID>(&dest);
-        if (!ownerKey)
-            throw JSONRPCError(RPC_WALLET_ERROR, "Unable to get spend pubkey hash from owneraddress");
         // Check that the owner address belongs to this wallet, or fForceExternalAddr is true
         bool fForceExternalAddr = params.size() > 3 && !params[3].isNull() ? params[3].get_bool() : false;
         if (!fForceExternalAddr && !pwalletMain->HaveKey(ownerKey)) {
@@ -1119,8 +1117,6 @@ UniValue CreateColdStakeDelegation(const UniValue& params, CWalletTx& wtxNew, CR
         // Get new owner address from keypool
         CTxDestination ownerAddr = GetNewAddressFromLabel("delegated", NullUniValue);
         ownerKey = *boost::get<CKeyID>(&ownerAddr);
-        if (!ownerKey)
-            throw JSONRPCError(RPC_WALLET_ERROR, "Unable to get spend pubkey hash from owneraddress");
         ownerAddressStr = EncodeDestination(ownerAddr);
     }
 
@@ -1838,12 +1834,12 @@ UniValue signmessage(const JSONRPCRequest& request)
     if (!IsValidDestination(dest))
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid address");
 
-    CKeyID keyID = *boost::get<CKeyID>(&dest);
+    const CKeyID* keyID = boost::get<CKeyID>(&dest);
     if (!keyID)
         throw JSONRPCError(RPC_TYPE_ERROR, "Address does not refer to key");
 
     CKey key;
-    if (!pwalletMain->GetKey(keyID, key))
+    if (!pwalletMain->GetKey(*keyID, key))
         throw JSONRPCError(RPC_WALLET_ERROR, "Private key not available");
 
     CHashWriter ss(SER_GETHASH, 0);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -784,7 +784,7 @@ bool CWallet::GetVinAndKeysFromOutput(COutput out, CTxIn& txinRet, CPubKey& pubK
     CTxDestination address1;
     ExtractDestination(pubScript, address1, fColdStake);
 
-    CKeyID* keyID = boost::get<CKeyID>(&address1);
+    const CKeyID* keyID = boost::get<CKeyID>(&address1);
     if (!keyID) {
         LogPrintf("CWallet::GetVinAndKeysFromOutput -- Address does not refer to a key\n");
         return false;


### PR DESCRIPTION
Keep going with the migration started in #1395 and #1414.
This time migrate the whole class `uint160`, so it is defined as a child of `base_blob` (essentially replace `uint160` with `blob_uint160`), thus migrating `CKeyID` and `CScriptID` as well.

Since opaque blobs (unlike the `arith_uint` classes) have trivial copy-assignment operator, this fixes the "scary" `-Wclass-memaccess` warning reported in #2076 (tested before/after patch, with gcc v9.3.0)

Bonus: this fixes also a minor bug found along the way: few places where we are checking the result of `boost::get<CKeyID>` over the pointed `CKeyID`, which shouldn't even have a `bool operator()`, and might even be un-initialized (though we always verify `IsValidDestination` before, so this is mostly redundant) instead of checking the pointer itself.