### PR TITLE
[Net] Remove unused RecvLine function.

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -85,8 +85,6 @@ static const size_t DEFAULT_MAXSENDBUFFER    = 1 * 1000;
 // NOTE: When adjusting this, update rpcnet:setban's help ("24h")
 static const unsigned int DEFAULT_MISBEHAVING_BANTIME = 60 * 60 * 24;  // Default 24-hour ban
 
-bool RecvLine(SOCKET hSocket, std::string& strLine);
-
 typedef int NodeId;
 
 struct AddedNodeInfo


### PR DESCRIPTION
Removing the `RecvLine` unused function in net.cpp.