### PR TITLE
[Qt][Feature Request] Add search option to My Addresses list

### DIFF
--- a/src/qt/pivx/forms/receivewidget.ui
+++ b/src/qt/pivx/forms/receivewidget.ui
@@ -530,6 +530,9 @@
              <property name="acceptDrops">
               <bool>false</bool>
              </property>
+             <property name="maxLength">
+              <number>40</number>
+             </property>
              <property name="placeholderText">
               <string>Filter</string>
              </property>

--- a/src/qt/pivx/forms/receivewidget.ui
+++ b/src/qt/pivx/forms/receivewidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>819</width>
+    <width>954</width>
     <height>629</height>
    </rect>
   </property>
@@ -511,6 +511,35 @@
             <number>5</number>
            </property>
            <item>
+            <widget class="QLabel" name="labelFilter">
+             <property name="text">
+              <string>Filter:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLineEdit" name="lineEditFilter">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="contextMenuPolicy">
+              <enum>Qt::DefaultContextMenu</enum>
+             </property>
+             <property name="acceptDrops">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
             <spacer name="horizontalSpacer_3">
              <property name="orientation">
               <enum>Qt::Horizontal</enum>
@@ -556,6 +585,10 @@
             </widget>
            </item>
           </layout>
+          <zorder>comboBoxSort</zorder>
+          <zorder>comboBoxSortOrder</zorder>
+          <zorder>lineEditFilter</zorder>
+          <zorder>labelFilter</zorder>
          </widget>
         </item>
         <item>

--- a/src/qt/pivx/forms/receivewidget.ui
+++ b/src/qt/pivx/forms/receivewidget.ui
@@ -511,13 +511,6 @@
             <number>5</number>
            </property>
            <item>
-            <widget class="QLabel" name="labelFilter">
-             <property name="text">
-              <string>Filter:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QLineEdit" name="lineEditFilter">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -537,6 +530,9 @@
              <property name="acceptDrops">
               <bool>false</bool>
              </property>
+             <property name="placeholderText">
+              <string>Filter</string>
+             </property>
             </widget>
            </item>
            <item>
@@ -544,9 +540,12 @@
              <property name="orientation">
               <enum>Qt::Horizontal</enum>
              </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Preferred</enum>
+             </property>
              <property name="sizeHint" stdset="0">
               <size>
-               <width>40</width>
+               <width>20</width>
                <height>20</height>
               </size>
              </property>
@@ -588,7 +587,6 @@
           <zorder>comboBoxSort</zorder>
           <zorder>comboBoxSortOrder</zorder>
           <zorder>lineEditFilter</zorder>
-          <zorder>labelFilter</zorder>
          </widget>
         </item>
         <item>

--- a/src/qt/pivx/receivewidget.cpp
+++ b/src/qt/pivx/receivewidget.cpp
@@ -91,6 +91,12 @@ ReceiveWidget::ReceiveWidget(PIVXGUI* parent) :
     ui->container_right->addItem(spacer);
     ui->listViewAddress->setVisible(false);
 
+    // My Address search filter
+    setCssSubtitleScreen(ui->labelFilter);
+
+    initCssEditLine(ui->lineEditFilter, true);
+    ui->lineEditFilter->setStyleSheet("font: 12px;");
+
     // Sort Controls
     SortEdit* lineEdit = new SortEdit(ui->comboBoxSort);
     connect(lineEdit, &SortEdit::Mouse_Pressed, [this](){ui->comboBoxSort->showPopup();});
@@ -108,6 +114,7 @@ ReceiveWidget::ReceiveWidget(PIVXGUI* parent) :
     connect(ui->listViewAddress, &QListView::clicked, this, &ReceiveWidget::handleAddressClicked);
     connect(ui->btnRequest, &OptionButton::clicked, this, &ReceiveWidget::onRequestClicked);
     connect(ui->btnMyAddresses, &OptionButton::clicked, this, &ReceiveWidget::onMyAddressesClicked);
+    connect(ui->lineEditFilter, &QLineEdit::textChanged, [this](){filterChanged(ui->lineEditFilter->text());});
 
     ui->pushLeft->setChecked(true);
     connect(ui->pushLeft, &QPushButton::clicked, [this](){onTransparentSelected(true);});
@@ -334,6 +341,11 @@ void ReceiveWidget::onSortOrderChanged(int idx)
 {
     sortOrder = (Qt::SortOrder) ui->comboBoxSortOrder->itemData(idx).toInt();
     sortAddresses();
+}
+
+void ReceiveWidget::filterChanged(const QString& str)
+{
+    this->filter->setFilterRegExp(str);
 }
 
 void ReceiveWidget::sortAddresses()

--- a/src/qt/pivx/receivewidget.cpp
+++ b/src/qt/pivx/receivewidget.cpp
@@ -92,10 +92,8 @@ ReceiveWidget::ReceiveWidget(PIVXGUI* parent) :
     ui->listViewAddress->setVisible(false);
 
     // My Address search filter
-    setCssSubtitleScreen(ui->labelFilter);
-
     initCssEditLine(ui->lineEditFilter, true);
-    ui->lineEditFilter->setStyleSheet("font: 12px;");
+    ui->lineEditFilter->setStyleSheet("font: 14px;");
 
     // Sort Controls
     SortEdit* lineEdit = new SortEdit(ui->comboBoxSort);

--- a/src/qt/pivx/receivewidget.h
+++ b/src/qt/pivx/receivewidget.h
@@ -49,6 +49,8 @@ private Q_SLOTS:
     void handleAddressClicked(const QModelIndex &index);
     void onSortChanged(int idx);
     void onSortOrderChanged(int idx);
+    void filterChanged(const QString& str);
+
 private:
     Ui::ReceiveWidget *ui{nullptr};
 


### PR DESCRIPTION
This PR adds a filter box to the My Addresses list in the Receive section.

Issue: #1635 

How it works:
https://user-images.githubusercontent.com/36901185/111183252-603cb500-85b8-11eb-8549-e31a9f18ba70.mp4

The edit box filters the address rows for both the name or the address itself. It also has a maximum input length of 40 characters.