### PR TITLE
[Refactor] move vtx[i] access to vtx.at(i).

### DIFF
--- a/src/blockassembler.cpp
+++ b/src/blockassembler.cpp
@@ -193,7 +193,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
     if (!fProofOfStake) {
         // Coinbase can get the fees.
-        CMutableTransaction txCoinbase(*pblock->vtx[0]);
+        CMutableTransaction txCoinbase(*pblock->vtx.at(0));
         txCoinbase.vout[0].nValue += nFees;
         pblock->vtx[0] = MakeTransactionRef(txCoinbase);
         pblocktemplate->vTxFees[0] = -nFees;
@@ -209,7 +209,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     if (!fProofOfStake) UpdateTime(pblock, consensus, pindexPrev);
     pblock->nBits = GetNextWorkRequired(pindexPrev, pblock);
     pblock->nNonce = 0;
-    pblocktemplate->vTxSigOps[0] = GetLegacySigOpCount(*(pblock->vtx[0]));
+    pblocktemplate->vTxSigOps[0] = GetLegacySigOpCount(*(pblock->vtx.at(0)));
     appendSaplingTreeRoot();
 
     if (fProofOfStake) { // this is only for PoS because the IncrementExtraNonce does it for PoW
@@ -483,7 +483,7 @@ void IncrementExtraNonce(std::shared_ptr<CBlock>& pblock, const CBlockIndex* pin
     }
     ++nExtraNonce;
     unsigned int nHeight = pindexPrev->nHeight + 1; // Height first in coinbase required for block.version=2
-    CMutableTransaction txCoinbase(*pblock->vtx[0]);
+    CMutableTransaction txCoinbase(*pblock->vtx.at(0));
     txCoinbase.vin[0].scriptSig = (CScript() << nHeight << CScriptNum(nExtraNonce)) + COINBASE_FLAGS;
     assert(txCoinbase.vin[0].scriptSig.size() <= 100);
 

--- a/src/blocksignature.cpp
+++ b/src/blocksignature.cpp
@@ -20,7 +20,7 @@ bool SignBlock(CBlock& block, const CKeyStore& keystore)
     CKeyID keyID;
     if (block.IsProofOfWork()) {
         bool fFoundID = false;
-        for (const CTxOut& txout : block.vtx[0]->vout) {
+        for (const CTxOut& txout : block.vtx.at(0)->vout) {
             if (!txout.GetKeyIDFromUTXO(keyID))
                 continue;
             fFoundID = true;
@@ -29,7 +29,7 @@ bool SignBlock(CBlock& block, const CKeyStore& keystore)
         if (!fFoundID)
             return error("%s: failed to find key for PoW", __func__);
     } else {
-        if (!block.vtx[1]->vout[1].GetKeyIDFromUTXO(keyID))
+        if (!block.vtx.at(1)->vout[1].GetKeyIDFromUTXO(keyID))
             return error("%s: failed to find key for PoS", __func__);
     }
 
@@ -53,14 +53,14 @@ bool CheckBlockSignature(const CBlock& block, const bool enableP2PKH)
      *  UTXO: The public key that signs must match the public key associated with the first utxo of the coinstake tx.
      */
     CPubKey pubkey;
-    bool fzPIVStake = block.vtx[1]->vin[0].IsZerocoinSpend();
+    bool fzPIVStake = block.vtx.at(1)->vin[0].IsZerocoinSpend();
     if (fzPIVStake) {
-        libzerocoin::CoinSpend spend = TxInToZerocoinSpend(block.vtx[1]->vin[0]);
+        libzerocoin::CoinSpend spend = TxInToZerocoinSpend(block.vtx.at(1)->vin[0]);
         pubkey = spend.getPubKey();
     } else {
         txnouttype whichType;
         std::vector<valtype> vSolutions;
-        const CTxOut& txout = block.vtx[1]->vout[1];
+        const CTxOut& txout = block.vtx.at(1)->vout[1];
         if (!Solver(txout.scriptPubKey, whichType, vSolutions))
             return false;
 
@@ -75,7 +75,7 @@ bool CheckBlockSignature(const CBlock& block, const bool enableP2PKH)
             valtype& vchPubKey = vSolutions[0];
             pubkey = CPubKey(vchPubKey);
         } else if (whichType == TX_PUBKEYHASH) {
-            const CTxIn& txin = block.vtx[1]->vin[0];
+            const CTxIn& txin = block.vtx.at(1)->vin[0];
             // Check if the scriptSig is for a p2pk or a p2pkh
             if (txin.scriptSig.size() == 73) { // Sig size + DER signature size.
                 // If the input is for a p2pk and the output is a p2pkh.
@@ -88,7 +88,7 @@ bool CheckBlockSignature(const CBlock& block, const bool enableP2PKH)
             }
         } else if (whichType == TX_COLDSTAKE) {
             // pick the public key from the P2CS input
-            const CTxIn& txin = block.vtx[1]->vin[0];
+            const CTxIn& txin = block.vtx.at(1)->vin[0];
             int start = 1 + (int) *txin.scriptSig.begin(); // skip sig
             start += 1 + (int) *(txin.scriptSig.begin()+start); // skip flag
             pubkey = CPubKey(txin.scriptSig.begin()+start+1, txin.scriptSig.end());

--- a/src/consensus/merkle.cpp
+++ b/src/consensus/merkle.cpp
@@ -156,7 +156,7 @@ uint256 BlockMerkleRoot(const CBlock& block, bool* mutated)
     std::vector<uint256> leaves;
     leaves.resize(block.vtx.size());
     for (size_t s = 0; s < block.vtx.size(); s++) {
-        leaves[s] = block.vtx[s]->GetHash();
+        leaves[s] = block.vtx.at(s)->GetHash();
     }
     return ComputeMerkleRoot(leaves, mutated);
 }
@@ -166,7 +166,7 @@ std::vector<uint256> BlockMerkleBranch(const CBlock& block, uint32_t position)
     std::vector<uint256> leaves;
     leaves.resize(block.vtx.size());
     for (size_t s = 0; s < block.vtx.size(); s++) {
-        leaves[s] = block.vtx[s]->GetHash();
+        leaves[s] = block.vtx.at(s)->GetHash();
     }
     return ComputeMerkleBranch(leaves, position);
 }

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -105,7 +105,7 @@ bool LoadStakeInput(const CBlock& block, const CBlockIndex* pindexPrev, std::uni
         return error("called on non PoS block");
 
     // Construct the stakeinput object
-    const CTxIn& txin = block.vtx[1]->vin[0];
+    const CTxIn& txin = block.vtx.at(1)->vin[0];
     stake = txin.IsZerocoinSpend() ?
             std::unique_ptr<CStakeInput>(new CLegacyZPivStake()) :
             std::unique_ptr<CStakeInput>(CPivStake::NewPivStake(txin));
@@ -180,7 +180,7 @@ bool CheckProofOfStake(const CBlock& block, std::string& strError, const CBlockI
         strError = "unable to get stake prevout for coinstake";
         return false;
     }
-    const auto& tx = block.vtx[1];
+    const auto& tx = block.vtx.at(1);
     const CTxIn& txin = tx->vin[0];
     ScriptError serror;
     if (!VerifyScript(txin.scriptSig, stakePrevout.scriptPubKey, STANDARD_SCRIPT_VERIFY_FLAGS,

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -247,7 +247,7 @@ bool IsBlockPayeeValid(const CBlock& block, int nBlockHeight)
     }
 
     const bool isPoSActive = Params().GetConsensus().NetworkUpgradeActive(nBlockHeight, Consensus::UPGRADE_POS);
-    const CTransaction& txNew = *(isPoSActive ? block.vtx[1] : block.vtx[0]);
+    const CTransaction& txNew = *(isPoSActive ? block.vtx.at(1) : block.vtx.at(0));
 
     //check if it's a budget block
     if (sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS)) {

--- a/src/merkleblock.cpp
+++ b/src/merkleblock.cpp
@@ -23,8 +23,8 @@ CMerkleBlock::CMerkleBlock(const CBlock& block, CBloomFilter& filter)
     vHashes.reserve(block.vtx.size());
 
     for (unsigned int i = 0; i < block.vtx.size(); i++) {
-        const uint256& hash = block.vtx[i]->GetHash();
-        if (filter.IsRelevantAndUpdate(*block.vtx[i])) {
+        const uint256& hash = block.vtx.at(i)->GetHash();
+        if (filter.IsRelevantAndUpdate(*block.vtx.at(i))) {
             vMatch.push_back(true);
             vMatchedTxn.emplace_back(i, hash);
         } else

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -63,7 +63,7 @@ std::unique_ptr<CBlockTemplate> CreateNewBlockWithKey(CReserveKey* reservekey, C
 bool ProcessBlockFound(const std::shared_ptr<const CBlock>& pblock, CWallet& wallet, Optional<CReserveKey>& reservekey)
 {
     LogPrintf("%s\n", pblock->ToString());
-    LogPrintf("generated %s\n", FormatMoney(pblock->vtx[0]->vout[0].nValue));
+    LogPrintf("generated %s\n", FormatMoney(pblock->vtx.at(0)->vout[0].nValue));
 
     // Found a solution
     {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -883,7 +883,7 @@ void static ProcessGetBlockData(CNode* pfrom, const CInv& inv, CConnman& connman
                 // Thus, the protocol spec specified allows for us to provide duplicate txn here,
                 // however we MUST always provide at least what the remote peer needs
                 for (std::pair<unsigned int, uint256>& pair : merkleBlock.vMatchedTxn)
-                    connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::TX, *block.vtx[pair.first]));
+                    connman.PushMessage(pfrom, msgMaker.Make(NetMsgType::TX, *block.vtx.at(pair.first)));
             }
             // else
             // no response

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -46,7 +46,7 @@ std::string CBlock::ToString() const
         vtx.size());
     for (unsigned int i = 0; i < vtx.size(); i++)
     {
-        s << "  " << vtx[i]->ToString() << "\n";
+        s << "  " << vtx.at(i)->ToString() << "\n";
     }
     return s.str();
 }

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -113,7 +113,7 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(*static_cast<CBlockHeader*>(this));
         READWRITE(vtx);
-        if(vtx.size() > 1 && vtx[1]->IsCoinStake())
+        if(vtx.size() > 1 && vtx.at(1)->IsCoinStake())
             READWRITE(vchBlockSig);
     }
 
@@ -143,7 +143,7 @@ public:
 
     bool IsProofOfStake() const
     {
-        return (vtx.size() > 1 && vtx[1]->IsCoinStake());
+        return (vtx.size() > 1 && vtx.at(1)->IsCoinStake());
     }
 
     bool IsProofOfWork() const

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1353,7 +1353,7 @@ UniValue getblockindexstats(const JSONRPCRequest& request) {
 
         // loop through each tx in block and save size and fee (except for coinbase/coinstake)
         for (int idx = firstTxIndex; idx < ntx; idx++) {
-            const CTransaction& tx = *(block.vtx[idx]);
+            const CTransaction& tx = *(block.vtx.at(idx));
 
             // zerocoin txes have fixed fee, don't count them here.
             if (tx.ContainsZerocoins())

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -632,7 +632,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     result.pushKV("previousblockhash", pblock->hashPrevBlock.GetHex());
     result.pushKV("transactions", transactions);
     result.pushKV("coinbaseaux", aux);
-    result.pushKV("coinbasevalue", (int64_t)pblock->vtx[0]->GetValueOut());
+    result.pushKV("coinbasevalue", (int64_t)pblock->vtx.at(0)->GetValueOut());
     result.pushKV("longpollid", chainActive.Tip()->GetBlockHash().GetHex() + i64tostr(nTransactionsUpdatedLast));
     result.pushKV("target", hashTarget.GetHex());
     result.pushKV("mintime", (int64_t)pindexPrev->GetMedianTimePast() + 1);
@@ -695,7 +695,7 @@ UniValue submitblock(const JSONRPCRequest& request)
     if (!DecodeHexBlk(block, request.params[0].get_str()))
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Block decode failed");
 
-    if (block.vtx.empty() || !block.vtx[0]->IsCoinBase()) {
+    if (block.vtx.empty() || !block.vtx.at(0)->IsCoinBase()) {
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Block does not start with a coinbase");
     }
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -97,16 +97,16 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     // Therefore, load 100 blocks :)
     std::vector<CTransactionRef>txFirst;
     std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>(pblocktemplate->block); // pointer for convenience
-    for (unsigned int i = 0; i < sizeof(blockinfo)/sizeof(*blockinfo); ++i) {
+    for (auto& info : blockinfo) {
         CBlockIndex* pindexPrev = WITH_LOCK(cs_main, return chainActive.Tip());
         assert(pindexPrev);
         pblock->nTime = pindexPrev->GetMedianTimePast() + 60;
         pblock->vtx.clear(); // Update coinbase input height manually
         CreateCoinbaseTx(pblock.get(), CScript(), pindexPrev);
         if (txFirst.size() < 2)
-            txFirst.emplace_back(pblock->vtx[0]);
+            txFirst.emplace_back(pblock->vtx.at(0));
         pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
-        pblock->nNonce = blockinfo[i].nonce;
+        pblock->nNonce = info.nonce;
         CValidationState state;
         BOOST_CHECK(ProcessNewBlock(state, nullptr, pblock, nullptr));
         BOOST_CHECK(state.IsValid());

--- a/src/test/test_pivx.cpp
+++ b/src/test/test_pivx.cpp
@@ -121,7 +121,7 @@ TestChainSetup::TestChainSetup(int blockCount)
     {
         std::vector<CMutableTransaction> noTxns;
         CBlock b = CreateAndProcessBlock(noTxns, scriptPubKey);
-        coinbaseTxns.push_back(*b.vtx[0]);
+        coinbaseTxns.push_back(*b.vtx.at(0));
     }
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1283,8 +1283,8 @@ void CWallet::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const 
         TransactionRemovedFromMempool(ptx);
     }
     for (size_t i = 0; i < pblock->vtx.size(); i++) {
-        SyncTransaction(pblock->vtx[i], pindex, i);
-        TransactionRemovedFromMempool(pblock->vtx[i]);
+        SyncTransaction(pblock->vtx.at(i), pindex, i);
+        TransactionRemovedFromMempool(pblock->vtx.at(i));
     }
 
     // Sapling: notify about the connected block
@@ -1814,7 +1814,7 @@ int CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate, b
             }
             int posInBlock;
             for (posInBlock = 0; posInBlock < (int)block.vtx.size(); posInBlock++) {
-                const auto& tx = block.vtx[posInBlock];
+                const auto& tx = block.vtx.at(posInBlock);
                 if (AddToWalletIfInvolvingMe(tx, pindex->GetBlockHash(), posInBlock, fUpdate)) {
                     myTxHashes.push_back(tx->GetHash());
                     ret++;


### PR DESCRIPTION
Moving block vtx brackets access operator to at() method. if the index is out of bounds, it will throw an exception instead of be an UB. So we can catch exactly where is the GA-only issue happening: https://github.com/PIVX-Project/PIVX/runs/1994035380?check_suite_focus=true