### PR TITLE
[P2P][BUG] Incorrect name logged for inventory messages

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -61,16 +61,16 @@ static const char* ppszTypeName[] = {
     "ix",   // deprecated
     "txlvote", // deprecated
     NetMsgType::SPORK,
-    NetMsgType::GETSPORKS,
+    NetMsgType::MNWINNER,
+    "mnodescanerr",
+    NetMsgType::BUDGETVOTE,
+    NetMsgType::BUDGETPROPOSAL,
+    NetMsgType::FINALBUDGET,
+    NetMsgType::FINALBUDGETVOTE,
+    "mnq",
     NetMsgType::MNBROADCAST,
     NetMsgType::MNPING,
-    NetMsgType::MNWINNER,
-    NetMsgType::GETMNWINNERS,
-    NetMsgType::GETMNLIST,
-    NetMsgType::BUDGETPROPOSAL,
-    NetMsgType::BUDGETVOTE,
-    NetMsgType::FINALBUDGET,
-    NetMsgType::FINALBUDGETVOTE
+    "dstx"  // deprecated
 };
 
 /** All known message types. Keep this in the same order as the list of
@@ -99,18 +99,24 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::FILTERCLEAR,
     NetMsgType::REJECT,
     NetMsgType::SENDHEADERS,
+    "filtered block", // Should never occur
+    "ix",   // deprecated
+    "txlvote", // deprecated
     NetMsgType::SPORK,
-    NetMsgType::GETSPORKS,
-    NetMsgType::MNBROADCAST,
-    NetMsgType::MNPING,
     NetMsgType::MNWINNER,
-    NetMsgType::GETMNWINNERS,
-    NetMsgType::GETMNLIST,
-    NetMsgType::BUDGETPROPOSAL,
+    "mnodescanerr",
     NetMsgType::BUDGETVOTE,
-    NetMsgType::BUDGETVOTESYNC,
+    NetMsgType::BUDGETPROPOSAL,
     NetMsgType::FINALBUDGET,
     NetMsgType::FINALBUDGETVOTE,
+    "mnq",
+    NetMsgType::MNBROADCAST,
+    NetMsgType::MNPING,
+    "dstx",  // deprecated
+    NetMsgType::GETMNWINNERS,
+    NetMsgType::GETMNLIST,
+    NetMsgType::BUDGETVOTESYNC,
+    NetMsgType::GETSPORKS,
     NetMsgType::SYNCSTATUSCOUNT
 };
 const static std::vector<std::string> allNetMessageTypesVec(allNetMessageTypes, allNetMessageTypes + ARRAYLEN(allNetMessageTypes));

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -199,20 +199,6 @@ CInv::CInv(int typeIn, const uint256& hashIn)
     hash = hashIn;
 }
 
-CInv::CInv(const std::string& strType, const uint256& hashIn)
-{
-    unsigned int i;
-    for (i = 1; i < ARRAYLEN(ppszTypeName); i++) {
-        if (strType == ppszTypeName[i]) {
-            type = i;
-            break;
-        }
-    }
-    if (i == ARRAYLEN(ppszTypeName))
-        LogPrint(BCLog::NET, "CInv::CInv(string, uint256) : unknown type '%s'", strType);
-    hash = hashIn;
-}
-
 bool operator<(const CInv& a, const CInv& b)
 {
     return (a.type < b.type || (a.type == b.type && a.hash < b.hash));
@@ -224,7 +210,7 @@ bool CInv::IsKnownType() const
 }
 
 bool CInv::IsMasterNodeType() const{
-     return (type >= 6);
+     return type > 2;
 }
 
 const char* CInv::GetCommand() const

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -348,7 +348,6 @@ class CInv
 public:
     CInv();
     CInv(int typeIn, const uint256& hashIn);
-    CInv(const std::string& strType, const uint256& hashIn);
 
     ADD_SERIALIZE_METHODS;
 
@@ -363,13 +362,15 @@ public:
 
     bool IsKnownType() const;
     bool IsMasterNodeType() const;
-    const char* GetCommand() const;
     std::string ToString() const;
 
     // TODO: make private (improves encapsulation)
 public:
     int type;
     uint256 hash;
+
+private:
+    const char* GetCommand() const;
 };
 
 enum {


### PR DESCRIPTION
**Issue**
Some p2p message is being logged with the improper command name. E.g. masternode pings logged as `fbs` (finalized budgets):
```
2021-01-11 11:52:16 got inv: fbs 6a3faa173c022f03268cbcd6f877ba935a0cfd3a7d1cc14a834bc3f335b4d349  new peer=17
2021-01-11 11:52:16 askfor fbs 6a3faa173c022f03268cbcd6f877ba935a0cfd3a7d1cc14a834bc3f335b4d349  1610366775535727 (12:06:15) peer=17
2021-01-11 11:52:16 received: mnp (151 bytes) peer=21
2021-01-11 11:52:16 mnp - Masternode ping, vin: 33996bf6cb102b73baacfe5cbfa178c0e1d47013cf46dd8b2fc0a7467220c36c
2021-01-11 11:52:16 CheckAndUpdate: New Ping - 6a3faa173c022f03268cbcd6f877ba935a0cfd3a7d1cc14a834bc3f335b4d349 - 0afbb2fc22536f5abc518475113ba945a902f6742112a3aaf79bf3408f22a3c4 - 1610365936
```

**Cause**
The `ppszTypeName` array is not properly ordered following the `MSG_` enum in protocol.h