### PR TITLE
[RPC][wallet] Add `rescanblockchain` RPC command functionality

### DIFF
--- a/src/qt/pivx/settings/settingsbittoolwidget.cpp
+++ b/src/qt/pivx/settings/settingsbittoolwidget.cpp
@@ -312,7 +312,7 @@ void SettingsBitToolWidget::importAddressFromDecKey()
 
         // whenever a key is imported, we need to scan the whole chain
         pwalletMain->nTimeFirstKey = 1; // 0 would be considered 'no value'
-        pwalletMain->ScanForWalletTransactions(chainActive.Genesis(), true);
+        pwalletMain->ScanForWalletTransactions(chainActive.Genesis(), nullptr, true);
     }
 
     ui->statusLabel_DEC->setStyleSheet("QLabel { color: green; }");

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -149,6 +149,8 @@ static const CRPCConvertParam vRPCConvertParams[] = {
     { "getblockindexstats", 1 },
     { "getfeeinfo", 0 },
     { "getsupplyinfo", 0 },
+    { "rescanblockchain", 0},
+    { "rescanblockchain", 1},
 };
 
 class CRPCConvertTable

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -151,6 +151,27 @@ UniValue importprivkey(const JSONRPCRequest& request)
     return NullUniValue;
 }
 
+UniValue abortrescan(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() > 0)
+        throw std::runtime_error(
+                "abortrescan\n"
+                "\nStops current wallet rescan triggered e.g. by an importprivkey call.\n"
+                "\nExamples:\n"
+                "\nImport a private key\n"
+                + HelpExampleCli("importprivkey", "\"mykey\"") +
+                "\nAbort the running wallet rescan\n"
+                + HelpExampleCli("abortrescan", "") +
+                "\nAs a JSON-RPC call\n"
+                + HelpExampleRpc("abortrescan", "")
+        );
+
+    EnsureWallet();
+    if (!pwalletMain->IsScanning() || pwalletMain->IsAbortingRescan()) return false;
+    pwalletMain->AbortRescan();
+    return true;
+}
+
 void ImportAddress(const CTxDestination& dest, const std::string& strLabel, const std::string& strPurpose);
 
 void ImportScript(const CScript& script, const std::string& strLabel, bool isRedeemScript)

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -144,7 +144,7 @@ UniValue importprivkey(const JSONRPCRequest& request)
                 // cold staking was activated after nBlockTimeProtocolV2 (PIVX v4.0). No need to scan the whole chain
                 pindex = chainActive[Params().GetConsensus().vUpgrades[Consensus::UPGRADE_V4_0].nActivationHeight];
             }
-            pwalletMain->ScanForWalletTransactions(pindex, true);
+            pwalletMain->ScanForWalletTransactions(pindex, nullptr, true);
         }
     }
 
@@ -231,7 +231,7 @@ UniValue importaddress(const JSONRPCRequest& request)
     }
 
     if (fRescan) {
-        pwalletMain->ScanForWalletTransactions(chainActive.Genesis(), true);
+        pwalletMain->ScanForWalletTransactions(chainActive.Genesis(), nullptr, true);
         pwalletMain->ReacceptWalletTransactions();
     }
 
@@ -275,7 +275,7 @@ UniValue importpubkey(const JSONRPCRequest& request)
     ImportScript(GetScriptForRawPubKey(pubKey), strLabel, false);
 
     if (fRescan) {
-        pwalletMain->ScanForWalletTransactions(chainActive.Genesis(), true);
+        pwalletMain->ScanForWalletTransactions(chainActive.Genesis(), nullptr, true);
         pwalletMain->ReacceptWalletTransactions();
     }
 
@@ -697,7 +697,7 @@ UniValue bip38decrypt(const JSONRPCRequest& request)
 
         // whenever a key is imported, we need to scan the whole chain
         pwalletMain->nTimeFirstKey = 1; // 0 would be considered 'no value'
-        pwalletMain->ScanForWalletTransactions(chainActive.Genesis(), true);
+        pwalletMain->ScanForWalletTransactions(chainActive.Genesis(), nullptr, true);
     }
 
     return result;
@@ -791,7 +791,7 @@ UniValue importsaplingkey(const JSONRPCRequest& request)
 
     // We want to scan for transactions and notes
     if (fRescan) {
-        pwalletMain->ScanForWalletTransactions(chainActive[nRescanHeight], true);
+        pwalletMain->ScanForWalletTransactions(chainActive[nRescanHeight], nullptr, true);
     }
 
     return result;
@@ -884,7 +884,7 @@ UniValue importsaplingviewingkey(const JSONRPCRequest& request)
 
     // We want to scan for transactions and notes
     if (fRescan) {
-        pwalletMain->ScanForWalletTransactions(chainActive[nRescanHeight], true);
+        pwalletMain->ScanForWalletTransactions(chainActive[nRescanHeight], nullptr, true);
     }
 
     return result;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4239,6 +4239,7 @@ UniValue rescanblockchain(const JSONRPCRequest& request)
     return response;
 }
 
