### PR TITLE
[BUG][Masternodes] Prevent broadcast of pre-5.0 stale masternode data

### DIFF
--- a/src/budget/budgetdb.cpp
+++ b/src/budget/budgetdb.cpp
@@ -140,23 +140,7 @@ void DumpBudgets(CBudgetManager& budgetman)
     int64_t nStart = GetTimeMillis();
 
     CBudgetDB budgetdb;
-    CBudgetManager tempBudget;
-
-    LogPrint(BCLog::MNBUDGET,"Verifying budget.dat format...\n");
-    CBudgetDB::ReadResult readResult = budgetdb.Read(tempBudget, true);
-    // there was an error and it was not an error on file opening => do not proceed
-    if (readResult == CBudgetDB::FileError)
-        LogPrint(BCLog::MNBUDGET,"Missing budgets file - budget.dat, will try to recreate\n");
-    else if (readResult != CBudgetDB::Ok) {
-        LogPrint(BCLog::MNBUDGET,"Error reading budget.dat: ");
-        if (readResult == CBudgetDB::IncorrectFormat)
-            LogPrint(BCLog::MNBUDGET,"magic is ok but data has invalid format, will try to recreate\n");
-        else {
-            LogPrint(BCLog::MNBUDGET,"file format is unknown or invalid, please fix it manually\n");
-            return;
-        }
-    }
-    LogPrint(BCLog::MNBUDGET,"Writting info to budget.dat...\n");
+    LogPrint(BCLog::MNBUDGET,"Writing info to budget.dat...\n");
     budgetdb.Write(budgetman);
 
     LogPrint(BCLog::MNBUDGET,"Budget dump finished  %dms\n", GetTimeMillis() - nStart);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1716,11 +1716,7 @@ bool AppInit2()
     if (readResult == CMasternodeDB::FileError)
         LogPrintf("Missing masternode cache file - mncache.dat, will try to recreate\n");
     else if (readResult != CMasternodeDB::Ok) {
-        LogPrintf("Error reading mncache.dat: ");
-        if (readResult == CMasternodeDB::IncorrectFormat)
-            LogPrintf("magic is ok but data has invalid format, will try to recreate\n");
-        else
-            LogPrintf("file format is unknown or invalid, please fix it manually\n");
+        LogPrintf("Error reading mncache.dat - cached data discarded\n");
     }
 
     uiInterface.InitMessage(_("Loading budget cache..."));
@@ -1733,17 +1729,12 @@ bool AppInit2()
     if (readResult2 == CBudgetDB::FileError)
         LogPrintf("Missing budget cache - budget.dat, will try to recreate\n");
     else if (readResult2 != CBudgetDB::Ok) {
-        LogPrintf("Error reading budget.dat: ");
-        if (readResult2 == CBudgetDB::IncorrectFormat)
-            LogPrintf("magic is ok but data has invalid format, will try to recreate\n");
-        else
-            LogPrintf("file format is unknown or invalid, please fix it manually\n");
+        LogPrintf("Error reading budget.dat - cached data discarded\n");
     }
 
     //flag our cached items so we send them to our peers
     g_budgetman.ResetSync();
     g_budgetman.ClearSeen();
-
 
     uiInterface.InitMessage(_("Loading masternode payment cache..."));
 
@@ -1753,11 +1744,7 @@ bool AppInit2()
     if (readResult3 == CMasternodePaymentDB::FileError)
         LogPrintf("Missing masternode payment cache - mnpayments.dat, will try to recreate\n");
     else if (readResult3 != CMasternodePaymentDB::Ok) {
-        LogPrintf("Error reading mnpayments.dat: ");
-        if (readResult3 == CMasternodePaymentDB::IncorrectFormat)
-            LogPrintf("magic is ok but data has invalid format, will try to recreate\n");
-        else
-            LogPrintf("file format is unknown or invalid, please fix it manually\n");
+        LogPrintf("Error reading mnpayments.dat - cached data discarded\n");
     }
 
     fMasterNode = gArgs.GetBoolArg("-masternode", DEFAULT_MASTERNODE);

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -205,23 +205,7 @@ void DumpMasternodePayments()
     int64_t nStart = GetTimeMillis();
 
     CMasternodePaymentDB paymentdb;
