### PR TITLE
[Qt] Make box of PIVX Send address return to purple when it's empty

### DIFF
--- a/src/qt/pivx/sendmultirow.cpp
+++ b/src/qt/pivx/sendmultirow.cpp
@@ -149,6 +149,10 @@ bool SendMultiRow::addressChanged(const QString& str, bool fOnlyValidate)
         updateStyle(ui->lineEditAddress);
         return valid;
     }
+
+    setCssProperty(ui->lineEditAddress, "edit-primary-multi-book");
+    updateStyle(ui->lineEditAddress);
+
     return false;
 }
 


### PR DESCRIPTION
This PR makes the box of the PIVX address in the send widget turn back to purple when previously filled and made empty.

Issue: #1639 

Before fix: 
![issue_1639_before](https://user-images.githubusercontent.com/36901185/111166098-717dc580-85a8-11eb-91d1-6c41a88fba88.gif)


After fix:
![issue_1639_after](https://user-images.githubusercontent.com/36901185/111166124-7a6e9700-85a8-11eb-8382-f04311413224.gif)

