### PR TITLE
[Test] Attempt to fix the diversified address equal to default address test scenario

### DIFF
--- a/src/test/librust/wallet_zkeys_tests.cpp
+++ b/src/test/librust/wallet_zkeys_tests.cpp
@@ -86,7 +86,12 @@ BOOST_AUTO_TEST_CASE(StoreAndLoadSaplingZkeys) {
     // verify wallet only has the default address
     libzcash::SaplingPaymentAddress defaultAddr = sk.DefaultAddress();
     BOOST_CHECK(wallet.HaveSaplingIncomingViewingKey(defaultAddr));
-    BOOST_CHECK_MESSAGE(!(dpa == defaultAddr), "ERROR: default address is equal to diversified address");
+
+    // Keep trying different diversifiers until we get a different address
+    while (dpa == defaultAddr && diversifier.begin()[0] < 255) {
+        diversifier.begin()[0] += 1;
+        dpa = sk.ToXFVK().Address(diversifier).get().second;
+    }
     BOOST_CHECK(!wallet.HaveSaplingIncomingViewingKey(dpa));
 
     // manually add a diversified address


### PR DESCRIPTION
Follow up investigation to #2116. Based on GA results, the diversified address is equal to the default address.
The code now will try to create a different address to the default one in a loop increasing the diversifier by one on each round.

This issue will need a deeper investigation in the future if/when we add diversified addresses features (at this moment, is pretty irrelevant as we aren't using diversified addresses at all). I have seen it only happening randomly on GA on linux and doesn't seems to be a library issue, if we provide the same seed to the process, the error isn't being thrown. It seems more to be an issue with the data pointer.