### PR TITLE
[BUG][Wallet] Restore AddressBook when marking used keys in the keypool

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -60,8 +60,8 @@ BASE_SCRIPTS= [
     'wallet_backup.py',                         # ~ 477 sec
 
     # vv Tests less than 5m vv
+    'wallet_hd.py',                             # ~ 300 sec
     'wallet_zapwallettxes.py',                  # ~ 300 sec
-    'wallet_hd.py',                             # ~ 280 sec
     'p2p_time_offset.py',                       # ~ 267 sec
     'rpc_fundrawtransaction.py',                # ~ 260 sec
     'mining_pos_coldStaking.py',                # ~ 215 sec

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -56,6 +56,12 @@ class WalletHDTest(PivxTestFramework):
         connect_nodes(self.nodes[1], 0)
         self.sync_all()
 
+    def check_addressbook(self, old_book, new_book):
+        assert_equal(len(old_book), len(new_book))
+        for add in new_book:
+            assert add in old_book
+            assert_equal(old_book[add], new_book[add])
+
     def run_test(self):
         # Make sure we use hd
         if '-legacywallet' in self.nodes[0].extra_args:
@@ -108,7 +114,18 @@ class WalletHDTest(PivxTestFramework):
         self.sync_all()
         assert_equal(self.nodes[1].getbalance(), NUM_HD_ADDS + NUM_SHIELD_ADDS + 1)
 
-        self.log.info("Restore backup ...")
+        # verify address-book recovery
+        self.log.info("Restore backup (with chain)...")
+        addrbook_old = self.nodes[1].getaddressesbylabel("")
+        self.stop_node(1)
+        shutil.copyfile(os.path.join(self.nodes[1].datadir, "hd.bak"), os.path.join(self.nodes[1].datadir, "regtest", "wallet.dat"))
+        self.start_node(1)
+        connect_nodes(self.nodes[0], 1)
+        self.sync_all()
+        self.check_addressbook(addrbook_old, self.nodes[1].getaddressesbylabel(""))
+
+        # now delete the chain and recreate the addresses
+        self.log.info("Restore backup (without chain)...")
         self.stop_node(1)
         # we need to delete the complete regtest directory
         # otherwise node1 would auto-recover all funds in flag the keypool keys as used


### PR DESCRIPTION
**Problem**
If a HD wallet uses some keys, and is later restored to a previous state (initial backup), it correctly recognizes the used keys and relative transactions, and spending from the relative addresses works fine.
Although, these addresses are not shown in the receive widget of the GUI, so their label cannot be edited, and they cannot be easily selected/copied.

**Cause**
When adding a transaction in `AddToWalletIfInvolvingMe`, the wallet loops over the outputs and checks if it affects any key from the keypool (supposed to be "unused"), in which case, it removes the key from the pool (`ScriptPubKeyMan::MarkUnusedAddresses`).

After restoring the old backup, when initializing the receive widget (and address table model), with `getAddressToShow`, there is no unused address in the AddressBook, and a new one is created.
`getNewAddress` accesses the key pool and returns the first unused key.
Since the used keys have been removed, this is a brand new address. 
All addresses relative to the keys removed from the pool in `MarkUnusedAddresses`, therefore, never enter the AddressBook, and thus are never shown in the receive widget.

**Solution**
When removing the key from the pool (in `MarkReserveKeysAsUsed`), also add the missing address to the AddressBook, with receive/coldstaking purpose.

This way, when restoring an old backup, the user loses only the labels (that were added after the wallet.dat backup) but can still repopulate his AddressBook with all the previously used addresses.