### PR TITLE
Killing wallet and GUI cs_main locks

### DIFF
--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -12,12 +12,9 @@
 
 bool IsFinalTx(const CTransactionRef& tx, int nBlockHeight, int64_t nBlockTime)
 {
-    AssertLockHeld(cs_main);
     // Time based nLockTime implemented in 0.1.6
     if (tx->nLockTime == 0)
         return true;
-    if (nBlockHeight == 0)
-        nBlockHeight = chainActive.Height();
     if (nBlockTime == 0)
         nBlockTime = GetAdjustedTime();
     if ((int64_t)tx->nLockTime < ((int64_t)tx->nLockTime < LOCKTIME_THRESHOLD ? (int64_t)nBlockHeight : nBlockTime))

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -39,6 +39,6 @@ unsigned int GetP2SHSigOpCount(const CTransaction& tx, const CCoinsViewCache& ma
  * Check if transaction is final and can be included in a block with the
  * specified height and time. Consensus critical.
  */
-bool IsFinalTx(const CTransactionRef& tx, int nBlockHeight = 0, int64_t nBlockTime = 0);
+bool IsFinalTx(const CTransactionRef& tx, int nBlockHeight, int64_t nBlockTime = 0);
 
 #endif // BITCOIN_CONSENSUS_TX_VERIFY_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1971,11 +1971,9 @@ bool AppInitMain()
 
     // ********************************************************* Step 12: finished
 
-    SetRPCWarmupFinished();
-    uiInterface.InitMessage(_("Done loading"));
-
 #ifdef ENABLE_WALLET
     if (pwalletMain) {
+        uiInterface.InitMessage(_("Reaccepting wallet transactions..."));
         pwalletMain->postInitProcess(scheduler);
 
         // StakeMiner thread disabled by default on regtest
@@ -1984,6 +1982,9 @@ bool AppInitMain()
         }
     }
 #endif
+
+    SetRPCWarmupFinished();
+    uiInterface.InitMessage(_("Done loading"));
 
     return true;
 }

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -19,8 +19,10 @@ namespace interfaces {
             result.unconfirmed_watch_only_balance = m_wallet.GetUnconfirmedWatchOnlyBalance();
             result.immature_watch_only_balance = m_wallet.GetImmatureWatchOnlyBalance();
         }
