### PR TITLE
[Backport] Disable the mempool P2P command when bloom filters disabled

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1637,6 +1637,12 @@ bool static ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vR
 
     else if (strCommand == NetMsgType::MEMPOOL) {
 
+        if (!(pfrom->GetLocalServices() & NODE_BLOOM) && !pfrom->fWhitelisted) {
+            LogPrint(BCLog::NET, "mempool request with bloom filters disabled, disconnect peer=%d\n", pfrom->GetId());
+            pfrom->fDisconnect = true;
+            return true;
+        }
+
         // todo: limit mempool request with a bandwidth limit
         LOCK(pfrom->cs_inventory);
         pfrom->fSendMempool = true;

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -58,6 +58,7 @@ BASE_SCRIPTS= [
     # Longest test should go first, to favor running tests in parallel
     'wallet_basic.py',                          # ~ 498 sec
     'wallet_backup.py',                         # ~ 477 sec
+    'mempool_persist.py',                       # ~ 417 sec
 
     # vv Tests less than 5m vv
     'wallet_hd.py',                             # ~ 300 sec
@@ -88,7 +89,6 @@ BASE_SCRIPTS= [
     'feature_blockhashcache.py',                # ~ 100 sec
     'wallet_listtransactions.py',               # ~ 97 sec
     'mempool_reorg.py',                         # ~ 92 sec
-    'mempool_persist.py',
     'wallet_encryption.py',                     # ~ 89 sec
     'wallet_keypool.py',                        # ~ 88 sec
     'wallet_dump.py',                           # ~ 83 sec
@@ -109,6 +109,7 @@ BASE_SCRIPTS= [
     'rpc_blockchain.py',                        # ~ 50 sec
     'wallet_disable.py',                        # ~ 50 sec
     'mining_v5_upgrade.py',                     # ~ 48 sec
+    'p2p_mempool.py',                           # ~ 46 sec
     'feature_help.py',                          # ~ 30 sec
 
     # Don't append tests at the end to avoid merge conflicts
@@ -119,7 +120,6 @@ BASE_SCRIPTS= [
     # 'interface_zmq.py',
     # 'rpc_getchaintips.py',
     # 'rpc_users.py',
-    # 'p2p_mempool.py',
     # 'mining_prioritisetransaction.py',
     # 'p2p_invalid_block.py',
     # 'p2p_invalid_tx.py',


### PR DESCRIPTION
Another DoS vector patch coming straight from #8078.

Plus, enabled and connected the `p2p_mempool.py` functional test and reordered the `mempool_persist.py` in the list based on its time, favoring running tests in parallel.