### PR TITLE
Guarding wallet access from init and print error for unknown MN collaterals

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1855,6 +1855,7 @@ bool AppInitMain()
     //get the mode of budget voting for this masternode
     strBudgetMode = gArgs.GetArg("-budgetvotemode", "auto");
 
+#ifdef ENABLE_WALLET
     if (gArgs.GetBoolArg("-mnconflock", DEFAULT_MNCONFLOCK) && pwalletMain) {
         LOCK(pwalletMain->cs_wallet);
         LogPrintf("Locking Masternodes:\n");
@@ -1866,6 +1867,7 @@ bool AppInitMain()
             pwalletMain->LockCoin(outpoint);
         }
     }
+#endif
 
     //lite mode disables all Masternode related functionality
     fLiteMode = gArgs.GetBoolArg("-litemode", false);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1858,18 +1858,19 @@ bool AppInitMain()
 #ifdef ENABLE_WALLET
     if (gArgs.GetBoolArg("-mnconflock", DEFAULT_MNCONFLOCK) && pwalletMain) {
         LOCK(pwalletMain->cs_wallet);
-        LogPrintf("Locking Masternodes:\n");
+        LogPrintf("Locking Masternodes collateral utxo:\n");
         uint256 mnTxHash;
-        for (const CMasternodeConfig::CMasternodeEntry& mne : masternodeConfig.getEntries()) {
-            LogPrintf("  %s %s\n", mne.getTxHash(), mne.getOutputIndex());
+        for (const auto& mne : masternodeConfig.getEntries()) {
             mnTxHash.SetHex(mne.getTxHash());
             COutPoint outpoint = COutPoint(mnTxHash, (unsigned int) std::stoul(mne.getOutputIndex()));
             pwalletMain->LockCoin(outpoint);
+            LogPrintf("Locked collateral, MN: %s, tx hash: %s, output index: %s\n",
+                      mne.getAlias(), mne.getTxHash(), mne.getOutputIndex());
         }
     }
 #endif
 
-    //lite mode disables all Masternode related functionality
+    // lite mode disables all Masternode related functionality
     fLiteMode = gArgs.GetBoolArg("-litemode", false);
     if (fMasterNode && fLiteMode) {
         return UIError("You can not start a masternode in litemode");


### PR DESCRIPTION
Two changes:

1) Guarding `pwalletMain` access from init.cpp, so in the future we could enable pivxd to run without the wallet.
2) BugFix: `Wallet::LockCoin` verifying that the MN collateral utxo is in the wallet's map before add it to the locked set. Printing the correct error if the transaction is unknown for the wallet.