### PR TITLE
[Doc] WSL Depends builds need --disable-online-rust

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -105,7 +105,7 @@ Build using:
     make HOST=x86_64-w64-mingw32
     cd ..
     ./autogen.sh # not required when building from tarball
-    CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site ./configure --prefix=/
+    CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site ./configure --prefix=/ --disable-online-rust
     make
     sudo bash -c "echo 1 > /proc/sys/fs/binfmt_misc/status" # Enable WSL support for Win32 applications.
 


### PR DESCRIPTION
When building the client on WSL using depends, the configure option
`--disable-online-rust` should be used to prevent a linker issue with
`librustzcash`

Closes #1846