### PR TITLE
[Startup] Do not block local peer port selection for Masternodes running over tor.

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -53,6 +53,13 @@ OperationResult initMasternode(const std::string& _strMasterNodePrivKey, const s
         return errorOut(strprintf(_("Invalid -masternodeaddr address: %s"), strMasterNodeAddr));
     }
 
+    // Peer port needs to match the masternode public one for IPv4 and IPv6.
+    // Onion can run in other ports because those are behind a hidden service which has the public port fixed to the default port.
+    if (nPort != GetListenPort() && !addrTest.IsTor() && !params.IsRegTestNet()) {
+        return errorOut(strprintf(_("Invalid -masternodeaddr port %d, isn't the same as the peer port %d"),
+                                  nPort, GetListenPort()));
+    }
+
     CKey key;
     CPubKey pubkey;
     if (!CMessageSigner::GetKeysFromSecret(_strMasterNodePrivKey, key, pubkey)) {

--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -55,7 +55,7 @@ OperationResult initMasternode(const std::string& _strMasterNodePrivKey, const s
 
     // Peer port needs to match the masternode public one for IPv4 and IPv6.
     // Onion can run in other ports because those are behind a hidden service which has the public port fixed to the default port.
-    if (nPort != GetListenPort() && !addrTest.IsTor() && !params.IsRegTestNet()) {
+    if (nPort != GetListenPort() && !addrTest.IsTor()) {
         return errorOut(strprintf(_("Invalid -masternodeaddr port %d, isn't the same as the peer port %d"),
                                   nPort, GetListenPort()));
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1035,11 +1035,6 @@ bool AppInit2()
     // Exit early if -masternode=1 and -listen=0
     if (gArgs.GetBoolArg("-masternode", DEFAULT_MASTERNODE) && !gArgs.GetBoolArg("-listen", DEFAULT_LISTEN))
         return UIError(_("Error: -listen must be true if -masternode is set."));
-    // Exit early if -masternode=1 and -port is not the default port
-    if (gArgs.GetBoolArg("-masternode", DEFAULT_MASTERNODE) && (GetListenPort() != Params().GetDefaultPort() && !Params().IsRegTestNet()))
-        return UIError(strprintf(_("Error: Invalid port %d for running a masternode."), GetListenPort()) + "\n\n" +
-                       strprintf(_("Masternodes are required to run on port %d for %s-net"), Params().GetDefaultPort(), Params().NetworkIDString()));
-
     if (gArgs.GetBoolArg("-benchmark", false))
         UIWarning(_("Warning: Unsupported argument -benchmark ignored, use -debug=bench."));
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1208,8 +1208,8 @@ class PivxTier2TestFramework(PivxTestFramework):
         self.stake(1)
         time.sleep(3)
         self.advance_mocktime(10)
-        remoteOnePort = p2p_port(self.remoteTwoPos)
-        remoteTwoPort = p2p_port(self.remoteOnePos)
+        remoteOnePort = p2p_port(self.remoteOnePos)
+        remoteTwoPort = p2p_port(self.remoteTwoPos)
         self.remoteOne.initmasternode(self.mnOnePrivkey, "127.0.0.1:"+str(remoteOnePort))
         self.remoteTwo.initmasternode(self.mnTwoPrivkey, "127.0.0.1:"+str(remoteTwoPort))
 


### PR DESCRIPTION
Do not return an error if a different peer port is used for Masternodes running over tor.
 The peer is behind a hidden service which has the public port fixed to the default port already. The local port can be used freely, the network cannot prevent it.