### PR TITLE
Guarding and encapsulating properly CStakerStatus inside the wallet.

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -543,13 +543,14 @@ bool fStakeableCoins = false;
 
 void CheckForCoins(CWallet* pwallet, std::vector<CStakeableOutput>* availableCoins)
 {
-    if (!pwallet || !pwallet->pStakerStatus)
+    if (!pwallet || !pwallet->HasStakingStatus())
         return;
 
     // control the amount of times the client will check for mintable coins (every block)
     {
         WAIT_LOCK(g_best_block_mutex, lock);
-        if (g_best_block == pwallet->pStakerStatus->GetLastHash())
+        Optional<uint256> opLastHash = pwallet->GetStakingStatusLastHash();
+        if (!opLastHash || g_best_block == *opLastHash)
             return;
     }
     fStakeableCoins = pwallet->StakeableCoins(availableCoins);
@@ -597,9 +598,9 @@ void BitcoinMiner(CWallet* pwallet, bool fProofOfStake)
             }
 
             //search our map of hashed blocks, see if bestblock has been hashed yet
-            if (pwallet->pStakerStatus &&
-                    pwallet->pStakerStatus->GetLastHash() == pindexPrev->GetBlockHash() &&
-                    pwallet->pStakerStatus->GetLastTime() >= GetCurrentTimeSlot()) {
+            if (pwallet->HasStakingStatus() &&
+                    *pwallet->GetStakingStatusLastHash() == pindexPrev->GetBlockHash() &&
+                    *pwallet->GetStakingStatusLastTime() >= GetCurrentTimeSlot()) {
                 MilliSleep(2000);
                 continue;
             }

--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -443,12 +443,13 @@ void TopBar::setStakingStatusActive(bool fActive)
 }
 void TopBar::updateStakingStatus()
 {
-    setStakingStatusActive(walletModel &&
-                           !walletModel->isWalletLocked() &&
-                           walletModel->isStakingStatusActive());
+    if (walletModel && !walletModel->isShutdownRequested()) {
+        setStakingStatusActive(!walletModel->isWalletLocked() &&
+                               walletModel->isStakingStatusActive());
 
-    // Taking advantage of this timer to update Tor status if needed.
-    updateTorIcon();
+        // Taking advantage of this timer to update Tor status if needed.
+        updateTorIcon();
+    }
 }
 
 void TopBar::setNumConnections(int count)

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -11,6 +11,7 @@
 #include "optionsmodel.h"
 #include "recentrequeststablemodel.h"
 #include "transactiontablemodel.h"
+#include "init.h" // for ShutdownRequested(). Future: move to an interface wrapper
 
 #include "base58.h"
 #include "coincontrol.h"
@@ -65,6 +66,11 @@ bool WalletModel::isTestNetwork() const
 bool WalletModel::isRegTestNetwork() const
 {
     return Params().IsRegTestNet();
+}
+
+bool WalletModel::isShutdownRequested()
+{
+    return ShutdownRequested();
 }
 
 bool WalletModel::isColdStakingNetworkelyEnabled() const

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -84,7 +84,7 @@ bool WalletModel::isSaplingEnforced() const
 
 bool WalletModel::isStakingStatusActive() const
 {
-    return wallet && wallet->pStakerStatus && wallet->pStakerStatus->IsActive();
+    return wallet && wallet->IsStakingActive();
 }
 
 bool WalletModel::isHDEnabled() const

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -152,6 +152,7 @@ public:
 
     bool isTestNetwork() const;
     bool isRegTestNetwork() const;
+    bool isShutdownRequested();
     /** Whether cold staking is enabled or disabled in the network **/
     bool isColdStakingNetworkelyEnabled() const;
     bool isSaplingInMaintenance() const;

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -119,7 +119,7 @@ UniValue getinfo(const JSONRPCRequest& request)
     if (pwalletMain) {
         obj.pushKV("walletversion", pwalletMain->GetVersion());
         obj.pushKV("balance", ValueFromAmount(pwalletMain->GetAvailableBalance()));
-        obj.pushKV("staking status", (pwalletMain->pStakerStatus->IsActive() ? "Staking Active" : "Staking Not Active"));
+        obj.pushKV("staking status", (pwalletMain->IsStakingActive() ? "Staking Active" : "Staking Not Active"));
     }
 #endif
     obj.pushKV("blocks", (int)chainActive.Height());

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3683,7 +3683,7 @@ UniValue getstakingstatus(const JSONRPCRequest& request)
     {
         LOCK2(cs_main, &pwalletMain->cs_wallet);
         UniValue obj(UniValue::VOBJ);
-        obj.pushKV("staking_status", pwalletMain->pStakerStatus->IsActive());
+        obj.pushKV("staking_status", pwalletMain->IsStakingActive());
         obj.pushKV("staking_enabled", gArgs.GetBoolArg("-staking", DEFAULT_STAKING));
         bool fColdStaking = gArgs.GetBoolArg("-coldstaking", true);
         obj.pushKV("coldstaking_enabled", fColdStaking);
@@ -3695,7 +3695,7 @@ UniValue getstakingstatus(const JSONRPCRequest& request)
         obj.pushKV("stakeablecoins", (int)vCoins.size());
         obj.pushKV("stakingbalance", ValueFromAmount(pwalletMain->GetStakingBalance(fColdStaking)));
         obj.pushKV("stakesplitthreshold", ValueFromAmount(pwalletMain->nStakeSplitThreshold));
-        CStakerStatus* ss = pwalletMain->pStakerStatus;
+        CStakerStatus* ss = pwalletMain->GetStakingStatus();
         if (ss) {
             obj.pushKV("lastattempt_age", (int)(GetTime() - ss->GetLastTime()));
             obj.pushKV("lastattempt_depth", (chainActive.Height() - ss->GetLastHeight()));

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4280,7 +4280,6 @@ CWallet::CWallet(std::string strWalletFileIn)
 CWallet::~CWallet()
 {
     delete pwalletdbEncryption;
-    delete pStakerStatus;
 }
 
 void CWallet::SetNull()
@@ -4300,7 +4299,7 @@ void CWallet::SetNull()
     if (pStakerStatus) {
         pStakerStatus->SetNull();
     } else {
-        pStakerStatus = new CStakerStatus();
+        pStakerStatus = MakeUnique<CStakerStatus>();
     }
     // Stake split threshold
     nStakeSplitThreshold = DEFAULT_STAKE_SPLIT_THRESHOLD;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -280,7 +280,7 @@ private:
     int64_t nLastResend;
 
     // Staker status (last hashed block and time)
-    CStakerStatus* pStakerStatus{nullptr};
+    std::unique_ptr<CStakerStatus> pStakerStatus;
 
     /**
      * Used to keep track of spent outpoints, and


### PR DESCRIPTION
Solving an edge case segfault at shutdown caused by the lack of thread access synchronization for the `pStakerStatus` member inside the wallet. The member is accessed by at least three different threads directly. One from the miner, the wallet shutdown and the GUI status update.