### PR TITLE
[Tests] sync_blocks and sync_mempool improvements

### DIFF
--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -79,6 +79,7 @@ $ curl localhost:18332/rest/getutxos/checkmempool/b2cdfd7b89def827ff8af7cd9bff76
 
 Returns various information about the TX mempool.
 Only supports JSON as output format.
+* loaded : (boolean) if the mempool is fully loaded
 * size : (numeric) the number of transactions in the TX mempool
 * bytes : (numeric) size of the TX mempool in bytes
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -248,8 +248,8 @@ void PrepareShutdown()
     DumpBudgets(g_budgetman);
     DumpMasternodePayments();
     UnregisterNodeSignals(GetNodeSignals());
-    if (g_is_mempool_loaded && gArgs.GetBoolArg("-persistmempool", DEFAULT_PERSIST_MEMPOOL)) {
-        DumpMempool();
+    if (::mempool.IsLoaded() && gArgs.GetBoolArg("-persistmempool", DEFAULT_PERSIST_MEMPOOL)) {
+        DumpMempool(::mempool);
     }
 
     if (fFeeEstimatesInitialized) {
@@ -728,9 +728,9 @@ void ThreadImport(const std::vector<fs::path>& vImportFiles)
     }
 
     if (gArgs.GetBoolArg("-persistmempool", DEFAULT_PERSIST_MEMPOOL)) {
-        LoadMempool();
+        LoadMempool(::mempool);
     }
-    g_is_mempool_loaded = !fRequestShutdown;
+    ::mempool.SetIsLoaded(!ShutdownRequested());
 }
 
 /** Sanity checks

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -14,6 +14,7 @@
 #include "kernel.h"
 #include "masternodeman.h"
 #include "policy/feerate.h"
+#include "policy/policy.h"
 #include "rpc/server.h"
 #include "sync.h"
 #include "txdb.h"
@@ -1149,9 +1150,13 @@ UniValue getchaintips(const JSONRPCRequest& request)
 UniValue mempoolInfoToJSON()
 {
     UniValue ret(UniValue::VOBJ);
+    ret.pushKV("loaded", g_is_mempool_loaded);
     ret.pushKV("size", (int64_t) mempool.size());
     ret.pushKV("bytes", (int64_t) mempool.GetTotalTxSize());
     ret.pushKV("usage", (int64_t) mempool.DynamicMemoryUsage());
+    size_t maxmempool = gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;
+    ret.pushKV("mempoolminfee", ValueFromAmount(std::max(mempool.GetMinFee(maxmempool), ::minRelayTxFee).GetFeePerK()));
+    ret.pushKV("minrelaytxfee", ValueFromAmount(::minRelayTxFee.GetFeePerK()));
 
     return ret;
 }
@@ -1165,9 +1170,13 @@ UniValue getmempoolinfo(const JSONRPCRequest& request)
 
             "\nResult:\n"
             "{\n"
+            "  \"loaded\": true|false         (boolean) True if the mempool is fully loaded\n"
             "  \"size\": xxxxx                (numeric) Current tx count\n"
             "  \"bytes\": xxxxx               (numeric) Sum of all tx sizes\n"
             "  \"usage\": xxxxx               (numeric) Total memory usage for the mempool\n"
+            "  \"maxmempool\": xxxxx,         (numeric) Maximum memory usage for the mempool\n"
+            "  \"mempoolminfee\": xxxxx       (numeric) Minimum fee rate in " + CURRENCY_UNIT + "/kB for tx to be accepted. Is the maximum of minrelaytxfee and minimum mempool fee\n"
+            "  \"minrelaytxfee\": xxxxx       (numeric) Current minimum relay fee for transactions\n"
             "}\n"
 
             "\nExamples:\n" +

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1150,7 +1150,7 @@ UniValue getchaintips(const JSONRPCRequest& request)
 UniValue mempoolInfoToJSON()
 {
     UniValue ret(UniValue::VOBJ);
-    ret.pushKV("loaded", g_is_mempool_loaded);
+    ret.pushKV("loaded", mempool.IsLoaded());
     ret.pushKV("size", (int64_t) mempool.size());
     ret.pushKV("bytes", (int64_t) mempool.GetTotalTxSize());
     ret.pushKV("usage", (int64_t) mempool.DynamicMemoryUsage());

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1213,3 +1213,15 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpends
 }
 
 
+bool CTxMemPool::IsLoaded() const
+{
+    LOCK(cs);
+    return m_is_loaded;
+}
+
+void CTxMemPool::SetIsLoaded(bool loaded)
+{
+    LOCK(cs);
+    m_is_loaded = loaded;
+}
+

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -419,6 +419,8 @@ private:
     std::map<uint256, CTransactionRef> mapSaplingNullifiers;
     void checkNullifiers() const;
 
+    bool m_is_loaded GUARDED_BY(cs){false};
+
 public:
 
     static const int ROLLING_FEE_HALFLIFE = 60 * 60 * 12; // public only for testing
@@ -618,7 +620,13 @@ public:
     /** Expire all transaction (and their dependencies) in the mempool older than time. Return the number of removed transactions. */
     int Expire(int64_t time);
 
