### PR TITLE
[Tests][BUG] Fix random range in feature_blockhashcache

### DIFF
--- a/test/functional/feature_blockhashcache.py
+++ b/test/functional/feature_blockhashcache.py
@@ -50,7 +50,7 @@ class BlockHashCacheTest(PivxTestFramework):
         self.log.info("Block %d correctly cached (overwriting genesis hash)" % CACHE_SIZE)
 
         # Mine a random number of blocks between 1 and CACHE_SIZE-1
-        x = random.randint(1, CACHE_SIZE)
+        x = random.randint(1, CACHE_SIZE - 1)
         self.log.info("Mining %d more blocks..." % x)
         for i in range(x):
             vBlocks.append(self.node.generate(1)[0])


### PR DESCRIPTION
`random.randint` is an alias for `randrange`, which includes the endpoint:
https://github.com/python/cpython/blob/998ae1fa3fb05a790071217cf8f6ae3a928da13f/Lib/random.py#L371-L375

In the test, we want a number strictly below 200, so we either use `randint(1, 199)` or `randrange(1, 200)`.

This fixes the GA failures like <https://github.com/PIVX-Project/PIVX/runs/1714017123>