### PR TITLE
[Build] Don't compile PoW mining RPC commands by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -129,6 +129,12 @@ AC_ARG_ENABLE([wallet],
   [enable_wallet=$enableval],
   [enable_wallet=yes])
 
+AC_ARG_ENABLE([mining-rpc],
+  [AS_HELP_STRING([--enable-mining-rpc],
+  [enable PoW mining RPC commands (disabled by default)])],
+  [enable_mining_rpc=$enableval],
+  [enable_mining_rpc=no])
+
 AC_ARG_WITH([miniupnpc],
   [AS_HELP_STRING([--with-miniupnpc],
   [enable UPNP (default is yes if libminiupnpc is found)])],
@@ -1292,6 +1298,16 @@ else
   AC_MSG_RESULT(no)
 fi
 
+dnl enable mining RPC
+AC_MSG_CHECKING([if mining RPC commands should be enabled])
+if test x$enable_mining_rpc != xno; then
+  AC_MSG_RESULT(yes)
+  AC_DEFINE_UNQUOTED([ENABLE_MINING_RPC],[1],[Define to 1 to enable mining rpc commands])
+
+else
+  AC_MSG_RESULT(no)
+fi
+
 dnl enable upnp support
 AC_MSG_CHECKING([whether to build with support for UPnP])
 if test x$have_miniupnpc = xno; then
@@ -1402,6 +1418,7 @@ AM_CONDITIONAL([TARGET_DARWIN], [test x$TARGET_OS = xdarwin])
 AM_CONDITIONAL([BUILD_DARWIN], [test x$BUILD_OS = xdarwin])
 AM_CONDITIONAL([TARGET_WINDOWS], [test x$TARGET_OS = xwindows])
 AM_CONDITIONAL([ENABLE_WALLET],[test x$enable_wallet = xyes])
+AM_CONDITIONAL([ENABLE_MINING_RPC],[test x$enable_mining_rpc = xyes])
 AM_CONDITIONAL([ENABLE_TESTS],[test x$BUILD_TEST = xyes])
 AM_CONDITIONAL([ENABLE_QT],[test x$bitcoin_enable_qt = xyes])
 AM_CONDITIONAL([ENABLE_QT_TESTS],[test x$BUILD_TEST_QT = xyes])
@@ -1548,6 +1565,7 @@ esac
 echo
 echo "Options used to compile and link:"
 echo "  with wallet   = $enable_wallet"
+echo "  with mining rpc = $enable_mining_rpc"
 echo "  with gui / qt = $bitcoin_enable_qt"
 if test x$bitcoin_enable_qt != xno; then
     echo "    with qtcharts     = $use_qtcharts"

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -45,6 +45,10 @@ Notable Changes
 (Developers: add your notes here as part of your pull requests whenever possible)
 
 
+#### Disable PoW mining RPC Commands
+
+A new configure flag has been introduced to allow more granular control over weather or not the PoW mining RPC commands are compiled into the wallet. By default they are not. This behavior can be overridden by passing `--enable-mining-rpc` to the `configure` script.
+
 
 *version* Change log
 ==============


### PR DESCRIPTION
This adds a configure flag to skip compiling the PoW-related mining RPC
commands, which aren't ever used outside of the initial PoW phase.

The `generate` command is retained for regtest compatibility.