-    unsigned long size()
+    /** @returns true if the mempool is fully loaded */
+    bool IsLoaded() const;
+
+    /** Sets the current loaded state */
+    void SetIsLoaded(bool loaded);
+
+    unsigned long size() const
     {
         LOCK(cs);
         return mapTx.size();

--- a/src/validation.h
+++ b/src/validation.h
@@ -124,7 +124,6 @@ struct BlockHasher {
 extern CScript COINBASE_FLAGS;
 extern RecursiveMutex cs_main;
 extern CTxMemPool mempool;
-extern std::atomic_bool g_is_mempool_loaded;
 typedef std::unordered_map<uint256, CBlockIndex*, BlockHasher> BlockMap;
 extern BlockMap mapBlockIndex;
 extern uint64_t nLastBlockTx;
@@ -401,9 +400,9 @@ static const unsigned int REJECT_ALREADY_KNOWN = 0x101;
 static const unsigned int REJECT_CONFLICT = 0x102;
 
 /** Dump the mempool to disk. */
-void DumpMempool();
+bool DumpMempool(const CTxMemPool& pool);
 
 /** Load the mempool from disk. */
-bool LoadMempool();
+bool LoadMempool(CTxMemPool& pool);
 
 #endif // BITCOIN_MAIN_H

--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -113,7 +113,7 @@ class ExampleTest(PivxTestFramework):
         # sync_all() should not include node2, since we're not expecting it to
         # sync.
         connect_nodes(self.nodes[0], 1)
-        self.sync_all([self.nodes[0:1]])
+        self.sync_all(self.nodes[0:1])
 
     # Use setup_nodes() to customize the node start behaviour (for example if
     # you don't want to start all nodes at the start of the test).
@@ -143,7 +143,7 @@ class ExampleTest(PivxTestFramework):
 
         # Generating a block on one of the nodes will get us out of IBD
         blocks = [int(self.nodes[0].generate(1)[0], 16)]
-        self.sync_all([self.nodes[0:1]])
+        self.sync_all(self.nodes[0:1])
 
         # Notice above how we called an RPC by calling a method with the same
         # name on the node object. Notice also how we used a keyword argument

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -191,9 +191,9 @@ class EstimateFeeTest(PivxTestFramework):
                                                       self.memutxo, Decimal("0.05"), MIN_FEE, MIN_FEE)
                 tx_kbytes = (len(txhex) // 2) / 1000.0
                 self.fees_per_kb.append(float(fee)/tx_kbytes)
-            sync_mempools(self.nodes[0:3], wait=.1)
+            self.sync_mempools(self.nodes[0:3], wait=.1)
             mined = mining_node.getblock(mining_node.generate(1)[0],True)["tx"]
-            sync_blocks(self.nodes[0:3], wait=.1)
+            self.sync_blocks(self.nodes[0:3], wait=.1)
             # update which txouts are confirmed
             newmem = []
             for utx in self.memutxo:
@@ -270,7 +270,7 @@ class EstimateFeeTest(PivxTestFramework):
         while len(self.nodes[1].getrawmempool()) > 0:
             self.nodes[1].generate(1)
 
-        sync_blocks(self.nodes[0:3], wait=.1)
+        self.sync_blocks(self.nodes[0:3], wait=.1)
         self.log.info("Final estimates after emptying mempools")
         check_estimates(self.nodes[1], self.fees_per_kb, 2)
 

--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -10,7 +10,7 @@
 """
 
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import wait_until
+from test_framework.util import assert_equal
 import time
 
 class ReindexTest(PivxTestFramework):
@@ -23,11 +23,9 @@ class ReindexTest(PivxTestFramework):
         self.nodes[0].generate(3)
         blockcount = self.nodes[0].getblockcount()
         self.stop_nodes()
-        time.sleep(5)
         extra_args = [["-reindex", "-checkblockindex=1"]]
         self.start_nodes(extra_args)
-        time.sleep(15)
-        wait_until(lambda: self.nodes[0].getblockcount() == blockcount)
+        assert_equal(self.nodes[0].getblockcount(), blockcount)  # start_node is blocking on reindex
         self.log.info("Success")
 
     def run_test(self):

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -12,8 +12,6 @@ from test_framework.util import (
     Decimal,
     ROUND_DOWN,
     JSONRPCException,
-    sync_blocks,
-    sync_mempools
 )
 
 def satoshi_round(amount):
@@ -141,7 +139,7 @@ class MempoolPackagesTest(PivxTestFramework):
         # Test reorg handling
         # First, the basics:
         self.nodes[0].generate(1)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
         self.nodes[1].invalidateblock(self.nodes[0].getbestblockhash())
         self.nodes[1].reconsiderblock(self.nodes[0].getbestblockhash())
 
@@ -196,12 +194,12 @@ class MempoolPackagesTest(PivxTestFramework):
         rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
         signedtx = self.nodes[0].signrawtransaction(rawtx)
         txid = self.nodes[0].sendrawtransaction(signedtx['hex'])
-        sync_mempools(self.nodes)
+        self.sync_mempools()
 
         # Now try to disconnect the tip on each node...
         self.nodes[1].invalidateblock(self.nodes[1].getbestblockhash())
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
-        sync_blocks(self.nodes)
+        self.sync_blocks()
 
 if __name__ == '__main__':
     MempoolPackagesTest().main()

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -31,8 +31,14 @@ Test is as follows:
 
 """
 
+from decimal import Decimal
+import os
+
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    wait_until,
+)
 
 class MempoolPersistTest(PivxTestFramework):
     def set_test_params(self):
@@ -64,10 +70,12 @@ class MempoolPersistTest(PivxTestFramework):
         self.start_node(1, extra_args=["-persistmempool=0"])
         self.start_node(0)
         self.start_node(2)
-        # Give pivxd a second to reload the mempool
-        wait_until(lambda: len(self.nodes[0].getrawmempool()) == 5, timeout=1)
-        wait_until(lambda: len(self.nodes[2].getrawmempool()) == 5, timeout=1)
-        # The others loaded their mempool. If node_1 loaded anything, we'd probably notice by now:
+
+        wait_until(lambda: self.nodes[0].getmempoolinfo()["loaded"], timeout=1)
+        wait_until(lambda: self.nodes[2].getmempoolinfo()["loaded"], timeout=1)
+        assert_equal(len(self.nodes[0].getrawmempool()), 5)
+        assert_equal(len(self.nodes[2].getrawmempool()), 5)
+        # The others have loaded their mempool. If node_1 loaded anything, we'd probably notice by now:
         assert_equal(len(self.nodes[1].getrawmempool()), 0)
 
         # Verify accounting of mempool transactions after restart is correct
@@ -77,38 +85,39 @@ class MempoolPersistTest(PivxTestFramework):
         self.log.debug("Stop-start node0 with -persistmempool=0. Verify that it doesn't load its mempool.dat file.")
         self.stop_nodes()
         self.start_node(0, extra_args=["-persistmempool=0"])
-        # Give bitcoind a second to reload the mempool
-        time.sleep(1)
+        wait_until(lambda: self.nodes[0].getmempoolinfo()["loaded"])
         assert_equal(len(self.nodes[0].getrawmempool()), 0)
 
         self.log.debug("Stop-start node0. Verify that it has the transactions in its mempool.")
         self.stop_nodes()
         self.start_node(0)
-        wait_until(lambda: len(self.nodes[0].getrawmempool()) == 5)
+        wait_until(lambda: self.nodes[0].getmempoolinfo()["loaded"])
+        assert_equal(len(self.nodes[0].getrawmempool()), 5)
 
         # Following code is ahead of our current repository state. Future back port.
+        '''
+        mempooldat0 = os.path.join(self.nodes[0].datadir, 'regtest', 'mempool.dat')
+        mempooldat1 = os.path.join(self.nodes[1].datadir, 'regtest', 'mempool.dat')
+        self.log.debug("Remove the mempool.dat file. Verify that savemempool to disk via RPC re-creates it")
+        os.remove(mempooldat0)
+        self.nodes[0].savemempool()
+        assert os.path.isfile(mempooldat0)
 
-        # mempooldat0 = os.path.join(self.options.tmpdir, 'node0', 'regtest', 'mempool.dat')
-        # mempooldat1 = os.path.join(self.options.tmpdir, 'node1', 'regtest', 'mempool.dat')
-        # self.log.debug("Remove the mempool.dat file. Verify that savemempool to disk via RPC re-creates it")
-        # os.remove(mempooldat0)
-        # self.nodes[0].savemempool()
-        # assert os.path.isfile(mempooldat0)
-        #
-        # self.log.debug("Stop nodes, make node1 use mempool.dat from node0. Verify it has 5 transactions")
-        # os.rename(mempooldat0, mempooldat1)
-        # self.stop_nodes()
-        # self.start_node(1, extra_args=[])
-        # wait_until(lambda: len(self.nodes[1].getrawmempool()) == 5)
-        #
-        # self.log.debug("Prevent bitcoind from writing mempool.dat to disk. Verify that `savemempool` fails")
-        # # to test the exception we are setting bad permissions on a tmp file called mempool.dat.new
-        # # which is an implementation detail that could change and break this test
-        # mempooldotnew1 = mempooldat1 + '.new'
-        # with os.fdopen(os.open(mempooldotnew1, os.O_CREAT, 0o000), 'w'):
-        #     pass
-        # assert_raises_rpc_error(-1, "Unable to dump mempool to disk", self.nodes[1].savemempool)
-        # os.remove(mempooldotnew1)
+        self.log.debug("Stop nodes, make node1 use mempool.dat from node0. Verify it has 5 transactions")
+        os.rename(mempooldat0, mempooldat1)
+        self.stop_nodes()
+        self.start_node(1, extra_args=[])
+        wait_until(lambda: self.nodes[1].getmempoolinfo()["loaded"])
+        assert_equal(len(self.nodes[1].getrawmempool()), 5)
+
+        self.log.debug("Prevent bitcoind from writing mempool.dat to disk. Verify that `savemempool` fails")
+        # to test the exception we are creating a tmp folder called mempool.dat.new
+        # which is an implementation detail that could change and break this test
+        mempooldotnew1 = mempooldat1 + '.new'
+        os.mkdir(mempooldotnew1)
+        assert_raises_rpc_error(-1, "Unable to dump mempool to disk", self.nodes[1].savemempool)
+        os.rmdir(mempooldotnew1)
+        '''
 
 if __name__ == '__main__':
     MempoolPersistTest().main()

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -70,9 +70,8 @@ class MempoolPersistTest(PivxTestFramework):
         self.start_node(1, extra_args=["-persistmempool=0"])
         self.start_node(0)
         self.start_node(2)
-
-        wait_until(lambda: self.nodes[0].getmempoolinfo()["loaded"], timeout=1)
-        wait_until(lambda: self.nodes[2].getmempoolinfo()["loaded"], timeout=1)
+        assert self.nodes[0].getmempoolinfo()["loaded"]  # start_node is blocking on the mempool being loaded
+        assert self.nodes[2].getmempoolinfo()["loaded"]
         assert_equal(len(self.nodes[0].getrawmempool()), 5)
         assert_equal(len(self.nodes[2].getrawmempool()), 5)
         # The others have loaded their mempool. If node_1 loaded anything, we'd probably notice by now:
@@ -85,13 +84,13 @@ class MempoolPersistTest(PivxTestFramework):
         self.log.debug("Stop-start node0 with -persistmempool=0. Verify that it doesn't load its mempool.dat file.")
         self.stop_nodes()
         self.start_node(0, extra_args=["-persistmempool=0"])
-        wait_until(lambda: self.nodes[0].getmempoolinfo()["loaded"])
+        assert self.nodes[0].getmempoolinfo()["loaded"]
         assert_equal(len(self.nodes[0].getrawmempool()), 0)
 
         self.log.debug("Stop-start node0. Verify that it has the transactions in its mempool.")
         self.stop_nodes()
         self.start_node(0)
-        wait_until(lambda: self.nodes[0].getmempoolinfo()["loaded"])
+        assert self.nodes[0].getmempoolinfo()["loaded"]
         assert_equal(len(self.nodes[0].getrawmempool()), 5)
 
         # Following code is ahead of our current repository state. Future back port.
@@ -107,7 +106,7 @@ class MempoolPersistTest(PivxTestFramework):
         os.rename(mempooldat0, mempooldat1)
         self.stop_nodes()
         self.start_node(1, extra_args=[])
-        wait_until(lambda: self.nodes[1].getmempoolinfo()["loaded"])
+        assert self.nodes[0].getmempoolinfo()["loaded"]
         assert_equal(len(self.nodes[1].getrawmempool()), 5)
 
         self.log.debug("Prevent bitcoind from writing mempool.dat to disk. Verify that `savemempool` fails")

--- a/test/functional/mining_pos_fakestake.py
+++ b/test/functional/mining_pos_fakestake.py
@@ -50,7 +50,6 @@ from test_framework.authproxy import JSONRPCException
 from test_framework.messages import COutPoint
 from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
-    sync_blocks,
     assert_equal,
     bytes_to_hex_str,
     set_node_times
@@ -93,7 +92,7 @@ class FakeStakeTest(PivxTestFramework):
         self.log.info("Mining 50 blocks to reach PoS phase...")
         for i in range(50):
             self.mocktime = self.generate_pow(0, self.mocktime)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
 
         # Check Tests 1-3
         self.test_1()
@@ -116,7 +115,7 @@ class FakeStakeTest(PivxTestFramework):
         self.log.info("Mining 5 blocks as fork depth...")
         for i in range(5):
             self.mocktime = self.generate_pow(0, self.mocktime)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
 
         # nodes[1] spams 3 blocks with height 256 --> [REJECTED]
         assert_equal(self.nodes[1].getblockcount(), 255)
@@ -138,7 +137,7 @@ class FakeStakeTest(PivxTestFramework):
         self.log.info("Mining 5 blocks to include the spends...")
         for i in range(5):
             self.mocktime = self.generate_pow(0, self.mocktime)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
         self.check_tx_in_chain(0, txid)
         assert_equal(self.nodes[1].getbalance(), 0)
 

--- a/test/functional/mining_pos_reorg.py
+++ b/test/functional/mining_pos_reorg.py
@@ -3,10 +3,8 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-from test_framework.authproxy import JSONRPCException
 from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
-    sync_blocks,
     assert_equal,
     assert_raises_rpc_error,
     connect_nodes,
@@ -113,7 +111,7 @@ class ReorgStakeTest(PivxTestFramework):
         # Connect with node 2 and sync
         self.log.info("Reconnecting node 0 and node 2")
         connect_nodes(self.nodes[0], 2)
-        sync_blocks([self.nodes[i] for i in [0, 2]])
+        self.sync_blocks([self.nodes[i] for i in [0, 2]])
 
         # verify that the stakeinput can't be spent
         stakeinput_tx_json = self.nodes[0].getrawtransaction(stakeinput["txid"], True)
@@ -143,7 +141,7 @@ class ReorgStakeTest(PivxTestFramework):
         self.log.info("Connecting and syncing nodes...")
         set_node_times(self.nodes, block_time_1)
         connect_nodes_clique(self.nodes)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
         for i in [0, 2]:
             assert_equal(self.nodes[i].getbestblockhash(), new_best_hash)
 
@@ -158,7 +156,7 @@ class ReorgStakeTest(PivxTestFramework):
             stakeinput["txid"][:9], stakeinput["txid"][-4:], stakeinput["vout"]))
         self.nodes[0].sendrawtransaction(rawtx["hex"])
         self.nodes[1].generate(1)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
         res, utxo = findUtxoInList(stakeinput["txid"], stakeinput["vout"], self.nodes[0].listunspent())
         assert (not res or not utxo["spendable"])
 

