### PR TITLE
[GUI] Generate FAQ answer content programmatically

### DIFF
--- a/src/qt/pivx/settings/forms/settingsfaqwidget.ui
+++ b/src/qt/pivx/settings/forms/settingsfaqwidget.ui
@@ -521,20 +521,7 @@
                       <item>
                        <widget class="QLabel" name="labelContent_Intro">
                         <property name="text">
-                         <string>
-                           &lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;justify&quot;&gt;
-                           PIVX is a form of digital online money using blockchain technology
-                           that can be easily transferred globally, instantly, and with near
-                           zero fees.  PIVX incorporates market leading security &amp;
-                           privacy and is also the first PoS (Proof of Stake) Cryptocurrency
-                           to implement Sapling(SHIELD), a zk-SNARKs based privacy protocol.
-                           &lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;
-                           PIVX utilizes a Proof of Stake (PoS) consensus system algorithm,
-                           allowing all owners of PIVX to participate in earning block rewards
-                           while securing the network with full node wallets, as well as to
-                           run Masternodes to create and vote on proposals.
-                           &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
-                         </string>
+                         <string notr="true">N/A</string>
                         </property>
                         <property name="alignment">
                          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
@@ -627,15 +614,7 @@
                       <item>
                        <widget class="QLabel" name="labelContent_UnspendablePIV">
                         <property name="text">
-                         <string>
-                           &lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;justify&quot;&gt;
-                           Newly received PIVX requires 6 confirmations on the network
-                           to become eligible for spending which can take ~6 minutes.
-                           &lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;
-                           Your PIVX wallet also needs to be completely synchronized
-                           to see and spend balances on the network.
-                           &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
-                         </string>
+                         <string notr="true">N/A</string>
                         </property>
                         <property name="alignment">
                          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
@@ -725,7 +704,7 @@
                       <item>
                        <widget class="QLabel" name="labelContent_Stake">
                         <property name="text">
-                         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;ol style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li align=&quot;justify&quot; style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Make sure your wallet is completely synchronized and you are using the latest release. &lt;/li&gt;&lt;li align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You must have a balance of PIVX with a minimum of 600 confirmations. &lt;/li&gt;&lt;li align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Your wallet must stay online and be unlocked for staking purposes. &lt;/li&gt;&lt;li align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Once all those steps are followed staking should be enabled. &lt;/li&gt;&lt;li align=&quot;justify&quot; style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;You can see the status of staking in the wallet by mousing over the package icon in the row on the top left of the wallet interface. There package will be lit up and will state &amp;quot;Staking Enabled&amp;quot; to indicate it is staking. Using the command line interface (pivx-cli); the command &lt;span style=&quot; font-style:italic;&quot;&gt;getstakingstatus&lt;/span&gt; will confirm that staking is active. &lt;/li&gt;&lt;/ol&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                         <string notr="true">N/A</string>
                         </property>
                         <property name="alignment">
                          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
@@ -815,13 +794,7 @@
                       <item>
                        <widget class="QLabel" name="labelContent_Support">
                         <property name="text">
-                         <string>
-                           &lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;justify&quot;&gt;
-                           We have support channels in most of our official chat groups, for example
-                           &lt;a style='color: #b088ff' href='https://discord.PIVX.org'&gt;
-                           #support in our Discord&lt;/a&gt;.
-                           &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
-                         </string>
+                         <string notr="true">N/A</string>
                         </property>
                         <property name="alignment">
                          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
@@ -911,47 +884,7 @@
                       <item>
                        <widget class="QLabel" name="labelContent_Masternode">
                         <property name="text">
