### PR TITLE
[GUI] Prevent invalid dashboard txs list filter value loaded from settings

### DIFF
--- a/src/qt/pivx/dashboardwidget.cpp
+++ b/src/qt/pivx/dashboardwidget.cpp
@@ -185,10 +185,10 @@ void DashboardWidget::loadWalletModel()
 
         // Read filter settings
         QSettings settings;
-        int filterByType = settings.value("transactionType", TransactionFilterProxy::ALL_TYPES).toInt();
-
-        filter->setTypeFilter(filterByType); // Set filter
+        quint32 filterByType = settings.value("transactionType", TransactionFilterProxy::ALL_TYPES).toInt();
         int filterIndex = ui->comboBoxSortType->findData(filterByType); // Find index
+        filterByType = (filterIndex == -1) ? TransactionFilterProxy::ALL_TYPES : filterByType;
+        filter->setTypeFilter(filterByType); // Set filter
         ui->comboBoxSortType->setCurrentIndex(filterIndex); // Set item in ComboBox
 
         // Read sort settings


### PR DESCRIPTION
Guard against any not expected `transactionType` value retrieved from the setting that doesn't map to any available filter type.

Can be tested changing the value manually inside the settings file and starting the wallet again, the tx filter type combobox will be shown empty without this fix.