### PR TITLE
[RPC] refactor autocombine into specific commands

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -48,6 +48,12 @@ Notable Changes
 
 A new init option flag '-blocksdir' will allow one to keep the blockfiles external from the data directory.
 
+
+#### Show wallet's auto-combine settings in getwalletinfo
+
+`getwalletinfo` now has two additional return fields. `autocombine_enabled` (boolean) and `autocombine_threshold` (numeric) that will show the auto-combine threshold and whether or not it is currently enabled.
+
+
 #### Disable PoW mining RPC Commands
 
 A new configure flag has been introduced to allow more granular control over weather or not the PoW mining RPC commands are compiled into the wallet. By default they are not. This behavior can be overridden by passing `--enable-mining-rpc` to the `configure` script.

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -53,6 +53,40 @@ A new init option flag '-blocksdir' will allow one to keep the blockfiles extern
 
 `getwalletinfo` now has two additional return fields. `autocombine_enabled` (boolean) and `autocombine_threshold` (numeric) that will show the auto-combine threshold and whether or not it is currently enabled.
 
+#### Deprecate the autocombine RPC command
+
+The `autocombine` RPC command has been replaced with specific set/get commands (`setautocombinethreshold` and `getautocombinethreshold`, respectively) to bring this functionality further in-line with our RPC standards. Previously, the `autocombine` command gave no user-facing feedback when the setting was changed. This is now resolved with the introduction of the two new commands as detailed below:
+
+* `setautocombinethreshold`
+    ```  
+    setautocombinethreshold enable ( value )
+    This will set the auto-combine threshold value.
+    Wallet will automatically monitor for any coins with value below the threshold amount, and combine them if they reside with the same PIVX address
+    When auto-combine runs it will create a transaction, and therefore will be subject to transaction fees.
+    
+    Arguments:
+    1. enable          (boolean, required) Enable auto combine (true) or disable (false)
+    2. threshold       (numeric, optional. required if enable is true) Threshold amount. Must be greater than 1.
+    
+    Result:
+    {
+      "enabled": true|false,     (boolean) true if auto-combine is enabled, otherwise false
+      "threshold": n.nnn,        (numeric) auto-combine threshold in PIV
+      "saved": true|false        (boolean) true if setting was saved to the database, otherwise false
+    }
+    ```
+
+* `getautocombinethreshold`
+    ```
+    getautocombinethreshold
+    Returns the current threshold for auto combining UTXOs, if any
+
+    Result:
+    {
+      "enabled": true|false,    (boolean) true if auto-combine is enabled, otherwise false
+      "threshold": n.nnn         (numeric) the auto-combine threshold amount in PIV
+    }
+    ```
 
 #### Disable PoW mining RPC Commands
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -147,6 +147,8 @@ static const CRPCConvertParam vRPCConvertParams[] = {
     { "setstakesplitthreshold", 0 },
     { "autocombinerewards", 0 },
     { "autocombinerewards", 1 },
+    { "setautocombinethreshold", 0 },
+    { "setautocombinethreshold", 1 },
     { "getblockindexstats", 0 },
     { "getblockindexstats", 1 },
     { "getfeeinfo", 0 },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3718,6 +3718,8 @@ UniValue getwalletinfo(const JSONRPCRequest& request)
             "  \"immature_cold_staking_balance\": xxxxxx, (numeric) the cold-staking immature balance of the wallet in PIV\n"
             "  \"immature_balance\": xxxxxx,              (numeric) the total immature balance of the wallet in PIV\n"
             "  \"txcount\": xxxxxxx,                      (numeric) the total number of transactions in the wallet\n"
+            "  \"autocombine_enabled\": true|false,       (boolean) true if autocombine is enabled, otherwise false\n"
+            "  \"autocombine_threshold\": x.xxx,          (numeric) the current autocombine threshold in PIV\n"
             "  \"keypoololdest\": xxxxxx,                 (numeric) the timestamp (seconds since GMT epoch) of the oldest pre-generated key in the key pool\n"
             "  \"keypoolsize\": xxxx,                     (numeric) how many new keys are pre-generated (only counts external keys)\n"
             "  \"keypoolsize_hd_internal\": xxxx,         (numeric) how many new keys are pre-generated for internal use (used for change outputs, only appears if the wallet is using this feature, otherwise external keys are used)\n"
@@ -3747,8 +3749,13 @@ UniValue getwalletinfo(const JSONRPCRequest& request)
     obj.pushKV("immature_delegated_balance",    ValueFromAmount(pwalletMain->GetImmatureDelegatedBalance()));
     obj.pushKV("immature_cold_staking_balance",    ValueFromAmount(pwalletMain->GetImmatureColdStakingBalance()));
     obj.pushKV("txcount", (int)pwalletMain->mapWallet.size());
-    obj.pushKV("keypoololdest", pwalletMain->GetOldestKeyPoolTime());
 
+    // Autocombine settings
+    obj.pushKV("autocombine_enabled", pwalletMain->fCombineDust);
+    obj.pushKV("autocombine_threshold", ValueFromAmount(pwalletMain->nAutoCombineThreshold));
+
+    // Keypool information
+    obj.pushKV("keypoololdest", pwalletMain->GetOldestKeyPoolTime());
     size_t kpExternalSize = pwalletMain->KeypoolCountExternalKeys();
     obj.pushKV("keypoolsize", (int64_t)kpExternalSize);
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3905,7 +3905,7 @@ UniValue autocombinerewards(const JSONRPCRequest& request)
     CAmount nThreshold = 0;
 
     if (fEnable)
-        nThreshold = request.params[1].get_int();
+        nThreshold = AmountFromValue(request.params[1]);
 
     pwalletMain->fCombineDust = fEnable;
     pwalletMain->nAutoCombineThreshold = nThreshold;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3996,7 +3996,7 @@ void CWallet::AutoCombineDust(CConnman* connman)
     }
 
     std::map<CTxDestination, std::vector<COutput> > mapCoinsByAddress =