--- a/test/functional/p2p_feefilter.py
+++ b/test/functional/p2p_feefilter.py
@@ -45,7 +45,7 @@ class FeeFilterTest(PivxTestFramework):
         node0 = self.nodes[0]
         # Get out of IBD
         node1.generate(1)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
 
         # Setup the p2p connections and start up the network thread.
         self.nodes[0].add_p2p_connection(TestNode())
@@ -69,7 +69,7 @@ class FeeFilterTest(PivxTestFramework):
         # Change tx fee rate to 10 sat/byte and test they are no longer received
         node1.settxfee(float(0.00010000))
         [node1.sendtoaddress(node1.getnewaddress(), 1) for x in range(3)]
-        sync_mempools(self.nodes) # must be sure node 0 has received all txs
+        self.sync_mempools()    # must be sure node 0 has received all txs
 
         # Send one transaction from node0 that should be received, so that we
         # we can sync the test on receipt (if node1's txs were relayed, they'd

--- a/test/functional/p2p_sendheaders.py
+++ b/test/functional/p2p_sendheaders.py
@@ -247,7 +247,7 @@ class SendHeadersTest(PivxTestFramework):
     # return the list of block hashes newly mined
     def mine_reorg(self, length):
         self.nodes[0].generate(length) # make sure all invalidated blocks are node0's
