### PR TITLE
[Consensus] New cold-staking opcode

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -44,6 +44,19 @@ Notable Changes
 
 (Developers: add your notes here as part of your pull requests whenever possible)
 
+Cold-Staking Re-Activation
+--------------------------
+PIVX Core v6.0.0 includes a fix for the vulnerability identified within the cold-staking protocol (see PR [#2258](https://github.com/PIVX-Project/PIVX/pull/2258)).
+Therefore the feature will be re-enabled on the network, via `SPORK_19`, shortly after the upgrade enforcement.
+
+#### Protocol changes
+
+A new opcode (`0xd2`) is introduced (see PR [#2275](https://github.com/PIVX-Project/PIVX/pull/2275)). It enforces the same rules as the legacy cold-staking opcode, but without allowing a "free" script for the last output of the transaction.
+This is in accord with the consensus change introduced with the "Deterministic Masternodes" update, as masternode/budget payments are now outputs of the *coinbase* transaction (rather than the *coinstake*), therefore a "free" output for the coinstake is no longer needed.
+The new opcode takes the name of `OP_CHECKCOLDSTAKEVERIFY`, and the legacy opcode (`0xd1`) is renamed to `OP_CHECKCOLDSTAKEVERIFY_LOF` (last-output-free).
+Scripts with the old opcode are still accepted on the network (the restriction on the last-output is enforced after the script validation in this case), but the client creates new delegations with the new opcode, by default, after the upgrade enforcement.
+
+
 GUI changes
 -----------
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -90,6 +90,11 @@ bool WalletModel::isSaplingEnforced() const
     return Params().GetConsensus().NetworkUpgradeActive(cachedNumBlocks, Consensus::UPGRADE_V5_0);
 }
 
+bool WalletModel::isV6Enforced() const
+{
+    return Params().GetConsensus().NetworkUpgradeActive(cachedNumBlocks, Consensus::UPGRADE_V6_0);
+}
+
 bool WalletModel::isStakingStatusActive() const
 {
     return wallet && wallet->pStakerStatus && wallet->pStakerStatus->IsActive();
@@ -480,7 +485,8 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
                     return InvalidAddress;
                 }
 
-                scriptPubKey = GetScriptForStakeDelegation(*stakerId, *ownerId);
+                scriptPubKey = isV6Enforced() ? GetScriptForStakeDelegation(*stakerId, *ownerId)
+                                              : GetScriptForStakeDelegationLOF(*stakerId, *ownerId);
             } else {
                 // Regular P2PK or P2PKH
                 scriptPubKey = GetScriptForDestination(out);

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -156,6 +156,7 @@ public:
     bool isColdStakingNetworkelyEnabled() const;
     bool isSaplingInMaintenance() const;
     bool isSaplingEnforced() const;
+    bool isV6Enforced() const;
     CAmount getMinColdStakingAmount() const;
     /* current staking status from the miner thread **/
     bool isStakingStatusActive() const;

--- a/src/sapling/sapling_operation.h
+++ b/src/sapling/sapling_operation.h
@@ -51,8 +51,9 @@ struct SendManyRecipient
     {}
 
     // Transparent recipient: P2CS
-    SendManyRecipient(const CKeyID& ownerKey, const CKeyID& stakerKey, const CAmount& amount):
-        transparentRecipient(CTxOut(amount, GetScriptForStakeDelegation(stakerKey, ownerKey)))
+    SendManyRecipient(const CKeyID& ownerKey, const CKeyID& stakerKey, const CAmount& amount, bool fV6Enforced):
+        transparentRecipient(CTxOut(amount, fV6Enforced ? GetScriptForStakeDelegation(stakerKey, ownerKey)
+                                                        : GetScriptForStakeDelegationLOF(stakerKey, ownerKey)))
     {}
 
     // Transparent recipient: multisig

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -960,7 +960,7 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
                 }
                 break;
 
-                case OP_CHECKCOLDSTAKEVERIFY:
+                case OP_CHECKCOLDSTAKEVERIFY_LOF:
                 {
                     if (g_IsV6Active) {
                         // the stack can contain only <sig> <pk> <pkh> at this point

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -960,30 +960,16 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
                 }
                 break;
 
+                case OP_CHECKCOLDSTAKEVERIFY:
+                {
+                    return checker.CheckColdStake(false, script, stack, flags, serror);
+                }
+                break;
+
                 case OP_CHECKCOLDSTAKEVERIFY_LOF:
                 {
-                    if (g_IsV6Active) {
-                        // the stack can contain only <sig> <pk> <pkh> at this point
-                        if ((int)stack.size() != 3) {
-                            return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                        }
-                        // check pubkey/signature encoding
-                        valtype& vchSig    = stacktop(-3);
-                        valtype& vchPubKey = stacktop(-2);
-                        if (!CheckSignatureEncoding(vchSig, flags, serror) ||
-                                !CheckPubKeyEncoding(vchPubKey, flags, serror)) {
-                            // serror is set
-                            return false;
-                        }
-                        // check hash size
-                        valtype& vchPubKeyHash = stacktop(-1);
-                        if ((int)vchPubKeyHash.size() != 20) {
-                            return set_error(serror, SCRIPT_ERR_SCRIPT_SIZE);
-                        }
-                    }
-                    if(!checker.CheckColdStake(script)) {
-                        return set_error(serror, SCRIPT_ERR_CHECKCOLDSTAKEVERIFY);
-                    }
+                    // Allow last output script "free"
+                    return checker.CheckColdStake(true, script, stack, flags, serror);
                 }
                 break;
 
@@ -1357,36 +1343,59 @@ bool TransactionSignatureChecker::CheckLockTime(const CScriptNum& nLockTime) con
     return true;
 }
 
-bool TransactionSignatureChecker::CheckColdStake(const CScript& prevoutScript) const
+bool TransactionSignatureChecker::CheckColdStake(bool fAllowLastOutputFree, const CScript& prevoutScript, std::vector<valtype>& stack, unsigned int flags, ScriptError* serror) const
 {
+    if (g_IsV6Active) {
+        // the stack can contain only <sig> <pk> <pkh> at this point
+        if ((int)stack.size() != 3) {
+            return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+        }
+        // check pubkey/signature encoding
+        valtype& vchSig    = stacktop(-3);
+        valtype& vchPubKey = stacktop(-2);
+        if (!CheckSignatureEncoding(vchSig, flags, serror) ||
+                !CheckPubKeyEncoding(vchPubKey, flags, serror)) {
+            // serror is set
+            return false;
+        }
+        // check hash size
+        valtype& vchPubKeyHash = stacktop(-1);
+        if ((int)vchPubKeyHash.size() != 20) {
+            return set_error(serror, SCRIPT_ERR_SCRIPT_SIZE);
+        }
+    }
+
+    // check it is used in a valid cold stake transaction.
     // Transaction must be a coinstake tx
     if (!txTo->IsCoinStake()) {
-        return false;
+        return set_error(serror, SCRIPT_ERR_CHECKCOLDSTAKEVERIFY);
     }
     // There must be one single input
     if (txTo->vin.size() != 1) {
-        return false;
+        return set_error(serror, SCRIPT_ERR_CHECKCOLDSTAKEVERIFY);
     }
     // Since this is a coinstake, it has at least 2 outputs
     const unsigned int outs = txTo->vout.size();
     assert(outs >= 2);
-    // All outputs, except the first, and (for cold stakes with outs >=3) the last one,
-    // must have the same pubKeyScript, and it must match the script we are spending.
-    // If the coinstake has at least 3 outputs, the last one is left free, to be used for
-    // budget/masternode payments, and is checked in CheckColdstakeFreeOutput().
+    // All outputs must have the same pubKeyScript, and it must match the script we are spending.
+    // If the coinstake has at least 3 outputs, the last one can be left free, to be used for
+    // budget/masternode payments (before v6.0 enforcement), and is checked in CheckColdstakeFreeOutput().
     // Here we verify only that input amount goes to the non-free outputs.
     CAmount outValue{0};
     for (unsigned int i = 1; i < outs; i++) {
         if (txTo->vout[i].scriptPubKey != prevoutScript) {
-            // Only the last one can be different (and only when outs >=3)
-            if (i != outs-1 || outs < 3) {
-                return false;
+            // Only the last one can be different (and only when outs >=3 and fAllowLastOutputFree=true)
+            if (!fAllowLastOutputFree || i != outs-1 || outs < 3) {
+                return set_error(serror, SCRIPT_ERR_CHECKCOLDSTAKEVERIFY);
             }
         } else {
             outValue += txTo->vout[i].nValue;
         }
     }
-    return outValue > amount;
+    if (outValue < amount) {
+        return set_error(serror, SCRIPT_ERR_CHECKCOLDSTAKEVERIFY);
+    }
+    return true;
 }
 
 

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -107,7 +107,7 @@ public:
          return false;
     }
 
-    virtual bool CheckColdStake(const CScript& script) const
+    virtual bool CheckColdStake(bool fAllowLastOutputFree, const CScript& prevoutScript, std::vector<valtype>& stack, unsigned int flags, ScriptError* error) const
     {
          return false;
     }
@@ -132,7 +132,7 @@ public:
 
     bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const override ;
     bool CheckLockTime(const CScriptNum& nLockTime) const override;
-    bool CheckColdStake(const CScript& prevoutScript) const override;
+    bool CheckColdStake(bool fAllowLastOutputFree, const CScript& prevoutScript, std::vector<valtype>& stack, unsigned int flags, ScriptError* serror) const override;
 };
 
 class MutableTransactionSignatureChecker : public TransactionSignatureChecker

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -149,6 +149,7 @@ const char* GetOpName(opcodetype opcode)
 
     // cold staking
     case OP_CHECKCOLDSTAKEVERIFY_LOF   : return "OP_CHECKCOLDSTAKEVERIFY_LOF";
+    case OP_CHECKCOLDSTAKEVERIFY       : return "OP_CHECKCOLDSTAKEVERIFY";
 
     case OP_INVALIDOPCODE          : return "OP_INVALIDOPCODE";
 
@@ -229,6 +230,7 @@ bool CScript::IsPayToScriptHash() const
 // can be removed once v6 enforcement is activated.
 std::atomic<bool> g_IsV6Active{false};
 
+// P2CS script: either with or without last output free
 bool CScript::IsPayToColdStaking() const
 {
     return (this->size() == 51 &&
@@ -236,13 +238,18 @@ bool CScript::IsPayToColdStaking() const
             (!g_IsV6Active || (*this)[1] == OP_HASH160) &&
             (*this)[2] == OP_ROT &&
             (!g_IsV6Active || (*this)[3] == OP_IF) &&
-            (*this)[4] == OP_CHECKCOLDSTAKEVERIFY_LOF &&
+            ((*this)[4] == OP_CHECKCOLDSTAKEVERIFY || (*this)[4] == OP_CHECKCOLDSTAKEVERIFY_LOF) &&
             (*this)[5] == 0x14 &&
             (!g_IsV6Active || (*this)[26] == OP_ELSE) &&
             (*this)[27] == 0x14 &&
             (!g_IsV6Active || (*this)[48] == OP_ENDIF) &&
             (*this)[49] == OP_EQUALVERIFY &&
             (*this)[50] == OP_CHECKSIG);
+}
+
+bool CScript::IsPayToColdStakingLOF() const
+{
+    return IsPayToColdStaking() && (*this)[4] == OP_CHECKCOLDSTAKEVERIFY_LOF;
 }
 
 bool CScript::StartsWithOpcode(const opcodetype opcode) const

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -148,7 +148,7 @@ const char* GetOpName(opcodetype opcode)
     case OP_ZEROCOINPUBLICSPEND    : return "OP_ZEROCOINPUBLICSPEND";
 
     // cold staking
-    case OP_CHECKCOLDSTAKEVERIFY   : return "OP_CHECKCOLDSTAKEVERIFY";
+    case OP_CHECKCOLDSTAKEVERIFY_LOF   : return "OP_CHECKCOLDSTAKEVERIFY_LOF";
 
     case OP_INVALIDOPCODE          : return "OP_INVALIDOPCODE";
 
@@ -236,7 +236,7 @@ bool CScript::IsPayToColdStaking() const
             (!g_IsV6Active || (*this)[1] == OP_HASH160) &&
             (*this)[2] == OP_ROT &&
             (!g_IsV6Active || (*this)[3] == OP_IF) &&
-            (*this)[4] == OP_CHECKCOLDSTAKEVERIFY &&
+            (*this)[4] == OP_CHECKCOLDSTAKEVERIFY_LOF &&
             (*this)[5] == 0x14 &&
             (!g_IsV6Active || (*this)[26] == OP_ELSE) &&
             (*this)[27] == 0x14 &&

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -184,7 +184,7 @@ enum opcodetype
     OP_ZEROCOINPUBLICSPEND = 0xc3,
 
     // cold staking
-    OP_CHECKCOLDSTAKEVERIFY = 0xd1,
+    OP_CHECKCOLDSTAKEVERIFY_LOF = 0xd1,     // last output free for masternode/budget payments
 
     OP_INVALIDOPCODE = 0xff,
 };

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -185,6 +185,7 @@ enum opcodetype
 
     // cold staking
     OP_CHECKCOLDSTAKEVERIFY_LOF = 0xd1,     // last output free for masternode/budget payments
