### PR TITLE
[Trivial][GUI] coin control: Fixed column size in list-mode

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -801,7 +801,7 @@ void CoinControlDialog::updateView()
         // save COLUMN_CHECKBOX width for tree-mode
         colCheckBoxWidth_treeMode = std::max(110, ui->treeWidget->columnWidth(COLUMN_CHECKBOX));
         // minimize COLUMN_CHECKBOX width in list-mode (need to display only the check box)
-        ui->treeWidget->resizeColumnToContents(COLUMN_CHECKBOX);
+        ui->treeWidget->setColumnWidth(COLUMN_CHECKBOX, 70);
     }
 
     // sort view


### PR DESCRIPTION
Resizing column checkbox to contents in coin-control (introduced in #2070) seems to be cutting off part of the lock icon, for locked utxos, on windows, as reported by @NoobieDev12 .

Let's set a default width of 70 then.
Here's how it looks on linux/gnome

![Screenshot from 2020-12-22 11-32-09](https://user-images.githubusercontent.com/18186894/102879620-52a8e080-444a-11eb-8bf6-08c4833da1b7.png)

