### PR TITLE
[Tests] Add more cases to sighash_tests for malleated txes

### DIFF
--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -244,6 +244,256 @@ BOOST_AUTO_TEST_CASE(sighash_from_data)
 
         sh = SignatureHash(scriptCode, tx, nIn, nHashType, 0, tx.GetRequiredSigVersion());
         BOOST_CHECK_MESSAGE(sh.GetHex() == sigHashHex, strTest);
+
     }
 }
+
+BOOST_AUTO_TEST_CASE(malleated_tx)
+{
+    int nRandomTests = 5000;
+    std::vector<uint256> vsh;
+    std::vector<CScript> vScriptCode;
+    for (int t = 0; t < nRandomTests; t++) {
+        vsh.clear();
+        vScriptCode.clear();
+        // create a random tx and get the signature hashes
+        CMutableTransaction _tx;
+        RandomTransaction(_tx, false);
+        const CTransaction tx(_tx);
+        for (int nIn = 0; nIn < (int) tx.vin.size(); nIn++) {
+            vScriptCode.emplace_back();
+            RandomScript(vScriptCode.back());
+            vsh.emplace_back(SignatureHash(vScriptCode.back(), tx, nIn, SIGHASH_ALL, 0, tx.GetRequiredSigVersion()));
+        }
+
+        // -- create malleated txes
+        CMutableTransaction mtx = _tx;
+        for (int nIn = 0; nIn < (int) tx.vin.size(); nIn++) {
+            BOOST_CHECK(vsh[nIn] == SignatureHash(vScriptCode[nIn], CTransaction(mtx), nIn, SIGHASH_ALL, 0, tx.GetRequiredSigVersion()));
+        }
+
+        // remove one transparent input
+        if (mtx.vin.size() > 0) {
+            mtx.vin.pop_back();
+            CTransaction tx2(mtx);
+            for (int nIn = 0; nIn < (int) tx.vin.size() - 1; nIn++) {
+                BOOST_CHECK(vsh[nIn] != SignatureHash(vScriptCode[nIn], tx2, nIn, SIGHASH_ALL, 0, tx2.GetRequiredSigVersion()));
+            }
+        }
+
+        // change the prevout of the transparent input being signed
+        mtx = _tx;
+        for (int nIn = 0; nIn < (int) tx.vin.size(); nIn++) {
+            while (mtx.vin[nIn].prevout.hash == tx.vin[nIn].prevout.hash)
+                mtx.vin[nIn].prevout.hash = InsecureRand256();
+            CTransaction tx2(mtx);
+            BOOST_CHECK(vsh[nIn] != SignatureHash(vScriptCode[nIn], tx2, nIn, SIGHASH_ALL, 0, tx2.GetRequiredSigVersion()));
+        }
+
+        // add one random transparent input
+        {
+            mtx = _tx;
+            CTxIn in(InsecureRand256(), InsecureRandBits(2));
+            RandomScript(in.scriptSig);
+            in.nSequence = (InsecureRandBool()) ? InsecureRand32() : (unsigned int)-1;
+            mtx.vin.emplace_back(in);
+            CTransaction tx2(mtx);
+            for (int nIn = 0; nIn < (int) tx.vin.size(); nIn++) {
+                BOOST_CHECK(vsh[nIn] != SignatureHash(vScriptCode[nIn], tx2, nIn, SIGHASH_ALL, 0, tx2.GetRequiredSigVersion()));
+            }
+        }
+
+        // Shield inputs
+        if (tx.sapData && tx.sapData->vShieldedSpend.size() > 0) {
+            // remove one spend
+            mtx = _tx;
+            mtx.sapData->vShieldedSpend.pop_back();
+            for (int nIn = 0; nIn < (int) tx.vin.size(); nIn++) {
+                BOOST_CHECK(vsh[nIn] != SignatureHash(vScriptCode[nIn], CTransaction(mtx), nIn, SIGHASH_ALL, 0, SigVersion::SIGVERSION_SAPLING));
+            }
+
+            // modify one spend (cv, anchor, nullifier, rk, zkproof, spendAuthSig)
+            int i = InsecureRandRange(tx.sapData->vShieldedSpend.size());
+
+            mtx = _tx;
+            while (mtx.sapData->vShieldedSpend[i].cv == tx.sapData->vShieldedSpend[i].cv)
+                mtx.sapData->vShieldedSpend[i].cv = GetRandHash();
+            for (int nIn = 0; nIn < (int) tx.vin.size(); nIn++) {
+                BOOST_CHECK(vsh[nIn] != SignatureHash(vScriptCode[nIn], CTransaction(mtx), nIn, SIGHASH_ALL, 0, SigVersion::SIGVERSION_SAPLING));
+            }
+
+            mtx = _tx;
+            while (mtx.sapData->vShieldedSpend[i].anchor == tx.sapData->vShieldedSpend[i].anchor)
+                mtx.sapData->vShieldedSpend[i].anchor = GetRandHash();
+            for (int nIn = 0; nIn < (int) tx.vin.size(); nIn++) {
+                BOOST_CHECK(vsh[nIn] != SignatureHash(vScriptCode[nIn], CTransaction(mtx), nIn, SIGHASH_ALL, 0, SigVersion::SIGVERSION_SAPLING));
+            }
+
+            mtx = _tx;
+            while (mtx.sapData->vShieldedSpend[i].nullifier == tx.sapData->vShieldedSpend[i].nullifier)
+                mtx.sapData->vShieldedSpend[i].nullifier = GetRandHash();
+            for (int nIn = 0; nIn < (int) tx.vin.size(); nIn++) {
+                BOOST_CHECK(vsh[nIn] != SignatureHash(vScriptCode[nIn], CTransaction(mtx), nIn, SIGHASH_ALL, 0, SigVersion::SIGVERSION_SAPLING));
+            }
+
+            mtx = _tx;
+            while (mtx.sapData->vShieldedSpend[i].rk == tx.sapData->vShieldedSpend[i].rk)
+                mtx.sapData->vShieldedSpend[i].rk = GetRandHash();
+            for (int nIn = 0; nIn < (int) tx.vin.size(); nIn++) {
+                BOOST_CHECK(vsh[nIn] != SignatureHash(vScriptCode[nIn], CTransaction(mtx), nIn, SIGHASH_ALL, 0, SigVersion::SIGVERSION_SAPLING));
+            }
+
+            mtx = _tx;
+            auto zkproof = &mtx.sapData->vShieldedSpend[i].zkproof;
+            randombytes_buf(zkproof->begin(), zkproof->size());
+            for (int nIn = 0; nIn < (int) tx.vin.size(); nIn++) {
+                BOOST_CHECK(vsh[nIn] != SignatureHash(vScriptCode[nIn], CTransaction(mtx), nIn, SIGHASH_ALL, 0, SigVersion::SIGVERSION_SAPLING));
+            }
+
+            mtx = _tx;
+            auto spendAuthSig = &mtx.sapData->vShieldedSpend[i].spendAuthSig;
+            randombytes_buf(spendAuthSig->begin(), spendAuthSig->size());
+            for (int nIn = 0; nIn < (int) tx.vin.size(); nIn++) {
+                BOOST_CHECK(vsh[nIn] != SignatureHash(vScriptCode[nIn], CTransaction(mtx), nIn, SIGHASH_ALL, 0, SigVersion::SIGVERSION_SAPLING));
+            }
+        }
+
+        // add one random spend
+        mtx = _tx;
+        SpendDescription sdesc;
+        sdesc.cv = GetRandHash();
+        sdesc.anchor = GetRandHash();
+        sdesc.nullifier = GetRandHash();
+        sdesc.rk = GetRandHash();
+        randombytes_buf(sdesc.zkproof.begin(), sdesc.zkproof.size());
+        mtx.sapData->vShieldedSpend.push_back(sdesc);
+        for (int nIn = 0; nIn < (int) tx.vin.size(); nIn++) {
+            BOOST_CHECK(vsh[nIn] != SignatureHash(vScriptCode[nIn], CTransaction(mtx), nIn, SIGHASH_ALL, 0, SigVersion::SIGVERSION_SAPLING));
+        }
+
+        // Transparent outputs
+        if (mtx.vout.size() > 0) {
+            // remove one
+            mtx = _tx;
+            mtx.vout.pop_back();
+            CTransaction tx2(mtx);
+            for (int nIn = 0; nIn < (int) tx.vin.size(); nIn++) {
+                BOOST_CHECK(vsh[nIn] != SignatureHash(vScriptCode[nIn], tx2, nIn, SIGHASH_ALL, 0, tx2.GetRequiredSigVersion()));
+            }
+
+            // modify one (amount, script)
+            int i = InsecureRandRange(tx.vout.size());
+            mtx = _tx;
+            while (mtx.vout[i].nValue == tx.vout[i].nValue)
+                mtx.vout[i].nValue = InsecureRandRange(100000000);
+            tx2 = CTransaction(mtx);
+            for (int nIn = 0; nIn < (int) tx.vin.size(); nIn++) {
+                BOOST_CHECK(vsh[nIn] != SignatureHash(vScriptCode[nIn], tx2, nIn, SIGHASH_ALL, 0, tx2.GetRequiredSigVersion()));
+            }
+
+            mtx = _tx;
+            while (mtx.vout[i].scriptPubKey == tx.vout[i].scriptPubKey)
+                RandomScript(mtx.vout[i].scriptPubKey);
+            tx2 = CTransaction(mtx);
+            for (int nIn = 0; nIn < (int) tx.vin.size(); nIn++) {
+                BOOST_CHECK(vsh[nIn] != SignatureHash(vScriptCode[nIn], tx2, nIn, SIGHASH_ALL, 0, tx2.GetRequiredSigVersion()));
+            }
+        }
+
+        // add a random trasparent output
+        {
+            mtx = _tx;
+            CTxOut out;
+            out.nValue = InsecureRandRange(100000000);
+            RandomScript(out.scriptPubKey);
+            mtx.vout.emplace_back(out);
+            CTransaction tx2(mtx);
+            for (int nIn = 0; nIn < (int) tx.vin.size(); nIn++) {
+                BOOST_CHECK(vsh[nIn] != SignatureHash(vScriptCode[nIn], tx2, nIn, SIGHASH_ALL, 0, tx2.GetRequiredSigVersion()));
+            }
+        }
+
+        // Shield outputs
+        if (tx.sapData && tx.sapData->vShieldedOutput.size() > 0) {
+            // remove one output
+            mtx = _tx;
+            mtx.sapData->vShieldedOutput.pop_back();
+            for (int nIn = 0; nIn < (int) tx.vin.size(); nIn++) {
+                BOOST_CHECK(vsh[nIn] != SignatureHash(vScriptCode[nIn], CTransaction(mtx), nIn, SIGHASH_ALL, 0, SigVersion::SIGVERSION_SAPLING));
+            }
+
+            // modify one output (cv, cmu, nullifier, ephemeralKey, encCiphertext, outCiphertext, zkproof)
+            int i = InsecureRandRange(tx.sapData->vShieldedOutput.size());
+
+            mtx = _tx;
+            while (mtx.sapData->vShieldedOutput[i].cv == tx.sapData->vShieldedOutput[i].cv)
+                mtx.sapData->vShieldedOutput[i].cv = GetRandHash();
+            for (int nIn = 0; nIn < (int) tx.vin.size(); nIn++) {
+                BOOST_CHECK(vsh[nIn] != SignatureHash(vScriptCode[nIn], CTransaction(mtx), nIn, SIGHASH_ALL, 0, SigVersion::SIGVERSION_SAPLING));
+            }
+
+            mtx = _tx;
+            while (mtx.sapData->vShieldedOutput[i].cmu == tx.sapData->vShieldedOutput[i].cmu)
+                mtx.sapData->vShieldedOutput[i].cmu = GetRandHash();
+            for (int nIn = 0; nIn < (int) tx.vin.size(); nIn++) {
+                BOOST_CHECK(vsh[nIn] != SignatureHash(vScriptCode[nIn], CTransaction(mtx), nIn, SIGHASH_ALL, 0, SigVersion::SIGVERSION_SAPLING));
+            }
+
+            mtx = _tx;
+            while (mtx.sapData->vShieldedOutput[i].ephemeralKey == tx.sapData->vShieldedOutput[i].ephemeralKey)
+                mtx.sapData->vShieldedOutput[i].ephemeralKey = GetRandHash();
+            for (int nIn = 0; nIn < (int) tx.vin.size(); nIn++) {
+                BOOST_CHECK(vsh[nIn] != SignatureHash(vScriptCode[nIn], CTransaction(mtx), nIn, SIGHASH_ALL, 0, SigVersion::SIGVERSION_SAPLING));
+            }
+
+            mtx = _tx;
+            auto encCiphertext = &mtx.sapData->vShieldedOutput[i].encCiphertext;
+            randombytes_buf(encCiphertext->begin(), encCiphertext->size());
+            for (int nIn = 0; nIn < (int) tx.vin.size(); nIn++) {
+                BOOST_CHECK(vsh[nIn] != SignatureHash(vScriptCode[nIn], CTransaction(mtx), nIn, SIGHASH_ALL, 0, SigVersion::SIGVERSION_SAPLING));
+            }
+
+            mtx = _tx;
+            auto outCiphertext = &mtx.sapData->vShieldedOutput[i].outCiphertext;
+            randombytes_buf(outCiphertext->begin(), outCiphertext->size());
+            for (int nIn = 0; nIn < (int) tx.vin.size(); nIn++) {
+                BOOST_CHECK(vsh[nIn] != SignatureHash(vScriptCode[nIn], CTransaction(mtx), nIn, SIGHASH_ALL, 0, SigVersion::SIGVERSION_SAPLING));
+            }
+
+            mtx = _tx;
+            auto zkproof = &mtx.sapData->vShieldedOutput[i].zkproof;
+            randombytes_buf(zkproof->begin(), zkproof->size());
+            for (int nIn = 0; nIn < (int) tx.vin.size(); nIn++) {
+                BOOST_CHECK(vsh[nIn] != SignatureHash(vScriptCode[nIn], CTransaction(mtx), nIn, SIGHASH_ALL, 0, SigVersion::SIGVERSION_SAPLING));
+            }
+        }
+
+        // add one random output
+        mtx = _tx;
+        OutputDescription odesc;
+        odesc.cv = GetRandHash();
+        odesc.cmu = GetRandHash();
+        odesc.ephemeralKey = GetRandHash();
+        randombytes_buf(odesc.encCiphertext.begin(), odesc.encCiphertext.size());
+        randombytes_buf(odesc.outCiphertext.begin(), odesc.outCiphertext.size());
+        randombytes_buf(odesc.zkproof.begin(), odesc.zkproof.size());
+        mtx.sapData->vShieldedOutput.push_back(odesc);
+        for (int nIn = 0; nIn < (int) tx.vin.size(); nIn++) {
+            BOOST_CHECK(vsh[nIn] != SignatureHash(vScriptCode[nIn], CTransaction(mtx), nIn, SIGHASH_ALL, 0, SigVersion::SIGVERSION_SAPLING));
+        }
+
+        // modify the value balance
+        if (tx.sapData &&
+                (!tx.sapData->vShieldedOutput.empty() || !tx.sapData->vShieldedSpend.empty())) {
+            mtx = _tx;
+            while (mtx.sapData->valueBalance == tx.sapData->valueBalance)
+                mtx.sapData->valueBalance = InsecureRandRange(100000000);
+            for (int nIn = 0; nIn < (int) tx.vin.size(); nIn++) {
+                BOOST_CHECK(vsh[nIn] != SignatureHash(vScriptCode[nIn], CTransaction(mtx), nIn, SIGHASH_ALL, 0, SigVersion::SIGVERSION_SAPLING));
+            }
+        }
+
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Create random txes, then add/modify/remove inputs, outputs, sapling data fields, and check the hash of the data serialized for transparent signatures.