-            AvailableCoinsByAddress(true, nAutoCombineThreshold * COIN, false);
+            AvailableCoinsByAddress(true, nAutoCombineThreshold, false);
 
     //coins are sectioned by address. This combination code only wants to combine inputs that belong to the same address
     for (std::map<CTxDestination, std::vector<COutput> >::iterator it = mapCoinsByAddress.begin(); it != mapCoinsByAddress.end(); it++) {
@@ -4021,7 +4021,7 @@ void CWallet::AutoCombineDust(CConnman* connman)
             nTotalRewardsValue += out.Value();
 
             // Combine to the threshold and not way above
-            if (nTotalRewardsValue > nAutoCombineThreshold * COIN)
+            if (nTotalRewardsValue > nAutoCombineThreshold)
                 break;
 
             // Around 180 bytes per input. We use 190 to be certain
@@ -4073,7 +4073,7 @@ void CWallet::AutoCombineDust(CConnman* connman)
         }
 
         //we don't combine below the threshold unless the fees are 0 to avoid paying fees over fees over fees
-        if (!maxSize && nTotalRewardsValue < nAutoCombineThreshold * COIN && nFeeRet > 0)
+        if (!maxSize && nTotalRewardsValue < nAutoCombineThreshold && nFeeRet > 0)
             continue;
 
         const CWallet::CommitResult& res = CommitTransaction(wtx, keyChange, connman);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -561,6 +561,9 @@ bool ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue, CW
             ssValue >> pSettings;
             pwallet->fCombineDust = pSettings.first;
             pwallet->nAutoCombineThreshold = pSettings.second;
