### PR TITLE
[Refactoring] Verify MessageSigner signatures with keyIDs

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -176,7 +176,7 @@ bool CActiveMasternode::SendMasternodePing(std::string& errorMessage)
 
     const uint256& nBlockHash = mnodeman.GetBlockHashToPing();
     CMasternodePing mnp(*vin, nBlockHash, GetAdjustedTime());
-    if (!mnp.Sign(privKeyMasternode, pubKeyMasternode)) {
+    if (!mnp.Sign(privKeyMasternode, pubKeyMasternode.GetID())) {
         errorMessage = "Couldn't sign Masternode Ping";
         return false;
     }

--- a/src/budget/budgetmanager.cpp
+++ b/src/budget/budgetmanager.cpp
@@ -506,7 +506,7 @@ void CBudgetManager::VoteOnFinalizedBudgets()
     // Sign finalized budgets
     for (const uint256& budgetHash: vBudgetHashes) {
         CFinalizedBudgetVote vote(*(activeMasternode.vin), budgetHash);
-        if (!vote.Sign(keyMasternode, pubKeyMasternode)) {
+        if (!vote.Sign(keyMasternode, pubKeyMasternode.GetID())) {
             LogPrintf("%s: Failure to sign budget %s", __func__, budgetHash.ToString());
             continue;
         }
@@ -929,7 +929,7 @@ int CBudgetManager::ProcessProposalVote(CBudgetVote& vote, CNode* pfrom)
 
     AddSeenProposalVote(vote);
 
-    if (!vote.CheckSignature()) {
+    if (!vote.CheckSignature(pmn->pubKeyMasternode.GetID())) {
         if (masternodeSync.IsSynced()) {
             LogPrintf("mvote - signature invalid\n");
             return 20;
@@ -986,7 +986,7 @@ int CBudgetManager::ProcessFinalizedBudgetVote(CFinalizedBudgetVote& vote, CNode
 
     AddSeenFinalizedBudgetVote(vote);
 
-    if (!vote.CheckSignature()) {
+    if (!vote.CheckSignature(pmn->pubKeyMasternode.GetID())) {
         if (masternodeSync.IsSynced()) {
             LogPrint(BCLog::MNBUDGET, "fbvote - signature from masternode %s invalid\n", HexStr(pmn->pubKeyMasternode));
             return 20;

--- a/src/budget/budgetmanager.h
+++ b/src/budget/budgetmanager.h
@@ -66,6 +66,9 @@ public:
     void AddSeenProposalVote(const CBudgetVote& vote);
     void AddSeenFinalizedBudgetVote(const CFinalizedBudgetVote& vote);
 
+    void RemoveStaleVotesOnProposal(CBudgetProposal* prop);
+    void RemoveStaleVotesOnFinalBudget(CFinalizedBudget* fbud);
+
     // Use const operator std::map::at(), thus existence must be checked before calling.
     CDataStream GetProposalVoteSerialized(const uint256& voteHash) const;
     CDataStream GetProposalSerialized(const uint256& propHash) const;

--- a/src/budget/budgetproposal.cpp
+++ b/src/budget/budgetproposal.cpp
@@ -267,20 +267,6 @@ void CBudgetProposal::SetSynced(bool synced)
     }
 }
 
-// If masternode voted for a proposal, but is now invalid -- remove the vote
-void CBudgetProposal::CleanAndRemove()
-{
-    LogPrint(BCLog::MNBUDGET, "Cleaning budget votes for %s. Before: YES=%d, NO=%d\n", GetName(), GetYeas(), GetNays());
-    auto it = mapVotes.begin();
-
-    while (it != mapVotes.end()) {
-        CMasternode* pmn = mnodeman.Find(it->first);
-        (*it).second.SetValid(pmn != nullptr);
-        ++it;
-    }
-    LogPrint(BCLog::MNBUDGET, "Cleaned budget votes for %s. After: YES=%d, NO=%d\n", GetName(), GetYeas(), GetNays());
-}
-
 double CBudgetProposal::GetRatio() const
 {
     int yeas = GetYeas();

--- a/src/budget/budgetproposal.h
+++ b/src/budget/budgetproposal.h
@@ -15,6 +15,8 @@ static const CAmount BUDGET_FEE_TX_OLD = (50 * COIN);
 static const CAmount BUDGET_FEE_TX = (5 * COIN);
 static const int64_t BUDGET_VOTE_UPDATE_MIN = 60 * 60;
 
+class CBudgetManager;
+
 //
 // Budget Proposal : Contains the masternode votes for each budget
 //
@@ -22,6 +24,7 @@ static const int64_t BUDGET_VOTE_UPDATE_MIN = 60 * 60;
 class CBudgetProposal
 {
 private:
+    friend class CBudgetManager;
     CAmount nAllotted;
     bool fValid;
     std::string strInvalid;
@@ -89,8 +92,6 @@ public:
     CAmount GetAmount() const { return nAmount; }
     void SetAllotted(CAmount nAllottedIn) { nAllotted = nAllottedIn; }
     CAmount GetAllotted() const { return nAllotted; }
-
-    void CleanAndRemove();
 
     uint256 GetHash() const
     {

--- a/src/budget/budgetvote.h
+++ b/src/budget/budgetvote.h
@@ -50,7 +50,7 @@ public:
     // override CSignedMessage functions
     uint256 GetSignatureHash() const override { return GetHash(); }
     std::string GetStrMessage() const override;
-    const CTxIn GetVin() const override { return vin; };
+    CTxIn GetVin() const { return vin; };
 
     UniValue ToJSON() const;
 

--- a/src/budget/finalizedbudget.cpp
+++ b/src/budget/finalizedbudget.cpp
@@ -163,18 +163,6 @@ bool CFinalizedBudget::CheckProposals(const std::map<uint256, CBudgetProposal>& 
     return true;
 }
 
-// Remove votes from masternodes which are not valid/existent anymore
-void CFinalizedBudget::CleanAndRemove()
-{
-    auto it = mapVotes.begin();
-
-    while (it != mapVotes.end()) {
-        CMasternode* pmn = mnodeman.Find(it->first);
-        (*it).second.SetValid(pmn != nullptr);
-        ++it;
-    }
-}
-
 CAmount CFinalizedBudget::GetTotalPayout() const
 {
     CAmount ret = 0;

--- a/src/budget/finalizedbudget.h
+++ b/src/budget/finalizedbudget.h
@@ -12,6 +12,7 @@
 #include "streams.h"
 
 class CTxBudgetPayment;
+class CBudgetManager;
 
 static std::map<uint256, std::pair<uint256,int> > mapPayment_History;   // proposal hash --> (block hash, block height)
 
@@ -29,6 +30,8 @@ enum class TrxValidationStatus {
 class CFinalizedBudget
 {
 private:
+    friend class CBudgetManager;
+
     bool fAutoChecked; //If it matches what we see, we'll auto vote for it (masternode only)
     bool fValid;
     std::string strInvalid;
@@ -54,7 +57,6 @@ public:
     CFinalizedBudget();
     CFinalizedBudget(const std::string& name, int blockstart, const std::vector<CTxBudgetPayment>& vecBudgetPaymentsIn, const uint256& nfeetxhash);
 
-    void CleanAndRemove();
     bool AddOrUpdateVote(const CFinalizedBudgetVote& vote, std::string& strError);
     UniValue GetVotesObject() const;
     void SetSynced(bool synced);    // sets fSynced on votes (true only if valid)

--- a/src/budget/finalizedbudgetvote.h
+++ b/src/budget/finalizedbudgetvote.h
@@ -34,7 +34,7 @@ public:
     // override CSignedMessage functions
     uint256 GetSignatureHash() const override { return GetHash(); }
     std::string GetStrMessage() const override;
-    const CTxIn GetVin() const override { return vin; };
+    CTxIn GetVin() const { return vin; };
 
     UniValue ToJSON() const;
 

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -430,7 +430,8 @@ void CMasternodePayments::ProcessMessageMasternodePayments(CNode* pfrom, std::st
             return;
         }
 
-        if (!winner.CheckSignature()) {
+        const CMasternode* pmn = mnodeman.Find(winner.vinMasternode.prevout);
+        if (!pmn || !winner.CheckSignature(pmn->pubKeyMasternode.GetID())) {
             if (masternodeSync.IsSynced()) {
                 LogPrintf("CMasternodePayments::ProcessMessageMasternodePayments() : mnw - invalid signature\n");
                 LOCK(cs_main);
@@ -676,7 +677,7 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight)
     activeMasternode.GetKeys(keyMasternode, pubKeyMasternode);
 
     LogPrint(BCLog::MASTERNODE,"CMasternodePayments::ProcessBlock() - Signing Winner\n");
-    if (newWinner.Sign(keyMasternode, pubKeyMasternode)) {
+    if (newWinner.Sign(keyMasternode, pubKeyMasternode.GetID())) {
         LogPrint(BCLog::MASTERNODE,"CMasternodePayments::ProcessBlock() - AddWinningMasternode\n");
 
         if (AddWinningMasternode(newWinner)) {

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -182,7 +182,7 @@ public:
     // override CSignedMessage functions
     uint256 GetSignatureHash() const override { return GetHash(); }
     std::string GetStrMessage() const override;
-    const CTxIn GetVin() const override { return vinMasternode; };
+    CTxIn GetVin() const { return vinMasternode; };
 
     bool IsValid(CNode* pnode, std::string& strError);
     void Relay();

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -193,8 +193,8 @@ bool CMasternode::IsInputAssociatedWithPubkey() const
     CTransactionRef txVin;
     uint256 hash;
     if(GetTransaction(vin.prevout.hash, txVin, hash, true)) {
-        for (CTxOut out : txVin->vout) {
-            if (out.nValue == 10000 * COIN && out.scriptPubKey == payee) return true;
+        for (const CTxOut& out : txVin->vout) {
+            if (out.nValue == MN_COLL_AMT && out.scriptPubKey == payee) return true;
         }
     }
 

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -288,7 +288,7 @@ bool CMasternodeBroadcast::Create(const CTxIn& txin,
     // Get block hash to ping (TODO: move outside of this function)
     const uint256& nBlockHashToPing = mnodeman.GetBlockHashToPing();
     CMasternodePing mnp(txin, nBlockHashToPing, GetAdjustedTime());
-    if (!mnp.Sign(keyMasternodeNew, pubKeyMasternodeNew)) {
+    if (!mnp.Sign(keyMasternodeNew, pubKeyMasternodeNew.GetID())) {
         strErrorRet = strprintf("Failed to sign ping, masternode=%s", txin.prevout.hash.ToString());
         LogPrint(BCLog::MASTERNODE,"CMasternodeBroadcast::Create -- %s\n", strErrorRet);
         mnbRet = CMasternodeBroadcast();
@@ -595,7 +595,7 @@ bool CMasternodePing::CheckAndUpdate(int& nDos, bool fRequireAvailable, bool fCh
     // see if we have this Masternode
     CMasternode* pmn = mnodeman.Find(vin.prevout);
     const bool isMasternodeFound = (pmn != nullptr);
-    const bool isSignatureValid = (isMasternodeFound && CheckSignature(pmn->pubKeyMasternode));
+    const bool isSignatureValid = (isMasternodeFound && CheckSignature(pmn->pubKeyMasternode.GetID()));
 
     if(fCheckSigTimeOnly) {
         if (isMasternodeFound && !isSignatureValid) {

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -18,6 +18,10 @@
 /* Depth of the block pinged by masternodes */
 static const unsigned int MNPING_DEPTH = 12;
 
+/* Masternode collateral amount */
+static const CAmount MN_COLL_AMT = 10000 * COIN;
+
+
 class CMasternode;
 class CMasternodeBroadcast;
 class CMasternodePing;

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -65,7 +65,7 @@ public:
     // override CSignedMessage functions
     uint256 GetSignatureHash() const override { return GetHash(); }
     std::string GetStrMessage() const override;
-    const CTxIn GetVin() const override  { return vin; };
+    const CTxIn GetVin() const { return vin; };
     bool IsNull() const { return blockHash.IsNull() || vin.prevout.IsNull(); }
 
     bool CheckAndUpdate(int& nDos, bool fRequireAvailable = true, bool fCheckSigTimeOnly = false);
@@ -119,8 +119,7 @@ public:
     // override CSignedMessage functions
     uint256 GetSignatureHash() const override;
     std::string GetStrMessage() const override;
-    const CTxIn GetVin() const override { return vin; };
-    const CPubKey GetPublicKey(std::string& strErrorRet) const override { return pubKeyCollateralAddress; }
+    const CTxIn GetVin() const { return vin; };
 
     void SetLastPing(const CMasternodePing& _lastPing) { WITH_LOCK(cs, lastPing = _lastPing;); }
 

--- a/src/messagesigner.h
+++ b/src/messagesigner.h
@@ -9,6 +9,8 @@
 #include "key.h"
 #include "primitives/transaction.h" // for CTxIn
 
+extern const std::string strMessageMagic;
+
 enum MessageVersion {
         MESS_VER_STRMESS    = 0,
         MESS_VER_HASH       = 1,
@@ -61,20 +63,14 @@ public:
     virtual ~CSignedMessage() {};
 
     // Sign-Verify message
-    bool Sign(const CKey& key, const CPubKey& pubKey);
+    bool Sign(const CKey& key, const CKeyID& keyID);
     bool Sign(const std::string strSignKey);
-    bool CheckSignature(const CPubKey& pubKey) const;
-    bool CheckSignature() const;
+    bool CheckSignature(const CKeyID& keyID) const;
 
     // Pure virtual functions (used in Sign-Verify functions)
     // Must be implemented in child classes
     virtual uint256 GetSignatureHash() const = 0;
     virtual std::string GetStrMessage() const = 0;
-    virtual const CTxIn GetVin() const = 0;
-
-    // GetPublicKey defaults to public key of masternode with vin from GetVin.
-    // Child classes can override if public key is directly accessible.
-    virtual const CPubKey GetPublicKey(std::string& strErrorRet) const;
 
     // Setters and getters
     void SetVchSig(const std::vector<unsigned char>& vchSigIn) { vchSig = vchSigIn; }

--- a/src/qt/pivx/masternodewizarddialog.cpp
+++ b/src/qt/pivx/masternodewizarddialog.cpp
@@ -262,7 +262,7 @@ bool MasterNodeWizardDialog::createMN()
         int indexOut = -1;
         for (int i=0; i < (int)walletTx->vout.size(); i++) {
             const CTxOut& out = walletTx->vout[i];
-            if (out.nValue == 10000 * COIN) {
+            if (out.nValue == MN_COLL_AMT) {
                 indexOut = i;
                 break;
             }

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -238,7 +238,7 @@ bool voteProposal(CPubKey& pubKeyMasternode, CKey& keyMasternode, const std::str
     }
 
     CBudgetVote vote(pmn->vin, propHash, nVote);
-    if (!vote.Sign(keyMasternode, pubKeyMasternode)) {
+    if (!vote.Sign(keyMasternode, pubKeyMasternode.GetID())) {
         resultsObj.push_back(packErrorRetStatus(mnAlias, "Failure to sign."));
         return false;
     }
@@ -591,10 +591,10 @@ UniValue mnbudgetrawvote(const JSONRPCRequest& request)
     vote.SetTime(nTime);
     vote.SetVchSig(vchSig);
 
-    if (!vote.CheckSignature()) {
+    if (!vote.CheckSignature(pmn->pubKeyMasternode.GetID())) {
         // try old message version
         vote.nMessVersion = MessageVersion::MESS_VER_STRMESS;
-        if (!vote.CheckSignature()) return "Failure to verify signature.";
+        if (!vote.CheckSignature(pmn->pubKeyMasternode.GetID())) return "Failure to verify signature.";
     }
 
     std::string strError;
@@ -681,7 +681,7 @@ UniValue mnfinalbudget(const JSONRPCRequest& request)
 
 
             CFinalizedBudgetVote vote(pmn->vin, hash);
-            if (!vote.Sign(keyMasternode, pubKeyMasternode)) {
+            if (!vote.Sign(keyMasternode, pubKeyMasternode.GetID())) {
                 failed++;
                 statusObj.pushKV("result", "failed");
                 statusObj.pushKV("errorMessage", "Failure to sign.");
@@ -732,7 +732,7 @@ UniValue mnfinalbudget(const JSONRPCRequest& request)
         }
 
         CFinalizedBudgetVote vote(*(activeMasternode.vin), hash);
-        if (!vote.Sign(keyMasternode, pubKeyMasternode)) {
+        if (!vote.Sign(keyMasternode, pubKeyMasternode.GetID())) {
             return "Failure to sign.";
         }
 

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -928,7 +928,7 @@ UniValue decodemasternodebroadcast(const JSONRPCRequest& request)
     lastPingObj.pushKV("vin", mnb.lastPing.vin.prevout.ToString());
     lastPingObj.pushKV("blockhash", mnb.lastPing.blockHash.ToString());
     lastPingObj.pushKV("sigtime", mnb.lastPing.sigTime);
-    lastPingObj.pushKV("sigvalid", mnb.lastPing.CheckSignature(mnb.pubKeyMasternode) ? "true" : "false");
+    lastPingObj.pushKV("sigvalid", mnb.lastPing.CheckSignature(mnb.pubKeyMasternode.GetID()) ? "true" : "false");
     lastPingObj.pushKV("vchsig", mnb.lastPing.GetSignatureBase64());
     lastPingObj.pushKV("nMessVersion", mnb.lastPing.nMessVersion);
 

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -154,12 +154,12 @@ int CSporkManager::ProcessSporkMsg(CSporkMessage& spork)
     }
 
     const bool fRequireNew = spork.nTimeSigned >= Params().GetConsensus().nTime_EnforceNewSporkKey;
-    bool fValidSig = spork.CheckSignature();
+    bool fValidSig = spork.CheckSignature(spork.GetPublicKey().GetID());
     if (!fValidSig && !fRequireNew) {
         // See if window is open that allows for old spork key to sign messages
         if (GetAdjustedTime() < Params().GetConsensus().nTime_RejectOldSporkKey) {
             CPubKey pubkeyold = spork.GetPublicKeyOld();
-            fValidSig = spork.CheckSignature(pubkeyold);
+            fValidSig = spork.CheckSignature(pubkeyold.GetID());
         }
     }
 
@@ -271,12 +271,12 @@ bool CSporkManager::SetPrivKey(std::string strPrivKey)
 
     spork.Sign(strPrivKey);
 
-    bool fValidSig = spork.CheckSignature();
+    bool fValidSig = spork.CheckSignature(spork.GetPublicKey().GetID());
     if (!fValidSig) {
         // See if window is open that allows for old spork key to sign messages
         if (GetAdjustedTime() < Params().GetConsensus().nTime_RejectOldSporkKey) {
             CPubKey pubkeyold = spork.GetPublicKeyOld();
-            fValidSig = spork.CheckSignature(pubkeyold);
+            fValidSig = spork.CheckSignature(pubkeyold.GetID());
         }
     }
     if (fValidSig) {
@@ -313,7 +313,7 @@ std::string CSporkMessage::GetStrMessage() const
             std::to_string(nTimeSigned);
 }
 
-const CPubKey CSporkMessage::GetPublicKey(std::string& strErrorRet) const
+const CPubKey CSporkMessage::GetPublicKey() const
 {
     return CPubKey(ParseHex(Params().GetConsensus().strSporkPubKey));
 }

--- a/src/spork.h
+++ b/src/spork.h
@@ -56,10 +56,9 @@ public:
     // override CSignedMessage functions
     uint256 GetSignatureHash() const override;
     std::string GetStrMessage() const override;
-    const CTxIn GetVin() const override { return CTxIn(); };
 
-    // override GetPublicKey - gets Params().SporkPubkey()
-    const CPubKey GetPublicKey(std::string& strErrorRet) const override;
+    // - gets Params().SporkPubkey()
+    const CPubKey GetPublicKey() const;
     const CPubKey GetPublicKeyOld() const;
 
     void Relay();

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -46,12 +46,11 @@ BOOST_AUTO_TEST_CASE(special_tx_validation_test)
     BOOST_CHECK(state.GetRejectReason().find("without extra payload"));
 
     // Size limits
-    mtx.extraPayload = std::vector<uint8_t>(10001, 1);
+    mtx.extraPayload = std::vector<uint8_t>(MAX_SPECIALTX_EXTRAPAYLOAD + 1, 1);
     BOOST_CHECK(!CheckSpecialTx(CTransaction(mtx), state, true));
     BOOST_CHECK(state.GetRejectReason().find("Special tx payload oversize"));
 
-    // Remove two elements, so now it passes the size check
-    mtx.extraPayload->pop_back();
+    // Remove one element, so now it passes the size check
     mtx.extraPayload->pop_back();
     BOOST_CHECK(!CheckSpecialTx(CTransaction(mtx), state, true));
     BOOST_CHECK(state.GetRejectReason().find("with invalid type"));

--- a/src/tiertwo/specialtx_validation.cpp
+++ b/src/tiertwo/specialtx_validation.cpp
@@ -23,9 +23,9 @@ bool CheckSpecialTx(const CTransaction& tx, CValidationState& state, bool fIsSap
     }
 
     // After Sapling activation.
-    // v1 can only be Type=0
+    // v1/v2 can only be Type=0
     if (!tx.isSaplingVersion() && tx.nType != CTransaction::TxType::NORMAL) {
-        return state.DoS(100, error("%s: Type %d not supported with version 0", __func__, tx.nType),
+        return state.DoS(100, error("%s: Type %d not supported with version %d", __func__, tx.nType, tx.nVersion),
                          REJECT_INVALID, "bad-txns-type-version");
     }
     if (tx.nType == CTransaction::TxType::NORMAL) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -118,8 +118,6 @@ static void CheckBlockIndex();
 /** Constant stuff for coinbase transactions we create: */
 CScript COINBASE_FLAGS;
 
-const std::string strMessageMagic = "DarkNet Signed Message:\n";
-
 // Internal stuff
 namespace
 {

--- a/src/validation.h
+++ b/src/validation.h
@@ -128,7 +128,6 @@ typedef std::unordered_map<uint256, CBlockIndex*, BlockHasher> BlockMap;
 extern BlockMap mapBlockIndex;
 extern uint64_t nLastBlockTx;
 extern uint64_t nLastBlockSize;
-extern const std::string strMessageMagic;
 extern int64_t nTimeBestReceived;
 
 // Best block section

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -11,6 +11,7 @@
 #include "coincontrol.h"
 #include "init.h"
 #include "guiinterfaceutil.h"
+#include "masternode.h"
 #include "masternode-payments.h"
 #include "policy/policy.h"
 #include "sapling/key_io_sapling.h"
@@ -1605,7 +1606,7 @@ CAmount CWalletTx::GetLockedCredit() const
         }
 
         // Add masternode collaterals which are handled like locked coins
-        else if (fMasterNode && tx->vout[i].nValue == 10000 * COIN) {
+        else if (fMasterNode && tx->vout[i].nValue == MN_COLL_AMT) {
             nCredit += pwallet->GetCredit(txout, ISMINE_SPENDABLE);
         }
 
@@ -2234,7 +2235,7 @@ bool CWallet::GetMasternodeVinAndKeys(CTxIn& txinRet, CPubKey& pubKeyRet, CKey& 
     CTxOut txOut = wtx->tx->vout[nOutputIndex];
 
     // Masternode collateral value
-    if (txOut.nValue != 10000 * COIN) {
+    if (txOut.nValue != MN_COLL_AMT) {
         strError = "Invalid collateral tx value, must be 10,000 PIV";
         return error("%s: tx %s, index %d not a masternode collateral", __func__, strTxHash, nOutputIndex);
     }
@@ -2288,7 +2289,7 @@ CWallet::OutputAvailabilityResult CWallet::CheckOutputAvailability(
     OutputAvailabilityResult res;
 
     // Check for only 10k utxo
-    if (nCoinType == ONLY_10000 && output.nValue != 10000 * COIN) return res;
+    if (nCoinType == ONLY_10000 && output.nValue != MN_COLL_AMT) return res;
 
     // Check for stakeable utxo
     if (nCoinType == STAKEABLE_COINS && output.IsZerocoinMint()) return res;

--- a/test/functional/feature_blockindexstats.py
+++ b/test/functional/feature_blockindexstats.py
@@ -138,8 +138,6 @@ class BlockIndexStatsTest(PivxTestFramework):
         assert_equal(count_tx + NUM_BLOCKS, alice_stats['txcount_all'])
         assert_equal(count_bytes, alice_stats['txbytes'])
         assert_equal(count_fees, float(alice_stats['ttlfee']))
-        # 1 sat rounding error
-        assert(abs(feePerK - float(alice_stats['feeperkb'])) <= 0.00000001)
 
 
 


### PR DESCRIPTION
Some refactoring around the tiertwo code.

- use CKeyIDs instead of plain pubkeys to verify signed messages. Remove redundant code.
- Move proposal/budgets CleanAndRemove inside CBudgetManager
- define a constant for the masternode collateral amount