### PR TITLE
[Test] Double spend inputs and notes unit tests coverage

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -95,6 +95,7 @@ BITCOIN_TESTS =\
   test/timedata_tests.cpp \
   test/torcontrol_tests.cpp \
   test/transaction_tests.cpp \
+  test/txvalidationcache_tests.cpp \
   test/uint256_tests.cpp \
   test/univalue_tests.cpp \
   test/util_tests.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -122,7 +122,8 @@ BITCOIN_TESTS += \
 SAPLING_TESTS +=\
   test/librust/sapling_rpc_wallet_tests.cpp \
   test/librust/sapling_wallet_tests.cpp \
-  wallet/test/wallet_shielded_balances_tests.cpp
+  wallet/test/wallet_shielded_balances_tests.cpp \
+  wallet/test/wallet_sapling_transactions_validations_tests.cpp
 endif
 
 test_test_pivx_SOURCES = $(BITCOIN_TEST_SUITE) $(BITCOIN_TESTS) $(SAPLING_TESTS) $(JSON_TEST_FILES) $(RAW_TEST_FILES)

--- a/src/blockassembler.cpp
+++ b/src/blockassembler.cpp
@@ -442,6 +442,12 @@ void BlockAssembler::addPriorityTxs()
 
 void BlockAssembler::appendSaplingTreeRoot()
 {
+    // Update header
+    pblock->hashFinalSaplingRoot = CalculateSaplingTreeRoot(pblock, nHeight, chainparams);
+}
+
+uint256 CalculateSaplingTreeRoot(CBlock* pblock, int nHeight, const CChainParams& chainparams)
+{
     if (NetworkUpgradeActive(nHeight, chainparams.GetConsensus(), Consensus::UPGRADE_V5_0)) {
         SaplingMerkleTree sapling_tree;
         assert(pcoinsTip->GetSaplingAnchorAt(pcoinsTip->GetBestAnchor(), sapling_tree));
@@ -454,9 +460,9 @@ void BlockAssembler::appendSaplingTreeRoot()
                 }
             }
         }
-        // Update header
-        pblock->hashFinalSaplingRoot = sapling_tree.root();
+        return sapling_tree.root();
     }
+    return UINT256_ZERO;
 }
 
 void IncrementExtraNonce(std::shared_ptr<CBlock>& pblock, const CBlockIndex* pindexPrev, unsigned int& nExtraNonce)

