### PR TITLE
[Trivial][RPC] Drop 'ed' suffix from vShielded* in TxSaplingToJSON

### DIFF
--- a/src/sapling/sapling_core_write.cpp
+++ b/src/sapling/sapling_core_write.cpp
@@ -46,9 +46,9 @@ void TxSaplingToJSON(const CTransaction& tx, UniValue& entry) {
         entry.pushKV("valueBalance", FormatMoney(tx.sapData->valueBalance));
         entry.pushKV("valueBalanceSat", tx.sapData->valueBalance);
         UniValue vspenddesc = TxShieldedSpendsToJSON(tx);
-        entry.pushKV("vShieldedSpend", vspenddesc);
+        entry.pushKV("vShieldSpend", vspenddesc);
         UniValue voutputdesc = TxShieldedOutputsToJSON(tx);
-        entry.pushKV("vShieldedOutput", voutputdesc);
+        entry.pushKV("vShieldOutput", voutputdesc);
         if (tx.sapData->hasBindingSig()) {
             entry.pushKV("bindingSig", HexStr(tx.sapData->bindingSig.begin(), tx.sapData->bindingSig.end()));
         }

--- a/test/functional/sapling_mempool.py
+++ b/test/functional/sapling_mempool.py
@@ -94,7 +94,7 @@ class SaplingMempoolTest(PivxTestFramework):
         # Now disconnect the block with the note's anchor,
         # and check that the tx is removed from the mempool
         self.log.info("Disconnect the last block to change the sapling anchor")
-        anchor = txC_json['vShieldedSpend'][0]['anchor']
+        anchor = txC_json['vShieldSpend'][0]['anchor']
         assert_equal(anchor, miner.getbestsaplinganchor())
         miner.invalidateblock(miner.getbestblockhash())
         assert (anchor != miner.getbestsaplinganchor())

--- a/test/functional/sapling_wallet.py
+++ b/test/functional/sapling_wallet.py
@@ -238,17 +238,17 @@ class WalletSaplingTest(PivxTestFramework):
         # Verify existence of Sapling related JSON fields
         resp = self.nodes[0].getrawtransaction(mytxid7, 1)
         assert_equal(Decimal(resp['valueBalance']), Decimal('11.00'))    # 20 shield input - 8 shield spend - 1 change
-        assert_equal(len(resp['vShieldedSpend']), 3)
-        assert_equal(len(resp['vShieldedOutput']), 2)
+        assert_equal(len(resp['vShieldSpend']), 3)
+        assert_equal(len(resp['vShieldOutput']), 2)
         assert('bindingSig' in resp)
-        shieldedSpend = resp['vShieldedSpend'][0]
+        shieldedSpend = resp['vShieldSpend'][0]
         assert('cv' in shieldedSpend)
         assert('anchor' in shieldedSpend)
         assert('nullifier' in shieldedSpend)
         assert('rk' in shieldedSpend)
         assert('proof' in shieldedSpend)
         assert('spendAuthSig' in shieldedSpend)
-        shieldedOutput = resp['vShieldedOutput'][0]
+        shieldedOutput = resp['vShieldOutput'][0]
         assert('cv' in shieldedOutput)
         assert('cmu' in shieldedOutput)
         assert('ephemeralKey' in shieldedOutput)

--- a/test/functional/sapling_wallet_listreceived.py
+++ b/test/functional/sapling_wallet_listreceived.py
@@ -136,7 +136,7 @@ class ListReceivedTest (PivxTestFramework):
 
         # Verify the spent nullifier
         tx_json = self.nodes[1].getrawtransaction(txid, True)
-        assert_equal(nullifier, tx_json["vShieldedSpend"][0]["nullifier"])
+        assert_equal(nullifier, tx_json["vShieldSpend"][0]["nullifier"])
 
         # Decrypted transaction details should be correct
         pt = self.nodes[1].viewshieldtransaction(txid)


### PR DESCRIPTION
One user-facing string left out in #2086 