### PR TITLE
[Logs] Add new "sporks" debug logging category

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -125,6 +125,7 @@ const CLogCategoryDesc LogCategories[] = {
         {BCLog::LEGACYZC,       "zero"},
         {BCLog::MNPING,         "mnping"},
         {BCLog::SAPLING,        "sapling"},
+        {BCLog::SPORKS,         "sporks"},
         {BCLog::ALL,            "1"},
         {BCLog::ALL,            "all"},
 };

--- a/src/logging.h
+++ b/src/logging.h
@@ -64,6 +64,7 @@ namespace BCLog {
         MNPING      = (1 << 24),
         LEGACYZC    = (1 << 25),
         SAPLING     = (1 << 26),
+        SPORKS      = (1 << 27),
         ALL         = ~(uint32_t)0,
     };
 


### PR DESCRIPTION
The "net" category is overly cluttered right now, so this introduces a
new "sporks" logging category specifically intended to catch spork
message errors.