### PR TITLE
[BUG] Fix deadlock in GetNextMasternodeInQueueForPayment

### DIFF
--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -465,10 +465,11 @@ void CMasternodeMan::CheckSpentCollaterals(const std::vector<CTransactionRef>& v
 //
 // Deterministically select the oldest/best masternode to pay on the network
 //
-const CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight, bool fFilterSigTime, int& nCount) const
+const CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight, bool fFilterSigTime, int& nCount, const CBlockIndex* pChainTip) const
 {
     AssertLockNotHeld(cs_main);
-    const CBlockIndex* BlockReading = GetChainTip();
+    const CBlockIndex* BlockReading = (pChainTip == nullptr ? GetChainTip() : pChainTip);
+    if (!BlockReading) return nullptr;
     LOCK(cs);
 
     const CMasternode* pBestMasternode = nullptr;
@@ -501,7 +502,7 @@ const CMasternode* CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlock
     nCount = (int)vecMasternodeLastPaid.size();
 
     //when the network is in the process of upgrading, don't penalize nodes that recently restarted
-    if (fFilterSigTime && nCount < nMnCount / 3) return GetNextMasternodeInQueueForPayment(nBlockHeight, false, nCount);
+    if (fFilterSigTime && nCount < nMnCount / 3) return GetNextMasternodeInQueueForPayment(nBlockHeight, false, nCount, BlockReading);
 
     // Sort them high to low
     sort(vecMasternodeLastPaid.rbegin(), vecMasternodeLastPaid.rend(), CompareLastPaid());

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -144,7 +144,7 @@ public:
     void CheckSpentCollaterals(const std::vector<CTransactionRef>& vtx);
 
     /// Find an entry in the masternode list that is next to be paid
-    const CMasternode* GetNextMasternodeInQueueForPayment(int nBlockHeight, bool fFilterSigTime, int& nCount) const;
+    const CMasternode* GetNextMasternodeInQueueForPayment(int nBlockHeight, bool fFilterSigTime, int& nCount, const CBlockIndex* pChainTip = nullptr) const;
 
     /// Get the current winner for this block
     const CMasternode* GetCurrentMasterNode(int mod = 1, int64_t nBlockHeight = 0, int minProtocol = 0) const;

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -203,10 +203,10 @@ UniValue getmasternodecount (const JSONRPCRequest& request)
     int nCount = 0;
     int ipv4 = 0, ipv6 = 0, onion = 0;
 
-    int nChainHeight = WITH_LOCK(cs_main, return chainActive.Height());
-    if (nChainHeight < 0) return "unknown";
+    const CBlockIndex* pChainTip = GetChainTip();
+    if (!pChainTip) return "unknown";
 
-    mnodeman.GetNextMasternodeInQueueForPayment(nChainHeight, true, nCount);
+    mnodeman.GetNextMasternodeInQueueForPayment(pChainTip->nHeight, true, nCount, pChainTip);
     int total = mnodeman.CountNetworks(ipv4, ipv6, onion);
 
     obj.pushKV("total", total);
@@ -239,9 +239,11 @@ UniValue masternodecurrent (const JSONRPCRequest& request)
             "\nExamples:\n" +
             HelpExampleCli("masternodecurrent", "") + HelpExampleRpc("masternodecurrent", ""));
 
-    const int nHeight = WITH_LOCK(cs_main, return chainActive.Height() + 1);
+    const CBlockIndex* pChainTip = GetChainTip();
+    if (!pChainTip) return "unknown";
+
     int nCount = 0;
-    const CMasternode* winner = mnodeman.GetNextMasternodeInQueueForPayment(nHeight, true, nCount);
+    const CMasternode* winner = mnodeman.GetNextMasternodeInQueueForPayment(pChainTip->nHeight + 1, true, nCount, pChainTip);
     if (winner) {
         UniValue obj(UniValue::VOBJ);
         obj.pushKV("protocol", (int64_t)winner->protocolVersion);


### PR DESCRIPTION
Due to the recursive call, `cs_main` may be locked after `CMasternodeMan::cs` (via `GetChainTip`).
This might cause the following deadlock:
```
2021-01-16 20:47:44 Previous lock order was:
2021-01-16 20:47:44  (1) cs masternodeman.cpp:472 (in thread bitcoin-httpworker)
2021-01-16 20:47:44  (2) cs_main validation.cpp:194 (in thread bitcoin-httpworker)
2021-01-16 20:47:44 Current lock order is:
2021-01-16 20:47:44  (2) cs_main validation.cpp:2276 (TRY) (in thread pivx-msghand)
2021-01-16 20:47:44  (1) cs masternodeman.cpp:454 (in thread pivx-msghand)
```

Note: This is a quick fix for the moment. The entire winner-selection flow will be refactored soon.