### PR TITLE
Better pivx.conf Masternode data error notification

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1817,7 +1817,7 @@ bool AppInitMain()
     if (fMasterNode) {
         LogPrintf("IS MASTER NODE\n");
         auto res = initMasternode(gArgs.GetArg("-masternodeprivkey", ""), gArgs.GetArg("-masternodeaddr", ""), true);
-        if (!res) UIError(res.getError());
+        if (!res) { return UIError(res.getError()); }
     }
 
     //get the mode of budget voting for this masternode


### PR DESCRIPTION
In case of pivxd, if there is for example an invalid masternode private key or an invalid masternode address we are only logging the error (In case of pivx-qt, a visual error popup notification is triggered).

This PR improves the Masternode data error detection exiting early at the node startup (same as we do on every other bad data provided by the user at startup).