### PR TITLE
[GA] Enable CMake macOS Build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -77,12 +77,11 @@ jobs:
             cc: gcc
             cxx: g++
 
-          # macOS disabled for now due to a compiler error
-          #- name: macOS
-          #  os: macos-10.15
-          #  packages: python3 autoconf automake berkeley-db4 libtool boost miniupnpc pkg-config protobuf qt5 zmq libevent qrencode gmp libsodium
-          #  cc: clang
-          #  cxx: clang++
+          - name: macOS
+            os: macos-10.15
+            packages: python3 autoconf automake berkeley-db4 libtool boost miniupnpc pkg-config protobuf qt5 zmq libevent qrencode gmp libsodium rust
+            cc: $(brew --prefix llvm)/bin/clang
+            cxx: $(brew --prefix llvm)/bin/clang++
 
     steps:
       - name: Get Source
@@ -117,6 +116,10 @@ jobs:
         run: |
           CC=${{ matrix.config.cc }}
           CXX=${{ matrix.config.cxx }}
+          if [[ ${{ matrix.config.os }} = macos* ]]; then
+            export CPPFLAGS="-I/usr/local/Cellar/gmp/6.2.1/include"
+            export LDFLAGS="-L/usr/local/Cellar/gmp/6.2.1/lib"
+          fi
           export CC
           export CXX
           mkdir -p ${{ github.workspace }}/cmake-build-debug && cd ${{ github.workspace }}/cmake-build-debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,14 @@ else()
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endif()
+
+# error out if configure fails
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/config/pivx-config.h")
+else()
+    execute_process(COMMAND cat config.log WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    message(FATAL_ERROR "configure script didn't finish properly see config.log output above")
+
+endif()
 add_definitions(-DHAVE_CONFIG_H)
 
 ExternalProject_Add (


### PR DESCRIPTION
Fixes the GA descriptor to work with the macOS 10.15 image that GA uses.

Note: Uses clang 11 instead of clang 12 due to a compiler error with the image's clang 12.

Also adds early error reporting for CMake if the `configure` script fails for any reason.