### PR TITLE
[GUI] fix 'split is deprecated' warnings

### DIFF
--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -268,6 +268,26 @@ QString formatTimeOffset(int64_t nTimeOffset);
     typedef QProgressBar ProgressBar;
 #endif
 
+/**
+* Splits the string into substrings wherever separator occurs, and returns
+* the list of those strings. Empty strings do not appear in the result.
+*
+* QString::split() signature differs in different Qt versions:
+*  - QString::SplitBehavior is deprecated since Qt 5.15
+*  - Qt::SplitBehavior was introduced in Qt 5.14
+* If {QString|Qt}::SkipEmptyParts behavior is required, use this
+* function instead of QString::split().
+*/
+template <typename SeparatorType>
+QStringList SplitSkipEmptyParts(const QString& string, const SeparatorType& separator)
+{
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    return string.split(separator, Qt::SkipEmptyParts);
+#else
+    return string.split(separator, QString::SkipEmptyParts);
+#endif
+}
+
 } // namespace GUIUtil
 
 #endif // BITCOIN_QT_GUIUTIL_H

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -247,12 +247,12 @@ QVariant OptionsModel::data(const QModelIndex& index, int role) const
             return settings.value("fUseProxy", false);
         case ProxyIP: {
             // contains IP at index 0 and port at index 1
-            QStringList strlIpPort = settings.value("addrProxy").toString().split(":", QString::SkipEmptyParts);
+            QStringList strlIpPort = GUIUtil::SplitSkipEmptyParts(settings.value("addrProxy").toString(), ":");
             return strlIpPort.at(0);
         }
         case ProxyPort: {
             // contains IP at index 0 and port at index 1
-            QStringList strlIpPort = settings.value("addrProxy").toString().split(":", QString::SkipEmptyParts);
+            QStringList strlIpPort = GUIUtil::SplitSkipEmptyParts(settings.value("addrProxy").toString(), ":");
             return strlIpPort.at(1);
         }
 
@@ -342,7 +342,7 @@ bool OptionsModel::setData(const QModelIndex& index, const QVariant& value, int 
             break;
         case ProxyIP: {
             // contains current IP at index 0 and current port at index 1
-            QStringList strlIpPort = settings.value("addrProxy").toString().split(":", QString::SkipEmptyParts);
+            QStringList strlIpPort = GUIUtil::SplitSkipEmptyParts(settings.value("addrProxy").toString(), ":");
             // if that key doesn't exist or has a changed IP
             if (!settings.contains("addrProxy") || strlIpPort.at(0) != value.toString()) {
                 // construct new value from new IP and current port
@@ -353,7 +353,7 @@ bool OptionsModel::setData(const QModelIndex& index, const QVariant& value, int 
         } break;
         case ProxyPort: {
             // contains current IP at index 0 and current port at index 1
-            QStringList strlIpPort = settings.value("addrProxy").toString().split(":", QString::SkipEmptyParts);
+            QStringList strlIpPort = GUIUtil::SplitSkipEmptyParts(settings.value("addrProxy").toString(), ":");
             // if that key doesn't exist or has a changed port
             if (!settings.contains("addrProxy") || strlIpPort.at(1) != value.toString()) {
                 // construct new value from current IP and new port


### PR DESCRIPTION
Qt 5.15 has deprecated QString::SplitBehavior, this provides a
work-around that is still compatible with our baseline Qt version.