### PR TITLE
[RPC] Fix more RPC help output

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -702,15 +702,19 @@ UniValue importsaplingkey(const JSONRPCRequest& request)
         throw std::runtime_error(
                 "importsaplingkey \"key\" ( rescan startHeight )\n"
                 "\nAdds a key (as returned by exportsaplingkey) to your wallet.\n"
+                + HelpRequiringPassphrase() + "\n"
+
                 "\nArguments:\n"
                 "1. \"key\"             (string, required) The zkey (see exportsaplingkey)\n"
                 "2. rescan             (string, optional, default=\"whenkeyisnew\") Rescan the wallet for transactions - can be \"yes\", \"no\" or \"whenkeyisnew\"\n"
                 "3. startHeight        (numeric, optional, default=0) Block height to start rescan from\n"
                 "\nNote: This call can take minutes to complete if rescan is true.\n"
+
                 "\nResult:\n"
                 "{\n"
                 "  \"address\" : \"address|DefaultAddress\",    (string) The address corresponding to the spending key (the default address).\n"
                 "}\n"
+
                 "\nExamples:\n"
                 "\nExport a zkey\n"
                 + HelpExampleCli("exportsaplingkey", "\"myaddress\"") +
@@ -790,15 +794,19 @@ UniValue importsaplingviewingkey(const JSONRPCRequest& request)
         throw std::runtime_error(
                 "importsaplingviewingkey \"vkey\" ( rescan startHeight )\n"
                 "\nAdds a viewing key (as returned by exportsaplingviewingkey) to your wallet.\n"
+                + HelpRequiringPassphrase() + "\n"
+
                 "\nArguments:\n"
                 "1. \"vkey\"             (string, required) The viewing key (see exportsaplingviewingkey)\n"
                 "2. rescan             (string, optional, default=\"whenkeyisnew\") Rescan the wallet for transactions - can be \"yes\", \"no\" or \"whenkeyisnew\"\n"
                 "3. startHeight        (numeric, optional, default=0) Block height to start rescan from\n"
                 "\nNote: This call can take minutes to complete if rescan is true.\n"
+
                 "\nResult:\n"
                 "{\n"
                 "  \"address\" : \"address|DefaultAddress\",    (string) The address corresponding to the viewing key (for Sapling, this is the default address).\n"
                 "}\n"
+
                 "\nExamples:\n"
                 "\nImport a viewing key\n"
                 + HelpExampleCli("importsaplingviewingkey", "\"vkey\"") +
@@ -880,10 +888,14 @@ UniValue exportsaplingviewingkey(const JSONRPCRequest& request)
                 "exportsaplingviewingkey \"shielded_addr\"\n"
                 "\nReveals the viewing key corresponding to 'shielded addr'.\n"
                 "Then the importsaplingviewingkey can be used with this output\n"
+                + HelpRequiringPassphrase() + "\n"
+
                 "\nArguments:\n"
                 "1. \"shielded_addr\"   (string, required) The shielded addr for the viewing key\n"
+
                 "\nResult:\n"
                 "\"vkey\"                  (string) The viewing key\n"
+
                 "\nExamples:\n"
                 + HelpExampleCli("exportsaplingviewingkey", "\"myaddress\"")
                 + HelpExampleRpc("exportsaplingviewingkey", "\"myaddress\"")
@@ -915,10 +927,14 @@ UniValue exportsaplingkey(const JSONRPCRequest& request)
                 "exportsaplingkey \"shielded addr\"\n"
                 "\nReveals the key corresponding to the 'shielded addr'.\n"
                 "Then the importsaplingkey can be used with this output\n"
+                + HelpRequiringPassphrase() + "\n"
+
                 "\nArguments:\n"
                 "1. \"addr\"   (string, required) The shielded addr for the private key\n"
+
                 "\nResult:\n"
                 "\"key\"                  (string) The private key\n"
+
                 "\nExamples:\n"
                 + HelpExampleCli("exportsaplingkey", "\"myaddress\"")
                 + HelpExampleRpc("exportsaplingkey", "\"myaddress\"")

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1233,45 +1233,7 @@ UniValue rawdelegatestake(const JSONRPCRequest& request)
             "7. \"fForceNotEnabled\"    (boolean, optional, default = false) ONLY FOR TESTING: force the creation even if SPORK 17 is disabled (for tests).\n"
 
             "\nResult:\n"
-            "{\n"
-            "  \"txid\" : \"id\",        (string) The transaction id (same as provided)\n"
-            "  \"version\" : n,          (numeric) The version\n"
-            "  \"type\" : n,             (numeric) The type\n"
-            "  \"size\" : n,             (numeric) The serialized transaction size\n"
-            "  \"locktime\" : ttt,       (numeric) The lock time\n"
-            "  \"vin\" : [               (array of json objects)\n"
-            "     {\n"
-            "       \"txid\": \"id\",    (string) The transaction id\n"
-            "       \"vout\": n,         (numeric) \n"
-            "       \"scriptSig\": {     (json object) The script\n"
-            "         \"asm\": \"asm\",  (string) asm\n"
-            "         \"hex\": \"hex\"   (string) hex\n"
-            "       },\n"
-            "       \"sequence\": n      (numeric) The script sequence number\n"
-            "     }\n"
-            "     ,...\n"
-            "  ],\n"
-            "  \"vout\" : [              (array of json objects)\n"
-            "     {\n"
-            "       \"value\" : x.xxx,            (numeric) The value in PIV\n"
-            "       \"n\" : n,                    (numeric) index\n"
-            "       \"scriptPubKey\" : {          (json object)\n"
-            "         \"asm\" : \"asm\",          (string) the asm\n"
-            "         \"hex\" : \"hex\",          (string) the hex\n"
-            "         \"reqSigs\" : n,            (numeric) The required sigs\n"
-            "         \"type\" : \"pubkeyhash\",  (string) The type, eg 'pubkeyhash'\n"
-            "         \"addresses\" : [           (json array of string)\n"
-            "           \"pivxaddress\"        (string) pivx address\n"
-            "           ,...\n"
-            "         ]\n"
-            "       }\n"
-            "     }\n"
-            "     ,...\n"
-            "  ],\n"
-            "  \"extraPayloadSize\" : n    (numeric) Size of extra payload. Only present if it's a special TX\n"
-            "  \"extraPayload\" : \"hex\"  (string) Hex encoded extra payload data. Only present if it's a special TX\n"
-            "  \"hex\" : \"data\",       (string) The serialized, hex-encoded data for 'txid'\n"
-            "}\n"
+            "\"transaction\"            (string) hex string of the transaction\n"
 
             "\nExamples:\n" +
             HelpExampleCli("rawdelegatestake", "\"S1t2a3kab9c8c71VA78xxxy4MxZg6vgeS6\" 100") +
@@ -1284,10 +1246,7 @@ UniValue rawdelegatestake(const JSONRPCRequest& request)
     CReserveKey reservekey(pwalletMain);
     CreateColdStakeDelegation(request.params, wtx, reservekey);
 
-    UniValue result(UniValue::VOBJ);
-    TxToUniv(wtx, UINT256_ZERO, result);
-
-    return result;
+    return EncodeHexTx(wtx);
 }
 
 
@@ -1753,6 +1712,7 @@ UniValue rawshieldsendmany(const JSONRPCRequest& request)
                 "                            based on the expected transaction size and the current value of -minRelayTxFee.\n"
                 "\nResult:\n"
                 "\"transaction\"            (string) hex string of the transaction\n"
+
                 "\nExamples:\n"
                 + HelpExampleCli("rawshieldsendmany",
                                  "\"DMJRSsuU9zfyrvxVaAEFQqK4MxZg6vgeS6\" '[{\"address\": \"ps1ra969yfhvhp73rw5ak2xvtcm9fkuqsnmad7qln79mphhdrst3lwu9vvv03yuyqlh42p42st47qd\" ,\"amount\": 5.0}]'")

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1742,7 +1742,7 @@ UniValue rawshieldsendmany(const JSONRPCRequest& request)
                 "                            If not specified, the wallet will try to compute the minimum possible fee for a shield TX,\n"
                 "                            based on the expected transaction size and the current value of -minRelayTxFee.\n"
                 "\nResult:\n"
-                "{tx_json}                (json object) decoded transaction\n"
+                "\"transaction\"            (string) hex string of the transaction\n"
                 "\nExamples:\n"
                 + HelpExampleCli("rawshieldsendmany",
                                  "\"DMJRSsuU9zfyrvxVaAEFQqK4MxZg6vgeS6\" '[{\"address\": \"ps1ra969yfhvhp73rw5ak2xvtcm9fkuqsnmad7qln79mphhdrst3lwu9vvv03yuyqlh42p42st47qd\" ,\"amount\": 5.0}]'")
@@ -1751,9 +1751,7 @@ UniValue rawshieldsendmany(const JSONRPCRequest& request)
         );
 
     CTransaction tx = CreateShieldedTransaction(request).getFinalTx();
