### PR TITLE
Revamping block validation interface interaction with wallet

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1908,7 +1908,7 @@ bool AppInitMain()
 
 #ifdef ENABLE_WALLET
     if (pwalletMain) {
-        pwalletMain->postInitProcess(threadGroup);
+        pwalletMain->postInitProcess(scheduler);
 
         // StakeMiner thread disabled by default on regtest
         if (gArgs.GetBoolArg("-staking", !Params().IsRegTestNet() && DEFAULT_STAKING)) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -521,9 +521,6 @@ bool ProcessBlockFound(const std::shared_ptr<const CBlock>& pblock, CWallet& wal
     if (reservekey)
         reservekey->KeepKey();
 
-    // Inform about the new block
-    GetMainSignals().BlockFound(pblock->GetHash());
-
     // Process this block the same as if we had received it from another node
     CValidationState state;
     if (!ProcessNewBlock(state, nullptr, pblock, nullptr)) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2142,7 +2142,7 @@ bool CConnman::Start(CScheduler& scheduler, std::string& strNodeError, Options c
     threadMessageHandler = std::thread(&TraceThread<std::function<void()> >, "msghand", std::function<void()>(std::bind(&CConnman::ThreadMessageHandler, this)));
 
     // Dump network addresses
-    scheduler.scheduleEvery(std::bind(&CConnman::DumpData, this), DUMP_ADDRESSES_INTERVAL);
+    scheduler.scheduleEvery(std::bind(&CConnman::DumpData, this), DUMP_ADDRESSES_INTERVAL * 1000);
 
     return true;
 }

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -41,8 +41,8 @@ public:
     PeerLogicValidation(CConnman* connmanIn);
     ~PeerLogicValidation() = default;
 
-    virtual void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload);
-    virtual void BlockChecked(const CBlock& block, const CValidationState& state);
+    void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
+    void BlockChecked(const CBlock& block, const CValidationState& state) override;
 };
 
 struct CNodeStateStats {

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -300,11 +300,11 @@ void DecrementNoteWitnesses(NoteDataMap& noteDataMap, int indexHeight, int64_t n
     }
 }
 
-void SaplingScriptPubKeyMan::DecrementNoteWitnesses(const CBlockIndex* pindex)
+void SaplingScriptPubKeyMan::DecrementNoteWitnesses(int nChainHeight)
 {
     LOCK(wallet->cs_wallet);
     for (std::pair<const uint256, CWalletTx>& wtxItem : wallet->mapWallet) {
-        ::DecrementNoteWitnesses(wtxItem.second.mapSaplingNoteData, pindex->nHeight, nWitnessCacheSize);
+        ::DecrementNoteWitnesses(wtxItem.second.mapSaplingNoteData, nChainHeight, nWitnessCacheSize);
     }
     nWitnessCacheSize -= 1;
     nWitnessCacheNeedsUpdate = true;

--- a/src/sapling/saplingscriptpubkeyman.h
+++ b/src/sapling/saplingscriptpubkeyman.h
@@ -163,9 +163,9 @@ public:
                                 const CBlock* pblock,
                                 SaplingMerkleTree& saplingTree);
     /**
-     * pindex is the old tip being disconnected.
+     * nChainHeight is the old tip height being disconnected.
      */
-    void DecrementNoteWitnesses(const CBlockIndex* pindex);
+    void DecrementNoteWitnesses(int nChainHeight);
 
     /**
      * Update mapSaplingNullifiersToNotes

--- a/src/sapling/saplingscriptpubkeyman.h
+++ b/src/sapling/saplingscriptpubkeyman.h
@@ -72,7 +72,7 @@ public:
      * Block height corresponding to the most current witness.
      *
      * When we first create a SaplingNoteData in SaplingScriptPubKeyMan::FindMySaplingNotes, this is set to
-     * -1 as a placeholder. The next time CWallet::ChainTip is called, we can
+     * -1 as a placeholder. The next time CWallet::BlockConnected/CWallet::BlockDisconnected is called, we can
      * determine what height the witness cache for this note is valid for (even
      * if no witnesses were cached), and so can set the correct value in
      * SaplingScriptPubKeyMan::IncrementNoteWitnesses and SaplingScriptPubKeyMan::DecrementNoteWitnesses.

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -93,20 +93,20 @@ void CScheduler::schedule(CScheduler::Function f, boost::chrono::system_clock::t
     newTaskScheduled.notify_one();
 }
 
-void CScheduler::scheduleFromNow(CScheduler::Function f, int64_t deltaSeconds)
+void CScheduler::scheduleFromNow(CScheduler::Function f, int64_t deltaMilliSeconds)
 {
-    schedule(f, boost::chrono::system_clock::now() + boost::chrono::seconds(deltaSeconds));
+    schedule(f, boost::chrono::system_clock::now() + boost::chrono::milliseconds(deltaMilliSeconds));
 }
 
-static void Repeat(CScheduler* s, CScheduler::Function f, int64_t deltaSeconds)
+static void Repeat(CScheduler* s, CScheduler::Function f, int64_t deltaMilliSeconds)
 {
     f();
-    s->scheduleFromNow(std::bind(&Repeat, s, f, deltaSeconds), deltaSeconds);
+    s->scheduleFromNow(std::bind(&Repeat, s, f, deltaMilliSeconds), deltaMilliSeconds);
 }
 
-void CScheduler::scheduleEvery(CScheduler::Function f, int64_t deltaSeconds)
+void CScheduler::scheduleEvery(CScheduler::Function f, int64_t deltaMilliSeconds)
 {
-    scheduleFromNow(std::bind(&Repeat, this, f, deltaSeconds), deltaSeconds);
+    scheduleFromNow(std::bind(&Repeat, this, f, deltaMilliSeconds), deltaMilliSeconds);
 }
 
 size_t CScheduler::getQueueInfo(boost::chrono::system_clock::time_point &first,

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -44,15 +44,15 @@ public:
     // Call func at/after time t
     void schedule(Function f, boost::chrono::system_clock::time_point t);
 
-    // Convenience method: call f once deltaSeconds from now
-    void scheduleFromNow(Function f, int64_t deltaSeconds);
+    // Convenience method: call f once deltaMilliSeconds from now
+    void scheduleFromNow(Function f, int64_t deltaMilliSeconds);
 
     // Another convenience method: call f approximately
-    // every deltaSeconds forever, starting deltaSeconds from now.
+    // every deltaMilliSeconds forever, starting deltaMilliSeconds from now.
     // To be more precise: every time f is finished, it
-    // is rescheduled to run deltaSeconds later. If you
+    // is rescheduled to run deltaMilliSeconds later. If you
     // need more accurate scheduling, don't use this method.
-    void scheduleEvery(Function f, int64_t deltaSeconds);
+    void scheduleEvery(Function f, int64_t deltaMilliSeconds);
 
     // To keep things as simple as possible, there is no unschedule.
 

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -53,18 +53,18 @@ BOOST_AUTO_TEST_CASE(MempoolRemoveTest)
 
 
     CTxMemPool testPool(CFeeRate(0));
-    std::vector<CTransactionRef> removed;
 
     // Nothing in pool, remove should do nothing:
-    testPool.removeRecursive(txParent, &removed);
-    BOOST_CHECK_EQUAL(removed.size(), 0);
+    unsigned int poolSize = testPool.size();
+    testPool.removeRecursive(txParent);
+    BOOST_CHECK_EQUAL(testPool.size(), poolSize);
 
     // Just the parent:
     testPool.addUnchecked(txParent.GetHash(), entry.FromTx(txParent));
-    testPool.removeRecursive(txParent, &removed);
-    BOOST_CHECK_EQUAL(removed.size(), 1);
-    removed.clear();
-    
+    poolSize = testPool.size();
+    testPool.removeRecursive(txParent);
+    BOOST_CHECK_EQUAL(testPool.size(), poolSize - 1);
+
     // Parent, children, grandchildren:
     testPool.addUnchecked(txParent.GetHash(), entry.FromTx(txParent));
     for (int i = 0; i < 3; i++)
@@ -73,19 +73,21 @@ BOOST_AUTO_TEST_CASE(MempoolRemoveTest)
         testPool.addUnchecked(txGrandChild[i].GetHash(), entry.FromTx(txGrandChild[i]));
     }
     // Remove Child[0], GrandChild[0] should be removed:
-    testPool.removeRecursive(txChild[0], &removed);
-    BOOST_CHECK_EQUAL(removed.size(), 2);
-    removed.clear();
+    poolSize = testPool.size();
+    testPool.removeRecursive(txChild[0]);
+    BOOST_CHECK_EQUAL(testPool.size(), poolSize - 2);
     // ... make sure grandchild and child are gone:
-    testPool.removeRecursive(txGrandChild[0], &removed);
-    BOOST_CHECK_EQUAL(removed.size(), 0);
-    testPool.removeRecursive(txChild[0], &removed);
-    BOOST_CHECK_EQUAL(removed.size(), 0);
+    poolSize = testPool.size();
+    testPool.removeRecursive(txGrandChild[0]);
+    BOOST_CHECK_EQUAL(testPool.size(), poolSize);
+    poolSize = testPool.size();
+    testPool.removeRecursive(txChild[0]);
+    BOOST_CHECK_EQUAL(testPool.size(), poolSize);
     // Remove parent, all children/grandchildren should go:
-    testPool.removeRecursive(txParent, &removed);
-    BOOST_CHECK_EQUAL(removed.size(), 5);
+    poolSize = testPool.size();
+    testPool.removeRecursive(txParent);
+    BOOST_CHECK_EQUAL(testPool.size(), poolSize - 5);
     BOOST_CHECK_EQUAL(testPool.size(), 0);
-    removed.clear();
 
     // Add children and grandchildren, but NOT the parent (simulate the parent being in a block)
     for (int i = 0; i < 3; i++)
@@ -95,10 +97,10 @@ BOOST_AUTO_TEST_CASE(MempoolRemoveTest)
     }
     // Now remove the parent, as might happen if a block-re-org occurs but the parent cannot be
     // put into the mempool (maybe because it is non-standard):
-    testPool.removeRecursive(txParent, &removed);
-    BOOST_CHECK_EQUAL(removed.size(), 6);
+    poolSize = testPool.size();
+    testPool.removeRecursive(txParent);
+    BOOST_CHECK_EQUAL(testPool.size(), poolSize - 6);
     BOOST_CHECK_EQUAL(testPool.size(), 0);
-    removed.clear();
 }
 
 template<typename name>

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -415,7 +415,7 @@ BOOST_AUTO_TEST_CASE(MempoolAncestorIndexingTest)
     /* after tx6 is mined, tx7 should move up in the sort */
     std::vector<CTransactionRef> vtx;
     vtx.emplace_back(MakeTransactionRef(tx6));
