### PR TITLE
[validation] CheckColdStakeFreeOutput() using coins cache.

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2566,14 +2566,14 @@ bool FindUndoPos(CValidationState& state, int nFile, CDiskBlockPos& pos, unsigne
     return true;
 }
 
-bool CheckColdStakeFreeOutput(const CTransaction& tx, const int nHeight)
+static bool CheckColdStakeFreeOutput(const CTransactionRef& tx, const int nHeight)
 {
-    if (!tx.HasP2CSOutputs())
+    if (!tx->HasP2CSOutputs())
         return true;
 
-    const unsigned int outs = tx.vout.size();
-    const CTxOut& lastOut = tx.vout[outs-1];
-    if (outs >=3 && lastOut.scriptPubKey != tx.vout[outs-2].scriptPubKey) {
+    const unsigned int outs = tx->vout.size();
+    const CTxOut& lastOut = tx->vout[outs-1];
+    if (outs >=3 && lastOut.scriptPubKey != tx->vout[outs-2].scriptPubKey) {
         if (lastOut.nValue == GetMasternodePayment())
             return true;
 
@@ -2584,13 +2584,14 @@ bool CheckColdStakeFreeOutput(const CTransaction& tx, const int nHeight)
         // if mnsync is incomplete, we cannot verify if this is a budget block.
         // so we check that the staker is not transferring value to the free output
         if (!masternodeSync.IsSynced()) {
-            // First try finding the previous transaction in database
-            CTransactionRef txPrev; uint256 hashBlock;
-            if (!GetTransaction(tx.vin[0].prevout.hash, txPrev, hashBlock, true))
-                return error("%s : read txPrev failed: %s",  __func__, tx.vin[0].prevout.hash.GetHex());
-            CAmount amtIn = txPrev->vout[tx.vin[0].prevout.n].nValue + GetBlockValue(nHeight);
+            // First try finding the previous transaction in cache/database
+            Coin coinstake;
+            if (!pcoinsTip->GetCoin(tx->vin[0].prevout, coinstake) || coinstake.IsSpent()) {
+                return error("%s : coinstake read failed: %s",  __func__, tx->vin[0].prevout.hash.GetHex());
+            }
+            CAmount amtIn = coinstake.out.nValue + GetBlockValue(nHeight);
             CAmount amtOut = 0;
-            for (unsigned int i = 1; i < outs-1; i++) amtOut += tx.vout[i].nValue;
+            for (unsigned int i = 1; i < outs-1; i++) amtOut += tx->vout[i].nValue;
             if (amtOut != amtIn)
                 return error("%s: non-free outputs value %d less than required %d", __func__, amtOut, amtIn);
             return true;
@@ -2606,7 +2607,7 @@ bool CheckColdStakeFreeOutput(const CTransaction& tx, const int nHeight)
 
         // wrong free output
         return error("%s: Wrong cold staking outputs: vout[%d].scriptPubKey (%s) != vout[%d].scriptPubKey (%s) - value: %s",
-                __func__, outs-1, HexStr(lastOut.scriptPubKey), outs-2, HexStr(tx.vout[outs-2].scriptPubKey), FormatMoney(lastOut.nValue).c_str());
+                __func__, outs-1, HexStr(lastOut.scriptPubKey), outs-2, HexStr(tx->vout[outs-2].scriptPubKey), FormatMoney(lastOut.nValue).c_str());
     }
 
     return true;
@@ -2709,7 +2710,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
         // that this block is invalid, so don't issue an outright ban.
         if (nHeight != 0 && !IsInitialBlockDownload()) {
             // Last output of Cold-Stake is not abused
-            if (IsPoS && !CheckColdStakeFreeOutput(*(block.vtx[1]), nHeight)) {
+            if (IsPoS && !CheckColdStakeFreeOutput(block.vtx[1], nHeight)) {
                 mapRejectedBlocks.emplace(block.GetHash(), GetTime());
                 return state.DoS(0, false, REJECT_INVALID, "bad-p2cs-outs", false, "invalid cold-stake output");
             }


### PR DESCRIPTION
As `CheckColdStakeFreeOutput()` function is called in `CheckBlock`, and `CheckBlock` always occurs before connecting the arriving block, we can use the coins cache to get the coinstake transaction previous output amount instead of directly going to disk for it. We should try to avoid slow disk operations during sync as much as possible.
Plus moved the function to use `CTransactionRef` instead of `CTransaction`.