### PR TITLE
[Refactor] Grouping misbehaving / cs_main lock calls into a single place

### DIFF
--- a/src/budget/budgetmanager.h
+++ b/src/budget/budgetmanager.h
@@ -91,6 +91,7 @@ public:
     void NewBlock(int height);
 
     int ProcessBudgetVoteSync(const uint256& nProp, CNode* pfrom);
+    int ProcessProposal(CBudgetProposal& proposal);
 
     // functions returning a pointer in the map. Need cs_proposals/cs_budgets locked from the caller
     CBudgetProposal* FindProposal(const uint256& nHash);

--- a/src/budget/budgetmanager.h
+++ b/src/budget/budgetmanager.h
@@ -88,6 +88,8 @@ public:
     int GetBestHeight() const { return nBestHeight.load(std::memory_order_acquire); }
 
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
+    /// Process the message and returns the ban score (0 if no banning is needed)
+    int ProcessMessageInner(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
     void NewBlock(int height);
 
     int ProcessBudgetVoteSync(const uint256& nProp, CNode* pfrom);

--- a/src/budget/budgetmanager.h
+++ b/src/budget/budgetmanager.h
@@ -90,6 +90,8 @@ public:
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
     void NewBlock(int height);
 
+    int ProcessBudgetVoteSync(const uint256& nProp, CNode* pfrom);
+
     // functions returning a pointer in the map. Need cs_proposals/cs_budgets locked from the caller
     CBudgetProposal* FindProposal(const uint256& nHash);
     CFinalizedBudget* FindFinalizedBudget(const uint256& nHash);

--- a/src/budget/budgetmanager.h
+++ b/src/budget/budgetmanager.h
@@ -93,6 +93,7 @@ public:
     int ProcessBudgetVoteSync(const uint256& nProp, CNode* pfrom);
     int ProcessProposal(CBudgetProposal& proposal);
     int ProcessProposalVote(CBudgetVote& proposal, CNode* pfrom);
+    int ProcessFinalizedBudget(CFinalizedBudget& finalbudget);
 
     // functions returning a pointer in the map. Need cs_proposals/cs_budgets locked from the caller
     CBudgetProposal* FindProposal(const uint256& nHash);

--- a/src/budget/budgetmanager.h
+++ b/src/budget/budgetmanager.h
@@ -94,6 +94,7 @@ public:
     int ProcessProposal(CBudgetProposal& proposal);
     int ProcessProposalVote(CBudgetVote& proposal, CNode* pfrom);
     int ProcessFinalizedBudget(CFinalizedBudget& finalbudget);
+    int ProcessFinalizedBudgetVote(CFinalizedBudgetVote& vote, CNode* pfrom);
 
     // functions returning a pointer in the map. Need cs_proposals/cs_budgets locked from the caller
     CBudgetProposal* FindProposal(const uint256& nHash);

--- a/src/budget/budgetmanager.h
+++ b/src/budget/budgetmanager.h
@@ -92,6 +92,7 @@ public:
 
     int ProcessBudgetVoteSync(const uint256& nProp, CNode* pfrom);
     int ProcessProposal(CBudgetProposal& proposal);
+    int ProcessProposalVote(CBudgetVote& proposal, CNode* pfrom);
 
     // functions returning a pointer in the map. Need cs_proposals/cs_budgets locked from the caller
     CBudgetProposal* FindProposal(const uint256& nHash);


### PR DESCRIPTION
Refactored the process message area, improving the code readability decoupling every message processing into its own function and unifying every `misbehaving` call in one single place, so we don't have `cs_main` locks spread around many functions that could require internal cs locks (which could be a deadlock cause).