### PR TITLE
[Refactor] Implement CheckColdStake in TransactionSignatureChecker

### DIFF
--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -171,31 +171,6 @@ bool CTransaction::IsCoinStake() const
     return (vout.size() >= 2 && vout[0].IsEmpty());
 }
 
-bool CTransaction::CheckColdStake(const CScript& script) const
-{
-
-    // tx is a coinstake tx
-    if (!IsCoinStake())
-        return false;
-
-    // all inputs have the same scriptSig
-    CScript firstScript = vin[0].scriptSig;
-    if (vin.size() > 1) {
-        for (unsigned int i=1; i<vin.size(); i++)
-            if (vin[i].scriptSig != firstScript) return false;
-    }
-
-    // all outputs except first (coinstake marker) and last (masternode payout)
-    // have the same pubKeyScript and it matches the script we are spending
-    if (vout[1].scriptPubKey != script) return false;
-    if (vin.size() > 3) {
-        for (unsigned int i=2; i<vout.size()-1; i++)
-            if (vout[i].scriptPubKey != script) return false;
-    }
-
-    return true;
-}
-
 bool CTransaction::HasP2CSOutputs() const
 {
     for(const CTxOut& txout : vout) {

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -388,7 +388,6 @@ public:
     }
 
     bool IsCoinStake() const;
-    bool CheckColdStake(const CScript& script) const;
     bool HasP2CSOutputs() const;
 
     friend bool operator==(const CTransaction& a, const CTransaction& b)

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -7,17 +7,13 @@
 #ifndef BITCOIN_SCRIPT_INTERPRETER_H
 #define BITCOIN_SCRIPT_INTERPRETER_H
 
-#include "script_error.h"
 #include "primitives/transaction.h"
+#include "script_error.h"
+#include "uint256.h"
 
 #include <vector>
 #include <stdint.h>
 #include <string>
-
-class CPubKey;
-class CScript;
-class CTransaction;
-class uint256;
 
 /** Special case nIn for signing Sapling txs. */
 const unsigned int NOT_AN_INPUT = UINT_MAX;
@@ -136,9 +132,7 @@ public:
 
     bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const override ;
     bool CheckLockTime(const CScriptNum& nLockTime) const override;
-    bool CheckColdStake(const CScript& script) const override {
-        return txTo->CheckColdStake(script);
-    }
+    bool CheckColdStake(const CScript& prevoutScript) const override;
 };
 
 class MutableTransactionSignatureChecker : public TransactionSignatureChecker

--- a/src/test/script_P2CS_tests.cpp
+++ b/src/test/script_P2CS_tests.cpp
@@ -5,10 +5,11 @@
 
 #include "base58.h"
 #include "key.h"