+    OP_CHECKCOLDSTAKEVERIFY = 0xd2,
 
     OP_INVALIDOPCODE = 0xff,
 };
@@ -632,6 +633,7 @@ public:
     bool IsPayToPublicKeyHash() const;
     bool IsPayToScriptHash() const;
     bool IsPayToColdStaking() const;
+    bool IsPayToColdStakingLOF() const;
     bool StartsWithOpcode(const opcodetype opcode) const;
     bool IsZerocoinMint() const;
     bool IsZerocoinSpend() const;

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -299,7 +299,7 @@ CScript GetScriptForStakeDelegation(const CKeyID& stakingKey, const CKeyID& spen
 {
     CScript script;
     script << OP_DUP << OP_HASH160 << OP_ROT <<
-            OP_IF << OP_CHECKCOLDSTAKEVERIFY << ToByteVector(stakingKey) <<
+            OP_IF << OP_CHECKCOLDSTAKEVERIFY_LOF << ToByteVector(stakingKey) <<
             OP_ELSE << ToByteVector(spendingKey) << OP_ENDIF <<
             OP_EQUALVERIFY << OP_CHECKSIG;
     return script;

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -299,6 +299,16 @@ CScript GetScriptForStakeDelegation(const CKeyID& stakingKey, const CKeyID& spen
 {
     CScript script;
     script << OP_DUP << OP_HASH160 << OP_ROT <<
+            OP_IF << OP_CHECKCOLDSTAKEVERIFY << ToByteVector(stakingKey) <<
+            OP_ELSE << ToByteVector(spendingKey) << OP_ENDIF <<
+            OP_EQUALVERIFY << OP_CHECKSIG;
+    return script;
+}
+
+CScript GetScriptForStakeDelegationLOF(const CKeyID& stakingKey, const CKeyID& spendingKey)
+{
+    CScript script;
+    script << OP_DUP << OP_HASH160 << OP_ROT <<
             OP_IF << OP_CHECKCOLDSTAKEVERIFY_LOF << ToByteVector(stakingKey) <<
             OP_ELSE << ToByteVector(spendingKey) << OP_ENDIF <<
             OP_EQUALVERIFY << OP_CHECKSIG;

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -84,6 +84,7 @@ CScript GetScriptForDestination(const CTxDestination& dest);
 CScript GetScriptForRawPubKey(const CPubKey& pubKey);
 CScript GetScriptForMultisig(int nRequired, const std::vector<CPubKey>& keys);
 CScript GetScriptForStakeDelegation(const CKeyID& stakingKey, const CKeyID& spendingKey);
+CScript GetScriptForStakeDelegationLOF(const CKeyID& stakingKey, const CKeyID& spendingKey);
 CScript GetScriptForOpReturn(const uint256& message);
 
 #endif // BITCOIN_SCRIPT_STANDARD_H

--- a/src/test/script_P2CS_tests.cpp
+++ b/src/test/script_P2CS_tests.cpp
@@ -206,7 +206,7 @@ static CScript GetFakeLockingScript(const CKeyID staker, const CKeyID& owner)
 {
     CScript script;
     script << opcodetype(0x2F) << opcodetype(0x01) << OP_ROT <<
-            OP_IF << OP_CHECKCOLDSTAKEVERIFY << ToByteVector(staker) <<
+            OP_IF << OP_CHECKCOLDSTAKEVERIFY_LOF << ToByteVector(staker) <<
             OP_ELSE << ToByteVector(owner) << OP_DROP <<
             OP_EQUALVERIFY << OP_CHECKSIG;
 

--- a/src/test/script_P2CS_tests.cpp
+++ b/src/test/script_P2CS_tests.cpp
@@ -57,12 +57,12 @@ BOOST_AUTO_TEST_CASE(extract_cold_staking_destination_keys)
     CheckValidKeyId(destVector[1], ownerId);
 }
 
-static CScript GetNewP2CS(CKey& stakerKey, CKey& ownerKey)
+static CScript GetNewP2CS(CKey& stakerKey, CKey& ownerKey, bool fLastOutFree)
 {
     stakerKey = DecodeSecret("91yo52JPHDVUG3jXWLKGyzEdjn1a9nbnurLdmQEf2UzbgzkTc2c");
     ownerKey = DecodeSecret("92KgNFNfmVVJRQuzssETc7NhwufGuHsLvPQxW9Nwmxs7PB4ByWB");
-    return GetScriptForStakeDelegation(stakerKey.GetPubKey().GetID(),
-                                       ownerKey.GetPubKey().GetID());
+    return fLastOutFree ? GetScriptForStakeDelegationLOF(stakerKey.GetPubKey().GetID(), ownerKey.GetPubKey().GetID())
+                        : GetScriptForStakeDelegation(stakerKey.GetPubKey().GetID(), ownerKey.GetPubKey().GetID());
 }
 
 static CScript GetDummyP2CS(const CKeyID& dummyKeyID)
@@ -78,9 +78,9 @@ static CScript GetDummyP2PKH(const CKeyID& dummyKeyID)
 static const CAmount amtIn = 200 * COIN;
 static const unsigned int flags = STANDARD_SCRIPT_VERIFY_FLAGS;
 
-static CMutableTransaction CreateNewColdStakeTx(CScript& scriptP2CS, CKey& stakerKey, CKey& ownerKey)
+static CMutableTransaction CreateNewColdStakeTx(CScript& scriptP2CS, CKey& stakerKey, CKey& ownerKey, bool fLastOutFree)
 {
-    scriptP2CS = GetNewP2CS(stakerKey, ownerKey);
+    scriptP2CS = GetNewP2CS(stakerKey, ownerKey, fLastOutFree);
 
     // Create prev transaction:
     CMutableTransaction txFrom;
@@ -122,14 +122,14 @@ static bool CheckP2CSScript(const CScript& scriptSig, const CScript& scriptPubKe
     return VerifyScript(scriptSig, scriptPubKey, flags, MutableTransactionSignatureChecker(&tx, 0, amtIn), tx.GetRequiredSigVersion(), &err);
 }
 
-BOOST_AUTO_TEST_CASE(coldstake_script)
+BOOST_AUTO_TEST_CASE(coldstake_lof_script)
 {
     SelectParams(CBaseChainParams::REGTEST);
     CScript scriptP2CS;
     CKey stakerKey, ownerKey;
 
     // create unsigned coinstake transaction
-    CMutableTransaction good_tx = CreateNewColdStakeTx(scriptP2CS, stakerKey, ownerKey);
+    CMutableTransaction good_tx = CreateNewColdStakeTx(scriptP2CS, stakerKey, ownerKey, true);
 
     // sign the input with the staker key
     SignColdStake(good_tx, 0, scriptP2CS, stakerKey, true);
@@ -160,8 +160,8 @@ BOOST_AUTO_TEST_CASE(coldstake_script)
     BOOST_CHECK(CheckP2CSScript(tx.vin[0].scriptSig, scriptP2CS, tx, err));
 
     // Transfer more coins to the masternode
-    tx.vout[2].nValue -= 2 * COIN;
-    tx.vout[3].nValue += 2 * COIN;
+    tx.vout[2].nValue -= 3 * COIN;
+    tx.vout[3].nValue += 3 * COIN;
     SignColdStake(tx, 0, scriptP2CS, stakerKey, true);
     BOOST_CHECK(!CheckP2CSScript(tx.vin[0].scriptSig, scriptP2CS, tx, err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_CHECKCOLDSTAKEVERIFY, ScriptErrorString(err));

--- a/test/functional/mining_pos_coldStaking.py
+++ b/test/functional/mining_pos_coldStaking.py
@@ -25,7 +25,7 @@ from decimal import Decimal
 
 # filter utxos based on first 5 bytes of scriptPubKey
 def getDelegatedUtxos(utxos):
-    return [x for x in utxos if x["scriptPubKey"][:10] == '76a97b63d1']
+    return [x for x in utxos if x["scriptPubKey"][:10] == '76a97b63d1' or x["scriptPubKey"][:10] == '76a97b63d2']
 
 
 class PIVX_ColdStakingTest(PivxTestFramework):
@@ -340,7 +340,7 @@ class PIVX_ColdStakingTest(PivxTestFramework):
         # Try to submit the block
         ret = self.nodes[1].submitblock(bytes_to_hex_str(new_block.serialize()))
         self.log.info("Block %s submitted." % new_block.hash)
-        assert_equal(ret, "bad-p2cs-outs")
+        assert ret in ["bad-p2cs-outs", "rejected"]
 
         # Verify that nodes[0] rejects it
         self.sync_blocks()


### PR DESCRIPTION
Extracted from #2267, and rebased on top of #2258.
Given the consensus change, introduced in #2274, we can define a more secure `OP_CHECKCOLDSTAKEVERIFY` opcode, which doesn't leave the last output of the coinstake "free" (as we no longer pay masternode/budgets in the coinstake tx).

Built on top of:
- [x] #2258
- [x] #2274