### PR TITLE
[Util] Pass pthread_self() to pthread_setschedparam instead of 0

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -843,7 +843,7 @@ int GetNumCores()
 int ScheduleBatchPriority(void)
 {
 #ifdef SCHED_BATCH
-    const static sched_param param{.sched_priority = 0};
+    const static sched_param param{0};
     if (int ret = pthread_setschedparam(pthread_self(), SCHED_BATCH, &param)) {
         LogPrintf("Failed to pthread_setschedparam: %s\n", strerror(errno));
         return ret;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -844,7 +844,7 @@ int ScheduleBatchPriority(void)
 {
 #ifdef SCHED_BATCH
     const static sched_param param{.sched_priority = 0};
-    if (int ret = pthread_setschedparam(0, SCHED_BATCH, &param)) {
+    if (int ret = pthread_setschedparam(pthread_self(), SCHED_BATCH, &param)) {
         LogPrintf("Failed to pthread_setschedparam: %s\n", strerror(errno));
         return ret;
     }


### PR DESCRIPTION
Coming straight from https://github.com/bitcoin/bitcoin/pull/12923. 

Fixes a bug introduced in #2212 for **some** POSIX linux systems (observed on CentOS 7 currently)

Original upstream text:

> Nowhere in the man page of pthread_setschedparam it is mentioned that 0 is a valid value. The example uses pthread_self(), so should we.