### PR TITLE
Removing `TX_ZEROCOINMINT` and `ScriptPubKeyToJSON`

### DIFF
--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -132,7 +132,11 @@ void ScriptPubKeyToUniv(const CScript& scriptPubKey,
         out.pushKV("hex", HexStr(scriptPubKey.begin(), scriptPubKey.end()));
 
     if (!ExtractDestinations(scriptPubKey, type, addresses, nRequired)) {
-        out.pushKV("type", GetTxnOutputType(type));
+        if (!scriptPubKey.empty() && scriptPubKey.IsZerocoinMint()) {
+            out.pushKV("type", "zerocoinmint"); // unsupported type.
+        } else {
+            out.pushKV("type", GetTxnOutputType(type));
+        }
         return;
     }
 

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -5,6 +5,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "chain.h"
+#include "core_io.h"
 #include "primitives/block.h"
 #include "primitives/transaction.h"
 #include "httpserver.h"
@@ -63,7 +64,6 @@ extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& 
 extern UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool txDetails = false);
 extern UniValue mempoolInfoToJSON();
 extern UniValue mempoolToJSON(bool fVerbose = false);
-extern void ScriptPubKeyToJSON(const CScript& scriptPubKey, UniValue& out, bool fIncludeHex);
 extern UniValue blockheaderToJSON(const CBlockIndex* blockindex);
 
 static bool RESTERR(HTTPRequest* req, enum HTTPStatusCode status, std::string message)
@@ -564,7 +564,7 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
 
             // include the script in a json output
             UniValue o(UniValue::VOBJ);
-            ScriptPubKeyToJSON(coin.out.scriptPubKey, o, true);
+            ScriptPubKeyToUniv(coin.out.scriptPubKey, o, true);
             utxo.pushKV("scriptPubKey", o);
             utxos.push_back(utxo);
         }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -9,11 +9,11 @@
 #include "budget/budgetmanager.h"
 #include "checkpoints.h"
 #include "clientversion.h"
+#include "core_io.h"
 #include "consensus/upgrades.h"
 #include "kernel.h"
 #include "masternodeman.h"
 #include "policy/feerate.h"
-#include "policy/policy.h"
 #include "rpc/server.h"
 #include "sync.h"
 #include "txdb.h"
@@ -23,14 +23,9 @@
 #include "hash.h"
 #include "validationinterface.h"
 #include "wallet/wallet.h"
-#include "zpiv/zpivmodule.h"
-#include "zpivchain.h"
 
 #include <stdint.h>
-#include <fstream>
-#include <iostream>
 #include <univalue.h>
-#include <mutex>
 #include <numeric>
 #include <condition_variable>
 
@@ -47,7 +42,6 @@ static std::condition_variable cond_blockchange;
 static CUpdatedBlock latestblock;
 
 extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry);
-void ScriptPubKeyToJSON(const CScript& scriptPubKey, UniValue& out, bool fIncludeHex);
 
 UniValue syncwithvalidationinterfacequeue(const JSONRPCRequest& request)
 {
@@ -870,7 +864,7 @@ UniValue gettxout(const JSONRPCRequest& request)
     }
     ret.pushKV("value", ValueFromAmount(coin.out.nValue));
     UniValue o(UniValue::VOBJ);