-        sync_blocks(self.nodes, wait=0.1)
+        self.sync_blocks(self.nodes, wait=0.1)
         for x in self.p2p_connections:
             x.wait_for_block_announcement(int(self.nodes[0].getbestblockhash(), 16))
             x.clear_last_announcement()
@@ -256,7 +256,7 @@ class SendHeadersTest(PivxTestFramework):
         hash_to_invalidate = self.nodes[1].getblockhash(tip_height-(length-1))
         self.nodes[1].invalidateblock(hash_to_invalidate)
         all_hashes = self.nodes[1].generate(length+1) # Must be longer than the orig chain
-        sync_blocks(self.nodes, wait=0.1)
+        self.sync_blocks(self.nodes, wait=0.1)
         return [int(x, 16) for x in all_hashes]
 
     def run_test(self):

--- a/test/functional/p2p_unrequested_blocks.py
+++ b/test/functional/p2p_unrequested_blocks.py
@@ -316,7 +316,7 @@ class AcceptBlockTest(PivxTestFramework):
 
         # 9. Connect node1 to node0 and ensure it is able to sync
         connect_nodes(self.nodes[0], 1)
-        sync_blocks([self.nodes[0], self.nodes[1]])
+        self.sync_blocks([self.nodes[0], self.nodes[1]])
         self.log.info("Successfully synced nodes 1 and 0")
 
 if __name__ == '__main__':

--- a/test/functional/rpc_getchaintips.py
+++ b/test/functional/rpc_getchaintips.py
@@ -28,7 +28,8 @@ class GetChainTipsTest (PivxTestFramework):
         self.split_network ()
         self.nodes[0].generate(10)
         self.nodes[2].generate(20)
-        self.sync_all([self.nodes[:2], self.nodes[2:]])
+        self.sync_all(self.nodes[:2])
+        self.sync_all(self.nodes[2:])
 
         tips = self.nodes[1].getchaintips ()
         assert_equal (len (tips), 1)

--- a/test/functional/rpc_invalidateblock.py
+++ b/test/functional/rpc_invalidateblock.py
@@ -28,7 +28,7 @@ class InvalidateTest(PivxTestFramework):
 
         self.log.info("Connect nodes to force a reorg")
         connect_nodes(self.nodes[0], 1)
-        sync_blocks(self.nodes[0:2])
+        self.sync_blocks(self.nodes[0:2])
         assert_equal(self.nodes[0].getblockcount(), 6)
         badhash = self.nodes[1].getblockhash(2)
 
@@ -40,7 +40,7 @@ class InvalidateTest(PivxTestFramework):
         self.log.info("Make sure we won't reorg to a lower work chain:")
         connect_nodes(self.nodes[1], 2)
         self.log.info("Sync node 2 to node 1 so both have 6 blocks")
-        sync_blocks(self.nodes[1:3])
+        self.sync_blocks(self.nodes[1:3])
         assert_equal(self.nodes[2].getblockcount(), 6)
         self.log.info("Invalidate block 5 on node 1 so its tip is now at 4")
         self.nodes[1].invalidateblock(self.nodes[1].getblockhash(5))

--- a/test/functional/sapling_fillblock.py
+++ b/test/functional/sapling_fillblock.py
@@ -11,8 +11,6 @@ from test_framework.util import (
     assert_equal,
     Decimal,
     satoshi_round,
-    sync_blocks,
-    sync_mempools,
 )
 
 import time
@@ -53,7 +51,7 @@ class SaplingFillBlockTest(PivxTestFramework):
 
     def check_mempool(self, miner, txids):
         self.log.info("Checking mempool...")
-        sync_mempools(self.nodes)
+        self.sync_mempools()
         mempool_info = miner.getmempoolinfo()
         assert_equal(mempool_info['size'], len(txids))
         mempool_bytes = mempool_info['bytes']
@@ -77,7 +75,7 @@ class SaplingFillBlockTest(PivxTestFramework):
             txids.append(node.shieldsendmany(from_address, shield_to))
             if (i + 1) % 200 == 0:
                 self.log.info("...%d Transactions created..." % (i + 1))
-                sync_mempools(self.nodes)
+                self.sync_mempools()
         return txids
 
 
@@ -87,7 +85,7 @@ class SaplingFillBlockTest(PivxTestFramework):
         # First mine 300 blocks
         self.log.info("Generating 300 blocks...")
         miner.generate(300)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
         assert_equal(self.nodes[0].getblockchaininfo()['upgrades']['v5 shield']['status'], 'active')
 
         ## -- First check that the miner never produces blocks with more than 750kB of shielded txes
@@ -99,7 +97,7 @@ class SaplingFillBlockTest(PivxTestFramework):
         txids = self.utxo_splitter(miner, UTXOS_TO_SPLIT, alice)
         assert_equal(len(txids), UTXOS_TO_SPLIT)
         miner.generate(2)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
         new_utxos = alice.listunspent()
         assert_equal(len(new_utxos), UTXOS_TO_SHIELD)
 

--- a/test/functional/sapling_mempool.py
+++ b/test/functional/sapling_mempool.py
@@ -7,7 +7,6 @@ from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
-    sync_mempools,
 )
 
 from decimal import Decimal
@@ -53,7 +52,7 @@ class SaplingMempoolTest(PivxTestFramework):
 
         # Miner receives tx_B and accepts it in the mempool
         assert (txid_B in alice.getrawmempool())
-        sync_mempools(self.nodes)
+        self.sync_mempools()
         assert(txid_B in miner.getrawmempool())
         self.log.info("tx_B accepted in the memory pool.")
 
@@ -87,7 +86,7 @@ class SaplingMempoolTest(PivxTestFramework):
         txid_C = alice.sendrawtransaction(txC_hex)
 
         # Miner receives tx_C and accepts it in the mempool
-        sync_mempools(self.nodes)
+        self.sync_mempools()
         assert(txid_C in miner.getrawmempool())
         self.log.info("tx_C accepted in the memory pool.")
 

--- a/test/functional/sapling_wallet.py
+++ b/test/functional/sapling_wallet.py
@@ -11,7 +11,6 @@ from test_framework.util import (
     connect_nodes,
     disconnect_nodes,
     satoshi_round,
-    sync_mempools,
     get_coinstake_address,
     wait_until,
 )
@@ -29,7 +28,7 @@ class WalletSaplingTest(PivxTestFramework):
         self.extra_args[0].append('-sporkkey=932HEevBSujW2ud7RfB1YF91AFygbBRQj3de3LyaCRqNzKKgWXi')
 
     def check_tx_priority(self, txids):
-        sync_mempools(self.nodes)
+        self.sync_mempools()
         mempool = self.nodes[0].getrawmempool(True)
         for txid in txids:
             assert(Decimal(mempool[txid]['startingpriority']) == Decimal('1E+25'))