-    pool.removeForBlock(vtx, 1, nullptr, false);
+    pool.removeForBlock(vtx, 1);
 
     sortedOrder.erase(sortedOrder.begin()+1);
     // Ties are broken by hash

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -481,7 +481,7 @@ void CTxMemPool::CalculateDescendants(txiter entryit, setEntries &setDescendants
     }
 }
 
-void CTxMemPool::removeRecursive(const CTransaction& origTx, std::vector<CTransactionRef>* removed)
+void CTxMemPool::removeRecursive(const CTransaction& origTx)
 {
     // Remove transaction from memory pool
     {
@@ -507,11 +507,6 @@ void CTxMemPool::removeRecursive(const CTransaction& origTx, std::vector<CTransa
         setEntries setAllRemoves;
         for (const txiter& it : txToRemove) {
             CalculateDescendants(it, setAllRemoves);
-        }
-        if (removed) {
-            for (const txiter& it : setAllRemoves) {
-                removed->emplace_back(it->GetSharedTx());
-            }
         }
         RemoveStaged(setAllRemoves, false);
     }
@@ -572,7 +567,7 @@ void CTxMemPool::removeWithAnchor(const uint256& invalidRoot)
     }
 }
 
-void CTxMemPool::removeConflicts(const CTransaction& tx, std::vector<CTransactionRef>* removed)
+void CTxMemPool::removeConflicts(const CTransaction& tx)
 {
     // Remove transactions which depend on inputs of tx, recursively
     std::list<CTransaction> result;
@@ -582,7 +577,7 @@ void CTxMemPool::removeConflicts(const CTransaction& tx, std::vector<CTransactio
         if (it != mapNextTx.end()) {
             const CTransaction& txConflict = *it->second;
             if (txConflict != tx) {
-                removeRecursive(txConflict, removed);
+                removeRecursive(txConflict);
             }
         }
     }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -368,13 +368,11 @@ void CTxMemPool::AddTransactionsUpdated(unsigned int n)
     nTransactionsUpdated += n;
 }
 
-
 bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry, setEntries &setAncestors, bool fCurrentEstimate)
 {
     // Add to memory pool without checking anything.
     // Used by AcceptToMemoryPool(), which DOES do all the appropriate checks.
     LOCK(cs);
-
     indexed_transaction_set::iterator newit = mapTx.insert(entry).first;
     mapLinks.insert(make_pair(newit, TxLinks()));
 
@@ -606,7 +604,7 @@ void CTxMemPool::removeConflicts(const CTransaction& tx, std::vector<CTransactio
  * Called when a block is connected. Removes from mempool and updates the miner fee estimator.
  */
 void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigned int nBlockHeight,
-                                std::vector<CTransactionRef>* conflicts, bool fCurrentEstimate)
+                                bool fCurrentEstimate)
 {
     LOCK(cs);
     std::vector<CTxMemPoolEntry> entries;
@@ -623,7 +621,7 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigne
             stage.insert(it);
             RemoveStaged(stage, true);
         }
-        removeConflicts(*tx, conflicts);
+        removeConflicts(*tx);
         ClearPrioritisation(tx->GetHash());
     }
     // After the txs in the new block have been removed from the mempool, update policy estimates

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -578,6 +578,7 @@ void CTxMemPool::removeConflicts(const CTransaction& tx)
             const CTransaction& txConflict = *it->second;
             if (txConflict != tx) {
                 removeRecursive(txConflict);
+                ClearPrioritisation(txConflict.GetHash());
             }
         }
     }
@@ -588,7 +589,8 @@ void CTxMemPool::removeConflicts(const CTransaction& tx)
             if (it != mapSaplingNullifiers.end()) {
                 const CTransaction& txConflict = *it->second;
                 if (txConflict != tx) {
-                    removeRecursive(txConflict, removed);
+                    removeRecursive(txConflict);
+                    ClearPrioritisation(txConflict.GetHash());
                 }
             }
         }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -527,7 +527,7 @@ public:
     void removeWithAnchor(const uint256& invalidRoot);
     void removeConflicts(const CTransaction& tx, std::vector<CTransactionRef>* removed = nullptr);
     void removeForBlock(const std::vector<CTransactionRef>& vtx, unsigned int nBlockHeight,
-                        std::vector<CTransactionRef>* conflicts = nullptr, bool fCurrentEstimate = true);
+                        bool fCurrentEstimate = true);
     void clear();
     void _clear();  // lock-free
     bool CompareDepthAndScore(const uint256& hasha, const uint256& hashb);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -522,10 +522,10 @@ public:
     // then invoke the second version.
     bool addUnchecked(const uint256& hash, const CTxMemPoolEntry& entry, bool fCurrentEstimate = true);
     bool addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry, setEntries &setAncestors, bool fCurrentEstimate = true);
-    void removeRecursive(const CTransaction& tx, std::vector<CTransactionRef>* removed = nullptr);
+    void removeRecursive(const CTransaction& tx);
     void removeForReorg(const CCoinsViewCache* pcoins, unsigned int nMemPoolHeight, int flags);
     void removeWithAnchor(const uint256& invalidRoot);
-    void removeConflicts(const CTransaction& tx, std::vector<CTransactionRef>* removed = nullptr);
+    void removeConflicts(const CTransaction& tx);
     void removeForBlock(const std::vector<CTransactionRef>& vtx, unsigned int nBlockHeight,
                         bool fCurrentEstimate = true);
     void clear();

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -23,6 +23,8 @@
 #include "boost/multi_index/ordered_index.hpp"
 #include "boost/multi_index/hashed_index.hpp"
 
+#include <boost/signals2/signal.hpp>
+
 class CAutoFile;
 
 inline double AllowFreeThreshold()
@@ -303,6 +305,19 @@ struct TxMempoolInfo
     int64_t nFeeDelta;
 };
 
+/** Reason why a transaction was removed from the mempool,
+ * this is passed to the notification signal.
+ */
+enum class MemPoolRemovalReason {
+    UNKNOWN = 0, //! Manually removed or unknown reason
+    EXPIRY,      //! Expired from mempool
+    SIZELIMIT,   //! Removed in size limiting
+    REORG,       //! Removed for reorganization
+    BLOCK,       //! Removed for block
+    CONFLICT,    //! Removed for conflict with in-block transaction
+    REPLACED     //! Removed for replacement
+};
+
 /**
  * CTxMemPool stores valid-according-to-the-current-best-chain
  * transactions that may be included in the next block.
@@ -522,12 +537,14 @@ public:
     // then invoke the second version.
     bool addUnchecked(const uint256& hash, const CTxMemPoolEntry& entry, bool fCurrentEstimate = true);
     bool addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry, setEntries &setAncestors, bool fCurrentEstimate = true);
-    void removeRecursive(const CTransaction& tx);
+
+    void removeRecursive(const CTransaction& tx, MemPoolRemovalReason reason = MemPoolRemovalReason::UNKNOWN);
     void removeForReorg(const CCoinsViewCache* pcoins, unsigned int nMemPoolHeight, int flags);
     void removeWithAnchor(const uint256& invalidRoot);
     void removeConflicts(const CTransaction& tx);
     void removeForBlock(const std::vector<CTransactionRef>& vtx, unsigned int nBlockHeight,
                         bool fCurrentEstimate = true);
+
     void clear();
     void _clear();  // lock-free
     bool CompareDepthAndScore(const uint256& hasha, const uint256& hashb);
@@ -556,7 +573,7 @@ public:
      *  Set updateDescendants to true when removing a tx that was in a block, so
      *  that any in-mempool descendants have their ancestor state updated.
      */
-    void RemoveStaged(setEntries &stage, bool updateDescendants);
+    void RemoveStaged(setEntries &stage, bool updateDescendants, MemPoolRemovalReason reason = MemPoolRemovalReason::UNKNOWN);
 
     /** When adding transactions from a disconnected block back to the mempool,
      *  new mempool entries may have children in the mempool (which is generally
@@ -650,6 +667,9 @@ public:
 
     size_t DynamicMemoryUsage() const;
 
+    boost::signals2::signal<void (CTransactionRef)> NotifyEntryAdded;
+    boost::signals2::signal<void (CTransactionRef, MemPoolRemovalReason)> NotifyEntryRemoved;
+
 private:
     /** UpdateForDescendants is used by UpdateTransactionsFromBlock to update
      *  the descendants for a single transaction that has been added to the
@@ -690,7 +710,7 @@ private:
      *  transactions in a chain before we've updated all the state for the
      *  removal.
      */