--- a/src/blockassembler.h
+++ b/src/blockassembler.h
@@ -100,4 +100,7 @@ int32_t ComputeBlockVersion(const Consensus::Params& consensusParams, int nHeigh
 // Visible for testing purposes only
 bool CreateCoinbaseTx(CBlock* pblock, const CScript& scriptPubKeyIn, CBlockIndex* pindexPrev);
 
+// Visible for testing purposes only
+uint256 CalculateSaplingTreeRoot(CBlock* pblock, int nHeight, const CChainParams& chainparams);
+
 #endif // PIVX_BLOCKASSEMBLER_H

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -136,6 +136,7 @@ set(BITCOIN_TESTS
         ${CMAKE_SOURCE_DIR}/src/wallet/test/wallet_tests.cpp
         ${CMAKE_SOURCE_DIR}/src/wallet/test/crypto_tests.cpp
         ${CMAKE_SOURCE_DIR}/src/wallet/test/wallet_shielded_balances_tests.cpp
+        ${CMAKE_SOURCE_DIR}/src/wallet/test/wallet_sapling_transactions_validations_tests.cpp
         )
 
 set(test_test_pivx_SOURCES ${BITCOIN_TEST_SUITE} ${BITCOIN_TESTS} ${JSON_TEST_FILES})

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -125,6 +125,7 @@ set(BITCOIN_TESTS
         ${CMAKE_CURRENT_SOURCE_DIR}/timedata_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/torcontrol_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/transaction_tests.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/txvalidationcache_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/uint256_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/univalue_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/util_tests.cpp

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -1,0 +1,89 @@
+// Copyright (c) 2011-2015 The Bitcoin Core developers
+// Copyright (c) 2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include "test/test_pivx.h"
+
+#include "consensus/validation.h"
+#include "pubkey.h"
+#include "random.h"
+#include "script/standard.h"
+#include "utiltime.h"
+#include "validation.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(tx_validationcache_tests)
+
+static bool ToMemPool(CMutableTransaction& tx)
+{
+    LOCK(cs_main);
+    CValidationState state;
+    return AcceptToMemoryPool(mempool, state, MakeTransactionRef(tx), false, nullptr, true, false, false);
+}
+
+BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain100Setup)
+{
+    // Make sure skipping validation of transactions that were
+    // validated going into the memory pool does not allow
+    // double-spends in blocks to pass validation when they should not.
+
+    CScript scriptPubKey = CScript() <<  ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG;
+
+    // Create a double-spend of mature coinbase txn:
+    std::vector<CMutableTransaction> spends;
+    spends.resize(2);
+    for (int i = 0; i < 2; i++)
+    {
+        spends[i].nVersion = 1;
+        spends[i].vin.resize(1);
+        spends[i].vin[0].prevout.hash = coinbaseTxns[0].GetHash();
+        spends[i].vin[0].prevout.n = 0;
+        spends[i].vout.resize(1);
+        spends[i].vout[0].nValue = 11*CENT;
+        spends[i].vout[0].scriptPubKey = scriptPubKey;
+
+        // Sign:
+        std::vector<unsigned char> vchSig;
+        uint256 hash = SignatureHash(scriptPubKey, spends[i], 0, SIGHASH_ALL, 0, SIGVERSION_BASE);
+        BOOST_CHECK(coinbaseKey.Sign(hash, vchSig));
+        vchSig.push_back((unsigned char)SIGHASH_ALL);
+        spends[i].vin[0].scriptSig << vchSig;
+    }
+
+    const uint256& tipHash = chainActive.Tip()->GetBlockHash();
+    CBlock block;
+
+    // Test 1: block with both of those transactions should be rejected.
+    block = CreateAndProcessBlock(spends, scriptPubKey);
+    BOOST_CHECK(chainActive.Tip()->GetBlockHash() != block.GetHash());
+    BOOST_CHECK(chainActive.Tip()->GetBlockHash() == tipHash);
+
+    // Test 2: ... and should be rejected if spend1 is in the memory pool
+    BOOST_CHECK(ToMemPool(spends[0]));
+    block = CreateAndProcessBlock(spends, scriptPubKey);
+    BOOST_CHECK(chainActive.Tip()->GetBlockHash() != block.GetHash());
+    BOOST_CHECK(chainActive.Tip()->GetBlockHash() == tipHash);
+    mempool.clear();
+
+    // Test 3: ... and should be rejected if spend2 is in the memory pool
+    BOOST_CHECK(ToMemPool(spends[1]));
+    SetMockTime(GetTime() + 60); // to generate a different block hash
+    block = CreateAndProcessBlock(spends, scriptPubKey);
+    BOOST_CHECK(chainActive.Tip()->GetBlockHash() != block.GetHash());
+    BOOST_CHECK(chainActive.Tip()->GetBlockHash() == tipHash);
+    mempool.clear();
+
+    // Final sanity test: first spend in mempool, second in block, that's OK:
+    std::vector<CMutableTransaction> oneSpend;
+    oneSpend.push_back(spends[0]);
+    BOOST_CHECK(ToMemPool(spends[1]));
+    block = CreateAndProcessBlock(oneSpend, scriptPubKey);
+    BOOST_CHECK(chainActive.Tip()->GetBlockHash() == block.GetHash());
+    // spends[1] should have been removed from the mempool when the
+    // block with spends[0] is accepted:
+    BOOST_CHECK_EQUAL(mempool.size(), 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/test/wallet_sapling_transactions_validations_tests.cpp
+++ b/src/wallet/test/wallet_sapling_transactions_validations_tests.cpp
@@ -1,0 +1,153 @@
+// Copyright (c) 2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include "wallet/test/wallet_test_fixture.h"
+
+#include "blockassembler.h"
+#include "consensus/merkle.h"
+#include "primitives/block.h"
+#include "sapling/transaction_builder.h"
+#include "sapling/sapling_operation.h"
+#include "wallet/wallet.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(wallet_sapling_transactions_validations_tests, WalletTestingSetup)
+
+void setupWallet()
+{
+    LOCK(pwalletMain->cs_wallet);
+    pwalletMain->SetMinVersion(FEATURE_SAPLING);
+    gArgs.ForceSetArg("-keypool", "5");
+    pwalletMain->SetupSPKM(true);
+}
+
+void generateBlock(const CScript& scriptPubKey, int expectedBlockHeight)
+{
+    std::unique_ptr<CBlockTemplate> pblocktemplate;
+    BOOST_CHECK(pblocktemplate = BlockAssembler(Params(), false).CreateNewBlock(scriptPubKey, pwalletMain, false));
+    std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>(pblocktemplate->block);
+    pblock->nTime = WITH_LOCK(cs_main, return chainActive.Tip()->GetMedianTimePast() + 60);
+    pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
+    CValidationState state;
+    BOOST_CHECK_MESSAGE(ProcessNewBlock(state, nullptr, pblock, nullptr), strprintf("Failed creating block at height %d", expectedBlockHeight));
+    BOOST_CHECK(state.IsValid());
+}
+
+SaplingOperation createOperationAndBuildTx(std::vector<SendManyRecipient> recipients,
+                                           int nextBlockHeight,
+                                           bool selectTransparentCoins)
+{
+    // Create the operation
+    TransactionBuilder txBuilder = TransactionBuilder(Params().GetConsensus(), nextBlockHeight, pwalletMain);
+    SaplingOperation operation(txBuilder);
+    auto operationResult = operation.setRecipients(recipients)
+            ->setSelectTransparentCoins(selectTransparentCoins)
+            ->setSelectShieldedCoins(!selectTransparentCoins)
+            ->build();
+    BOOST_ASSERT_MSG(operationResult, operationResult.getError().c_str());
+
+    CValidationState state;
+    BOOST_ASSERT_MSG(
+            CheckTransaction(operation.getFinalTx(), true, true, state, true, false, true),
+            "Invalid Sapling transaction");
+    return operation;
+}
+
+// Test double spend notes in the mempool and in blocks.
+BOOST_AUTO_TEST_CASE(test_in_block_and_mempool_notes_double_spend)
+{
+    SelectParams(CBaseChainParams::REGTEST);
+    int SAPLING_ACTIVATION_HEIGHT = 99;
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_V5_0, SAPLING_ACTIVATION_HEIGHT);
+    setupWallet();
+
+    CTxDestination coinbaseDest;
+    auto ret = pwalletMain->getNewAddress(coinbaseDest, "coinbase");
+    BOOST_ASSERT_MSG(ret.result, "cannot create address");
+    BOOST_ASSERT_MSG(IsValidDestination(coinbaseDest), "invalid destination");
+    BOOST_ASSERT_MSG(IsMine(*pwalletMain, coinbaseDest), "destination not from wallet");
+
+    // create the chain
+    const CScript& scriptPubKey = GetScriptForDestination(coinbaseDest);
+    int nGenerateBlocks = 110;
+    for (int i = 0; i < nGenerateBlocks; ++i) {
+        generateBlock(scriptPubKey, (int) i);
+    }
+
+    // Verify that we are at block 110
+    int tipHeight = WITH_LOCK(cs_main, return chainActive.Tip()->nHeight);
+    BOOST_CHECK_EQUAL(tipHeight, nGenerateBlocks);
+    // Verify that the wallet has all of the coins
+    BOOST_CHECK_EQUAL(pwalletMain->GetAvailableBalance(), CAmount(250 * COIN * 10)); // 10 blocks available
+    BOOST_CHECK_EQUAL(pwalletMain->GetImmatureBalance(), CAmount(250 * COIN * 100)); // 100 blocks immature
+
+    // Now that we have the chain, let's shield 100 PIVs
+    // single recipient
+    std::vector<SendManyRecipient> recipients;
+    libzcash::SaplingPaymentAddress pa = pwalletMain->GenerateNewSaplingZKey("sapling1");
+    recipients.emplace_back(pa, CAmount(100 * COIN), "");
+
+    // Create the operation and build the transaction
+    SaplingOperation operation = createOperationAndBuildTx(recipients, tipHeight + 1, true);
+    // broadcast the tx to the network
+    std::string retHash;
+    BOOST_ASSERT_MSG(operation.send(retHash), "error committing and broadcasting the transaction");
+
+    // Generate a five blocks to fully confirm the tx and test balance
+    for (int i = 0; i < 5; ++i) { generateBlock(scriptPubKey, WITH_LOCK(cs_main, return chainActive.Tip()->nHeight + 1)); }
+    BOOST_CHECK_EQUAL(pwalletMain->GetAvailableShieldedBalance(), CAmount(100 * COIN)); // 100 shield PIVs
+    BOOST_CHECK_EQUAL(pwalletMain->GetUnconfirmedShieldedBalance(), CAmount(0)); // 0 shield PIVs
+
+    // ##############################################
+    // Context set!
+    // Now let's try to double spend the same note twice in the same block
+
+    // first generate a valid tx spending only one note
+    // Create the operation and build the transaction
+    CTxDestination tDest2;
+    pwalletMain->getNewAddress(tDest2, "receiveValid");
+    std::vector<SendManyRecipient> recipients2;
+    recipients2.emplace_back(tDest2, CAmount(90 * COIN));
+    SaplingOperation operation2 = createOperationAndBuildTx(recipients2, tipHeight + 1, false);
+
+    // Create a second transaction that spends the same note with a different output now
+    CTxDestination tDest3;
+    pwalletMain->getNewAddress(tDest3, "receiveInvalid");
+    std::vector<SendManyRecipient> recipients3;
+    recipients3.emplace_back(tDest3, CAmount(5 * COIN));
+    SaplingOperation operation3 = createOperationAndBuildTx(recipients3, tipHeight + 1, false);
+
+    // Now that both transactions were created, broadcast the first one
+    std::string retTxHash2;
+    BOOST_CHECK(operation2.send(retTxHash2));
+
+    // Now broadcast the second one, this one should fail when tried to enter in the mempool as there is already another note spending the same nullifier
+    std::string retTxHash3;
+    auto opResult3 = operation3.send(retTxHash3);
+    BOOST_CHECK(!opResult3);
+    BOOST_CHECK(opResult3.getError().find("bad-txns-nullifier-double-spent"));
+
+    // let's now test it inside a block
+    // create the block with the two transactions and test validity
+    std::unique_ptr<CBlockTemplate> pblocktemplate;
+    BOOST_CHECK(pblocktemplate = BlockAssembler(Params(), false).CreateNewBlock(scriptPubKey, pwalletMain, false));
+    std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>(pblocktemplate->block);
+    pblock->nTime = WITH_LOCK(cs_main, return chainActive.Tip()->GetMedianTimePast() + 60);
+    pblock->vtx.emplace_back(MakeTransactionRef(operation3.getFinalTx())); // Force the invalid tx append
+    pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
+    pblock->hashFinalSaplingRoot = CalculateSaplingTreeRoot(pblock.get(), 116, Params());
+    CValidationState state;
+    ProcessNewBlock(state, nullptr, pblock, nullptr);
+    BOOST_CHECK(state.IsValid());
+
+    {
+        LOCK(cs_main);
+        // Same tip as before, no block connection
+        BOOST_CHECK(chainActive.Tip()->GetBlockHash() != pblock->GetHash());
+        BOOST_ASSERT_MSG(chainActive.Tip()->nHeight, 115);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Added unit test coverage for double spend inputs and double spend notes in the mempool and in new blocks.