### PR TITLE
[GUI][Trivial] Save cold-staking address in contacts

### DIFF
--- a/src/qt/pivx/addresseswidget.cpp
+++ b/src/qt/pivx/addresseswidget.cpp
@@ -189,7 +189,7 @@ void AddressesWidget::onStoreContactClicked()
         bool isStakingAddress = false;
         auto pivAdd = Standard::DecodeDestination(address.toUtf8().constData(), isStakingAddress);
 
-        if (!Standard::IsValidDestination(pivAdd) || isStakingAddress) {
+        if (!Standard::IsValidDestination(pivAdd)) {
             setCssEditLine(ui->lineEditAddress, false, true);
             inform(tr("Invalid Contact Address"));
             return;


### PR DESCRIPTION
Cold-staking contacts are only saved when sending a delegation (with label for staker address), but they cannot be added directly in the addresses widget.
Remove the check preventing this.