### PR TITLE
[GUI] Hide shield all coins button.

### DIFF
--- a/src/qt/pivx/send.cpp
+++ b/src/qt/pivx/send.cpp
@@ -77,6 +77,7 @@ SendWidget::SendWidget(PIVXGUI* parent) :
     // Shield coins
     ui->btnShieldCoins->setTitleClassAndText("btn-title-grey", tr("Shield Coins"));
     ui->btnShieldCoins->setSubTitleClassAndText("text-subtitle", tr("Convert all transparent coins into shielded coins"));
+    ui->btnShieldCoins->setVisible(false);
 
     connect(ui->pushButtonFee, &QPushButton::clicked, this, &SendWidget::onChangeCustomFeeClicked);
     connect(ui->btnCoinControl, &OptionButton::clicked, this, &SendWidget::onCoinControlClicked);


### PR DESCRIPTION
Hiding the "shield all" functionality for now.
Would be good to expand this functionality later on splitting big transactions into smaller ones, dividing it across blocks, adding decoys etc.