### PR TITLE
[Logging] remove unused return value from LogPrintStr

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -203,7 +203,9 @@ void BCLog::Logger::LogPrintStr(const std::string &str)
         // print to console
         fwrite(strTimestamped.data(), 1, strTimestamped.size(), stdout);
         fflush(stdout);
-    } else if (m_print_to_file) {
+    }
+
+    if (m_print_to_file) {
         std::lock_guard<std::mutex> scoped_lock(m_file_mutex);
 
         // buffer if we haven't opened the log yet

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -195,21 +195,19 @@ std::string BCLog::Logger::LogTimestampStr(const std::string &str)
     return strStamped;
 }
 
-int BCLog::Logger::LogPrintStr(const std::string &str)
+void BCLog::Logger::LogPrintStr(const std::string &str)
 {
-    int ret = 0; // Returns total number of characters written
+    std::string strTimestamped = LogTimestampStr(str);
+
     if (m_print_to_console) {
         // print to console
-        ret = fwrite(str.data(), 1, str.size(), stdout);
+        fwrite(strTimestamped.data(), 1, strTimestamped.size(), stdout);
         fflush(stdout);
     } else if (m_print_to_file) {
         std::lock_guard<std::mutex> scoped_lock(m_file_mutex);
 
-        std::string strTimestamped = LogTimestampStr(str);
-
         // buffer if we haven't opened the log yet
-        if (m_fileout == NULL) {
-            ret = strTimestamped.length();
+        if (m_fileout == nullptr) {
             m_msgs_before_open.push_back(strTimestamped);
 
         } else {
@@ -226,8 +224,6 @@ int BCLog::Logger::LogPrintStr(const std::string &str)
             FileWriteStr(strTimestamped, m_fileout);
         }
     }
-
-    return ret;
 }
 
 void BCLog::Logger::ShrinkDebugFile()

--- a/src/logging.h
+++ b/src/logging.h
@@ -98,7 +98,7 @@ namespace BCLog {
         std::atomic<bool> m_reopen_file{false};
 
         /** Send a string to the log output */
-        int LogPrintStr(const std::string &str);
+        void LogPrintStr(const std::string &str);
 
         /** Returns whether logs will be written to any output */
         bool Enabled() const { return m_print_to_console || m_print_to_file; }


### PR DESCRIPTION
Bug introduced in b3a1d84a86888b68aaca954cd1529e651adc24c1: `LogPrintStr` no longer returning the character count, because bitcoin/bitcoin#13148 should have been included in the backport.