### PR TITLE
[RPC] fix getbalance transparent watch-only amount.

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1983,7 +1983,7 @@ UniValue getbalance(const JSONRPCRequest& request)
     bool fIncludeShielded = paramsSize <= 3 || request.params[3].get_bool();
 
     isminefilter filter = ISMINE_SPENDABLE | (fIncludeWatchOnly ?
-                                              (fIncludeShielded ? ISMINE_WATCH_ONLY_SHIELDED : ISMINE_WATCH_ONLY) : ISMINE_NO);
+                                              (fIncludeShielded ? ISMINE_WATCH_ONLY_ALL : ISMINE_WATCH_ONLY) : ISMINE_NO);
     filter |= fIncludeDelegated ? ISMINE_SPENDABLE_DELEGATED : ISMINE_NO;
     filter |= fIncludeShielded ? ISMINE_SPENDABLE_SHIELDED : ISMINE_NO;
     return ValueFromAmount(pwalletMain->GetAvailableBalance(filter, true, nMinDepth));


### PR DESCRIPTION
Fixing an issue with `getbalance`, which at the moment is not including the transparent watch-only balance.

`getbalance` includes or not the shield balance, it will never return the shield balance only as the modified if/else block was doing. To get every specific balance type separately we use `getwalletinfo`.