### PR TITLE
[Validation] Remove dead zc checks from ATMP

### DIFF
--- a/src/legacy/validation_zerocoin_legacy.cpp
+++ b/src/legacy/validation_zerocoin_legacy.cpp
@@ -3,44 +3,10 @@
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 #include "legacy/validation_zerocoin_legacy.h"
 
-#include "consensus/zerocoin_verify.h"
 #include "libzerocoin/CoinSpend.h"
 #include "wallet/wallet.h"
 #include "zpivchain.h"
 #include "zpiv/zpivmodule.h"
-
-bool AcceptToMemoryPoolZerocoin(const CTransaction& tx, CAmount& nValueIn, int chainHeight, CValidationState& state, const Consensus::Params& consensus)
-{
-    nValueIn = tx.GetZerocoinSpent();
-
-    //Check that txid is not already in the chain
-    int nHeightTx = 0;
-    if (IsTransactionInChain(tx.GetHash(), nHeightTx))
-        return state.Invalid(error("%s : zPIV spend tx %s already in block %d", __func__, tx.GetHash().GetHex(), nHeightTx),
-                             REJECT_DUPLICATE, "bad-txns-inputs-spent");
-
-    //Check for double spending of serial #'s
-    for (const CTxIn& txIn : tx.vin) {
-        // Only allow for public zc spends inputs
-        if (!txIn.IsZerocoinPublicSpend())
-            return state.Invalid(false, REJECT_INVALID, "bad-zc-spend-notpublic");
-
-        libzerocoin::ZerocoinParams* params = consensus.Zerocoin_Params(false);
-        PublicCoinSpend publicSpend(params);
-        if (!ZPIVModule::ParseZerocoinPublicSpend(txIn, tx, state, publicSpend)){
-            return false;
-        }
-        if (!ContextualCheckZerocoinSpend(tx, &publicSpend, chainHeight, UINT256_ZERO))
-            return state.Invalid(false, REJECT_INVALID, "bad-zc-spend-contextcheck");
-
-        // Check that the version matches the one enforced with SPORK_18
-        if (!CheckPublicCoinSpendVersion(publicSpend.getVersion())) {
-            return state.Invalid(false, REJECT_INVALID, "bad-zc-spend-version");
-        }
-    }
-
-    return true;
-}
 
 bool DisconnectZerocoinTx(const CTransaction& tx, CZerocoinDB* zerocoinDB)
 {

--- a/src/legacy/validation_zerocoin_legacy.h
+++ b/src/legacy/validation_zerocoin_legacy.h
@@ -10,7 +10,6 @@
 #include "txdb.h" // for the zerocoinDB implementation.
 #include "validationinterface.h"
 
-bool AcceptToMemoryPoolZerocoin(const CTransaction& tx, CAmount& nValueIn, int chainHeight, CValidationState& state, const Consensus::Params& consensus);
 bool DisconnectZerocoinTx(const CTransaction& tx, CZerocoinDB* zerocoinDB);
 void DataBaseAccChecksum(const CBlockIndex* pindex, bool fWrite);
 


### PR DESCRIPTION
Since v5 the network is not longer accepting zc transactions. No need to continue having the zerocoin dead code in the accept to mempool function.
This PR cleans it up, removing the unneeded zc mentions in the ATMP process.