### PR TITLE
[BUG][GUI] Don't return StakingOnlyUnlocked from WalletModel::sendCoins

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -463,12 +463,6 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
 
 WalletModel::SendCoinsReturn WalletModel::sendCoins(WalletModelTransaction& transaction)
 {
-    QByteArray transaction_array; /* store serialized transaction */
-
-    if (isStakingOnlyUnlocked()) {
-        return StakingOnlyUnlocked;
-    }
-
     bool fColdStakingActive = isColdStakingNetworkelyEnabled();
     bool fSaplingActive = Params().GetConsensus().NetworkUpgradeActive(cachedNumBlocks, Consensus::UPGRADE_V5_0);
 
@@ -478,6 +472,8 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(WalletModelTransaction& tran
     if (!CheckTransaction(*newTx, true, true, state, true, fColdStakingActive, fSaplingActive)) {
         return TransactionCheckFailed;
     }
+
+    QByteArray transaction_array; /* store serialized transaction */
 
     {
         LOCK2(cs_main, wallet->cs_wallet);


### PR DESCRIPTION
Bug found in current master.
Steps to reproduce
1) Unlock the wallet `for staking only`.
2) Try to send a transaction
3) The wallet asks to insert the password (to fully unlock).
4) Insert the password, and then accept the confirmation dialog.

**Issue**:
Instead of sending the tx, the wallet asks again for the password, and still doesn't send the transaction (without any feedback) even when the password is entered a second time.

**Cause**:
By the time the flow reaches `WalletModel::sendCoins`, the UnlockContext is lost, and the wallet has been relocked (for staking only) already.
This is correct, as the transaction is created and signed in `WalletModel::prepareTransaction`, and `sendCoins` only commits the transaction, therefore it doesn't need a fully-unlocked wallet.

The function, though, currently returns early with return value `SendCoinsReturn::StakingOnlyUnlocked`, if the wallet is unlocked for-staking-only, and the transaction isn't sent.

**Fix**:
Simply remove the un-needed check in sendCoins.