### PR TITLE
[GUI] Fixing tooltip balance amount cropped 

### DIFF
--- a/src/qt/pivx/balancebubble.cpp
+++ b/src/qt/pivx/balancebubble.cpp
@@ -28,10 +28,16 @@ BalanceBubble::BalanceBubble(QWidget *parent) :
     for (QWidget* w : lblTitles) { w->setFont(font); }
 }
 
-void BalanceBubble::updateValues(int64_t nTransparentBalance, int64_t nShieldedBalance, int unit){
+void BalanceBubble::updateValues(int64_t nTransparentBalance, int64_t nShieldedBalance, int unit)
+{
+    QString valueTrans = BitcoinUnits::formatWithUnit(unit, nTransparentBalance, false, BitcoinUnits::separatorAlways);
+    valueTrans = valueTrans.replace(QChar(THIN_SP_CP), QString(","));
+    QString valueShield = BitcoinUnits::formatWithUnit(unit, nShieldedBalance, false, BitcoinUnits::separatorAlways);
+    valueShield = valueShield.replace(QChar(THIN_SP_CP), QString(","));
 
-    ui->textTransparent->setText(BitcoinUnits::formatWithUnit(unit, nTransparentBalance, false, BitcoinUnits::separatorAlways));
-    ui->textShielded->setText(BitcoinUnits::formatWithUnit(unit, nShieldedBalance, false, BitcoinUnits::separatorAlways));
+    ui->textTransparent->setText(valueTrans);
+    ui->textShielded->setText(valueShield);
+    adjustSize();
 }
 
 void BalanceBubble::showEvent(QShowEvent *event)

--- a/src/qt/pivx/forms/balancebubble.ui
+++ b/src/qt/pivx/forms/balancebubble.ui
@@ -10,9 +10,15 @@
     <height>178</height>
    </rect>
   </property>
-  <property name="maximumSize">
+  <property name="minimumSize">
    <size>
     <width>218</width>
+    <height>178</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>250</width>
     <height>178</height>
    </size>
   </property>
@@ -38,7 +44,7 @@ background-color:transparent
      </property>
      <property name="maximumSize">
       <size>
-       <width>200</width>
+       <width>250</width>
        <height>160</height>
       </size>
      </property>
@@ -78,8 +84,7 @@ background-color:transparent
       <item>
        <widget class="QLabel" name="textTransparent">
         <property name="styleSheet">
-         <string notr="true">
-                                      </string>
+         <string notr="true"/>
         </property>
         <property name="text">
          <string>0.00 pivx</string>

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -20,8 +20,6 @@
 
 #include <db_cxx.h>
 
-extern unsigned int nWalletDBUpdated;
-
 static const unsigned int DEFAULT_WALLET_DBLOGSIZE = 100;
 static const bool DEFAULT_WALLET_PRIVDB = true;
 


### PR DESCRIPTION
Fixing a small visual bug in the tooltip balance dialog (imperceptible in mainnet but still a bug). When the value surpass the 1kk range, the text gets cropped.