-                         <string>
-                           &lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;justify&quot;&gt;
-                           A masternode is a computer running a full node PIVX core wallet with a
-                           requirement of 10,000 PIV secured collateral to provide extra services
-                           to the network and in return, receive a portion of the block reward
-                           regularly.  These services include:
-                           &lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;
-
-                           &lt;ul&gt;
-                           &lt;li&gt;A decentralized governance (Proposal Voting)&lt;/li&gt;
-                           &lt;li&gt;A decentralized budgeting system (Treasury)&lt;/li&gt;
-                           &lt;li&gt;Validation of transactions within each block&lt;/li&gt;
-                           &lt;li&gt;Act as an additional full node in the network&lt;/li&gt;
-                           &lt;/ul&gt;
-
-                           &lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;
-                           For providing such services, masternodes are also paid a certain portion
-                           of reward for each block. This can serve as a passive income to the
-                           masternode owners minus their running cost.
-                           &lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;
-
-                           Masternode Perks:
-                           &lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;
-                           &lt;ul&gt;
-                           &lt;li&gt;Participate in PIVX Governance&lt;/li&gt;
-                           &lt;li&gt;Earn Masternode Rewards&lt;/li&gt;
-                           &lt;li&gt;Commodity option for future sale&lt;/li&gt;
-                           &lt;li&gt;Help secure the PIVX network&lt;/li&gt;
-                           &lt;/ul&gt;
-                           &lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;
-
-                           Requirements:
-                           &lt;/p&gt;&lt;p align=&quot;justify&quot;&gt;
-                           &lt;ul&gt;
-                           &lt;li&gt;10,000 PIV per single Masternode instance&lt;/li&gt;
-                           &lt;li&gt;Must be stored in a core wallet&lt;/li&gt;
-                           &lt;li&gt;Need dedicated IP address&lt;/li&gt;
-                           &lt;li&gt;Masternode wallet to remain online&lt;/li&gt;
-                           &lt;/ul&gt;
-                           &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
-                         </string>
+                         <string notr="true">N/A</string>
                         </property>
                         <property name="alignment">
                          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
@@ -1041,7 +974,7 @@
                       <item>
                        <widget class="QLabel" name="labelContent_MNController">
                         <property name="text">
-                         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;justify&quot;&gt;A Masternode Controller wallet is where the 10,000 PIV collateral can reside during a Controller-Remote masternode setup. It is a wallet that can activate the remote masternode wallet(s) and allows you to keep your collateral coins offline while the remote masternode remains online. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                         <string notr="true">N/A</string>
                         </property>
                         <property name="alignment">
                          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>

--- a/src/qt/pivx/settings/settingsfaqwidget.cpp
+++ b/src/qt/pivx/settings/settingsfaqwidget.cpp
@@ -65,6 +65,91 @@ SettingsFaqWidget::SettingsFaqWidget(PIVXGUI *parent) :
 
     ui->labelContent_Support->setOpenExternalLinks(true);
 
+    // Set FAQ content strings
+    QString introContent = formatFAQContent(
+        formatFAQParagraph(
+            tr("PIVX is a form of digital online money using blockchain technology "
+               "that can be easily transferred globally, instantly, and with near "
+               "zero fees. PIVX incorporates market leading security & "
+               "privacy and is also the first PoS (Proof of Stake) Cryptocurrency "
+               "to implement Sapling(SHIELD), a zk-SNARKs based privacy protocol.")) +
+        formatFAQParagraph(
+            tr("PIVX utilizes a Proof of Stake (PoS) consensus system algorithm, "
+               "allowing all owners of PIVX to participate in earning block rewards "
+               "while securing the network with full node wallets, as well as to "
+               "run Masternodes to create and vote on proposals.")));
+    ui->labelContent_Intro->setText(introContent);
+
+    QString unspendablePIVContent = formatFAQContent(
+        formatFAQParagraph(
+            tr("Newly received PIVX requires 6 confirmations on the network "
+               "to become eligible for spending which can take ~6 minutes.")) +
+        formatFAQParagraph(
+            tr("Your PIVX wallet also needs to be completely synchronized "
+               "to see and spend balances on the network.")));
+    ui->labelContent_UnspendablePIV->setText(unspendablePIVContent);
+
+    QString stakeContent = formatFAQContent(
+        formatFAQOrderedList(
+            formatFAQListItem(tr("Make sure your wallet is completely synchronized and you are using the latest release.")) +
+            formatFAQListItem(tr("You must have a balance of PIVX with a minimum of 600 confirmations.")) +
+            formatFAQListItem(tr("Your wallet must stay online and be unlocked for staking purposes.")) +
+            formatFAQListItem(tr("Once all those steps are followed staking should be enabled."))) +
+        formatFAQParagraph(
+            tr("You can see the status of staking in the wallet by mousing over the "
+               "package icon in the row on the top left of the wallet interface. The "
+               "package will be lit up and will state \"Staking Enabled\" to indicate "
+               "it is staking. Using the command line interface (%1); the command %2 "
+               "will confirm that staking is active.")
+                .arg("pivx-core", "<span style=\"font-style:italic\">getstakingstatus</span>")));
+    ui->labelContent_Stake->setText(stakeContent);
+
+    QString supportContent = formatFAQContent(
+        formatFAQParagraph(
+            tr("We have support channels in most of our official chat groups, for example %1")
+                .arg("<a style='color: #b088ff' href='https://discord.PIVX.org'>" + tr("#support in our Discord") + "</a>.")));
+    ui->labelContent_Support->setText(supportContent);
+
+    QString masternodeContent = formatFAQContent(
+        formatFAQParagraph(
+            tr("A masternode is a computer running a full node PIVX core wallet with a "
+               "requirement of 10,000 PIV secured collateral to provide extra services "
+               "to the network and in return, receive a portion of the block reward "
+               "regularly. These services include:") +
+            formatFAQUnorderedList(
+                formatFAQListItem(tr("A decentralized governance (Proposal Voting)")) +
+                formatFAQListItem(tr("A decentralized budgeting system (Treasury)")) +
+                formatFAQListItem(tr("Validation of transactions within each block")) +
+                formatFAQListItem(tr("Act as an additional full node in the network")))) +
+        formatFAQParagraph(
+            tr("For providing such services, masternodes are also paid a certain portion "
+               "of reward for each block. This can serve as a passive income to the "
+               "masternode owners minus their running cost.")) +
+        formatFAQParagraph(
+            tr("Masternode Perks:") +
+            formatFAQUnorderedList(
+                formatFAQListItem(tr("Participate in PIVX Governance")) +
+                formatFAQListItem(tr("Earn Masternode Rewards")) +
+                formatFAQListItem(tr("Commodity option for future sale")) +
+                formatFAQListItem(tr("Help secure the PIVX network")))) +
+        formatFAQParagraph(
+            tr("Requirements:") +
+            formatFAQUnorderedList(
+                formatFAQListItem(tr("10,000 PIV per single Masternode instance")) +
+                formatFAQListItem(tr("Must be stored in a core wallet")) +
+                formatFAQListItem(tr("Need dedicated IP address")) +
+                formatFAQListItem(tr("Masternode wallet to remain online")))));
+    ui->labelContent_Masternode->setText(masternodeContent);
+
+    QString mNControllerContent = formatFAQContent(
+        formatFAQParagraph(
+            tr("A Masternode Controller wallet is where the 10,000 PIV collateral "
+               "can reside during a Controller-Remote masternode setup. It is a wallet "
+               "that can activate the remote masternode wallet(s) and allows you to keep "
+               "your collateral coins offline while the remote masternode remains online.")));
+    ui->labelContent_MNController->setText(mNControllerContent);
+
+
     // Exit button
     setCssProperty(ui->pushButtonExit, "btn-faq-exit");
 

