### PR TITLE
Qt: Reduce whitespace around qr code fixes #1562

### DIFF
--- a/src/qt/pivx/qtutils.cpp
+++ b/src/qt/pivx/qtutils.cpp
@@ -113,12 +113,12 @@ QPixmap encodeToQr(QString str, QString& errorStr, QColor qrColor)
                 errorStr = "Error encoding URI into QR Code.";
                 return QPixmap();
             }
-            QImage myImage = QImage(code->width + 8, code->width + 8, QImage::Format_RGB32);
+            QImage myImage = QImage(code->width + 2, code->width + 2, QImage::Format_RGB32);
             myImage.fill(0xffffff);
             unsigned char* p = code->data;
             for (int y = 0; y < code->width; y++) {
                 for (int x = 0; x < code->width; x++) {
-                    myImage.setPixel(x + 4, y + 4, ((*p & 1) ? qrColor.rgb() : 0xffffff));
+                    myImage.setPixel(x + 1, y + 1, ((*p & 1) ? qrColor.rgb() : 0xffffff));
                     p++;
                 }
             }


### PR DESCRIPTION
When in dark mode there's redundant 4 pixel indentation from
each side of the qr code in Receive dialog and widget. This
reduces it to 1 pixel, this way it still works as intended,
but looks nicer.

closes #1562 