### PR TITLE
[Wallet] Close DB on error

### DIFF
--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -104,8 +104,10 @@ bool CDBEnv::Open(const fs::path& pathIn)
             DB_RECOVER |
             nEnvFlags,
         S_IRUSR | S_IWUSR);
-    if (ret != 0)
+    if (ret != 0) {
+        dbenv->close(0);
         return error("CDBEnv::Open : Error %d opening database environment: %s\n", ret, DbEnv::strerror(ret));
+    }
 
     fDbEnvInit = true;
     fMockDb = false;
@@ -199,6 +201,7 @@ bool CDB::Recover(const std::string& filename, void *callbackDataIn, bool (*reco
                             0);
     if (ret > 0) {
         LogPrintf("Cannot create database file %s\n", filename);
+        pdbCopy->close(0);
         return false;
     }
 
@@ -533,8 +536,10 @@ bool CDB::Rewrite(CWalletDBWrapper& dbw, const char* pszSkip)
                         env->CloseDb(strFile);
                         if (pdbCopy->close(0))
                             fSuccess = false;
-                        delete pdbCopy;
+                    } else {
+                        pdbCopy->close(0);
                     }
+                    delete pdbCopy;
                 }
                 if (fSuccess) {
                     Db dbA(env->dbenv, 0);


### PR DESCRIPTION
Coming from https://github.com/bitcoin/bitcoin/pull/11017

> This PR intends to plug some leaks. It specifically implements adherence to the requirement in BDB to close a handle which failed to open (https://docs.oracle.com/cd/E17276_01/html/api_reference/C/dbopen.html):
> 
> >   The DB->open() method returns a non-zero error value on failure and 0 on success. If DB->open() fails, the DB->close() method 
> >   must be called to discard the DB handle.