### PR TITLE
[BUG][GUI] Fix CWalletTx* casts to CTransaction*

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -499,9 +499,8 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(WalletModelTransaction& tran
             return SendCoinsReturn(res);
         }
 
-        CTransaction* t = (CTransaction*)newTx;
         CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
-        ssTx << *t;
+        ssTx << *(newTx->tx);
         transaction_array.append(&(ssTx[0]), ssTx.size());
     }
 

--- a/src/qt/walletmodeltransaction.cpp
+++ b/src/qt/walletmodeltransaction.cpp
@@ -38,7 +38,7 @@ void WalletModelTransaction::setTransaction(CWalletTx* tx)
 
 unsigned int WalletModelTransaction::getTransactionSize()
 {
-    return (!walletTransaction ? 0 : (::GetSerializeSize(*(CTransaction*)walletTransaction, SER_NETWORK, PROTOCOL_VERSION)));
+    return (!walletTransaction ? 0 : (::GetSerializeSize(*(walletTransaction->tx), SER_NETWORK, PROTOCOL_VERSION)));
 }
 
 CAmount WalletModelTransaction::getTransactionFee()


### PR DESCRIPTION
Fix random GUI segfault during send.
Since #2044 , we cannot cast `CWalletTx*` directly to `CTransaction*` (as `CMerkleTx` no longer inherits from `CTransaction`).
We must use the `CTransactionRef` stored within it.