### PR TITLE
[GUI] Transaction filter, minimize model data request + cleanup.

### DIFF
--- a/src/qt/pivx/settings/settingsexportcsv.cpp
+++ b/src/qt/pivx/settings/settingsexportcsv.cpp
@@ -140,7 +140,7 @@ void SettingsExportCSV::exportTxes(const QString& filename)
         writer.addColumn(tr("Label"), 0, TransactionTableModel::LabelRole);
         writer.addColumn(tr("Address"), 0, TransactionTableModel::AddressRole);
         writer.addColumn(BitcoinUnits::getAmountColumnTitle(walletModel->getOptionsModel()->getDisplayUnit()), 0, TransactionTableModel::FormattedAmountRole);
-        writer.addColumn(tr("ID"), 0, TransactionTableModel::TxIDRole);
+        writer.addColumn(tr("ID"), 0, TransactionTableModel::TxHashRole);
         fExport = writer.write();
     }
 

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2011-2013 The Bitcoin developers
 // Copyright (c) 2017-2020 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 #include "transactionfilterproxy.h"
 
@@ -86,6 +86,7 @@ void TransactionFilterProxy::setAddressPrefix(const QString& addrPrefix)
 
 void TransactionFilterProxy::setTypeFilter(quint32 modes)
 {
+    if (typeFilter == modes) return;
     this->typeFilter = modes;
     invalidateFilter();
 }

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -34,39 +34,36 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex& 
 {
     QModelIndex index = sourceModel()->index(sourceRow, 0, sourceParent);
 
-    int type = index.data(TransactionTableModel::TypeRole).toInt();
-    QDateTime datetime = index.data(TransactionTableModel::DateRole).toDateTime();
-    bool involvesWatchAddress = index.data(TransactionTableModel::WatchonlyRole).toBool();
-    QString address = index.data(TransactionTableModel::AddressRole).toString();
-    QString label = index.data(TransactionTableModel::LabelRole).toString();
-    qint64 amount = llabs(index.data(TransactionTableModel::AmountRole).toLongLong());
     int status = index.data(TransactionTableModel::StatusRole).toInt();
-
     if (!showInactive && status == TransactionStatus::Conflicted)
         return false;
-    if (fHideOrphans && isOrphan(status, type))
-        return false;
-    if (!(bool)(TYPE(type) & typeFilter))
-        return false;
+
+    int type = index.data(TransactionTableModel::TypeRole).toInt();
+    if (fHideOrphans && isOrphan(status, type)) return false;
+    if (!(bool)(TYPE(type) & typeFilter)) return false;
+    if (fOnlyZc && !isZcTx(type)) return false;
+    if (fOnlyStakes && !isStakeTx(type)) return false;
+    if (fOnlyColdStaking && !isColdStake(type)) return false;
+
+    bool involvesWatchAddress = index.data(TransactionTableModel::WatchonlyRole).toBool();
     if (involvesWatchAddress && watchOnlyFilter == WatchOnlyFilter_No)
         return false;
     if (!involvesWatchAddress && watchOnlyFilter == WatchOnlyFilter_Yes)
         return false;
+
+    QDateTime datetime = index.data(TransactionTableModel::DateRole).toDateTime();
     if (datetime < dateFrom || datetime > dateTo)
         return false;
+
+    QString address = index.data(TransactionTableModel::AddressRole).toString();
+    QString label = index.data(TransactionTableModel::LabelRole).toString();
     if (!addrPrefix.isEmpty()) {
         if (!address.contains(addrPrefix, Qt::CaseInsensitive) && !label.contains(addrPrefix, Qt::CaseInsensitive))
             return false;
     }
-    if (amount < minAmount)
-        return false;
-    if (fOnlyZc && !isZcTx(type)){
-        return false;
-    }
-    if (fOnlyStakes && !isStakeTx(type))
-        return false;
 
-    if (fOnlyColdStaking && !isColdStake(type))
+    qint64 amount = llabs(index.data(TransactionTableModel::AmountRole).toLongLong());
+    if (amount < minAmount)
         return false;
 
     return true;

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -122,21 +122,9 @@ void TransactionFilterProxy::setHideOrphans(bool fHide)
     invalidateFilter();
 }
 
-void TransactionFilterProxy::setShowZcTxes(bool fOnlyZc)
-{
-    this->fOnlyZc = fOnlyZc;
-    invalidateFilter();
-}
-
 void TransactionFilterProxy::setOnlyStakes(bool fOnlyStakes)
 {
     this->fOnlyStakes = fOnlyStakes;
-    invalidateFilter();
-}
-
-void TransactionFilterProxy::setOnlyColdStakes(bool fOnlyColdStakes)
-{
-    this->fOnlyColdStaking = fOnlyColdStakes;
     invalidateFilter();
 }
 
