### PR TITLE
[Wallet] clear StakeableCoins before initializing

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2414,6 +2414,8 @@ bool CWallet::StakeableCoins(std::vector<CStakeableOutput>* pCoins)
     const bool fIncludeColdStaking = !sporkManager.IsSporkActive(SPORK_19_COLDSTAKING_MAINTENANCE) &&
                                      gArgs.GetBoolArg("-coldstaking", DEFAULT_COLDSTAKING);
 
+    if (pCoins) pCoins->clear();
+
     LOCK2(cs_main, cs_wallet);
     for (const auto& it : mapWallet) {
         const uint256& wtxid = it.first;


### PR DESCRIPTION
### Problem ###
The list of StakeableCoins is growing with every incomming block.

### Root Cause ###
In f935801f73839a668a94bdd39b73d2499df4582f a slightly different StakeableCoins initialization was introduced, but the list of StakeableCoins is not cleared before initializing, which causes the list of StakeableCoins to grow with every incomming block.

### Solution ###
Clear StakeableCoins before initializing.

### Testing Results ###

#### Before ####
```UpdateTip: new best=0770a4dcbd516819056934cc472689bbdd89d97f785cc659bee6ae5591b55687  height=5449 version=8  log2_work=58.3823621202891658  tx=10854  date=2020-12-21 09:41:00 progress=0.999994  cache=0.1MiB(581txo)
ProcessNewBlock : ACCEPTED Block 5449 in 7 milliseconds with size=511
CreateCoinStake: attempted staking 1 times
SolveProofOfStake : stake not found
CreateCoinStake: attempted staking 1 times
SolveProofOfStake : stake not found
CreateCoinStake: attempted staking 1 times
SolveProofOfStake : stake not found
CheckKernelHash : Proof Of Stake:
ssUniqueID=2c0000001f9fcce856206f2f0122157e3e4ac332da3f7298df8d5fd2da016926e729f44d
nTimeTx=1608543705
hashProofOfStake=00013687d13ebb6afee40cf44033c2f41baa394af495760097168c08d55ccb72
nBits=453257636
weight=131082385330
bnTarget=0001453bc53097d4000000000000000000000000000000000000000000000000 (res: 1)

UpdateTip: new best=2cb1450de56ab75b85d7d0c724d9c0b5fa613809a698513ce8b60d331a5b6cf4  height=5450 version=8  log2_work=58.3826217546884578  tx=10856  date=2020-12-21 09:41:45 progress=1.000000  cache=0.1MiB(587txo)
ProcessNewBlock : ACCEPTED Block 5450 in 7 milliseconds with size=517
CreateCoinStake: attempted staking 2 times
SolveProofOfStake : stake not found
CreateCoinStake: attempted staking 2 times
SolveProofOfStake : stake not found
CheckKernelHash : Proof Of Stake:
ssUniqueID=010000007e7b76750da0f9acaabb6667f285198e96db26dfb5350489ca0886893472a360
nTimeTx=1608543720
hashProofOfStake=000e7625a66fdbdefedfd388d0f9acddb3001c1d905283d0f033cc4ca682e759
nBits=453253235
weight=2022043729136
bnTarget=0013480887a59451000000000000000000000000000000000000000000000000 (res: 1)

UpdateTip: new best=f5eeb1f3d441eef0cba922eaacf406243f5e7292770331bf063757da31bab729  height=5451 version=8  log2_work=58.3828855984372836  tx=10858  date=2020-12-21 09:42:00 progress=0.999994  cache=0.1MiB(592txo)
ProcessNewBlock : ACCEPTED Block 5451 in 6 milliseconds with size=512
CreateCoinStake: attempted staking 3 times
SolveProofOfStake : stake not found
CreateCoinStake: attempted staking 3 times
SolveProofOfStake : stake not found
```
#### After ####
```UpdateTip: new best=62baad86717d51fa8b307a1847e666a24801875f7064fadb8903a5b88a08c67e  height=5479 version=8  log2_work=58.3892664084646000  tx=10914  date=2020-12-21 10:15:30 progress=0.999997  cache=0.0MiB(53txo)
ProcessNewBlock : ACCEPTED Block 5479 in 26 milliseconds with size=512
CreateCoinStake: attempted staking 1 times
SolveProofOfStake : stake not found
CreateCoinStake: attempted staking 1 times
SolveProofOfStake : stake not found
CreateCoinStake: attempted staking 1 times
SolveProofOfStake : stake not found
CheckKernelHash : Proof Of Stake:
ssUniqueID=01000000f18270e29f76bde829f583b159d9e2db02dac17ac9997102e9fbae5defff1c09
nTimeTx=1608545760
hashProofOfStake=00087184a7ddac39c0cb67cc0cddb88a6fcebcb030764833d26e8422143b5cc8
nBits=453334996
weight=2001607996934
bnTarget=0018e6912c241754000000000000000000000000000000000000000000000000 (res: 1)

UpdateTip: new best=be02fd25c84bcaa92596ae531c6292d922c6e4cf19fc6609e1a48290dd48758b  height=5480 version=8  log2_work=58.3894677214790718  tx=10916  date=2020-12-21 10:16:00 progress=0.999994  cache=0.0MiB(58txo)
ProcessNewBlock : ACCEPTED Block 5480 in 29 milliseconds with size=512
CreateCoinStake: attempted staking 1 times
SolveProofOfStake : stake not found
CreateCoinStake: attempted staking 1 times
SolveProofOfStake : stake not found
CreateCoinStake: attempted staking 1 times
SolveProofOfStake : stake not found
CheckKernelHash : Proof Of Stake:
ssUniqueID=12000000a696dcf10b582d62fcdff791797287bf34db3f91fc067fa920c5ae28a59cce47
nTimeTx=1608545805
hashProofOfStake=000050aad911bd0634c1cb2deb2ec35a719ae0e275e7ffdb8d39ca5d9e706978
nBits=453323700
weight=131082385330
bnTarget=000193fe80224ca4000000000000000000000000000000000000000000000000 (res: 1)

UpdateTip: new best=d954a74c595d8470f8730b167c514c72b2bd8d7f0c394699c78195e973caeff7  height=5481 version=8  log2_work=58.3896757156578516  tx=10918  date=2020-12-21 10:16:45 progress=1.000000  cache=0.0MiB(64txo)
ProcessNewBlock : ACCEPTED Block 5481 in 25 milliseconds with size=516
CreateCoinStake: attempted staking 1 times
SolveProofOfStake : stake not found
CreateCoinStake: attempted staking 1 times
SolveProofOfStake : stake not found
```