### PR TITLE
[BUG][GUI] Fix double conf dialog for RPC commands that expose privkeys

### DIFF
--- a/src/qt/pivx/settings/settingsconsolewidget.cpp
+++ b/src/qt/pivx/settings/settingsconsolewidget.cpp
@@ -13,6 +13,7 @@
 #include "chainparams.h"
 #include "rpc/client.h"
 #include "rpc/server.h"
+#include "sapling/key_io_sapling.h"
 #include "util.h"
 #include "utilitydialog.h"
 
@@ -460,6 +461,12 @@ static bool PotentiallyDangerousCommand(const QString& cmd)
         std::vector<std::string> args;
         parseCommandLineSettings(args, cmd.toStdString());
         return (args.size() == 2 && IsValidDestinationString(args[1], false));
+    }
+    if (cmd.size() >= 18 && cmd.leftRef(16) == "exportsaplingkey") {
+        // valid PIVX Shield Address
+        std::vector<std::string> args;
+        parseCommandLineSettings(args, cmd.toStdString());
+        return (args.size() == 2 && KeyIO::IsValidPaymentAddressString(args[1]));
     }
 
     return false;


### PR DESCRIPTION
Fix an issue with the double confirmation dialog introduced in #1928 

Currently the confirmation pop-up is shown only when the RPC command string is exactly "dumpwallet"/"dumpprivkey" (with no arguments).
Such command strings are not valid, as both RPC functions require one argument (the filename for "dumpwallet" and the PIVX address for "dumpprivkey").

So, when the user confirms the dialog, the RPC console returns an error (as the argument is missing), showing the RPC help.

When, instead, the user enters the correct RPC strings (`dumpwallet <filename>`/`dumpprivkey <pivxaddress>`), then **the warning dialog is NOT presented** and the command is executed immediately.

Fix it by doing a pre-validation for the potentially dangerous commands.
Bonus: include `exportsaplingkey` to the list.

Note: for `dumpprivkey`/`exportsaplingkey` this means a double parsing of the command string and decoding of the address argument (one during the pre-validation, and one during the actual execution of the RPC). But I think we can live with that for now.