--- a/test/functional/sapling_wallet_anchorfork.py
+++ b/test/functional/sapling_wallet_anchorfork.py
@@ -63,7 +63,7 @@ class WalletAnchorForkTest(PivxTestFramework):
 
         # Partition B, node 1 mines an empty block
         self.nodes[1].generate(1)
-        sync_blocks(self.nodes[1:3])
+        self.sync_blocks(self.nodes[1:3])
 
         # Check partition
         assert_equal(self.nodes[1].getblockcount(), self.nodes[2].getblockcount())
@@ -77,7 +77,7 @@ class WalletAnchorForkTest(PivxTestFramework):
 
         # Partition A, node 0 mines a block with the transaction
         self.nodes[0].generate(1)
-        self.sync_all([self.nodes[1:3]])
+        self.sync_all(self.nodes[1:3])
 
         # Partition B, node 1 mines the same shield transaction
         txid2 = self.nodes[1].sendrawtransaction(rawhex)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -57,8 +57,6 @@ from .util import (
     set_node_times,
     SPORK_ACTIVATION_TIME,
     SPORK_DEACTIVATION_TIME,
-    sync_blocks,
-    sync_mempools,
     vZC_DENOMS,
     wait_until,
 )
@@ -365,7 +363,8 @@ class PivxTestFramework():
         """
         disconnect_nodes(self.nodes[1], 2)
         disconnect_nodes(self.nodes[2], 1)
-        self.sync_all([self.nodes[:2], self.nodes[2:]])
+        self.sync_all(self.nodes[:2])
+        self.sync_all(self.nodes[2:])
 
     def join_network(self):
         """
@@ -374,13 +373,52 @@ class PivxTestFramework():
         connect_nodes(self.nodes[1], 2)
         self.sync_all()
 
-    def sync_all(self, node_groups=None):
-        if not node_groups:
-            node_groups = [self.nodes]
+    def sync_blocks(self, nodes=None, wait=1, timeout=60):
+        """
+        Wait until everybody has the same tip.
+        sync_blocks needs to be called with an rpc_connections set that has least
+        one node already synced to the latest, stable tip, otherwise there's a
+        chance it might return before all nodes are stably synced.
+        """
+        rpc_connections = nodes or self.nodes
+        stop_time = time.time() + timeout
+        while time.time() <= stop_time:
+            best_hash = [x.getbestblockhash() for x in rpc_connections]
+            if best_hash.count(best_hash[0]) == len(rpc_connections):
+                return
+            # Check that each peer has at least one connection
+            assert (all([len(x.getpeerinfo()) for x in rpc_connections]))
+            time.sleep(wait)
+        raise AssertionError("Block sync timed out after {}s:{}".format(
+            timeout,
+            "".join("\n  {!r}".format(b) for b in best_hash),
+        ))
 
