### PR TITLE
Qt: Refresh view on wallet options widget shown #fixes 1838

### DIFF
--- a/src/qt/pivx/settings/settingswalletoptionswidget.cpp
+++ b/src/qt/pivx/settings/settingswalletoptionswidget.cpp
@@ -84,6 +84,15 @@ void SettingsWalletOptionsWidget::setSpinBoxStakeSplitThreshold(double val)
     ui->spinBoxStakeSplitThreshold->setValue(val);
 }
 
+void SettingsWalletOptionsWidget::showEvent(QShowEvent *event)
+{
+    PWidget::showEvent(event);
+    if (clientModel) {
+        OptionsModel *optionsModel = clientModel->getOptionsModel();
+        optionsModel->refreshDataView();
+    }
+}
+
 SettingsWalletOptionsWidget::~SettingsWalletOptionsWidget(){
     delete ui;
 }

--- a/src/qt/pivx/settings/settingswalletoptionswidget.h
+++ b/src/qt/pivx/settings/settingswalletoptionswidget.h
@@ -31,6 +31,7 @@ public Q_SLOTS:
     void onResetClicked();
 
 private:
+    void showEvent(QShowEvent *event);
     Ui::SettingsWalletOptionsWidget *ui;
 };
 

--- a/src/qt/pivx/settings/settingswalletoptionswidget.h
+++ b/src/qt/pivx/settings/settingswalletoptionswidget.h
@@ -31,7 +31,7 @@ public Q_SLOTS:
     void onResetClicked();
 
 private:
-    void showEvent(QShowEvent *event);
+    void showEvent(QShowEvent *event) override;
     Ui::SettingsWalletOptionsWidget *ui;
 };
 


### PR DESCRIPTION
Refresh view when wallet options widget is shown, so that changes applied in debug console are visible in the widget.
![1](https://user-images.githubusercontent.com/22178604/110397671-f9307500-807a-11eb-8a91-e98728d6c315.png)
![2](https://user-images.githubusercontent.com/22178604/110397674-fa61a200-807a-11eb-9b41-bbd9f55c1295.png)