--- a/src/qt/pivx/settings/settingsfaqwidget.h
+++ b/src/qt/pivx/settings/settingsfaqwidget.h
@@ -42,6 +42,31 @@ private:
 
     // This needs to be edited if changes are made to the Section enum.
     std::vector<QPushButton*> getButtons();
+
+    // Formats a QString into a FAQ Content section with HTML
+    static inline QString formatFAQContent(const QString& str) {
+        return "<html><head/><body>" + str + "</body></html>";
+    }
+
+    // Formats a QString into a FAQ content paragraph with HTML
+    static inline QString formatFAQParagraph(const QString& str) {
+        return "<p align=\"justify\">" + str + "</p>";
+    }
+
+    // Formats a QString into a FAQ content ordered list with HTML
+    static inline QString formatFAQOrderedList(const QString& str) {
+        return "<ol>" + str + "</ol>";
+    }
+
+    // Formats a QString into a FAQ content un-ordered list with HTML
+    static inline QString formatFAQUnorderedList(const QString& str) {
+        return "<ul>" + str + "</ul>";
+    }
+
+    // Formats a QString into a FAQ content list item with HTML
+    static inline QString formatFAQListItem(const QString& str) {
+        return "<li>" + str + "</li>";
+    }
 };
 
 #endif // SETTINGSFAQWIDGET_H


### PR DESCRIPTION
Each FAQ answer content is formatted as a self-contained HTML page for
styling purposes, however, having raw HTML in the `.ui` file's
`<string>` properties means that said HTML tags are also exported to
Transifex. This leads to a very ugly and confusing translation
experience that is prone to errors.

Here, we split up the content into shorter HTML-less strings: each list
item is it's own string, and each paragraph is it's own string. No HTML
tags are exported to Transifex.

The necessary HTML tags are added by way of helper functions that wrap
each string programmatically.

------ 
Avoids strings such as this one from being passed to Transifex, where spacing, line breaks, and ambiguous numbered "tags" must be carried over to the translated string precisely in order for the translated string to be considered "valid":
![ScreenShot_20210322160421](https://user-images.githubusercontent.com/7393257/112069792-aef2cd80-8b29-11eb-9f43-8a6955fa5f97.png)