### PR TITLE
[Consensus][Refactoring] Blocks v10: TierTwo payments in the coinbase transaction

### DIFF
--- a/src/blockassembler.cpp
+++ b/src/blockassembler.cpp
@@ -82,7 +82,6 @@ bool SolveProofOfStake(CBlock* pblock, CBlockIndex* pindexPrev, CWallet* pwallet
     boost::this_thread::interruption_point();
 
     assert(pindexPrev);
-    const int nHeight = pindexPrev->nHeight + 1;
     pblock->nBits = GetNextWorkRequired(pindexPrev, pblock);
 
     // Sync wallet before create coinstake
@@ -97,8 +96,8 @@ bool SolveProofOfStake(CBlock* pblock, CBlockIndex* pindexPrev, CWallet* pwallet
     // Stake found
 
     // Create coinbase tx and add masternode/budget payments
-    CMutableTransaction txCoinbase = NewCoinbase(nHeight);
-    FillBlockPayee(txCoinbase, txCoinStake, nHeight, true);
+    CMutableTransaction txCoinbase = NewCoinbase(pindexPrev->nHeight + 1);
+    FillBlockPayee(txCoinbase, txCoinStake, pindexPrev, true);
 
     // Sign coinstake
     if (!pwallet->SignCoinStake(txCoinStake)) {
@@ -122,7 +121,7 @@ bool CreateCoinbaseTx(CBlock* pblock, const CScript& scriptPubKeyIn, CBlockIndex
 
     //Masternode and general budget payments
     CMutableTransaction txDummy;    // POW blocks have no coinstake
-    FillBlockPayee(txCoinbase, txDummy, nHeight, false);
+    FillBlockPayee(txCoinbase, txDummy, pindexPrev, false);
 
     // If no payee was detected, then the whole block value goes to the first output.
     if (txCoinbase.vout.size() == 1) {

--- a/src/blockassembler.cpp
+++ b/src/blockassembler.cpp
@@ -504,8 +504,10 @@ void IncrementExtraNonce(std::shared_ptr<CBlock>& pblock, const CBlockIndex* pin
 
 int32_t ComputeBlockVersion(const Consensus::Params& consensus, int nHeight)
 {
-    if (NetworkUpgradeActive(nHeight, consensus, Consensus::UPGRADE_V5_0)) {
-        return CBlockHeader::CURRENT_VERSION;    // v9
+    if (NetworkUpgradeActive(nHeight, consensus, Consensus::UPGRADE_V6_0)) {
+        return CBlockHeader::CURRENT_VERSION;    // v10
+    } else if (NetworkUpgradeActive(nHeight, consensus, Consensus::UPGRADE_V5_0)) {
+        return 9;
     } else if (consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V4_0)) {
         return 7;
     } else if (consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V3_4)) {

--- a/src/blockassembler.cpp
+++ b/src/blockassembler.cpp
@@ -76,9 +76,13 @@ bool SolveProofOfStake(CBlock* pblock, CBlockIndex* pindexPrev, CWallet* pwallet
 
     CMutableTransaction txCoinStake;
     int64_t nTxNewTime = 0;
-    if (!pwallet->CreateCoinStake(*pwallet, pindexPrev, pblock->nBits, txCoinStake, nTxNewTime, availableCoins)) {
+    if (!pwallet->CreateCoinStake(pindexPrev, pblock->nBits, txCoinStake, nTxNewTime, availableCoins)) {
         LogPrint(BCLog::STAKING, "%s : stake not found\n", __func__);
         return false;
+    }
+    if (!pwallet->SignCoinStake(txCoinStake)) {
+        const COutPoint& stakeIn = txCoinStake.vin[0].prevout;
+        return error("Unable to sign coinstake with input %s-%d", stakeIn.hash.ToString(), stakeIn.n);
     }
     // Stake found
     pblock->nTime = nTxNewTime;

--- a/src/budget/budgetmanager.cpp
+++ b/src/budget/budgetmanager.cpp
@@ -415,7 +415,7 @@ bool CBudgetManager::GetExpectedPayeeAmount(int chainHeight, CAmount& nAmountRet
     return GetPayeeAndAmount(chainHeight, payeeRet, nAmountRet);
 }
 
-bool CBudgetManager::FillBlockPayee(CMutableTransaction& txNew, const int nHeight, bool fProofOfStake) const
+bool CBudgetManager::FillBlockPayee(CMutableTransaction& txCoinbase, CMutableTransaction& txCoinstake, const int nHeight, bool fProofOfStake) const
 {
     if (nHeight <= 0) return false;
 
@@ -427,19 +427,29 @@ bool CBudgetManager::FillBlockPayee(CMutableTransaction& txNew, const int nHeigh
 
     CAmount blockValue = GetBlockValue(nHeight);
 
+    // Starting from PIVX v6.0 masternode and budgets are paid in the coinbase tx of PoS blocks
+    const bool fPayCoinstake = fProofOfStake &&
+                               !Params().GetConsensus().NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V6_0);
+
     if (fProofOfStake) {
-        unsigned int i = txNew.vout.size();
-        txNew.vout.resize(i + 1);
-        txNew.vout[i].scriptPubKey = payee;
-        txNew.vout[i].nValue = nAmount;
+        if (fPayCoinstake) {
+            unsigned int i = txCoinstake.vout.size();
+            txCoinstake.vout.resize(i + 1);
+            txCoinstake.vout[i].scriptPubKey = payee;
+            txCoinstake.vout[i].nValue = nAmount;
+        } else {
+            txCoinbase.vout.resize(1);
+            txCoinbase.vout[0].scriptPubKey = payee;
+            txCoinbase.vout[0].nValue = nAmount;
+        }
     } else {
         //miners get the full amount on these blocks
-        txNew.vout[0].nValue = blockValue;
-        txNew.vout.resize(2);
+        txCoinbase.vout[0].nValue = blockValue;
+        txCoinbase.vout.resize(2);
 
         //these are super blocks, so their value can be much larger than normal
-        txNew.vout[1].scriptPubKey = payee;
-        txNew.vout[1].nValue = nAmount;
+        txCoinbase.vout[1].scriptPubKey = payee;
+        txCoinbase.vout[1].nValue = nAmount;
     }
 
     CTxDestination address;

--- a/src/budget/budgetmanager.cpp
+++ b/src/budget/budgetmanager.cpp
@@ -427,7 +427,7 @@ bool CBudgetManager::FillBlockPayee(CMutableTransaction& txCoinbase, CMutableTra
 
     CAmount blockValue = GetBlockValue(nHeight);
 
-    // Starting from PIVX v6.0 masternode and budgets are paid in the coinbase tx of PoS blocks
+    // Starting from PIVX v6.0 masternode and budgets are paid in the coinbase tx of PoS blocks (block v10)
     const bool fPayCoinstake = fProofOfStake &&
                                !Params().GetConsensus().NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V6_0);
 

--- a/src/budget/budgetmanager.h
+++ b/src/budget/budgetmanager.h
@@ -125,7 +125,7 @@ public:
     bool UpdateFinalizedBudget(CFinalizedBudgetVote& vote, CNode* pfrom, std::string& strError);
     TrxValidationStatus IsTransactionValid(const CTransaction& txNew, const uint256& nBlockHash, int nBlockHeight) const;
     std::string GetRequiredPaymentsString(int nBlockHeight);
-    bool FillBlockPayee(CMutableTransaction& txNew, const int nHeight, bool fProofOfStake) const;
+    bool FillBlockPayee(CMutableTransaction& txCoinbase, CMutableTransaction& txCoinstake, const int nHeight, bool fProofOfStake) const;
 
     // Only initialized masternodes: sign and submit votes on valid finalized budgets
     void VoteOnFinalizedBudgets();

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -142,7 +142,6 @@ public:
         consensus.nCoinbaseMaturity = 100;
         consensus.nFutureTimeDriftPoW = 7200;
         consensus.nFutureTimeDriftPoS = 180;
-        consensus.nMasternodeCountDrift = 20;       // num of MN we allow the see-saw payments to be off by
         consensus.nMaxMoneyOut = 21000000 * COIN;
         consensus.nPoolMaxTransactions = 3;
         consensus.nProposalEstablishmentTime = 60 * 60 * 24;    // must be at least a day old to make it into a budget
@@ -280,7 +279,6 @@ public:
         consensus.nCoinbaseMaturity = 15;
         consensus.nFutureTimeDriftPoW = 7200;
         consensus.nFutureTimeDriftPoS = 180;
-        consensus.nMasternodeCountDrift = 20;       // num of MN we allow the see-saw payments to be off by
         consensus.nMaxMoneyOut = 21000000 * COIN;
         consensus.nPoolMaxTransactions = 3;
         consensus.nProposalEstablishmentTime = 60 * 5;  // at least 5 min old to make it into a budget
@@ -402,7 +400,6 @@ public:
         consensus.nCoinbaseMaturity = 100;
         consensus.nFutureTimeDriftPoW = 7200;
         consensus.nFutureTimeDriftPoS = 180;
-        consensus.nMasternodeCountDrift = 4;        // num of MN we allow the see-saw payments to be off by
         consensus.nMaxMoneyOut = 43199500 * COIN;
         consensus.nPoolMaxTransactions = 2;
         consensus.nProposalEstablishmentTime = 60 * 5;  // at least 5 min old to make it into a budget

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -96,7 +96,6 @@ struct Params {
     int nCoinbaseMaturity;
     int nFutureTimeDriftPoW;
     int nFutureTimeDriftPoS;
-    int nMasternodeCountDrift;
     CAmount nMaxMoneyOut;
     int nPoolMaxTransactions;
     int64_t nProposalEstablishmentTime;

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -751,6 +751,10 @@ CDeterministicMNList CDeterministicMNManager::GetListForBlock(const CBlockIndex*
 {
     LOCK(cs);
 
+    if (!IsDIP3Enforced(pindex->nHeight)) {
+        return {};
+    }
+
     CDeterministicMNList snapshot;
     std::list<const CBlockIndex*> listDiffIndexes;
 

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -338,21 +338,19 @@ void CMasternodePayments::FillBlockPayee(CMutableTransaction& txCoinbase, CMutab
             txCoinstake.vout[i].nValue = masternodePayment;
 
             //subtract mn payment from the stake reward
-            if (!txCoinstake.vout[1].IsZerocoinMint()) {
-                if (i == 2) {
-                    // Majority of cases; do it quick and move on
-                    txCoinstake.vout[i - 1].nValue -= masternodePayment;
-                } else if (i > 2) {
-                    // special case, stake is split between (i-1) outputs
-                    unsigned int outputs = i-1;
-                    CAmount mnPaymentSplit = masternodePayment / outputs;
-                    CAmount mnPaymentRemainder = masternodePayment - (mnPaymentSplit * outputs);
-                    for (unsigned int j=1; j<=outputs; j++) {
-                        txCoinstake.vout[j].nValue -= mnPaymentSplit;
-                    }
-                    // in case it's not an even division, take the last bit of dust from the last one
-                    txCoinstake.vout[outputs].nValue -= mnPaymentRemainder;
+            if (i == 2) {
+                // Majority of cases; do it quick and move on
+                txCoinstake.vout[i - 1].nValue -= masternodePayment;
+            } else if (i > 2) {
+                // special case, stake is split between (i-1) outputs
+                unsigned int outputs = i-1;
+                CAmount mnPaymentSplit = masternodePayment / outputs;
+                CAmount mnPaymentRemainder = masternodePayment - (mnPaymentSplit * outputs);
+                for (unsigned int j=1; j<=outputs; j++) {
+                    txCoinstake.vout[j].nValue -= mnPaymentSplit;
                 }
+                // in case it's not an even division, take the last bit of dust from the last one
+                txCoinstake.vout[outputs].nValue -= mnPaymentRemainder;
             }
         } else {
             txCoinbase.vout.resize(2);

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -176,10 +176,10 @@ public:
         payee()
     {}
 
-    CMasternodePaymentWinner(CTxIn vinIn) :
+    CMasternodePaymentWinner(CTxIn vinIn, int nHeight) :
         CSignedMessage(),
         vinMasternode(vinIn),
-        nBlockHeight(0),
+        nBlockHeight(nHeight),
         payee()
     {}
 

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -27,7 +27,7 @@ void ProcessMessageMasternodePayments(CNode* pfrom, std::string& strCommand, CDa
 bool IsBlockPayeeValid(const CBlock& block, int nBlockHeight);
 std::string GetRequiredPaymentsString(int nBlockHeight);
 bool IsBlockValueValid(int nHeight, CAmount& nExpectedValue, CAmount nMinted);
-void FillBlockPayee(CMutableTransaction& txNew, const int nHeight, bool fProofOfStake);
+void FillBlockPayee(CMutableTransaction& txCoinbase, CMutableTransaction& txCoinstake, const int nHeight, bool fProofOfStake);
 
 void DumpMasternodePayments();
 
@@ -116,12 +116,12 @@ public:
         vecPayments.push_back(c);
     }
 
-    bool GetPayee(CScript& payee)
+    bool GetPayee(CScript& payee) const
     {
         LOCK(cs_vecPayments);
 
         int nVotes = -1;
-        for (CMasternodePayee& p : vecPayments) {
+        for (const CMasternodePayee& p : vecPayments) {
             if (p.nVotes > nVotes) {
                 payee = p.scriptPubKey;
                 nVotes = p.nVotes;
@@ -253,7 +253,7 @@ public:
     void Sync(CNode* node, int nCountNeeded);
     void CleanPaymentList(int mnCount, int nHeight);
 
-    bool GetBlockPayee(int nBlockHeight, CScript& payee);
+    bool GetBlockPayee(int nBlockHeight, CScript& payee) const;
     bool IsTransactionValid(const CTransaction& txNew, int nBlockHeight);
     bool IsScheduled(const CMasternode& mn, int nNotBlockHeight);
 
@@ -274,7 +274,7 @@ public:
 
     void ProcessMessageMasternodePayments(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
     std::string GetRequiredPaymentsString(int nBlockHeight);
-    void FillBlockPayee(CMutableTransaction& txNew, const int nHeight, bool fProofOfStake);
+    void FillBlockPayee(CMutableTransaction& txCoinbase, CMutableTransaction& txCoinstake, const int nHeight, bool fProofOfStake) const;
     std::string ToString() const;
 
     ADD_SERIALIZE_METHODS;

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -26,8 +26,14 @@ extern CMasternodePayments masternodePayments;
 void ProcessMessageMasternodePayments(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
 bool IsBlockPayeeValid(const CBlock& block, int nBlockHeight);
 std::string GetRequiredPaymentsString(int nBlockHeight);
-bool IsBlockValueValid(int nHeight, CAmount& nExpectedValue, CAmount nMinted);
+bool IsBlockValueValid(int nHeight, CAmount& nExpectedValue, CAmount nMinted, CAmount& nBudgetAmt);
 void FillBlockPayee(CMutableTransaction& txCoinbase, CMutableTransaction& txCoinstake, const int nHeight, bool fProofOfStake);
+
+/**
+ * Check coinbase output value for blocks v10+.
+ * It must pay the masternode for regular blocks and a proposal during superblocks.
+ */
+bool IsCoinbaseValueValid(const CTransactionRef& tx, CAmount nBudgetAmt);
 
 void DumpMasternodePayments();
 

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -24,10 +24,10 @@ extern CMasternodePayments masternodePayments;
 #define MNPAYMENTS_SIGNATURES_TOTAL 10
 
 void ProcessMessageMasternodePayments(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
-bool IsBlockPayeeValid(const CBlock& block, int nBlockHeight);
+bool IsBlockPayeeValid(const CBlock& block, const CBlockIndex* pindexPrev);
 std::string GetRequiredPaymentsString(int nBlockHeight);
 bool IsBlockValueValid(int nHeight, CAmount& nExpectedValue, CAmount nMinted, CAmount& nBudgetAmt);
-void FillBlockPayee(CMutableTransaction& txCoinbase, CMutableTransaction& txCoinstake, const int nHeight, bool fProofOfStake);
+void FillBlockPayee(CMutableTransaction& txCoinbase, CMutableTransaction& txCoinstake, const CBlockIndex* pindexPrev, bool fProofOfStake);
 
 /**
  * Check coinbase output value for blocks v10+.
@@ -259,8 +259,14 @@ public:
     void Sync(CNode* node, int nCountNeeded);
     void CleanPaymentList(int mnCount, int nHeight);
 
+    // get the masternode payment outs for block built on top of pindexPrev
+    bool GetMasternodeTxOuts(const CBlockIndex* pindexPrev, std::vector<CTxOut>& voutMasternodePaymentsRet) const;
+
+    // can be removed after transition to DMN
+    bool GetLegacyMasternodeTxOut(int nHeight, std::vector<CTxOut>& voutMasternodePaymentsRet) const;
     bool GetBlockPayee(int nBlockHeight, CScript& payee) const;
-    bool IsTransactionValid(const CTransaction& txNew, int nBlockHeight);
+
+    bool IsTransactionValid(const CTransaction& txNew, const CBlockIndex* pindexPrev);
     bool IsScheduled(const CMasternode& mn, int nNotBlockHeight);
 
     bool CanVote(const COutPoint& outMasternode, int nBlockHeight)
@@ -280,7 +286,7 @@ public:
 
     void ProcessMessageMasternodePayments(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
     std::string GetRequiredPaymentsString(int nBlockHeight);
-    void FillBlockPayee(CMutableTransaction& txCoinbase, CMutableTransaction& txCoinstake, const int nHeight, bool fProofOfStake) const;
+    void FillBlockPayee(CMutableTransaction& txCoinbase, CMutableTransaction& txCoinstake, const CBlockIndex* pindexPrev, bool fProofOfStake) const;
     std::string ToString() const;
 
     ADD_SERIALIZE_METHODS;

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -17,6 +17,7 @@ extern RecursiveMutex cs_mapMasternodePayeeVotes;
 class CMasternodePayments;
 class CMasternodePaymentWinner;
 class CMasternodeBlockPayees;
+class CValidationState;
 
 extern CMasternodePayments masternodePayments;
 
@@ -33,7 +34,7 @@ void FillBlockPayee(CMutableTransaction& txCoinbase, CMutableTransaction& txCoin
  * Check coinbase output value for blocks v10+.
  * It must pay the masternode for regular blocks and a proposal during superblocks.
  */
-bool IsCoinbaseValueValid(const CTransactionRef& tx, CAmount nBudgetAmt);
+bool IsCoinbaseValueValid(const CTransactionRef& tx, CAmount nBudgetAmt, CValidationState& _state);
 
 void DumpMasternodePayments();
 

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -144,17 +144,17 @@ public:
     void CheckSpentCollaterals(const std::vector<CTransactionRef>& vtx);
 
     /// Find an entry in the masternode list that is next to be paid
-    const CMasternode* GetNextMasternodeInQueueForPayment(int nBlockHeight, bool fFilterSigTime, int& nCount, const CBlockIndex* pChainTip = nullptr) const;
+    MasternodeRef GetNextMasternodeInQueueForPayment(int nBlockHeight, bool fFilterSigTime, int& nCount, const CBlockIndex* pChainTip = nullptr) const;
 
     /// Get the current winner for this block
-    const CMasternode* GetCurrentMasterNode(int mod = 1, int64_t nBlockHeight = 0, int minProtocol = 0) const;
+    MasternodeRef GetCurrentMasterNode(int nHeight, const uint256& hash) const;
 
     /// vector of pairs <masternode winner, height>
     std::vector<std::pair<MasternodeRef, int>> GetMnScores(int nLast) const;
 
     // Retrieve the known masternodes ordered by scoring without checking them. (Only used for listmasternodes RPC call)
     std::vector<std::pair<int64_t, MasternodeRef>> GetMasternodeRanks(int nBlockHeight) const;
-    int GetMasternodeRank(const CTxIn& vin, int64_t nBlockHeight, int minProtocol = 0, bool fOnlyActive = true) const;
+    int GetMasternodeRank(const CTxIn& vin, int64_t nBlockHeight) const;
 
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
 

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -23,7 +23,7 @@ class CBlockHeader
 {
 public:
     // header
-    static const int32_t CURRENT_VERSION=9;
+    static const int32_t CURRENT_VERSION=10;     //!> Version 10 Masternode/Budget payments in the coinbase
     int32_t nVersion;
     uint256 hashPrevBlock;
     uint256 hashMerkleRoot;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -389,7 +389,7 @@ public:
 
     bool IsCoinBase() const
     {
-        return (vin.size() == 1 && vin[0].prevout.IsNull() && !ContainsZerocoins());
+        return (vin.size() == 1 && vin[0].prevout.IsNull() && !vin[0].scriptSig.IsZerocoinSpend());
     }
 
     bool IsCoinStake() const;

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -243,7 +243,7 @@ UniValue masternodecurrent (const JSONRPCRequest& request)
     if (!pChainTip) return "unknown";
 
     int nCount = 0;
-    const CMasternode* winner = mnodeman.GetNextMasternodeInQueueForPayment(pChainTip->nHeight + 1, true, nCount, pChainTip);
+    MasternodeRef winner = mnodeman.GetNextMasternodeInQueueForPayment(pChainTip->nHeight + 1, true, nCount, pChainTip);
     if (winner) {
         UniValue obj(UniValue::VOBJ);
         obj.pushKV("protocol", (int64_t)winner->protocolVersion);

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -211,13 +211,18 @@ bool CSporkManager::UpdateSpork(SporkId nSporkID, int64_t nValue)
 
     if(spork.Sign(strMasterPrivKey)){
         spork.Relay();
-        LOCK(cs);
-        mapSporks[spork.GetHash()] = spork;
-        mapSporksActive[nSporkID] = spork;
+        AddSporkMessage(spork);
         return true;
     }
 
     return false;
+}
+
+void CSporkManager::AddSporkMessage(const CSporkMessage& spork)
+{
+    LOCK(cs);
+    mapSporks[spork.GetHash()] = spork;
+    mapSporksActive[spork.nSporkID] = spork;
 }
 
 // grab the spork value, and see if it's off

--- a/src/spork.h
+++ b/src/spork.h
@@ -109,7 +109,10 @@ public:
     void ProcessSpork(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
     int64_t GetSporkValue(SporkId nSporkID);
     void ExecuteSpork(SporkId nSporkID, int nValue);
+    // Create/Sign/Relay the spork message, and update the maps
     bool UpdateSpork(SporkId nSporkID, int64_t nValue);
+    // Add spork message to mapSporks and mapSporksActive
+    void AddSporkMessage(const CSporkMessage& spork);
 
     bool IsSporkActive(SporkId nSporkID);
     std::string GetSporkNameByID(SporkId id);

--- a/src/stakeinput.cpp
+++ b/src/stakeinput.cpp
@@ -46,10 +46,9 @@ bool CPivStake::GetTxOutFrom(CTxOut& out) const
     return true;
 }
 
-bool CPivStake::CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut)
+CTxIn CPivStake::GetTxIn() const
 {
-    txIn = CTxIn(outpointFrom.hash, outpointFrom.n);
-    return true;
+    return CTxIn(outpointFrom.hash, outpointFrom.n);
 }
 
 CAmount CPivStake::GetValue() const

--- a/src/stakeinput.cpp
+++ b/src/stakeinput.cpp
@@ -56,7 +56,7 @@ CAmount CPivStake::GetValue() const
     return outputFrom.nValue;
 }
 
-bool CPivStake::CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal)
+bool CPivStake::CreateTxOuts(const CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) const
 {
     std::vector<valtype> vSolutions;
     txnouttype whichType;

--- a/src/stakeinput.h
+++ b/src/stakeinput.h
@@ -25,7 +25,6 @@ public:
     virtual const CBlockIndex* GetIndexFrom() const = 0;
     virtual bool GetTxOutFrom(CTxOut& out) const = 0;
     virtual CAmount GetValue() const = 0;
-    virtual bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) = 0;
     virtual bool IsZPIV() const = 0;
     virtual CDataStream GetUniqueness() const = 0;
     virtual bool ContextCheck(int nHeight, uint32_t nTime) = 0;
@@ -50,7 +49,7 @@ public:
     CAmount GetValue() const override;
     CDataStream GetUniqueness() const override;
     CTxIn GetTxIn() const;
-    bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) override;
+    bool CreateTxOuts(const CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) const;
     bool IsZPIV() const override { return false; }
     bool ContextCheck(int nHeight, uint32_t nTime) override;
 };

--- a/src/stakeinput.h
+++ b/src/stakeinput.h
@@ -23,7 +23,6 @@ public:
     virtual ~CStakeInput(){};
     virtual bool InitFromTxIn(const CTxIn& txin) = 0;
     virtual const CBlockIndex* GetIndexFrom() const = 0;
-    virtual bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = UINT256_ZERO) = 0;
     virtual bool GetTxOutFrom(CTxOut& out) const = 0;
     virtual CAmount GetValue() const = 0;
     virtual bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) = 0;
@@ -50,7 +49,7 @@ public:
     bool GetTxOutFrom(CTxOut& out) const override;
     CAmount GetValue() const override;
     CDataStream GetUniqueness() const override;
-    bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = UINT256_ZERO) override;
+    CTxIn GetTxIn() const;
     bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) override;
     bool IsZPIV() const override { return false; }
     bool ContextCheck(int nHeight, uint32_t nTime) override;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1748,8 +1748,9 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
     }
 
     // For blocks v10+: Check that the coinbase pays the exact amount
-    if (isPoSActive && pindex->nVersion >= 10 && !IsCoinbaseValueValid(block.vtx[0], nBudgetAmt)) {
-        return state.DoS(100, false, REJECT_INVALID, "bad-cb-amount");
+    if (isPoSActive && pindex->nVersion >= 10 && !IsCoinbaseValueValid(block.vtx[0], nBudgetAmt, state)) {
+        // pass the state returned by the function above
+        return false;
     }
 
     if (!control.Wait())

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2814,8 +2814,8 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
             return state.DoS(100, false, REJECT_INVALID, "bad-cb-multiple", false, "more than one coinbase");
 
     if (IsPoS) {
-        // Coinbase output should be empty if proof-of-stake block
-        if (block.vtx[0]->vout.size() != 1 || !block.vtx[0]->vout[0].IsEmpty())
+        // Coinbase output should be empty if proof-of-stake block (before block v10)
+        if (block.nVersion < 10 && (block.vtx[0]->vout.size() != 1 || !block.vtx[0]->vout[0].IsEmpty()))
             return state.DoS(100, false, REJECT_INVALID, "bad-cb-pos", false, "coinbase output not empty for proof-of-stake block");
 
         // Second transaction must be coinstake, the rest must not be
@@ -3009,7 +3009,8 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
         (block.nVersion < 5 && consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_BIP65)) ||
         (block.nVersion < 6 && consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V3_4)) ||
         (block.nVersion < 7 && consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V4_0)) ||
-        (block.nVersion < 8 && consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V5_0)))
+        (block.nVersion < 8 && consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V5_0)) ||
+        (block.nVersion < 10 && consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V6_0)))
     {
         std::string stringErr = strprintf("rejected block version %d at height %d", block.nVersion, nHeight);
         return state.Invalid(false, REJECT_OBSOLETE, "bad-version", stringErr);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2335,25 +2335,29 @@ UniValue ListReceived(const UniValue& params, bool by_label, int nBlockHeight)
     for (std::map<uint256, CWalletTx>::iterator it = pwalletMain->mapWallet.begin(); it != pwalletMain->mapWallet.end(); ++it) {
         const CWalletTx& wtx = (*it).second;
 
-        if (wtx.IsCoinBase() || !IsFinalTx(wtx.tx, nBlockHeight))
+        if (!IsFinalTx(wtx.tx, nBlockHeight)) {
             continue;
+        }
 
         int nDepth = wtx.GetDepthInMainChain();
-        if (nDepth < nMinDepth)
+        if (nDepth < nMinDepth) {
             continue;
+        }
 
         for (const CTxOut& txout : wtx.tx->vout) {
             CTxDestination address;
-            if (!ExtractDestination(txout.scriptPubKey, address))
+            if (!ExtractDestination(txout.scriptPubKey, address)) {
                 continue;
+            }
 
             if (has_filtered_address && !(filtered_address == address)) {
                 continue;
             }
 
             isminefilter mine = IsMine(*pwalletMain, address);
-            if (!(mine & filter))
+            if (!(mine & filter)) {
                 continue;
+            }
 
             tallyitem& item = mapTally[address];
             item.nAmount += txout.nValue;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3296,24 +3296,16 @@ bool CWallet::CreateCoinStake(
         // put the remaining on the last output (which all into the first if only one output)
         txNew.vout[outputs].nValue += nRemaining;
 
-        // Limit size
-        unsigned int nBytes = ::GetSerializeSize(txNew, SER_NETWORK, PROTOCOL_VERSION);
-        if (nBytes >= DEFAULT_BLOCK_MAX_SIZE / 5)
-            return error("%s : exceeded coinstake size limit", __func__);
+        // Set coinstake input
+        txNew.vin.emplace_back(stakeInput.GetTxIn());
 
         // Masternode payment
         FillBlockPayee(txNew, pindexPrev->nHeight + 1, true);
 
-        const uint256& hashTxOut = txNew.GetHash();
-        CTxIn in;
-        if (!stakeInput.CreateTxIn(this, in, hashTxOut)) {
-            LogPrintf("%s : failed to create TxIn\n", __func__);
-            txNew.vin.clear();
-            txNew.vout.clear();
-            it++;
-            continue;
-        }
-        txNew.vin.emplace_back(in);
+        // Limit size
+        unsigned int nBytes = ::GetSerializeSize(txNew, SER_NETWORK, PROTOCOL_VERSION);
+        if (nBytes >= DEFAULT_BLOCK_MAX_SIZE / 5)
+            return error("%s : exceeded coinstake size limit", __func__);
 
         break;
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3208,16 +3208,12 @@ bool CWallet::CreateTransaction(CScript scriptPubKey, const CAmount& nValue, CTr
 }
 
 bool CWallet::CreateCoinStake(
-        const CKeyStore& keystore,
         const CBlockIndex* pindexPrev,
         unsigned int nBits,
         CMutableTransaction& txNew,
         int64_t& nTxNewTime,
-        std::vector<CStakeableOutput>* availableCoins)
+        std::vector<CStakeableOutput>* availableCoins) const
 {
-
-    const Consensus::Params& consensus = Params().GetConsensus();
-
     // Mark coin stake transaction
     txNew.vin.clear();
     txNew.vout.clear();
@@ -3311,9 +3307,11 @@ bool CWallet::CreateCoinStake(
     }
     LogPrint(BCLog::STAKING, "%s: attempted staking %d times\n", __func__, nAttempts);
 
-    if (!fKernelFound)
-        return false;
+    return fKernelFound;
+}
 
+bool CWallet::SignCoinStake(CMutableTransaction& txNew) const
+{
     // Sign it
     int nIn = 0;
     for (const CTxIn& txIn : txNew.vin) {
@@ -3322,7 +3320,7 @@ bool CWallet::CreateCoinStake(
             return error("%s : failed to sign coinstake", __func__);
     }
 
-    // Successfully generated coinstake
+    // Successfully signed coinstake
     return true;
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3295,9 +3295,6 @@ bool CWallet::CreateCoinStake(
         // Set coinstake input
         txNew.vin.emplace_back(stakeInput.GetTxIn());
 
-        // Masternode payment
-        FillBlockPayee(txNew, pindexPrev->nHeight + 1, true);
-
         // Limit size
         unsigned int nBytes = ::GetSerializeSize(txNew, SER_NETWORK, PROTOCOL_VERSION);
         if (nBytes >= DEFAULT_BLOCK_MAX_SIZE / 5)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1032,12 +1032,12 @@ public:
     };
     CWallet::CommitResult CommitTransaction(CTransactionRef tx, CReserveKey& opReservekey, CConnman* connman);
     CWallet::CommitResult CommitTransaction(CTransactionRef tx, CReserveKey* reservekey, CConnman* connman);
-    bool CreateCoinStake(const CKeyStore& keystore,
-                         const CBlockIndex* pindexPrev,
+    bool CreateCoinStake(const CBlockIndex* pindexPrev,
                          unsigned int nBits,
                          CMutableTransaction& txNew,
                          int64_t& nTxNewTime,
-                         std::vector<CStakeableOutput>* availableCoins);
+                         std::vector<CStakeableOutput>* availableCoins) const;
+    bool SignCoinStake(CMutableTransaction& txNew) const;
     void AutoCombineDust(CConnman* connman);
 
     // Shielded balances

--- a/src/zpiv/zpos.h
+++ b/src/zpiv/zpos.h
@@ -25,7 +25,6 @@ public:
     const CBlockIndex* GetIndexFrom() const override;
     CAmount GetValue() const override;
     CDataStream GetUniqueness() const override;
-    bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = UINT256_ZERO) override { return false; /* creation disabled */}
     bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) override { return false; /* creation disabled */}
     bool GetTxOutFrom(CTxOut& out) const override { return false; /* not available */ }
     virtual bool ContextCheck(int nHeight, uint32_t nTime) override;

--- a/src/zpiv/zpos.h
+++ b/src/zpiv/zpos.h
@@ -25,7 +25,6 @@ public:
     const CBlockIndex* GetIndexFrom() const override;
     CAmount GetValue() const override;
     CDataStream GetUniqueness() const override;
-    bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) override { return false; /* creation disabled */}
     bool GetTxOutFrom(CTxOut& out) const override { return false; /* not available */ }
     virtual bool ContextCheck(int nHeight, uint32_t nTime) override;
 };


### PR DESCRIPTION
Extracted from #2267.
This PR introduces an important consensus change. As per title, mn/budget payments are now outputs of the coinbase transaction, rather than the coinstake (which, now, contains only outputs belonging to the staker).
The block version is bumped to 10.
Also refactor the budget-payment functions, in preparation for the compatibility code and the new payment logic.

Built on top of:
- [x] #2273 