### PR TITLE
[BUG] Flush the chainstate after pruning invalid entries.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1628,6 +1628,11 @@ bool AppInitMain()
                     if (fZerocoinActive && pblocktree->Read('M', nDummySupply)) {
                         LogPrintf("Pruning zerocoin mints / invalid outs, at height %d\n", chainHeight);
                         pcoinsTip->PruneInvalidEntries();
+                        if (!pcoinsTip->Flush()) {
+                            strLoadError = _("System error while flushing the chainstate after pruning invalid entries. Possible corrupt database.");
+                            break;
+                        }
+                        MoneySupply.Update(pcoinsTip->GetTotalAmount(), chainHeight);
                         pblocktree->Erase('M');
                     }
                 }


### PR DESCRIPTION
Fix an edge case where the 'M' key is removed from the blockTree DB but the chainstate still contains the invalid entries, due to it not being flushed after the update.