### PR TITLE
[GUI] Automatically set the lowest possible Custom Fee when user provided fee is too low

### DIFF
--- a/src/qt/pivx/sendcustomfeedialog.cpp
+++ b/src/qt/pivx/sendcustomfeedialog.cpp
@@ -126,6 +126,9 @@ void SendCustomFeeDialog::accept()
         inform(tr("Fee too high. Must be below: %1").arg(
                 BitcoinUnits::formatWithUnit(walletModel->getOptionsModel()->getDisplayUnit(), insaneFee)));
     } else if (customFee < CWallet::GetRequiredFee(1000)) {
+        CAmount nFee;
+        walletModel->getWalletCustomFee(nFee);
+        ui->lineEditCustomFee->setText(BitcoinUnits::format(walletModel->getOptionsModel()->getDisplayUnit(), nFee));
         inform(tr("Fee too low. Must be at least: %1").arg(
                 BitcoinUnits::formatWithUnit(walletModel->getOptionsModel()->getDisplayUnit(), CWallet::GetRequiredFee(1000))));
     } else {


### PR DESCRIPTION
### What does it do?
Automatically set the lowest possible Custom Fee when user type in fee that is too low.
More details: https://github.com/PIVX-Project/PIVX/issues/1836

Demonstration:

![LowestFeeDemonstration](https://user-images.githubusercontent.com/17647788/109294172-83840800-7835-11eb-8f55-bcbedbfe5b73.gif)