+extern UniValue abortrescan(const JSONRPCRequest& request); // in rpcdump.cpp
 extern UniValue dumpprivkey(const JSONRPCRequest& request); // in rpcdump.cpp
 extern UniValue importprivkey(const JSONRPCRequest& request);
 extern UniValue importaddress(const JSONRPCRequest& request);
@@ -4259,6 +4260,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "getaddressinfo",           &getaddressinfo,           true  },
     { "wallet",             "autocombinerewards",       &autocombinerewards,       false },
     { "wallet",             "abandontransaction",       &abandontransaction,       false },
+    { "wallet",             "abortrescan",              &abortrescan,              false },
     { "wallet",             "addmultisigaddress",       &addmultisigaddress,       true  },
     { "wallet",             "backupwallet",             &backupwallet,             true  },
     { "wallet",             "delegatestake",            &delegatestake,            false },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4223,10 +4223,9 @@ UniValue rescanblockchain(const JSONRPCRequest& request)
 
     CBlockIndex *stopBlock = pwalletMain->ScanForWalletTransactions(pindexStart, pindexStop, true);
     if (!stopBlock) {
-        // future: backport abort rescan
-        //if (pwalletMain->IsAbortingRescan()) {
-        //    throw JSONRPCError(RPC_MISC_ERROR, "Rescan aborted.");
-        //}
+        if (pwalletMain->IsAbortingRescan()) {
+            throw JSONRPCError(RPC_MISC_ERROR, "Rescan aborted.");
+        }
         // if we got a nullptr returned, ScanForWalletTransactions did rescan up to the requested stopindex
         stopBlock = pindexStop ? pindexStop : chainActive.Tip();
     }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4179,6 +4179,67 @@ UniValue getsaplingnotescount(const JSONRPCRequest& request)
     return count;
 }
 
+UniValue rescanblockchain(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() > 2) {
+        throw std::runtime_error(
+                "rescanblockchain (start_height) (stop_height)\n"
+                "\nRescan the local blockchain for wallet related transactions.\n"
+                "\nArguments:\n"
+                "1. start_height    (numeric, optional) block height where the rescan should start\n"
+                "2. stop_height     (numeric, optional) the last block height that should be scanned\n"
+                "\nResult:\n"
+                "{\n"
+                "  start_height     (numeric) The block height where the rescan has started. If omitted, rescan started from the genesis block.\n"
+                "  stop_height      (numeric) The height of the last rescanned block. If omitted, rescan stopped at the chain tip.\n"
+                "}\n"
+                "\nExamples:\n"
+                + HelpExampleCli("rescanblockchain", "100000 120000")
+                + HelpExampleRpc("rescanblockchain", "100000 120000")
+        );
+    }
+
+    EnsureWallet();
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+
+    CBlockIndex *pindexStart = chainActive.Genesis();
+    CBlockIndex *pindexStop = nullptr;
+    if (!request.params[0].isNull()) {
+        pindexStart = chainActive[request.params[0].get_int()];
+        if (!pindexStart) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid start_height");
+        }
+    }
+
+    if (!request.params[1].isNull()) {
+        pindexStop = chainActive[request.params[1].get_int()];
+        if (!pindexStop) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid stop_height");
+        }
+        else if (pindexStop->nHeight < pindexStart->nHeight) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "stop_height must be greater then start_height");
+        }
+    }
+
+    CBlockIndex *stopBlock = pwalletMain->ScanForWalletTransactions(pindexStart, pindexStop, true);
+    if (!stopBlock) {
+        // future: backport abort rescan
+        //if (pwalletMain->IsAbortingRescan()) {
+        //    throw JSONRPCError(RPC_MISC_ERROR, "Rescan aborted.");
+        //}
+        // if we got a nullptr returned, ScanForWalletTransactions did rescan up to the requested stopindex
+        stopBlock = pindexStop ? pindexStop : chainActive.Tip();
+    }
+    else {
+        throw JSONRPCError(RPC_MISC_ERROR, "Rescan failed. Potentially corrupted data files.");
+    }
+
+    UniValue response(UniValue::VOBJ);
+    response.pushKV("start_height", pindexStart->nHeight);
+    response.pushKV("stop_height", stopBlock->nHeight);
+    return response;
+}
+
 extern UniValue dumpprivkey(const JSONRPCRequest& request); // in rpcdump.cpp
 extern UniValue importprivkey(const JSONRPCRequest& request);
 extern UniValue importaddress(const JSONRPCRequest& request);