+#include "policy/policy.h"
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(script_P2CS_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(script_P2CS_tests, TestingSetup)
 
 void CheckValidKeyId(const CTxDestination& dest, const CKeyID& expectedKey)
 {
@@ -52,6 +53,148 @@ BOOST_AUTO_TEST_CASE(extract_cold_staking_destination_keys)
     BOOST_CHECK(destVector.size() == 2);
     CheckValidKeyId(destVector[0], stakerId);
     CheckValidKeyId(destVector[1], ownerId);
+}
+
+static CScript GetNewP2CS(CKey& stakerKey, CKey& ownerKey)
+{
+    stakerKey = DecodeSecret("91yo52JPHDVUG3jXWLKGyzEdjn1a9nbnurLdmQEf2UzbgzkTc2c");
+    ownerKey = DecodeSecret("92KgNFNfmVVJRQuzssETc7NhwufGuHsLvPQxW9Nwmxs7PB4ByWB");
+    return GetScriptForStakeDelegation(stakerKey.GetPubKey().GetID(),
+                                       ownerKey.GetPubKey().GetID());
+}
+
+static CScript GetDummyP2CS(const CKeyID& dummyKeyID)
+{
+    return GetScriptForStakeDelegation(dummyKeyID, dummyKeyID);
+}
+
+static CScript GetDummyP2PKH(const CKeyID& dummyKeyID)
+{
+    return GetScriptForDestination(dummyKeyID);
+}
+
+static const CAmount amtIn = 200 * COIN;
+static const unsigned int flags = STANDARD_SCRIPT_VERIFY_FLAGS;
+
+static CMutableTransaction CreateNewColdStakeTx(CScript& scriptP2CS, CKey& stakerKey, CKey& ownerKey)
+{
+    scriptP2CS = GetNewP2CS(stakerKey, ownerKey);
+
+    // Create prev transaction:
+    CMutableTransaction txFrom;
+    txFrom.vout.resize(1);
+    txFrom.vout[0].nValue = amtIn;
+    txFrom.vout[0].scriptPubKey = scriptP2CS;
+
+    // Create coldstake
+    CMutableTransaction tx;
+    tx.vin.resize(1);
+    tx.vout.resize(2);
+    tx.vin[0].prevout.n = 0;
+    tx.vin[0].prevout.hash = txFrom.GetHash();
+    tx.vout[0].nValue = 0;
+    tx.vout[0].scriptPubKey.clear();
+    tx.vout[1].nValue = amtIn + 2 * COIN;
+    tx.vout[1].scriptPubKey = scriptP2CS;
+
+    return tx;
+}
+
+void SignColdStake(CMutableTransaction& tx, int nIn, const CScript& prevScript, const CKey& key, bool fStaker)
+{
+    assert(nIn < (int) tx.vin.size());
+    tx.vin[nIn].scriptSig.clear();
+    const CTransaction _tx(tx);
+    SigVersion sv = _tx.GetRequiredSigVersion();
+    const uint256& hash = SignatureHash(prevScript, _tx, nIn, SIGHASH_ALL, amtIn, sv);
+    std::vector<unsigned char> vchSig;
+    BOOST_CHECK(key.Sign(hash, vchSig));
+    vchSig.push_back((unsigned char)SIGHASH_ALL);
+    std::vector<unsigned char> selector(1, fStaker ? (int) OP_TRUE : OP_FALSE);
+    tx.vin[nIn].scriptSig << vchSig << selector << ToByteVector(key.GetPubKey());
+}
+
+static bool CheckP2CSScript(const CScript& scriptSig, const CScript& scriptPubKey, const CMutableTransaction& tx, ScriptError& err)
+{
+    err = SCRIPT_ERR_OK;
+    return VerifyScript(scriptSig, scriptPubKey, flags, MutableTransactionSignatureChecker(&tx, 0, amtIn), tx.GetRequiredSigVersion(), &err);
+}
+
+BOOST_AUTO_TEST_CASE(coldstake_script)
+{
+    SelectParams(CBaseChainParams::REGTEST);
+    CScript scriptP2CS;
+    CKey stakerKey, ownerKey;
+
+    // create unsigned coinstake transaction
+    CMutableTransaction good_tx = CreateNewColdStakeTx(scriptP2CS, stakerKey, ownerKey);
+
+    // sign the input with the staker key
+    SignColdStake(good_tx, 0, scriptP2CS, stakerKey, true);
+
+    // check the signature and script
+    ScriptError err = SCRIPT_ERR_OK;
+    CMutableTransaction tx(good_tx);
+    BOOST_CHECK(CheckP2CSScript(tx.vin[0].scriptSig, scriptP2CS, tx, err));
+
+    // pay less than expected
+    tx.vout[1].nValue -= 3 * COIN;
+    SignColdStake(tx, 0, scriptP2CS, stakerKey, true);
+    BOOST_CHECK(!CheckP2CSScript(tx.vin[0].scriptSig, scriptP2CS, tx, err));
+    BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_CHECKCOLDSTAKEVERIFY, ScriptErrorString(err));
+
+    // Add another p2cs out
+    tx.vout.emplace_back(3 * COIN, scriptP2CS);
+    SignColdStake(tx, 0, scriptP2CS, stakerKey, true);
+    BOOST_CHECK(CheckP2CSScript(tx.vin[0].scriptSig, scriptP2CS, tx, err));
+
+    const CKey& dummyKey = DecodeSecret("91t7cwPGevo885Uccg87nVjzUxKhXta9JprHM3R21PQkBFMFg2i");
+    const CKeyID& dummyKeyID = dummyKey.GetPubKey().GetID();
+    const CScript& dummyP2PKH = GetDummyP2PKH(dummyKeyID);
+
+    // Add a masternode out
+    tx.vout.emplace_back(3 * COIN, dummyP2PKH);
+    SignColdStake(tx, 0, scriptP2CS, stakerKey, true);
+    BOOST_CHECK(CheckP2CSScript(tx.vin[0].scriptSig, scriptP2CS, tx, err));
+
+    // Transfer more coins to the masternode
+    tx.vout[2].nValue -= 2 * COIN;
+    tx.vout[3].nValue += 2 * COIN;
+    SignColdStake(tx, 0, scriptP2CS, stakerKey, true);
+    BOOST_CHECK(!CheckP2CSScript(tx.vin[0].scriptSig, scriptP2CS, tx, err));
+    BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_CHECKCOLDSTAKEVERIFY, ScriptErrorString(err));
+
+    // Add two "free" outputs
+    tx = good_tx;
+    tx.vout[1].nValue -= 3 * COIN;
+    tx.vout.emplace_back(3 * COIN, dummyP2PKH);
+    tx.vout.emplace_back(3 * COIN, dummyP2PKH);
+    SignColdStake(tx, 0, scriptP2CS, stakerKey, true);
+    BOOST_CHECK(!CheckP2CSScript(tx.vin[0].scriptSig, scriptP2CS, tx, err));
+    BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_CHECKCOLDSTAKEVERIFY, ScriptErrorString(err));
+    // -- but the owner can
+    SignColdStake(tx, 0, scriptP2CS, ownerKey, false);
+    BOOST_CHECK(CheckP2CSScript(tx.vin[0].scriptSig, scriptP2CS, tx, err));
+
+    // Replace with new p2cs
+    tx = good_tx;
+    tx.vout[1].scriptPubKey = GetDummyP2CS(dummyKeyID);
+    SignColdStake(tx, 0, scriptP2CS, stakerKey, true);
+    BOOST_CHECK(!CheckP2CSScript(tx.vin[0].scriptSig, scriptP2CS, tx, err));
+    BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_CHECKCOLDSTAKEVERIFY, ScriptErrorString(err));
+    // -- but the owner can
+    SignColdStake(tx, 0, scriptP2CS, ownerKey, false);
+    BOOST_CHECK(CheckP2CSScript(tx.vin[0].scriptSig, scriptP2CS, tx, err));
+
+    // Replace with single dummy out
+    tx = good_tx;
+    tx.vout[1] = CTxOut(COIN, dummyP2PKH);
+    SignColdStake(tx, 0, scriptP2CS, stakerKey, true);
+    BOOST_CHECK(!CheckP2CSScript(tx.vin[0].scriptSig, scriptP2CS, tx, err));
+    BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_CHECKCOLDSTAKEVERIFY, ScriptErrorString(err));
+    // -- but the owner can
+    SignColdStake(tx, 0, scriptP2CS, ownerKey, false);
+    BOOST_CHECK(CheckP2CSScript(tx.vin[0].scriptSig, scriptP2CS, tx, err));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Fix and rework CheckColdStake, removing it from the CTransaction primitive, and implementing directly inside `TransactionSignatureChecker`.
Add unit test.