### PR TITLE
[Refactoring] Sapling classes - initialize fields and pass parameters by reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,4 @@ ui_*
 build*
 pivxd.*
 pivxd-new-gui.*
+/cov-int/

--- a/src/sapling/address.h
+++ b/src/sapling/address.h
@@ -24,11 +24,11 @@ const size_t SerializedSaplingSpendingKeySize = 32;
 //! Sapling functions.
 class SaplingPaymentAddress {
 public:
-    diversifier_t d;
-    uint256 pk_d;
+    diversifier_t d = {{0}};
+    uint256 pk_d{UINT256_ZERO};
 
-    SaplingPaymentAddress() : d(), pk_d() { }
-    SaplingPaymentAddress(diversifier_t _d, uint256 _pk_d) : d(_d), pk_d(_pk_d) { }
+    SaplingPaymentAddress() {}
+    SaplingPaymentAddress(const diversifier_t& _d, const uint256& _pk_d) : d(_d), pk_d(_pk_d) { }
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/sapling/address.h
+++ b/src/sapling/address.h
@@ -28,7 +28,7 @@ public:
     uint256 pk_d;
 
     SaplingPaymentAddress() : d(), pk_d() { }
-    SaplingPaymentAddress(diversifier_t d, uint256 pk_d) : d(d), pk_d(pk_d) { }
+    SaplingPaymentAddress(diversifier_t _d, uint256 _pk_d) : d(_d), pk_d(_pk_d) { }
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/sapling/note.cpp
+++ b/src/sapling/note.cpp
@@ -13,14 +13,17 @@
 using namespace libzcash;
 
 // Construct and populate Sapling note for a given payment address and value.
-SaplingNote::SaplingNote(const SaplingPaymentAddress& address, const uint64_t value) : BaseNote(value) {
+SaplingNote::SaplingNote(const SaplingPaymentAddress& address, const uint64_t value) :
+        BaseNote(value)
+{
     d = address.d;
     pk_d = address.pk_d;
     librustzcash_sapling_generate_r(r.begin());
 }
 
 // Call librustzcash to compute the commitment
-boost::optional<uint256> SaplingNote::cmu() const {
+boost::optional<uint256> SaplingNote::cmu() const
+{
     uint256 result;
     if (!librustzcash_sapling_compute_cm(
             d.data(),
@@ -63,7 +66,7 @@ boost::optional<uint256> SaplingNote::nullifier(const SaplingFullViewingKey& vk,
 // Construct and populate SaplingNotePlaintext for a given note and memo.
 SaplingNotePlaintext::SaplingNotePlaintext(
     const SaplingNote& note,
-    std::array<unsigned char, ZC_MEMO_SIZE> memo) : BaseNotePlaintext(note, memo)
+    const std::array<unsigned char, ZC_MEMO_SIZE>& memo) : BaseNotePlaintext(note, memo)
 {
     d = note.d;
     rcm = note.r;
@@ -81,7 +84,7 @@ boost::optional<SaplingNote> SaplingNotePlaintext::note(const SaplingIncomingVie
 }
 
 boost::optional<SaplingOutgoingPlaintext> SaplingOutgoingPlaintext::decrypt(
-    const SaplingOutCiphertext &ciphertext,
+    const SaplingOutCiphertext& ciphertext,
     const uint256& ovk,
     const uint256& cv,
     const uint256& cm,
@@ -106,10 +109,10 @@ boost::optional<SaplingOutgoingPlaintext> SaplingOutgoingPlaintext::decrypt(
 }
 
 boost::optional<SaplingNotePlaintext> SaplingNotePlaintext::decrypt(
-    const SaplingEncCiphertext &ciphertext,
-    const uint256 &ivk,
-    const uint256 &epk,
-    const uint256 &cmu
+    const SaplingEncCiphertext& ciphertext,
+    const uint256& ivk,
+    const uint256& epk,
+    const uint256& cmu
 )
 {
     auto pt = AttemptSaplingEncDecryption(ciphertext, ivk, epk);
@@ -151,11 +154,11 @@ boost::optional<SaplingNotePlaintext> SaplingNotePlaintext::decrypt(
 }
 
 boost::optional<SaplingNotePlaintext> SaplingNotePlaintext::decrypt(
-    const SaplingEncCiphertext &ciphertext,
-    const uint256 &epk,
-    const uint256 &esk,
-    const uint256 &pk_d,
-    const uint256 &cmu
+    const SaplingEncCiphertext& ciphertext,
+    const uint256& epk,
+    const uint256& esk,
+    const uint256& pk_d,
+    const uint256& cmu
 )
 {
     auto pt = AttemptSaplingEncDecryption(ciphertext, epk, esk, pk_d);

--- a/src/sapling/note.h
+++ b/src/sapling/note.h
@@ -32,17 +32,17 @@ public:
     uint256 r{UINT256_ZERO};
 
     SaplingNote() {};
-    SaplingNote(diversifier_t _d, uint256 _pk_d, uint64_t value, uint256 _r):
+    SaplingNote(const diversifier_t& _d, const uint256& _pk_d, uint64_t value, const uint256& _r):
         BaseNote(value),
         d(_d),
         pk_d(_pk_d),
         r(_r)
     {}
-    SaplingNote(const SaplingPaymentAddress &address, uint64_t value);
+    SaplingNote(const SaplingPaymentAddress& address, uint64_t value);
     virtual ~SaplingNote() {};
 
     boost::optional<uint256> cmu() const;
-    boost::optional<uint256> nullifier(const SaplingFullViewingKey &vk, const uint64_t position) const;
+    boost::optional<uint256> nullifier(const SaplingFullViewingKey& vk, const uint64_t position) const;
 };
 
 class BaseNotePlaintext {
@@ -51,7 +51,7 @@ protected:
     std::array<unsigned char, ZC_MEMO_SIZE> memo_ = {{0}};
 public:
     BaseNotePlaintext() {}
-    BaseNotePlaintext(const BaseNote& note, std::array<unsigned char, ZC_MEMO_SIZE> memo):
+    BaseNotePlaintext(const BaseNote& note, const std::array<unsigned char, ZC_MEMO_SIZE>& memo):
         value_(note.value()),
         memo_(memo)
     {}
@@ -69,22 +69,22 @@ public:
     uint256 rcm{UINT256_ZERO};
 
     SaplingNotePlaintext() {}
-    SaplingNotePlaintext(const SaplingNote& note, std::array<unsigned char, ZC_MEMO_SIZE> memo);
+    SaplingNotePlaintext(const SaplingNote& note, const std::array<unsigned char, ZC_MEMO_SIZE>& memo);
     virtual ~SaplingNotePlaintext() {}
 
     static boost::optional<SaplingNotePlaintext> decrypt(
-        const SaplingEncCiphertext &ciphertext,
-        const uint256 &ivk,
-        const uint256 &epk,
-        const uint256 &cmu
+        const SaplingEncCiphertext& ciphertext,
+        const uint256& ivk,
+        const uint256& epk,
+        const uint256& cmu
     );
 
     static boost::optional<SaplingNotePlaintext> decrypt(
-        const SaplingEncCiphertext &ciphertext,
-        const uint256 &epk,
-        const uint256 &esk,
-        const uint256 &pk_d,
-        const uint256 &cmu
+        const SaplingEncCiphertext& ciphertext,
+        const uint256& epk,
+        const uint256& esk,
+        const uint256& pk_d,
+        const uint256& cmu
     );
 
     boost::optional<SaplingNote> note(const SaplingIncomingViewingKey& ivk) const;
@@ -116,7 +116,7 @@ public:
     uint256 esk{UINT256_ZERO};
 
     SaplingOutgoingPlaintext() {};
-    SaplingOutgoingPlaintext(uint256 _pk_d, uint256 _esk) :
+    SaplingOutgoingPlaintext(const uint256& _pk_d, const uint256& _esk) :
         pk_d(_pk_d),
         esk(_esk)
     {}
@@ -130,7 +130,7 @@ public:
     }
 
     static boost::optional<SaplingOutgoingPlaintext> decrypt(
-        const SaplingOutCiphertext &ciphertext,
+        const SaplingOutCiphertext& ciphertext,
         const uint256& ovk,
         const uint256& cv,
         const uint256& cm,

--- a/src/sapling/note.h
+++ b/src/sapling/note.h
@@ -16,7 +16,7 @@ namespace libzcash {
  */
 class BaseNote {
 protected:
-    uint64_t value_ = 0;
+    uint64_t value_{0};
 public:
     BaseNote() {}
     BaseNote(uint64_t value) : value_(value) {};
@@ -27,17 +27,18 @@ public:
 
 class SaplingNote : public BaseNote {
 public:
-    diversifier_t d;
-    uint256 pk_d;
-    uint256 r;
-
-    SaplingNote(diversifier_t d, uint256 pk_d, uint64_t value, uint256 r)
-            : BaseNote(value), d(d), pk_d(pk_d), r(r) {}
+    diversifier_t d = {{0}};
+    uint256 pk_d{UINT256_ZERO};
+    uint256 r{UINT256_ZERO};
 
     SaplingNote() {};
-
+    SaplingNote(diversifier_t _d, uint256 _pk_d, uint64_t value, uint256 _r):
+        BaseNote(value),
+        d(_d),
+        pk_d(_pk_d),
+        r(_r)
+    {}
     SaplingNote(const SaplingPaymentAddress &address, uint64_t value);
-
     virtual ~SaplingNote() {};
 
     boost::optional<uint256> cmu() const;
@@ -46,12 +47,14 @@ public:
 
 class BaseNotePlaintext {
 protected:
-    uint64_t value_ = 0;
-    std::array<unsigned char, ZC_MEMO_SIZE> memo_;
+    uint64_t value_{0};
+    std::array<unsigned char, ZC_MEMO_SIZE> memo_ = {{0}};
 public:
     BaseNotePlaintext() {}
-    BaseNotePlaintext(const BaseNote& note, std::array<unsigned char, ZC_MEMO_SIZE> memo)
-        : value_(note.value()), memo_(memo) {}
+    BaseNotePlaintext(const BaseNote& note, std::array<unsigned char, ZC_MEMO_SIZE> memo):
+        value_(note.value()),
+        memo_(memo)
+    {}
     virtual ~BaseNotePlaintext() {}
 
     inline uint64_t value() const { return value_; }
@@ -62,12 +65,12 @@ typedef std::pair<SaplingEncCiphertext, SaplingNoteEncryption> SaplingNotePlaint
 
 class SaplingNotePlaintext : public BaseNotePlaintext {
 public:
-    diversifier_t d;
-    uint256 rcm;
+    diversifier_t d = {{0}};
+    uint256 rcm{UINT256_ZERO};
 
     SaplingNotePlaintext() {}
-
     SaplingNotePlaintext(const SaplingNote& note, std::array<unsigned char, ZC_MEMO_SIZE> memo);
+    virtual ~SaplingNotePlaintext() {}
 
     static boost::optional<SaplingNotePlaintext> decrypt(
         const SaplingEncCiphertext &ciphertext,
@@ -85,8 +88,6 @@ public:
     );
 
     boost::optional<SaplingNote> note(const SaplingIncomingViewingKey& ivk) const;
-
-    virtual ~SaplingNotePlaintext() {}
 
     ADD_SERIALIZE_METHODS;
 
@@ -111,12 +112,14 @@ public:
 class SaplingOutgoingPlaintext
 {
 public:
-    uint256 pk_d;
-    uint256 esk;
+    uint256 pk_d{UINT256_ZERO};
+    uint256 esk{UINT256_ZERO};
 
     SaplingOutgoingPlaintext() {};
-
-    SaplingOutgoingPlaintext(uint256 pk_d, uint256 esk) : pk_d(pk_d), esk(esk) {}
+    SaplingOutgoingPlaintext(uint256 _pk_d, uint256 _esk) :
+        pk_d(_pk_d),
+        esk(_esk)
+    {}
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/sapling/sapling_transaction.h
+++ b/src/sapling/sapling_transaction.h
@@ -44,14 +44,14 @@ class SpendDescription
 public:
     typedef std::array<unsigned char, 64> spend_auth_sig_t;
 
-    uint256 cv;                    //!< A value commitment to the value of the input note.
-    uint256 anchor;                //!< A Merkle root of the Sapling note commitment tree at some block height in the past.
-    uint256 nullifier;             //!< The nullifier of the input note.
-    uint256 rk;                    //!< The randomized public key for spendAuthSig.
-    libzcash::GrothProof zkproof;  //!< A zero-knowledge proof using the spend circuit.
-    spend_auth_sig_t spendAuthSig; //!< A signature authorizing this spend.
+    uint256 cv{UINT256_ZERO};              //!< A value commitment to the value of the input note.
+    uint256 anchor{UINT256_ZERO};          //!< A Merkle root of the Sapling note commitment tree at some block height in the past.
+    uint256 nullifier{UINT256_ZERO};       //!< The nullifier of the input note.
+    uint256 rk{UINT256_ZERO};              //!< The randomized public key for spendAuthSig.
+    libzcash::GrothProof zkproof = {{0}};  //!< A zero-knowledge proof using the spend circuit.
+    spend_auth_sig_t spendAuthSig = {{0}}; //!< A signature authorizing this spend.
 
-    SpendDescription() { }
+    SpendDescription() {}
 
     ADD_SERIALIZE_METHODS;
 
@@ -89,14 +89,14 @@ public:
 class OutputDescription
 {
 public:
-    uint256 cv;                     //!< A value commitment to the value of the output note.
-    uint256 cmu;                     //!< The u-coordinate of the note commitment for the output note.
-    uint256 ephemeralKey;           //!< A Jubjub public key.
-    libzcash::SaplingEncCiphertext encCiphertext; //!< A ciphertext component for the encrypted output note.
-    libzcash::SaplingOutCiphertext outCiphertext; //!< A ciphertext component for the encrypted output note.
-    libzcash::GrothProof zkproof;   //!< A zero-knowledge proof using the output circuit.
+    uint256 cv{UINT256_ZERO};                             //!< A value commitment to the value of the output note.
+    uint256 cmu{UINT256_ZERO};                            //!< The u-coordinate of the note commitment for the output note.
+    uint256 ephemeralKey{UINT256_ZERO};                   //!< A Jubjub public key.
+    libzcash::SaplingEncCiphertext encCiphertext = {{0}}; //!< A ciphertext component for the encrypted output note.
+    libzcash::SaplingOutCiphertext outCiphertext = {{0}}; //!< A ciphertext component for the encrypted output note.
+    libzcash::GrothProof zkproof = {{0}};                 //!< A zero-knowledge proof using the output circuit.
 
-    OutputDescription() { }
+    OutputDescription() {}
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -219,7 +219,11 @@ void SaplingScriptPubKeyMan::IncrementNoteWitnesses(const CBlockIndex* pindex,
     const CBlock* pblock {pblockIn};
     CBlock block;
     if (!pblock) {
-        ReadBlockFromDisk(block, pindex);
+        if (!ReadBlockFromDisk(block, pindex)) {
+            std::string read_failed_str = strprintf("Unable to read block %d (%s) from disk.",
+                    pindex->nHeight, pindex->GetBlockHash().ToString());
+            throw std::runtime_error(read_failed_str);
+        }
         pblock = &block;
     }
 

--- a/src/sapling/transaction_builder.cpp
+++ b/src/sapling/transaction_builder.cpp
@@ -14,10 +14,10 @@
 #include <librustzcash.h>
 
 SpendDescriptionInfo::SpendDescriptionInfo(
-    libzcash::SaplingExpandedSpendingKey expsk,
-    libzcash::SaplingNote note,
-    uint256 anchor,
-    SaplingWitness witness) : expsk(expsk), note(note), anchor(anchor), witness(witness)
+    libzcash::SaplingExpandedSpendingKey _expsk,
+    libzcash::SaplingNote _note,
+    uint256 _anchor,
+    SaplingWitness _witness) : expsk(_expsk), note(_note), anchor(_anchor), witness(_witness)
 {
     librustzcash_sapling_generate_r(alpha.begin());
 }

--- a/src/sapling/transaction_builder.cpp
+++ b/src/sapling/transaction_builder.cpp
@@ -13,11 +13,14 @@
 
 #include <librustzcash.h>
 
-SpendDescriptionInfo::SpendDescriptionInfo(
-    libzcash::SaplingExpandedSpendingKey _expsk,
-    libzcash::SaplingNote _note,
-    uint256 _anchor,
-    SaplingWitness _witness) : expsk(_expsk), note(_note), anchor(_anchor), witness(_witness)
+SpendDescriptionInfo::SpendDescriptionInfo(const libzcash::SaplingExpandedSpendingKey& _expsk,
+                                           const libzcash::SaplingNote& _note,
+                                           const uint256& _anchor,
+                                           const SaplingWitness& _witness):
+   expsk(_expsk),
+   note(_note),
+   anchor(_anchor),
+   witness(_witness)
 {
     librustzcash_sapling_generate_r(alpha.begin());
 }
@@ -158,10 +161,10 @@ void TransactionBuilder::Clear()
 }
 
 void TransactionBuilder::AddSaplingSpend(
-    libzcash::SaplingExpandedSpendingKey expsk,
-    libzcash::SaplingNote note,
-    uint256 anchor,
-    SaplingWitness witness)
+    const libzcash::SaplingExpandedSpendingKey& expsk,
+    const libzcash::SaplingNote& note,
+    const uint256& anchor,
+    const SaplingWitness& witness)
 {
     // Sanity check: cannot add Sapling spend to pre-Sapling transaction
     if (mtx.nVersion < CTransaction::TxVersion::SAPLING) {
@@ -178,10 +181,10 @@ void TransactionBuilder::AddSaplingSpend(
 }
 
 void TransactionBuilder::AddSaplingOutput(
-    uint256 ovk,
-    libzcash::SaplingPaymentAddress to,
+    const uint256& ovk,
+    const libzcash::SaplingPaymentAddress& to,
     CAmount value,
-    std::array<unsigned char, ZC_MEMO_SIZE> memo)
+    const std::array<unsigned char, ZC_MEMO_SIZE>& memo)
 {
     // Sanity check: cannot add Sapling output to pre-Sapling transaction
     if (mtx.nVersion < CTransaction::TxVersion::SAPLING) {
@@ -193,7 +196,7 @@ void TransactionBuilder::AddSaplingOutput(
     mtx.sapData->valueBalance -= value;
 }
 
-void TransactionBuilder::AddTransparentInput(const COutPoint& utxo, const CScript& scriptPubKey, const CAmount& value)
+void TransactionBuilder::AddTransparentInput(const COutPoint& utxo, const CScript& scriptPubKey, CAmount value)
 {
     if (keystore == nullptr) {
         throw std::runtime_error("Cannot add transparent inputs to a TransactionBuilder without a keystore");
@@ -212,7 +215,7 @@ void TransactionBuilder::AddTransparentOutput(const CTxOut& out)
     mtx.vout.push_back(out);
 }
 
-void TransactionBuilder::AddTransparentOutput(const CTxDestination& dest, const CAmount& value)
+void TransactionBuilder::AddTransparentOutput(const CTxDestination& dest, CAmount value)
 {
     AddTransparentOutput(CTxOut(value, GetScriptForDestination(dest)));
 }
@@ -222,13 +225,13 @@ void TransactionBuilder::SetFee(CAmount _fee)
     this->fee = _fee;
 }
 
-void TransactionBuilder::SendChangeTo(libzcash::SaplingPaymentAddress changeAddr, uint256 ovk)
+void TransactionBuilder::SendChangeTo(const libzcash::SaplingPaymentAddress& changeAddr, const uint256& ovk)
 {
     saplingChangeAddr = std::make_pair(ovk, changeAddr);
     tChangeAddr = nullopt;
 }
 
-void TransactionBuilder::SendChangeTo(CTxDestination& changeAddr)
+void TransactionBuilder::SendChangeTo(const CTxDestination& changeAddr)
 {
     if (!IsValidDestination(changeAddr)) {
         throw std::runtime_error("Invalid change address, not a valid taddr.");

--- a/src/sapling/transaction_builder.h
+++ b/src/sapling/transaction_builder.h
@@ -27,10 +27,10 @@ struct SpendDescriptionInfo {
     SaplingWitness witness;
 
     SpendDescriptionInfo(
-        libzcash::SaplingExpandedSpendingKey _expsk,
-        libzcash::SaplingNote _note,
-        uint256 _anchor,
-        SaplingWitness _witness);
+        const libzcash::SaplingExpandedSpendingKey& _expsk,
+        const libzcash::SaplingNote& _note,
+        const uint256& _anchor,
+        const SaplingWitness& _witness);
 };
 
 struct OutputDescriptionInfo {
@@ -39,9 +39,13 @@ struct OutputDescriptionInfo {
     std::array<unsigned char, ZC_MEMO_SIZE> memo;
 
     OutputDescriptionInfo(
-        uint256 _ovk,
-        libzcash::SaplingNote _note,
-        std::array<unsigned char, ZC_MEMO_SIZE> _memo) : ovk(_ovk), note(_note), memo(_memo) {}
+        const uint256& _ovk,
+        const libzcash::SaplingNote& _note,
+        const std::array<unsigned char, ZC_MEMO_SIZE>& _memo):
+            ovk(_ovk),
+            note(_note),
+            memo(_memo)
+    {}
 
     Optional<OutputDescription> Build(void* ctx);
 };
@@ -50,9 +54,10 @@ struct TransparentInputInfo {
     CScript scriptPubKey;
     CAmount value;
 
-    TransparentInputInfo(
-        CScript _scriptPubKey,
-        CAmount _value) : scriptPubKey(_scriptPubKey), value(_value) {}
+    TransparentInputInfo(const CScript& _scriptPubKey, CAmount _value):
+        scriptPubKey(_scriptPubKey),
+        value(_value)
+    {}
 };
 
 // Dummy constants used during fee-calculation loop
@@ -104,26 +109,35 @@ public:
     // Throws if the anchor does not match the anchor used by
     // previously-added Sapling spends.
     void AddSaplingSpend(
-        libzcash::SaplingExpandedSpendingKey expsk,
-        libzcash::SaplingNote note,
-        uint256 anchor,
-        SaplingWitness witness);
+        const libzcash::SaplingExpandedSpendingKey& expsk,
+        const libzcash::SaplingNote& note,
+        const uint256& anchor,
+        const SaplingWitness& witness);
 
     void AddSaplingOutput(
-        uint256 ovk,
-        libzcash::SaplingPaymentAddress to,
+        const uint256& ovk,
+        const libzcash::SaplingPaymentAddress& to,
         CAmount value,
-        std::array<unsigned char, ZC_MEMO_SIZE> memo = {{0xF6}});
+        const std::array<unsigned char, ZC_MEMO_SIZE>& memo);
+
+    void AddSaplingOutput(
+        const uint256& ovk,
+        const libzcash::SaplingPaymentAddress& to,
+        CAmount value)
+    {
+        const std::array<unsigned char, ZC_MEMO_SIZE> memo = {{0xF6}};
+        AddSaplingOutput(ovk, to, value, memo);
+    }
 
     // Assumes that the value correctly corresponds to the provided UTXO.
-    void AddTransparentInput(const COutPoint& utxo, const CScript& scriptPubKey, const CAmount& value);
+    void AddTransparentInput(const COutPoint& utxo, const CScript& scriptPubKey, CAmount value);
 
     void AddTransparentOutput(const CTxOut& out);
-    void AddTransparentOutput(const CTxDestination& dest, const CAmount& value);
+    void AddTransparentOutput(const CTxDestination& dest, CAmount value);
 
-    void SendChangeTo(libzcash::SaplingPaymentAddress changeAddr, uint256 ovk);
+    void SendChangeTo(const libzcash::SaplingPaymentAddress& changeAddr, const uint256& ovk);
 
-    void SendChangeTo(CTxDestination& changeAddr);
+    void SendChangeTo(const CTxDestination& changeAddr);
 
     TransactionBuilderResult Build(bool fDummySig = false);
     // Add Sapling Spend/Output descriptions, binding sig, and transparent signatures

--- a/src/sapling/transaction_builder.h
+++ b/src/sapling/transaction_builder.h
@@ -27,10 +27,10 @@ struct SpendDescriptionInfo {
     SaplingWitness witness;
 
     SpendDescriptionInfo(
-        libzcash::SaplingExpandedSpendingKey expsk,
-        libzcash::SaplingNote note,
-        uint256 anchor,
-        SaplingWitness witness);
+        libzcash::SaplingExpandedSpendingKey _expsk,
+        libzcash::SaplingNote _note,
+        uint256 _anchor,
+        SaplingWitness _witness);
 };
 
 struct OutputDescriptionInfo {
@@ -39,9 +39,9 @@ struct OutputDescriptionInfo {
     std::array<unsigned char, ZC_MEMO_SIZE> memo;
 
     OutputDescriptionInfo(
-        uint256 ovk,
-        libzcash::SaplingNote note,
-        std::array<unsigned char, ZC_MEMO_SIZE> memo) : ovk(ovk), note(note), memo(memo) {}
+        uint256 _ovk,
+        libzcash::SaplingNote _note,
+        std::array<unsigned char, ZC_MEMO_SIZE> _memo) : ovk(_ovk), note(_note), memo(_memo) {}
 
     Optional<OutputDescription> Build(void* ctx);
 };
@@ -51,8 +51,8 @@ struct TransparentInputInfo {
     CAmount value;
 
     TransparentInputInfo(
-        CScript scriptPubKey,
-        CAmount value) : scriptPubKey(scriptPubKey), value(value) {}
+        CScript _scriptPubKey,
+        CAmount _value) : scriptPubKey(_scriptPubKey), value(_value) {}
 };
 
 // Dummy constants used during fee-calculation loop

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1753,7 +1753,10 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate, b
             }
 
             CBlock block;
-            ReadBlockFromDisk(block, pindex);
+            if (!ReadBlockFromDisk(block, pindex)) {
+                LogPrintf("Unable to read block %d (%s) from disk.", pindex->nHeight, pindex->GetBlockHash().ToString());
+                return -1;
+            }
             int posInBlock;
             for (posInBlock = 0; posInBlock < (int)block.vtx.size(); posInBlock++) {
                 const auto& tx = block.vtx[posInBlock];


### PR DESCRIPTION
Fixes three minor issues with sapling notes and txes:

- Possible uninitialized fields (with empty ctor)
- Big parameters passed by value
- Unchecked return value of ReadBlockFromDisk

Note: these were reported by Synopsys Coverity® (more to come). The `cov-int` folder is added to .gitignore, so the tool can be run directly on the cloned repository, without the risk of staging its files.