-    UniValue tx_json(UniValue::VOBJ);
-    TxToUniv(tx, UINT256_ZERO, tx_json);
-    return tx_json;
+    return EncodeHexTx(tx);
 }
 
 UniValue listaddressgroupings(const JSONRPCRequest& request)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -507,9 +507,11 @@ UniValue getnewshieldaddress(const JSONRPCRequest& request)
         throw std::runtime_error(
                 "getnewshieldaddress\n"
                 "\nReturns a new shield address for receiving payments.\n"
-                "\nArguments:\n"
+                + HelpRequiringPassphrase() + "\n"
+
                 "\nResult:\n"
                 "\"address\"    (string) The new shield address.\n"
+
                 "\nExamples:\n"
                 + HelpExampleCli("getnewshieldaddress", "")
                 + HelpExampleRpc("getnewshieldaddress", "")
@@ -532,6 +534,7 @@ UniValue listshieldunspent(const JSONRPCRequest& request)
                 "\nReturns array of unspent shield notes with between minconf and maxconf (inclusive) confirmations.\n"
                 "Optionally filter to only include notes sent to specified addresses.\n"
                 "When minconf is 0, unspent notes with zero confirmations are returned, even though they are not immediately spendable.\n"
+
                 "\nArguments:\n"
                 "1. minconf          (numeric, optional, default=1) The minimum confirmations to filter\n"
                 "2. maxconf          (numeric, optional, default=9999999) The maximum confirmations to filter\n"
@@ -541,6 +544,7 @@ UniValue listshieldunspent(const JSONRPCRequest& request)
                 "      \"address\"     (string) shield addr\n"
                 "      ,...\n"
                 "    ]\n"
+
                 "\nResult:\n"
                 "[                             (array of json object)\n"
                 "  {\n"
@@ -808,13 +812,16 @@ UniValue listshieldaddresses(const JSONRPCRequest& request)
         throw std::runtime_error(
                 "listshieldaddresses ( includeWatchonly )\n"
                 "\nReturns the list of shield addresses belonging to the wallet.\n"
+
                 "\nArguments:\n"
                 "1. includeWatchonly (bool, optional, default=false) Also include watchonly addresses (see 'importviewingkey')\n"
+
                 "\nResult:\n"
                 "[                     (json array of string)\n"
                 "  \"addr\"           (string) a shield address belonging to the wallet\n"
                 "  ,...\n"
                 "]\n"
+
                 "\nExamples:\n"
                 + HelpExampleCli("listshieldaddresses", "")
                 + HelpExampleRpc("listshieldaddresses", "")
@@ -1308,12 +1315,15 @@ UniValue getshieldbalance(const JSONRPCRequest& request)
                 "\nCAUTION: If the wallet contains any addresses for which it only has incoming viewing keys,"
                 "\nthe returned private balance may be larger than the actual balance, because spends cannot"
                 "\nbe detected with incoming viewing keys.\n"
+
                 "\nArguments:\n"
                 "1. \"address\"      (string, optional) The selected address. If non empty nor \"*\", it must be a Sapling address\n"
                 "2. minconf          (numeric, optional, default=1) Only include private and transparent transactions confirmed at least this many times.\n"
                 "3. includeWatchonly (bool, optional, default=false) Also include balance in watchonly addresses (see 'importaddress' and 'importsaplingviewingkey')\n"
+
                 "\nResult:\n"
                 "amount              (numeric) the total balance of shield funds (in Sapling addresses)\n"
+
                 "\nExamples:\n"
                 "\nThe total amount in the wallet\n"
                 + HelpExampleCli("getshieldbalance", "")
@@ -1352,7 +1362,7 @@ UniValue viewshieldtransaction(const JSONRPCRequest& request)
     if (request.fHelp || request.params.size() != 1)
         throw std::runtime_error(
                 "viewshieldtransaction \"txid\"\n"
-                "\nGet detailed shield information about in-wallet transaction <txid>\n"
+                "\nGet detailed shield information about in-wallet transaction \"txid\"\n"
                 + HelpRequiringPassphrase() + "\n"
                 "\nArguments:\n"
                 "1. \"txid\"    (string, required) The transaction id\n"
@@ -2170,6 +2180,8 @@ UniValue sendmany(const JSONRPCRequest& request)
             HelpExampleRpc("sendmany", "\"\", \"{\\\"DMJRSsuU9zfyrvxVaAEFQqK4MxZg6vgeS6\\\":0.01,\\\"DAD3Y6ivr8nPQLT1NEPX84DxGCw9jz9Jvg\\\":0.02}\", 6, \"testing\"")
         );
 
+    EnsureWalletIsUnlocked();
+
     // Read Params
     if (!request.params[0].isNull() && !request.params[0].get_str().empty()) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Dummy value must be set to \"\"");
@@ -2439,9 +2451,11 @@ UniValue listreceivedbyshieldaddress(const JSONRPCRequest& request)
         throw std::runtime_error(
                 "listreceivedbyshieldaddress \"address\" ( minconf )\n"
                 "\nReturn a list of amounts received by a shield addr belonging to the node's wallet.\n"
+
                 "\nArguments:\n"
                 "1. \"address\"      (string) The private address.\n"
                 "2. minconf          (numeric, optional, default=1) Only include transactions confirmed at least this many times.\n"
+
                 "\nResult:\n"
                 "{\n"
                 "  \"txid\": \"txid\",           (string) the transaction id\n"
@@ -2454,6 +2468,7 @@ UniValue listreceivedbyshieldaddress(const JSONRPCRequest& request)
                 "  \"outindex\" (sapling) : n,     (numeric) the output index\n"
                 "  \"change\": true|false,    (boolean) true if the address that received the note is also one of the sending addresses\n"
                 "}\n"
+
                 "\nExamples:\n"
                 + HelpExampleCli("listreceivedbyshieldaddress", "\"ps1ra969yfhvhp73rw5ak2xvtcm9fkuqsnmad7qln79mphhdrst3lwu9vvv03yuyqlh42p42st47qd\"")
                 + HelpExampleRpc("listreceivedbyshieldaddress", "\"ps1ra969yfhvhp73rw5ak2xvtcm9fkuqsnmad7qln79mphhdrst3lwu9vvv03yuyqlh42p42st47qd\"")
@@ -2904,7 +2919,7 @@ UniValue gettransaction(const JSONRPCRequest& request)
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
         throw std::runtime_error(
             "gettransaction \"txid\" ( includeWatchonly )\n"
-            "\nGet detailed information about in-wallet transaction <txid>\n"
+            "\nGet detailed information about in-wallet transaction \"txid\"\n"
 
             "\nArguments:\n"
             "1. \"txid\"    (string, required) The transaction id\n"
@@ -2980,7 +2995,7 @@ UniValue abandontransaction(const JSONRPCRequest& request)
     if (request.fHelp || request.params.size() != 1)
         throw std::runtime_error(
             "abandontransaction \"txid\"\n"
-            "\nMark in-wallet transaction <txid> as abandoned\n"
+            "\nMark in-wallet transaction \"txid\" as abandoned\n"
             "This will mark this transaction and all its in-wallet descendants as abandoned which will allow\n"
             "for their inputs to be respent.  It can be used to replace \"stuck\" or evicted transactions.\n"
             "It only works on transactions which are not included in a block and are not currently in the mempool.\n"
@@ -4050,12 +4065,13 @@ UniValue getsaplingnotescount(const JSONRPCRequest& request)
         throw std::runtime_error(
                 "getsaplingnotescount ( minconf )\n"
                 "Returns the number of sapling notes available in the wallet.\n"
+
                 "\nArguments:\n"
                 "1. minconf      (numeric, optional, default=1) Only include notes in transactions confirmed at least this many times.\n"
-                "\nResult:\n"
+
                 "\nResult:\n"
                 "num             (numeric) the number of sapling notes in the wallet\n"
-                "}\n"
+
                 "\nExamples:\n"
                 + HelpExampleCli("getsaplingnotescount", "0")
                 + HelpExampleRpc("getsaplingnotescount", "0")
@@ -4063,7 +4079,7 @@ UniValue getsaplingnotescount(const JSONRPCRequest& request)
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
-    int nMinDepth = request.params.size() > 0 ? request.params[0].get_int() : 1;
+    int nMinDepth = !request.params.empty() ? request.params[0].get_int() : 1;
     int count = 0;
     for (const auto& wtx : pwalletMain->mapWallet) {
         if (wtx.second.GetDepthInMainChain() >= nMinDepth) {

--- a/test/functional/sapling_malleable_sigs.py
+++ b/test/functional/sapling_malleable_sigs.py
@@ -36,13 +36,13 @@ class MalleableSigsTest(PivxTestFramework):
 
         # Create rawtx shielding 10 PIV
         self.log.info("Shielding 10 PIV...")
-        rawtx = node.rawshieldsendmany("from_transparent", shield_to)["hex"]
+        rawtx_hex = node.rawshieldsendmany("from_transparent", shield_to)
         self.log.info("Raw tx created")
 
         # Creating malleated tx
         self.log.info("Removing sapling data...")
         new_tx = CTransaction()
-        new_tx.deserialize(BytesIO(hex_str_to_bytes(rawtx)))
+        new_tx.deserialize(BytesIO(hex_str_to_bytes(rawtx_hex)))
         new_tx.sapData = b""
         new_rawtx = bytes_to_hex_str(new_tx.serialize())
         self.log.info("Sending malleated tx...")

--- a/test/functional/sapling_wallet.py
+++ b/test/functional/sapling_wallet.py
@@ -75,11 +75,11 @@ class WalletSaplingTest(PivxTestFramework):
         # Trying to send a rawtx with low fee directly
         self.log.info("Good. It was not possible. Now try with a raw tx...")
         self.restart_node(0, extra_args=self.extra_args[0]+['-minrelaytxfee=0.0000001'])
-        rawtx = self.nodes[0].rawshieldsendmany("from_transparent", recipients, 1)["hex"]
+        rawtx_hex = self.nodes[0].rawshieldsendmany("from_transparent", recipients, 1)
         self.restart_node(0, extra_args=self.extra_args[0])
         connect_nodes(self.nodes[0], 1)
         assert_raises_rpc_error(-26, "insufficient fee",
-                                self.nodes[0].sendrawtransaction, rawtx)
+                                self.nodes[0].sendrawtransaction, rawtx_hex)
         self.log.info("Good. Not accepted in the mempool.")
 
         # Fixed fee
@@ -103,14 +103,14 @@ class WalletSaplingTest(PivxTestFramework):
 
         # shield more funds creating and then sending a raw transaction
         self.log.info("TX 3: shield funds creating and sending raw transaction.")
-        tx_json = self.nodes[0].rawshieldsendmany("from_transparent", recipients, 1, fee)
+        tx_hex = self.nodes[0].rawshieldsendmany("from_transparent", recipients, 1, fee)
 
         # Check SPORK_20 for sapling maintenance mode
         SPORK_20 = "SPORK_20_SAPLING_MAINTENANCE"
         self.activate_spork(0, SPORK_20)
         self.wait_for_spork(True, SPORK_20)
         assert_raises_rpc_error(-26, "bad-tx-sapling-maintenance",
-                                self.nodes[0].sendrawtransaction, tx_json["hex"])
+                                self.nodes[0].sendrawtransaction, tx_hex)
         self.log.info("Good. Not accepted when SPORK_20 is active.")
 
         # Try with RPC...
@@ -121,7 +121,7 @@ class WalletSaplingTest(PivxTestFramework):
         sleep(5)
         self.deactivate_spork(0, SPORK_20)
         self.wait_for_spork(False, SPORK_20)
-        mytxid3 = self.nodes[0].sendrawtransaction(tx_json["hex"])
+        mytxid3 = self.nodes[0].sendrawtransaction(tx_hex)
         self.log.info("Good. Accepted when SPORK_20 is not active.")
 
         # Verify priority of tx is INF_PRIORITY, defined as 1E+25 (10000000000000000000000000)
@@ -181,8 +181,8 @@ class WalletSaplingTest(PivxTestFramework):
 
         # Send more shield funds (with create + send raw transaction)
         self.log.info("TX 6: shield raw transaction.")
-        tx_json = self.nodes[0].rawshieldsendmany("from_shield", recipients5, 1, fee)
-        mytxid6 = self.nodes[0].sendrawtransaction(tx_json["hex"])
+        tx_hex = self.nodes[0].rawshieldsendmany("from_shield", recipients5, 1, fee)
+        mytxid6 = self.nodes[0].sendrawtransaction(tx_hex)
         self.check_tx_priority([mytxid6])
 
         self.nodes[2].generate(1)


### PR DESCRIPTION
Improve code readability, ensure that we're including the wallet unlock notice where appropriate, remove some redundant help output lines, and finally, make the return output of `rawshieldsendmany` be just the transaction's hex string rather than the full JSON object (functional tests are updated to reflect this change).