### PR TITLE
[Refactoring] Remove BaseOutPoint::GetHash

### DIFF
--- a/src/budget/budgetproposal.cpp
+++ b/src/budget/budgetproposal.cpp
@@ -215,11 +215,11 @@ bool CBudgetProposal::IsPassing(int nBlockStartBudget, int nBlockEndBudget, int 
 bool CBudgetProposal::AddOrUpdateVote(const CBudgetVote& vote, std::string& strError)
 {
     std::string strAction = "New vote inserted:";
-    const uint256& hash = vote.GetVin().prevout.GetHash();
+    const COutPoint& mnId = vote.GetVin().prevout;
     const int64_t voteTime = vote.GetTime();
 
-    if (mapVotes.count(hash)) {
-        const int64_t& oldTime = mapVotes[hash].GetTime();
+    if (mapVotes.count(mnId)) {
+        const int64_t& oldTime = mapVotes[mnId].GetTime();
         if (oldTime > voteTime) {
             strError = strprintf("new vote older than existing vote - %s\n", vote.GetHash().ToString());
             LogPrint(BCLog::MNBUDGET, "%s: %s\n", __func__, strError);
@@ -240,7 +240,7 @@ bool CBudgetProposal::AddOrUpdateVote(const CBudgetVote& vote, std::string& strE
         return false;
     }
 
-    mapVotes[hash] = vote;
+    mapVotes[mnId] = vote;
     LogPrint(BCLog::MNBUDGET, "%s: %s %s\n", __func__, strAction.c_str(), vote.GetHash().ToString().c_str());
 
     return true;
@@ -271,10 +271,10 @@ void CBudgetProposal::SetSynced(bool synced)
 void CBudgetProposal::CleanAndRemove()
 {
     LogPrint(BCLog::MNBUDGET, "Cleaning budget votes for %s. Before: YES=%d, NO=%d\n", GetName(), GetYeas(), GetNays());
-    std::map<uint256, CBudgetVote>::iterator it = mapVotes.begin();
+    auto it = mapVotes.begin();
 
     while (it != mapVotes.end()) {
-        CMasternode* pmn = mnodeman.Find(it->second.GetVin().prevout);
+        CMasternode* pmn = mnodeman.Find(it->first);
         (*it).second.SetValid(pmn != nullptr);
         ++it;
     }

--- a/src/budget/budgetproposal.cpp
+++ b/src/budget/budgetproposal.cpp
@@ -306,7 +306,7 @@ std::vector<uint256> CBudgetProposal::GetVotesHashes() const
 {
     std::vector<uint256> vRet;
     for (const auto& it: mapVotes) {
-        vRet.push_back(it.first);
+        vRet.push_back(it.second.GetHash());
     }
     return vRet;
 }

--- a/src/budget/budgetproposal.h
+++ b/src/budget/budgetproposal.h
@@ -34,7 +34,7 @@ private:
     bool CheckAddress();
 
 protected:
-    std::map<uint256, CBudgetVote> mapVotes;
+    std::map<COutPoint, CBudgetVote> mapVotes;
     std::string strProposalName;
     std::string strURL;
     int nBlockStart;

--- a/src/budget/budgetvote.cpp
+++ b/src/budget/budgetvote.cpp
@@ -53,8 +53,8 @@ std::string CBudgetVote::GetStrMessage() const
 UniValue CBudgetVote::ToJSON() const
 {
     UniValue bObj(UniValue::VOBJ);
-    bObj.pushKV("mnId", vin.prevout.hash.ToString());
-    bObj.pushKV("nHash", vin.prevout.GetHash().ToString());
+    bObj.pushKV("mnId", vin.prevout.ToStringShort());
+    bObj.pushKV("nHash", GetHash().ToString());
     bObj.pushKV("Vote", GetVoteString());
     bObj.pushKV("nTime", nTime);
     bObj.pushKV("fValid", fValid);

--- a/src/budget/finalizedbudget.cpp
+++ b/src/budget/finalizedbudget.cpp
@@ -53,12 +53,12 @@ bool CFinalizedBudget::ParseBroadcast(CDataStream& broadcast)
 
 bool CFinalizedBudget::AddOrUpdateVote(const CFinalizedBudgetVote& vote, std::string& strError)
 {
-    const uint256& hash = vote.GetVin().prevout.GetHash();
+    const COutPoint& mnId = vote.GetVin().prevout;
     const int64_t voteTime = vote.GetTime();
     std::string strAction = "New vote inserted:";
 
-    if (mapVotes.count(hash)) {
-        const int64_t oldTime = mapVotes[hash].GetTime();
+    if (mapVotes.count(mnId)) {
+        const int64_t oldTime = mapVotes[mnId].GetTime();
         if (oldTime > voteTime) {
             strError = strprintf("new vote older than existing vote - %s\n", vote.GetHash().ToString());
             LogPrint(BCLog::MNBUDGET, "%s: %s\n", __func__, strError);
@@ -80,7 +80,7 @@ bool CFinalizedBudget::AddOrUpdateVote(const CFinalizedBudgetVote& vote, std::st
         return false;
     }
 
-    mapVotes[hash] = vote;
+    mapVotes[mnId] = vote;
     LogPrint(BCLog::MNBUDGET, "%s: %s %s\n", __func__, strAction.c_str(), vote.GetHash().ToString().c_str());
     return true;
 }
@@ -166,10 +166,10 @@ bool CFinalizedBudget::CheckProposals(const std::map<uint256, CBudgetProposal>& 
 // Remove votes from masternodes which are not valid/existent anymore
 void CFinalizedBudget::CleanAndRemove()
 {
-    std::map<uint256, CFinalizedBudgetVote>::iterator it = mapVotes.begin();
+    auto it = mapVotes.begin();
 
     while (it != mapVotes.end()) {
-        CMasternode* pmn = mnodeman.Find(it->second.GetVin().prevout);
+        CMasternode* pmn = mnodeman.Find(it->first);
         (*it).second.SetValid(pmn != nullptr);
         ++it;
     }

--- a/src/budget/finalizedbudget.cpp
+++ b/src/budget/finalizedbudget.cpp
@@ -289,7 +289,7 @@ std::vector<uint256> CFinalizedBudget::GetVotesHashes() const
 {
     std::vector<uint256> vRet;
     for (const auto& it: mapVotes) {
-        vRet.push_back(it.first);
+        vRet.push_back(it.second.GetHash());
     }
     return vRet;
 }

--- a/src/budget/finalizedbudget.h
+++ b/src/budget/finalizedbudget.h
@@ -40,7 +40,7 @@ private:
     bool CheckName();
 
 protected:
-    std::map<uint256, CFinalizedBudgetVote> mapVotes;
+    std::map<COutPoint, CFinalizedBudgetVote> mapVotes;
     std::string strBudgetName;
     int nBlockStart;
     std::vector<CTxBudgetPayment> vecBudgetPayments;

--- a/src/budget/finalizedbudgetvote.cpp
+++ b/src/budget/finalizedbudgetvote.cpp
@@ -44,7 +44,7 @@ uint256 CFinalizedBudgetVote::GetHash() const
 UniValue CFinalizedBudgetVote::ToJSON() const
 {
     UniValue bObj(UniValue::VOBJ);
-    bObj.pushKV("nHash", vin.prevout.GetHash().ToString());
+    bObj.pushKV("nHash", GetHash().ToString());
     bObj.pushKV("nTime", (int64_t) nTime);
     bObj.pushKV("fValid", fValid);
     return bObj;

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -20,11 +20,6 @@ std::string BaseOutPoint::ToStringShort() const
     return strprintf("%s-%u", hash.ToString().substr(0,64), n);
 }
 
-uint256 BaseOutPoint::GetHash() const
-{
-    return Hash(BEGIN(hash), END(hash), BEGIN(n), END(n));
-}
-
 std::string COutPoint::ToString() const
 {
     return strprintf("COutPoint(%s, %u)", hash.ToString().substr(0,10), n);

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -74,8 +74,6 @@ public:
 
     size_t DynamicMemoryUsage() const { return 0; }
 
-    uint256 GetHash() const;
-
 };
 
 /** An outpoint - a combination of a transaction hash and an index n into its vout */

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -481,7 +481,7 @@ UniValue getbudgetvotes(const JSONRPCRequest& request)
             "\nResult:\n"
             "[\n"
             "  {\n"
-            "    \"mnId\": \"xxxx\",        (string) Hash of the masternode's collateral transaction\n"
+            "    \"mnId\": \"xxxx-x\",      (string) Masternode's outpoint collateral transaction (hash-n)\n"
             "    \"nHash\": \"xxxx\",       (string) Hash of the vote\n"
             "    \"Vote\": \"YES|NO\",      (string) Vote cast ('YES' or 'NO')\n"
             "    \"nTime\": xxxx,         (numeric) Time in seconds since epoch the vote was cast\n"

--- a/test/functional/tiertwo_governance_sync_basic.py
+++ b/test/functional/tiertwo_governance_sync_basic.py
@@ -56,7 +56,7 @@ class MasternodeGovernanceBasicTest(PivxTier2TestFramework):
             assert(len(votesInfo) > 0)
             found = False
             for voteInfo in votesInfo:
-                if (voteInfo["mnId"] == mnCollateralHash) :
+                if (voteInfo["mnId"].split("-")[0] == mnCollateralHash) :
                     assert_equal(voteInfo["Vote"], voteType)
                     found = True
             assert_true(found, "Error checking vote existence in node " + str(i))


### PR DESCRIPTION
`BaseOutPoint` has a member variable named `hash`, but `GetHash()` does not return its value. 
It returns the hash of the serialized class (`hash` and `n`) instead. 
This is confusing and might lead to sneaky bugs (in fact, it already did in the past: https://github.com/PIVX-Project/PIVX/pull/1963#discussion_r530033452)

Further, the implementation of `GetHash()` is rather ugly, as it accesses the singleton pointer `&this->n` as an array (with `BEGIN()`/`END()`), which could result in misinterpretation or corruption of adjacent memory locations.

This function is used only in two places:
- in the RPC `getbudgetvotes` for the key `"nHash"`. This is wrong, as nHash is supposed to be the **vote** hash (as described in the help), and not the collateral outpoint hash.
- to index `mapVotes` inside budgets and proposal objects. Here we can just index directly by collateral outpoint (instead of its hash).

With these two changes, we can get rid of `BaseOutPoint::GetHash`.
This also fixes another bug fund along the way: `CBP/CFB::GetVotesHashes` should return the vote hashes, not the masternode collateral hash.

Note: `mapVotes` is not directly sent on the network, it is only stored locally for each proposal.