-    void removeUnchecked(txiter entry);
+    void removeUnchecked(txiter entry, MemPoolRemovalReason reason = MemPoolRemovalReason::UNKNOWN);
 };
 
 /** 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2386,7 +2386,7 @@ bool ActivateBestChain(CValidationState& state, std::shared_ptr<const CBlock> pb
 
                 // Sapling: notify wallet about the connected blocks ordered
                 // Get prev block tree anchor
-                CBlockIndex* pprev = pair.first->pprev;
+                CBlockIndex* pprev = trace.pindex->pprev;
                 SaplingMerkleTree oldSaplingTree;
                 bool isSaplingActive = (pprev) != nullptr &&
                                        Params().GetConsensus().NetworkUpgradeActive(pprev->nHeight,
@@ -2398,7 +2398,7 @@ bool ActivateBestChain(CValidationState& state, std::shared_ptr<const CBlock> pb
                 }
 
                 // Sapling: Update cached incremental witnesses
-                GetMainSignals().ChainTip(pair.first, &block, oldSaplingTree);
+                GetMainSignals().ChainTip(trace.pindex, &block, oldSaplingTree);
             }
 
             break;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2021,6 +2021,12 @@ static int64_t nTimeFlush = 0;
 static int64_t nTimeChainState = 0;
 static int64_t nTimePostConnect = 0;
 
+struct PerBlockConnectTrace {
+    CBlockIndex* pindex = nullptr;
+    std::shared_ptr<const CBlock> pblock;
+    std::shared_ptr<std::vector<CTransactionRef>> conflictedTxs;
+    PerBlockConnectTrace() : conflictedTxs(std::make_shared<std::vector<CTransactionRef>>()) {}
+};
 /**
  * Used to track blocks whose transactions were applied to the UTXO state as a
  * part of a single ActivateBestChainStep call.
@@ -2028,16 +2034,23 @@ static int64_t nTimePostConnect = 0;
  * This class also tracks transactions that are removed from the mempool as
  * conflicts (per block) and can be used to pass all those transactions
  * through SyncTransaction.
+ *
+ * This class assumes (and asserts) that the conflicted transactions for a given
+ * block are added via mempool callbacks prior to the BlockConnected() associated
+ * with those transactions. If any transactions are marked conflicted, it is
+ * assumed that an associated block will always be added.
+ *
+ * This class is single-use, once you call GetBlocksConnected() you have to throw
+ * it away and make a new one.
  */
 class ConnectTrace {
 private:
-    std::vector<std::pair<CBlockIndex*, std::shared_ptr<const CBlock> > > blocksConnected;
-    std::vector<std::vector<CTransactionRef> > conflictedTxs;
+    std::vector<PerBlockConnectTrace> blocksConnected;
     CTxMemPool &pool;
     std::unique_ptr<interfaces::Handler> m_handler_notify_entry_removed;
 
 public:
-    ConnectTrace(CTxMemPool &_pool) : conflictedTxs(1), pool(_pool) {
+    ConnectTrace(CTxMemPool &_pool) : blocksConnected(1), pool(_pool) {
         m_handler_notify_entry_removed = interfaces::MakeHandler(pool.NotifyEntryRemoved.connect(std::bind(&ConnectTrace::NotifyEntryRemoved, this, std::placeholders::_1, std::placeholders::_2)));
     }
 
@@ -2046,28 +2059,31 @@ public:
     }
 
     void BlockConnected(CBlockIndex* pindex, std::shared_ptr<const CBlock> pblock) {
-        blocksConnected.emplace_back(pindex, std::move(pblock));
-        conflictedTxs.emplace_back();
+        assert(!blocksConnected.back().pindex);
+        assert(pindex);
+        assert(pblock);
+        blocksConnected.back().pindex = pindex;
+        blocksConnected.back().pblock = std::move(pblock);
+        blocksConnected.emplace_back();
     }
 
-    std::vector<std::pair<CBlockIndex*, std::shared_ptr<const CBlock> > >& GetBlocksConnected() {
+    std::vector<PerBlockConnectTrace>& GetBlocksConnected() {
+        // We always keep one extra block at the end of our list because
+        // blocks are added after all the conflicted transactions have
+        // been filled in. Thus, the last entry should always be an empty
+        // one waiting for the transactions from the next block. We pop
+        // the last entry here to make sure the list we return is sane.
+        assert(!blocksConnected.back().pindex);
+        assert(blocksConnected.back().conflictedTxs->empty());
+        blocksConnected.pop_back();
         return blocksConnected;
     }
 
     void NotifyEntryRemoved(CTransactionRef txRemoved, MemPoolRemovalReason reason) {
+        assert(!blocksConnected.back().pindex);
         if (reason == MemPoolRemovalReason::CONFLICT) {
-            conflictedTxs.back().emplace_back(txRemoved);
+            blocksConnected.back().conflictedTxs->emplace_back(std::move(txRemoved));
         }
-    }
-
-    void CallSyncTransactionOnConflictedTransactions() {
-        for (const auto& txRemovedForBlock : conflictedTxs) {
-            for (const auto& tx : txRemovedForBlock) {
-                GetMainSignals().SyncTransaction(*tx, nullptr, CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK);
-            }
-        }
-        conflictedTxs.clear();
-        conflictedTxs.emplace_back();
     }
 };
 
@@ -2343,9 +2359,6 @@ bool ActivateBestChain(CValidationState& state, std::shared_ptr<const CBlock> pb
             pindexFork = chainActive.FindFork(pindexOldTip);
             fInitialDownload = IsInitialBlockDownload();
 
-            // throw all transactions though the signal-interface
-            connectTrace.CallSyncTransactionOnConflictedTransactions();
-
             // TODO: Temporarily ensure that mempool removals are notified before
             // connected transactions.  This shouldn't matter, but the abandoned
             // state of transactions in our wallet is currently cleared when we
@@ -2354,12 +2367,21 @@ bool ActivateBestChain(CValidationState& state, std::shared_ptr<const CBlock> pb
             // to abandon a transaction and then have it inadvertently cleared by
             // the notification that the conflicted transaction was evicted.
 
+            // throw all transactions though the signal-interface
+            auto blocksConnected = connectTrace.GetBlocksConnected();
+            for (const PerBlockConnectTrace& trace : blocksConnected) {
+                assert(trace.conflictedTxs);
+                for (const auto& tx : *trace.conflictedTxs) {
+                    GetMainSignals().SyncTransaction(*tx, NULL, CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK);
+                }
+            }
+
             // Transactions in the connnected block are notified
-            for (const auto& pair : connectTrace.GetBlocksConnected()) {
-                assert(pair.second);
-                const CBlock& block = *(pair.second);
+            for (const PerBlockConnectTrace& trace : blocksConnected) {
+                assert(trace.pblock && trace.pindex);
+                const CBlock& block = *(trace.pblock);
                 for (unsigned int i = 0; i < block.vtx.size(); i++) {
-                    GetMainSignals().SyncTransaction(*block.vtx[i], pair.first, i);
+                    GetMainSignals().SyncTransaction(*block.vtx[i], trace.pindex, i);
                 }
 
                 // Sapling: notify wallet about the connected blocks ordered

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2067,9 +2067,7 @@ struct ConnectTrace {
  * Connect a new block to chainActive. pblock is either NULL or a pointer to a CBlock
  * corresponding to pindexNew, to bypass loading it again from disk.
  *
- * The block is always added to connectTrace (either after loading from disk or by copying
- * pblock) - if that is not intended, care must be taken to remove the last entry in
- * blocksConnected in case of failure.
+ * The block is added to connectTrace if connection succeeds.
  */
 bool static ConnectTip(CValidationState& state, CBlockIndex* pindexNew, const std::shared_ptr<const CBlock>& pblock, bool fAlreadyChecked, ConnectTrace& connectTrace)
 {
@@ -2080,15 +2078,16 @@ bool static ConnectTip(CValidationState& state, CBlockIndex* pindexNew, const st
 
     // Read block from disk.
     int64_t nTime1 = GetTimeMicros();
+    std::shared_ptr<const CBlock> pthisBlock;
     if (!pblock) {
         std::shared_ptr<CBlock> pblockNew = std::make_shared<CBlock>();
-        connectTrace.blocksConnected.emplace_back(pindexNew, pblockNew);
         if (!ReadBlockFromDisk(*pblockNew, pindexNew))
             return AbortNode(state, "Failed to read block");
+        pthisBlock = pblockNew;
     } else {
-        connectTrace.blocksConnected.emplace_back(pindexNew, pblock);
+        pthisBlock = pblock;
     }
-    const CBlock& blockConnecting = *connectTrace.blocksConnected.back().second;
+    const CBlock& blockConnecting = *pthisBlock;
 
     // Apply the block atomically to the chain state.
     int64_t nTime2 = GetTimeMicros();
@@ -2136,6 +2135,8 @@ bool static ConnectTip(CValidationState& state, CBlockIndex* pindexNew, const st
     nTimeTotal += nTime6 - nTime1;
     LogPrint(BCLog::BENCH, "  - Connect postprocess: %.2fms [%.2fs]\n", (nTime6 - nTime5) * 0.001, nTimePostConnect * 0.000001);
     LogPrint(BCLog::BENCH, "- Connect block: %.2fms [%.2fs]\n", (nTime6 - nTime1) * 0.001, nTimeTotal * 0.000001);
+
+    connectTrace.blocksConnected.emplace_back(pindexNew, std::move(pthisBlock));
     return true;
 }
 
@@ -2259,8 +2260,6 @@ static bool ActivateBestChainStep(CValidationState& state, CBlockIndex* pindexMo
                     state = CValidationState();
                     fInvalidFound = true;
                     fContinue = false;
-                    // If we didn't actually connect the block, don't notify listeners about it
-                    connectTrace.blocksConnected.pop_back();
                     break;
                 } else {
                     // A system error occurred (disk space, database error, ...).

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2023,11 +2023,10 @@ static int64_t nTimeChainState = 0;
 static int64_t nTimePostConnect = 0;
 
 /**
- * Used to track conflicted transactions removed from mempool and transactions
- * applied to the UTXO state as a part of a single ActivateBestChainStep call.
+ * Used to track blocks whose transactions were applied to the UTXO state as a
+ * part of a single ActivateBestChainStep call.
  */
 struct ConnectTrace {
-    std::vector<CTransactionRef> txConflicted;
     std::vector<std::pair<CBlockIndex*, std::shared_ptr<const CBlock> > > blocksConnected;
 };
 
@@ -2092,7 +2091,7 @@ bool static ConnectTip(CValidationState& state, CBlockIndex* pindexNew, const st
     LogPrint(BCLog::BENCH, "  - Writing chainstate: %.2fms [%.2fs]\n", (nTime5 - nTime4) * 0.001, nTimeChainState * 0.000001);
 
     // Remove conflicting transactions from the mempool.
-    mempool.removeForBlock(blockConnecting.vtx, pindexNew->nHeight, &connectTrace.txConflicted, !IsInitialBlockDownload());
+    mempool.removeForBlock(blockConnecting.vtx, pindexNew->nHeight, !IsInitialBlockDownload());
     // Update chainActive & related variables.
     UpdateTip(pindexNew);
     // Update MN manager cache
@@ -2305,10 +2304,6 @@ bool ActivateBestChain(CValidationState& state, std::shared_ptr<const CBlock> pb
             fInitialDownload = IsInitialBlockDownload();
 
             // throw all transactions though the signal-interface
-            for (const auto &tx : connectTrace.txConflicted) {
-                GetMainSignals().SyncTransaction(*tx, pindexNewTip, CMainSignals::SYNC_TRANSACTION_NOT_IN_BLOCK);
-            }
-            // ... and about transactions that got confirmed:
             for (const auto& pair : connectTrace.blocksConnected) {
                 assert(pair.second);
                 const CBlock& block = *(pair.second);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1975,7 +1975,7 @@ bool static DisconnectTip(CValidationState& state, const CChainParams& chainpara
         // ignore validation errors in resurrected transactions
         CValidationState stateDummy;
         if (tx->IsCoinBase() || tx->IsCoinStake() || !AcceptToMemoryPool(mempool, stateDummy, tx, false, nullptr, true)) {
-            mempool.removeRecursive(*tx);
+            mempool.removeRecursive(*tx, MemPoolRemovalReason::REORG);
         } else if (mempool.exists(tx->GetHash())) {
             vHashUpdate.push_back(tx->GetHash());
         }

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -27,7 +27,12 @@ struct MainSignalsInstance {
     boost::signals2::signal<void (const CBlockIndex *, const CBlockIndex *, bool fInitialDownload)> UpdatedBlockTip;
     /** A posInBlock value for SyncTransaction which indicates the transaction was conflicted, disconnected, or not in a block */
     static const int SYNC_TRANSACTION_NOT_IN_BLOCK = -1;
-    /** Notifies listeners of updated transaction data (transaction, and optionally the block it is found in. */
+    /** Notifies listeners of updated transaction data (transaction, and
+     * optionally the block it is found in). Called with block data when
+     * transaction is included in a connected block, and without block data when
+     * transaction was accepted to mempool, removed from mempool (only when
+     * removal was due to conflict from connected block), or appeared in a
+     * disconnected block.*/
     boost::signals2::signal<void (const CTransaction &, const CBlockIndex *pindex, int posInBlock)> SyncTransaction;
     /** Notifies listeners of an updated transaction lock without new data. */
     boost::signals2::signal<void (const CTransaction &)> NotifyTransactionLock;

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -34,7 +34,7 @@ struct MainSignalsInstance {
      */
     boost::signals2::signal<void (const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex, const std::vector<CTransactionRef> &)> BlockConnected;
     /** Notifies listeners of a block being disconnected */
-    boost::signals2::signal<void (const std::shared_ptr<const CBlock> &)> BlockDisconnected;
+    boost::signals2::signal<void (const std::shared_ptr<const CBlock> &, int nBlockHeight)> BlockDisconnected;
     /** Notifies listeners of an updated transaction lock without new data. */
     boost::signals2::signal<void (const CTransaction &)> NotifyTransactionLock;
     /** Notifies listeners of an updated transaction without new data (for now: a coinbase potentially becoming visible). */
@@ -69,7 +69,7 @@ void RegisterValidationInterface(CValidationInterface* pwalletIn)
     conns.UpdatedBlockTip = g_signals.m_internals->UpdatedBlockTip.connect(std::bind(&CValidationInterface::UpdatedBlockTip, pwalletIn, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
     conns.TransactionAddedToMempool = g_signals.m_internals->TransactionAddedToMempool.connect(std::bind(&CValidationInterface::TransactionAddedToMempool, pwalletIn, std::placeholders::_1));
     conns.BlockConnected = g_signals.m_internals->BlockConnected.connect(std::bind(&CValidationInterface::BlockConnected, pwalletIn, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-    conns.BlockDisconnected = g_signals.m_internals->BlockDisconnected.connect(std::bind(&CValidationInterface::BlockDisconnected, pwalletIn, std::placeholders::_1));
+    conns.BlockDisconnected = g_signals.m_internals->BlockDisconnected.connect(std::bind(&CValidationInterface::BlockDisconnected, pwalletIn, std::placeholders::_1, std::placeholders::_2));
     conns.ChainTip = g_signals.m_internals->ChainTip.connect(std::bind(&CValidationInterface::ChainTip, pwalletIn, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
     conns.NotifyTransactionLock = g_signals.m_internals->NotifyTransactionLock.connect(std::bind(&CValidationInterface::NotifyTransactionLock, pwalletIn, std::placeholders::_1));
     conns.UpdatedTransaction = g_signals.m_internals->UpdatedTransaction.connect(std::bind(&CValidationInterface::UpdatedTransaction, pwalletIn, std::placeholders::_1));
@@ -105,8 +105,8 @@ void CMainSignals::BlockConnected(const std::shared_ptr<const CBlock> &block, co
     m_internals->BlockConnected(block, pindex, txnConflicted);
 }
 
-void CMainSignals::BlockDisconnected(const std::shared_ptr<const CBlock> &block) {
-    m_internals->BlockDisconnected(block);
+void CMainSignals::BlockDisconnected(const std::shared_ptr<const CBlock> &block, int nBlockHeight) {
+    m_internals->BlockDisconnected(block, nBlockHeight);
 }
 
 void CMainSignals::NotifyTransactionLock(const CTransaction& tx) {

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -19,7 +19,6 @@ struct ValidationInterfaceConnections {
     boost::signals2::scoped_connection SetBestChain;
     boost::signals2::scoped_connection Broadcast;
     boost::signals2::scoped_connection BlockChecked;
-    boost::signals2::scoped_connection BlockFound;
     boost::signals2::scoped_connection ChainTip;
 };
 
@@ -46,8 +45,6 @@ struct MainSignalsInstance {
     boost::signals2::signal<void (CConnman* connman)> Broadcast;
     /** Notifies listeners of a block validation result */
     boost::signals2::signal<void (const CBlock&, const CValidationState&)> BlockChecked;
-    /** Notifies listeners that a block has been successfully mined */
-    boost::signals2::signal<void (const uint256 &)> BlockFound;
 
     /** Notifies listeners of a change to the tip of the active block chain. */
     boost::signals2::signal<void (const CBlockIndex *, const CBlock *, Optional<SaplingMerkleTree>)> ChainTip;
@@ -79,7 +76,6 @@ void RegisterValidationInterface(CValidationInterface* pwalletIn)
     conns.SetBestChain = g_signals.m_internals->SetBestChain.connect(std::bind(&CValidationInterface::SetBestChain, pwalletIn, std::placeholders::_1));
     conns.Broadcast = g_signals.m_internals->Broadcast.connect(std::bind(&CValidationInterface::ResendWalletTransactions, pwalletIn, std::placeholders::_1));
     conns.BlockChecked = g_signals.m_internals->BlockChecked.connect(std::bind(&CValidationInterface::BlockChecked, pwalletIn, std::placeholders::_1, std::placeholders::_2));
-    conns.BlockFound = g_signals.m_internals->BlockFound.connect(std::bind(&CValidationInterface::ResetRequestCount, pwalletIn, std::placeholders::_1));
 }
 
 void UnregisterValidationInterface(CValidationInterface* pwalletIn)
@@ -131,10 +127,6 @@ void CMainSignals::Broadcast(CConnman* connman) {
 
 void CMainSignals::BlockChecked(const CBlock& block, const CValidationState& state) {
     m_internals->BlockChecked(block, state);
-}
-
-void CMainSignals::BlockFound(const uint256& hash) {
-    m_internals->BlockFound(hash);
 }
 
 void CMainSignals::ChainTip(const CBlockIndex* pindex, const CBlock* block, Optional<SaplingMerkleTree> tree) {

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -19,11 +19,10 @@ struct ValidationInterfaceConnections {
     boost::signals2::scoped_connection SetBestChain;
     boost::signals2::scoped_connection Broadcast;
     boost::signals2::scoped_connection BlockChecked;
-    boost::signals2::scoped_connection ChainTip;
 };
 
 struct MainSignalsInstance {
-// XX42    boost::signals2::signal<void(const uint256&)> EraseTransaction;
+
     /** Notifies listeners of updated block chain tip */
     boost::signals2::signal<void (const CBlockIndex *, const CBlockIndex *, bool fInitialDownload)> UpdatedBlockTip;
     /** Notifies listeners of a transaction having been added to mempool. */
@@ -46,9 +45,6 @@ struct MainSignalsInstance {
     /** Notifies listeners of a block validation result */
     boost::signals2::signal<void (const CBlock&, const CValidationState&)> BlockChecked;
 
-    /** Notifies listeners of a change to the tip of the active block chain. */
-    boost::signals2::signal<void (const CBlockIndex *, const CBlock *, Optional<SaplingMerkleTree>)> ChainTip;
-
     std::unordered_map<CValidationInterface*, ValidationInterfaceConnections> m_connMainSignals;
 };
 
@@ -70,7 +66,6 @@ void RegisterValidationInterface(CValidationInterface* pwalletIn)
     conns.TransactionAddedToMempool = g_signals.m_internals->TransactionAddedToMempool.connect(std::bind(&CValidationInterface::TransactionAddedToMempool, pwalletIn, std::placeholders::_1));
     conns.BlockConnected = g_signals.m_internals->BlockConnected.connect(std::bind(&CValidationInterface::BlockConnected, pwalletIn, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
     conns.BlockDisconnected = g_signals.m_internals->BlockDisconnected.connect(std::bind(&CValidationInterface::BlockDisconnected, pwalletIn, std::placeholders::_1, std::placeholders::_2));
-    conns.ChainTip = g_signals.m_internals->ChainTip.connect(std::bind(&CValidationInterface::ChainTip, pwalletIn, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
     conns.NotifyTransactionLock = g_signals.m_internals->NotifyTransactionLock.connect(std::bind(&CValidationInterface::NotifyTransactionLock, pwalletIn, std::placeholders::_1));
     conns.UpdatedTransaction = g_signals.m_internals->UpdatedTransaction.connect(std::bind(&CValidationInterface::UpdatedTransaction, pwalletIn, std::placeholders::_1));
     conns.SetBestChain = g_signals.m_internals->SetBestChain.connect(std::bind(&CValidationInterface::SetBestChain, pwalletIn, std::placeholders::_1));
@@ -127,8 +122,4 @@ void CMainSignals::Broadcast(CConnman* connman) {
 
 void CMainSignals::BlockChecked(const CBlock& block, const CValidationState& state) {
     m_internals->BlockChecked(block, state);
-}
-
-void CMainSignals::ChainTip(const CBlockIndex* pindex, const CBlock* block, Optional<SaplingMerkleTree> tree) {
-    m_internals->ChainTip(pindex, block, tree);
 }

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -43,7 +43,6 @@ protected:
     /** Tells listeners to broadcast their data. */
     virtual void ResendWalletTransactions(CConnman* connman) {}
     virtual void BlockChecked(const CBlock&, const CValidationState&) {}
-    virtual void ResetRequestCount(const uint256 &hash) {};
     friend void ::RegisterValidationInterface(CValidationInterface*);
     friend void ::UnregisterValidationInterface(CValidationInterface*);
     friend void ::UnregisterAllValidationInterfaces();
@@ -69,7 +68,6 @@ public:
     void SetBestChain(const CBlockLocator &);
     void Broadcast(CConnman* connman);
     void BlockChecked(const CBlock&, const CValidationState&);
-    void BlockFound(const uint256&);
     void ChainTip(const CBlockIndex *, const CBlock *, Optional<SaplingMerkleTree>);
 };
 

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -35,7 +35,6 @@ protected:
     virtual void TransactionAddedToMempool(const CTransactionRef &ptxn) {}
     virtual void BlockConnected(const std::shared_ptr<const CBlock> &block, const CBlockIndex *pindex, const std::vector<CTransactionRef> &txnConflicted) {}
     virtual void BlockDisconnected(const std::shared_ptr<const CBlock> &block, int nBlockHeight) {}
-    virtual void ChainTip(const CBlockIndex *pindex, const CBlock *pblock, Optional<SaplingMerkleTree> added) {}
     virtual void NotifyTransactionLock(const CTransaction &tx) {}
     /** Notifies listeners of the new active block chain on-disk. */
     virtual void SetBestChain(const CBlockLocator &locator) {}
@@ -68,7 +67,6 @@ public:
     void SetBestChain(const CBlockLocator &);
     void Broadcast(CConnman* connman);
     void BlockChecked(const CBlock&, const CValidationState&);
-    void ChainTip(const CBlockIndex *, const CBlock *, Optional<SaplingMerkleTree>);
 };
 
 CMainSignals& GetMainSignals();

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -34,7 +34,7 @@ protected:
     virtual void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) {}
     virtual void TransactionAddedToMempool(const CTransactionRef &ptxn) {}
     virtual void BlockConnected(const std::shared_ptr<const CBlock> &block, const CBlockIndex *pindex, const std::vector<CTransactionRef> &txnConflicted) {}
-    virtual void BlockDisconnected(const std::shared_ptr<const CBlock> &block) {}
+    virtual void BlockDisconnected(const std::shared_ptr<const CBlock> &block, int nBlockHeight) {}
     virtual void ChainTip(const CBlockIndex *pindex, const CBlock *pblock, Optional<SaplingMerkleTree> added) {}
     virtual void NotifyTransactionLock(const CTransaction &tx) {}
     /** Notifies listeners of the new active block chain on-disk. */
@@ -62,7 +62,7 @@ public:
     void UpdatedBlockTip(const CBlockIndex *, const CBlockIndex *, bool fInitialDownload);
     void TransactionAddedToMempool(const CTransactionRef &ptxn);
     void BlockConnected(const std::shared_ptr<const CBlock> &block, const CBlockIndex *pindex, const std::vector<CTransactionRef> &txnConflicted);
-    void BlockDisconnected(const std::shared_ptr<const CBlock> &block);
+    void BlockDisconnected(const std::shared_ptr<const CBlock> &block, int nBlockHeight);
     void NotifyTransactionLock(const CTransaction&);
     void UpdatedTransaction(const uint256 &);
     void SetBestChain(const CBlockLocator &);

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -59,7 +59,9 @@ private:
 public:
     CMainSignals();
 
-    /** A posInBlock value for SyncTransaction which indicates the transaction was conflicted, disconnected, or not in a block */
+    /** A posInBlock value for SyncTransaction calls for transactions not
+     * included in connected blocks such as transactions removed from mempool,
+     * accepted to mempool or appearing in disconnected blocks.*/
     static const int SYNC_TRANSACTION_NOT_IN_BLOCK = -1;
 
     void UpdatedBlockTip(const CBlockIndex *, const CBlockIndex *, bool fInitialDownload);

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -9,13 +9,12 @@
 
 #include "optional.h"
 #include "sapling/incrementalmerkletree.h"
+#include "primitives/transaction.h"
 
 class CBlock;
 struct CBlockLocator;
 class CBlockIndex;
 class CConnman;
-class CReserveScript;
-class CTransaction;
 class CValidationInterface;
 class CValidationState;
 class uint256;
@@ -33,7 +32,9 @@ class CValidationInterface {
 protected:
     /** Notifies listeners of updated block chain tip */
     virtual void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) {}
-    virtual void SyncTransaction(const CTransaction &tx, const CBlockIndex *pindex, int posInBlock) {}
+    virtual void TransactionAddedToMempool(const CTransactionRef &ptxn) {}
+    virtual void BlockConnected(const std::shared_ptr<const CBlock> &block, const CBlockIndex *pindex, const std::vector<CTransactionRef> &txnConflicted) {}
+    virtual void BlockDisconnected(const std::shared_ptr<const CBlock> &block) {}
     virtual void ChainTip(const CBlockIndex *pindex, const CBlock *pblock, Optional<SaplingMerkleTree> added) {}
     virtual void NotifyTransactionLock(const CTransaction &tx) {}
     /** Notifies listeners of the new active block chain on-disk. */
@@ -59,13 +60,10 @@ private:
 public:
     CMainSignals();
 
-    /** A posInBlock value for SyncTransaction calls for transactions not
-     * included in connected blocks such as transactions removed from mempool,
-     * accepted to mempool or appearing in disconnected blocks.*/
-    static const int SYNC_TRANSACTION_NOT_IN_BLOCK = -1;
-
     void UpdatedBlockTip(const CBlockIndex *, const CBlockIndex *, bool fInitialDownload);
-    void SyncTransaction(const CTransaction &, const CBlockIndex *pindex, int posInBlock);
+    void TransactionAddedToMempool(const CTransactionRef &ptxn);
+    void BlockConnected(const std::shared_ptr<const CBlock> &block, const CBlockIndex *pindex, const std::vector<CTransactionRef> &txnConflicted);
+    void BlockDisconnected(const std::shared_ptr<const CBlock> &block);
     void NotifyTransactionLock(const CTransaction&);
     void UpdatedTransaction(const uint256 &);
     void SetBestChain(const CBlockLocator &);

--- a/src/wallet/test/wallet_shielded_balances_tests.cpp
+++ b/src/wallet/test/wallet_shielded_balances_tests.cpp
@@ -348,7 +348,9 @@ BOOST_AUTO_TEST_CASE(GetShieldedAvailableCredit)
     // 2) Confirm the tx
     SaplingMerkleTree tree;
     FakeBlock fakeBlock = SimpleFakeMine(wtxUpdated, tree);
-    wallet.ChainTip(fakeBlock.pindex, &fakeBlock.block, tree);
+    // Simulate receiving a new block and updating the witnesses/nullifiers
+    wallet.IncrementNoteWitnesses(fakeBlock.pindex, &fakeBlock.block, tree);
+    wallet.GetSaplingScriptPubKeyMan()->UpdateSaplingNullifierNoteMapForBlock(&fakeBlock.block);
     wtxUpdated = wallet.mapWallet[wtxUpdated.GetHash()];
 
     // 3) Now can spend one output and recalculate the shielded credit.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1048,9 +1048,17 @@ void CWallet::AddExternalNotesDataToTx(CWalletTx& wtx) const
 }
 
 /**
- * Add a transaction to the wallet, or update it.
- * pblock is optional, but should be provided if the transaction is known to be in a block.
+ * Add a transaction to the wallet, or update it. pIndex and posInBlock should
+ * be set when the transaction was known to be included in a block.  When
+ * posInBlock = SYNC_TRANSACTION_NOT_IN_BLOCK (-1) , then wallet state is not
+ * updated in AddToWallet, but notifications happen and cached balances are
+ * marked dirty.
  * If fUpdate is true, existing transactions will be updated.
+ * TODO: One exception to this is that the abandoned state is cleared under the
+ * assumption that any further notification of a transaction that was considered
+ * abandoned is an indication that it is not safe to be considered abandoned.
+ * Abandoned state should probably be more carefully tracked via different
+ * posInBlock signals or by checking mempool presence when necessary.
  */
 bool CWallet::AddToWalletIfInvolvingMe(const CTransaction& tx, const uint256& blockHash, int posInBlock, bool fUpdate)
 {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1261,6 +1261,7 @@ void CWallet::TransactionAddedToMempool(const CTransactionRef& ptx)
 
 void CWallet::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex, const std::vector<CTransactionRef>& vtxConflicted)
 {
+    LOCK2(cs_main, cs_wallet);
     // TODO: Tempoarily ensure that mempool removals are notified before
     // connected transactions.  This shouldn't matter, but the abandoned
     // state of transactions in our wallet is currently cleared when we
@@ -1270,19 +1271,17 @@ void CWallet::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const 
     // the notification that the conflicted transaction was evicted.
 
     for (const CTransactionRef& ptx : vtxConflicted) {
-        LOCK2(cs_main, cs_wallet);
         SyncTransaction(ptx, NULL, -1);
     }
     for (size_t i = 0; i < pblock->vtx.size(); i++) {
-        LOCK2(cs_main, cs_wallet);
         SyncTransaction(pblock->vtx[i], pindex, i);
     }
 }
 
 void CWallet::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock)
 {
+    LOCK2(cs_main, cs_wallet);
     for (const CTransactionRef& ptx : pblock->vtx) {
-        LOCK2(cs_main, cs_wallet);
         SyncTransaction(ptx, NULL, -1);
     }
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1780,10 +1780,7 @@ void CWallet::ReacceptWalletTransactions(bool fFirstLoad)
 bool CWalletTx::InMempool() const
 {
     LOCK(mempool.cs);
-    if (mempool.exists(GetHash())) {
-        return true;
-    }
-    return false;
+    return mempool.exists(GetHash());
 }
 
 void CWalletTx::RelayWalletTransaction(CConnman* connman)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1240,13 +1240,51 @@ void CWallet::MarkConflicted(const uint256& hashBlock, const uint256& hashTx)
     }
 }
 
-void CWallet::SyncTransaction(const CTransaction& tx, const CBlockIndex *pindex, int posInBlock)
+void CWallet::SyncTransaction(const CTransactionRef& ptx, const CBlockIndex *pindexBlockConnected, int posInBlock)
 {
-    LOCK(cs_wallet);
-    if (!AddToWalletIfInvolvingMe(tx, (pindex) ? pindex->GetBlockHash() : uint256(), posInBlock, true))
+    const CTransaction& tx = *ptx;
+    if (!AddToWalletIfInvolvingMe(tx,
+                                  (pindexBlockConnected) ? pindexBlockConnected->GetBlockHash() : uint256(),
+                                  posInBlock,
+                                  true)) {
         return; // Not one of ours
+    }
 
     MarkAffectedTransactionsDirty(tx);
+}
+
+void CWallet::TransactionAddedToMempool(const CTransactionRef& ptx)
+{
+    LOCK2(cs_main, cs_wallet);
+    SyncTransaction(ptx, NULL, -1);
+}
+
+void CWallet::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex, const std::vector<CTransactionRef>& vtxConflicted)
+{
+    // TODO: Tempoarily ensure that mempool removals are notified before
+    // connected transactions.  This shouldn't matter, but the abandoned
+    // state of transactions in our wallet is currently cleared when we
+    // receive another notification and there is a race condition where
+    // notification of a connected conflict might cause an outside process
+    // to abandon a transaction and then have it inadvertantly cleared by
+    // the notification that the conflicted transaction was evicted.
+
+    for (const CTransactionRef& ptx : vtxConflicted) {
+        LOCK2(cs_main, cs_wallet);
+        SyncTransaction(ptx, NULL, -1);
+    }
+    for (size_t i = 0; i < pblock->vtx.size(); i++) {
+        LOCK2(cs_main, cs_wallet);
+        SyncTransaction(pblock->vtx[i], pindex, i);
+    }
+}
+
+void CWallet::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock)
+{
+    for (const CTransactionRef& ptx : pblock->vtx) {
+        LOCK2(cs_main, cs_wallet);
+        SyncTransaction(ptx, NULL, -1);
+    }
 }
 
 void CWallet::MarkAffectedTransactionsDirty(const CTransaction& tx)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4138,7 +4138,7 @@ void CWallet::postInitProcess(CScheduler& scheduler)
 
     // Run a thread to flush wallet periodically
     if (!CWallet::fFlushScheduled.exchange(true)) {
-        scheduler.scheduleEvery(MaybeFlushWalletDB, 500);
+        scheduler.scheduleEvery(MaybeCompactWalletDB, 500);
     }
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -445,18 +445,6 @@ void CWallet::ChainTipAdded(const CBlockIndex *pindex,
     m_sspk_man->UpdateSaplingNullifierNoteMapForBlock(pblock);
 }
 
-void CWallet::ChainTip(const CBlockIndex *pindex,
-                       const CBlock *pblock,
-                       Optional<SaplingMerkleTree> added)
-{
-    if (added) {
-        ChainTipAdded(pindex, pblock, added.get());
-    } else {
-        DecrementNoteWitnesses(pindex);
-        m_sspk_man->UpdateSaplingNullifierNoteMapForBlock(pblock);
-    }
-}
-
 void CWallet::SetBestChain(const CBlockLocator& loc)
 {
     CWalletDB walletdb(*dbw);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -301,6 +301,9 @@ private:
     void SyncMetaData(std::pair<typename TxSpendMap<T>::iterator, typename TxSpendMap<T>::iterator> range);
     void ChainTipAdded(const CBlockIndex *pindex, const CBlock *pblock, SaplingMerkleTree saplingTree);
 
+    /* Used by TransactionAddedToMemorypool/BlockConnected/Disconnected */
+    void SyncTransaction(const CTransactionRef& tx, const CBlockIndex *pindexBlockConnected, int posInBlock);
+
     bool IsKeyUsed(const CPubKey& vchPubKey);
 
     struct OutputAvailabilityResult
@@ -598,7 +601,9 @@ public:
     void MarkDirty();
     bool AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose = true);
     bool LoadToWallet(const CWalletTx& wtxIn);
-    void SyncTransaction(const CTransaction& tx, const CBlockIndex *pindex, int posInBlock);
+    void TransactionAddedToMempool(const CTransactionRef& tx) override;
+    void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex, const std::vector<CTransactionRef>& vtxConflicted) override;
+    void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock) override;
     bool AddToWalletIfInvolvingMe(const CTransaction& tx, const uint256& blockHash, int posInBlock, bool fUpdate);
     void EraseFromWallet(const uint256& hash);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -604,7 +604,7 @@ public:
     void TransactionAddedToMempool(const CTransactionRef& tx) override;
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex, const std::vector<CTransactionRef>& vtxConflicted) override;
     void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock) override;
-    bool AddToWalletIfInvolvingMe(const CTransaction& tx, const uint256& blockHash, int posInBlock, bool fUpdate);
+    bool AddToWalletIfInvolvingMe(const CTransactionRef& tx, const uint256& blockHash, int posInBlock, bool fUpdate);
     void EraseFromWallet(const uint256& hash);
 
     /**

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -554,7 +554,7 @@ public:
     //////////// End Sapling //////////////
 
     //! Adds a key to the store, and saves it to disk.
-    bool AddKeyPubKey(const CKey& key, const CPubKey& pubkey);
+    bool AddKeyPubKey(const CKey& key, const CPubKey& pubkey) override;
     //! Adds a key to the store, without saving it to disk (used by LoadWallet)
     bool LoadKey(const CKey& key, const CPubKey& pubkey) { return CCryptoKeyStore::AddKeyPubKey(key, pubkey); }
     //! Load metadata (used by LoadWallet)
@@ -563,10 +563,10 @@ public:
     bool LoadMinVersion(int nVersion);
 
     //! Adds an encrypted key to the store, and saves it to disk.
-    bool AddCryptedKey(const CPubKey& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret);
+    bool AddCryptedKey(const CPubKey& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret) override;
     //! Adds an encrypted key to the store, without saving it to disk (used by LoadWallet)
     bool LoadCryptedKey(const CPubKey& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret);
-    bool AddCScript(const CScript& redeemScript);
+    bool AddCScript(const CScript& redeemScript) override;
     bool LoadCScript(const CScript& redeemScript);
 
     //! Adds a destination data tuple to the store, and saves it to disk
@@ -577,8 +577,8 @@ public:
     bool LoadDestData(const CTxDestination& dest, const std::string& key, const std::string& value);
 
     //! Adds a watch-only address to the store, and saves it to disk.
-    bool AddWatchOnly(const CScript& dest);
-    bool RemoveWatchOnly(const CScript& dest);
+    bool AddWatchOnly(const CScript& dest) override;
+    bool RemoveWatchOnly(const CScript& dest) override;
     //! Adds a watch-only address to the store, without saving it to disk (used by LoadWallet)
     bool LoadWatchOnly(const CScript& dest);
 
@@ -615,7 +615,7 @@ public:
 
     int ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false, bool fromStartup = false);
     void ReacceptWalletTransactions(bool fFirstLoad = false);
-    void ResendWalletTransactions(CConnman* connman);
+    void ResendWalletTransactions(CConnman* connman) override;
 
     CAmount loopTxsBalance(std::function<void(const uint256&, const CWalletTx&, CAmount&)>method) const;
     CAmount GetAvailableBalance(bool fIncludeDelegated = true, bool fIncludeShielded = true) const;
@@ -727,9 +727,9 @@ public:
     //! Sapling merkle tree update
     void ChainTip(const CBlockIndex *pindex,
             const CBlock *pblock,
-            Optional<SaplingMerkleTree> added);
+            Optional<SaplingMerkleTree> added) override;
 
-    void SetBestChain(const CBlockLocator& loc);
+    void SetBestChain(const CBlockLocator& loc) override;
     void SetBestChainInternal(CWalletDB& walletdb, const CBlockLocator& loc); // only public for testing purposes, must never be called directly in any other situation
     // Force balance recomputation if any transaction got conflicted
     void MarkAffectedTransactionsDirty(const CTransaction& tx); // only public for testing purposes, must never be called directly in any other situation
@@ -753,7 +753,7 @@ public:
     void LoadAddressBookName(const CWDestination& dest, const std::string& strName);
     void LoadAddressBookPurpose(const CWDestination& dest, const std::string& strPurpose);
 
-    bool UpdatedTransaction(const uint256& hashTx);
+    bool UpdatedTransaction(const uint256& hashTx) override;
 
     unsigned int GetKeyPoolSize();
     unsigned int GetStakingKeyPoolSize();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -603,7 +603,7 @@ public:
     bool LoadToWallet(const CWalletTx& wtxIn);
     void TransactionAddedToMempool(const CTransactionRef& tx) override;
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex, const std::vector<CTransactionRef>& vtxConflicted) override;
-    void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock) override;
+    void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, int nBlockHeight) override;
     bool AddToWalletIfInvolvingMe(const CTransactionRef& tx, const uint256& blockHash, int posInBlock, bool fUpdate);
     void EraseFromWallet(const uint256& hash);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -44,8 +44,6 @@
 #include <utility>
 #include <vector>
 
-#include <boost/thread/thread.hpp>
-
 extern CWallet* pwalletMain;
 
 /**
@@ -94,6 +92,7 @@ class COutput;
 class CStakeableOutput;
 class CReserveKey;
 class CScript;
+class CScheduler;
 class CWalletTx;
 class ScriptPubKeyMan;
 class SaplingScriptPubKeyMan;
@@ -265,7 +264,7 @@ typedef std::map<SaplingOutPoint, SaplingNoteData> mapSaplingNoteData_t;
 class CWallet : public CCryptoKeyStore, public CValidationInterface
 {
 private:
-    static std::atomic<bool> fFlushThreadRunning;
+    static std::atomic<bool> fFlushScheduled;
 
     //! keeps track of whether Unlock has run a thorough check before
     bool fDecryptionThoroughlyChecked{false};
@@ -786,7 +785,7 @@ public:
      * Wallet post-init setup
      * Gives the wallet a chance to register repetitive tasks and complete post-init tasks
      */
-    void postInitProcess(boost::thread_group& threadGroup);
+    void postInitProcess(CScheduler& scheduler);
 
     /**
      * Address book entry changed.

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -724,11 +724,6 @@ public:
     CAmount GetCredit(const CWalletTx& tx, const isminefilter& filter) const;
     CAmount GetChange(const CTransaction& tx) const;
 
-    //! Sapling merkle tree update
-    void ChainTip(const CBlockIndex *pindex,
-            const CBlock *pblock,
-            Optional<SaplingMerkleTree> added) override;
-
     void SetBestChain(const CBlockLocator& loc) override;
     void SetBestChainInternal(CWalletDB& walletdb, const CBlockLocator& loc); // only public for testing purposes, must never be called directly in any other situation
     // Force balance recomputation if any transaction got conflicted

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -891,35 +891,31 @@ DBErrors CWalletDB::ZapWalletTx(CWallet* pwallet, std::vector<CWalletTx>& vWtx)
     return DB_LOAD_OK;
 }
 
-void ThreadFlushWalletDB()
+void MaybeFlushWalletDB()
 {
-    // Make this thread recognisable as the wallet flushing thread
-    util::ThreadRename("pivx-wallet");
-
-    static bool fOneThread;
-    if (fOneThread)
+    static std::atomic<bool> fOneThread;
+    if (fOneThread.exchange(true)) {
         return;
-    fOneThread = true;
-    if (!gArgs.GetBoolArg("-flushwallet", DEFAULT_FLUSHWALLET))
+    }
+    if (!gArgs.GetBoolArg("-flushwallet", DEFAULT_FLUSHWALLET)) {
         return;
+    }
 
-    unsigned int nLastSeen = CWalletDB::GetUpdateCounter();
-    unsigned int nLastFlushed = CWalletDB::GetUpdateCounter();
-    int64_t nLastWalletUpdate = GetTime();
-    while (true) {
-        MilliSleep(500);
+    static unsigned int nLastSeen = CWalletDB::GetUpdateCounter();
+    static unsigned int nLastFlushed = CWalletDB::GetUpdateCounter();
+    static int64_t nLastWalletUpdate = GetTime();
 
-        if (nLastSeen != CWalletDB::GetUpdateCounter()) {
-            nLastSeen = CWalletDB::GetUpdateCounter();
-            nLastWalletUpdate = GetTime();
-        }
+    if (nLastSeen != CWalletDB::GetUpdateCounter()) {
+        nLastSeen = CWalletDB::GetUpdateCounter();
+        nLastWalletUpdate = GetTime();
+    }
 
-        if (nLastFlushed != CWalletDB::GetUpdateCounter() && GetTime() - nLastWalletUpdate >= 2) {
-            if (CDB::PeriodicFlush(pwalletMain->GetDBHandle())) {
-                nLastFlushed = CWalletDB::GetUpdateCounter();
-            }
+    if (nLastFlushed != CWalletDB::GetUpdateCounter() && GetTime() - nLastWalletUpdate >= 2) {
+        if (CDB::PeriodicFlush(pwalletMain->GetDBHandle())) {
+            nLastFlushed = CWalletDB::GetUpdateCounter();
         }
     }
+    fOneThread = false;
 }
 
 void NotifyBacked(const CWallet& wallet, bool fSuccess, std::string strMessage)

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -891,7 +891,7 @@ DBErrors CWalletDB::ZapWalletTx(CWallet* pwallet, std::vector<CWalletTx>& vWtx)
     return DB_LOAD_OK;
 }
 
-void MaybeFlushWalletDB()
+void MaybeCompactWalletDB()
 {
     static std::atomic<bool> fOneThread;
     if (fOneThread.exchange(true)) {

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -230,6 +230,6 @@ void NotifyBacked(const CWallet& wallet, bool fSuccess, std::string strMessage);
 bool BackupWallet(const CWallet& wallet, const fs::path& strDest);
 bool AttemptBackupWallet(const CWallet& wallet, const fs::path& pathSrc, const fs::path& pathDest);
 
-void ThreadFlushWalletDB();
+void MaybeFlushWalletDB();
 
 #endif // BITCOIN_WALLETDB_H

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -230,6 +230,7 @@ void NotifyBacked(const CWallet& wallet, bool fSuccess, std::string strMessage);
 bool BackupWallet(const CWallet& wallet, const fs::path& strDest);
 bool AttemptBackupWallet(const CWallet& wallet, const fs::path& pathSrc, const fs::path& pathDest);
 
-void MaybeFlushWalletDB();
+//! Compacts BDB state so that wallet.dat is self-contained (if there are changes)
+void MaybeCompactWalletDB();
 
 #endif // BITCOIN_WALLETDB_H

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -145,8 +145,12 @@ void CZMQNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, co
     }
 }
 
-void CZMQNotificationInterface::SyncTransaction(const CTransaction& tx, const CBlockIndex* pindex, int posInBlock)
+void CZMQNotificationInterface::TransactionAddedToMempool(const CTransactionRef& ptx)
 {
+    // Used by BlockConnected and BlockDisconnected as well, because they're
+    // all the same external callback.
+    const CTransaction& tx = *ptx;
+
     for (std::list<CZMQAbstractNotifier*>::iterator i = notifiers.begin(); i!=notifiers.end(); )
     {
         CZMQAbstractNotifier *notifier = *i;
@@ -159,6 +163,22 @@ void CZMQNotificationInterface::SyncTransaction(const CTransaction& tx, const CB
             notifier->Shutdown();
             i = notifiers.erase(i);
         }
+    }
+}
+
+void CZMQNotificationInterface::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected, const std::vector<CTransactionRef>& vtxConflicted)
+{
+    for (const CTransactionRef& ptx : pblock->vtx) {
+        // Do a normal notify for each transaction added in the block
+        TransactionAddedToMempool(ptx);
+    }
+}
+
+void CZMQNotificationInterface::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock)
+{
+    for (const CTransactionRef& ptx : pblock->vtx) {
+        // Do a normal notify for each transaction removed in block disconnection
+        TransactionAddedToMempool(ptx);
     }
 }
 

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -174,7 +174,7 @@ void CZMQNotificationInterface::BlockConnected(const std::shared_ptr<const CBloc
     }
 }
 
-void CZMQNotificationInterface::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock)
+void CZMQNotificationInterface::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, int nBlockHeight)
 {
     for (const CTransactionRef& ptx : pblock->vtx) {
         // Do a normal notify for each transaction removed in block disconnection

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -8,6 +8,7 @@
 #include "validationinterface.h"
 #include <string>
 #include <map>
+#include <list>
 
 class CBlockIndex;
 class CZMQAbstractNotifier;

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -25,11 +25,11 @@ protected:
     void Shutdown();
 
     // CValidationInterface
-    void TransactionAddedToMempool(const CTransactionRef& tx);
-    void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected, const std::vector<CTransactionRef>& vtxConflicted);
-    void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock);
-    void NotifyTransactionLock(const CTransaction &tx);
-    void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload);
+    void TransactionAddedToMempool(const CTransactionRef& tx) override;
+    void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected, const std::vector<CTransactionRef>& vtxConflicted) override;
+    void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock) override;
+    void NotifyTransactionLock(const CTransaction &tx) override;
+    void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
 
 private:
     CZMQNotificationInterface();

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -27,7 +27,7 @@ protected:
     // CValidationInterface
     void TransactionAddedToMempool(const CTransactionRef& tx) override;
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected, const std::vector<CTransactionRef>& vtxConflicted) override;
-    void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock) override;
+    void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, int nBlockHeight) override;
     void NotifyTransactionLock(const CTransaction &tx) override;
     void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
 

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -25,7 +25,9 @@ protected:
     void Shutdown();
 
     // CValidationInterface
-    void SyncTransaction(const CTransaction& tx, const CBlockIndex *pindex, int posInBlock);
+    void TransactionAddedToMempool(const CTransactionRef& tx);
+    void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected, const std::vector<CTransactionRef>& vtxConflicted);
+    void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock);
     void NotifyTransactionLock(const CTransaction &tx);
     void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload);
 

--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -18,17 +18,20 @@ class NotificationsTest(PivxTestFramework):
         self.setup_clean_chain = True
 
     def setup_network(self):
-        self.alert_filename = os.path.join(self.options.tmpdir, "alert.txt")
-        self.block_filename = os.path.join(self.options.tmpdir, "blocks.txt")
-        self.tx_filename = os.path.join(self.options.tmpdir, "transactions.txt")
+        self.alertnotify_dir = os.path.join(self.options.tmpdir, "alertnotify")
+        self.blocknotify_dir = os.path.join(self.options.tmpdir, "blocknotify")
+        self.walletnotify_dir = os.path.join(self.options.tmpdir, "walletnotify")
+        os.mkdir(self.alertnotify_dir)
+        os.mkdir(self.blocknotify_dir)
+        os.mkdir(self.walletnotify_dir)
 
         # -alertnotify and -blocknotify on node0, walletnotify on node1
-        self.extra_args = [["-blockversion=4",
-                            "-alertnotify=echo %%s >> %s" % self.alert_filename,
-                            "-blocknotify=echo %%s >> %s" % self.block_filename],
+        self.extra_args = [["-blockversion=8",
+                            "-alertnotify=echo > {}".format(os.path.join(self.alertnotify_dir, '%s')),
+                            "-blocknotify=echo > {}".format(os.path.join(self.blocknotify_dir, '%s'))],
                            ["-blockversion=211",
                             "-rescan",
-                            "-walletnotify=echo %%s >> %s" % self.tx_filename]]
+                            "-walletnotify=echo > {}".format(os.path.join(self.walletnotify_dir, '%s'))]]
         super().setup_network()
 
     def run_test(self):
@@ -36,55 +39,50 @@ class NotificationsTest(PivxTestFramework):
         block_count = 10
         blocks = self.nodes[1].generate(block_count)
 
-        # wait at most 10 seconds for expected file size before reading the content
-        wait_until(lambda: os.path.isfile(self.block_filename) and os.stat(self.block_filename).st_size >= (block_count * 65), timeout=10)
+        # wait at most 10 seconds for expected number of files before reading the content
+        wait_until(lambda: len(os.listdir(self.blocknotify_dir)) == block_count, timeout=10)
 
-        # file content should equal the generated blocks hashes
-        with open(self.block_filename, 'r') as f:
-            assert_equal(sorted(blocks), sorted(f.read().splitlines()))
+        # directory content should equal the generated blocks hashes
+        assert_equal(sorted(blocks), sorted(os.listdir(self.blocknotify_dir)))
 
         self.log.info("test -walletnotify")
-        # wait at most 10 seconds for expected file size before reading the content
-        wait_until(lambda: os.path.isfile(self.tx_filename) and os.stat(self.tx_filename).st_size >= (block_count * 65), timeout=10)
+        # wait at most 10 seconds for expected number of files before reading the content
+        wait_until(lambda: len(os.listdir(self.walletnotify_dir)) == block_count, timeout=10)
 
-        # file content should equal the generated transaction hashes
+        # directory content should equal the generated transaction hashes
         txids_rpc = list(map(lambda t: t['txid'], self.nodes[1].listtransactions("*", block_count)))
-        with open(self.tx_filename, 'r') as f:
-            assert_equal(sorted(txids_rpc), sorted(f.read().splitlines()))
-        os.remove(self.tx_filename)
+        assert_equal(sorted(txids_rpc), sorted(os.listdir(self.walletnotify_dir)))
+        for tx_file in os.listdir(self.walletnotify_dir):
+            os.remove(os.path.join(self.walletnotify_dir, tx_file))
 
         self.log.info("test -walletnotify after rescan")
         # restart node to rescan to force wallet notifications
         self.restart_node(1)
         connect_nodes(self.nodes[0], 1)
 
-        wait_until(lambda: os.path.isfile(self.tx_filename) and os.stat(self.tx_filename).st_size >= (block_count * 65), timeout=10)
+        wait_until(lambda: len(os.listdir(self.walletnotify_dir)) == block_count, timeout=10)
 
-        # file content should equal the generated transaction hashes
+        # directory content should equal the generated transaction hashes
         txids_rpc = list(map(lambda t: t['txid'], self.nodes[1].listtransactions("*", block_count)))
-        with open(self.tx_filename, 'r') as f:
-            assert_equal(sorted(txids_rpc), sorted(f.read().splitlines()))
+        assert_equal(sorted(txids_rpc), sorted(os.listdir(self.walletnotify_dir)))
 
         # Mine another 41 up-version blocks. -alertnotify should trigger on the 51st.
         self.log.info("test -alertnotify")
         self.nodes[1].generate(51)
         self.sync_all()
 
-        # Give pivxd 10 seconds to write the alert notification
-        wait_until(lambda: os.path.isfile(self.alert_filename) and os.path.getsize(self.alert_filename), timeout=10)
+        # Give bitcoind 10 seconds to write the alert notification
+        wait_until(lambda: len(os.listdir(self.alertnotify_dir)), timeout=10)
 
-        with open(self.alert_filename, 'r', encoding='utf8') as f:
-            alert_text = f.read()
+        for notify_file in os.listdir(self.alertnotify_dir):
+            os.remove(os.path.join(self.alertnotify_dir, notify_file))
 
         # Mine more up-version blocks, should not get more alerts:
         self.nodes[1].generate(2)
         self.sync_all()
 
-        with open(self.alert_filename, 'r', encoding='utf8') as f:
-            alert_text2 = f.read()
-
         self.log.info("-alertnotify should not continue notifying for more unknown version blocks")
-        assert_equal(alert_text, alert_text2)
+        assert_equal(len(os.listdir(self.alertnotify_dir)), 0)
 
 if __name__ == '__main__':
     NotificationsTest().main()

--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -52,12 +52,13 @@ class NotificationsTest(PivxTestFramework):
         # directory content should equal the generated transaction hashes
         txids_rpc = list(map(lambda t: t['txid'], self.nodes[1].listtransactions("*", block_count)))
         assert_equal(sorted(txids_rpc), sorted(os.listdir(self.walletnotify_dir)))
+        self.stop_node(1)
         for tx_file in os.listdir(self.walletnotify_dir):
             os.remove(os.path.join(self.walletnotify_dir, tx_file))
 
         self.log.info("test -walletnotify after rescan")
         # restart node to rescan to force wallet notifications
-        self.restart_node(1)
+        self.start_node(1)
         connect_nodes(self.nodes[0], 1)
 
         wait_until(lambda: len(os.listdir(self.walletnotify_dir)) == block_count, timeout=10)


### PR DESCRIPTION
Revamped the validation interface interaction with the wallet, encapsulating and improving the mempool and block signaling and each of the wallet signals handler.
Restructured the Sapling witnesses and nullifiers update under the new signals.
Solved several bugs that found on the way as well (Check each commit description).

This PR concludes with #1726 long road :). Pushing our repository around 2 years ahead in btc time in the mempool and validation interface areas (without including RBF). 
The new validation -> wallet interaction architecture will enable further, and much more user facing important, improvements for the syncing process, overall software responsiveness and multithreading locking issues.

Adapted backports:
#6464 --> Always clean up manual transaction prioritization (mempool)
#9240 --> Remove txConflicted (mempool)
#9371 --> Notify on removal (mempool) 
#9605 --> Use CScheduler for wallet flushing, remove ThreadFlushWalletDB (walletdb)
#9725 --> CValidationInterface Cleanups (wallet, validation and validation interface)