-        result.delegate_balance = m_wallet.GetDelegatedBalance();
-        result.coldstaked_balance = m_wallet.GetColdStakingBalance();
+        if (result.have_coldstaking) { // At the moment, the GUI is not using these two balances.
+            result.delegate_balance = m_wallet.GetDelegatedBalance();
+            result.coldstaked_balance = m_wallet.GetColdStakingBalance();
+        }
         result.shielded_balance = m_wallet.GetAvailableShieldedBalance();
         result.unconfirmed_shielded_balance = m_wallet.GetUnconfirmedShieldedBalance();
         return result;

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -10,9 +10,10 @@ namespace interfaces {
 
     WalletBalances Wallet::getBalances() {
         WalletBalances result;
-        result.balance = m_wallet.GetAvailableBalance();
-        result.unconfirmed_balance = m_wallet.GetUnconfirmedBalance(ISMINE_SPENDABLE_TRANSPARENT);
-        result.immature_balance = m_wallet.GetImmatureBalance();
+        CWallet::Balance balance = m_wallet.GetBalance();
+        result.balance = balance.m_mine_trusted + balance.m_mine_trusted_shield;
+        result.unconfirmed_balance = balance.m_mine_untrusted_pending;
+        result.immature_balance = balance.m_mine_immature;
         result.have_watch_only = m_wallet.HaveWatchOnly();
         if (result.have_watch_only) {
             result.watch_only_balance = m_wallet.GetWatchOnlyBalance();
@@ -23,8 +24,8 @@ namespace interfaces {
             result.delegate_balance = m_wallet.GetDelegatedBalance();
             result.coldstaked_balance = m_wallet.GetColdStakingBalance();
         }
-        result.shielded_balance = m_wallet.GetAvailableShieldedBalance();
-        result.unconfirmed_shielded_balance = m_wallet.GetUnconfirmedShieldedBalance();
+        result.shielded_balance = balance.m_mine_trusted_shield;
+        result.unconfirmed_shielded_balance = balance.m_mine_untrusted_shielded_balance;
         return result;
     }
 

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -20,8 +20,8 @@ namespace interfaces {
             result.unconfirmed_watch_only_balance = m_wallet.GetUnconfirmedWatchOnlyBalance();
             result.immature_watch_only_balance = m_wallet.GetImmatureWatchOnlyBalance();
         }
-        if (result.have_coldstaking) { // At the moment, the GUI is not using these two balances.
-            result.delegate_balance = m_wallet.GetDelegatedBalance();
+        result.delegate_balance = balance.m_mine_cs_delegated_trusted;
+        if (result.have_coldstaking) { // At the moment, the GUI is not using the cold staked balance.
             result.coldstaked_balance = m_wallet.GetColdStakingBalance();
         }
         result.shielded_balance = balance.m_mine_trusted_shield;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -21,6 +21,7 @@ struct WalletBalances
     CAmount watch_only_balance{0};
     CAmount unconfirmed_watch_only_balance{0};
     CAmount immature_watch_only_balance{0};
+    bool have_coldstaking{false};
     CAmount delegate_balance{0};
     CAmount coldstaked_balance{0};
     CAmount shielded_balance{0};

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -78,6 +78,11 @@ bool CMasternodeSync::IsBlockchainSynced()
     return true;
 }
 
+bool CMasternodeSync::IsBlockchainSyncedReadOnly() const
+{
+    return fBlockchainSynced;
+}
+
 void CMasternodeSync::Reset()
 {
     fBlockchainSynced = false;

--- a/src/masternode-sync.h
+++ b/src/masternode-sync.h
@@ -98,6 +98,8 @@ public:
     bool IsBlockchainSynced();
     void ClearFulfilledRequest();
 
+    bool IsBlockchainSyncedReadOnly() const;
+
     // Sync message dispatcher
     bool MessageDispatcher(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
 

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -150,6 +150,11 @@ int64_t ClientModel::getLastBlockProcessedTime() const
     return cacheTip == nullptr ? Params().GenesisBlock().GetBlockTime() : cacheTip->GetBlockTime();
 }
 
+bool ClientModel::isTipCached() const
+{
+    return cacheTip;
+}
+
 double ClientModel::getVerificationProgress() const
 {
     return Checkpoints::GuessVerificationProgress(cacheTip);

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -135,6 +135,21 @@ QString ClientModel::getLastBlockHash() const
     return QString::fromStdString(nHash.GetHex());
 }
 
+uint256 ClientModel::getLastBlockProcessed() const
+{
+    return cacheTip == nullptr ? Params().GenesisBlock().GetHash() : cacheTip->GetBlockHash();
+}
+
+int ClientModel::getLastBlockProcessedHeight() const
+{
+    return cacheTip == nullptr ? 0 : cacheTip->nHeight;
+}
+
+int64_t ClientModel::getLastBlockProcessedTime() const
+{
+    return cacheTip == nullptr ? Params().GenesisBlock().GetBlockTime() : cacheTip->GetBlockTime();
+}
+
 double ClientModel::getVerificationProgress() const
 {
     return Checkpoints::GuessVerificationProgress(cacheTip);

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -64,6 +64,9 @@ public:
     int getNumBlocks();
     QDateTime getLastBlockDate() const;
     QString getLastBlockHash() const;
+    uint256 getLastBlockProcessed() const;
+    int getLastBlockProcessedHeight() const;
+    int64_t getLastBlockProcessedTime() const;
     double getVerificationProgress() const;
 
     quint64 getTotalBytesRecv() const;

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -68,6 +68,7 @@ public:
     int getLastBlockProcessedHeight() const;
     int64_t getLastBlockProcessedTime() const;
     double getVerificationProgress() const;
+    bool isTipCached() const;
 
     quint64 getTotalBytesRecv() const;
     quint64 getTotalBytesSent() const;

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -117,7 +117,7 @@ private:
     QString cachedMasternodeCountString;
     bool cachedReindexing;
     bool cachedImporting;
-    bool cachedInitialSync;
+    std::atomic<bool> cachedInitialSync{false};
 
     int numBlocksAtStartup;
 

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -65,6 +65,7 @@ public:
     void clearPayAmounts();
     void addPayAmount(const CAmount& amount, bool isShieldedRecipient);
     void setSelectionType(bool isTransparent) { fSelectTransparent = isTransparent; }
+    bool hasModel() { return model; }
 
     CCoinControl* coinControl{nullptr};
 

--- a/src/qt/macnotificationhandler.mm
+++ b/src/qt/macnotificationhandler.mm
@@ -25,25 +25,10 @@ void MacNotificationHandler::showNotification(const QString &title, const QStrin
 {
     // check if users OS has support for NSUserNotification
     if(this->hasUserNotificationCenterSupport()) {
-        // okay, seems like 10.8+
-        QByteArray utf8 = title.toUtf8();
-        char* cString = (char *)utf8.constData();
-        NSString *titleMac = [[NSString alloc] initWithUTF8String:cString];
-
-        utf8 = text.toUtf8();
-        cString = (char *)utf8.constData();
-        NSString *textMac = [[NSString alloc] initWithUTF8String:cString];
-
-        // do everything weak linked (because we will keep <10.8 compatibility)
-        id userNotification = [[NSClassFromString(@"NSUserNotification") alloc] init];
-        [userNotification performSelector:@selector(setTitle:) withObject:titleMac];
-        [userNotification performSelector:@selector(setInformativeText:) withObject:textMac];
-
-        id notificationCenterInstance = [NSClassFromString(@"NSUserNotificationCenter") performSelector:@selector(defaultUserNotificationCenter)];
-        [notificationCenterInstance performSelector:@selector(deliverNotification:) withObject:userNotification];
-
-        [titleMac release];
-        [textMac release];
+        NSUserNotification* userNotification = [[NSUserNotification alloc] init];
+        userNotification.title = title.toNSString();
+        userNotification.informativeText = text.toNSString();
+        [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification: userNotification];
         [userNotification release];
     }
 }

--- a/src/qt/pivx.cpp
+++ b/src/qt/pivx.cpp
@@ -449,16 +449,17 @@ void BitcoinApplication::requestShutdown()
     qDebug() << __func__ << ": Requesting shutdown";
     startThread();
     window->hide();
-    window->setClientModel(0);
+    if (walletModel) walletModel->stop();
+    window->setClientModel(nullptr);
     pollShutdownTimer->stop();
 
 #ifdef ENABLE_WALLET
     window->removeAllWallets();
     delete walletModel;
-    walletModel = 0;
+    walletModel = nullptr;
 #endif
     delete clientModel;
-    clientModel = 0;
+    clientModel = nullptr;
 
     // Show a simple window indicating shutdown status
     ShutdownWindow::showShutdownWindow(window);

--- a/src/qt/pivx.cpp
+++ b/src/qt/pivx.cpp
@@ -25,6 +25,7 @@
 #ifdef ENABLE_WALLET
 #include "paymentserver.h"
 #include "walletmodel.h"
+#include "interfaces/wallet.h"
 #endif
 #include "masternodeconfig.h"
 
@@ -69,6 +70,8 @@ Q_IMPORT_PLUGIN(QGifPlugin);
 // Declare meta types used for QMetaObject::invokeMethod
 Q_DECLARE_METATYPE(bool*)
 Q_DECLARE_METATYPE(CAmount)
+Q_DECLARE_METATYPE(interfaces::WalletBalances);
+Q_DECLARE_METATYPE(uint256)
 
 static void InitMessage(const std::string& message)
 {
@@ -571,6 +574,8 @@ int main(int argc, char* argv[])
     //   Need to pass name here as CAmount is a typedef (see http://qt-project.org/doc/qt-5/qmetatype.html#qRegisterMetaType)
     //   IMPORTANT if it is no longer a typedef use the normal variant above
     qRegisterMetaType<CAmount>("CAmount");
+    qRegisterMetaType<CAmount>("interfaces::WalletBalances");
+    qRegisterMetaType<size_t>("size_t");
 
     /// 3. Application identification
     // must be set before OptionsModel is initialized or translations are loaded,

--- a/src/qt/pivx.cpp
+++ b/src/qt/pivx.cpp
@@ -486,6 +486,7 @@ void BitcoinApplication::initializeResult(int retval)
 #ifdef ENABLE_WALLET
         if (pwalletMain) {
             walletModel = new WalletModel(pwalletMain, optionsModel);
+            walletModel->setClientModel(clientModel);
 
             window->addWallet(PIVXGUI::DEFAULT_WALLET, walletModel);
             window->setCurrentWallet(PIVXGUI::DEFAULT_WALLET);

--- a/src/qt/pivx/coldstakingwidget.cpp
+++ b/src/qt/pivx/coldstakingwidget.cpp
@@ -224,8 +224,6 @@ void ColdStakingWidget::loadWalletModel()
         ui->containerHistoryLabel->setVisible(false);
         ui->emptyContainer->setVisible(false);
         ui->listView->setVisible(false);
-
-        tryRefreshDelegations();
     }
 
 }
@@ -245,8 +243,14 @@ void ColdStakingWidget::walletSynced(bool sync)
     }
 }
 
+void ColdStakingWidget::showEvent(QShowEvent *event)
+{
+    tryRefreshDelegations();
+}
+
 void ColdStakingWidget::tryRefreshDelegations()
 {
+    if (!isVisible()) return;
     // Check for min update time to not reload the UI so often if the node is syncing.
     int64_t now = GetTime();
     if (lastRefreshTime + LOAD_MIN_TIME_INTERVAL < now) {

--- a/src/qt/pivx/coldstakingwidget.cpp
+++ b/src/qt/pivx/coldstakingwidget.cpp
@@ -204,7 +204,6 @@ ColdStakingWidget::ColdStakingWidget(PIVXGUI* parent) :
 void ColdStakingWidget::loadWalletModel()
 {
     if (walletModel) {
-        coinControlDialog->setModel(walletModel);
         sendMultiRow->setWalletModel(walletModel);
         txModel = walletModel->getTransactionTableModel();
         csModel = new ColdStakingModel(walletModel, txModel, walletModel->getAddressTableModel(), this);
@@ -213,10 +212,10 @@ void ColdStakingWidget::loadWalletModel()
 
         addressTableModel = walletModel->getAddressTableModel();
         addressesFilter = new AddressFilterProxyModel(AddressTableModel::ColdStaking, this);
-        addressesFilter->setSourceModel(addressTableModel);
         addressesFilter->sort(sortType, sortOrder);
-        ui->listViewStakingAddress->setModel(addressesFilter);
+        addressesFilter->setSourceModel(addressTableModel);
         ui->listViewStakingAddress->setModelColumn(AddressTableModel::Address);
+        ui->listViewStakingAddress->setModel(addressesFilter);
 
         connect(txModel, &TransactionTableModel::txArrived, this, &ColdStakingWidget::onTxArrived);
 
@@ -533,6 +532,7 @@ void ColdStakingWidget::onCoinControlClicked()
 {
     if (isInDelegation) {
         if (walletModel->getBalance() > 0) {
+            if (!coinControlDialog->hasModel()) coinControlDialog->setModel(walletModel);
             coinControlDialog->refreshDialog();
             setCoinControlPayAmounts();
             coinControlDialog->exec();

--- a/src/qt/pivx/coldstakingwidget.h
+++ b/src/qt/pivx/coldstakingwidget.h
@@ -48,6 +48,8 @@ public:
     void run(int type) override;
     void onError(QString error, int type) override;
 
+    void showEvent(QShowEvent *event) override;
+
 public Q_SLOTS:
     void walletSynced(bool sync);
 

--- a/src/qt/pivx/dashboardwidget.cpp
+++ b/src/qt/pivx/dashboardwidget.cpp
@@ -223,6 +223,7 @@ void DashboardWidget::loadWalletModel()
 void DashboardWidget::onTxArrived(const QString& hash, const bool& isCoinStake, const bool& isCSAnyType)
 {
     showList();
+    if (!isVisible()) return;
 #ifdef USE_QTCHARTS
     if (isCoinStake) {
         // Update value if this is our first stake
@@ -333,6 +334,7 @@ void DashboardWidget::walletSynced(bool sync)
         this->isSync = sync;
         ui->layoutWarning->setVisible(!this->isSync);
 #ifdef USE_QTCHARTS
+        if (!isVisible()) return;
         tryChartRefresh();
 #endif
     }

--- a/src/qt/pivx/dashboardwidget.cpp
+++ b/src/qt/pivx/dashboardwidget.cpp
@@ -521,7 +521,10 @@ void DashboardWidget::updateStakeFilter()
 // pair PIV, zPIV
 const QMap<int, std::pair<qint64, qint64>> DashboardWidget::getAmountBy()
 {
-    updateStakeFilter();
+    if (filterUpdateNeeded) {
+        filterUpdateNeeded = false;
+        updateStakeFilter();
+    }
     const int size = stakesFilter->rowCount();
     QMap<int, std::pair<qint64, qint64>> amountBy;
     // Get all of the stakes
@@ -617,6 +620,7 @@ void DashboardWidget::onChartYearChanged(const QString& yearStr)
         int newYear = yearStr.toInt();
         if (newYear != yearFilter) {
             yearFilter = newYear;
+            filterUpdateNeeded = true;
             refreshChart();
         }
     }
@@ -628,6 +632,7 @@ void DashboardWidget::onChartMonthChanged(const QString& monthStr)
         int newMonth = ui->comboBoxMonths->currentData().toInt();
         if (newMonth != monthFilter) {
             monthFilter = newMonth;
+            filterUpdateNeeded = true;
             refreshChart();
 #ifndef Q_OS_MAC
         // quick hack to re paint the chart view.
@@ -820,7 +825,7 @@ void DashboardWidget::onChartArrowClicked(bool goLeft)
             }
         }
     }
-
+    filterUpdateNeeded = true;
     refreshChart();
     //Check if data end day is current date and monthfilter is current month
     bool fEndDayisCurrent = dataenddate  == currentDate.day() && monthFilter == currentDate.month();

--- a/src/qt/pivx/dashboardwidget.cpp
+++ b/src/qt/pivx/dashboardwidget.cpp
@@ -361,7 +361,9 @@ void DashboardWidget::tryChartRefresh()
         } else {
             // Check for min update time to not reload the UI so often if the node is syncing.
             int64_t now = GetTime();
-            if (lastRefreshTime + CHART_LOAD_MIN_TIME_INTERVAL < now) {
+            int chartLoadIntervalTime = CHART_LOAD_MIN_TIME_INTERVAL;
+            if (clientModel->inInitialBlockDownload()) chartLoadIntervalTime *= 6; // 90 seconds update
+            if (lastRefreshTime + chartLoadIntervalTime < now) {
                 lastRefreshTime = now;
                 refreshChart();
             }

--- a/src/qt/pivx/dashboardwidget.h
+++ b/src/qt/pivx/dashboardwidget.h
@@ -170,6 +170,7 @@ private:
     ChartData* chartData{nullptr};
     bool hasStakes{false};
     bool fShowCharts{true};
+    std::atomic<bool> filterUpdateNeeded{false};
 
     void initChart();
     void showHideEmptyChart(bool show, bool loading, bool forceView = false);

--- a/src/qt/pivx/loadingdialog.h
+++ b/src/qt/pivx/loadingdialog.h
@@ -25,6 +25,7 @@ public:
         runnable = nullptr;
     }
     virtual void clean() {};
+    void setType(int _type) { type = _type; }
 public Q_SLOTS:
     void process();
 Q_SIGNALS:

--- a/src/qt/pivx/pwidget.cpp
+++ b/src/qt/pivx/pwidget.cpp
@@ -108,6 +108,8 @@ bool PWidget::execute(int type, std::unique_ptr<WalletModel::UnlockContext> pctx
             WalletWorker* _worker = static_cast<WalletWorker*>(task->worker.data());
             _worker->setContext(std::move(pctx));
         }
+        // Update type
+        task->worker->setType(type);
     }
     QThreadPool::globalInstance()->start(task.data());
     return true;

--- a/src/qt/pivx/send.h
+++ b/src/qt/pivx/send.h
@@ -57,7 +57,10 @@ public Q_SLOTS:
     void onValueChanged();
     void refreshAmounts();
     void changeTheme(bool isLightTheme, QString &theme) override;
-    void updateAmounts(const QString& titleTotalRemaining, const QString& labelAmountSend, const QString& labelAmountRemaining);
+    void updateAmounts(const QString& titleTotalRemaining,
+                       const QString& labelAmountSend,
+                       const QString& labelAmountRemaining,
+                       CAmount _delegationBalance);
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
@@ -88,7 +91,6 @@ private:
     SendCustomFeeDialog* customFeeDialog = nullptr;
     bool isCustomFeeSelected = false;
     bool fDelegationsChecked = false;
-    CAmount cachedDelegatedBalance{0};
 
     int nDisplayUnit;
     QList<SendMultiRow*> entries;
@@ -117,7 +119,7 @@ private:
     OperationResult prepareTransparent(WalletModelTransaction* tx);
     bool sendFinalStep();
     void setFocusOnLastEntry();
-    void showHideCheckBoxDelegations();
+    void showHideCheckBoxDelegations(CAmount delegationBalance);
     void updateEntryLabels(const QList<SendCoinsRecipient>& recipients);
     void setCustomFeeSelected(bool isSelected, const CAmount& customFee = DEFAULT_TRANSACTION_FEE);
     void setCoinControlPayAmounts();

--- a/src/qt/pivx/send.h
+++ b/src/qt/pivx/send.h
@@ -57,6 +57,7 @@ public Q_SLOTS:
     void onValueChanged();
     void refreshAmounts();
     void changeTheme(bool isLightTheme, QString &theme) override;
+    void updateAmounts(const QString& titleTotalRemaining, const QString& labelAmountSend, const QString& labelAmountRemaining);
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
@@ -99,6 +100,9 @@ private:
     Optional<QString> processingResultError{nullopt};
     std::atomic<bool> processingResult{false};
 
+    // Balance update
+    std::atomic<bool> isUpdatingBalance{false};
+
     ContactsDropdown *menuContacts = nullptr;
     TooltipMenu *menu = nullptr;
     // Current focus entry
@@ -114,12 +118,13 @@ private:
     bool sendFinalStep();
     void setFocusOnLastEntry();
     void showHideCheckBoxDelegations();
-    void updateEntryLabels(QList<SendCoinsRecipient> recipients);
+    void updateEntryLabels(const QList<SendCoinsRecipient>& recipients);
     void setCustomFeeSelected(bool isSelected, const CAmount& customFee = DEFAULT_TRANSACTION_FEE);
     void setCoinControlPayAmounts();
     void resetCoinControl();
     void resetChangeAddress();
     void hideContactsMenu();
+    void tryRefreshAmounts();
 };
 
 #endif // SEND_H

--- a/src/qt/pivx/settings/settingsinformationwidget.cpp
+++ b/src/qt/pivx/settings/settingsinformationwidget.cpp
@@ -14,7 +14,7 @@
 
 #include <QDir>
 
-#define REQUEST_UPDATE_MN_COUNT 0
+#define REQUEST_UPDATE_COUNTS 0
 
 SettingsInformationWidget::SettingsInformationWidget(PIVXGUI* _window,QWidget *parent) :
     PWidget(_window,parent),
@@ -141,6 +141,7 @@ void SettingsInformationWidget::setNumConnections(int count)
 
 void SettingsInformationWidget::setNumBlocks(int count)
 {
+    if (!isVisible()) return;
     ui->labelInfoBlockNumber->setText(QString::number(count));
     if (clientModel) {
         ui->labelInfoBlockTime->setText(clientModel->getLastBlockDate().toString());
@@ -168,7 +169,7 @@ void SettingsInformationWidget::showEvent(QShowEvent *event)
     if (clientModel) {
         clientModel->startMasternodesTimer();
         // Initial masternodes count value, running in a worker thread to not lock mnmanager mutex in the main thread.
-        execute(REQUEST_UPDATE_MN_COUNT);
+        execute(REQUEST_UPDATE_COUNTS);
     }
 }
 
@@ -181,15 +182,17 @@ void SettingsInformationWidget::hideEvent(QHideEvent *event) {
 
 void SettingsInformationWidget::run(int type)
 {
-    if (type == REQUEST_UPDATE_MN_COUNT) {
+    if (type == REQUEST_UPDATE_COUNTS) {
         QMetaObject::invokeMethod(this, "setMasternodeCount",
                                   Qt::QueuedConnection, Q_ARG(QString, clientModel->getMasternodesCount()));
+        QMetaObject::invokeMethod(this, "setNumBlocks",
+                                  Qt::QueuedConnection, Q_ARG(int, clientModel->getLastBlockProcessedHeight()));
     }
 }
 
 void SettingsInformationWidget::onError(QString error, int type)
 {
-    if (type == REQUEST_UPDATE_MN_COUNT) {
+    if (type == REQUEST_UPDATE_COUNTS) {
         setMasternodeCount(tr("No available data"));
     }
 }

--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -13,13 +13,11 @@
 #include "bitcoinunits.h"
 #include "qt/pivx/balancebubble.h"
 #include "clientmodel.h"
-#include "qt/guiconstants.h"
 #include "qt/guiutil.h"
 #include "optionsmodel.h"
 #include "qt/platformstyle.h"
 #include "walletmodel.h"
 #include "addresstablemodel.h"
-#include "guiinterface.h"
 
 #include "masternode-sync.h"
 #include "wallet/wallet.h"
@@ -476,7 +474,7 @@ void TopBar::setNumBlocks(int count)
 
     std::string text;
     bool needState = true;
-    if (masternodeSync.IsBlockchainSynced()) {
+    if (masternodeSync.IsBlockchainSyncedReadOnly()) {
         // chain synced
         Q_EMIT walletSynced(true);
         if (masternodeSync.IsSynced()) {

--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -474,26 +474,7 @@ void TopBar::setNumBlocks(int count)
     if (!clientModel)
         return;
 
-    // Acquire current block source
-    enum BlockSource blockSource = clientModel->getBlockSource();
-    std::string text = "";
-    switch (blockSource) {
-        case BLOCK_SOURCE_NETWORK:
-            text = "Synchronizing..";
-            break;
-        case BLOCK_SOURCE_DISK:
-            text = "Importing blocks from disk..";
-            break;
-        case BLOCK_SOURCE_REINDEX:
-            text = "Reindexing blocks on disk..";
-            break;
-        case BLOCK_SOURCE_NONE:
-            // Case: not Importing, not Reindexing and no network connection
-            text = "No block source available..";
-            ui->pushButtonSync->setChecked(false);
-            break;
-    }
-
+    std::string text;
     bool needState = true;
     if (masternodeSync.IsBlockchainSynced()) {
         // chain synced
@@ -523,7 +504,7 @@ void TopBar::setNumBlocks(int count)
         Q_EMIT walletSynced(false);
     }
 
-    if (needState) {
+    if (needState && clientModel->isTipCached()) {
         // Represent time from last generated block in human readable text
         QDateTime lastBlockDate = clientModel->getLastBlockDate();
         QDateTime currentDate = QDateTime::currentDateTime();

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -573,7 +573,7 @@ void TransactionRecord::updateStatus(const CWalletTx& wtx, int chainHeight)
     // Sort order, unrecorded transactions sort to the top
     status.sortKey = strprintf("%010d-%01d-%010u-%03d",
         wtx.m_confirm.block_height,
-        (wtx.IsCoinBase() ? 1 : 0),
+        ((wtx.IsCoinBase() || wtx.IsCoinStake()) ? 1 : 0),
         time,
         idx);
 

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -562,17 +562,8 @@ void TransactionRecord::loadHotOrColdStakeOrContract(
     ExtractAddress(p2csUtxo.scriptPubKey, false, record.address);
 }
 
-void TransactionRecord::updateStatus(const CWalletTx& wtx)
+void TransactionRecord::updateStatus(const CWalletTx& wtx, int chainHeight)
 {
-    AssertLockHeld(cs_main);
-    int chainHeight = chainActive.Height();
-
-    CBlockIndex *pindex = nullptr;
-    // Find the block the tx is in
-    BlockMap::iterator mi = mapBlockIndex.find(wtx.m_confirm.hashBlock);
-    if (mi != mapBlockIndex.end())
-        pindex = (*mi).second;
-
     // Determine transaction status
 
     // Update time if needed
@@ -581,7 +572,7 @@ void TransactionRecord::updateStatus(const CWalletTx& wtx)
 
     // Sort order, unrecorded transactions sort to the top
     status.sortKey = strprintf("%010d-%01d-%010u-%03d",
-        (pindex ? pindex->nHeight : std::numeric_limits<int>::max()),
+        wtx.m_confirm.block_height,
         (wtx.IsCoinBase() ? 1 : 0),
         time,
         idx);
@@ -634,12 +625,12 @@ void TransactionRecord::updateStatus(const CWalletTx& wtx)
             status.status = TransactionStatus::Confirmed;
         }
     }
+    status.needsUpdate = false;
 }
 
-bool TransactionRecord::statusUpdateNeeded()
+bool TransactionRecord::statusUpdateNeeded(int blockHeight) const
 {
-    AssertLockHeld(cs_main);
-    return status.cur_num_blocks != chainActive.Height();
+    return status.cur_num_blocks != blockHeight || status.needsUpdate;
 }
 
 int TransactionRecord::getOutputIndex() const

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -569,7 +569,7 @@ void TransactionRecord::updateStatus(const CWalletTx& wtx)
 
     CBlockIndex *pindex = nullptr;
     // Find the block the tx is in
-    BlockMap::iterator mi = mapBlockIndex.find(wtx.hashBlock);
+    BlockMap::iterator mi = mapBlockIndex.find(wtx.m_confirm.hashBlock);
     if (mi != mapBlockIndex.end())
         pindex = (*mi).second;
 

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -62,6 +62,8 @@ public:
 
     /** Current number of blocks (to know whether cached status is still valid) */
     int cur_num_blocks;
+
+    bool needsUpdate;
 };
 
 /** UI model for a transaction. A core transaction can be represented by multiple UI transactions if it has
@@ -181,11 +183,11 @@ public:
 
     /** Update status from core wallet tx.
      */
-    void updateStatus(const CWalletTx& wtx);
+    void updateStatus(const CWalletTx& wtx, int chainHeight);
 
     /** Return whether a status update is needed.
      */
-    bool statusUpdateNeeded();
+    bool statusUpdateNeeded(int blockHeight) const;
 
     /** Return transaction status
      */

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -239,24 +239,22 @@ public:
                     break;
                 }
                 if (showTransaction) {
-                    LOCK2(cs_main, wallet->cs_wallet);
                     // Find transaction in wallet
-                    auto mi = wallet->mapWallet.find(hash);
-                    if (mi == wallet->mapWallet.end()) {
+                    const CWalletTx* wtx = wallet->GetWalletTx(hash);
+                    if (!wtx) {
                         qWarning() << "TransactionTablePriv::updateWallet : Warning: Got CT_NEW, but transaction is not in wallet";
                         break;
                     }
-                    const CWalletTx& wtx = mi->second;
 
                     // As old transactions are still getting updated (+20k range),
                     // do not add them if we deliberately didn't load them at startup.
-                    if (cachedWallet.size() >= MAX_AMOUNT_LOADED_RECORDS && wtx.GetTxTime() < nFirstLoadedTxTime) {
+                    if (cachedWallet.size() >= MAX_AMOUNT_LOADED_RECORDS && wtx->GetTxTime() < nFirstLoadedTxTime) {
                         return;
                     }
 
                     // Added -- insert at the right position
                     QList<TransactionRecord> toInsert =
-                        TransactionRecord::decomposeTransaction(wallet, wtx);
+                        TransactionRecord::decomposeTransaction(wallet, *wtx);
                     if (!toInsert.isEmpty()) { /* only if something to insert */
                         parent->beginInsertRows(QModelIndex(), lowerIndex, lowerIndex + toInsert.size() - 1);
                         int insert_idx = lowerIndex;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -949,7 +949,7 @@ bool WalletModel::getMNCollateralCandidate(COutPoint& outPoint)
 
 bool WalletModel::isSpent(const COutPoint& outpoint) const
 {
-    LOCK2(cs_main, wallet->cs_wallet);
+    LOCK(wallet->cs_wallet);
     return wallet->IsSpent(outpoint.hash, outpoint.n);
 }
 
@@ -1026,19 +1026,19 @@ void WalletModel::listCoins(std::map<ListCoinsKey, std::vector<ListCoinsValue>>&
 
 bool WalletModel::isLockedCoin(uint256 hash, unsigned int n) const
 {
-    LOCK2(cs_main, wallet->cs_wallet);
+    LOCK(wallet->cs_wallet);
     return wallet->IsLockedCoin(hash, n);
 }
 
 void WalletModel::lockCoin(COutPoint& output)
 {
-    LOCK2(cs_main, wallet->cs_wallet);
+    LOCK(wallet->cs_wallet);
     wallet->LockCoin(output);
 }
 
 void WalletModel::unlockCoin(COutPoint& output)
 {
-    LOCK2(cs_main, wallet->cs_wallet);
+    LOCK(wallet->cs_wallet);
     wallet->UnlockCoin(output);
 }
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -29,7 +29,7 @@
 #include <stdint.h>
 #include <iostream>
 
-#include <QDebug>
+#include <QtConcurrent/QtConcurrent>
 #include <QSet>
 #include <QTimer>
 
@@ -193,57 +193,78 @@ bool WalletModel::isWalletLocked(bool fFullUnlocked) const
     return (status == Locked || (!fFullUnlocked && status == UnlockedForStaking));
 }
 
-bool IsImportingOrReindexing()
+static bool IsImportingOrReindexing()
 {
     return fImporting || fReindex;
 }
 
+std::atomic<bool> processingBalance{false};
+
+static bool processBalanceChangeInternal(WalletModel* walletModel)
+{
+    int chainHeight = walletModel->getLastBlockProcessedNum();
+    const uint256& blockHash = walletModel->getLastBlockProcessed();
+
+    if (walletModel->hasForceCheckBalance() || chainHeight != walletModel->getCacheNumBLocks()) {
+        // Try to get lock only if needed
+        TRY_LOCK(pwalletMain->cs_wallet, lockWallet);
+        if (!lockWallet)
+            return false;
+
+        walletModel->setfForceCheckBalanceChanged(false);
+
+        // Balance and number of transactions might have changed
+        walletModel->setCacheNumBlocks(chainHeight);
+        walletModel->setCacheBlockHash(blockHash);
+        walletModel->checkBalanceChanged(walletModel->getBalances());
+        QMetaObject::invokeMethod(walletModel, "updateTxModelData", Qt::QueuedConnection);
+        QMetaObject::invokeMethod(walletModel, "pollFinished", Qt::QueuedConnection);
+
+        // Address in receive tab may have been used
+        Q_EMIT walletModel->notifyReceiveAddressChanged();
+    }
+    return true;
+}
+
+static void processBalanceChange(WalletModel* walletModel)
+{
+    if (!processBalanceChangeInternal(walletModel)) {
+        processingBalance = false;
+    }
+}
+
 void WalletModel::pollBalanceChanged()
 {
+    if (processingBalance || !m_client_model) return;
+
     // Wait a little bit more when the wallet is reindexing and/or importing, no need to lock cs_main so often.
-    if (IsImportingOrReindexing()) {
+    if (IsImportingOrReindexing() || m_client_model->inInitialBlockDownload()) {
         static uint8_t waitLonger = 0;
         waitLonger++;
-        if (waitLonger < 10) // 10 seconds
+        if (waitLonger < 30) // 30 seconds
             return;
         waitLonger = 0;
     }
+
+    // Don't continue processing if the chain tip time is less than the first
+    // key creation time as there is no need to iterate over the transaction
+    // table model in this case.
+    int64_t blockTime = clientModel().getLastBlockProcessedTime();
+    if (blockTime < getCreationTime())
+        return;
 
     // Avoid recomputing wallet balances unless a tx changed or
     // BlockTip notification was received.
     if (!fForceCheckBalanceChanged && m_cached_best_block_hash == getLastBlockProcessed()) return;
 
-    // Get required locks upfront. This avoids the GUI from getting stuck on
-    // periodical polls if the core is holding the locks for a longer time -
-    // for example, during a wallet rescan.
-    int chainHeight = m_client_model->getLastBlockProcessedHeight();
-    const uint256& blockHash = m_client_model->getLastBlockProcessed();
-    int64_t blockTime = m_client_model->getLastBlockProcessedTime();
+    processingBalance = true;
+    pollFuture = QtConcurrent::run(processBalanceChange, this);
+}
 
-    // Don't continue processing if the chain tip time is less than the first
-    // key creation time as there is no need to iterate over the transaction
-    // table model in this case.
-    if (blockTime < getCreationTime())
-        return;
-
-    TRY_LOCK(wallet->cs_wallet, lockWallet);
-    if (!lockWallet)
-        return;
-
-    if (fForceCheckBalanceChanged || chainHeight != cachedNumBlocks) {
-        fForceCheckBalanceChanged = false;
-
-        // Balance and number of transactions might have changed
-        cachedNumBlocks = chainHeight;
-        m_cached_best_block_hash = blockHash;
-
-        checkBalanceChanged(walletWrapper.getBalances());
-        if (transactionTableModel) {
-            transactionTableModel->updateConfirmations();
-        }
-
-        // Address in receive tab may have been used
-        Q_EMIT notifyReceiveAddressChanged();
+void WalletModel::updateTxModelData()
+{
+    if (transactionTableModel) {
+        transactionTableModel->updateConfirmations();
     }
 }
 
@@ -257,7 +278,25 @@ void WalletModel::checkBalanceChanged(const interfaces::WalletBalances& newBalan
 {
     if (newBalance.balanceChanged(m_cached_balances)) {
         m_cached_balances = newBalance;
-        Q_EMIT balanceChanged(m_cached_balances);
+        QMetaObject::invokeMethod(this, "balanceNotify", Qt::QueuedConnection);
+    }
+}
+
+void WalletModel::balanceNotify()
+{
+    Q_EMIT balanceChanged(m_cached_balances);
+}
+
+void WalletModel::pollFinished()
+{
+    processingBalance = false;
+}
+
+void WalletModel::stop()
+{
+    if(pollFuture.isRunning()) {
+        pollFuture.cancel();
+        pollFuture.setPaused(true);
     }
 }
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -49,7 +49,7 @@ WalletModel::WalletModel(CWallet* wallet, OptionsModel* optionsModel, QObject* p
     // This timer will be fired repeatedly to update the balance
     pollTimer = new QTimer(this);
     connect(pollTimer, &QTimer::timeout, this, &WalletModel::pollBalanceChanged);
-    pollTimer->start(MODEL_UPDATE_DELAY);
+    pollTimer->start(MODEL_UPDATE_DELAY * 5);
 
     subscribeToCoreSignals();
 }
@@ -241,7 +241,7 @@ void WalletModel::pollBalanceChanged()
     if (IsImportingOrReindexing() || m_client_model->inInitialBlockDownload()) {
         static uint8_t waitLonger = 0;
         waitLonger++;
-        if (waitLonger < 30) // 30 seconds
+        if (waitLonger < 6) // 30 seconds
             return;
         waitLonger = 0;
     }

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -24,6 +24,7 @@
 #include <QObject>
 
 class AddressTableModel;
+class ClientModel;
 class OptionsModel;
 class RecentRequestsTableModel;
 class TransactionTableModel;
@@ -327,6 +328,12 @@ public:
     void loadReceiveRequests(std::vector<std::string>& vReceiveRequests);
     bool saveReceiveRequest(const std::string& sAddress, const int64_t nId, const std::string& sRequest);
 
+    ClientModel& clientModel() const { return *m_client_model; }
+    void setClientModel(ClientModel* client_model);
+
+    uint256 getLastBlockProcessed() const;
+    int getLastBlockProcessedNum() const;
+
 private:
     CWallet* wallet;
     // Simple Wallet interface.
@@ -341,6 +348,7 @@ private:
     std::unique_ptr<interfaces::Handler> m_handler_show_progress;
     std::unique_ptr<interfaces::Handler> m_handler_notify_watch_only_changed;
     std::unique_ptr<interfaces::Handler> m_handler_notify_walletbacked;
+    ClientModel* m_client_model;
 
     bool fHaveWatchOnly;
     bool fForceCheckBalanceChanged;
@@ -358,6 +366,7 @@ private:
 
     EncryptionStatus cachedEncryptionStatus;
     int cachedNumBlocks;
+    uint256 m_cached_best_block_hash;
 
     QTimer* pollTimer;
 

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include <QObject>
+#include <QFuture>
 
 class AddressTableModel;
 class ClientModel;
@@ -334,6 +335,16 @@ public:
     uint256 getLastBlockProcessed() const;
     int getLastBlockProcessedNum() const;
 
+    interfaces::WalletBalances getBalances() { return walletWrapper.getBalances(); };
+    bool hasForceCheckBalance() { return fForceCheckBalanceChanged; }
+    void setCacheNumBlocks(int _cachedNumBlocks) { cachedNumBlocks = _cachedNumBlocks; }
+    int getCacheNumBLocks() { return cachedNumBlocks; }
+    void setCacheBlockHash(const uint256& _blockHash) { m_cached_best_block_hash = _blockHash; }
+    void setfForceCheckBalanceChanged(bool _fForceCheckBalanceChanged) { fForceCheckBalanceChanged = _fForceCheckBalanceChanged; }
+    Q_INVOKABLE void checkBalanceChanged(const interfaces::WalletBalances& new_balances);
+
+    void stop();
+
 private:
     CWallet* wallet;
     // Simple Wallet interface.
@@ -369,10 +380,10 @@ private:
     uint256 m_cached_best_block_hash;
 
     QTimer* pollTimer;
+    QFuture<void> pollFuture;
 
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();
-    Q_INVOKABLE void checkBalanceChanged(const interfaces::WalletBalances& new_balances);
 
 Q_SIGNALS:
     // Signal that balance in wallet changed
@@ -402,6 +413,12 @@ Q_SIGNALS:
     void notifyReceiveAddressChanged();
 
 public Q_SLOTS:
+    /* Wallet balances changes */
+    void balanceNotify();
+    /* Update transaction model after wallet changes */
+    void updateTxModelData();
+    /* Balance polling process finished */
+    void pollFinished();
     /* Wallet status might have changed */
     void updateStatus();
     /* New transaction, or transaction changed status */

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -482,7 +482,7 @@ void SaplingScriptPubKeyMan::GetFilteredNotes(
         }
 
         // Filter the transactions before checking for notes
-        if (!CheckFinalTx(wtx.tx) ||
+        if (!IsFinalTx(wtx.tx, wallet->GetLastBlockHeight() + 1, GetAdjustedTime()) ||
             wtx.GetDepthInMainChain() < minDepth ||
             wtx.GetDepthInMainChain() > maxDepth) {
             continue;

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -9,6 +9,7 @@
 
 void SaplingScriptPubKeyMan::AddToSaplingSpends(const uint256& nullifier, const uint256& wtxid)
 {
+    AssertLockHeld(wallet->cs_wallet);
     mapTxSaplingNullifiers.emplace(nullifier, wtxid);
 
     std::pair<TxNullifiers::iterator, TxNullifiers::iterator> range;
@@ -17,7 +18,7 @@ void SaplingScriptPubKeyMan::AddToSaplingSpends(const uint256& nullifier, const 
 }
 
 bool SaplingScriptPubKeyMan::IsSaplingSpent(const uint256& nullifier) const {
-    LOCK(cs_main);
+    LOCK(wallet->cs_wallet); // future: move to AssertLockHeld()
     std::pair<TxNullifiers::const_iterator, TxNullifiers::const_iterator> range;
     range = mapTxSaplingNullifiers.equal_range(nullifier);
 
@@ -470,7 +471,7 @@ void SaplingScriptPubKeyMan::GetFilteredNotes(
         bool requireSpendingKey,
         bool ignoreLocked) const
 {
-    LOCK2(cs_main, wallet->cs_wallet);
+    LOCK(wallet->cs_wallet);
 
     for (auto& p : wallet->mapWallet) {
         const CWalletTx& wtx = p.second;

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -203,7 +203,7 @@ void UpdateWitnessHeights(NoteDataMap& noteDataMap, int indexHeight, int64_t nWi
 }
 
 void SaplingScriptPubKeyMan::IncrementNoteWitnesses(const CBlockIndex* pindex,
-                                     const CBlock* pblockIn,
+                                     const CBlock* pblock,
                                      SaplingMerkleTree& saplingTree)
 {
     LOCK(wallet->cs_wallet);
@@ -215,17 +215,6 @@ void SaplingScriptPubKeyMan::IncrementNoteWitnesses(const CBlockIndex* pindex,
     if (nWitnessCacheSize < WITNESS_CACHE_SIZE) {
         nWitnessCacheSize += 1;
         nWitnessCacheNeedsUpdate = true;
-    }
-
-    const CBlock* pblock {pblockIn};
-    CBlock block;
-    if (!pblock) {
-        if (!ReadBlockFromDisk(block, pindex)) {
-            std::string read_failed_str = strprintf("Unable to read block %d (%s) from disk.",
-                    pindex->nHeight, pindex->GetBlockHash().ToString());
-            throw std::runtime_error(read_failed_str);
-        }
-        pblock = &block;
     }
 
     for (const auto& tx : pblock->vtx) {

--- a/src/test/librust/sapling_rpc_wallet_tests.cpp
+++ b/src/test/librust/sapling_rpc_wallet_tests.cpp
@@ -432,7 +432,7 @@ BOOST_AUTO_TEST_CASE(rpc_shieldsendmany_taddr_to_sapling)
     chainActive.SetTip(&fakeIndex);
     BOOST_CHECK(chainActive.Contains(&fakeIndex));
     BOOST_CHECK_EQUAL(1, chainActive.Height());
-    wtx.SetMerkleBranch(blockHash, 0);
+    wtx.SetConf(CWalletTx::Status::CONFIRMED, blockHash, 0);
     pwalletMain->LoadToWallet(wtx);
     BOOST_CHECK_MESSAGE(pwalletMain->GetAvailableBalance() > 0, "tx not confirmed");
 

--- a/src/test/librust/sapling_rpc_wallet_tests.cpp
+++ b/src/test/librust/sapling_rpc_wallet_tests.cpp
@@ -433,7 +433,7 @@ BOOST_AUTO_TEST_CASE(rpc_shieldsendmany_taddr_to_sapling)
     chainActive.SetTip(&fakeIndex);
     BOOST_CHECK(chainActive.Contains(&fakeIndex));
     BOOST_CHECK_EQUAL(1, chainActive.Height());
-    wtx.SetConf(CWalletTx::Status::CONFIRMED, blockHash, 0);
+    wtx.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, blockHash, 0);
     pwalletMain->LoadToWallet(wtx);
     BOOST_CHECK_MESSAGE(pwalletMain->GetAvailableBalance() > 0, "tx not confirmed");
 

--- a/src/test/librust/sapling_rpc_wallet_tests.cpp
+++ b/src/test/librust/sapling_rpc_wallet_tests.cpp
@@ -416,7 +416,8 @@ BOOST_AUTO_TEST_CASE(rpc_shieldsendmany_taddr_to_sapling)
     CMutableTransaction mtx;
     mtx.vout.emplace_back(5 * COIN, GetScriptForDestination(taddr));
     // Add to wallet and get the updated wtx
-    pwalletMain->LoadToWallet({pwalletMain, MakeTransactionRef(mtx)});
+    CWalletTx wtxIn(pwalletMain, MakeTransactionRef(mtx));
+    pwalletMain->LoadToWallet(wtxIn);
     CWalletTx& wtx = pwalletMain->mapWallet.at(mtx.GetHash());
 
     // Fake-mine the transaction

--- a/src/test/librust/sapling_rpc_wallet_tests.cpp
+++ b/src/test/librust/sapling_rpc_wallet_tests.cpp
@@ -433,7 +433,7 @@ BOOST_AUTO_TEST_CASE(rpc_shieldsendmany_taddr_to_sapling)
     chainActive.SetTip(&fakeIndex);
     BOOST_CHECK(chainActive.Contains(&fakeIndex));
     BOOST_CHECK_EQUAL(1, chainActive.Height());
-    wtx.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, blockHash, 0);
+    wtx.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, fakeIndex.nHeight, blockHash, 0);
     pwalletMain->LoadToWallet(wtx);
     BOOST_CHECK_MESSAGE(pwalletMain->GetAvailableBalance() > 0, "tx not confirmed");
 

--- a/src/test/librust/sapling_wallet_tests.cpp
+++ b/src/test/librust/sapling_wallet_tests.cpp
@@ -232,7 +232,7 @@ BOOST_AUTO_TEST_CASE(GetConflictedSaplingNotes) {
     auto saplingNoteData = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(*wtx.tx).first;
     BOOST_CHECK(saplingNoteData.size() > 0);
     wtx.SetSaplingNoteData(saplingNoteData);
-    wtx.SetMerkleBranch(block.GetHash(), 0);
+    wtx.SetConf(CWalletTx::Status::CONFIRMED, block.GetHash(), 0);
     BOOST_CHECK(wallet.LoadToWallet(wtx));
 
     // Simulate receiving new block and ChainTip signal
@@ -351,7 +351,7 @@ BOOST_AUTO_TEST_CASE(SaplingNullifierIsSpent) {
     BOOST_CHECK(chainActive.Contains(&fakeIndex));
     BOOST_CHECK_EQUAL(0, chainActive.Height());
 
-    wtx.SetMerkleBranch(block.GetHash(), 0);
+    wtx.SetConf(CWalletTx::Status::CONFIRMED, block.GetHash(), 0);
     wallet.LoadToWallet(wtx);
 
     // Verify note has been spent
@@ -414,7 +414,7 @@ BOOST_AUTO_TEST_CASE(NavigateFromSaplingNullifierToNote) {
     BOOST_CHECK_EQUAL(0, chainActive.Height());
 
     // Simulate SyncTransaction which calls AddToWalletIfInvolvingMe
-    wtx.SetMerkleBranch(block.GetHash(), 0);
+    wtx.SetConf(CWalletTx::Status::CONFIRMED, block.GetHash(), 0);
     auto saplingNoteData = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(*wtx.tx).first;
     BOOST_CHECK(saplingNoteData.size() > 0);
     wtx.SetSaplingNoteData(saplingNoteData);
@@ -512,7 +512,7 @@ BOOST_AUTO_TEST_CASE(SpentSaplingNoteIsFromMe) {
     auto saplingNoteData = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(*wtx.tx).first;
     BOOST_CHECK(saplingNoteData.size() > 0);
     wtx.SetSaplingNoteData(saplingNoteData);
-    wtx.SetMerkleBranch(block.GetHash(), 0);
+    wtx.SetConf(CWalletTx::Status::CONFIRMED, block.GetHash(), 0);
     wallet.LoadToWallet(wtx);
 
     // Simulate receiving new block and ChainTip signal.
@@ -588,7 +588,7 @@ BOOST_AUTO_TEST_CASE(SpentSaplingNoteIsFromMe) {
     auto saplingNoteData2 = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(*wtx2.tx).first;
     BOOST_CHECK(saplingNoteData2.size() > 0);
     wtx2.SetSaplingNoteData(saplingNoteData2);
-    wtx2.SetMerkleBranch(block2.GetHash(), 0);
+    wtx2.SetConf(CWalletTx::Status::CONFIRMED, block2.GetHash(), 0);
     wallet.LoadToWallet(wtx2);
 
     // Verify note B is spent. AddToWallet invokes AddToSpends which updates mapTxSaplingNullifiers
@@ -967,7 +967,7 @@ BOOST_AUTO_TEST_CASE(UpdatedSaplingNoteData) {
     auto saplingNoteData = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(*wtx.tx).first;
     BOOST_CHECK(saplingNoteData.size() == 1); // wallet only has key for change output
     wtx.SetSaplingNoteData(saplingNoteData);
-    wtx.SetMerkleBranch(block.GetHash(), 0);
+    wtx.SetConf(CWalletTx::Status::CONFIRMED, block.GetHash(), 0);
     wallet.LoadToWallet(wtx);
 
     // Simulate receiving new block and ChainTip signal
@@ -1083,7 +1083,7 @@ BOOST_AUTO_TEST_CASE(MarkAffectedSaplingTransactionsDirty) {
     auto saplingNoteData = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(*wtx.tx).first;
     BOOST_CHECK(saplingNoteData.size() > 0);
     wtx.SetSaplingNoteData(saplingNoteData);
-    wtx.SetMerkleBranch(block.GetHash(), 0);
+    wtx.SetConf(CWalletTx::Status::CONFIRMED, block.GetHash(), 0);
     wallet.LoadToWallet(wtx);
 
     // Simulate receiving new block and ChainTip signal

--- a/src/test/librust/sapling_wallet_tests.cpp
+++ b/src/test/librust/sapling_wallet_tests.cpp
@@ -232,7 +232,7 @@ BOOST_AUTO_TEST_CASE(GetConflictedSaplingNotes) {
     auto saplingNoteData = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(*wtx.tx).first;
     BOOST_CHECK(saplingNoteData.size() > 0);
     wtx.SetSaplingNoteData(saplingNoteData);
-    wtx.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, block.GetHash(), 0);
+    wtx.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, fakeIndex.nHeight, block.GetHash(), 0);
     BOOST_CHECK(wallet.LoadToWallet(wtx));
 
     // Simulate receiving new block and ChainTip signal
@@ -351,7 +351,7 @@ BOOST_AUTO_TEST_CASE(SaplingNullifierIsSpent) {
     BOOST_CHECK(chainActive.Contains(&fakeIndex));
     BOOST_CHECK_EQUAL(0, chainActive.Height());
 
-    wtx.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, block.GetHash(), 0);
+    wtx.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, 0, block.GetHash(), 0);
     wallet.LoadToWallet(wtx);
 
     // Verify note has been spent
@@ -414,7 +414,7 @@ BOOST_AUTO_TEST_CASE(NavigateFromSaplingNullifierToNote) {
     BOOST_CHECK_EQUAL(0, chainActive.Height());
 
     // Simulate SyncTransaction which calls AddToWalletIfInvolvingMe
-    wtx.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, block.GetHash(), 0);
+    wtx.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, fakeIndex.nHeight, block.GetHash(), 0);
     auto saplingNoteData = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(*wtx.tx).first;
     BOOST_CHECK(saplingNoteData.size() > 0);
     wtx.SetSaplingNoteData(saplingNoteData);
@@ -512,7 +512,7 @@ BOOST_AUTO_TEST_CASE(SpentSaplingNoteIsFromMe) {
     auto saplingNoteData = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(*wtx.tx).first;
     BOOST_CHECK(saplingNoteData.size() > 0);
     wtx.SetSaplingNoteData(saplingNoteData);
-    wtx.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, block.GetHash(), 0);
+    wtx.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, fakeIndex.nHeight, block.GetHash(), 0);
     wallet.LoadToWallet(wtx);
 
     // Simulate receiving new block and ChainTip signal.
@@ -588,7 +588,7 @@ BOOST_AUTO_TEST_CASE(SpentSaplingNoteIsFromMe) {
     auto saplingNoteData2 = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(*wtx2.tx).first;
     BOOST_CHECK(saplingNoteData2.size() > 0);
     wtx2.SetSaplingNoteData(saplingNoteData2);
-    wtx2.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, block2.GetHash(), 0);
+    wtx2.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, fakeIndex2.nHeight, block2.GetHash(), 0);
     wallet.LoadToWallet(wtx2);
 
     // Verify note B is spent. AddToWallet invokes AddToSpends which updates mapTxSaplingNullifiers
@@ -967,7 +967,7 @@ BOOST_AUTO_TEST_CASE(UpdatedSaplingNoteData) {
     auto saplingNoteData = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(*wtx.tx).first;
     BOOST_CHECK(saplingNoteData.size() == 1); // wallet only has key for change output
     wtx.SetSaplingNoteData(saplingNoteData);
-    wtx.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, block.GetHash(), 0);
+    wtx.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, fakeIndex.nHeight, block.GetHash(), 0);
     wallet.LoadToWallet(wtx);
 
     // Simulate receiving new block and ChainTip signal
@@ -1083,7 +1083,7 @@ BOOST_AUTO_TEST_CASE(MarkAffectedSaplingTransactionsDirty) {
     auto saplingNoteData = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(*wtx.tx).first;
     BOOST_CHECK(saplingNoteData.size() > 0);
     wtx.SetSaplingNoteData(saplingNoteData);
-    wtx.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, block.GetHash(), 0);
+    wtx.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, fakeIndex.nHeight, block.GetHash(), 0);
     wallet.LoadToWallet(wtx);
 
     // Simulate receiving new block and ChainTip signal

--- a/src/test/librust/sapling_wallet_tests.cpp
+++ b/src/test/librust/sapling_wallet_tests.cpp
@@ -232,7 +232,7 @@ BOOST_AUTO_TEST_CASE(GetConflictedSaplingNotes) {
     auto saplingNoteData = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(*wtx.tx).first;
     BOOST_CHECK(saplingNoteData.size() > 0);
     wtx.SetSaplingNoteData(saplingNoteData);
-    wtx.SetConf(CWalletTx::Status::CONFIRMED, block.GetHash(), 0);
+    wtx.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, block.GetHash(), 0);
     BOOST_CHECK(wallet.LoadToWallet(wtx));
 
     // Simulate receiving new block and ChainTip signal
@@ -351,7 +351,7 @@ BOOST_AUTO_TEST_CASE(SaplingNullifierIsSpent) {
     BOOST_CHECK(chainActive.Contains(&fakeIndex));
     BOOST_CHECK_EQUAL(0, chainActive.Height());
 
-    wtx.SetConf(CWalletTx::Status::CONFIRMED, block.GetHash(), 0);
+    wtx.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, block.GetHash(), 0);
     wallet.LoadToWallet(wtx);
 
     // Verify note has been spent
@@ -414,7 +414,7 @@ BOOST_AUTO_TEST_CASE(NavigateFromSaplingNullifierToNote) {
     BOOST_CHECK_EQUAL(0, chainActive.Height());
 
     // Simulate SyncTransaction which calls AddToWalletIfInvolvingMe
-    wtx.SetConf(CWalletTx::Status::CONFIRMED, block.GetHash(), 0);
+    wtx.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, block.GetHash(), 0);
     auto saplingNoteData = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(*wtx.tx).first;
     BOOST_CHECK(saplingNoteData.size() > 0);
     wtx.SetSaplingNoteData(saplingNoteData);
@@ -512,7 +512,7 @@ BOOST_AUTO_TEST_CASE(SpentSaplingNoteIsFromMe) {
     auto saplingNoteData = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(*wtx.tx).first;
     BOOST_CHECK(saplingNoteData.size() > 0);
     wtx.SetSaplingNoteData(saplingNoteData);
-    wtx.SetConf(CWalletTx::Status::CONFIRMED, block.GetHash(), 0);
+    wtx.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, block.GetHash(), 0);
     wallet.LoadToWallet(wtx);
 
     // Simulate receiving new block and ChainTip signal.
@@ -588,7 +588,7 @@ BOOST_AUTO_TEST_CASE(SpentSaplingNoteIsFromMe) {
     auto saplingNoteData2 = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(*wtx2.tx).first;
     BOOST_CHECK(saplingNoteData2.size() > 0);
     wtx2.SetSaplingNoteData(saplingNoteData2);
-    wtx2.SetConf(CWalletTx::Status::CONFIRMED, block2.GetHash(), 0);
+    wtx2.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, block2.GetHash(), 0);
     wallet.LoadToWallet(wtx2);
 
     // Verify note B is spent. AddToWallet invokes AddToSpends which updates mapTxSaplingNullifiers
@@ -967,7 +967,7 @@ BOOST_AUTO_TEST_CASE(UpdatedSaplingNoteData) {
     auto saplingNoteData = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(*wtx.tx).first;
     BOOST_CHECK(saplingNoteData.size() == 1); // wallet only has key for change output
     wtx.SetSaplingNoteData(saplingNoteData);
-    wtx.SetConf(CWalletTx::Status::CONFIRMED, block.GetHash(), 0);
+    wtx.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, block.GetHash(), 0);
     wallet.LoadToWallet(wtx);
 
     // Simulate receiving new block and ChainTip signal
@@ -1083,7 +1083,7 @@ BOOST_AUTO_TEST_CASE(MarkAffectedSaplingTransactionsDirty) {
     auto saplingNoteData = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(*wtx.tx).first;
     BOOST_CHECK(saplingNoteData.size() > 0);
     wtx.SetSaplingNoteData(saplingNoteData);
-    wtx.SetConf(CWalletTx::Status::CONFIRMED, block.GetHash(), 0);
+    wtx.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, block.GetHash(), 0);
     wallet.LoadToWallet(wtx);
 
     // Simulate receiving new block and ChainTip signal

--- a/src/test/librust/utiltest.cpp
+++ b/src/test/librust/utiltest.cpp
@@ -43,6 +43,11 @@ CKey AddTestCKeyToKeyStore(CBasicKeyStore& keyStore, bool genNewKey) {
     return tsk;
 }
 
+CKey AddTestCKeyToWallet(CWallet& wallet, bool genNewKey) {
+    LOCK(wallet.cs_wallet);
+    return AddTestCKeyToKeyStore(wallet, genNewKey);
+}
+
 TestSaplingNote GetTestSaplingNote(const libzcash::SaplingPaymentAddress& pa, CAmount value) {
     // Generate dummy Sapling note
     libzcash::SaplingNote note(pa, value);
@@ -80,13 +85,13 @@ CWalletTx GetValidSaplingReceive(const Consensus::Params& consensusParams,
 
 // Two dummy input (to trick coinbase check), one or many shielded outputs
 CWalletTx GetValidSaplingReceive(const Consensus::Params& consensusParams,
-                                 CBasicKeyStore& keyStoreFrom,
+                                 CWallet& keyStoreFrom,
                                  CAmount inputAmount,
                                  std::vector<ShieldedDestination> vDest,
                                  bool genNewKey,
                                  const CWallet* pwalletIn) {
     // From taddr
-    CKey tsk = AddTestCKeyToKeyStore(keyStoreFrom, genNewKey);
+    CKey tsk = AddTestCKeyToWallet(keyStoreFrom, genNewKey);
     auto scriptPubKey = GetScriptForDestination(tsk.GetPubKey().GetID());
 
     // Two equal dummy inputs to by-pass the coinbase check.
@@ -97,7 +102,7 @@ CWalletTx GetValidSaplingReceive(const Consensus::Params& consensusParams,
 
 // Single input, single shielded output
 CWalletTx GetValidSaplingReceive(const Consensus::Params& consensusParams,
-                                 CBasicKeyStore& keyStore,
+                                 CWallet& keyStore,
                                  const libzcash::SaplingExtendedSpendingKey &sk,
                                  CAmount value,
                                  bool genNewKey,

--- a/src/test/librust/utiltest.h
+++ b/src/test/librust/utiltest.h
@@ -35,6 +35,7 @@ void RegtestDeactivateSapling();
 libzcash::SaplingExtendedSpendingKey GetTestMasterSaplingSpendingKey();
 
 CKey AddTestCKeyToKeyStore(CBasicKeyStore& keyStore, bool genNewKey = false);
+CKey AddTestCKeyToWallet(CWallet& wallet, bool genNewKey = false);
 
 /**
  * Generates a dummy destination script
@@ -60,7 +61,7 @@ CWalletTx GetValidSaplingReceive(const Consensus::Params& consensusParams,
  * Single dummy input, one or many shielded outputs.
  */
 CWalletTx GetValidSaplingReceive(const Consensus::Params& consensusParams,
-                                 CBasicKeyStore& keyStoreFrom,
+                                 CWallet& keyStoreFrom,
                                  CAmount inputAmount,
                                  std::vector<ShieldedDestination> vDest,
                                  bool genNewKey = false,
@@ -70,7 +71,7 @@ CWalletTx GetValidSaplingReceive(const Consensus::Params& consensusParams,
  * Single dummy input, single shielded output to sk default address.
  */
 CWalletTx GetValidSaplingReceive(const Consensus::Params& consensusParams,
-                                 CBasicKeyStore& keyStore,
+                                 CWallet& keyStore,
                                  const libzcash::SaplingExtendedSpendingKey &sk,
                                  CAmount value,
                                  bool genNewKey = false,

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3297,18 +3297,6 @@ bool ProcessNewBlock(CValidationState& state, CNode* pfrom, const std::shared_pt
         }
     }
 
-    if (pwalletMain) {
-        /* disable multisend
-        // If turned on MultiSend will send a transaction (or more) on the after maturity of a stake
-        if (pwalletMain->isMultiSendEnabled())
-            pwalletMain->MultiSend();
-        */
-
-        // If turned on Auto Combine will scan wallet for dust to combine
-        if (pwalletMain->fCombineDust)
-            pwalletMain->AutoCombineDust(g_connman.get());
-    }
-
     LogPrintf("%s : ACCEPTED Block %ld in %ld milliseconds with size=%d\n", __func__, newHeight, GetTimeMillis() - nStartTime,
               GetSerializeSize(*pblock, SER_DISK, CLIENT_VERSION));
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1913,7 +1913,7 @@ bool static DisconnectTip(CValidationState& state, const CChainParams& chainpara
     UpdateTip(pindexDelete->pprev);
     // Let wallets know transactions went from 1-confirmed to
     // 0-confirmed or conflicted:
-    GetMainSignals().BlockDisconnected(pblock, pindexDelete->nHeight);
+    GetMainSignals().BlockDisconnected(pblock, pindexDelete->GetBlockHash(), pindexDelete->nHeight, pindexDelete->GetBlockTime());
 
     return true;
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -177,6 +177,7 @@ std::set<int> setDirtyFileInfo;
 
 CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& locator)
 {
+    AssertLockHeld(cs_main);
     // Find the first block the caller has in the main chain
     for (const uint256& hash : locator.vHave) {
         BlockMap::iterator mi = mapBlockIndex.find(hash);

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -37,7 +37,7 @@ struct MainSignalsInstance {
      */
     boost::signals2::signal<void (const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex, const std::vector<CTransactionRef> &)> BlockConnected;
     /** Notifies listeners of a block being disconnected */
-    boost::signals2::signal<void (const std::shared_ptr<const CBlock> &, int nBlockHeight)> BlockDisconnected;
+    boost::signals2::signal<void (const std::shared_ptr<const CBlock> &, const uint256& blockHash, int nBlockHeight, int64_t blockTime)> BlockDisconnected;
     /** Notifies listeners of a transaction removal from the mempool */
     boost::signals2::signal<void (const CTransactionRef &)> TransactionRemovedFromMempool;
     /** Notifies listeners of a new active block chain. */
@@ -98,7 +98,7 @@ void RegisterValidationInterface(CValidationInterface* pwalletIn)
     conns.UpdatedBlockTip = g_signals.m_internals->UpdatedBlockTip.connect(std::bind(&CValidationInterface::UpdatedBlockTip, pwalletIn, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
     conns.TransactionAddedToMempool = g_signals.m_internals->TransactionAddedToMempool.connect(std::bind(&CValidationInterface::TransactionAddedToMempool, pwalletIn, std::placeholders::_1));
     conns.BlockConnected = g_signals.m_internals->BlockConnected.connect(std::bind(&CValidationInterface::BlockConnected, pwalletIn, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
-    conns.BlockDisconnected = g_signals.m_internals->BlockDisconnected.connect(std::bind(&CValidationInterface::BlockDisconnected, pwalletIn, std::placeholders::_1, std::placeholders::_2));
+    conns.BlockDisconnected = g_signals.m_internals->BlockDisconnected.connect(std::bind(&CValidationInterface::BlockDisconnected, pwalletIn, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));
     conns.TransactionRemovedFromMempool = g_signals.m_internals->TransactionRemovedFromMempool.connect(std::bind(&CValidationInterface::TransactionRemovedFromMempool, pwalletIn, std::placeholders::_1));
     conns.SetBestChain = g_signals.m_internals->SetBestChain.connect(std::bind(&CValidationInterface::SetBestChain, pwalletIn, std::placeholders::_1));
     conns.Broadcast = g_signals.m_internals->Broadcast.connect(std::bind(&CValidationInterface::ResendWalletTransactions, pwalletIn, std::placeholders::_1));
@@ -163,9 +163,9 @@ void CMainSignals::BlockConnected(const std::shared_ptr<const CBlock> &pblock, c
     });
 }
 
-void CMainSignals::BlockDisconnected(const std::shared_ptr<const CBlock> &pblock, int nBlockHeight) {
-    m_internals->m_schedulerClient.AddToProcessQueue([pblock, nBlockHeight, this] {
-        m_internals->BlockDisconnected(pblock, nBlockHeight);
+void CMainSignals::BlockDisconnected(const std::shared_ptr<const CBlock> &pblock, const uint256& blockHash, int nBlockHeight, int64_t blockTime) {
+    m_internals->m_schedulerClient.AddToProcessQueue([pblock, blockHash, nBlockHeight, blockTime, this] {
+        m_internals->BlockDisconnected(pblock, blockHash, nBlockHeight, blockTime);
     });
 }
 

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -93,7 +93,7 @@ protected:
      *
      * Called on a background thread.
      */
-    virtual void BlockDisconnected(const std::shared_ptr<const CBlock> &block, int nBlockHeight) {}
+    virtual void BlockDisconnected(const std::shared_ptr<const CBlock> &block, const uint256& blockHash, int nBlockHeight, int64_t blockTime) {}
     /**
      * Notifies listeners of the new active block chain on-disk.
      *
@@ -138,7 +138,7 @@ public:
     void UpdatedBlockTip(const CBlockIndex *, const CBlockIndex *, bool fInitialDownload);
     void TransactionAddedToMempool(const CTransactionRef &ptxn);
     void BlockConnected(const std::shared_ptr<const CBlock> &block, const CBlockIndex *pindex, const std::shared_ptr<const std::vector<CTransactionRef>> &);
-    void BlockDisconnected(const std::shared_ptr<const CBlock> &block, int nBlockHeight);
+    void BlockDisconnected(const std::shared_ptr<const CBlock> &block, const uint256& blockHash, int nBlockHeight, int64_t blockTime);
     void SetBestChain(const CBlockLocator &);
     void Broadcast(CConnman* connman);
     void BlockChecked(const CBlock&, const CValidationState&);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3056,20 +3056,23 @@ UniValue abandontransaction(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 1)
         throw std::runtime_error(
-            "abandontransaction \"txid\"\n"
-            "\nMark in-wallet transaction \"txid\" as abandoned\n"
-            "This will mark this transaction and all its in-wallet descendants as abandoned which will allow\n"
-            "for their inputs to be respent.  It can be used to replace \"stuck\" or evicted transactions.\n"
-            "It only works on transactions which are not included in a block and are not currently in the mempool.\n"
-            "It has no effect on transactions which are already conflicted or abandoned.\n"
-            "\nArguments:\n"
-            "1. \"txid\"    (string, required) The transaction id\n"
-            "\nResult:\n"
-            "\nExamples:\n"
-            + HelpExampleCli("abandontransaction", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
-            + HelpExampleRpc("abandontransaction", "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
+                "abandontransaction \"txid\"\n"
+                "\nMark in-wallet transaction \"txid\" as abandoned\n"
+                "This will mark this transaction and all its in-wallet descendants as abandoned which will allow\n"
+                "for their inputs to be respent.  It can be used to replace \"stuck\" or evicted transactions.\n"
+                "It only works on transactions which are not included in a block and are not currently in the mempool.\n"
+                "It has no effect on transactions which are already abandoned.\n"
+                "\nArguments:\n"
+                "1. \"txid\"    (string, required) The transaction id\n"
+                "\nResult:\n"
+                "\nExamples:\n"
+                + HelpExampleCli("abandontransaction",
+                                 "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
+                + HelpExampleRpc("abandontransaction",
+                                 "\"1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d\"")
         );
 
+    EnsureWallet();
     EnsureWalletIsUnlocked();
 
     // Make sure the results are valid at least up to the most recent block

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -62,9 +62,9 @@ void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
     if (wtx.IsCoinBase() || wtx.IsCoinStake())
         entry.pushKV("generated", true);
     if (confirms > 0) {
-        entry.pushKV("blockhash", wtx.hashBlock.GetHex());
-        entry.pushKV("blockindex", wtx.nIndex);
-        entry.pushKV("blocktime", mapBlockIndex[wtx.hashBlock]->GetBlockTime());
+        entry.pushKV("blockhash", wtx.m_confirm.hashBlock.GetHex());
+        entry.pushKV("blockindex", wtx.m_confirm.nIndex);
+        entry.pushKV("blocktime", mapBlockIndex[wtx.m_confirm.hashBlock]->GetBlockTime());
     } else {
         entry.pushKV("trusted", wtx.IsTrusted());
     }
@@ -2563,9 +2563,9 @@ UniValue listreceivedbyshieldaddress(const JSONRPCRequest& request)
 
         if (pwalletMain->mapWallet.count(entry.op.hash)) {
             const CWalletTx& wtx = pwalletMain->mapWallet.at(entry.op.hash);
-            if (!wtx.hashBlock.IsNull())
-                height = mapBlockIndex[wtx.hashBlock]->nHeight;
-            index = wtx.nIndex;
+            if (!wtx.m_confirm.hashBlock.IsNull())
+                height = mapBlockIndex[wtx.m_confirm.hashBlock]->nHeight;
+            index = wtx.m_confirm.nIndex;
             time = wtx.GetTxTime();
         }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1895,6 +1895,7 @@ UniValue getreceivedbyaddress(const JSONRPCRequest& request)
     pwalletMain->BlockUntilSyncedToCurrentChain();
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
+    int nBlockHeight = chainActive.Height();
 
     // pivx address
     CTxDestination address = DecodeDestination(request.params[0].get_str());
@@ -1913,7 +1914,7 @@ UniValue getreceivedbyaddress(const JSONRPCRequest& request)
     CAmount nAmount = 0;
     for (std::map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it) {
         const CWalletTx& wtx = (*it).second;
-        if (wtx.IsCoinBase() || !IsFinalTx(wtx.tx))
+        if (wtx.IsCoinBase() || !IsFinalTx(wtx.tx, nBlockHeight))
             continue;
 
         for (const CTxOut& txout : wtx.tx->vout)
@@ -1955,6 +1956,7 @@ UniValue getreceivedbylabel(const JSONRPCRequest& request)
     pwalletMain->BlockUntilSyncedToCurrentChain();
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
+    int nBlockHeight = chainActive.Height();
 
     // Minimum confirmations
     int nMinDepth = 1;
@@ -1969,7 +1971,7 @@ UniValue getreceivedbylabel(const JSONRPCRequest& request)
     CAmount nAmount = 0;
     for (std::map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it) {
         const CWalletTx& wtx = (*it).second;
-        if (wtx.IsCoinBase() || !IsFinalTx(wtx.tx))
+        if (wtx.IsCoinBase() || !IsFinalTx(wtx.tx, nBlockHeight))
             continue;
 
         for (const CTxOut& txout : wtx.tx->vout) {
@@ -2302,7 +2304,7 @@ struct tallyitem {
     }
 };
 
-UniValue ListReceived(const UniValue& params, bool by_label)
+UniValue ListReceived(const UniValue& params, bool by_label, int nBlockHeight)
 {
     // Minimum confirmations
     int nMinDepth = 1;
@@ -2335,7 +2337,7 @@ UniValue ListReceived(const UniValue& params, bool by_label)
     for (std::map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it) {
         const CWalletTx& wtx = (*it).second;
 
-        if (wtx.IsCoinBase() || !IsFinalTx(wtx.tx))
+        if (wtx.IsCoinBase() || !IsFinalTx(wtx.tx, nBlockHeight))
             continue;
 
         int nDepth = wtx.GetDepthInMainChain();
@@ -2477,8 +2479,8 @@ UniValue listreceivedbyaddress(const JSONRPCRequest& request)
     pwalletMain->BlockUntilSyncedToCurrentChain();
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
-
-    return ListReceived(request.params, false);
+    int nBlockHeight = chainActive.Height();
+    return ListReceived(request.params, false, nBlockHeight);
 }
 
 UniValue listreceivedbyshieldaddress(const JSONRPCRequest& request)
@@ -2613,8 +2615,8 @@ UniValue listreceivedbylabel(const JSONRPCRequest& request)
     pwalletMain->BlockUntilSyncedToCurrentChain();
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
-
-    return ListReceived(request.params, true);
+    int nBlockHeight = chainActive.Height();
+    return ListReceived(request.params, true, nBlockHeight);
 }
 
 UniValue listcoldutxos(const JSONRPCRequest& request)

--- a/src/wallet/test/wallet_shielded_balances_tests.cpp
+++ b/src/wallet/test/wallet_shielded_balances_tests.cpp
@@ -306,7 +306,7 @@ FakeBlock SimpleFakeMine(CWalletTx& wtx, SaplingMerkleTree& currentTree)
     fakeBlock.pindex->phashBlock = &mapBlockIndex.find(fakeBlock.block.GetHash())->first;
     chainActive.SetTip(fakeBlock.pindex);
     BOOST_CHECK(chainActive.Contains(fakeBlock.pindex));
-    wtx.SetMerkleBranch(fakeBlock.pindex->GetBlockHash(), 0);
+    wtx.SetConf(CWalletTx::Status::CONFIRMED, fakeBlock.pindex->GetBlockHash(), 0);
     return fakeBlock;
 }
 

--- a/src/wallet/test/wallet_shielded_balances_tests.cpp
+++ b/src/wallet/test/wallet_shielded_balances_tests.cpp
@@ -307,7 +307,7 @@ FakeBlock SimpleFakeMine(CWalletTx& wtx, SaplingMerkleTree& currentTree, CWallet
     chainActive.SetTip(fakeBlock.pindex);
     BOOST_CHECK(chainActive.Contains(fakeBlock.pindex));
     WITH_LOCK(wallet.cs_wallet, wallet.SetLastBlockProcessed(fakeBlock.pindex));
-    wtx.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, fakeBlock.pindex->GetBlockHash(), 0);
+    wtx.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, fakeBlock.pindex->nHeight, fakeBlock.pindex->GetBlockHash(), 0);
     return fakeBlock;
 }
 

--- a/src/wallet/test/wallet_shielded_balances_tests.cpp
+++ b/src/wallet/test/wallet_shielded_balances_tests.cpp
@@ -307,7 +307,7 @@ FakeBlock SimpleFakeMine(CWalletTx& wtx, SaplingMerkleTree& currentTree, CWallet
     chainActive.SetTip(fakeBlock.pindex);
     BOOST_CHECK(chainActive.Contains(fakeBlock.pindex));
     WITH_LOCK(wallet.cs_wallet, wallet.SetLastBlockProcessed(fakeBlock.pindex));
-    wtx.SetConf(CWalletTx::Status::CONFIRMED, fakeBlock.pindex->GetBlockHash(), 0);
+    wtx.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, fakeBlock.pindex->GetBlockHash(), 0);
     return fakeBlock;
 }
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -353,7 +353,8 @@ CWalletTx& BuildAndLoadTxToWallet(const std::vector<CTxIn>& vin,
     mTx.vin = vin;
     mTx.vout = vout;
     CTransaction tx(mTx);
-    wallet.LoadToWallet({&wallet, MakeTransactionRef(tx)});
+    CWalletTx wtx(&wallet, MakeTransactionRef(tx));
+    wallet.LoadToWallet(wtx);
     return wallet.mapWallet.at(tx.GetHash());
 }
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -332,7 +332,7 @@ CBlockIndex* SimpleFakeMine(CWalletTx& wtx, CBlockIndex* pprev = nullptr)
     fakeIndex->phashBlock = &mapBlockIndex.find(block.GetHash())->first;
     chainActive.SetTip(fakeIndex);
     BOOST_CHECK(chainActive.Contains(fakeIndex));
-    wtx.SetMerkleBranch(fakeIndex->GetBlockHash(), 0);
+    wtx.SetConf(CWalletTx::Status::CONFIRMED, fakeIndex->GetBlockHash(), 0);
     removeTxFromMempool(wtx);
     wtx.fInMempool = false;
     return fakeIndex;

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -333,7 +333,7 @@ CBlockIndex* SimpleFakeMine(CWalletTx& wtx, CWallet &wallet, CBlockIndex* pprev 
     chainActive.SetTip(fakeIndex);
     BOOST_CHECK(chainActive.Contains(fakeIndex));
     WITH_LOCK(wallet.cs_wallet, wallet.SetLastBlockProcessed(fakeIndex));
-    wtx.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, fakeIndex->GetBlockHash(), 0);
+    wtx.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, fakeIndex->nHeight, fakeIndex->GetBlockHash(), 0);
     removeTxFromMempool(wtx);
     wtx.fInMempool = false;
     return fakeIndex;

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -420,6 +420,7 @@ BOOST_AUTO_TEST_CASE(cached_balances_tests)
     LOCK2(cs_main, wallet.cs_wallet);
     wallet.SetMinVersion(FEATURE_PRE_SPLIT_KEYPOOL);
     wallet.SetupSPKM(false);
+    wallet.SetLastBlockProcessed(chainActive.Tip());
 
     // Receive balance from an external source
     CTxDestination receivingAddr;

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -333,7 +333,7 @@ CBlockIndex* SimpleFakeMine(CWalletTx& wtx, CWallet &wallet, CBlockIndex* pprev 
     chainActive.SetTip(fakeIndex);
     BOOST_CHECK(chainActive.Contains(fakeIndex));
     WITH_LOCK(wallet.cs_wallet, wallet.SetLastBlockProcessed(fakeIndex));
-    wtx.SetConf(CWalletTx::Status::CONFIRMED, fakeIndex->GetBlockHash(), 0);
+    wtx.m_confirm = CWalletTx::Confirmation(CWalletTx::Status::CONFIRMED, fakeIndex->GetBlockHash(), 0);
     removeTxFromMempool(wtx);
     wtx.fInMempool = false;
     return fakeIndex;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1203,16 +1203,9 @@ bool CWallet::AbandonTransaction(const uint256& hashTx)
 
 void CWallet::MarkConflicted(const uint256& hashBlock, int conflicting_height, const uint256& hashTx)
 {
-    LOCK2(cs_main, cs_wallet);
+    LOCK(cs_wallet);
 
-    int conflictconfirms = 0;
-    if (mapBlockIndex.count(hashBlock)) {
-        CBlockIndex* pindex = mapBlockIndex[hashBlock];
-        if (chainActive.Contains(pindex)) {
-            conflictconfirms = -(chainActive.Height() - pindex->nHeight + 1);
-        }
-    }
-
+    int conflictconfirms = (m_last_block_processed_height - conflicting_height + 1) * -1;
     // If number of conflict confirms cannot be determined, this means
     // that the block is still unknown or not yet part of the main chain,
     // for example when loading the wallet during a reindex. Do nothing in that

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4321,24 +4321,11 @@ CWalletKey::CWalletKey(int64_t nExpires)
 
 int CWalletTx::GetDepthInMainChain() const
 {
+    assert(pwallet != nullptr);
+    AssertLockHeld(pwallet->cs_wallet);
     if (isUnconfirmed() || isAbandoned()) return 0;
-    AssertLockHeld(cs_main);
-    int nResult;
 
-    // Find the block it claims to be in
-    BlockMap::iterator mi = mapBlockIndex.find(m_confirm.hashBlock);
-    if (mi == mapBlockIndex.end()) {
-        nResult = 0;
-    } else {
-        CBlockIndex* pindex = (*mi).second;
-        if (!pindex || !chainActive.Contains(pindex)) {
-            nResult = 0;
-        } else {
-            nResult = (isConflicted() ? (-1) : 1) * (chainActive.Height() - pindex->nHeight + 1);
-        }
-    }
-
-    return nResult;
+    return (pwallet->GetLastBlockHeight() - m_confirm.block_height + 1) * (isConflicted() ? -1 : 1);
 }
 
 int CWalletTx::GetBlocksToMaturity() const

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1265,21 +1265,13 @@ void CWallet::TransactionRemovedFromMempool(const CTransactionRef &ptx) {
 void CWallet::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex, const std::vector<CTransactionRef>& vtxConflicted)
 {
     LOCK2(cs_main, cs_wallet);
-    // TODO: Tempoarily ensure that mempool removals are notified before
-    // connected transactions.  This shouldn't matter, but the abandoned
-    // state of transactions in our wallet is currently cleared when we
-    // receive another notification and there is a race condition where
-    // notification of a connected conflict might cause an outside process
-    // to abandon a transaction and then have it inadvertently cleared by
-    // the notification that the conflicted transaction was evicted.
 
-    for (const CTransactionRef& ptx : vtxConflicted) {
-        SyncTransaction(ptx, CWalletTx::Status::CONFLICTED, nullptr, -1);
-        TransactionRemovedFromMempool(ptx);
-    }
     for (size_t i = 0; i < pblock->vtx.size(); i++) {
         SyncTransaction(pblock->vtx[i], CWalletTx::Status::CONFIRMED, pindex, i);
         TransactionRemovedFromMempool(pblock->vtx[i]);
+    }
+    for (const CTransactionRef& ptx : vtxConflicted) {
+        TransactionRemovedFromMempool(ptx);
     }
 
     // Sapling: notify about the connected block

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4188,16 +4188,12 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
 
     LogPrintf("Wallet completed loading in %15dms\n", GetTimeMillis() - nStart);
 
-    CBlockIndex* pindexRescan = chainActive.Tip();
-    if (gArgs.GetBoolArg("-rescan", false))
-        pindexRescan = chainActive.Genesis();
-    else {
+    CBlockIndex* pindexRescan = chainActive.Genesis();
+    if (!gArgs.GetBoolArg("-rescan", false)) {
         CWalletDB walletdb(*walletInstance->dbw);
         CBlockLocator locator;
         if (walletdb.ReadBestBlock(locator))
             pindexRescan = FindForkInGlobalIndex(chainActive, locator);
-        else
-            pindexRescan = chainActive.Genesis();
     }
 
     walletInstance->m_last_block_processed = chainActive.Tip();

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1270,7 +1270,7 @@ void CWallet::SyncTransaction(const CTransactionRef& ptx, const CWalletTx::Confi
 
 void CWallet::TransactionAddedToMempool(const CTransactionRef& ptx)
 {
-    LOCK2(cs_main, cs_wallet);
+    LOCK(cs_wallet);
     CWalletTx::Confirmation confirm(CWalletTx::Status::UNCONFIRMED, /* block_height */ 0, {}, /* nIndex */ 0);
     SyncTransaction(ptx, confirm);
 
@@ -1290,7 +1290,7 @@ void CWallet::TransactionRemovedFromMempool(const CTransactionRef &ptx) {
 
 void CWallet::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex, const std::vector<CTransactionRef>& vtxConflicted)
 {
-    LOCK2(cs_main, cs_wallet);
+    LOCK(cs_wallet);
 
     m_last_block_processed = pindex->GetBlockHash();
     m_last_block_processed_time = pindex->GetBlockTime();
@@ -1329,7 +1329,7 @@ void CWallet::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const 
 
 void CWallet::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const uint256& blockHash, int nBlockHeight, int64_t blockTime)
 {
-    LOCK2(cs_main, cs_wallet);
+    LOCK(cs_wallet);
 
     // At block disconnection, this will change an abandoned transaction to
     // be unconfirmed, whether or not the transaction is added back to the mempool.
@@ -3848,7 +3848,7 @@ bool CWallet::LoadDestData(const CTxDestination& dest, const std::string& key, c
 
 void CWallet::AutoCombineDust(CConnman* connman)
 {
-    LOCK(cs_wallet);
+    AssertLockHeld(cs_wallet);
     if (m_last_block_processed.IsNull() ||
         m_last_block_processed_time < (GetAdjustedTime() - 300) ||
         IsLocked()) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4337,11 +4337,6 @@ int CWalletTx::GetBlocksToMaturity() const
     return std::max(0, (Params().GetConsensus().nCoinbaseMaturity + 1) - GetDepthInMainChain());
 }
 
-bool CWalletTx::IsInMainChain() const
-{
-    return GetDepthInMainChain() > 0;
-}
-
 bool CWalletTx::IsInMainChainImmature() const
 {
     if (!IsCoinBase() && !IsCoinStake()) return false;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1156,7 +1156,7 @@ bool CWallet::AbandonTransaction(const uint256& hashTx)
     auto it = mapWallet.find(hashTx);
     assert(it != mapWallet.end());
     CWalletTx& origtx = it->second;
-    if (origtx.GetDepthInMainChain() > 0 || origtx.InMempool()) {
+    if (origtx.GetDepthInMainChain() != 0 || origtx.InMempool()) {
         return false;
     }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -703,6 +703,7 @@ bool CWallet::HasSaplingSPKM() const
  */
 bool CWallet::IsSpent(const COutPoint& outpoint) const
 {
+    AssertLockHeld(cs_wallet);
     std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range;
     range = mapTxSpends.equal_range(outpoint);
     for (TxSpends::const_iterator it = range.first; it != range.second; ++it) {
@@ -3112,9 +3113,7 @@ bool CWallet::CreateCoinStake(
         if (IsLocked() || ShutdownRequested()) return false;
 
         // Make sure the stake input hasn't been spent since last check
-        // for now, IsSpent() requires cs_main lock due its internal call to GetDepthInMainChain.
-        // This dependency will be completely removed moving forward, in #2209.
-        if (WITH_LOCK(cs_main, return IsSpent(outPoint))) {
+        if (WITH_LOCK(cs_wallet, return IsSpent(outPoint))) {
             // remove it from the available coins
             it = availableCoins->erase(it);
             continue;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1930,11 +1930,9 @@ void CWallet::ReacceptWalletTransactions(bool fFirstLoad)
     }
 
     // Try to add wallet transactions to memory pool
-    for (std::pair<const int64_t, CWalletTx*>& item: mapSorted)
-    {
+    for (std::pair<const int64_t, CWalletTx*>& item: mapSorted) {
         CWalletTx& wtx = *(item.second);
 
-        LOCK(mempool.cs);
         CValidationState state;
         bool fSuccess = wtx.AcceptToMemoryPool(state, false);
         if (!fSuccess && fFirstLoad && GetTime() - wtx.GetTxTime() > 12*60*60) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1318,6 +1318,12 @@ void CWallet::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const 
 
     // Sapling: Update cached incremental witnesses
     ChainTipAdded(pindex, pblock.get(), oldSaplingTree);
+
+    // Auto-combine functionality
+    // If turned on Auto Combine will scan wallet for dust to combine
+    if (fCombineDust) {
+        AutoCombineDust(g_connman.get());
+    }
 }
 
 void CWallet::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const uint256& blockHash, int nBlockHeight, int64_t blockTime)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1257,7 +1257,7 @@ void CWallet::SyncTransaction(const CTransactionRef& ptx, CWalletTx::Status stat
 void CWallet::TransactionAddedToMempool(const CTransactionRef& ptx)
 {
     LOCK2(cs_main, cs_wallet);
-    SyncTransaction(ptx, CWalletTx::Status::UNCONFIRMED, nullptr, -1);
+    SyncTransaction(ptx, CWalletTx::Status::UNCONFIRMED, nullptr, 0);
 
     auto it = mapWallet.find(ptx->GetHash());
     if (it != mapWallet.end()) {
@@ -1313,7 +1313,7 @@ void CWallet::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, int
     // User may have to call abandontransaction again. It may be addressed in the
     // future with a stickier abandoned state or even removing abandontransaction call.
     for (const CTransactionRef& ptx : pblock->vtx) {
-        SyncTransaction(ptx, CWalletTx::Status::UNCONFIRMED, nullptr, -1);
+        SyncTransaction(ptx, CWalletTx::Status::UNCONFIRMED, nullptr, 0);
     }
 
     if (Params().GetConsensus().NetworkUpgradeActive(nBlockHeight, Consensus::UPGRADE_V5_0)) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3085,8 +3085,8 @@ bool CWallet::CreateCoinStake(
                              outPoint,
                              it->pindex);
 
-        //new block came in, move on
-        if (WITH_LOCK(cs_main, return chainActive.Height()) != pindexPrev->nHeight) return false;
+        // New block came in, move on
+        if (WITH_LOCK(cs_wallet, return m_last_block_processed_height) != pindexPrev->nHeight) return false;
 
         // Make sure the wallet is unlocked and shutdown hasn't been requested
         if (IsLocked() || ShutdownRequested()) return false;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1950,7 +1950,6 @@ void CWalletTx::RelayWalletTransaction(CConnman* connman)
         // Nothing to do. Return early
         return;
     }
-    LOCK(cs_main);
     if (GetDepthInMainChain() == 0 && !isAbandoned()) {
         const uint256& hash = GetHash();
         LogPrintf("Relaying wtx %s\n", hash.ToString());
@@ -2801,7 +2800,7 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, bool ov
             tx.vin.push_back(txin);
 
             if (lockUnspents) {
-              LOCK2(cs_main, cs_wallet);
+              LOCK(cs_wallet);
               LockCoin(txin.prevout);
             }
         }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -977,7 +977,8 @@ bool CWallet::LoadToWallet(CWalletTx& wtxIn)
     // If tx hasn't been reorged out of chain while wallet being shutdown
     // change tx status to UNCONFIRMED and reset hashBlock/nIndex.
     if (!wtxIn.m_confirm.hashBlock.IsNull()) {
-        CBlockIndex* pindex = mapBlockIndex[wtxIn.m_confirm.hashBlock];
+        auto it = mapBlockIndex.find(wtxIn.m_confirm.hashBlock);
+        CBlockIndex* pindex = it == mapBlockIndex.end() ? nullptr : it->second;
         if (!pindex || !chainActive.Contains(pindex)) {
             wtxIn.setUnconfirmed();
             wtxIn.m_confirm.hashBlock = UINT256_ZERO;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1363,12 +1363,9 @@ void CWallet::BlockUntilSyncedToCurrentChain() {
         uint256 last_block_hash = WITH_LOCK(cs_wallet, return m_last_block_processed);
         LOCK(cs_main);
         const CBlockIndex* initialChainTip = chainActive.Tip();
-
-        if (!last_block_hash.IsNull()) {
-            auto it = mapBlockIndex.find(last_block_hash);
-            if (it == mapBlockIndex.end() || it->second->GetAncestor(initialChainTip->nHeight) == initialChainTip) {
+        if (!last_block_hash.IsNull() && initialChainTip &&
+            last_block_hash == initialChainTip->GetBlockHash()) {
                 return;
-            }
         }
     }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2070,6 +2070,9 @@ CWallet::Balance CWallet::GetBalance(const int min_depth) const
             if (is_trusted && tx_depth >= min_depth) {
                 ret.m_mine_trusted += tx_credit_mine;
                 ret.m_mine_trusted_shield += tx_credit_shield_mine;
+                if (wtx.tx->HasP2CSOutputs()) {
+                    ret.m_mine_cs_delegated_trusted += wtx.GetStakeDelegationCredit();
+                }
             }
             if (!is_trusted && tx_depth == 0 && wtx.InMempool()) {
                 ret.m_mine_untrusted_pending += tx_credit_mine;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4222,11 +4222,12 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
             return nullptr;
         }
 
-        walletInstance->SetBestChain(chainActive.GetLocator());
+        walletInstance->SetBestChain(WITH_LOCK(cs_main, return chainActive.GetLocator()));
     }
 
     LogPrintf("Wallet completed loading in %15dms\n", GetTimeMillis() - nStart);
 
+    LOCK(cs_main);
     CBlockIndex* pindexRescan = chainActive.Genesis();
     if (!gArgs.GetBoolArg("-rescan", false)) {
         CWalletDB walletdb(*walletInstance->dbw);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -522,7 +522,6 @@ public:
      */
     int GetDepthInMainChain(const CBlockIndex*& pindexRet) const;
     int GetDepthInMainChain() const;
-    bool IsInMainChain() const;
     bool IsInMainChainImmature() const;
     int GetBlocksToMaturity() const;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -520,7 +520,6 @@ public:
      *  0  : in memory pool, waiting to be included in a block
      * >=1 : this many blocks deep in the main chain
      */
-    int GetDepthInMainChain(const CBlockIndex*& pindexRet) const;
     int GetDepthInMainChain() const;
     bool IsInMainChainImmature() const;
     int GetBlocksToMaturity() const;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -902,7 +902,7 @@ public:
 
     void MarkDirty();
     bool AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose = true);
-    bool LoadToWallet(const CWalletTx& wtxIn);
+    bool LoadToWallet(CWalletTx& wtxIn);
     void TransactionAddedToMempool(const CTransactionRef& tx) override;
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex, const std::vector<CTransactionRef>& vtxConflicted) override;
     void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, int nBlockHeight) override;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -644,8 +644,22 @@ public:
     bool IsHDEnabled() const;
     //! Whether the wallet supports Sapling or not //
     bool IsSaplingUpgradeEnabled() const;
-    //! Return the height of the last processed block
-    int GetLastBlockHeight() const { return m_last_block_processed_height; }
+
+    /** Get last block processed height */
+    int GetLastBlockHeight() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
+    {
+        AssertLockHeld(cs_wallet);
+        assert(m_last_block_processed_height >= 0);
+        return m_last_block_processed_height;
+    };
+    /** Set last block processed height, currently only use in unit test */
+    void SetLastBlockProcessed(const CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
+    {
+        AssertLockHeld(cs_wallet);
+        m_last_block_processed_height = pindex->nHeight;
+        m_last_block_processed = pindex->GetBlockHash();
+        m_last_block_processed_time = pindex->GetBlockTime();
+    };
 
     /* SPKM Helpers */
     const CKeyingMaterial& GetEncryptionKey() const;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -960,6 +960,7 @@ public:
         CAmount m_mine_immature{0};              //!< Immature coinbases/coinstakes in the main chain
         CAmount m_mine_trusted_shield{0};        //!< Trusted shield, at depth=GetBalance.min_depth or more
         CAmount m_mine_untrusted_shielded_balance{0}; //!< Untrusted shield, but in mempool (pending)
+        CAmount m_mine_cs_delegated_trusted{0};  //!< Trusted, at depth=GetBalance.min_depth or more. Part of m_mine_trusted as well
     };
     Balance GetBalance(int min_depth = 0) const;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -812,7 +812,7 @@ public:
     //! >> Available coins (P2CS)
     void GetAvailableP2CSCoins(std::vector<COutput>& vCoins) const;
 
-    std::map<CTxDestination, std::vector<COutput> > AvailableCoinsByAddress(bool fConfirmed = true, CAmount maxCoinValue = 0);
+    std::map<CTxDestination, std::vector<COutput> > AvailableCoinsByAddress(bool fConfirmed, CAmount maxCoinValue, bool fIncludeColdStaking);
 
     /// Get 10000 PIV output and keys which can be used for the Masternode
     bool GetMasternodeVinAndKeys(CTxIn& txinRet, CPubKey& pubKeyRet,

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -520,7 +520,13 @@ public:
      *  0  : in memory pool, waiting to be included in a block
      * >=1 : this many blocks deep in the main chain
      */
-    int GetDepthInMainChain() const;
+    // TODO: Remove "NO_THREAD_SAFETY_ANALYSIS" and replace it with the correct
+    // annotation "EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)". The annotation
+    // "NO_THREAD_SAFETY_ANALYSIS" was temporarily added to avoid having to
+    // resolve the issue of member access into incomplete type CWallet. Note
+    // that we still have the runtime check "AssertLockHeld(pwallet->cs_wallet)"
+    // in place.
+    int GetDepthInMainChain() const NO_THREAD_SAFETY_ANALYSIS;
     bool IsInMainChainImmature() const;
     int GetBlocksToMaturity() const;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -954,6 +954,15 @@ public:
     void ReacceptWalletTransactions(bool fFirstLoad = false);
     void ResendWalletTransactions(CConnman* connman) override;
 
+    struct Balance {
+        CAmount m_mine_trusted{0};               //!< Trusted, at depth=GetBalance.min_depth or more
+        CAmount m_mine_untrusted_pending{0};     //!< Untrusted, but in mempool (pending)
+        CAmount m_mine_immature{0};              //!< Immature coinbases/coinstakes in the main chain
+        CAmount m_mine_trusted_shield{0};        //!< Trusted shield, at depth=GetBalance.min_depth or more
+        CAmount m_mine_untrusted_shielded_balance{0}; //!< Untrusted shield, but in mempool (pending)
+    };
+    Balance GetBalance(int min_depth = 0) const;
+
     CAmount loopTxsBalance(std::function<void(const uint256&, const CWalletTx&, CAmount&)>method) const;
     CAmount GetAvailableBalance(bool fIncludeDelegated = true, bool fIncludeShielded = true) const;
     CAmount GetAvailableBalance(isminefilter& filter, bool useCache = false, int minDepth = 1) const;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -369,9 +369,10 @@ public:
      * where they instead point to block hash and index of the deepest conflicting tx.
      */
     struct Confirmation {
-        Status status = UNCONFIRMED;
-        uint256 hashBlock = uint256();
-        int nIndex = 0;
+        Status status;
+        uint256 hashBlock;
+        int nIndex;
+        Confirmation(Status s = UNCONFIRMED, uint256 h = uint256(), int i = 0) : status(s), hashBlock(h), nIndex(i) {}
     };
 
     Confirmation m_confirm;
@@ -512,8 +513,6 @@ public:
     void RelayWalletTransaction(CConnman* connman);
     std::set<uint256> GetConflicts() const;
 
-    void SetConf(Status status, const uint256& blockHash, int posInBlock);
-
     /**
      * Return depth of transaction in blockchain:
      * <0  : conflicts with a transaction this deep in the blockchain
@@ -610,7 +609,7 @@ private:
     void ChainTipAdded(const CBlockIndex *pindex, const CBlock *pblock, SaplingMerkleTree saplingTree);
 
     /* Used by TransactionAddedToMemorypool/BlockConnected/Disconnected */
-    void SyncTransaction(const CTransactionRef& tx, CWalletTx::Status status, const CBlockIndex *pindexBlockConnected, int posInBlock);
+    void SyncTransaction(const CTransactionRef& tx, const CWalletTx::Confirmation& confirm);
 
     bool IsKeyUsed(const CPubKey& vchPubKey);
 
@@ -928,7 +927,7 @@ public:
     void TransactionAddedToMempool(const CTransactionRef& tx) override;
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex, const std::vector<CTransactionRef>& vtxConflicted) override;
     void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const uint256& blockHash, int nBlockHeight, int64_t blockTime) override;
-    bool AddToWalletIfInvolvingMe(const CTransactionRef& tx, CWalletTx::Status status, const uint256& blockHash, int posInBlock, bool fUpdate);
+    bool AddToWalletIfInvolvingMe(const CTransactionRef& tx, const CWalletTx::Confirmation& confirm, bool fUpdate);
     void EraseFromWallet(const uint256& hash);
 
     /**

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -779,7 +779,8 @@ public:
                              bool _fOnlySpendable,
                              std::set<CTxDestination>* _onlyFilteredDest,
                              int _minDepth,
-                             bool _fIncludeLocked = false) :
+                             bool _fIncludeLocked = false,
+                             CAmount _nMaxOutValue = 0) :
                 fIncludeDelegated(_fIncludeDelegated),
                 fIncludeColdStaking(_fIncludeColdStaking),
                 nCoinType(_nCoinType),
@@ -787,7 +788,8 @@ public:
                 fOnlySpendable(_fOnlySpendable),
                 onlyFilteredDest(_onlyFilteredDest),
                 minDepth(_minDepth),
-                fIncludeLocked(_fIncludeLocked) {}
+                fIncludeLocked(_fIncludeLocked),
+                nMaxOutValue(_nMaxOutValue) {}
 
         bool fIncludeDelegated{true};
         bool fIncludeColdStaking{false};
@@ -797,6 +799,8 @@ public:
         std::set<CTxDestination>* onlyFilteredDest{nullptr};
         int minDepth{0};
         bool fIncludeLocked{false};
+        // Select outputs with value <= nMaxOutValue
+        CAmount nMaxOutValue{0};
     };
 
     //! >> Available coins (generic)

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -172,7 +172,7 @@ void CZMQNotificationInterface::BlockConnected(const std::shared_ptr<const CBloc
     }
 }
 
-void CZMQNotificationInterface::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, int nBlockHeight)
+void CZMQNotificationInterface::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const uint256& blockHash, int nBlockHeight, int64_t blockTime)
 {
     for (const CTransactionRef& ptx : pblock->vtx) {
         // Do a normal notify for each transaction removed in block disconnection

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -27,7 +27,7 @@ protected:
     // CValidationInterface
     void TransactionAddedToMempool(const CTransactionRef& tx) override;
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected, const std::vector<CTransactionRef>& vtxConflicted) override;
-    void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, int nBlockHeight) override;
+    void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const uint256& blockHash, int nBlockHeight, int64_t blockTime) override;
     void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
 
 private:

--- a/test/functional/sapling_wallet_listreceived.py
+++ b/test/functional/sapling_wallet_listreceived.py
@@ -95,7 +95,7 @@ class ListReceivedTest (PivxTestFramework):
         assert_false(r[0]['change'], "Note should not be change")
         assert_equal(my_memo_hex, r[0]['memo'])
         assert_equal(0, r[0]['confirmations'])
-        assert_equal(-1, r[0]['blockindex'])
+        assert_equal(0, r[0]['blockindex'])
         assert_equal(0, r[0]['blockheight'])
 
         c = self.nodes[1].getsaplingnotescount(0)

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -58,6 +58,7 @@ BASE_SCRIPTS= [
     # Longest test should go first, to favor running tests in parallel
     'wallet_basic.py',                          # ~ 498 sec
     'wallet_backup.py',                         # ~ 477 sec
+    'wallet_reorgsrestore.py',                  # ~ 391 sec
     'mempool_persist.py',                       # ~ 417 sec
 
     # vv Tests less than 5m vv

--- a/test/functional/wallet_abandonconflict.py
+++ b/test/functional/wallet_abandonconflict.py
@@ -7,6 +7,7 @@
 from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_raises_rpc_error,
     connect_nodes,
     Decimal,
     disconnect_nodes,
@@ -31,6 +32,11 @@ class AbandonConflictTest(PivxTestFramework):
         txC = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 10)
         sync_mempools(self.nodes)
         self.nodes[1].generate(1)
+
+        # Can not abandon non-wallet transaction
+        assert_raises_rpc_error(-5, 'Invalid or non-wallet transaction id', lambda: self.nodes[0].abandontransaction('ff' * 32))
+        # Can not abandon confirmed transaction
+        assert_raises_rpc_error(-5, 'Transaction not eligible for abandonment', lambda: self.nodes[0].abandontransaction(txA))
 
         sync_blocks(self.nodes)
         newbalance = self.nodes[0].getbalance()

--- a/test/functional/wallet_reorgsrestore.py
+++ b/test/functional/wallet_reorgsrestore.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Bitcoin Core developers
+# Copyright (c) 2021 The PIVX Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+"""Test tx status in case of reorgs while wallet being shutdown.
+
+Wallet txn status rely on block connection/disconnection for its
+accuracy. In case of reorgs happening while wallet being shutdown
+block updates are not going to be received. At wallet loading, we
+check against chain if confirmed txn are still in chain and change
+their status if block in which they have been included has been
+disconnected.
+"""
+
+from decimal import Decimal
+import os
+import shutil
+
+from test_framework.test_framework import PivxTestFramework
+from test_framework.util import (
+        assert_equal,
+        connect_nodes,
+        disconnect_nodes,
+        sync_blocks,
+)
+
+class ReorgsRestoreTest(PivxTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 3
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        # Send a tx from which to conflict outputs later
+        txid_conflict_from = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("10"))
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        # Disconnect node1 from others to reorg its chain later
+        disconnect_nodes(self.nodes[0], 1)
+        disconnect_nodes(self.nodes[1], 2)
+        connect_nodes(self.nodes[0], 2)
+
+        # Send a tx to be unconfirmed later
+        txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("10"))
+        tx = self.nodes[0].gettransaction(txid)
+        self.nodes[0].generate(4)
+        tx_before_reorg = self.nodes[0].gettransaction(txid)
+        assert_equal(tx_before_reorg["confirmations"], 4)
+
+        # Disconnect node0 from node2 to broadcast a conflict on their respective chains
+        disconnect_nodes(self.nodes[0], 2)
+        nA = next(tx_out["vout"] for tx_out in self.nodes[0].gettransaction(txid_conflict_from)["details"] if tx_out["amount"] == Decimal("10"))
+        inputs = []
+        inputs.append({"txid": txid_conflict_from, "vout": nA})
+        outputs_1 = {}
+        outputs_2 = {}
+
+        # Create a conflicted tx broadcast on node0 chain and conflicting tx broadcast on node2 chain. Both spend from txid_conflict_from
+        outputs_1[self.nodes[0].getnewaddress()] = Decimal("9.99998")
+        outputs_2[self.nodes[0].getnewaddress()] = Decimal("9.99998")
+        conflicted = self.nodes[0].signrawtransaction(self.nodes[0].createrawtransaction(inputs, outputs_1))
+        conflicting = self.nodes[0].signrawtransaction(self.nodes[0].createrawtransaction(inputs, outputs_2))
+
+        conflicted_txid = self.nodes[0].sendrawtransaction(conflicted["hex"])
+        self.nodes[0].generate(1)
+        conflicting_txid = self.nodes[2].sendrawtransaction(conflicting["hex"])
+        self.nodes[2].generate(9)
+
+        # Reconnect node0 and node2 and check that conflicted_txid is effectively conflicted
+        connect_nodes(self.nodes[0], 2)
+        sync_blocks([self.nodes[0], self.nodes[2]])
+        conflicted = self.nodes[0].gettransaction(conflicted_txid)
+        conflicting = self.nodes[0].gettransaction(conflicting_txid)
+        assert_equal(conflicted["confirmations"], -9)
+        assert_equal(conflicted["walletconflicts"][0], conflicting["txid"])
+
+        # Node0 wallet is shutdown
+        self.stop_node(0)
+        self.start_node(0)
+
+        # The block chain re-orgs and the tx is included in a different block
+        self.nodes[1].generate(9)
+        self.nodes[1].sendrawtransaction(tx["hex"])
+        self.nodes[1].generate(1)
+        self.nodes[1].sendrawtransaction(conflicted["hex"])
+        self.nodes[1].generate(1)
+
+        # Node0 wallet file is loaded on longest sync'ed node1
+        self.stop_node(1)
+        self.nodes[0].backupwallet(os.path.join(self.nodes[0].datadir, 'wallet.bak'))
+        shutil.copyfile(os.path.join(self.nodes[0].datadir, 'wallet.bak'), os.path.join(self.nodes[1].datadir, 'regtest', 'wallet.dat'))
+        self.start_node(1)
+        tx_after_reorg = self.nodes[1].gettransaction(txid)
+        # Check that normal confirmed tx is confirmed again but with different blockhash
+        assert_equal(tx_after_reorg["confirmations"], 2)
+        assert(tx_before_reorg["blockhash"] != tx_after_reorg["blockhash"])
+        conflicted_after_reorg = self.nodes[1].gettransaction(conflicted_txid)
+        # Check that conflicted tx is confirmed again with blockhash different than previously conflicting tx
+        assert_equal(conflicted_after_reorg["confirmations"], 1)
+        assert(conflicting["blockhash"] != conflicted_after_reorg["blockhash"])
+
+if __name__ == '__main__':
+    ReorgsRestoreTest().main()


### PR DESCRIPTION
This is the conclusion of a deep deep rabbit hole: #1726, #2150, #2082, #2118, #2150, #2179, #2191, #2192, #2195, #2201, #2203..

Effectively removing every `cs_main` lock from the wallet and GUI processing threads. Completely decoupling the wallet state and the visual interface update procedures from the main message and validation handler thread.

Meaning that the messages & validation handler thread will be largely more active, accepting and verifying way more data in less time, not being affected by several other threads accessing to the main critical section. And, at the same time, the wallet and GUI worker threads will be able to perform and process their tasks concurrently, without waiting for the `cs_main` mutex acquisition.
Improving the overall software performance, the GUI responsiveness and decreasing the synchronization time.

To make this possible, the wallet is maintaining in memory a view of the chain and updating it only via the validation interface signals. Using the view to perform all of the chain related calculations.
