### PR TITLE
[Backport] Check interruptNet during dnsseed lookups

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1542,6 +1542,9 @@ void CConnman::ThreadDNSAddressSeed()
     LogPrintf("Loading addresses from DNS seeds (could take a while)\n");
 
     for (const CDNSSeedData& seed : vSeeds) {
+        if (interruptNet) {
+            return;
+        }
         if (HaveNameProxy()) {
             AddOneShot(seed.host);
         } else {
@@ -1556,6 +1559,9 @@ void CConnman::ThreadDNSAddressSeed()
                     vAdd.push_back(addr);
                     found++;
                 }
+            }
+            if (interruptNet) {
+                return;
             }
             // TODO: The seed name resolve may fail, yielding an IP of [::], which results in
             // addrman assigning the same source to results from different seeds.


### PR DESCRIPTION
Coming straight from #10215.
As the description says there, this could be a cause of long waits at shutdown.