### PR TITLE
Fixing few shutdown problems

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1793,8 +1793,11 @@ bool AppInitMain()
 
     // scan for better chains in the block chain database, that are not yet connected in the active best chain
     CValidationState state;
-    if (!ActivateBestChain(state))
+    if (!ActivateBestChain(state)) {
         strErrors << "Failed to connect best block";
+        StartShutdown();
+        return false;
+    }
     // update g_best_block if needed
     {
         LOCK(g_best_block_mutex);

--- a/src/qt/pivx.cpp
+++ b/src/qt/pivx.cpp
@@ -373,7 +373,6 @@ void BitcoinApplication::createWindow(const NetworkStyle* networkStyle)
 
     pollShutdownTimer = new QTimer(window);
     connect(pollShutdownTimer, &QTimer::timeout, window, &PIVXGUI::detectShutdown);
-    pollShutdownTimer->start(200);
 }
 
 void BitcoinApplication::createSplashScreen(const NetworkStyle* networkStyle)
@@ -514,6 +513,7 @@ void BitcoinApplication::initializeResult(int retval)
         });
         QTimer::singleShot(100, paymentServer, &PaymentServer::uiReady);
 #endif
+        pollShutdownTimer->start(200);
     } else {
         quit(); // Exit main loop
     }

--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -443,12 +443,13 @@ void TopBar::setStakingStatusActive(bool fActive)
 }
 void TopBar::updateStakingStatus()
 {
-    setStakingStatusActive(walletModel &&
-                           !walletModel->isWalletLocked() &&
-                           walletModel->isStakingStatusActive());
+    if (walletModel && !walletModel->isShutdownRequested()) {
+        setStakingStatusActive(!walletModel->isWalletLocked() &&
+                               walletModel->isStakingStatusActive());
 
-    // Taking advantage of this timer to update Tor status if needed.
-    updateTorIcon();
+        // Taking advantage of this timer to update Tor status if needed.
+        updateTorIcon();
+    }
 }
 
 void TopBar::setNumConnections(int count)

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -11,6 +11,7 @@
 #include "optionsmodel.h"
 #include "recentrequeststablemodel.h"
 #include "transactiontablemodel.h"
+#include "init.h" // for ShutdownRequested(). Future: move to an interface wrapper
 
 #include "base58.h"
 #include "coincontrol.h"
@@ -65,6 +66,11 @@ bool WalletModel::isTestNetwork() const
 bool WalletModel::isRegTestNetwork() const
 {
     return Params().IsRegTestNet();
+}
+
+bool WalletModel::isShutdownRequested()
+{
+    return ShutdownRequested();
 }
 
 bool WalletModel::isColdStakingNetworkelyEnabled() const

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -151,6 +151,7 @@ public:
 
     bool isTestNetwork() const;
     bool isRegTestNetwork() const;
+    bool isShutdownRequested();
     /** Whether cold staking is enabled or disabled in the network **/
     bool isColdStakingNetworkelyEnabled() const;
     bool isSaplingInMaintenance() const;


### PR DESCRIPTION
First commit was decoupled from #2131, the topbar staking status polling should not try to refresh data if shutdown was requested.
Second commit is coming from #12377.
Third commit is starting the shutdown process and returning early (without starting the import thread) if the best chain cannot be activated during the node's initialization.