### PR TITLE
[Tests] Don't create dust outputs in small_txpuzzle_randfee

### DIFF
--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -10,7 +10,7 @@ from test_framework.script import CScript, OP_1, OP_DROP, OP_2, OP_HASH160, OP_E
 from test_framework.mininode import CTransaction, CTxIn, CTxOut, COutPoint, ToHex, COIN
 
 # Use as minTxFee
-MIN_FEE = Decimal("0.0001")
+MIN_FEE = Decimal("0.00001")
 
 # Construct 2 trivial P2SH's and the ScriptSigs that spend them
 # So we can create many transactions without needing to spend
@@ -35,6 +35,9 @@ def small_txpuzzle_randfee(from_node, conflist, unconflist, amount, min_fee, fee
     It adds the newly created outputs to the unconfirmed list.
     Returns (raw transaction, fee)
     """
+    # Don't send dust (3 * dustRelayFee.GetFee(182))
+    DUST_THRESHOLD = 55
+    assert int(amount*COIN) > DUST_THRESHOLD
     # It's best to exponentially distribute our random fees
     # because the buckets are exponentially spaced.
     # Exponentially distributed from 1-128 * fee_increment
@@ -54,15 +57,24 @@ def small_txpuzzle_randfee(from_node, conflist, unconflist, amount, min_fee, fee
             tx.vin.append(CTxIn(COutPoint(int(t["txid"], 16), t["vout"]), b""))
         if total_in <= amount + fee:
             raise RuntimeError("Insufficient funds: need %d, have %d"%(amount+fee, total_in))
-    tx.vout.append(CTxOut(int((total_in - amount - fee)*COIN), P2SH_1))
-    tx.vout.append(CTxOut(int(amount*COIN), P2SH_2))
+
+    tx.vout.append(CTxOut(int(amount * COIN), P2SH_1))
+    # Prevent the creation of dust change outputs (otherwise add the change value to the fee)
+    change = int((total_in - amount - fee)*COIN)
+    if change > DUST_THRESHOLD:
+        tx.vout.append(CTxOut(change, P2SH_2))
+    else:
+        fee += change
+
     # These transactions don't need to be signed, but we still have to insert
     # the ScriptSig that will satisfy the ScriptPubKey.
     for inp in tx.vin:
         inp.scriptSig = SCRIPT_SIG[inp.prevout.n]
     txid = from_node.sendrawtransaction(ToHex(tx), True)
-    unconflist.append({ "txid" : txid, "vout" : 0 , "amount" : total_in - amount - fee})
-    unconflist.append({ "txid" : txid, "vout" : 1 , "amount" : amount})
+
+    unconflist.append({"txid": txid, "vout": 0, "amount": amount})
+    if change > DUST_THRESHOLD:
+        unconflist.append({ "txid" : txid, "vout" : 1 , "amount" : total_in - amount - fee})
 
     return (ToHex(tx), fee)
 


### PR DESCRIPTION
`small_txpuzzle_randfee` function (in `feature_fee_estimation` functional test) can rarely create raw transactions with dust outputs, which cause the test failure (https://github.com/PIVX-Project/PIVX/runs/1745765860).

Prevent this by checking the change value, and adding it to the fee, if it is below the threshold, same as we do in internally in `CWallet::CreateTransaction`.