### PR TITLE
[validation] Crash if disconnecting a block fails

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1926,7 +1926,7 @@ bool static DisconnectTip(CValidationState& state, const CChainParams& chainpara
     std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>();
     CBlock& block = *pblock;
     if (!ReadBlockFromDisk(block, pindexDelete))
-        return AbortNode(state, "Failed to read block");
+        return error("%s: Failed to read block", __func__);
     // Apply the block atomically to the chain state.
     const uint256& saplingAnchorBeforeDisconnect = pcoinsTip->GetBestAnchor();
     int64_t nStart = GetTimeMicros();
@@ -2222,7 +2222,11 @@ static bool ActivateBestChainStep(CValidationState& state, CBlockIndex* pindexMo
             // This is likely a fatal error, but keep the mempool consistent,
             // just in case. Only remove from the mempool in this case.
             UpdateMempoolForReorg(disconnectpool, false);
-            return false;
+
+            // If we're unable to disconnect a block during normal operation,
+            // then that is a failure of our local system -- we should abort
+            // rather than stay on a less work chain.
+            return AbortNode(state, "Failed to disconnect block; see debug.log for details");
         }
         fBlocksDisconnected = true;
     }

--- a/test/functional/feature_abortnode.py
+++ b/test/functional/feature_abortnode.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://www.opensource.org/licenses/mit-license.php.
+"""Test bitcoind aborts if can't disconnect a block.
+
+- Start a single node and generate 3 blocks.
+- Delete the undo data.
+- Mine a fork that requires disconnecting the tip.
+- Verify that bitcoind AbortNode's.
+"""
+
+from test_framework.test_framework import PivxTestFramework
+from test_framework.util import wait_until, get_datadir_path, connect_nodes
+import os
+
+class AbortNodeTest(PivxTestFramework):
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+
+    def setup_network(self):
+        self.setup_nodes()
+        # We'll connect the nodes later
+
+    def run_test(self):
+        self.nodes[0].generate(3)
+        datadir = get_datadir_path(self.options.tmpdir, 0)
+
+        # Deleting the undo file will result in reorg failure
+        os.unlink(os.path.join(datadir, 'regtest', 'blocks', 'rev00000.dat'))
+
+        # Connecting to a node with a more work chain will trigger a reorg
+        # attempt.
+        self.nodes[1].generate(3)
+        with self.nodes[0].assert_debug_log(["Failed to disconnect block"]):
+            connect_nodes(self.nodes[0], 1)
+            self.nodes[1].generate(1)
+
+            # Check that node0 aborted
+            self.log.info("Waiting for crash")
+            wait_until(lambda: self.nodes[0].is_node_stopped(), timeout=60)
+        self.log.info("Node crashed - now verifying restart fails")
+        self.assert_start_raises_init_error(0)
+
+if __name__ == '__main__':
+    AbortNodeTest().main()

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -337,6 +337,7 @@ class PivxTestFramework():
         with tempfile.SpooledTemporaryFile(max_size=2**16) as log_stderr:
             try:
                 self.start_node(i, extra_args, stderr=log_stderr, *args, **kwargs)
+                self.nodes[i].wait_for_rpc_connection()
                 self.stop_node(i)
             except Exception as e:
                 assert 'pivxd exited' in str(e)  # node must have shutdown

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -4,6 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Class for pivxd node under test"""
 
+import contextlib
 import decimal
 import errno
 import http.client
@@ -200,6 +201,23 @@ class TestNode():
 
     def wait_until_stopped(self, timeout=BITCOIND_PROC_WAIT_TIMEOUT):
         wait_until(self.is_node_stopped, timeout=timeout)
+
+    @contextlib.contextmanager
+    def assert_debug_log(self, expected_msgs):
+        debug_log = os.path.join(self.datadir, 'regtest', 'debug.log')
+        with open(debug_log, encoding='utf-8') as dl:
+            dl.seek(0, 2)
+            prev_size = dl.tell()
+        try:
+            yield
+        finally:
+            with open(debug_log, encoding='utf-8') as dl:
+                dl.seek(prev_size)
+                log = dl.read()
+            print_log = " - " + "\n - ".join(log.splitlines())
+            for expected_msg in expected_msgs:
+                if re.search(re.escape(expected_msg), log, flags=re.MULTILINE) is None:
+                    self._raise_assertion_error('Expected message "{}" does not partially match log:\n\n{}\n\n'.format(expected_msg, print_log))
 
     def node_encrypt_wallet(self, passphrase):
         """"Encrypts the wallet.

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -171,6 +171,7 @@ EXTENDED_SCRIPTS = [
     #'p2p_timeouts.py',
     # vv Tests less than 60s vv
     #'p2p_feefilter.py',
+    'feature_abortnode.py',
     'rpc_bind.py',
     # vv Tests less than 30s vv
     #'example_test.py',


### PR DESCRIPTION
Coming from upstream #15305 with some adaptations.

> If we're unable to disconnect a block during normal operation, then that is a
failure of our local system (such as disk failure) or the chain that we are on
(eg CVE-2018-17144), but cannot be due to failure of the (more work) chain that
we're trying to validate.
We should abort rather than stay on a less work chain.