### PR TITLE
[GUI] Use wchar_t API explicitly on Windows

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -737,13 +737,13 @@ void AllocateFileRange(FILE* file, unsigned int offset, unsigned int length)
 #ifdef WIN32
 fs::path GetSpecialFolderPath(int nFolder, bool fCreate)
 {
-    char pszPath[MAX_PATH] = "";
+    WCHAR pszPath[MAX_PATH] = L"";
 
-    if (SHGetSpecialFolderPathA(NULL, pszPath, nFolder, fCreate)) {
+    if (SHGetSpecialFolderPathW(nullptr, pszPath, nFolder, fCreate)) {
         return fs::path(pszPath);
     }
 
-    LogPrintf("SHGetSpecialFolderPathA() failed, could not obtain requested path.\n");
+    LogPrintf("SHGetSpecialFolderPathW() failed, could not obtain requested path.\n");
     return fs::path("");
 }
 #endif


### PR DESCRIPTION
backport of https://github.com/bitcoin/bitcoin/pull/13734 to use the wchar API for windows startup function. This is the first in a long list of upstream PRs that aim to bring full Unicode support to Windows clients as detailed in https://github.com/bitcoin/bitcoin/issues/13869

Also included here is the relevant parts of https://github.com/bitcoin/bitcoin/pull/5793, to use per-network auto startup shortcuts.