+            // originally saved as integer
+            if (pwallet->nAutoCombineThreshold < COIN)
+                pwallet->nAutoCombineThreshold *= COIN;
         } else if (strType == DBKeys::DESTDATA) {
             std::string strAddress, strKey, strValue;
             ssKey >> strAddress;

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -117,6 +117,7 @@ BASE_SCRIPTS= [
     'rpc_decodescript.py',                      # ~ 50 sec
     'rpc_blockchain.py',                        # ~ 50 sec
     'wallet_disable.py',                        # ~ 50 sec
+    'wallet_autocombine.py',                    # ~ 49 sec
     'mining_v5_upgrade.py',                     # ~ 48 sec
     'feature_blocksdir.py',
     'p2p_mempool.py',                           # ~ 46 sec

--- a/test/functional/wallet_autocombine.py
+++ b/test/functional/wallet_autocombine.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The PIVX developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Test the wallet's autocombine feature."""
+
+from test_framework.test_framework import PivxTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error
+)
+
+import time
+
+
+class AutoCombineTest(PivxTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def run_test(self):
+        # Check that there's no UTXOs
+        assert_equal(len(self.nodes[0].listunspent()), 0)
+
+        # Check the failure conditions for setautocombinethreshold
+        assert_raises_rpc_error(-8, "Missing threshold value", self.nodes[0].setautocombinethreshold, True)
+        assert_raises_rpc_error(-8, "The threshold value cannot be less than 1.00", self.nodes[0].setautocombinethreshold, True, 0.99)
+
+        self.log.info("Mining initial 100 blocks...")
+        self.nodes[0].generate(100)
+
+        walletinfo = self.nodes[0].getwalletinfo()
+        assert_equal(walletinfo['immature_balance'], 25000)
+        assert_equal(walletinfo['balance'], 0)
+
+        self.log.info("Mining 2 more blocks to use as autocombine inputs")
+        self.nodes[0].generate(2)
+
+        walletinfo = self.nodes[0].getwalletinfo()
+        assert_equal(walletinfo['balance'], 500)
+        assert_equal(walletinfo['txcount'], 102)
+
+        self.log.info("Set autocombine to 500 PIV")
+        setautocombine = self.nodes[0].setautocombinethreshold(True, 500)
+        assert_equal(setautocombine['enabled'], True)
+        assert_equal(setautocombine['threshold'], 500)
+        getautocombine = self.nodes[0].getautocombinethreshold()
+        assert_equal(getautocombine['enabled'], True)
+        assert_equal(getautocombine['threshold'], 500)
+        walletinfo = self.nodes[0].getwalletinfo()
+        assert_equal(walletinfo['autocombine_enabled'], True)
+        assert_equal(walletinfo['autocombine_threshold'], 500)
+
+        self.log.info("Mine 1 more block to initiate an autocombine transaction")
+        self.nodes[0].generate(1)
+        time.sleep(1)
+
+        mempool = self.nodes[0].getrawmempool()
+        assert_equal(len(mempool), 1)
+        tx = mempool[0]
+        nFee = self.nodes[0].getrawmempool(True)[mempool[0]]['fee']
+        walletinfo = self.nodes[0].getwalletinfo()
+        assert_equal(walletinfo['balance'], 750 - nFee)
+        assert_equal(walletinfo['txcount'], 104)
+
+        self.log.info("Mine 1 more block to confirm the autocombine transaction")
+        block = self.nodes[0].generate(1)
+        time.sleep(1)
+
+        walletinfo = self.nodes[0].getwalletinfo()
+        assert_equal(walletinfo['balance'], 250 + 750 - nFee)
+        assert_equal(walletinfo['txcount'], 105)
+
+        txinfo = self.nodes[0].gettransaction(tx)
+        assert_equal(txinfo['fee'], 0 - nFee)
+        assert_equal(txinfo['confirmations'], 1)
+        assert_equal(txinfo['amount'], 0)
+        assert_equal(txinfo['blockhash'], block[0])
+
+        self.log.info("Disable autocombine")
+        setautocombine = self.nodes[0].setautocombinethreshold(False)
+        assert_equal(setautocombine['enabled'], False)
+        assert_equal(setautocombine['threshold'], 0)
+        getautocombine = self.nodes[0].getautocombinethreshold()
+        assert_equal(getautocombine['enabled'], False)
+        assert_equal(getautocombine['threshold'], 0)
+        walletinfo = self.nodes[0].getwalletinfo()
+        assert_equal(walletinfo['autocombine_enabled'], False)
+        assert_equal(walletinfo['autocombine_threshold'], 0)
+
+        self.log.info("Mine 1 more block to make sure autocombine is disabled")
+        self.nodes[0].generate(1)
+        time.sleep(1)
+
+        mempool = self.nodes[0].getrawmempool()
+        assert_equal(len(mempool), 0)
+
+        walletinfo = self.nodes[0].getwalletinfo()
+        assert_equal(walletinfo['balance'], 250 + 250 + 750 - nFee)
+        assert_equal(walletinfo['txcount'], 106)
+
+
+if __name__ == '__main__':
+    AutoCombineTest().main()


### PR DESCRIPTION
The current `autocombine` command is limited to whole numbers only, and infringes on our RPC standards by not providing deterministic output even when successfully changing the setting.

This PR addresses the deterministic issue as well as makes the setting information available to `getwalletinfo`