### PR TITLE
[TierTwo] Enable budget payment to a P2SH addresses + functional test coverage.

### DIFF
--- a/src/budget/budgetproposal.cpp
+++ b/src/budget/budgetproposal.cpp
@@ -131,13 +131,6 @@ bool CBudgetProposal::CheckAmount(const CAmount& nTotalBudget)
 
 bool CBudgetProposal::CheckAddress()
 {
-    // !TODO: There might be an issue with multisig in the coinbase on mainnet
-    // we will add support for it in a future release.
-    if (address.IsPayToScriptHash()) {
-        strInvalid = "Multisig is not currently supported.";
-        return false;
-    }
-
     // Check address
     CTxDestination dest;
     if (!ExtractDestination(address, dest, false)) {


### PR DESCRIPTION
Added tier two network support for budget proposal payment to P2SH addresses.
This means for example, that multi-sig addresses will be accepted as the proposal payment recipient.

First commit is a functional test, covering the functionality. Which fails alone as we are not, consensus wise, supporting them.
Second commit adds the consensus change to enable the functionality.

TODO: 
* Add a third commit enabling this functionality only after the next hard fork.
* Review the impact of this change on the new tier two budget sources.
