### PR TITLE
[Masternode] Manage status cleanup

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -105,12 +105,17 @@ void CActiveMasternode::ManageStatus()
         status = ACTIVE_MASTERNODE_NOT_CAPABLE;
         notCapableReason = "";
 
-        LogPrintf("CActiveMasternode::ManageStatus() - Checking inbound connection to '%s'\n", service.ToString());
+        LogPrintf("%s - Checking inbound connection for masternode to '%s'\n", __func__ , service.ToString());
 
         CAddress addr(service, NODE_NETWORK);
-        if (!g_connman->OpenNetworkConnection(addr, true, nullptr)) {
-            notCapableReason = "Could not connect to " + service.ToString();
-            LogPrintf("CActiveMasternode::ManageStatus() - not capable: %s\n", notCapableReason);
+        if (!g_connman->IsNodeConnected(addr)) {
+            CNode* node = g_connman->ConnectNode(addr);
+            if (!node) {
+                notCapableReason =
+                        "Masternode address:port connection availability test failed, could not open a connection to the public masternode address (" +
+                        service.ToString() + ")";
+                LogPrintf("%s - not capable: %s\n", __func__, notCapableReason);
+            }
             return;
         }
 

--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -68,6 +68,7 @@ OperationResult initMasternode(const std::string& _strMasterNodePrivKey, const s
 
     activeMasternode.pubKeyMasternode = pubkey;
     activeMasternode.privKeyMasternode = key;
+    activeMasternode.service = addrTest;
     fMasterNode = true;
     return OperationResult(true);
 }
@@ -103,24 +104,6 @@ void CActiveMasternode::ManageStatus()
         // Set defaults
         status = ACTIVE_MASTERNODE_NOT_CAPABLE;
         notCapableReason = "";
-
-        if (strMasterNodeAddr.empty()) {
-            if (!GetLocal(service)) {
-                notCapableReason = "Can't detect external address. Please use the masternodeaddr configuration option.";
-                LogPrintf("CActiveMasternode::ManageStatus() - not capable: %s\n", notCapableReason);
-                return;
-            }
-        } else {
-            int nPort = 0;
-            std::string strHost;
-            SplitHostPort(strMasterNodeAddr, nPort, strHost);
-            service = LookupNumeric(strHost.c_str(), nPort);
-        }
-
-        // The service needs the correct default port to work properly
-        if (!CMasternodeBroadcast::CheckDefaultPort(service, notCapableReason, "CActiveMasternode::ManageStatus()")) {
-            return;
-        }
 
         LogPrintf("CActiveMasternode::ManageStatus() - Checking inbound connection to '%s'\n", service.ToString());
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2594,6 +2594,16 @@ bool CConnman::ForNode(NodeId id, std::function<bool(CNode* pnode)> func)
     return found != nullptr && NodeFullyConnected(found) && func(found);
 }
 
+bool CConnman::IsNodeConnected(const CAddress& addr)
+{
+    return FindNode(addr.ToStringIPPort());
+}
+
+CNode* CConnman::ConnectNode(CAddress addrConnect)
+{
+    return ConnectNode(addrConnect, nullptr, true);
+}
+
 // valid, reachable and routable address (except for RegTest)
 bool validateMasternodeIP(const std::string& addrStr)
 {

--- a/src/net.h
+++ b/src/net.h
@@ -213,6 +213,9 @@ public:
     };
 
     void RelayInv(CInv& inv);
+    bool IsNodeConnected(const CAddress& addr);
+    // Retrieves a connected peer (if connection success). Used only to check peer address availability for now.
+    CNode* ConnectNode(CAddress addrConnect);
 
     // Addrman functions
     size_t GetAddressCount() const;


### PR DESCRIPTION
Focused on two changes inside the active masternode state manager function:

1) Removed a redundant MN address parsing and port validation (both are covered at startup inside `initMasternode`).
2) Modified the inbound connection availability test to not add the self-connection to the connection manager peers vector (as it makes no sense to have it, nor maintain it). This change fixes the scenario in which the node connection already exists locally and the node invalidly logs the "Could not connect to xxx". Plus, changed the logging in the area to be more understandable as well.