-    ScriptPubKeyToJSON(coin.out.scriptPubKey, o, true);
+    ScriptPubKeyToUniv(coin.out.scriptPubKey, o, true);
     ret.pushKV("scriptPubKey", o);
     ret.pushKV("coinbase", (bool)coin.fCoinBase);
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -43,7 +43,11 @@ void ScriptPubKeyToJSON(const CScript& scriptPubKey, UniValue& out, bool fInclud
         out.pushKV("hex", HexStr(scriptPubKey.begin(), scriptPubKey.end()));
 
     if (!ExtractDestinations(scriptPubKey, type, addresses, nRequired)) {
-        out.pushKV("type", GetTxnOutputType(type));
+        if (!scriptPubKey.empty() && scriptPubKey.IsZerocoinMint()) {
+            out.pushKV("type", "zerocoinmint"); // unsupported type.
+        } else {
+            out.pushKV("type", GetTxnOutputType(type));
+        }
         return;
     }
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -31,35 +31,6 @@
 
 #include <univalue.h>
 
-
-void ScriptPubKeyToJSON(const CScript& scriptPubKey, UniValue& out, bool fIncludeHex)
-{
-    txnouttype type;
-    std::vector<CTxDestination> addresses;
-    int nRequired;
-
-    out.pushKV("asm", ScriptToAsmStr(scriptPubKey));
-    if (fIncludeHex)
-        out.pushKV("hex", HexStr(scriptPubKey.begin(), scriptPubKey.end()));
-
-    if (!ExtractDestinations(scriptPubKey, type, addresses, nRequired)) {
-        if (!scriptPubKey.empty() && scriptPubKey.IsZerocoinMint()) {
-            out.pushKV("type", "zerocoinmint"); // unsupported type.
-        } else {
-            out.pushKV("type", GetTxnOutputType(type));
-        }
-        return;
-    }
-
-    out.pushKV("reqSigs", nRequired);
-    out.pushKV("type", GetTxnOutputType(type));
-
-    UniValue a(UniValue::VARR);
-    for (const CTxDestination& addr : addresses)
-        a.push_back(EncodeDestination(addr));
-    out.pushKV("addresses", a);
-}
-
 void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
 {
     // Call into TxToUniv() in bitcoin-common to decode the transaction hex.
@@ -460,7 +431,7 @@ UniValue decodescript(const JSONRPCRequest& request)
     } else {
         // Empty scripts are valid
     }
-    ScriptPubKeyToJSON(script, r, false);
+    ScriptPubKeyToUniv(script, r, false);
 
     r.pushKV("p2sh", EncodeDestination(CScriptID(script)));
     return r;

--- a/src/script/ismine.cpp
+++ b/src/script/ismine.cpp
@@ -90,7 +90,6 @@ isminetype IsMine(const CKeyStore& keystore, const CScript& scriptPubKey)
     case TX_NONSTANDARD:
     case TX_NULL_DATA:
         break;
-    case TX_ZEROCOINMINT:
     case TX_PUBKEY:
         keyID = CPubKey(vSolutions[0]).GetID();
         if(keystore.HaveKey(keyID))

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -83,8 +83,6 @@ static bool SignStep(const BaseSignatureCreator& creator, const CScript& scriptP
     case TX_NONSTANDARD:
     case TX_NULL_DATA:
         return false;
-    case TX_ZEROCOINMINT:
-        return false;
     case TX_PUBKEY:
         keyID = CPubKey(vSolutions[0]).GetID();
         return Sign1(keyID, creator, scriptPubKey, ret, sigversion);
@@ -296,7 +294,6 @@ static Stacks CombineSignatures(const CScript& scriptPubKey, const BaseSignature
     {
     case TX_NONSTANDARD:
     case TX_NULL_DATA:
-    case TX_ZEROCOINMINT:
         // Don't know anything about this, assume bigger one is correct:
         if (sigs1.script.size() >= sigs2.script.size())
             return sigs1;

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -26,7 +26,6 @@ const char* GetTxnOutputType(txnouttype t)
     case TX_MULTISIG: return "multisig";
     case TX_COLDSTAKE: return "coldstake";
     case TX_NULL_DATA: return "nulldata";
-    case TX_ZEROCOINMINT: return "zerocoinmint";
     }
     return NULL;
 }
@@ -107,15 +106,6 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, std::vector<std::v
         return true;
     }
 
-    // Zerocoin
-    if (scriptPubKey.IsZerocoinMint()) {
-        typeRet = TX_ZEROCOINMINT;
-        if(scriptPubKey.size() > 150) return false;
-        std::vector<unsigned char> hashBytes(scriptPubKey.begin()+2, scriptPubKey.end());
-        vSolutionsRet.push_back(hashBytes);
-        return true;
-    }
-
     // Provably prunable, data-carrying output
     //
     // So long as script passes the IsUnspendable() test and all but the first
@@ -168,7 +158,6 @@ int ScriptSigArgsExpected(txnouttype t, const std::vector<std::vector<unsigned c
     {
     case TX_NONSTANDARD:
     case TX_NULL_DATA:
-    case TX_ZEROCOINMINT:
         return -1;
     case TX_PUBKEY:
         return 1;

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -52,7 +52,6 @@ enum txnouttype
     TX_SCRIPTHASH,
     TX_MULTISIG,
     TX_NULL_DATA,
-    TX_ZEROCOINMINT,
     TX_COLDSTAKE
 };
 


### PR DESCRIPTION
The `TX_ZEROCOINMINT` output type is not needed, nor used anywhere. Same as the function `ScriptPubKeyToJSON` that is a plain copy of `ScriptPubKeyToUniv` without cold staking scripts support.