### PR TITLE
[GUI] Support for op_return proposal output records.

### DIFF
--- a/src/qt/pivx/qtutils.cpp
+++ b/src/qt/pivx/qtutils.cpp
@@ -164,7 +164,8 @@ void setSortTxTypeFilter(QComboBox* filter, SortEdit* lineEditType)
     filter->addItem(QObject::tr("Sent"),
                     TransactionFilterProxy::TYPE(TransactionRecord::SendToAddress) |
                     TransactionFilterProxy::TYPE(TransactionRecord::SendToOther) |
-                    TransactionFilterProxy::TYPE(TransactionRecord::SendToShielded));
+                    TransactionFilterProxy::TYPE(TransactionRecord::SendToShielded) |
+                    TransactionFilterProxy::TYPE(TransactionRecord::SendToNobody));
     filter->addItem(QObject::tr("Shield"),
                     TransactionFilterProxy::TYPE(TransactionRecord::RecvWithShieldedAddress) |
                     TransactionFilterProxy::TYPE(TransactionRecord::SendToShielded) |

--- a/src/qt/pivx/txrow.cpp
+++ b/src/qt/pivx/txrow.cpp
@@ -94,6 +94,7 @@ void TxRow::setType(bool isLightTheme, int type, bool isConfirmed)
         case TransactionRecord::ZerocoinSpend_Change_zPiv:
         case TransactionRecord::ZerocoinSpend_FromMe:
         case TransactionRecord::SendToShielded:
+        case TransactionRecord::SendToNobody:
             path = "://ic-transaction-sent";
             css = "text-list-amount-send";
             break;

--- a/src/qt/pivx/txviewholder.cpp
+++ b/src/qt/pivx/txviewholder.cpp
@@ -35,11 +35,21 @@ void TxViewHolder::init(QWidget* holder, const QModelIndex &index, bool isHovere
             type !=  TransactionRecord::ZerocoinSpend_Change_zPiv &&
             type !=  TransactionRecord::StakeZPIV &&
             type != TransactionRecord::Other) {
+
         QString address = rIndex.data(Qt::DisplayRole).toString();
-        if (address.length() > 20) {
-            address = address.left(ADDRESS_SIZE) + "..." + address.right(ADDRESS_SIZE);
+        if (!address.isEmpty()) {
+            if (type == TransactionRecord::SendToNobody) {
+                // OP_RETURN record with a valid utf-8 string to show
+                label.clear();
+                label += address;
+            } else {
+                // Regular addresses
+                if (address.length() > 20) {
+                    address = address.left(ADDRESS_SIZE) + "..." + address.right(ADDRESS_SIZE);
+                }
+                label += " " + address;
+            }
         }
-        label += " " + address;
     } else if (type == TransactionRecord::Other) {
         label += rIndex.data(Qt::DisplayRole).toString();
     }

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -329,6 +329,15 @@ bool TransactionRecord::decomposeDebitTransaction(const CWallet* wallet, const C
             // Sent to IP, or other non-address transaction like OP_EVAL
             sub.type = TransactionRecord::SendToOther;
             sub.address = getValueOrReturnEmpty(wtx.mapValue, "to");
+            if (sub.address.empty() && txout.scriptPubKey.StartsWithOpcode(OP_RETURN)) {
+                sub.type = TransactionRecord::SendToNobody;
+                // Burned PIVs, op_return could be for a proposal/budget fee or another sort of data stored there.
+                std::string comment = wtx.GetComment();
+                if (IsValidUTF8(comment)) {
+                    sub.address = comment;
+                }
+                // future: could expand this to support base64 or hex encoded messages
+            }
         }
 
         CAmount nValue = txout.nValue;

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -97,7 +97,8 @@ public:
         RecvWithShieldedAddress, // Shielded receive
         SendToSelfShieldedAddress, // Shielded send to self
         SendToSelfShieldToTransparent, // Unshield coins to self
-        SendToSelfShieldToShieldChangeAddress // Changing coins from one shielded address to another inside the wallet.
+        SendToSelfShieldToShieldChangeAddress, // Changing coins from one shielded address to another inside the wallet.
+        SendToNobody // Burned PIVs, op_return output.
     };
 
     /** Number of confirmation recommended for accepting a transaction */

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -503,6 +503,8 @@ QString TransactionTableModel::formatTxType(const TransactionRecord* wtx) const
         return tr("Received with shielded");
     case TransactionRecord::SendToShielded:
         return tr("Shielded send to");
+    case TransactionRecord::SendToNobody:
+        return tr("Burned PIVs");
     default:
         return QString();
     }
@@ -555,6 +557,8 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord* wtx, b
         return QString::fromStdString(wtx->address);
     case TransactionRecord::SendToOther:
         return QString::fromStdString(wtx->address) + watchAddress;
+    case TransactionRecord::SendToNobody:
+        return QString::fromStdString(wtx->address); // the address here is storing the op_return data.
     case TransactionRecord::ZerocoinMint:
     case TransactionRecord::ZerocoinSpend_Change_zPiv:
     case TransactionRecord::StakeZPIV:

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -151,6 +151,10 @@ UniValue preparebudget(const JSONRPCRequest& request)
     if (res.status != CWallet::CommitStatus::OK)
         throw JSONRPCError(RPC_WALLET_ERROR, res.ToString());
 
+    // Store proposal name as a comment
+    assert(pwalletMain->mapWallet.count(wtx.GetHash()));
+    pwalletMain->mapWallet[wtx.GetHash()].SetComment("Proposal: " + strProposalName);
+
     return wtx.GetHash().ToString();
 }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -74,8 +74,6 @@ static const int DEFAULT_CUSTOMBACKUPTHRESHOLD = 1;
 static const CAmount DEFAULT_MIN_STAKE_SPLIT_THRESHOLD = 100 * COIN;
 //! Default for -spendzeroconfchange
 static const bool DEFAULT_SPEND_ZEROCONF_CHANGE = true;
-//! Default for -sendfreetransactions
-static const bool DEFAULT_SEND_FREE_TRANSACTIONS = false;
 //! Default for -staking
 static const bool DEFAULT_STAKING = true;
 //! Default for -coldstaking
@@ -1014,6 +1012,13 @@ public:
 
     //! checks whether a tx has P2CS inputs or not
     bool HasP2CSInputs() const;
+
+    //! Store a comment
+    void SetComment(const std::string& comment) { mapValue["comment"] = comment; }
+    std::string GetComment() const {
+        const auto& it = mapValue.find("comment");
+        return it != mapValue.end() ? it->second : "";
+    }
 
     int GetDepthAndMempool(bool& fConflicted) const;
 


### PR DESCRIPTION
As the GUI is showing OP_RETURN output records as "no information", proposals fee outputs aren't being presented properly.

Proposal fee outputs only store the proposal hash in the op_return data and can't be distinguished only with the network data (proposals data is ephemeral), this PR aims to tackle it storing the proposal name inside the "comments" field of the wallet transaction.