@@ -168,9 +156,3 @@ bool TransactionFilterProxy::isStakeTx(int type) const {
 bool TransactionFilterProxy::isColdStake(int type) const {
     return type == TransactionRecord::P2CSDelegation || type == TransactionRecord::P2CSDelegationSent || type == TransactionRecord::P2CSDelegationSentOwner || type == TransactionRecord::StakeDelegated || type == TransactionRecord::StakeHot;
 }
-
-/*QVariant TransactionFilterProxy::dataFromSourcePos(int sourceRow, int role) const {
-    QModelIndex index = sourceModel()->index(sourceRow, 0, sourceParent);
-    return index.data(index, role);
-}
- */

--- a/src/qt/transactionfilterproxy.h
+++ b/src/qt/transactionfilterproxy.h
@@ -59,19 +59,11 @@ public:
     /** Set whether to hide orphan stakes. */
     void setHideOrphans(bool fHide);
 
-    /** Only zc txes **/
-    void setShowZcTxes(bool fOnlyZc);
-
     /** Only stakes txes **/
     void setOnlyStakes(bool fOnlyStakes);
 
-    /** Shows only p2cs-p2cs && xxx-p2cs **/
-    void setOnlyColdStakes(bool fOnlyColdStakes);
-
     int rowCount(const QModelIndex& parent = QModelIndex()) const;
     static bool isOrphan(const int status, const int type);
-
-    //QVariant dataFromSourcePos(int sourceRow, int role) const;
 
 protected:
     bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const;

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -9,7 +9,6 @@
 #include "base58.h"
 #include "sapling/key_io_sapling.h"
 #include "wallet/wallet.h"
-#include "zpivchain.h"
 
 #include <algorithm>
 #include <stdint.h>
@@ -561,21 +560,6 @@ void TransactionRecord::loadHotOrColdStakeOrContract(
 
     // Extract and set the owner address
     ExtractAddress(p2csUtxo.scriptPubKey, false, record.address);
-}
-
-bool IsZPIVType(TransactionRecord::Type type)
-{
-    switch (type) {
-        case TransactionRecord::StakeZPIV:
-        case TransactionRecord::ZerocoinMint:
-        case TransactionRecord::ZerocoinSpend:
-        case TransactionRecord::RecvFromZerocoinSpend:
-        case TransactionRecord::ZerocoinSpend_Change_zPiv:
-        case TransactionRecord::ZerocoinSpend_FromMe:
-            return true;
-        default:
-            return false;
-    }
 }
 
 void TransactionRecord::updateStatus(const CWalletTx& wtx)

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -658,11 +658,6 @@ bool TransactionRecord::statusUpdateNeeded()
     return status.cur_num_blocks != chainActive.Height();
 }
 
-QString TransactionRecord::getTxID() const
-{
-    return QString::fromStdString(hash.ToString());
-}
-
 int TransactionRecord::getOutputIndex() const
 {
     return idx;

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -176,9 +176,6 @@ public:
     /** Whether the transaction was sent/received with a watch-only address */
     bool involvesWatchAddress{false};
 
-    /** Return the unique identifier for this transaction (part) */
-    QString getTxID() const;
-
     /** Return the output index of the subtransaction  */
     int getOutputIndex() const;
 

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -766,8 +766,6 @@ QVariant TransactionTableModel::data(const QModelIndex& index, int role) const
         return qint64(rec->credit + rec->debit);
     case ShieldedCreditAmountRole:
         return  rec->shieldedCredit ? qint64(*rec->shieldedCredit) : 0;
-    case TxIDRole:
-        return rec->getTxID();
     case TxHashRole:
         return QString::fromStdString(rec->hash.ToString());
     case ConfirmedRole:

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -60,8 +60,6 @@ public:
         LabelRole,
         /** Net amount of transaction */
         AmountRole,
-        /** Unique identifier */
-        TxIDRole,
         /** Transaction hash */
         TxHashRole,
         /** Is transaction confirmed? */


### PR DESCRIPTION
Added the following changes:

1) Removed the redundant `TxIDRole` from the transaction table model. It's just a duplication of `TxHashRole`.
2) Improved the transaction filter proxy to only request data from the model when is needed, not before-hand.
3) Added a validation to not invalidate the filter if the input type isn't modifying the type that the filter already has.
4) Removed unused `IsZPIVType()`, `setShowZcTxes()` and `setOnlyColdStake` functions.