### PR TITLE
[Backport][Net] Do not make it trivial for inbound peers to generate log entries

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1082,7 +1082,7 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
     }
 
     if (IsBanned(addr) && !whitelisted) {
-        LogPrintf("connection from %s dropped (banned)\n", addr.ToString());
+        LogPrint(BCLog::NET, "connection from %s dropped (banned)\n", addr.ToString());
         CloseSocket(hSocket);
         return;
     }

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -256,7 +256,7 @@ std::string CSporkManager::GetSporkNameByID(SporkId nSporkID)
 {
     auto it = sporkDefsById.find(nSporkID);
     if (it == sporkDefsById.end()) {
-        LogPrintf("%s : Unknown Spork ID %d\n", __func__, nSporkID);
+        LogPrint(BCLog::NET, "%s : Unknown Spork ID %d\n", __func__, nSporkID);
         return "Unknown";
     }
     return it->second->name;


### PR DESCRIPTION
Adapted from #11583, following the same rationale:

We have to be much more conservative when using LogPrintf/error or other things which unconditionally log to debug.log, It should not be the case that an inbound peer can fill up a users disk with debug.log entries (DoS).

This rule should be applied in many other areas of the sources as well (not only on the net area). But well, step by step.