-        for group in node_groups:
-            sync_blocks(group)
-            sync_mempools(group)
+    def sync_mempools(self, nodes=None, wait=1, timeout=60, flush_scheduler=True):
+        """
+        Wait until everybody has the same transactions in their memory
+        pools
+        """
+        rpc_connections = nodes or self.nodes
+        stop_time = time.time() + timeout
+        while time.time() <= stop_time:
+            pool = [set(r.getrawmempool()) for r in rpc_connections]
+            if pool.count(pool[0]) == len(rpc_connections):
+                if flush_scheduler:
+                    for r in rpc_connections:
+                        r.syncwithvalidationinterfacequeue()
+                return
+            # Check that each peer has at least one connection
+            assert (all([len(x.getpeerinfo()) for x in rpc_connections]))
+            time.sleep(wait)
+        raise AssertionError("Mempool sync timed out after {}s:{}".format(
+            timeout,
+            "".join("\n  {!r}".format(m) for m in pool),
+        ))
+
+    def sync_all(self, nodes=None):
+        self.sync_blocks(nodes)
+        self.sync_mempools(nodes)
 
     def enable_mocktime(self):
         """Enable mocktime for the script.
@@ -551,7 +589,7 @@ class PivxTestFramework():
                         self.nodes[peer].generate(1)
                         block_time += 60
                     # Must sync before next peer starts generating blocks
-                    sync_blocks(self.nodes)
+                    self.sync_blocks()
 
             # Shut them down, and clean up cache directories:
             self.log.info("Stopping nodes")
@@ -1018,7 +1056,7 @@ class PivxTestFramework():
     def stake_and_sync(self, node_id, num_blocks):
         for i in range(num_blocks):
             self.mocktime = self.generate_pos(node_id, self.mocktime)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
         time.sleep(1)
 
 
@@ -1181,7 +1219,7 @@ class PivxTier2TestFramework(PivxTestFramework):
         # First mine 250 PoW blocks
         for i in range(250):
             self.mocktime = self.generate_pow(self.minerPos, self.mocktime)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
         # Then start staking
         self.stake(9)
 

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -121,8 +121,25 @@ class TestNode():
             assert self.process.poll() is None, "pivxd exited with status %i during initialization" % self.process.returncode
             try:
                 self.rpc = get_rpc_proxy(rpc_url(self.datadir, self.index, self.rpchost), self.index, timeout=self.rpc_timeout, coveragedir=self.coverage_dir)
-                while self.rpc.getblockcount() < 0:
-                    time.sleep(1)
+                self.rpc.getblockcount()
+                wait_until(lambda: self.rpc.getmempoolinfo()['loaded'])
+                # Wait for the node to finish reindex, block import, and
+                # loading the mempool. Usually importing happens fast or
+                # even "immediate" when the node is started. However, there
+                # is no guarantee and sometimes ThreadImport might finish
+                # later. This is going to cause intermittent test failures,
+                # because generally the tests assume the node is fully
+                # ready after being started.
+                #
+                # For example, the node will reject block messages from p2p
+                # when it is still importing with the error "Unexpected
+                # block message received"
+                #
+                # The wait is done here to make tests as robust as possible
+                # and prevent racy tests and intermittent failures as much
+                # as possible. Some tests might not need this, but the
+                # overhead is trivial, and the added gurantees are worth
+                # the minimal performance cost.
                 # If the call to getblockcount() succeeds then the RPC connection is up
                 self.rpc_connected = True
                 self.url = self.rpc.url

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -390,48 +390,6 @@ def connect_nodes_clique(nodes):
             connect_nodes(nodes[a], b)
             connect_nodes(nodes[b], a)
 
-def sync_blocks(rpc_connections, *, wait=1, timeout=60):
-    """
-    Wait until everybody has the same tip.
-
-    sync_blocks needs to be called with an rpc_connections set that has least
-    one node already synced to the latest, stable tip, otherwise there's a
-    chance it might return before all nodes are stably synced.
-    """
-    stop_time = time.time() + timeout
-    while time.time() <= stop_time:
-        best_hash = [x.getbestblockhash() for x in rpc_connections]
-        if best_hash.count(best_hash[0]) == len(rpc_connections):
-            return
-        # Check that each peer has at least one connection
-        assert (all([len(x.getpeerinfo()) for x in rpc_connections]))
-        time.sleep(wait)
-    raise AssertionError("Block sync timed out after {}s:{}".format(
-        timeout,
-        "".join("\n  {!r}".format(b) for b in best_hash),
-    ))
-
-def sync_mempools(rpc_connections, *, wait=1, timeout=60, flush_scheduler=True):
-    """
-    Wait until everybody has the same transactions in their memory
-    pools
-    """
-    stop_time = time.time() + timeout
-    while time.time() <= stop_time:
-        pool = [set(r.getrawmempool()) for r in rpc_connections]
-        if pool.count(pool[0]) == len(rpc_connections):
-            if flush_scheduler:
-                for r in rpc_connections:
-                    r.syncwithvalidationinterfacequeue()
-            return
-        # Check that each peer has at least one connection
-        assert (all([len(x.getpeerinfo()) for x in rpc_connections]))
-        time.sleep(wait)
-    raise AssertionError("Mempool sync timed out after {}s:{}".format(
-        timeout,
-        "".join("\n  {!r}".format(m) for m in pool),
-    ))
-
 # Transaction/Block functions
 #############################
 

--- a/test/functional/tiertwo_masternode_activation.py
+++ b/test/functional/tiertwo_masternode_activation.py
@@ -9,8 +9,6 @@ from test_framework.util import (
     connect_nodes_clique,
     disconnect_nodes,
     satoshi_round,
-    sync_blocks,
-    sync_mempools,
     wait_until,
 )
 
@@ -56,7 +54,7 @@ class MasternodeActivationTest(PivxTier2TestFramework):
         rawtx = self.ownerOne.createrawtransaction(inputs, outputs)
         signedtx = self.ownerOne.signrawtransaction(rawtx)
         txid = self.miner.sendrawtransaction(signedtx['hex'])
-        sync_mempools(self.nodes)
+        self.sync_mempools()
         self.log.info("Collateral spent in %s" % txid)
         self.send_pings([self.remoteTwo])
         self.stake(1, [self.remoteTwo])
@@ -111,7 +109,7 @@ class MasternodeActivationTest(PivxTier2TestFramework):
         self.advance_mocktime(30)
         self.log.info("spending the collateral now..")
         self.spend_collateral()
-        sync_blocks(self.nodes)
+        self.sync_blocks()
         self.log.info("checking mn status..")
         time.sleep(3)           # wait a little bit
         self.wait_until_mn_vinspent(self.mnOneTxHash, 30, [self.remoteTwo])

--- a/test/functional/tiertwo_masternode_ping.py
+++ b/test/functional/tiertwo_masternode_ping.py
@@ -9,7 +9,6 @@ from test_framework.util import (
     assert_greater_than,
     Decimal,
     p2p_port,
-    sync_blocks,
 )
 
 import os
@@ -38,7 +37,7 @@ class MasternodePingTest(PivxTestFramework):
 
         self.log.info("generating 141 blocks...")
         miner.generate(141)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
 
         # Create collateral
         self.log.info("funding masternode controller...")
@@ -46,7 +45,7 @@ class MasternodePingTest(PivxTestFramework):
         mnAddress = owner.getnewaddress(masternodeAlias)
         collateralTxId = miner.sendtoaddress(mnAddress, Decimal('10000'))
         miner.generate(2)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
         time.sleep(1)
         collateral_rawTx = owner.getrawtransaction(collateralTxId, 1)
         assert_equal(owner.getbalance(), Decimal('10000'))
@@ -88,14 +87,14 @@ class MasternodePingTest(PivxTestFramework):
         self.wait_until_mnsync_finished()
         self.log.info("MnSync completed in %d seconds" % (time.time() - start_time))
         miner.generate(1)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
         time.sleep(1)
 
         # Send Start message
         self.log.info("sending masternode broadcast...")
         self.controller_start_masternode(owner, masternodeAlias)
         miner.generate(1)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
         time.sleep(1)
 
         # Wait until masternode is enabled everywhere (max 180 secs)
@@ -106,7 +105,7 @@ class MasternodePingTest(PivxTestFramework):
         self.log.info("Masternode enabled in %d seconds" % (time.time() - start_time))
         self.log.info("Good. Masternode enabled")
         miner.generate(1)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
         time.sleep(1)
 
         last_seen = [self.get_mn_lastseen(node, collateralTxId) for node in self.nodes]

--- a/test/functional/wallet_abandonconflict.py
+++ b/test/functional/wallet_abandonconflict.py
@@ -11,8 +11,6 @@ from test_framework.util import (
     connect_nodes,
     Decimal,
     disconnect_nodes,
-    sync_blocks,
-    sync_mempools
 )
 
 class AbandonConflictTest(PivxTestFramework):
@@ -23,14 +21,14 @@ class AbandonConflictTest(PivxTestFramework):
 
     def run_test(self):
         self.nodes[0].generate(5)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
         self.nodes[1].generate(110)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
         balance = self.nodes[0].getbalance()
         txA = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 10)
         txB = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 10)
         txC = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 10)
-        sync_mempools(self.nodes)
+        self.sync_mempools()
         self.nodes[1].generate(1)
 
         # Can not abandon non-wallet transaction
@@ -38,7 +36,7 @@ class AbandonConflictTest(PivxTestFramework):
         # Can not abandon confirmed transaction
         assert_raises_rpc_error(-5, 'Transaction not eligible for abandonment', lambda: self.nodes[0].abandontransaction(txA))
 
-        sync_blocks(self.nodes)
+        self.sync_blocks()
         newbalance = self.nodes[0].getbalance()
         assert(balance - newbalance < Decimal("0.001")) #no more than fees lost
         balance = newbalance
@@ -156,7 +154,7 @@ class AbandonConflictTest(PivxTestFramework):
         self.nodes[1].generate(1)
 
         connect_nodes(self.nodes[0], 1)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
 
         # Verify that B and C's 10 BTC outputs are available for spending again because AB1 is now conflicted
         newbalance = self.nodes[0].getbalance()

--- a/test/functional/wallet_backup.py
+++ b/test/functional/wallet_backup.py
@@ -30,11 +30,17 @@ confirm 1/2/3/4 balances are same as before.
 Shutdown again, restore using importwallet,
 and confirm again balances are correct.
 """
+from decimal import Decimal
+import os
 from random import randint
 import shutil
 
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+    connect_nodes,
+)
 
 class WalletBackupTest(PivxTestFramework):
     def set_test_params(self):
@@ -70,9 +76,9 @@ class WalletBackupTest(PivxTestFramework):
 
         # Have the miner (node3) mine a block.
         # Must sync mempools before mining.
-        sync_mempools(self.nodes)
+        self.sync_mempools()
         self.nodes[3].generate(1)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
 
     # As above, this mirrors the original bash test.
     def start_three(self):
@@ -97,13 +103,13 @@ class WalletBackupTest(PivxTestFramework):
     def run_test(self):
         self.log.info("Generating initial blockchain")
         self.nodes[0].generate(1)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
         self.nodes[1].generate(1)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
         self.nodes[2].generate(1)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
         self.nodes[3].generate(100)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
 
         assert_equal(self.nodes[0].getbalance(), 250)
         assert_equal(self.nodes[1].getbalance(), 250)
@@ -160,7 +166,7 @@ class WalletBackupTest(PivxTestFramework):
 
         self.log.info("Re-starting nodes")
         self.start_three()
-        sync_blocks(self.nodes)
+        self.sync_blocks()
 
         assert_equal(self.nodes[0].getbalance(), balance0)
         assert_equal(self.nodes[1].getbalance(), balance1)
