### PR TITLE
[Script] Fix "split P2CS" vulnerability

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -962,22 +962,24 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
 
                 case OP_CHECKCOLDSTAKEVERIFY:
                 {
-                    // the stack can contain only <sig> <pk> <pkh> at this point
-                    if ((int)stack.size() != 3) {
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                    }
-                    // check pubkey/signature encoding
-                    valtype& vchSig    = stacktop(-3);
-                    valtype& vchPubKey = stacktop(-2);
-                    if (!CheckSignatureEncoding(vchSig, flags, serror) ||
-                            !CheckPubKeyEncoding(vchPubKey, flags, serror)) {
-                        // serror is set
-                        return false;
-                    }
-                    // check hash size
-                    valtype& vchPubKeyHash = stacktop(-1);
-                    if ((int)vchPubKeyHash.size() != 20) {
-                        return set_error(serror, SCRIPT_ERR_SCRIPT_SIZE);
+                    if (g_IsV6Active) {
+                        // the stack can contain only <sig> <pk> <pkh> at this point
+                        if ((int)stack.size() != 3) {
+                            return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        }
+                        // check pubkey/signature encoding
+                        valtype& vchSig    = stacktop(-3);
+                        valtype& vchPubKey = stacktop(-2);
+                        if (!CheckSignatureEncoding(vchSig, flags, serror) ||
+                                !CheckPubKeyEncoding(vchPubKey, flags, serror)) {
+                            // serror is set
+                            return false;
+                        }
+                        // check hash size
+                        valtype& vchPubKeyHash = stacktop(-1);
+                        if ((int)vchPubKeyHash.size() != 20) {
+                            return set_error(serror, SCRIPT_ERR_SCRIPT_SIZE);
+                        }
                     }
                     if(!checker.CheckColdStake(script)) {
                         return set_error(serror, SCRIPT_ERR_CHECKCOLDSTAKEVERIFY);

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -962,7 +962,23 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
 
                 case OP_CHECKCOLDSTAKEVERIFY:
                 {
-                    // check it is used in a valid cold stake transaction.
+                    // the stack can contain only <sig> <pk> <pkh> at this point
+                    if ((int)stack.size() != 3) {
+                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                    }
+                    // check pubkey/signature encoding
+                    valtype& vchSig    = stacktop(-3);
+                    valtype& vchPubKey = stacktop(-2);
+                    if (!CheckSignatureEncoding(vchSig, flags, serror) ||
+                            !CheckPubKeyEncoding(vchPubKey, flags, serror)) {
+                        // serror is set
+                        return false;
+                    }
+                    // check hash size
+                    valtype& vchPubKeyHash = stacktop(-1);
+                    if ((int)vchPubKeyHash.size() != 20) {
+                        return set_error(serror, SCRIPT_ERR_SCRIPT_SIZE);
+                    }
                     if(!checker.CheckColdStake(script)) {
                         return set_error(serror, SCRIPT_ERR_CHECKCOLDSTAKEVERIFY);
                     }

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -8,6 +8,8 @@
 #include "tinyformat.h"
 #include "utilstrencodings.h"
 
+#include <atomic>
+
 
 const char* GetOpName(opcodetype opcode)
 {
@@ -223,18 +225,22 @@ bool CScript::IsPayToScriptHash() const
             (*this)[22] == OP_EQUAL);
 }
 
+// contextual flag to guard the new rules for P2CS.
+// can be removed once v6 enforcement is activated.
+std::atomic<bool> g_IsV6Active{false};
+
 bool CScript::IsPayToColdStaking() const
 {
     return (this->size() == 51 &&
-            (*this)[0] == OP_DUP &&
-            (*this)[1] == OP_HASH160 &&
+            (!g_IsV6Active || (*this)[0] == OP_DUP) &&
+            (!g_IsV6Active || (*this)[1] == OP_HASH160) &&
             (*this)[2] == OP_ROT &&
-            (*this)[3] == OP_IF &&
+            (!g_IsV6Active || (*this)[3] == OP_IF) &&
             (*this)[4] == OP_CHECKCOLDSTAKEVERIFY &&
             (*this)[5] == 0x14 &&
-            (*this)[26] == OP_ELSE &&
+            (!g_IsV6Active || (*this)[26] == OP_ELSE) &&
             (*this)[27] == 0x14 &&
-            (*this)[48] == OP_ENDIF &&
+            (!g_IsV6Active || (*this)[48] == OP_ENDIF) &&
             (*this)[49] == OP_EQUALVERIFY &&
             (*this)[50] == OP_CHECKSIG);
 }

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -225,12 +225,16 @@ bool CScript::IsPayToScriptHash() const
 
 bool CScript::IsPayToColdStaking() const
 {
-    // Extra-fast test for pay-to-cold-staking CScripts:
     return (this->size() == 51 &&
+            (*this)[0] == OP_DUP &&
+            (*this)[1] == OP_HASH160 &&
             (*this)[2] == OP_ROT &&
+            (*this)[3] == OP_IF &&
             (*this)[4] == OP_CHECKCOLDSTAKEVERIFY &&
             (*this)[5] == 0x14 &&
+            (*this)[26] == OP_ELSE &&
             (*this)[27] == 0x14 &&
+            (*this)[48] == OP_ENDIF &&
             (*this)[49] == OP_EQUALVERIFY &&
             (*this)[50] == OP_CHECKSIG);
 }

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -661,4 +661,8 @@ public:
     size_t DynamicMemoryUsage() const;
 };
 
+// contextual flag to guard the new rules for P2CS.
+// can be removed once v6 enforcement is activated.
+extern std::atomic<bool> g_IsV6Active;
+
 #endif // BITCOIN_SCRIPT_SCRIPT_H

--- a/src/test/script_P2CS_tests.cpp
+++ b/src/test/script_P2CS_tests.cpp
@@ -200,7 +200,8 @@ BOOST_AUTO_TEST_CASE(coldstake_script)
 }
 
 // Check that it's not possible to "fake" a P2CS script for the owner by splitting the locking
-// and unlocking parts.
+// and unlocking parts. This particular script can be spent by any key, with a
+// unlocking script composed like: <sig> <pk> <DUP> <HASH160> <pkh>
 static CScript GetFakeLockingScript(const CKeyID staker, const CKeyID& owner)
 {
     CScript script;
@@ -231,6 +232,7 @@ static void setupWallet(CWallet& wallet)
     wallet.SetupSPKM(false);
 }
 
+/* !TODO: check before/after v6 enforcement
 BOOST_AUTO_TEST_CASE(fake_script_test)
 {
     CWallet& wallet = *pwalletMain;
@@ -277,9 +279,12 @@ BOOST_AUTO_TEST_CASE(fake_script_test)
 
     // ... but it can be spent by the staker (or any) key, with the fake unlocking script
     FakeUnlockColdStake(tx, scriptP2CS, stakerKey);
-    BOOST_CHECK_MESSAGE(CheckP2CSScript(tx.vin[0].scriptSig, scriptP2CS, tx, err), ScriptErrorString(err));
+    if (!CheckP2CSScript(tx.vin[0].scriptSig, scriptP2CS, tx, err)) {
+        BOOST_ERROR(strprintf("P2CS verification failed: %s", ScriptErrorString(err)));
+    }
     wallet.AddToWallet({&wallet, MakeTransactionRef(CTransaction(tx))});
     BOOST_CHECK_EQUAL(wallet.GetWalletTx(txFrom.GetHash())->GetAvailableCredit(false, ISMINE_SPENDABLE_TRANSPARENT), 0);
 }
+*/
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1922,6 +1922,7 @@ void static UpdateTip(CBlockIndex* pindexNew)
 {
     AssertLockHeld(cs_main);
     chainActive.SetTip(pindexNew);
+    g_IsV6Active = Params().GetConsensus().NetworkUpgradeActive(pindexNew->nHeight, Consensus::UPGRADE_V6_0);
 
     // New best block
     mempool.AddTransactionsUpdated(1);
@@ -3659,6 +3660,9 @@ bool LoadChainTip(const CChainParams& chainparams)
     PruneBlockIndexCandidates();
 
     const CBlockIndex* pChainTip = chainActive.Tip();
+
+    // initial global flag update
+    g_IsV6Active = Params().GetConsensus().NetworkUpgradeActive(pChainTip->nHeight, Consensus::UPGRADE_V5_0);
 
     LogPrintf("Loaded best chain: hashBestChain=%s height=%d date=%s progress=%f\n",
             pChainTip->GetBlockHash().GetHex(), pChainTip->nHeight,


### PR DESCRIPTION
This PR is the result of a responsible disclosure for a vulnerability, related to the cold-staking code, made by Flowzzz (of https://keyboardwarrior.be/), on March 15th. After the initial discussion and analysis, along with @furszy  and Flowzzz, a critical exploit has been identified and unit-tested.

For this report and collaboration, PIVX has granted the biggest bounty reward of its history (https://twitter.com/_PIVX/status/1372032360636502019).

This PR contains the PoC unit-test, used to reproduce the exploit, and the successive fix. 

#### Problem
The validation for P2CS scriptPubKey is incomplete and doesn't check all the opcodes.
This opens up a possible exploit. A script could be crafted so that:
* it is identified as P2CS (passing `IsPayToColdStaking`), and recognized by the wallet as `SPENDABLE_DELEGATED` ismine-type.
* the assumed owner is not actually the owner (or not the only one) of the utxo.

In this Proof of concept, we craft a script that is recognized as own P2CS by the owner wallet, but can actually be spent with **any** key.
This is achieved by including `OP_DROP` in a strategic position, so that, during the script evaluation, part of the locking condition (included only to fake IsPayToColdStaking) is removed, and replaced by a new condition embedded in the spending scriptSig.

#### Fix
1) In `IsPayToColdStaking` check that the script matches exactly the expected template (51 bytes, with 11 fixed bytes, and the remaining 40 for the two keyIDs). This patches the discovered exploit.
2) Additionally, check the consistency of the stack when evaluating `OP_CHECKCOLDSTAKEVERIFY` in `EvalScript` (at this point of evaluation, the stack must contain only the pubkeyID, the pubkey, and the signature, properly encoded).