### PR TITLE
[BUG][GUI] Cache unconfirmed_balance only for transparent outs

### DIFF
--- a/src/interface/wallet.cpp
+++ b/src/interface/wallet.cpp
@@ -11,7 +11,7 @@ namespace interfaces {
     WalletBalances Wallet::getBalances() {
         WalletBalances result;
         result.balance = m_wallet.GetAvailableBalance();
-        result.unconfirmed_balance = m_wallet.GetUnconfirmedBalance();
+        result.unconfirmed_balance = m_wallet.GetUnconfirmedBalance(ISMINE_SPENDABLE_TRANSPARENT);
         result.immature_balance = m_wallet.GetImmatureBalance();
         result.have_watch_only = m_wallet.HaveWatchOnly();
         if (result.have_watch_only) {


### PR DESCRIPTION
Another great find by @NoobieDev12 .
Shielded balance is counted twice in the GUI when "pending".
Since we have a separate cached amount (`unconfirmed_shielded_balance`) in the `WalletBalances` struct, we should save in `unconfirmed_balance` only the sum of *transparent* unconfirmed outputs.