@@ -184,7 +190,7 @@ class WalletBackupTest(PivxTestFramework):
         self.nodes[1].importwallet(tmpdir + "/node1/wallet.dump")
         self.nodes[2].importwallet(tmpdir + "/node2/wallet.dump")
 
-        sync_blocks(self.nodes)
+        self.sync_blocks()
 
         assert_equal(self.nodes[0].getbalance(), balance0)
         assert_equal(self.nodes[1].getbalance(), balance1)

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -27,7 +27,7 @@ class WalletTest(PivxTestFramework):
         connect_nodes(self.nodes[0], 1)
         connect_nodes(self.nodes[1], 2)
         connect_nodes(self.nodes[0], 2)
-        self.sync_all([self.nodes[0:3]])
+        self.sync_all(self.nodes[0:3])
 
     def get_vsize(self, txn):
         return self.nodes[0].decoderawtransaction(txn)['size']
@@ -46,9 +46,9 @@ class WalletTest(PivxTestFramework):
         assert_equal(walletinfo['immature_balance'], 250)
         assert_equal(walletinfo['balance'], 0)
 
-        self.sync_all([self.nodes[0:3]])
+        self.sync_all(self.nodes[0:3])
         self.nodes[1].generate(101)
-        self.sync_all([self.nodes[0:3]])
+        self.sync_all(self.nodes[0:3])
 
         assert_equal(self.nodes[0].getbalance(), 250)
         assert_equal(self.nodes[1].getbalance(), 250)
@@ -75,7 +75,7 @@ class WalletTest(PivxTestFramework):
         # Send 21 PIV from 1 to 0 using sendtoaddress call.
         self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 21)
         self.nodes[1].generate(1)
-        self.sync_all([self.nodes[0:3]])
+        self.sync_all(self.nodes[0:3])
 
         # Node0 should have two unspent outputs.
         # Create a couple of transactions to send them to node2, submit them through
@@ -100,7 +100,7 @@ class WalletTest(PivxTestFramework):
 
         # Have node1 mine a block to confirm transactions:
         self.nodes[1].generate(1)
-        self.sync_all([self.nodes[0:3]])
+        self.sync_all(self.nodes[0:3])
 
         assert_equal(self.nodes[0].getbalance(), 0)
         node_2_expected_bal = Decimal('250') + Decimal('21') - 2 * fee_per_kbyte
@@ -115,7 +115,7 @@ class WalletTest(PivxTestFramework):
         node_2_bal -= (Decimal('10') - fee)
         assert_equal(self.nodes[2].getbalance(), node_2_bal)
         self.nodes[2].generate(1)
-        self.sync_all([self.nodes[0:3]])
+        self.sync_all(self.nodes[0:3])
         node_0_bal = self.nodes[0].getbalance()
         assert_equal(node_0_bal, Decimal('10'))
 
@@ -123,7 +123,7 @@ class WalletTest(PivxTestFramework):
         txid = self.nodes[2].sendmany('', {address: 10}, 0, "")
         fee = self.nodes[2].gettransaction(txid)["fee"]
         self.nodes[2].generate(1)
-        self.sync_all([self.nodes[0:3]])
+        self.sync_all(self.nodes[0:3])
         node_0_bal += Decimal('10')
         node_2_bal -= (Decimal('10') - fee)
         assert_equal(self.nodes[2].getbalance(), node_2_bal)
@@ -138,7 +138,7 @@ class WalletTest(PivxTestFramework):
         address_to_import = self.nodes[2].getnewaddress()
         self.nodes[0].sendtoaddress(address_to_import, 1)
         self.nodes[0].generate(1)
-        self.sync_all([self.nodes[0:3]])
+        self.sync_all(self.nodes[0:3])
 
         # 2. Import address from node2 to node1
         self.nodes[1].importaddress(address_to_import)
@@ -162,9 +162,9 @@ class WalletTest(PivxTestFramework):
                            {"spendable": True})
 
         # check if wallet or blochchain maintenance changes the balance
-        self.sync_all([self.nodes[0:3]])
+        self.sync_all(self.nodes[0:3])
         blocks = self.nodes[0].generate(2)
-        self.sync_all([self.nodes[0:3]])
+        self.sync_all(self.nodes[0:3])
         balance_nodes = [self.nodes[i].getbalance() for i in range(3)]
         block_count = self.nodes[0].getblockcount()
 

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -61,7 +61,7 @@ class BumpFeeTest(PivxTestFramework):
 
         self.log.info("Running tests")
         dest_address = peer_node.getnewaddress()
-        test_simple_bumpfee_succeeds(rbf_node, peer_node, dest_address)
+        test_simple_bumpfee_succeeds(self, rbf_node, peer_node, dest_address)
         test_segwit_bumpfee_succeeds(rbf_node, dest_address)
         test_nonrbf_bumpfee_fails(peer_node, dest_address)
         test_notmine_bumpfee_fails(rbf_node, peer_node, dest_address)
@@ -77,16 +77,16 @@ class BumpFeeTest(PivxTestFramework):
         self.log.info("Success")
 
 
-def test_simple_bumpfee_succeeds(rbf_node, peer_node, dest_address):
+def test_simple_bumpfee_succeeds(test, rbf_node, peer_node, dest_address):
     rbfid = spend_one_input(rbf_node, dest_address)
     rbftx = rbf_node.gettransaction(rbfid)
-    sync_mempools((rbf_node, peer_node))
+    test.sync_mempools((rbf_node, peer_node))
     assert rbfid in rbf_node.getrawmempool() and rbfid in peer_node.getrawmempool()
     bumped_tx = rbf_node.bumpfee(rbfid)
     assert_equal(bumped_tx["errors"], [])
     assert bumped_tx["fee"] - abs(rbftx["fee"]) > 0
     # check that bumped_tx propagates, original tx was evicted and has a wallet conflict
-    sync_mempools((rbf_node, peer_node))
+    test.sync_mempools((rbf_node, peer_node))
     assert bumped_tx["txid"] in rbf_node.getrawmempool()
     assert bumped_tx["txid"] in peer_node.getrawmempool()
     assert rbfid not in rbf_node.getrawmempool()

