### PR TITLE
[RPC] `validateaddress` remove duplicate return address value.

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -353,8 +353,6 @@ public:
 
     UniValue operator()(const CTxDestination &dest) const {
         UniValue ret(UniValue::VOBJ);
-        std::string currentAddress = EncodeDestination(dest, isStaking);
-        ret.pushKV("address", currentAddress);
         CScript scriptPubKey = GetScriptForDestination(dest);
         ret.pushKV("scriptPubKey", HexStr(scriptPubKey.begin(), scriptPubKey.end()));
 


### PR DESCRIPTION
Bug in `validateaddress`, is returning the address value twice for regular addresses. The first value is added before calling the visitor and the second one inside it.