### PR TITLE
[Qt] Fix double fade-in Topbar Available click animation. Issue 2216

### DIFF
--- a/src/qt/pivx/balancebubble.cpp
+++ b/src/qt/pivx/balancebubble.cpp
@@ -44,12 +44,12 @@ void BalanceBubble::showEvent(QShowEvent *event)
 {
     QGraphicsOpacityEffect *eff = new QGraphicsOpacityEffect(this);
     this->setGraphicsEffect(eff);
-    QPropertyAnimation *a = new QPropertyAnimation(eff,"opacity");
-    a->setDuration(400);
-    a->setStartValue(0.1);
-    a->setEndValue(1);
-    a->setEasingCurve(QEasingCurve::InBack);
-    a->start(QPropertyAnimation::DeleteWhenStopped);
+    QPropertyAnimation *anim = new QPropertyAnimation(eff,"opacity");
+    anim->setDuration(400);
+    anim->setStartValue(0);
+    anim->setEndValue(1);
+    anim->setEasingCurve(QEasingCurve::Linear);
+    anim->start(QPropertyAnimation::DeleteWhenStopped);
 
     if (!hideTimer) hideTimer = new QTimer(this);
     connect(hideTimer, &QTimer::timeout, this, &BalanceBubble::hideTimeout);


### PR DESCRIPTION
Fixes double fade-in animation when clicking the question mark next to the 'Available' label in the top bar. 
Issue: #2216

Video of issue:
https://user-images.githubusercontent.com/36901185/109182893-12d9de80-7796-11eb-8ad7-cecb9d0c9286.mp4

After fix:
https://user-images.githubusercontent.com/36901185/109183124-4d437b80-7796-11eb-926d-06108a1713a1.mp4