-    CMasternodePayments tempPayments;
-
-    LogPrint(BCLog::MASTERNODE,"Verifying mnpayments.dat format...\n");
-    CMasternodePaymentDB::ReadResult readResult = paymentdb.Read(tempPayments);
-    // there was an error and it was not an error on file opening => do not proceed
-    if (readResult == CMasternodePaymentDB::FileError)
-        LogPrint(BCLog::MASTERNODE,"Missing budgets file - mnpayments.dat, will try to recreate\n");
-    else if (readResult != CMasternodePaymentDB::Ok) {
-        LogPrint(BCLog::MASTERNODE,"Error reading mnpayments.dat: ");
-        if (readResult == CMasternodePaymentDB::IncorrectFormat)
-            LogPrint(BCLog::MASTERNODE,"magic is ok but data has invalid format, will try to recreate\n");
-        else {
-            LogPrint(BCLog::MASTERNODE,"file format is unknown or invalid, please fix it manually\n");
-            return;
-        }
-    }
-    LogPrint(BCLog::MASTERNODE,"Writting info to mnpayments.dat...\n");
+    LogPrint(BCLog::MASTERNODE,"Writing info to mnpayments.dat...\n");
     paymentdb.Write(masternodePayments);
 
     LogPrint(BCLog::MASTERNODE,"Budget dump finished  %dms\n", GetTimeMillis() - nStart);

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -606,7 +606,8 @@ bool CMasternodePing::CheckAndUpdate(int& nDos, bool fRequireAvailable, bool fCh
     if (!mnodeman.IsWithinDepth(blockHash, 2 * MNPING_DEPTH)) {
         LogPrint(BCLog::MNPING,"%s: Masternode %s block hash %s is too old or has an invalid block hash\n",
                                         __func__, vin.prevout.hash.ToString(), blockHash.ToString());
-        nDos = 33;
+        // don't ban peers relaying stale data before the active protocol enforcement
+        nDos = (ActiveProtocol() < MIN_PEER_CACHEDVERSION ? 0 : 33);
         return false;
     }
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -177,23 +177,7 @@ void DumpMasternodes()
     int64_t nStart = GetTimeMillis();
 
     CMasternodeDB mndb;
-    CMasternodeMan tempMnodeman;
-
-    LogPrint(BCLog::MASTERNODE,"Verifying mncache.dat format...\n");
-    CMasternodeDB::ReadResult readResult = mndb.Read(tempMnodeman);
-    // there was an error and it was not an error on file opening => do not proceed
-    if (readResult == CMasternodeDB::FileError)
-        LogPrint(BCLog::MASTERNODE,"Missing masternode cache file - mncache.dat, will try to recreate\n");
-    else if (readResult != CMasternodeDB::Ok) {
-        LogPrint(BCLog::MASTERNODE,"Error reading mncache.dat: ");
-        if (readResult == CMasternodeDB::IncorrectFormat)
-            LogPrint(BCLog::MASTERNODE,"magic is ok but data has invalid format, will try to recreate\n");
-        else {
-            LogPrint(BCLog::MASTERNODE,"file format is unknown or invalid, please fix it manually\n");
-            return;
-        }
-    }
-    LogPrint(BCLog::MASTERNODE,"Writting info to mncache.dat...\n");
+    LogPrint(BCLog::MASTERNODE,"Writing info to mncache.dat...\n");
     mndb.Write(mnodeman);
 
     LogPrint(BCLog::MASTERNODE,"Masternode dump finished  %dms\n", GetTimeMillis() - nStart);

--- a/src/version.h
+++ b/src/version.h
@@ -23,6 +23,9 @@ static const int GETHEADERS_VERSION = 70077;
 static const int MIN_PEER_PROTO_VERSION_BEFORE_ENFORCEMENT = 70919;
 static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT = 70920;
 
+//! peers with version older than this, could relay invalid (stale) mn pings
+static const int MIN_PEER_CACHEDVERSION = 70921;
+
 //! masternodes older than this proto version use old strMessage format for mnannounce
 static const int MIN_PEER_MNANNOUNCE = 70913;
 


### PR DESCRIPTION
Which is currently causing excessive banning.
Add a "database" version at the beginning of cache files.

Also, for this reason, do not ban when receiving invalid ping block hashes before the enforcement of protocol 70921.