@@ -4243,6 +4304,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "walletlock",               &walletlock,               true  },
     { "wallet",             "walletpassphrasechange",   &walletpassphrasechange,   true  },
     { "wallet",             "walletpassphrase",         &walletpassphrase,         true  },
+    { "wallet",             "rescanblockchain",         &rescanblockchain,         true  },
     { "wallet",             "delegatoradd",             &delegatoradd,             true  },
     { "wallet",             "delegatorremove",          &delegatorremove,          true  },
     { "wallet",             "bip38encrypt",             &bip38encrypt,             true  },

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -863,7 +863,7 @@ public:
     bool Upgrade(std::string& error, const int& prevVersion);
     bool ActivateSaplingWallet(bool memOnly = false);
 
-    CBlockIndex* ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false, bool fromStartup = false);
+    CBlockIndex* ScanForWalletTransactions(CBlockIndex* pindexStart, CBlockIndex* pindexStop = nullptr, bool fUpdate = false, bool fromStartup = false);
     void TransactionRemovedFromMempool(const CTransactionRef &ptx) override;
     void ReacceptWalletTransactions(bool fFirstLoad = false);
     void ResendWalletTransactions(CConnman* connman) override;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -503,6 +503,8 @@ class CWallet : public CCryptoKeyStore, public CValidationInterface
 {
 private:
     static std::atomic<bool> fFlushScheduled;
+    std::atomic<bool> fAbortRescan;
+    std::atomic<bool> fScanningWallet;
 
     //! keeps track of whether Unlock has run a thorough check before
     bool fDecryptionThoroughlyChecked{false};
@@ -746,6 +748,13 @@ public:
     void UnlockCoin(const COutPoint& output);
     void UnlockAllCoins();
     std::set<COutPoint> ListLockedCoins();
+
+    /*
+     * Rescan abort properties
+     */
+    void AbortRescan() { fAbortRescan = true; }
+    bool IsAbortingRescan() { return fAbortRescan; }
+    bool IsScanning() { return fScanningWallet; }
 
     //  keystore implementation
     PairResult getNewAddress(CTxDestination& ret, const std::string addressLabel, const std::string purpose,

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -863,7 +863,7 @@ public:
     bool Upgrade(std::string& error, const int& prevVersion);
     bool ActivateSaplingWallet(bool memOnly = false);
 
-    int ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false, bool fromStartup = false);
+    CBlockIndex* ScanForWalletTransactions(CBlockIndex* pindexStart, bool fUpdate = false, bool fromStartup = false);
     void TransactionRemovedFromMempool(const CTransactionRef &ptx) override;
     void ReacceptWalletTransactions(bool fFirstLoad = false);
     void ResendWalletTransactions(CConnman* connman) override;

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -150,7 +150,7 @@ class WalletHDTest(PivxTestFramework):
         self.start_node(1, extra_args=self.extra_args[1] + ['-rescan'])
         assert_equal(self.nodes[1].getbalance(), NUM_HD_ADDS + NUM_SHIELD_ADDS + 1)
 
-        # Delete chain and resync (without recreating shield addresses)
+        # Try a RPC based rescan
         self.stop_node(1)
         shutil.rmtree(os.path.join(self.nodes[1].datadir, "regtest", "blocks"))
         shutil.rmtree(os.path.join(self.nodes[1].datadir, "regtest", "chainstate"))
@@ -158,8 +158,7 @@ class WalletHDTest(PivxTestFramework):
         self.start_and_connect_node1()
         # Wallet automatically scans blocks older than key on startup (but shielded addresses need to be regenerated)
         assert_equal(self.nodes[1].getbalance(), NUM_HD_ADDS + 1)
-
-        """ todo: Implement rescanblockchain
+        # Wallet automatically scans blocks older than key on startup
         out = self.nodes[1].rescanblockchain(0, 1)
         assert_equal(out['start_height'], 0)
         assert_equal(out['stop_height'], 1)
@@ -167,7 +166,6 @@ class WalletHDTest(PivxTestFramework):
         assert_equal(out['start_height'], 0)
         assert_equal(out['stop_height'], self.nodes[1].getblockcount())
         assert_equal(self.nodes[1].getbalance(), NUM_HD_ADDS + 1)
-        """
 
         # send a tx and make sure its using the internal chain for the changeoutput
         txid = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 1)


### PR DESCRIPTION
Added the following changes:

1) The wallet scan chain for transactions process will now return null if scan was successful. Otherwise, if a complete rescan was not possible (due to corruption or abort), returns pointer to the most recent block that could not be scanned.
2) New `rescanblockchain` RPC command with two arguments `start_height` `end_height` to trigger a chain rescan at any time during runtime + test case (adaptation of #7061).
3) New `abortrescan` RPC command to stop any long running rescan if needed at runtime (this is helpful for example in case of importing a private/sapling key that if the user is not aware of the extra "scan" boolean argument, it will rescan the complete chain). Coming from #10208.