### PR TITLE
[GUI] send widget, hide contacts menu when clear event is triggered.

### DIFF
--- a/src/qt/pivx/send.cpp
+++ b/src/qt/pivx/send.cpp
@@ -214,10 +214,18 @@ void SendWidget::loadWalletModel()
     }
 }
 
+void SendWidget::hideContactsMenu()
+{
+    if (menuContacts && menuContacts->isVisible()) {
+        menuContacts->hide();
+    }
+}
+
 void SendWidget::clearAll(bool fClearSettings)
 {
     onResetCustomOptions(false);
     if (fClearSettings) onResetSettings();
+    hideContactsMenu();
     clearEntries();
     refreshAmounts();
 }

--- a/src/qt/pivx/send.h
+++ b/src/qt/pivx/send.h
@@ -119,6 +119,7 @@ private:
     void setCoinControlPayAmounts();
     void resetCoinControl();
     void resetChangeAddress();
+    void hideContactsMenu();
 };
 
 #endif // SEND_H


### PR DESCRIPTION
Fixing crash reported in #2160 .

Inside the send screen the "clear all" event removes every row and there by every entry from the widget, as the contacts menu stores a local pointer to the entry where is being open and the data being pointed does't exist anymore, it was occasioning a crash there.
The solution is simple, close the menu contacts when the clear button is pressed.