### PR TITLE
[Test] Print error if shield diversified address is equal to the default address

### DIFF
--- a/src/test/librust/wallet_zkeys_tests.cpp
+++ b/src/test/librust/wallet_zkeys_tests.cpp
@@ -84,7 +84,9 @@ BOOST_AUTO_TEST_CASE(StoreAndLoadSaplingZkeys) {
     auto dpa = sk.ToXFVK().Address(diversifier).get().second;
 
     // verify wallet only has the default address
-    BOOST_CHECK(wallet.HaveSaplingIncomingViewingKey(sk.DefaultAddress()));
+    libzcash::SaplingPaymentAddress defaultAddr = sk.DefaultAddress();
+    BOOST_CHECK(wallet.HaveSaplingIncomingViewingKey(defaultAddr));
+    BOOST_CHECK_MESSAGE(!(dpa == defaultAddr), "ERROR: default address is equal to diversified address");
     BOOST_CHECK(!wallet.HaveSaplingIncomingViewingKey(dpa));
 
     // manually add a diversified address


### PR DESCRIPTION
Trying to determine the inconsistent failing, linux-only, unit test case.

The hypothesis is that the diversified address is equal to the the default address (empty diversified).
As I haven't been able to replicate it locally, this PR is printing the error if happens in GA. The error is the following:

```
 Test cases order is shuffled using seed: 1449329889
2325
  Entering test module "Pivx Test Suite"
2326
  test/librust/wallet_zkeys_tests.cpp(23): Entering test suite "wallet_zkeys_tests"
2327
  test/librust/wallet_zkeys_tests.cpp(122): Entering test case "WriteCryptedSaplingZkeyDirectToDb"
2328
  test/librust/wallet_zkeys_tests.cpp(122): Leaving test case "WriteCryptedSaplingZkeyDirectToDb"; testing time: 1675295us
2329
  test/librust/wallet_zkeys_tests.cpp(32): Entering test case "StoreAndLoadSaplingZkeys"
2330
  test/librust/wallet_zkeys_tests.cpp(88): error: in "wallet_zkeys_tests/StoreAndLoadSaplingZkeys": check !wallet.HaveSaplingIncomingViewingKey(dpa) has failed
2331
  test/librust/wallet_zkeys_tests.cpp(32): Leaving test case "StoreAndLoadSaplingZkeys"; testing time: 360812us
2332
  test/librust/wallet_zkeys_tests.cpp(23): Leaving test suite "wallet_zkeys_tests"; testing time: 2036175us
2333
  Leaving test module "Pivx Test Suite"; testing time: 2036270us

```

--------------

Aside from that, have to mention that this isn't something that will affect/delay mainnet release in any way. 
We are not using diversified addresses at all in the wallet and even if we add this feature in the future, the address is already on the wallet, so it's simply matter of verify if it's in the wallet and move to the next diversified in the path if we already have the address loaded.