--- a/test/functional/wallet_import_rescan.py
+++ b/test/functional/wallet_import_rescan.py
@@ -20,7 +20,7 @@ happened previously.
 """
 
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import (assert_raises_rpc_error, connect_nodes, sync_blocks, assert_equal, set_node_times)
+from test_framework.util import (assert_raises_rpc_error, connect_nodes, assert_equal, set_node_times)
 
 import collections
 import enum
@@ -137,7 +137,7 @@ class ImportRescanTest(PivxTestFramework):
         timestamp = self.nodes[0].getblockheader(self.nodes[0].getbestblockhash())["time"]
         set_node_times(self.nodes, timestamp + TIMESTAMP_WINDOW + 1)
         self.nodes[0].generate(1)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
 
         # For each variation of wallet key import, invoke the import RPC and
         # check the results from getbalance and listtransactions.
@@ -163,7 +163,7 @@ class ImportRescanTest(PivxTestFramework):
         # Generate a block containing the new transactions.
         self.nodes[0].generate(1)
         assert_equal(self.nodes[0].getrawmempool(), [])
-        sync_blocks(self.nodes)
+        self.sync_blocks()
 
         # Check the latest results from getbalance and listtransactions.
         for variant in IMPORT_VARIANTS:

--- a/test/functional/wallet_import_stakingaddress.py
+++ b/test/functional/wallet_import_stakingaddress.py
@@ -15,7 +15,6 @@ from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
     assert_equal,
     DecimalAmt,
-    sync_blocks,
 )
 
 class ImportStakingTest(PivxTestFramework):
@@ -45,7 +44,7 @@ class ImportStakingTest(PivxTestFramework):
             # mine a block and check staking balance
             self.nodes[0].generate(1)
             assert_equal(self.nodes[0].getdelegatedbalance(), DecimalAmt(10 * (i+1)))
-            sync_blocks(self.nodes)
+            self.sync_blocks()
 
         # Export keys
         self.log.info("Exporting keys and importing in node 1")

--- a/test/functional/wallet_keypool_topup.py
+++ b/test/functional/wallet_keypool_topup.py
@@ -16,7 +16,6 @@ from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
     assert_equal,
     connect_nodes,
-    sync_blocks,
 )
 
 class KeypoolRestoreTest(PivxTestFramework):
@@ -51,7 +50,7 @@ class KeypoolRestoreTest(PivxTestFramework):
         self.nodes[0].generate(1)
         self.nodes[0].sendtoaddress(addr_extpool, 5)
         self.nodes[0].generate(1)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
 
         self.log.info("Restart node with wallet backup")
 

--- a/test/functional/wallet_listreceivedby.py
+++ b/test/functional/wallet_listreceivedby.py
@@ -10,7 +10,6 @@ from test_framework.util import (
     assert_array_result,
     assert_equal,
     assert_raises_rpc_error,
-    sync_blocks,
 )
 
 
@@ -21,7 +20,7 @@ class ReceivedByTest(PivxTestFramework):
     def run_test(self):
         # Generate block to get out of IBD
         self.nodes[0].generate(1)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
 
         self.log.info("listreceivedbyaddress Test")
 

--- a/test/functional/wallet_listsinceblock.py
+++ b/test/functional/wallet_listsinceblock.py
@@ -99,7 +99,8 @@ class ListSinceBlockTest (PivxTestFramework):
         self.nodes[2].generate(7)
         self.log.info('lastblockhash=%s' % (lastblockhash))
 
-        self.sync_all([self.nodes[:2], self.nodes[2:]])
+        self.sync_all(self.nodes[:2])
+        self.sync_all(self.nodes[2:])
 
         self.join_network()
 

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -6,14 +6,11 @@
 from decimal import Decimal
 from io import BytesIO
 
-from test_framework.mininode import CTransaction, COIN
+from test_framework.mininode import CTransaction
 from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
     assert_array_result,
-    assert_equal,
-    bytes_to_hex_str,
     hex_str_to_bytes,
-    sync_mempools,
 )
 
 def txFromHex(hexstring):

--- a/test/functional/wallet_reorgsrestore.py
+++ b/test/functional/wallet_reorgsrestore.py
@@ -23,7 +23,6 @@ from test_framework.util import (
         assert_equal,
         connect_nodes,
         disconnect_nodes,
-        sync_blocks,
 )
 
 class ReorgsRestoreTest(PivxTestFramework):
@@ -37,7 +36,7 @@ class ReorgsRestoreTest(PivxTestFramework):
         # Send a tx from which to conflict outputs later
         txid_conflict_from = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("10"))
         self.nodes[0].generate(1)
-        sync_blocks(self.nodes)
+        self.sync_blocks()
 
         # Disconnect node1 from others to reorg its chain later
         disconnect_nodes(self.nodes[0], 1)
@@ -72,7 +71,7 @@ class ReorgsRestoreTest(PivxTestFramework):
 
         # Reconnect node0 and node2 and check that conflicted_txid is effectively conflicted
         connect_nodes(self.nodes[0], 2)
-        sync_blocks([self.nodes[0], self.nodes[2]])
+        self.sync_blocks([self.nodes[0], self.nodes[2]])
         conflicted = self.nodes[0].gettransaction(conflicted_txid)
         conflicting = self.nodes[0].gettransaction(conflicting_txid)
         assert_equal(conflicted["confirmations"], -9)

--- a/test/functional/wallet_txn_clone.py
+++ b/test/functional/wallet_txn_clone.py
@@ -79,7 +79,7 @@ class TxnMallTest(PivxTestFramework):
         # Have node0 mine a block, if requested:
         if (self.options.mine_block):
             self.nodes[0].generate(1)
-            sync_blocks(self.nodes[0:2])
+            self.sync_blocks(self.nodes[0:2])
 
         tx1 = self.nodes[0].gettransaction(txid1)
         tx2 = self.nodes[0].gettransaction(txid2)
@@ -114,7 +114,7 @@ class TxnMallTest(PivxTestFramework):
         self.nodes[2].sendrawtransaction(node0_tx2["hex"])
         self.nodes[2].sendrawtransaction(tx2["hex"])
         self.nodes[2].generate(1)  # Mine another block to make sure we sync
-        sync_blocks(self.nodes)
+        self.sync_blocks()
 
         # Re-fetch transaction info:
         tx1 = self.nodes[0].gettransaction(txid1)

--- a/test/functional/wallet_txn_doublespend.py
+++ b/test/functional/wallet_txn_doublespend.py
@@ -69,7 +69,7 @@ class TxnMallTest(PivxTestFramework):
         # Have node0 mine a block:
         if (self.options.mine_block):
             self.nodes[0].generate(1)
-            sync_blocks(self.nodes[0:2])
+            self.sync_blocks(self.nodes[0:2])
 
         tx1 = self.nodes[0].gettransaction(txid1)
         tx2 = self.nodes[0].gettransaction(txid2)
@@ -105,7 +105,7 @@ class TxnMallTest(PivxTestFramework):
         connect_nodes(self.nodes[2], 0)
         connect_nodes(self.nodes[2], 1)
         self.nodes[2].generate(1)  # Mine another block to make sure we sync
-        sync_blocks(self.nodes)
+        self.sync_blocks()
         assert_equal(self.nodes[0].gettransaction(doublespend_txid)["confirmations"], 2)
 
         # Re-fetch transaction info:

--- a/test/functional/wallet_zapwallettxes.py
+++ b/test/functional/wallet_zapwallettxes.py
@@ -18,7 +18,6 @@ from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
-    sync_mempools,
 )
 
 class ZapWalletTXesTest (PivxTestFramework):
@@ -44,7 +43,7 @@ class ZapWalletTXesTest (PivxTestFramework):
 
         # This transaction will not be confirmed
         txid2 = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 20)
-        sync_mempools(self.nodes, wait=.1)
+        self.sync_mempools(wait=.1)
 
         # Confirmed and unconfirmed transactions are now in the wallet.
         assert_equal(self.nodes[0].gettransaction(txid1)['txid'], txid1)


### PR DESCRIPTION
Backport the following PRs:
- bitcoin#15323: rpc: Expose g_is_mempool_loaded via getmempoolinfo
- bitcoin#18873: test: Fix intermittent sync_blocks failures
- bitcoin#19208: test: move sync_blocks and sync_mempool functions to test_framework.py