### PR TITLE
[Wallet] CTransactionRef migration + CWalletTx/CMerkleTx refactor

### DIFF
--- a/src/blockassembler.cpp
+++ b/src/blockassembler.cpp
@@ -288,7 +288,7 @@ bool BlockAssembler::TestForBlock(CTxMemPool::txiter iter)
     // Must check that lock times are still valid
     // This can be removed once MTP is always enforced
     // as long as reorgs keep the mempool consistent.
-    if (!IsFinalTx(iter->GetTx(), nHeight))
+    if (!IsFinalTx(iter->GetSharedTx(), nHeight))
         return false;
 
     return true;

--- a/src/budget/budgetmanager.cpp
+++ b/src/budget/budgetmanager.cpp
@@ -105,7 +105,7 @@ uint256 CBudgetManager::SubmitFinalBudget()
     // See if collateral tx exists
     if (!mapUnconfirmedFeeTx.count(budgetHash)) {
         // create the collateral tx, send it to the network and return
-        CWalletTx wtx;
+        CTransactionRef wtx;
         // Get our change address
         CReserveKey keyChange(pwalletMain);
         if (!pwalletMain->CreateBudgetFeeTX(wtx, budgetHash, keyChange, true)) {
@@ -115,7 +115,7 @@ uint256 CBudgetManager::SubmitFinalBudget()
         // Send the tx to the network
         const CWallet::CommitResult& res = pwalletMain->CommitTransaction(wtx, keyChange, g_connman.get());
         if (res.status == CWallet::CommitStatus::OK) {
-            const uint256& collateraltxid = wtx.GetHash();
+            const uint256& collateraltxid = wtx->GetHash();
             mapUnconfirmedFeeTx.emplace(budgetHash, collateraltxid);
             LogPrint(BCLog::MNBUDGET,"%s: Collateral sent. txid: %s\n", __func__, collateraltxid.ToString());
             return budgetHash;

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -7,23 +7,22 @@
 #include "consensus/consensus.h"
 #include "consensus/zerocoin_verify.h"
 #include "sapling/sapling_validation.h"
-#include "script/interpreter.h"
 #include "tiertwo/specialtx_validation.h"
 #include "../validation.h"
 
-bool IsFinalTx(const CTransaction& tx, int nBlockHeight, int64_t nBlockTime)
+bool IsFinalTx(const CTransactionRef& tx, int nBlockHeight, int64_t nBlockTime)
 {
     AssertLockHeld(cs_main);
     // Time based nLockTime implemented in 0.1.6
-    if (tx.nLockTime == 0)
+    if (tx->nLockTime == 0)
         return true;
     if (nBlockHeight == 0)
         nBlockHeight = chainActive.Height();
     if (nBlockTime == 0)
         nBlockTime = GetAdjustedTime();
-    if ((int64_t)tx.nLockTime < ((int64_t)tx.nLockTime < LOCKTIME_THRESHOLD ? (int64_t)nBlockHeight : nBlockTime))
+    if ((int64_t)tx->nLockTime < ((int64_t)tx->nLockTime < LOCKTIME_THRESHOLD ? (int64_t)nBlockHeight : nBlockTime))
         return true;
-    for (const CTxIn& txin : tx.vin)
+    for (const CTxIn& txin : tx->vin)
         if (!txin.IsFinal())
             return false;
     return true;

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -5,12 +5,13 @@
 #ifndef BITCOIN_CONSENSUS_TX_VERIFY_H
 #define BITCOIN_CONSENSUS_TX_VERIFY_H
 
+#include "primitives/transaction.h"
+
 #include <stdint.h>
 #include <vector>
 
 class CBlockIndex;
 class CCoinsViewCache;
-class CTransaction;
 class CValidationState;
 
 /** Transaction validation functions */
@@ -38,6 +39,6 @@ unsigned int GetP2SHSigOpCount(const CTransaction& tx, const CCoinsViewCache& ma
  * Check if transaction is final and can be included in a block with the
  * specified height and time. Consensus critical.
  */
-bool IsFinalTx(const CTransaction& tx, int nBlockHeight = 0, int64_t nBlockTime = 0);
+bool IsFinalTx(const CTransactionRef& tx, int nBlockHeight = 0, int64_t nBlockTime = 0);
 
 #endif // BITCOIN_CONSENSUS_TX_VERIFY_H

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -62,7 +62,7 @@ bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType);
 /** Check for standard transaction types
  * @return True if all outputs (scriptPubKeys) use only standard transaction forms
  */
-bool IsStandardTx(const CTransaction& tx, int nBlockHeight, std::string& reason);
+bool IsStandardTx(const CTransactionRef& tx, int nBlockHeight, std::string& reason);
 
 /**
  * Check for standard transaction types

--- a/src/qt/pivx/masternodewizarddialog.cpp
+++ b/src/qt/pivx/masternodewizarddialog.cpp
@@ -257,11 +257,11 @@ bool MasterNodeWizardDialog::createMN()
         }
 
         // look for the tx index of the collateral
-        CWalletTx* walletTx = currentTransaction.getTransaction();
+        CTransactionRef walletTx = currentTransaction.getTransaction();
         std::string txID = walletTx->GetHash().GetHex();
         int indexOut = -1;
-        for (int i=0; i < (int)walletTx->tx->vout.size(); i++) {
-            const CTxOut& out = walletTx->tx->vout[i];
+        for (int i=0; i < (int)walletTx->vout.size(); i++) {
+            const CTxOut& out = walletTx->vout[i];
             if (out.nValue == 10000 * COIN) {
                 indexOut = i;
                 break;

--- a/src/qt/pivx/send.cpp
+++ b/src/qt/pivx/send.cpp
@@ -499,7 +499,7 @@ OperationResult SendWidget::prepareTransparent(WalletModelTransaction* currentTr
 bool SendWidget::sendFinalStep()
 {
     showHideOp(true);
-    const bool fStakeDelegationVoided = ptrModelTx->getTransaction()->fStakeDelegationVoided;
+    const bool fStakeDelegationVoided = ptrModelTx->fIsStakeDelegationVoided;
     QString warningStr = QString();
     if (fStakeDelegationVoided)
         warningStr = tr("WARNING:\nTransaction spends a cold-stake delegation, voiding it.\n"

--- a/src/qt/pivx/sendconfirmdialog.h
+++ b/src/qt/pivx/sendconfirmdialog.h
@@ -57,7 +57,7 @@ private:
     bool inputsLoaded = false;
     bool outputsLoaded = false;
 
-    void setInputsType(const CWalletTx* _tx);
+    void setInputsType(CTransactionRef _tx);
 };
 
 #endif // SENDCONFIRMDIALOG_H

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -533,7 +533,7 @@ void TransactionRecord::loadHotOrColdStakeOrContract(
     }
 
     bool isSpendable = (wallet->IsMine(p2csUtxo) & ISMINE_SPENDABLE_DELEGATED);
-    bool isFromMe = wallet->IsFromMe(wtx);
+    bool isFromMe = wallet->IsFromMe(wtx.tx);
 
     if (isContract) {
         if (isSpendable && isFromMe) {
@@ -611,7 +611,7 @@ void TransactionRecord::updateStatus(const CWalletTx& wtx)
     status.cur_num_blocks = chainHeight;
     status.depth = depth;
 
-    if (!IsFinalTx(wtx, chainHeight + 1)) {
+    if (!IsFinalTx(wtx.tx, chainHeight + 1)) {
         if (wtx.tx->nLockTime < LOCKTIME_THRESHOLD) {
             status.status = TransactionStatus::OpenUntilBlock;
             status.open_for = wtx.tx->nLockTime - chainHeight;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -438,7 +438,8 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
                                                   ALL_COINS,
                                                   true,
                                                   0,
-                                                  fIncludeDelegations);
+                                                  fIncludeDelegations,
+                                                  &transaction->fIsStakeDelegationVoided);
         transaction->setTransactionFee(nFeeRequired);
 
         if (!fCreated) {
@@ -1081,8 +1082,8 @@ bool WalletModel::isUsed(CTxDestination address)
     return wallet->IsUsed(address);
 }
 
-Optional<QString> WalletModel::getShieldedAddressFromSpendDesc(const CWalletTx* wtx, int index)
+Optional<QString> WalletModel::getShieldedAddressFromSpendDesc(const uint256& txHash, int index)
 {
-    Optional<libzcash::SaplingPaymentAddress> opAddr = wallet->GetSaplingScriptPubKeyMan()->GetAddressFromInputIfPossible(wtx, index);
+    Optional<libzcash::SaplingPaymentAddress> opAddr = wallet->GetSaplingScriptPubKeyMan()->GetAddressFromInputIfPossible(txHash, index);
     return opAddr ? Optional<QString>(QString::fromStdString(KeyIO::EncodePaymentAddress(*opAddr))) : nullopt;
 }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -470,7 +470,7 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(WalletModelTransaction& tran
     // Double check the tx before doing anything
     CWalletTx* newTx = transaction.getTransaction();
     CValidationState state;
-    if (!CheckTransaction(*newTx, true, true, state, true, fColdStakingActive, fSaplingActive)) {
+    if (!CheckTransaction(*newTx->tx, true, true, state, true, fColdStakingActive, fSaplingActive)) {
         return TransactionCheckFailed;
     }
 

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -189,7 +189,7 @@ public:
     bool validateAddress(const QString& address, bool fStaking, bool& isShielded);
 
     // Return the address from where the shielded spend is taking the funds from (if possible)
-    Optional<QString> getShieldedAddressFromSpendDesc(const CWalletTx* wtx, int index);
+    Optional<QString> getShieldedAddressFromSpendDesc(const uint256& txHash, int index);
 
     // Return status record for SendCoins, contains error id + information
     struct SendCoinsReturn {

--- a/src/qt/walletmodeltransaction.cpp
+++ b/src/qt/walletmodeltransaction.cpp
@@ -11,14 +11,11 @@ WalletModelTransaction::WalletModelTransaction(const QList<SendCoinsRecipient>& 
                                                                                               walletTransaction(0),
                                                                                               keyChange(0),
                                                                                               fee(0)
-{
-    walletTransaction = new CWalletTx();
-}
+{ }
 
 WalletModelTransaction::~WalletModelTransaction()
 {
     delete keyChange;
-    delete walletTransaction;
 }
 
 QList<SendCoinsRecipient> WalletModelTransaction::getRecipients()
@@ -26,19 +23,14 @@ QList<SendCoinsRecipient> WalletModelTransaction::getRecipients()
     return recipients;
 }
 
-CWalletTx* WalletModelTransaction::getTransaction()
+CTransactionRef& WalletModelTransaction::getTransaction()
 {
     return walletTransaction;
 }
 
-void WalletModelTransaction::setTransaction(CWalletTx* tx)
-{
-    walletTransaction = tx;
-}
-
 unsigned int WalletModelTransaction::getTransactionSize()
 {
-    return (!walletTransaction ? 0 : (::GetSerializeSize(*(walletTransaction->tx), SER_NETWORK, PROTOCOL_VERSION)));
+    return (!walletTransaction ? 0 : (::GetSerializeSize(*walletTransaction, SER_NETWORK, PROTOCOL_VERSION)));
 }
 
 CAmount WalletModelTransaction::getTransactionFee()

--- a/src/qt/walletmodeltransaction.h
+++ b/src/qt/walletmodeltransaction.h
@@ -24,7 +24,6 @@ public:
 
     QList<SendCoinsRecipient> getRecipients();
 
-    CWalletTx* getTransaction();
     unsigned int getTransactionSize();
 
     void setTransactionFee(const CAmount& newFee);
@@ -35,14 +34,14 @@ public:
     CReserveKey* newPossibleKeyChange(CWallet* wallet);
     CReserveKey* getPossibleKeyChange();
 
-    void setTransaction(CWalletTx* tx);
+    CTransactionRef& getTransaction();
 
     // Whether should create a +v2 tx or go simple and create a v1.
     bool useV2{false};
 
 private:
     const QList<SendCoinsRecipient> recipients;
-    CWalletTx* walletTransaction{nullptr};
+    CTransactionRef walletTransaction;
     CReserveKey* keyChange{nullptr};
     CAmount fee;
 };

--- a/src/qt/walletmodeltransaction.h
+++ b/src/qt/walletmodeltransaction.h
@@ -38,6 +38,7 @@ public:
 
     // Whether should create a +v2 tx or go simple and create a v1.
     bool useV2{false};
+    bool fIsStakeDelegationVoided{false};
 
 private:
     const QList<SendCoinsRecipient> recipients;

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -143,7 +143,7 @@ UniValue preparebudget(const JSONRPCRequest& request)
     if (!proposal.IsWellFormed(g_budgetman.GetTotalBudget(proposal.GetBlockStart())))
         throw std::runtime_error("Proposal is not valid " + proposal.IsInvalidReason());
 
-    CWalletTx wtx;
+    CTransactionRef wtx;
     // make our change address
     CReserveKey keyChange(pwalletMain);
     if (!pwalletMain->CreateBudgetFeeTX(wtx, nHash, keyChange, false)) { // 50 PIV collateral for proposal
@@ -156,10 +156,10 @@ UniValue preparebudget(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_WALLET_ERROR, res.ToString());
 
     // Store proposal name as a comment
-    assert(pwalletMain->mapWallet.count(wtx.GetHash()));
-    pwalletMain->mapWallet[wtx.GetHash()].SetComment("Proposal: " + strProposalName);
+    assert(pwalletMain->mapWallet.count(wtx->GetHash()));
+    pwalletMain->mapWallet[wtx->GetHash()].SetComment("Proposal: " + strProposalName);
 
-    return wtx.GetHash().ToString();
+    return wtx->GetHash().ToString();
 }
 
 UniValue submitbudget(const JSONRPCRequest& request)

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -157,7 +157,7 @@ UniValue preparebudget(const JSONRPCRequest& request)
 
     // Store proposal name as a comment
     assert(pwalletMain->mapWallet.count(wtx->GetHash()));
-    pwalletMain->mapWallet[wtx->GetHash()].SetComment("Proposal: " + strProposalName);
+    pwalletMain->mapWallet.at(wtx->GetHash()).SetComment("Proposal: " + strProposalName);
 
     return wtx->GetHash().ToString();
 }

--- a/src/sapling/sapling_operation.cpp
+++ b/src/sapling/sapling_operation.cpp
@@ -230,8 +230,7 @@ OperationResult SaplingOperation::build()
 
 OperationResult SaplingOperation::send(std::string& retTxHash)
 {
-    CWalletTx wtx(pwalletMain, finalTx);
-    const CWallet::CommitResult& res = pwalletMain->CommitTransaction(wtx, tkeyChange, g_connman.get());
+    const CWallet::CommitResult& res = pwalletMain->CommitTransaction(finalTx, tkeyChange, g_connman.get());
     if (res.status != CWallet::CommitStatus::OK) {
         return errorOut(res.ToString());
     }

--- a/src/sapling/sapling_operation.cpp
+++ b/src/sapling/sapling_operation.cpp
@@ -177,13 +177,11 @@ OperationResult SaplingOperation::build()
         if (!opTx) {
             return errorOut("Failed to build transaction: " + txResult.GetError());
         }
-        finalTx.reset();
-        finalTx = MakeTransactionRef(*opTx);
 
         // Now check fee
-        bool isShielded = finalTx->IsShieldedTx();
-        const CAmount& nFeeNeeded = isShielded ? GetShieldedTxMinFee(*finalTx) :
-                                                 GetMinRelayFee(finalTx->GetTotalSize(), false);
+        bool isShielded = opTx->IsShieldedTx();
+        const CAmount& nFeeNeeded = isShielded ? GetShieldedTxMinFee(*opTx) :
+                                                 GetMinRelayFee(opTx->GetTotalSize(), false);
         if (nFeeNeeded <= nFeeRet) {
             // Check that the fee is not too high.
             CAmount nMaxFee = nFeeNeeded * (isShielded ? 100 : 10000);
@@ -223,7 +221,6 @@ OperationResult SaplingOperation::build()
     if (!opTx) {
         return errorOut("Failed to build transaction: " + txResult.GetError());
     }
-    finalTx.reset();
     finalTx = MakeTransactionRef(*opTx);
     return OperationResult(true);
 }

--- a/src/sapling/sapling_validation.cpp
+++ b/src/sapling/sapling_validation.cpp
@@ -6,7 +6,6 @@
 #include "sapling/sapling_validation.h"
 
 #include "consensus/consensus.h" // for MAX_BLOCK_SIZE_CURRENT
-#include "validation.h" // for MAX_ZEROCOIN_TX_SIZE
 #include "script/interpreter.h" // for SigHash
 #include "consensus/validation.h" // for CValidationState
 #include "util.h" // for error()

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -481,7 +481,7 @@ void SaplingScriptPubKeyMan::GetFilteredNotes(
         }
 
         // Filter the transactions before checking for notes
-        if (!CheckFinalTx(wtx) ||
+        if (!CheckFinalTx(wtx.tx) ||
             wtx.GetDepthInMainChain() < minDepth ||
             wtx.GetDepthInMainChain() > maxDepth) {
             continue;

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -38,7 +38,7 @@ void SaplingScriptPubKeyMan::UpdateSaplingNullifierNoteMapForBlock(const CBlock 
         const uint256& hash = tx->GetHash();
         bool txIsOurs = wallet->mapWallet.count(hash);
         if (txIsOurs) {
-            UpdateSaplingNullifierNoteMapWithTx(wallet->mapWallet[hash]);
+            UpdateSaplingNullifierNoteMapWithTx(wallet->mapWallet.at(hash));
         }
     }
 }
@@ -246,7 +246,7 @@ void SaplingScriptPubKeyMan::IncrementNoteWitnesses(const CBlockIndex* pindex,
             // If this is our note, witness it
             if (txIsOurs) {
                 SaplingOutPoint outPoint {hash, i};
-                ::WitnessNoteIfMine(wallet->mapWallet[hash].mapSaplingNoteData, chainHeight, nWitnessCacheSize, outPoint, saplingTree.witness());
+                ::WitnessNoteIfMine(wallet->mapWallet.at(hash).mapSaplingNoteData, chainHeight, nWitnessCacheSize, outPoint, saplingTree.witness());
             }
         }
 
@@ -768,7 +768,7 @@ bool SaplingScriptPubKeyMan::IsNoteSaplingChange(const std::set<std::pair<libzca
     // - Change created by spending fractions of Notes (because
     //   shieldsendmany sends change to the originating shielded address).
     // - Notes sent from one address to itself.
-    const auto& tx = wallet->mapWallet[op.hash];
+    const auto& tx = wallet->mapWallet.at(op.hash);
     if (tx.tx->sapData) {
         for (const SpendDescription& spend : tx.tx->sapData->vShieldedSpend) {
             if (nullifierSet.count(std::make_pair(address, spend.nullifier))) {
@@ -789,9 +789,9 @@ void SaplingScriptPubKeyMan::GetSaplingNoteWitnesses(const std::vector<SaplingOu
     int i = 0;
     for (SaplingOutPoint note : notes) {
         if (wallet->mapWallet.count(note.hash) &&
-            wallet->mapWallet[note.hash].mapSaplingNoteData.count(note) &&
-            wallet->mapWallet[note.hash].mapSaplingNoteData[note].witnesses.size() > 0) {
-            witnesses[i] = wallet->mapWallet[note.hash].mapSaplingNoteData[note].witnesses.front();
+            wallet->mapWallet.at(note.hash).mapSaplingNoteData.count(note) &&
+            wallet->mapWallet.at(note.hash).mapSaplingNoteData[note].witnesses.size() > 0) {
+            witnesses[i] = wallet->mapWallet.at(note.hash).mapSaplingNoteData[note].witnesses.front();
             if (!rt) {
                 rt = witnesses[i]->root();
             } else {

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -533,6 +533,14 @@ void SaplingScriptPubKeyMan::GetFilteredNotes(
 }
 
 Optional<libzcash::SaplingPaymentAddress>
+SaplingScriptPubKeyMan::GetAddressFromInputIfPossible(const uint256& txHash, int index) const
+{
+    const CWalletTx* wtx = wallet->GetWalletTx(txHash);
+    if (!wtx) return nullopt;
+    return GetAddressFromInputIfPossible(wtx, index);
+}
+
+Optional<libzcash::SaplingPaymentAddress>
         SaplingScriptPubKeyMan::GetAddressFromInputIfPossible(const CWalletTx* wtx, int index) const
 {
     if (!wtx->tx->sapData || wtx->tx->sapData->vShieldedSpend.empty()) return nullopt;

--- a/src/sapling/saplingscriptpubkeyman.h
+++ b/src/sapling/saplingscriptpubkeyman.h
@@ -300,6 +300,7 @@ public:
 
     //! Return the address from where the shielded spend is taking the funds from (if possible)
     Optional<libzcash::SaplingPaymentAddress> GetAddressFromInputIfPossible(const CWalletTx* wtx, int index) const;
+    Optional<libzcash::SaplingPaymentAddress> GetAddressFromInputIfPossible(const uint256& txHash, int index) const;
 
     //! Whether the nullifier is from this wallet
     bool IsSaplingNullifierFromMe(const uint256& nullifier) const;

--- a/src/test/librust/sapling_rpc_wallet_tests.cpp
+++ b/src/test/librust/sapling_rpc_wallet_tests.cpp
@@ -408,8 +408,9 @@ BOOST_AUTO_TEST_CASE(rpc_shieldsendmany_taddr_to_sapling)
     // Add a fake transaction to the wallet
     CMutableTransaction mtx;
     mtx.vout.emplace_back(5 * COIN, GetScriptForDestination(taddr));
-    CWalletTx wtx(pwalletMain, MakeTransactionRef(mtx));
-    pwalletMain->LoadToWallet(wtx);
+    // Add to wallet and get the updated wtx
+    pwalletMain->LoadToWallet({pwalletMain, MakeTransactionRef(mtx)});
+    CWalletTx& wtx = pwalletMain->mapWallet.at(mtx.GetHash());
 
     // Fake-mine the transaction
     BOOST_CHECK_EQUAL(0, chainActive.Height());
@@ -426,6 +427,7 @@ BOOST_AUTO_TEST_CASE(rpc_shieldsendmany_taddr_to_sapling)
     BOOST_CHECK_EQUAL(1, chainActive.Height());
     wtx.SetMerkleBranch(blockHash, 0);
     pwalletMain->LoadToWallet(wtx);
+    BOOST_CHECK_MESSAGE(pwalletMain->GetAvailableBalance() > 0, "tx not confirmed");
 
     // Context that shieldsendmany requires
     auto builder = TransactionBuilder(consensusParams, nextBlockHeight, pwalletMain);

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -245,7 +245,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.nLockTime = WITH_LOCK(cs_main, return chainActive.Tip()->nHeight+1);
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Fee(100000000L).Time(GetTime()).SpendsCoinbaseOrCoinstake(true).FromTx(tx));
-    { LOCK(cs_main); BOOST_CHECK(!CheckFinalTx(tx, LOCKTIME_MEDIAN_TIME_PAST)); }
+    { LOCK(cs_main); BOOST_CHECK(!CheckFinalTx(MakeTransactionRef(tx), LOCKTIME_MEDIAN_TIME_PAST)); }
 
     // time locked
     tx2.vin.resize(1);
@@ -259,7 +259,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx2.nLockTime = WITH_LOCK(cs_main, return chainActive.Tip()->GetMedianTimePast()+1);
     hash = tx2.GetHash();
     mempool.addUnchecked(hash, entry.Fee(100000000L).Time(GetTime()).SpendsCoinbaseOrCoinstake(true).FromTx(tx2));
-    { LOCK(cs_main); BOOST_CHECK(!CheckFinalTx(tx2, LOCKTIME_MEDIAN_TIME_PAST)); }
+    { LOCK(cs_main); BOOST_CHECK(!CheckFinalTx(MakeTransactionRef(tx2), LOCKTIME_MEDIAN_TIME_PAST)); }
 
     BOOST_CHECK(pblocktemplate = BlockAssembler(Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey, pwalletMain, false));
 

--- a/src/test/script_P2SH_tests.cpp
+++ b/src/test/script_P2SH_tests.cpp
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(sign)
         txFrom.vout[i+4].scriptPubKey = standardScripts[i];
         txFrom.vout[i+4].nValue = COIN;
     }
-    BOOST_CHECK(IsStandardTx(txFrom, 0, reason));
+    BOOST_CHECK(IsStandardTx(MakeTransactionRef(txFrom), 0, reason));
 
     CMutableTransaction txTo[8]; // Spending transactions
     for (int i = 0; i < 8; i++)
@@ -187,7 +187,7 @@ BOOST_AUTO_TEST_CASE(set)
         txFrom.vout[i].scriptPubKey = outer[i];
         txFrom.vout[i].nValue = CENT;
     }
-    BOOST_CHECK(IsStandardTx(txFrom, 0, reason));
+    BOOST_CHECK(IsStandardTx(MakeTransactionRef(txFrom), 0, reason));
 
     CMutableTransaction txTo[4]; // Spending transactions
     for (int i = 0; i < 4; i++)
@@ -203,7 +203,7 @@ BOOST_AUTO_TEST_CASE(set)
     for (int i = 0; i < 4; i++)
     {
         BOOST_CHECK_MESSAGE(SignSignature(keystore, txFrom, txTo[i], 0, SIGHASH_ALL), strprintf("SignSignature %d", i));
-        BOOST_CHECK_MESSAGE(IsStandardTx(txTo[i], 0, reason), strprintf("txTo[%d].IsStandard", i));
+        BOOST_CHECK_MESSAGE(IsStandardTx(MakeTransactionRef(txTo[i]), 0, reason), strprintf("txTo[%d].IsStandard", i));
     }
 }
 

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -29,6 +29,12 @@
 // In script_tests.cpp
 extern UniValue read_json(const std::string& jsondata);
 
+// Helper
+bool IsStandardTx(const CTransaction& tx, int nBlockHeight, std::string& reason)
+{
+    return IsStandardTx(MakeTransactionRef(tx), nBlockHeight, reason);
+}
+
 static std::map<std::string, unsigned int> mapFlagNames = {
     {std::string("NONE"), (unsigned int)SCRIPT_VERIFY_NONE},
     {std::string("P2SH"), (unsigned int)SCRIPT_VERIFY_P2SH},

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -522,11 +522,11 @@ void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMem
     LOCK(cs);
     setEntries txToRemove;
     for (indexed_transaction_set::const_iterator it = mapTx.begin(); it != mapTx.end(); it++) {
-        const CTransaction& tx = it->GetTx();
+        const CTransactionRef& tx = it->GetSharedTx();
         if (!CheckFinalTx(tx, flags)) {
             txToRemove.insert(it);
         } else if (it->GetSpendsCoinbaseOrCoinstake()) {
-            for (const CTxIn& txin : tx.vin) {
+            for (const CTxIn& txin : tx->vin) {
                 indexed_transaction_set::const_iterator it2 = mapTx.find(txin.prevout.hash);
                 if (it2 != mapTx.end())
                     continue;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -214,7 +214,7 @@ enum FlushStateMode {
 // See definition for documentation
 bool static FlushStateToDisk(CValidationState &state, FlushStateMode mode);
 
-bool CheckFinalTx(const CTransaction& tx, int flags)
+bool CheckFinalTx(const CTransactionRef& tx, int flags)
 {
     AssertLockHeld(cs_main);
 
@@ -359,12 +359,12 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState &state, const C
     // Only accept nLockTime-using transactions that can be mined in the next
     // block; we don't want our mempool filled up with transactions that can't
     // be mined yet.
-    if (!CheckFinalTx(tx, STANDARD_LOCKTIME_VERIFY_FLAGS))
+    if (!CheckFinalTx(_tx, STANDARD_LOCKTIME_VERIFY_FLAGS))
         return state.DoS(0, false, REJECT_NONSTANDARD, "non-final");
 
     // Rather not work on nonstandard transactions
     std::string reason;
-    if (!IsStandardTx(tx, nextBlockHeight, reason))
+    if (!IsStandardTx(_tx, nextBlockHeight, reason))
         return state.DoS(0, false, REJECT_NONSTANDARD, reason);
     // is it already in the memory pool?
     const uint256& hash = tx.GetHash();
@@ -2952,7 +2952,7 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
             return false; // Failure reason has been set in validation state object
         }
 
-        if (!IsFinalTx(*tx, nHeight, block.GetBlockTime())) {
+        if (!IsFinalTx(tx, nHeight, block.GetBlockTime())) {
             return state.DoS(10, false, REJECT_INVALID, "bad-txns-nonfinal", false, "non-final transaction");
         }
     }

--- a/src/validation.h
+++ b/src/validation.h
@@ -266,7 +266,7 @@ bool ValidOutPoint(const COutPoint& out, int nHeight);
  *
  * See consensus/consensus.h for flag definitions.
  */
-bool CheckFinalTx(const CTransaction& tx, int flags = -1);
+bool CheckFinalTx(const CTransactionRef& tx, int flags = -1);
 
 /**
  * Closure representing one script verification

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1256,7 +1256,7 @@ UniValue rawdelegatestake(const JSONRPCRequest& request)
     CReserveKey reservekey(pwalletMain);
     CreateColdStakeDelegation(request.params, wtx, reservekey);
 
-    return EncodeHexTx(wtx);
+    return EncodeHexTx(*wtx.tx);
 }
 
 
@@ -1489,7 +1489,7 @@ UniValue viewshieldtransaction(const JSONRPCRequest& request)
         outputs.push_back(entry_);
     }
 
-    entry.pushKV("fee", FormatMoney(pcoinsTip->GetValueIn(wtx) - wtx.tx->GetValueOut()));
+    entry.pushKV("fee", FormatMoney(pcoinsTip->GetValueIn(*wtx.tx) - wtx.tx->GetValueOut()));
     entry.pushKV("spends", spends);
     entry.pushKV("outputs", outputs);
 
@@ -1878,7 +1878,7 @@ UniValue getreceivedbyaddress(const JSONRPCRequest& request)
     CAmount nAmount = 0;
     for (std::map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it) {
         const CWalletTx& wtx = (*it).second;
-        if (wtx.IsCoinBase() || !IsFinalTx(wtx))
+        if (wtx.IsCoinBase() || !IsFinalTx(wtx.tx))
             continue;
 
         for (const CTxOut& txout : wtx.tx->vout)
@@ -1930,7 +1930,7 @@ UniValue getreceivedbylabel(const JSONRPCRequest& request)
     CAmount nAmount = 0;
     for (std::map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it) {
         const CWalletTx& wtx = (*it).second;
-        if (wtx.IsCoinBase() || !IsFinalTx(wtx))
+        if (wtx.IsCoinBase() || !IsFinalTx(wtx.tx))
             continue;
 
         for (const CTxOut& txout : wtx.tx->vout) {
@@ -2273,7 +2273,7 @@ UniValue ListReceived(const UniValue& params, bool by_label)
     for (std::map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it) {
         const CWalletTx& wtx = (*it).second;
 
-        if (wtx.IsCoinBase() || !IsFinalTx(wtx))
+        if (wtx.IsCoinBase() || !IsFinalTx(wtx.tx))
             continue;
 
         int nDepth = wtx.GetDepthInMainChain();
@@ -2581,7 +2581,7 @@ UniValue listcoldutxos(const JSONRPCRequest& request)
             pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it) {
         const uint256& wtxid = it->first;
         const CWalletTx* pcoin = &(*it).second;
-        if (!CheckFinalTx(*pcoin) || !pcoin->IsTrusted())
+        if (!CheckFinalTx(pcoin->tx) || !pcoin->IsTrusted())
             continue;
 
         // if this tx has no unspent P2CS outputs for us, skip it
@@ -2954,7 +2954,7 @@ UniValue gettransaction(const JSONRPCRequest& request)
     ListTransactions(wtx, 0, false, details, filter);
     entry.pushKV("details", details);
 
-    std::string strHex = EncodeHexTx(static_cast<CTransaction>(wtx));
+    std::string strHex = EncodeHexTx(*wtx.tx);
     entry.pushKV("hex", strHex);
 
     return entry;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -997,10 +997,10 @@ static UniValue ShieldSendManyTo(const UniValue& sendTo,
     const uint256 txHash(txid);
     assert(pwalletMain->mapWallet.count(txHash));
     if (!commentStr.empty()) {
-        pwalletMain->mapWallet[txHash].mapValue["comment"] = commentStr;
+        pwalletMain->mapWallet.at(txHash).mapValue["comment"] = commentStr;
     }
     if (!toStr.empty()) {
-        pwalletMain->mapWallet[txHash].mapValue["to"] = toStr;
+        pwalletMain->mapWallet.at(txHash).mapValue["to"] = toStr;
     }
 
     return txid;
@@ -1059,7 +1059,7 @@ UniValue sendtoaddress(const JSONRPCRequest& request)
     SendMoney(address, nAmount, tx);
 
     // Wallet comments
-    CWalletTx& wtx = pwalletMain->mapWallet[tx->GetHash()];
+    CWalletTx& wtx = pwalletMain->mapWallet.at(tx->GetHash());
     if (!commentStr.empty())
         wtx.mapValue["comment"] = commentStr;
     if (!toStr.empty())
@@ -1383,7 +1383,7 @@ UniValue viewshieldtransaction(const JSONRPCRequest& request)
     UniValue entry(UniValue::VOBJ);
     if (!pwalletMain->mapWallet.count(hash))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid or non-wallet transaction id");
-    const CWalletTx& wtx = pwalletMain->mapWallet[hash];
+    const CWalletTx& wtx = pwalletMain->mapWallet.at(hash);
 
     if (!wtx.tx->IsShieldedTx()) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid transaction, no shield data available");
@@ -2106,7 +2106,7 @@ static UniValue legacy_sendmany(const UniValue& sendTo, int nMinDepth, std::stri
         throw JSONRPCError(RPC_WALLET_ERROR, res.ToString());
 
     // Set comment
-    CWalletTx& wtx = pwalletMain->mapWallet[txNew->GetHash()];
+    CWalletTx& wtx = pwalletMain->mapWallet.at(txNew->GetHash());
     if (!comment.empty()) {
         wtx.mapValue["comment"] = comment;
     }
@@ -2496,7 +2496,7 @@ UniValue listreceivedbyshieldaddress(const JSONRPCRequest& request)
         int64_t time = 0;
 
         if (pwalletMain->mapWallet.count(entry.op.hash)) {
-            const CWalletTx& wtx = pwalletMain->mapWallet[entry.op.hash];
+            const CWalletTx& wtx = pwalletMain->mapWallet.at(entry.op.hash);
             if (!wtx.hashBlock.IsNull())
                 height = mapBlockIndex[wtx.hashBlock]->nHeight;
             index = wtx.nIndex;
@@ -2941,7 +2941,7 @@ UniValue gettransaction(const JSONRPCRequest& request)
     UniValue entry(UniValue::VOBJ);
     if (!pwalletMain->mapWallet.count(hash))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid or non-wallet transaction id");
-    const CWalletTx& wtx = pwalletMain->mapWallet[hash];
+    const CWalletTx& wtx = pwalletMain->mapWallet.at(hash);
 
     CAmount nCredit = wtx.GetCredit(filter);
     CAmount nDebit = wtx.GetDebit(filter);

--- a/src/wallet/test/wallet_shielded_balances_tests.cpp
+++ b/src/wallet/test/wallet_shielded_balances_tests.cpp
@@ -31,7 +31,7 @@ void setupWallet(CWallet& wallet)
 CWalletTx& SetWalletNotesData(CWallet* wallet, CWalletTx& wtx)
 {
     Optional<mapSaplingNoteData_t> saplingNoteData{nullopt};
-    wallet->FindNotesDataAndAddMissingIVKToKeystore(wtx, saplingNoteData);
+    wallet->FindNotesDataAndAddMissingIVKToKeystore(*wtx.tx, saplingNoteData);
     assert(static_cast<bool>(saplingNoteData));
     wtx.SetSaplingNoteData(*saplingNoteData);
     BOOST_CHECK(wallet->AddToWallet(wtx));

--- a/src/wallet/test/wallet_shielded_balances_tests.cpp
+++ b/src/wallet/test/wallet_shielded_balances_tests.cpp
@@ -36,7 +36,7 @@ CWalletTx& SetWalletNotesData(CWallet* wallet, CWalletTx& wtx)
     wtx.SetSaplingNoteData(*saplingNoteData);
     BOOST_CHECK(wallet->AddToWallet(wtx));
     // Updated tx
-    return wallet->mapWallet[wtx.GetHash()];
+    return wallet->mapWallet.at(wtx.GetHash());
 }
 
 /**
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(GetShieldedSimpleCachedCreditAndDebit)
     CTransaction tx = builder.Build().GetTxOrThrow();
     // add tx to wallet and update it.
     wallet.AddToWallet({&wallet, MakeTransactionRef(tx)});
-    CWalletTx& wtxDebit = wallet.mapWallet[tx.GetHash()];
+    CWalletTx& wtxDebit = wallet.mapWallet.at(tx.GetHash());
     // Update tx notes data (shielded change need it)
     CWalletTx& wtxDebitUpdated = SetWalletNotesData(&wallet, wtxDebit);
 
@@ -227,7 +227,7 @@ CWalletTx& buildTxAndLoadToWallet(CWallet& wallet, const libzcash::SaplingExtend
     CTransaction tx = builder.Build().GetTxOrThrow();
     // add tx to wallet and update it.
     wallet.AddToWallet({&wallet, MakeTransactionRef(tx)});
-    CWalletTx& wtx = wallet.mapWallet[tx.GetHash()];
+    CWalletTx& wtx = wallet.mapWallet.at(tx.GetHash());
     // Update tx notes data and return the updated wtx.
     return SetWalletNotesData(&wallet, wtx);
 }
@@ -351,7 +351,7 @@ BOOST_AUTO_TEST_CASE(GetShieldedAvailableCredit)
     // Simulate receiving a new block and updating the witnesses/nullifiers
     wallet.IncrementNoteWitnesses(fakeBlock.pindex, &fakeBlock.block, tree);
     wallet.GetSaplingScriptPubKeyMan()->UpdateSaplingNullifierNoteMapForBlock(&fakeBlock.block);
-    wtxUpdated = wallet.mapWallet[wtxUpdated.GetHash()];
+    wtxUpdated = wallet.mapWallet.at(wtxUpdated.GetHash());
 
     // 3) Now can spend one output and recalculate the shielded credit.
     std::vector<SaplingNoteEntry> saplingEntries;

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -323,7 +323,7 @@ void removeTxFromMempool(CWalletTx& wtx)
 CBlockIndex* SimpleFakeMine(CWalletTx& wtx, CBlockIndex* pprev = nullptr)
 {
     CBlock block;
-    block.vtx.emplace_back(std::make_shared<const CTransaction>(wtx));
+    block.vtx.emplace_back(wtx.tx);
     block.hashMerkleRoot = BlockMerkleRoot(block);
     if (pprev) block.hashPrevBlock = pprev->GetBlockHash();
     CBlockIndex* fakeIndex = new CBlockIndex(block);

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -353,7 +353,7 @@ CWalletTx& BuildAndLoadTxToWallet(const std::vector<CTxIn>& vin,
     mTx.vout = vout;
     CTransaction tx(mTx);
     wallet.LoadToWallet({&wallet, MakeTransactionRef(tx)});
-    return wallet.mapWallet[tx.GetHash()];
+    return wallet.mapWallet.at(tx.GetHash());
 }
 
 CWalletTx& ReceiveBalanceWith(const std::vector<CTxOut>& vout,

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -49,7 +49,7 @@ CFeeRate CWallet::minTxFee = CFeeRate(10000);
  */
 CAmount CWallet::minStakeSplitThreshold = DEFAULT_MIN_STAKE_SPLIT_THRESHOLD;
 
-const uint256 CMerkleTx::ABANDON_HASH(uint256S("0000000000000000000000000000000000000000000000000000000000000001"));
+const uint256 CWalletTx::ABANDON_HASH(uint256S("0000000000000000000000000000000000000000000000000000000000000001"));
 
 /** @defgroup mapWallet
  *
@@ -4211,7 +4211,7 @@ CWalletKey::CWalletKey(int64_t nExpires)
     nTimeExpires = nExpires;
 }
 
-void CMerkleTx::SetMerkleBranch(const uint256& blockHash, int posInBlock)
+void CWalletTx::SetMerkleBranch(const uint256& blockHash, int posInBlock)
 {
     // Update the tx's hashBlock
     hashBlock = blockHash;
@@ -4220,13 +4220,13 @@ void CMerkleTx::SetMerkleBranch(const uint256& blockHash, int posInBlock)
     nIndex = posInBlock;
 }
 
-int CMerkleTx::GetDepthInMainChain() const
+int CWalletTx::GetDepthInMainChain() const
 {
     const CBlockIndex* pindexRet = nullptr;
     return GetDepthInMainChain(pindexRet);
 }
 
-int CMerkleTx::GetDepthInMainChain(const CBlockIndex*& pindexRet) const
+int CWalletTx::GetDepthInMainChain(const CBlockIndex*& pindexRet) const
 {
     if (hashUnset())
         return 0;
@@ -4250,7 +4250,7 @@ int CMerkleTx::GetDepthInMainChain(const CBlockIndex*& pindexRet) const
     return nResult;
 }
 
-int CMerkleTx::GetBlocksToMaturity() const
+int CWalletTx::GetBlocksToMaturity() const
 {
     LOCK(cs_main);
     if (!(IsCoinBase() || IsCoinStake()))
@@ -4258,12 +4258,12 @@ int CMerkleTx::GetBlocksToMaturity() const
     return std::max(0, (Params().GetConsensus().nCoinbaseMaturity + 1) - GetDepthInMainChain());
 }
 
-bool CMerkleTx::IsInMainChain() const
+bool CWalletTx::IsInMainChain() const
 {
     return GetDepthInMainChain() > 0;
 }
 
-bool CMerkleTx::IsInMainChainImmature() const
+bool CWalletTx::IsInMainChainImmature() const
 {
     if (!IsCoinBase() && !IsCoinStake()) return false;
     const int depth = GetDepthInMainChain();
@@ -4271,7 +4271,7 @@ bool CMerkleTx::IsInMainChainImmature() const
 }
 
 
-bool CMerkleTx::AcceptToMemoryPool(CValidationState& state, bool fLimitFree, bool fRejectInsaneFee, bool ignoreFees)
+bool CWalletTx::AcceptToMemoryPool(CValidationState& state, bool fLimitFree, bool fRejectInsaneFee, bool ignoreFees)
 {
     bool fAccepted = ::AcceptToMemoryPool(mempool, state, tx, fLimitFree, nullptr, false, fRejectInsaneFee, ignoreFees);
     if (!fAccepted)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2725,7 +2725,8 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend,
     AvailableCoinsType coin_type,
     bool sign,
     CAmount nFeePay,
-    bool fIncludeDelegated)
+    bool fIncludeDelegated,
+    bool* fStakeDelegationVoided)
 {
     CAmount nValue = 0;
     int nChangePosRequest = nChangePosInOut;
@@ -2856,6 +2857,9 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend,
 
                 // Fill vin
                 for (const std::pair<const CWalletTx*, unsigned int>& coin : setCoins) {
+                    if(coin.first->tx->vout[coin.second].scriptPubKey.IsPayToColdStaking()) {
+                        *fStakeDelegationVoided = true;
+                    }
                     txNew.vin.emplace_back(coin.first->GetHash(), coin.second);
                 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4532,11 +4532,6 @@ bool CWallet::LoadSaplingPaymentAddress(
 ///////////////// End Sapling Methods //////////////////////
 ////////////////////////////////////////////////////////////
 
-CWalletTx::CWalletTx() : CMerkleTx()
-{
-    Init(NULL);
-}
-
 CWalletTx::CWalletTx(const CWallet* pwalletIn, CTransactionRef arg) : CMerkleTx(std::move(arg))
 {
     // todo: set tx ref

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4532,9 +4532,11 @@ bool CWallet::LoadSaplingPaymentAddress(
 ///////////////// End Sapling Methods //////////////////////
 ////////////////////////////////////////////////////////////
 
-CWalletTx::CWalletTx(const CWallet* pwalletIn, CTransactionRef arg) : CMerkleTx(std::move(arg))
+CWalletTx::CWalletTx(const CWallet* pwalletIn, CTransactionRef arg)
+    : tx(std::move(arg)),
+      hashBlock(uint256()),
+      nIndex(-1)
 {
-    // todo: set tx ref
     Init(pwalletIn);
 }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -955,7 +955,6 @@ public:
     mutable bool fShieldedChangeCached;
     mutable CAmount nShieldedChangeCached;
 
-    CWalletTx();
     CWalletTx(const CWallet* pwalletIn, CTransactionRef arg);
     void Init(const CWallet* pwalletIn);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -639,7 +639,7 @@ public:
      * @note passing nChangePosInOut as -1 will result in setting a random position
      */
     bool CreateTransaction(const std::vector<CRecipient>& vecSend,
-        CWalletTx* wtxNew,
+        CTransactionRef& txRet,
         CReserveKey& reservekey,
         CAmount& nFeeRet,
         int& nChangePosInOut,
@@ -649,7 +649,7 @@ public:
         bool sign = true,
         CAmount nFeePay = 0,
         bool fIncludeDelegated = false);
-    bool CreateTransaction(CScript scriptPubKey, const CAmount& nValue, CWalletTx* wtxNew, CReserveKey& reservekey, CAmount& nFeeRet, std::string& strFailReason, const CCoinControl* coinControl = NULL, AvailableCoinsType coin_type = ALL_COINS, CAmount nFeePay = 0, bool fIncludeDelegated = false);
+    bool CreateTransaction(CScript scriptPubKey, const CAmount& nValue, CTransactionRef& tx, CReserveKey& reservekey, CAmount& nFeeRet, std::string& strFailReason, const CCoinControl* coinControl = NULL, AvailableCoinsType coin_type = ALL_COINS, CAmount nFeePay = 0, bool fIncludeDelegated = false);
 
     // enumeration for CommitResult (return status of CommitTransaction)
     enum CommitStatus
@@ -667,8 +667,8 @@ public:
         // converts CommitResult in human-readable format
         std::string ToString() const;
     };
-    CWallet::CommitResult CommitTransaction(CWalletTx& wtxNew, CReserveKey& opReservekey, CConnman* connman);
-    CWallet::CommitResult CommitTransaction(CWalletTx& wtxNew, CReserveKey* reservekey, CConnman* connman);
+    CWallet::CommitResult CommitTransaction(CTransactionRef tx, CReserveKey& opReservekey, CConnman* connman);
+    CWallet::CommitResult CommitTransaction(CTransactionRef tx, CReserveKey* reservekey, CConnman* connman);
     bool CreateCoinStake(const CKeyStore& keystore,
                          const CBlockIndex* pindexPrev,
                          unsigned int nBits,
@@ -706,7 +706,7 @@ public:
 
     std::set<CTxDestination> GetLabelAddresses(const std::string& label) const;
 
-    bool CreateBudgetFeeTX(CWalletTx& tx, const uint256& hash, CReserveKey& keyChange, bool fFinalization);
+    bool CreateBudgetFeeTX(CTransactionRef& tx, const uint256& hash, CReserveKey& keyChange, bool fFinalization);
 
     bool IsUsed(const CTxDestination address) const;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -885,7 +885,8 @@ public:
         AvailableCoinsType coin_type = ALL_COINS,
         bool sign = true,
         CAmount nFeePay = 0,
-        bool fIncludeDelegated = false);
+        bool fIncludeDelegated = false,
+        bool* fStakeDelegationVoided = nullptr);
     bool CreateTransaction(CScript scriptPubKey, const CAmount& nValue, CTransactionRef& tx, CReserveKey& reservekey, CAmount& nFeeRet, std::string& strFailReason, const CCoinControl* coinControl = NULL, AvailableCoinsType coin_type = ALL_COINS, CAmount nFeePay = 0, bool fIncludeDelegated = false);
 
     // enumeration for CommitResult (return status of CommitTransaction)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -717,12 +717,12 @@ public:
     bool IsChange(const CTxOut& txout) const;
     bool IsChange(const CTxDestination& address) const;
     CAmount GetChange(const CTxOut& txout) const;
-    bool IsMine(const CTransaction& tx) const;
+    bool IsMine(const CTransactionRef& tx) const;
     /** should probably be renamed to IsRelevantToMe */
-    bool IsFromMe(const CTransaction& tx) const;
-    CAmount GetDebit(const CTransaction& tx, const isminefilter& filter) const;
+    bool IsFromMe(const CTransactionRef& tx) const;
+    CAmount GetDebit(const CTransactionRef& tx, const isminefilter& filter) const;
     CAmount GetCredit(const CWalletTx& tx, const isminefilter& filter) const;
-    CAmount GetChange(const CTransaction& tx) const;
+    CAmount GetChange(const CTransactionRef& tx) const;
 
     void SetBestChain(const CBlockLocator& loc) override;
     void SetBestChainInternal(CWalletDB& walletdb, const CBlockLocator& loc); // only public for testing purposes, must never be called directly in any other situation
@@ -890,10 +890,6 @@ public:
         SetTx(std::move(arg));
         Init();
     }
-
-    /** Helper conversion operator to allow passing CMerkleTx where CTransaction is expected.
-     *  TODO: adapt callers and remove this operator. */
-    operator const CTransaction&() const { return *tx; }
 
     void Init()
     {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -872,19 +872,15 @@ class CMerkleTx
 private:
 
 public:
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    template<typename Stream>
+    void Unserialize(Stream& s)
     {
         CTransactionRef tx;
         uint256 hashBlock;
+        std::vector<uint256> vMerkleBranch;
         int nIndex;
-        std::vector<uint256> vMerkleBranch; // For compatibility with older versions.
-        READWRITE(tx);
-        READWRITE(hashBlock);
-        READWRITE(vMerkleBranch);
-        READWRITE(nIndex);
+
+        s >> tx >> hashBlock >> vMerkleBranch >> nIndex;
     }
 };
 
@@ -941,7 +937,6 @@ public:
     template<typename Stream>
     void Serialize(Stream& s) const
     {
-        char fSpent = false;
         mapValue_t mapValueCopy = mapValue;
 
         mapValueCopy["fromaccount"] = "";
@@ -950,10 +945,10 @@ public:
             mapValueCopy["timesmart"] = strprintf("%u", nTimeSmart);
         }
 
-        std::vector<uint256> dummy_vector; //!< Used to be vMerkleBranch
-        s << tx << hashBlock << dummy_vector << nIndex;
-        std::vector<CMerkleTx> vUnused; //!< Used to be vtxPrev
-        s << vUnused << mapValueCopy << vOrderForm << fTimeReceivedIsTxTime << nTimeReceived << fFromMe << fSpent;
+        std::vector<char> dummy_vector1; //!< Used to be vMerkleBranch
+        std::vector<char> dummy_vector2; //!< Used to be vtxPrev
+        char dummy_char = false; //!< Used to be fSpent
+        s << tx << hashBlock << dummy_vector1 << nIndex << dummy_vector2 << mapValueCopy << vOrderForm << fTimeReceivedIsTxTime << nTimeReceived << fFromMe << dummy_char;
 
         if (this->tx->isSaplingVersion()) {
             s << mapSaplingNoteData;
@@ -964,12 +959,11 @@ public:
     void Unserialize(Stream& s)
     {
         Init(nullptr);
-        char fSpent;
 
-        std::vector<uint256> dummy_vector; //!< Used to be vMerkleBranch
-        s >> tx >> hashBlock >> dummy_vector >> nIndex;
-        std::vector<CMerkleTx> vUnused; //!< Used to be vtxPrev
-        s >> vUnused >> mapValue >> vOrderForm >> fTimeReceivedIsTxTime >> nTimeReceived >> fFromMe >> fSpent;
+        std::vector<uint256> dummy_vector1; //!< Used to be vMerkleBranch
+        std::vector<CMerkleTx> dummy_vector2; //!< Used to be vtxPrev
+        char dummy_char; //! Used to be fSpent
+        s >> tx >> hashBlock >> dummy_vector1 >> nIndex >> dummy_vector2 >> mapValue >> vOrderForm >> fTimeReceivedIsTxTime >> nTimeReceived >> fFromMe >> dummy_char;
 
         if (this->tx->isSaplingVersion()) {
             s >> mapSaplingNoteData;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -445,7 +445,7 @@ bool ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue, CW
         } else if (strType == "tx") {
             uint256 hash;
             ssKey >> hash;
-            CWalletTx wtx;
+            CWalletTx wtx(nullptr /* pwallet */, MakeTransactionRef());
             ssValue >> wtx;
             if (wtx.GetHash() != hash)
                 return false;
@@ -801,7 +801,7 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
         pwallet->nTimeFirstKey = 1; // 0 would be considered 'no value'
 
     for (const uint256& hash : wss.vWalletUpgrade)
-        WriteTx(pwallet->mapWallet[hash]);
+        WriteTx(pwallet->mapWallet.at(hash));
 
     // Rewrite encrypted wallets of versions 0.4.0 and 0.5.0rc:
     if (wss.fIsEncrypted && (wss.nFileVersion == 40000 || wss.nFileVersion == 50000))
@@ -855,7 +855,7 @@ DBErrors CWalletDB::FindWalletTx(CWallet* pwallet, std::vector<uint256>& vTxHash
                 uint256 hash;
                 ssKey >> hash;
 
-                CWalletTx wtx;
+                CWalletTx wtx(nullptr /* pwallet */, MakeTransactionRef());
                 ssValue >> wtx;
 
                 vTxHash.push_back(hash);


### PR DESCRIPTION
Have grouped a good number of improvements and updates over the wallet area, need all of them for a subsequent, probably larger, PR that i'm cooking:

1) Migrated several functions using `CTransaction` to `CTransactionRef`.
2) Moved `CreateTransaction` and `CommitTransaction` methods signatures from using `CWalletTx` to use `CTransactionRef`.
3) Refactored every `mapWallet` bracket operator usage.
4) Removed `CWalletTx` default constructor (Thanks to (2) and (3))
5) Decouple `CWalletTx` templated serialization in specific ser & unser functions.
6) Solved a small bug inside the sapling operation process, which was setting the final transaction before finalizing successfully.
7) Move-only, moved the `CWalletTx` and it's related classes definition above the `CWallet` class definition (required groundwork for a future PR).
8) Adapted upstream #16451 to our sources.