### PR TITLE
[GUI] RPC-Console support nested commands and simple value queries

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -163,9 +163,7 @@ BITCOIN_MM = \
 
 QT_MOC = \
   qt/pivx.moc \
-  qt/intro.moc \
-  qt/rpcconsole.moc \
-  qt/pivx/settings/moc_settingsconsolewidget.cpp
+  qt/intro.moc
 
 QT_QRC_CPP = qt/qrc_pivx.cpp
 QT_QRC = qt/pivx.qrc

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -95,6 +95,7 @@ QT_MOC_CPP = \
   qt/moc_qvaluecombobox.cpp \
   qt/moc_recentrequeststablemodel.cpp \
   qt/moc_rpcconsole.cpp \
+  qt/moc_rpcexecutor.cpp \
   qt/moc_trafficgraphwidget.cpp \
   qt/moc_transactionfilterproxy.cpp \
   qt/moc_transactiontablemodel.cpp \
@@ -206,6 +207,7 @@ BITCOIN_QT_H = \
   qt/qvaluecombobox.h \
   qt/recentrequeststablemodel.h \
   qt/rpcconsole.h \
+  qt/rpcexecutor.h \
   qt/trafficgraphwidget.h \
   qt/transactionfilterproxy.h \
   qt/transactionrecord.h \
@@ -518,6 +520,7 @@ BITCOIN_QT_BASE_CPP = \
   qt/qvalidatedlineedit.cpp \
   qt/qvaluecombobox.cpp \
   qt/rpcconsole.cpp \
+  qt/rpcexecutor.cpp \
   qt/trafficgraphwidget.cpp \
   qt/utilitydialog.cpp
 

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -175,13 +175,6 @@ SET(QT_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/pivx/splash.cpp
         )
 
-# Workaround until the old rpcconsole UI window is fully removed
-set_property(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/pivx/settings/settingsconsolewidget.cpp PROPERTY SKIP_AUTOMOC ON)
-execute_process(
-        COMMAND ${MOC_BIN} -o moc_settingsconsolewidget.cpp settingsconsolewidget.h
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/pivx/settings
-)
-
 execute_process(
         COMMAND ${MOC_BIN} -o moc_pfborderimage.cpp pfborderimage.h
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/pivx

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -94,6 +94,7 @@ SET(QT_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/qvalidatedlineedit.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/qvaluecombobox.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/rpcconsole.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/rpcexecutor.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/trafficgraphwidget.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/utilitydialog.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/addressbookpage.cpp

--- a/src/qt/pivx/settings/settingsconsolewidget.cpp
+++ b/src/qt/pivx/settings/settingsconsolewidget.cpp
@@ -4,15 +4,15 @@
 
 #include "qt/pivx/settings/settingsconsolewidget.h"
 #include "qt/pivx/settings/forms/ui_settingsconsolewidget.h"
+#include "qt/pivx/settings/moc_settingsconsolewidget.cpp"
 
 #include "qt/pivx/qtutils.h"
+#include "qt/rpcexecutor.h"
 
 #include "clientmodel.h"
 #include "guiutil.h"
 
 #include "chainparams.h"
-#include "rpc/client.h"
-#include "rpc/server.h"
 #include "sapling/key_io_sapling.h"
 #include "util.h"
 #include "utilitydialog.h"
@@ -37,7 +37,6 @@
 #include <QSignalMapper>
 #include <QThread>
 #include <QTime>
-#include <QTimer>
 #include <QStringList>
 
 const int CONSOLE_HISTORY = 50;
@@ -51,270 +50,6 @@ const struct {
         {"cmd-error", ":/icons/ic-transaction-sent"},
         {"misc", ":/icons/ic-transaction-staked"},
         {NULL, NULL}};
-
-/* Object for executing console RPC commands in a separate thread.
-*/
-class RPCExecutor : public QObject
-{
-    Q_OBJECT
-
-public Q_SLOTS:
-     void requestCommand(const QString& command);
-
-Q_SIGNALS:
-     void reply(int category, const QString& command);
-};
-
-/** Class for handling RPC timers
- * (used for e.g. re-locking the wallet after a timeout)
- */
-class QtRPCTimerBase: public QObject, public RPCTimerBase
-{
-    Q_OBJECT
-public:
-    QtRPCTimerBase(std::function<void(void)>& _func, int64_t millis):
-            func(_func)
-    {
-        timer.setSingleShot(true);
-        connect(&timer, &QTimer::timeout, [this]{ func(); });
-        timer.start(millis);
-    }
-    ~QtRPCTimerBase() {}
-
-private:
-    QTimer timer;
-    std::function<void(void)> func;
-};
-
-class QtRPCTimerInterface: public RPCTimerInterface
-{
-public:
-    ~QtRPCTimerInterface() {}
-    const char *Name() { return "Qt"; }
-    RPCTimerBase* NewTimer(std::function<void(void)>& func, int64_t millis)
-    {
-        return new QtRPCTimerBase(func, millis);
-    }
-};
-
-#include "qt/pivx/settings/moc_settingsconsolewidget.cpp"
-
-/**
- * Split shell command line into a list of arguments and execute the command(s).
- * Aims to emulate \c bash and friends.
- *
- * - Command nesting is possible with brackets [example: validateaddress(getnewaddress())]
- * - Arguments are delimited with whitespace or comma
- * - Extra whitespace at the beginning and end and between arguments will be ignored
- * - Text can be "double" or 'single' quoted
- * - The backslash \c \ is used as escape character
- *   - Outside quotes, any character can be escaped
- *   - Within double quotes, only escape \c " and backslashes before a \c " or another backslash
- *   - Within single quotes, no escaping is possible and no special interpretation takes place
- *
- * @param[out]   result      stringified Result from the executed command(chain)
- * @param[in]    strCommand  Command line to split
- */
-bool RPCExecuteCommandLine(std::string &strResult, const std::string &strCommand)
-{
-    std::vector< std::vector<std::string> > stack;
-    stack.push_back(std::vector<std::string>());
-
-    enum CmdParseState
-    {
-        STATE_EATING_SPACES,
-        STATE_ARGUMENT,
-        STATE_SINGLEQUOTED,
-        STATE_DOUBLEQUOTED,
-        STATE_ESCAPE_OUTER,
-        STATE_ESCAPE_DOUBLEQUOTED,
-        STATE_COMMAND_EXECUTED,
-        STATE_COMMAND_EXECUTED_INNER
-    } state = STATE_EATING_SPACES;
-    std::string curarg;
-    UniValue lastResult;
-
-    std::string strCommandTerminated = strCommand;
-    if (strCommandTerminated.back() != '\n')
-        strCommandTerminated += "\n";
-    for(char ch: strCommandTerminated)
-    {
-        switch(state)
-        {
-            case STATE_COMMAND_EXECUTED_INNER:
-            case STATE_COMMAND_EXECUTED:
-            {
-                bool breakParsing = true;
-                switch(ch)
-                {
-                    case '[': curarg.clear(); state = STATE_COMMAND_EXECUTED_INNER; break;
-                    default:
-                        if (state == STATE_COMMAND_EXECUTED_INNER)
-                        {
-                            if (ch != ']')
-                            {
-                                // append char to the current argument (which is also used for the query command)
-                                curarg += ch;
-                                break;
-                            }
-                            if (curarg.size())
-                            {
-                                // if we have a value query, query arrays with index and objects with a string key
-                                UniValue subelement;
-                                if (lastResult.isArray())
-                                {
-                                    for(char argch: curarg)
-                                        if (!std::isdigit(argch))
-                                            throw std::runtime_error("Invalid result query");
-                                    subelement = lastResult[atoi(curarg.c_str())];
-                                }
-                                else if (lastResult.isObject())
-                                    subelement = find_value(lastResult, curarg);
-                                else
-                                    throw std::runtime_error("Invalid result query"); //no array or object: abort
-                                lastResult = subelement;
-                            }
-
-                            state = STATE_COMMAND_EXECUTED;
-                            break;
-                        }
-                        // don't break parsing when the char is required for the next argument
-                        breakParsing = false;
-
-                        // pop the stack and return the result to the current command arguments
-                        stack.pop_back();
-
-                        // don't stringify the json in case of a string to avoid doublequotes
-                        if (lastResult.isStr())
-                            curarg = lastResult.get_str();
-                        else
-                            curarg = lastResult.write(2);
-
-                        // if we have a non empty result, use it as stack argument otherwise as general result
-                        if (curarg.size())
-                        {
-                            if (stack.size())
-                                stack.back().push_back(curarg);
-                            else
-                                strResult = curarg;
-                        }
-                        curarg.clear();
-                        // assume eating space state
-                        state = STATE_EATING_SPACES;
-                }
-                if (breakParsing)
-                    break;
-            }
-            case STATE_ARGUMENT: // In or after argument
-            case STATE_EATING_SPACES: // Handle runs of whitespace
-                switch(ch)
-            {
-                case '"': state = STATE_DOUBLEQUOTED; break;
-                case '\'': state = STATE_SINGLEQUOTED; break;
-                case '\\': state = STATE_ESCAPE_OUTER; break;
-                case '(': case ')': case '\n':
-                    if (state == STATE_ARGUMENT)
-                    {
-                        if (ch == '(' && stack.size() && stack.back().size() > 0)
-                            stack.push_back(std::vector<std::string>());
-                        if (curarg.size())
-                        {
-                            // don't allow commands after executed commands on baselevel
-                            if (!stack.size())
-                                throw std::runtime_error("Invalid Syntax");
-                            stack.back().push_back(curarg);
-                        }
-                        curarg.clear();
-                        state = STATE_EATING_SPACES;
-                    }
-                    if ((ch == ')' || ch == '\n') && stack.size() > 0)
-                    {
-                        std::string strPrint;
-                        // Convert argument list to JSON objects in method-dependent way,
-                        // and pass it along with the method name to the dispatcher.
-                        JSONRPCRequest req;
-                        req.params = RPCConvertValues(stack.back()[0], std::vector<std::string>(stack.back().begin() + 1, stack.back().end()));
-                        req.strMethod = stack.back()[0];
-                        lastResult = tableRPC.execute(req);
-                        state = STATE_COMMAND_EXECUTED;
-                        curarg.clear();
-                    }
-                    break;
-                case ' ': case ',': case '\t':
-                    if(state == STATE_ARGUMENT) // Space ends argument
-                    {
-                        if (curarg.size())
-                            stack.back().push_back(curarg);
-                        curarg.clear();
-                    }
-                    state = STATE_EATING_SPACES;
-                    break;
-                default: curarg += ch; state = STATE_ARGUMENT;
-            }
-                break;
-            case STATE_SINGLEQUOTED: // Single-quoted string
-                switch(ch)
-            {
-                case '\'': state = STATE_ARGUMENT; break;
-                default: curarg += ch;
-            }
-                break;
-            case STATE_DOUBLEQUOTED: // Double-quoted string
-                switch(ch)
-            {
-                case '"': state = STATE_ARGUMENT; break;
-                case '\\': state = STATE_ESCAPE_DOUBLEQUOTED; break;
-                default: curarg += ch;
-            }
-                break;
-            case STATE_ESCAPE_OUTER: // '\' outside quotes
-                curarg += ch; state = STATE_ARGUMENT;
-                break;
-            case STATE_ESCAPE_DOUBLEQUOTED: // '\' in double-quoted text
-                if(ch != '"' && ch != '\\') curarg += '\\'; // keep '\' for everything but the quote and '\' itself
-                curarg += ch; state = STATE_DOUBLEQUOTED;
-                break;
-        }
-    }
-    switch (state) // final state
-    {
-        case STATE_COMMAND_EXECUTED:
-            if (lastResult.isStr())
-                strResult = lastResult.get_str();
-            else
-                strResult = lastResult.write(2);
-        case STATE_ARGUMENT:
-        case STATE_EATING_SPACES:
-            return true;
-        default: // ERROR to end in one of the other states
-            return false;
-    }
-}
-
-void RPCExecutor::requestCommand(const QString& command)
-{
-    try {
-        std::string result;
-        std::string executableCommand = command.toStdString() + "\n";
-        if (!RPCExecuteCommandLine(result, executableCommand)) {
-            Q_EMIT reply(SettingsConsoleWidget::CMD_ERROR, QString("Parse error: unbalanced ' or \""));
-            return;
-        }
-        Q_EMIT reply(SettingsConsoleWidget::CMD_REPLY, QString::fromStdString(result));
-    } catch (UniValue& objError) {
-        try // Nice formatting for standard-format error
-        {
-            int code = find_value(objError, "code").get_int();
-            std::string message = find_value(objError, "message").get_str();
-            Q_EMIT reply(RPCConsole::CMD_ERROR, QString::fromStdString(message) + " (code " + QString::number(code) + ")");
-        } catch (const std::runtime_error&) // raised when converting to invalid type, i.e. missing code or message
-        {                             // Show raw JSON object
-            Q_EMIT reply(RPCConsole::CMD_ERROR, QString::fromStdString(objError.write()));
-        }
-    } catch (const std::exception& e) {
-        Q_EMIT reply(RPCConsole::CMD_ERROR, QString("Error: ") + QString::fromStdString(e.what()));
-    }
-}
 
 SettingsConsoleWidget::SettingsConsoleWidget(PIVXGUI* _window, QWidget *parent) :
     PWidget(_window,parent),
@@ -460,20 +195,6 @@ void SettingsConsoleWidget::showEvent(QShowEvent *event)
     if (ui->lineEdit) ui->lineEdit->setFocus();
 }
 
-static QString categoryClass(int category)
-{
-    switch (category) {
-        case SettingsConsoleWidget::CMD_REQUEST:
-            return "cmd-request";
-        case SettingsConsoleWidget::CMD_REPLY:
-            return "cmd-reply";
-        case SettingsConsoleWidget::CMD_ERROR:
-            return "cmd-error";
-        default:
-            return "misc";
-    }
-}
-
 void SettingsConsoleWidget::clear(bool clearHistory)
 {
     ui->messagesWidget->clear();
@@ -502,7 +223,7 @@ void SettingsConsoleWidget::clear(bool clearHistory)
     QString clsKey = "Ctrl-L";
 #endif
 
-    messageInternal(CMD_REPLY, (tr("Welcome to the PIVX RPC console.") + "<br>" +
+    messageInternal(RPCExecutor::CMD_REPLY, (tr("Welcome to the PIVX RPC console.") + "<br>" +
                         tr("Use up and down arrows to navigate history, and %1 to clear screen.").arg("<b>"+clsKey+"</b>") + "<br>" +
                         tr("Type <b>help</b> for an overview of available commands.") +
                         "<br><span class=\"secwarning\"><br>" +
@@ -517,8 +238,8 @@ void SettingsConsoleWidget::messageInternal(int category, const QString& message
     QString timeString = time.toString();
     QString out;
     out += "<table><tr><td class=\"time\" width=\"65\">" + timeString + "</td>";
-    out += "<td class=\"icon\" width=\"32\"><img src=\"" + categoryClass(category) + "\"></td>";
-    out += "<td class=\"message " + categoryClass(category) + "\" valign=\"middle\">";
+    out += "<td class=\"icon\" width=\"32\"><img src=\"" + RPCExecutor::categoryClass(category) + "\"></td>";
+    out += "<td class=\"message " + RPCExecutor::categoryClass(category) + "\" valign=\"middle\">";
     if (html)
         out += message;
     else
@@ -555,7 +276,7 @@ void SettingsConsoleWidget::on_lineEdit_returnPressed()
             return;
         }
 
-        messageInternal(CMD_REQUEST, cmd);
+        messageInternal(RPCExecutor::CMD_REQUEST, cmd);
         Q_EMIT cmdCommandRequest(cmd);
         // Remove command, if already in history
         history.removeOne(cmd);
@@ -594,7 +315,7 @@ void SettingsConsoleWidget::startExecutor()
     // Replies from executor object must go to this object
     connect(executor, &RPCExecutor::reply, this, &SettingsConsoleWidget::response);
     // Requests from this object must go to executor
-    connect(this, &SettingsConsoleWidget::cmdCommandRequest, executor, &RPCExecutor::requestCommand);
+    connect(this, &SettingsConsoleWidget::cmdCommandRequest, executor, &RPCExecutor::request);
 
     // On stopExecutor signal
     // - queue executor for deletion (in execution thread)

--- a/src/qt/pivx/settings/settingsconsolewidget.h
+++ b/src/qt/pivx/settings/settingsconsolewidget.h
@@ -34,14 +34,6 @@ public:
     void loadClientModel() override;
     void showEvent(QShowEvent *event) override;
 
-    enum MessageClass {
-        MC_ERROR,
-        MC_DEBUG,
-        CMD_REQUEST,
-        CMD_REPLY,
-        CMD_ERROR
-    };
-
 public Q_SLOTS:
     void clear(bool clearHistory = true);
     void response(int category, const QString &message) { messageInternal(category, message); };

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -20,8 +20,6 @@
 #include "wallet/wallet.h"
 #endif // ENABLE_WALLET
 
-#include <univalue.h>
-
 #ifdef ENABLE_WALLET
 #include <db_cxx.h>
 #endif
@@ -61,8 +59,6 @@ const struct {
     {"cmd-error", ":/icons/tx_output"},
     {"misc", ":/icons/tx_inout"},
     {NULL, NULL}};
-
-#include "rpcconsole.moc"
 
 RPCConsole::RPCConsole(QWidget* parent) : QDialog(parent, Qt::WindowSystemMenuHint | Qt::WindowTitleHint | Qt::WindowCloseButtonHint),
                                           ui(new Ui::RPCConsole),

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -11,11 +11,10 @@
 #include "clientmodel.h"
 #include "guiutil.h"
 #include "peertablemodel.h"
+#include "qt/rpcexecutor.h"
 
 #include "chainparams.h"
 #include "netbase.h"
-#include "rpc/client.h"
-#include "rpc/server.h"
 #include "util.h"
 #ifdef ENABLE_WALLET
 #include "wallet/wallet.h"
@@ -33,7 +32,6 @@
 #include <QScrollBar>
 #include <QThread>
 #include <QTime>
-#include <QTimer>
 #include <QStringList>
 
 // TODO: add a scrollback limit, as there is currently none
@@ -64,273 +62,7 @@ const struct {
     {"misc", ":/icons/tx_inout"},
     {NULL, NULL}};
 
-/* Object for executing console RPC commands in a separate thread.
-*/
-class RPCExecutor : public QObject
-{
-    Q_OBJECT
-
-public Q_SLOTS:
-    void request(const QString& command);
-
-Q_SIGNALS:
-    void reply(int category, const QString& command);
-};
-
-/** Class for handling RPC timers
- * (used for e.g. re-locking the wallet after a timeout)
- */
-class QtRPCTimerBase: public QObject, public RPCTimerBase
-{
-    Q_OBJECT
-public:
-    QtRPCTimerBase(std::function<void(void)>& _func, int64_t millis):
-        func(_func)
-    {
-        timer.setSingleShot(true);
-        connect(&timer, &QTimer::timeout, [this]{ func(); });
-        timer.start(millis);
-    }
-    ~QtRPCTimerBase() {}
-
-private:
-    QTimer timer;
-    std::function<void(void)> func;
-};
-
-class QtRPCTimerInterface: public RPCTimerInterface
-{
-public:
-    ~QtRPCTimerInterface() {}
-    const char *Name() { return "Qt"; }
-    RPCTimerBase* NewTimer(std::function<void(void)>& func, int64_t millis)
-    {
-        return new QtRPCTimerBase(func, millis);
-    }
-};
-
 #include "rpcconsole.moc"
-
-/**
- * Split shell command line into a list of arguments and execute the command(s).
- * Aims to emulate \c bash and friends.
- *
- * - Command nesting is possible with brackets [example: validateaddress(getnewaddress())]
- * - Arguments are delimited with whitespace or comma
- * - Extra whitespace at the beginning and end and between arguments will be ignored
- * - Text can be "double" or 'single' quoted
- * - The backslash \c \ is used as escape character
- *   - Outside quotes, any character can be escaped
- *   - Within double quotes, only escape \c " and backslashes before a \c " or another backslash
- *   - Within single quotes, no escaping is possible and no special interpretation takes place
- *
- * @param[out]   result      stringified Result from the executed command(chain)
- * @param[in]    strCommand  Command line to split
- */
-bool RPCConsole::RPCExecuteCommandLine(std::string &strResult, const std::string &strCommand)
-{
-    std::vector< std::vector<std::string> > stack;
-    stack.push_back(std::vector<std::string>());
-
-    enum CmdParseState
-    {
-        STATE_EATING_SPACES,
-        STATE_ARGUMENT,
-        STATE_SINGLEQUOTED,
-        STATE_DOUBLEQUOTED,
-        STATE_ESCAPE_OUTER,
-        STATE_ESCAPE_DOUBLEQUOTED,
-        STATE_COMMAND_EXECUTED,
-        STATE_COMMAND_EXECUTED_INNER
-    } state = STATE_EATING_SPACES;
-    std::string curarg;
-    UniValue lastResult;
-
-    std::string strCommandTerminated = strCommand;
-    if (strCommandTerminated.back() != '\n')
-        strCommandTerminated += "\n";
-    for(char ch: strCommandTerminated)
-    {
-        switch(state)
-        {
-            case STATE_COMMAND_EXECUTED_INNER:
-            case STATE_COMMAND_EXECUTED:
-            {
-                bool breakParsing = true;
-                switch(ch)
-                {
-                    case '[': curarg.clear(); state = STATE_COMMAND_EXECUTED_INNER; break;
-                    default:
-                        if (state == STATE_COMMAND_EXECUTED_INNER)
-                        {
-                            if (ch != ']')
-                            {
-                                // append char to the current argument (which is also used for the query command)
-                                curarg += ch;
-                                break;
-                            }
-                            if (curarg.size())
-                            {
-                                // if we have a value query, query arrays with index and objects with a string key
-                                UniValue subelement;
-                                if (lastResult.isArray())
-                                {
-                                    for(char argch: curarg)
-                                        if (!std::isdigit(argch))
-                                            throw std::runtime_error("Invalid result query");
-                                    subelement = lastResult[atoi(curarg.c_str())];
-                                }
-                                else if (lastResult.isObject())
-                                    subelement = find_value(lastResult, curarg);
-                                else
-                                    throw std::runtime_error("Invalid result query"); //no array or object: abort
-                                lastResult = subelement;
-                            }
-
-                            state = STATE_COMMAND_EXECUTED;
-                            break;
-                        }
-                        // don't break parsing when the char is required for the next argument
-                        breakParsing = false;
-
-                        // pop the stack and return the result to the current command arguments
-                        stack.pop_back();
-
-                        // don't stringify the json in case of a string to avoid doublequotes
-                        if (lastResult.isStr())
-                            curarg = lastResult.get_str();
-                        else
-                            curarg = lastResult.write(2);
-
-                        // if we have a non empty result, use it as stack argument otherwise as general result
-                        if (curarg.size())
-                        {
-                            if (stack.size())
-                                stack.back().push_back(curarg);
-                            else
-                                strResult = curarg;
-                        }
-                        curarg.clear();
-                        // assume eating space state
-                        state = STATE_EATING_SPACES;
-                }
-                if (breakParsing)
-                    break;
-            }
-            case STATE_ARGUMENT: // In or after argument
-            case STATE_EATING_SPACES: // Handle runs of whitespace
-                switch(ch)
-            {
-                case '"': state = STATE_DOUBLEQUOTED; break;
-                case '\'': state = STATE_SINGLEQUOTED; break;
-                case '\\': state = STATE_ESCAPE_OUTER; break;
-                case '(': case ')': case '\n':
-                    if (state == STATE_ARGUMENT)
-                    {
-                        if (ch == '(' && stack.size() && stack.back().size() > 0)
-                            stack.push_back(std::vector<std::string>());
-                        if (curarg.size())
-                        {
-                            // don't allow commands after executed commands on baselevel
-                            if (!stack.size())
-                                throw std::runtime_error("Invalid Syntax");
-                            stack.back().push_back(curarg);
-                        }
-                        curarg.clear();
-                        state = STATE_EATING_SPACES;
-                    }
-                    if ((ch == ')' || ch == '\n') && stack.size() > 0)
-                    {
-                        std::string strPrint;
-                        // Convert argument list to JSON objects in method-dependent way,
-                        // and pass it along with the method name to the dispatcher.
-                        JSONRPCRequest req;
-                        req.params = RPCConvertValues(stack.back()[0], std::vector<std::string>(stack.back().begin() + 1, stack.back().end()));
-                        req.strMethod = stack.back()[0];
-                        lastResult = tableRPC.execute(req);
-                        state = STATE_COMMAND_EXECUTED;
-                        curarg.clear();
-                    }
-                    break;
-                case ' ': case ',': case '\t':
-                    if(state == STATE_ARGUMENT) // Space ends argument
-                    {
-                        if (curarg.size())
-                            stack.back().push_back(curarg);
-                        curarg.clear();
-                    }
-                    state = STATE_EATING_SPACES;
-                    break;
-                default: curarg += ch; state = STATE_ARGUMENT;
-            }
-                break;
-            case STATE_SINGLEQUOTED: // Single-quoted string
-                switch(ch)
-            {
-                case '\'': state = STATE_ARGUMENT; break;
-                default: curarg += ch;
-            }
-                break;
-            case STATE_DOUBLEQUOTED: // Double-quoted string
-                switch(ch)
-            {
-                case '"': state = STATE_ARGUMENT; break;
-                case '\\': state = STATE_ESCAPE_DOUBLEQUOTED; break;
-                default: curarg += ch;
-            }
-                break;
-            case STATE_ESCAPE_OUTER: // '\' outside quotes
-                curarg += ch; state = STATE_ARGUMENT;
-                break;
-            case STATE_ESCAPE_DOUBLEQUOTED: // '\' in double-quoted text
-                if(ch != '"' && ch != '\\') curarg += '\\'; // keep '\' for everything but the quote and '\' itself
-                curarg += ch; state = STATE_DOUBLEQUOTED;
-                break;
-        }
-    }
-    switch (state) // final state
-    {
-        case STATE_COMMAND_EXECUTED:
-            if (lastResult.isStr())
-                strResult = lastResult.get_str();
-            else
-                strResult = lastResult.write(2);
-        case STATE_ARGUMENT:
-        case STATE_EATING_SPACES:
-            return true;
-        default: // ERROR to end in one of the other states
-            return false;
-    }
-}
-
-void RPCExecutor::request(const QString& command)
-{
-    try
-    {
-        std::string result;
-        std::string executableCommand = command.toStdString() + "\n";
-        if(!RPCConsole::RPCExecuteCommandLine(result, executableCommand))
-        {
-            Q_EMIT reply(RPCConsole::CMD_ERROR, QString("Parse error: unbalanced ' or \""));
-            return;
-        }
-        Q_EMIT reply(RPCConsole::CMD_REPLY, QString::fromStdString(result));
-    }
-    catch (UniValue& objError)
-    {
-        try // Nice formatting for standard-format error
-        {
-            int code = find_value(objError, "code").get_int();
-            std::string message = find_value(objError, "message").get_str();
-            Q_EMIT reply(RPCConsole::CMD_ERROR, QString::fromStdString(message) + " (code " + QString::number(code) + ")");
-        } catch (const std::runtime_error&) // raised when converting to invalid type, i.e. missing code or message
-        {                             // Show raw JSON object
-            Q_EMIT reply(RPCConsole::CMD_ERROR, QString::fromStdString(objError.write()));
-        }
-    } catch (const std::exception& e) {
-        Q_EMIT reply(RPCConsole::CMD_ERROR, QString("Error: ") + QString::fromStdString(e.what()));
-    }
-}
 
 RPCConsole::RPCConsole(QWidget* parent) : QDialog(parent, Qt::WindowSystemMenuHint | Qt::WindowTitleHint | Qt::WindowCloseButtonHint),
                                           ui(new Ui::RPCConsole),
@@ -572,23 +304,6 @@ void RPCConsole::setClientModel(ClientModel* model)
     }
 }
 
-static QString categoryClass(int category)
-{
-    switch (category) {
-    case RPCConsole::CMD_REQUEST:
-        return "cmd-request";
-        break;
-    case RPCConsole::CMD_REPLY:
-        return "cmd-reply";
-        break;
-    case RPCConsole::CMD_ERROR:
-        return "cmd-error";
-        break;
-    default:
-        return "misc";
-    }
-}
-
 /** Restart wallet with "-salvagewallet" */
 void RPCConsole::walletSalvage()
 {
@@ -701,7 +416,7 @@ void RPCConsole::clear()
     QString clsKey = "Ctrl-L";
 #endif
 
-    message(CMD_REPLY, (tr("Welcome to the PIVX RPC console.") + "<br>" +
+    message(RPCExecutor::CMD_REPLY, (tr("Welcome to the PIVX RPC console.") + "<br>" +
                         tr("Use up and down arrows to navigate history, and %1 to clear screen.").arg("<b>"+clsKey+"</b>") + "<br>" +
                         tr("Type <b>help</b> for an overview of available commands.") +
                         "<br><span class=\"secwarning\"><br>" +
@@ -723,8 +438,8 @@ void RPCConsole::message(int category, const QString& message, bool html)
     QString timeString = time.toString();
     QString out;
     out += "<table><tr><td class=\"time\" width=\"65\">" + timeString + "</td>";
-    out += "<td class=\"icon\" width=\"32\"><img src=\"" + categoryClass(category) + "\"></td>";
-    out += "<td class=\"message " + categoryClass(category) + "\" valign=\"middle\">";
+    out += "<td class=\"icon\" width=\"32\"><img src=\"" + RPCExecutor::categoryClass(category) + "\"></td>";
+    out += "<td class=\"message " + RPCExecutor::categoryClass(category) + "\" valign=\"middle\">";
     if (html)
         out += message;
     else
@@ -765,7 +480,7 @@ void RPCConsole::on_lineEdit_returnPressed()
     ui->lineEdit->clear();
 
     if (!cmd.isEmpty()) {
-        message(CMD_REQUEST, cmd);
+        message(RPCExecutor::CMD_REQUEST, cmd);
         Q_EMIT cmdRequest(cmd);
         // Remove command, if already in history
         history.removeOne(cmd);

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -112,9 +112,11 @@ public:
 #include "rpcconsole.moc"
 
 /**
- * Split shell command line into a list of arguments. Aims to emulate \c bash and friends.
+ * Split shell command line into a list of arguments and execute the command(s).
+ * Aims to emulate \c bash and friends.
  *
- * - Arguments are delimited with whitespace
+ * - Command nesting is possible with brackets [example: validateaddress(getnewaddress())]
+ * - Arguments are delimited with whitespace or comma
  * - Extra whitespace at the beginning and end and between arguments will be ignored
  * - Text can be "double" or 'single' quoted
  * - The backslash \c \ is used as escape character
@@ -122,121 +124,200 @@ public:
  *   - Within double quotes, only escape \c " and backslashes before a \c " or another backslash
  *   - Within single quotes, no escaping is possible and no special interpretation takes place
  *
- * @param[out]   args        Parsed arguments will be appended to this list
+ * @param[out]   result      stringified Result from the executed command(chain)
  * @param[in]    strCommand  Command line to split
  */
-bool parseCommandLine(std::vector<std::string>& args, const std::string& strCommand)
+bool RPCConsole::RPCExecuteCommandLine(std::string &strResult, const std::string &strCommand)
 {
-    enum CmdParseState {
+    std::vector< std::vector<std::string> > stack;
+    stack.push_back(std::vector<std::string>());
+
+    enum CmdParseState
+    {
         STATE_EATING_SPACES,
         STATE_ARGUMENT,
         STATE_SINGLEQUOTED,
         STATE_DOUBLEQUOTED,
         STATE_ESCAPE_OUTER,
-        STATE_ESCAPE_DOUBLEQUOTED
+        STATE_ESCAPE_DOUBLEQUOTED,
+        STATE_COMMAND_EXECUTED,
+        STATE_COMMAND_EXECUTED_INNER
     } state = STATE_EATING_SPACES;
     std::string curarg;
-    for (char ch : strCommand) {
-        switch (state) {
-        case STATE_ARGUMENT:      // In or after argument
-        case STATE_EATING_SPACES: // Handle runs of whitespace
-            switch (ch) {
-            case '"':
-                state = STATE_DOUBLEQUOTED;
-                break;
-            case '\'':
-                state = STATE_SINGLEQUOTED;
-                break;
-            case '\\':
-                state = STATE_ESCAPE_OUTER;
-                break;
-            case ' ':
-            case '\n':
-            case '\t':
-                if (state == STATE_ARGUMENT) // Space ends argument
+    UniValue lastResult;
+
+    std::string strCommandTerminated = strCommand;
+    if (strCommandTerminated.back() != '\n')
+        strCommandTerminated += "\n";
+    for(char ch: strCommandTerminated)
+    {
+        switch(state)
+        {
+            case STATE_COMMAND_EXECUTED_INNER:
+            case STATE_COMMAND_EXECUTED:
+            {
+                bool breakParsing = true;
+                switch(ch)
                 {
-                    args.push_back(curarg);
-                    curarg.clear();
+                    case '[': curarg.clear(); state = STATE_COMMAND_EXECUTED_INNER; break;
+                    default:
+                        if (state == STATE_COMMAND_EXECUTED_INNER)
+                        {
+                            if (ch != ']')
+                            {
+                                // append char to the current argument (which is also used for the query command)
+                                curarg += ch;
+                                break;
+                            }
+                            if (curarg.size())
+                            {
+                                // if we have a value query, query arrays with index and objects with a string key
+                                UniValue subelement;
+                                if (lastResult.isArray())
+                                {
+                                    for(char argch: curarg)
+                                        if (!std::isdigit(argch))
+                                            throw std::runtime_error("Invalid result query");
+                                    subelement = lastResult[atoi(curarg.c_str())];
+                                }
+                                else if (lastResult.isObject())
+                                    subelement = find_value(lastResult, curarg);
+                                else
+                                    throw std::runtime_error("Invalid result query"); //no array or object: abort
+                                lastResult = subelement;
+                            }
+
+                            state = STATE_COMMAND_EXECUTED;
+                            break;
+                        }
+                        // don't break parsing when the char is required for the next argument
+                        breakParsing = false;
+
+                        // pop the stack and return the result to the current command arguments
+                        stack.pop_back();
+
+                        // don't stringify the json in case of a string to avoid doublequotes
+                        if (lastResult.isStr())
+                            curarg = lastResult.get_str();
+                        else
+                            curarg = lastResult.write(2);
+
+                        // if we have a non empty result, use it as stack argument otherwise as general result
+                        if (curarg.size())
+                        {
+                            if (stack.size())
+                                stack.back().push_back(curarg);
+                            else
+                                strResult = curarg;
+                        }
+                        curarg.clear();
+                        // assume eating space state
+                        state = STATE_EATING_SPACES;
                 }
-                state = STATE_EATING_SPACES;
-                break;
-            default:
-                curarg += ch;
-                state = STATE_ARGUMENT;
+                if (breakParsing)
+                    break;
             }
-            break;
-        case STATE_SINGLEQUOTED: // Single-quoted string
-            switch (ch) {
-            case '\'':
-                state = STATE_ARGUMENT;
-                break;
-            default:
-                curarg += ch;
+            case STATE_ARGUMENT: // In or after argument
+            case STATE_EATING_SPACES: // Handle runs of whitespace
+                switch(ch)
+            {
+                case '"': state = STATE_DOUBLEQUOTED; break;
+                case '\'': state = STATE_SINGLEQUOTED; break;
+                case '\\': state = STATE_ESCAPE_OUTER; break;
+                case '(': case ')': case '\n':
+                    if (state == STATE_ARGUMENT)
+                    {
+                        if (ch == '(' && stack.size() && stack.back().size() > 0)
+                            stack.push_back(std::vector<std::string>());
+                        if (curarg.size())
+                        {
+                            // don't allow commands after executed commands on baselevel
+                            if (!stack.size())
+                                throw std::runtime_error("Invalid Syntax");
+                            stack.back().push_back(curarg);
+                        }
+                        curarg.clear();
+                        state = STATE_EATING_SPACES;
+                    }
+                    if ((ch == ')' || ch == '\n') && stack.size() > 0)
+                    {
+                        std::string strPrint;
+                        // Convert argument list to JSON objects in method-dependent way,
+                        // and pass it along with the method name to the dispatcher.
+                        JSONRPCRequest req;
+                        req.params = RPCConvertValues(stack.back()[0], std::vector<std::string>(stack.back().begin() + 1, stack.back().end()));
+                        req.strMethod = stack.back()[0];
+                        lastResult = tableRPC.execute(req);
+                        state = STATE_COMMAND_EXECUTED;
+                        curarg.clear();
+                    }
+                    break;
+                case ' ': case ',': case '\t':
+                    if(state == STATE_ARGUMENT) // Space ends argument
+                    {
+                        if (curarg.size())
+                            stack.back().push_back(curarg);
+                        curarg.clear();
+                    }
+                    state = STATE_EATING_SPACES;
+                    break;
+                default: curarg += ch; state = STATE_ARGUMENT;
             }
-            break;
-        case STATE_DOUBLEQUOTED: // Double-quoted string
-            switch (ch) {
-            case '"':
-                state = STATE_ARGUMENT;
                 break;
-            case '\\':
-                state = STATE_ESCAPE_DOUBLEQUOTED;
-                break;
-            default:
-                curarg += ch;
+            case STATE_SINGLEQUOTED: // Single-quoted string
+                switch(ch)
+            {
+                case '\'': state = STATE_ARGUMENT; break;
+                default: curarg += ch;
             }
-            break;
-        case STATE_ESCAPE_OUTER: // '\' outside quotes
-            curarg += ch;
-            state = STATE_ARGUMENT;
-            break;
-        case STATE_ESCAPE_DOUBLEQUOTED:                  // '\' in double-quoted text
-            if (ch != '"' && ch != '\\') curarg += '\\'; // keep '\' for everything but the quote and '\' itself
-            curarg += ch;
-            state = STATE_DOUBLEQUOTED;
-            break;
+                break;
+            case STATE_DOUBLEQUOTED: // Double-quoted string
+                switch(ch)
+            {
+                case '"': state = STATE_ARGUMENT; break;
+                case '\\': state = STATE_ESCAPE_DOUBLEQUOTED; break;
+                default: curarg += ch;
+            }
+                break;
+            case STATE_ESCAPE_OUTER: // '\' outside quotes
+                curarg += ch; state = STATE_ARGUMENT;
+                break;
+            case STATE_ESCAPE_DOUBLEQUOTED: // '\' in double-quoted text
+                if(ch != '"' && ch != '\\') curarg += '\\'; // keep '\' for everything but the quote and '\' itself
+                curarg += ch; state = STATE_DOUBLEQUOTED;
+                break;
         }
     }
     switch (state) // final state
     {
-    case STATE_EATING_SPACES:
-        return true;
-    case STATE_ARGUMENT:
-        args.push_back(curarg);
-        return true;
-    default: // ERROR to end in one of the other states
-        return false;
+        case STATE_COMMAND_EXECUTED:
+            if (lastResult.isStr())
+                strResult = lastResult.get_str();
+            else
+                strResult = lastResult.write(2);
+        case STATE_ARGUMENT:
+        case STATE_EATING_SPACES:
+            return true;
+        default: // ERROR to end in one of the other states
+            return false;
     }
 }
 
 void RPCExecutor::request(const QString& command)
 {
-    std::vector<std::string> args;
-    if (!parseCommandLine(args, command.toStdString())) {
-        Q_EMIT reply(RPCConsole::CMD_ERROR, QString("Parse error: unbalanced ' or \""));
-        return;
+    try
+    {
+        std::string result;
+        std::string executableCommand = command.toStdString() + "\n";
+        if(!RPCConsole::RPCExecuteCommandLine(result, executableCommand))
+        {
+            Q_EMIT reply(RPCConsole::CMD_ERROR, QString("Parse error: unbalanced ' or \""));
+            return;
+        }
+        Q_EMIT reply(RPCConsole::CMD_REPLY, QString::fromStdString(result));
     }
-    if (args.empty())
-        return; // Nothing to do
-    try {
-        std::string strPrint;
-        // Convert argument list to JSON objects in method-dependent way,
-        // and pass it along with the method name to the dispatcher.
-        JSONRPCRequest req;
-        req.params = RPCConvertValues(args[0], std::vector<std::string>(args.begin() + 1, args.end()));
-        req.strMethod = args[0];
-        UniValue result = tableRPC.execute(req);
-
-        // Format result reply
-        if (result.isNull())
-            strPrint = "";
-        else if (result.isStr())
-            strPrint = result.get_str();
-        else
-            strPrint = result.write(2);
-
-        Q_EMIT reply(RPCConsole::CMD_REPLY, QString::fromStdString(strPrint));
-    } catch (const UniValue& objError) {
+    catch (UniValue& objError)
+    {
         try // Nice formatting for standard-format error
         {
             int code = find_value(objError, "code").get_int();

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -36,18 +36,7 @@ public:
     explicit RPCConsole(QWidget* parent);
     ~RPCConsole();
 
-    static bool RPCExecuteCommandLine(std::string &strResult, const std::string &strCommand);
-
     void setClientModel(ClientModel* model);
-
-
-    enum MessageClass {
-        MC_ERROR,
-        MC_DEBUG,
-        CMD_REQUEST,
-        CMD_REPLY,
-        CMD_ERROR
-    };
 
 protected:
     virtual bool eventFilter(QObject* obj, QEvent* event);

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -36,7 +36,10 @@ public:
     explicit RPCConsole(QWidget* parent);
     ~RPCConsole();
 
+    static bool RPCExecuteCommandLine(std::string &strResult, const std::string &strCommand);
+
     void setClientModel(ClientModel* model);
+
 
     enum MessageClass {
         MC_ERROR,

--- a/src/qt/rpcexecutor.cpp
+++ b/src/qt/rpcexecutor.cpp
@@ -1,0 +1,250 @@
+// Copyright (c) 2011-2017 The Bitcoin developers
+// Copyright (c) 2015-2021 The PIVX developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "qt/rpcexecutor.h"
+#include "qt/moc_rpcexecutor.cpp"
+#include "rpc/client.h"
+
+#include <univalue.h>
+
+QString RPCExecutor::categoryClass(int category)
+{
+    switch (category) {
+    case CMD_REQUEST:
+        return "cmd-request";
+        break;
+    case CMD_REPLY:
+        return "cmd-reply";
+        break;
+    case CMD_ERROR:
+        return "cmd-error";
+        break;
+    default:
+        return "misc";
+    }
+}
+
+void RPCExecutor::request(const QString& command)
+{
+    try
+    {
+        std::string result;
+        std::string executableCommand = command.toStdString() + "\n";
+        if(!ExecuteCommandLine(result, executableCommand))
+        {
+            Q_EMIT reply(CMD_ERROR, QString("Parse error: unbalanced ' or \""));
+            return;
+        }
+        Q_EMIT reply(CMD_REPLY, QString::fromStdString(result));
+    }
+    catch (UniValue& objError)
+    {
+        try {
+            // Nice formatting for standard-format error
+            int code = find_value(objError, "code").get_int();
+            std::string message = find_value(objError, "message").get_str();
+            Q_EMIT reply(CMD_ERROR, QString::fromStdString(message) + " (code " + QString::number(code) + ")");
+
+        } catch (const std::runtime_error&) {
+            // raised when converting to invalid type, i.e. missing code or message
+            // Show raw JSON object
+            Q_EMIT reply(CMD_ERROR, QString::fromStdString(objError.write()));
+        }
+    } catch (const std::exception& e) {
+        Q_EMIT reply(CMD_ERROR, QString("Error: ") + QString::fromStdString(e.what()));
+    }
+}
+
+/**
+ * Split shell command line into a list of arguments and execute the command(s).
+ * Aims to emulate \c bash and friends.
+ *
+ * - Command nesting is possible with brackets [example: validateaddress(getnewaddress())]
+ * - Arguments are delimited with whitespace or comma
+ * - Extra whitespace at the beginning and end and between arguments will be ignored
+ * - Text can be "double" or 'single' quoted
+ * - The backslash \c \ is used as escape character
+ *   - Outside quotes, any character can be escaped
+ *   - Within double quotes, only escape \c " and backslashes before a \c " or another backslash
+ *   - Within single quotes, no escaping is possible and no special interpretation takes place
+ *
+ * @param[out]   result      stringified Result from the executed command(chain)
+ * @param[in]    strCommand  Command line to split
+ */
+bool RPCExecutor::ExecuteCommandLine(std::string& strResult, const std::string& strCommand)
+{
+    std::vector< std::vector<std::string> > stack;
+    stack.push_back(std::vector<std::string>());
+
+    enum CmdParseState
+    {
+        STATE_EATING_SPACES,
+        STATE_ARGUMENT,
+        STATE_SINGLEQUOTED,
+        STATE_DOUBLEQUOTED,
+        STATE_ESCAPE_OUTER,
+        STATE_ESCAPE_DOUBLEQUOTED,
+        STATE_COMMAND_EXECUTED,
+        STATE_COMMAND_EXECUTED_INNER
+    } state = STATE_EATING_SPACES;
+    std::string curarg;
+    UniValue lastResult;
+
+    std::string strCommandTerminated = strCommand;
+    if (strCommandTerminated.back() != '\n')
+        strCommandTerminated += "\n";
+    for(char ch: strCommandTerminated)
+    {
+        switch(state)
+        {
+            case STATE_COMMAND_EXECUTED_INNER:
+            case STATE_COMMAND_EXECUTED:
+            {
+                bool breakParsing = true;
+                switch(ch)
+                {
+                    case '[': curarg.clear(); state = STATE_COMMAND_EXECUTED_INNER; break;
+                    default:
+                        if (state == STATE_COMMAND_EXECUTED_INNER)
+                        {
+                            if (ch != ']')
+                            {
+                                // append char to the current argument (which is also used for the query command)
+                                curarg += ch;
+                                break;
+                            }
+                            if (curarg.size())
+                            {
+                                // if we have a value query, query arrays with index and objects with a string key
+                                UniValue subelement;
+                                if (lastResult.isArray())
+                                {
+                                    for(char argch: curarg)
+                                        if (!std::isdigit(argch))
+                                            throw std::runtime_error("Invalid result query");
+                                    subelement = lastResult[atoi(curarg.c_str())];
+                                }
+                                else if (lastResult.isObject())
+                                    subelement = find_value(lastResult, curarg);
+                                else
+                                    throw std::runtime_error("Invalid result query"); //no array or object: abort
+                                lastResult = subelement;
+                            }
+
+                            state = STATE_COMMAND_EXECUTED;
+                            break;
+                        }
+                        // don't break parsing when the char is required for the next argument
+                        breakParsing = false;
+
+                        // pop the stack and return the result to the current command arguments
+                        stack.pop_back();
+
+                        // don't stringify the json in case of a string to avoid doublequotes
+                        if (lastResult.isStr())
+                            curarg = lastResult.get_str();
+                        else
+                            curarg = lastResult.write(2);
+
+                        // if we have a non empty result, use it as stack argument otherwise as general result
+                        if (curarg.size())
+                        {
+                            if (stack.size())
+                                stack.back().push_back(curarg);
+                            else
+                                strResult = curarg;
+                        }
+                        curarg.clear();
+                        // assume eating space state
+                        state = STATE_EATING_SPACES;
+                }
+                if (breakParsing)
+                    break;
+            }
+            case STATE_ARGUMENT: // In or after argument
+            case STATE_EATING_SPACES: // Handle runs of whitespace
+                switch(ch)
+            {
+                case '"': state = STATE_DOUBLEQUOTED; break;
+                case '\'': state = STATE_SINGLEQUOTED; break;
+                case '\\': state = STATE_ESCAPE_OUTER; break;
+                case '(': case ')': case '\n':
+                    if (state == STATE_ARGUMENT)
+                    {
+                        if (ch == '(' && stack.size() && stack.back().size() > 0)
+                            stack.push_back(std::vector<std::string>());
+                        if (curarg.size())
+                        {
+                            // don't allow commands after executed commands on baselevel
+                            if (!stack.size())
+                                throw std::runtime_error("Invalid Syntax");
+                            stack.back().push_back(curarg);
+                        }
+                        curarg.clear();
+                        state = STATE_EATING_SPACES;
+                    }
+                    if ((ch == ')' || ch == '\n') && stack.size() > 0)
+                    {
+                        std::string strPrint;
+                        // Convert argument list to JSON objects in method-dependent way,
+                        // and pass it along with the method name to the dispatcher.
+                        JSONRPCRequest req;
+                        req.params = RPCConvertValues(stack.back()[0], std::vector<std::string>(stack.back().begin() + 1, stack.back().end()));
+                        req.strMethod = stack.back()[0];
+                        lastResult = tableRPC.execute(req);
+                        state = STATE_COMMAND_EXECUTED;
+                        curarg.clear();
+                    }
+                    break;
+                case ' ': case ',': case '\t':
+                    if(state == STATE_ARGUMENT) // Space ends argument
+                    {
+                        if (curarg.size())
+                            stack.back().push_back(curarg);
+                        curarg.clear();
+                    }
+                    state = STATE_EATING_SPACES;
+                    break;
+                default: curarg += ch; state = STATE_ARGUMENT;
+            }
+                break;
+            case STATE_SINGLEQUOTED: // Single-quoted string
+                switch(ch)
+            {
+                case '\'': state = STATE_ARGUMENT; break;
+                default: curarg += ch;
+            }
+                break;
+            case STATE_DOUBLEQUOTED: // Double-quoted string
+                switch(ch)
+            {
+                case '"': state = STATE_ARGUMENT; break;
+                case '\\': state = STATE_ESCAPE_DOUBLEQUOTED; break;
+                default: curarg += ch;
+            }
+                break;
+            case STATE_ESCAPE_OUTER: // '\' outside quotes
+                curarg += ch; state = STATE_ARGUMENT;
+                break;
+            case STATE_ESCAPE_DOUBLEQUOTED: // '\' in double-quoted text
+                if(ch != '"' && ch != '\\') curarg += '\\'; // keep '\' for everything but the quote and '\' itself
+                curarg += ch; state = STATE_DOUBLEQUOTED;
+                break;
+        }
+    }
+    switch (state) // final state
+    {
+        case STATE_COMMAND_EXECUTED:
+            if (lastResult.isStr())
+                strResult = lastResult.get_str();
+            else
+                strResult = lastResult.write(2);
+        case STATE_ARGUMENT:
+        case STATE_EATING_SPACES:
+            return true;
+        default: // ERROR to end in one of the other states
+            return false;
+    }
+}

--- a/src/qt/rpcexecutor.h
+++ b/src/qt/rpcexecutor.h
@@ -1,0 +1,78 @@
+// Copyright (c) 2011-2017 The Bitcoin developers
+// Copyright (c) 2015-2021 The PIVX developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef PIVX_QT_RPCEXECUTOR_H
+#define PIVX_QT_RPCEXECUTOR_H
+
+#include "rpc/server.h"
+
+#include <QObject>
+#include <QString>
+#include <QTimer>
+
+/*
+ * Object for executing console RPC commands in a separate thread.
+*/
+class RPCExecutor : public QObject
+{
+    Q_OBJECT
+public:
+    enum CommandClass {
+        CMD_REQUEST,
+        CMD_REPLY,
+        CMD_ERROR
+    };
+
+    static QString categoryClass(int category);
+
+public Q_SLOTS:
+    void request(const QString& command);
+
+Q_SIGNALS:
+    void reply(int category, const QString& command);
+
+private:
+    bool ExecuteCommandLine(std::string& strResult, const std::string& strCommand);
+};
+
+
+/*
+ * Class for handling RPC timers
+ * (used for e.g. re-locking the wallet after a timeout)
+ */
+class QtRPCTimerBase: public QObject, public RPCTimerBase
+{
+    Q_OBJECT
+public:
+    QtRPCTimerBase(std::function<void(void)>& _func, int64_t millis):
+        func(_func)
+    {
+        timer.setSingleShot(true);
+        connect(&timer, &QTimer::timeout, [this]{ func(); });
+        timer.start(millis);
+    }
+    ~QtRPCTimerBase() {}
+
+private:
+    QTimer timer;
+    std::function<void(void)> func;
+};
+
+/*
+ * Specialization of the RPCTimer interface
+*/
+class QtRPCTimerInterface: public RPCTimerInterface
+{
+public:
+    ~QtRPCTimerInterface() {}
+    const char *Name() { return "Qt"; }
+    RPCTimerBase* NewTimer(std::function<void(void)>& func, int64_t millis)
+    {
+        return new QtRPCTimerBase(func, millis);
+    }
+};
+
+
+#endif // PIVX_QT_RPCEXECUTOR_H

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -929,7 +929,7 @@ static UniValue SoftForkMajorityDesc(int version, const CBlockIndex* pindex, con
         rv.pushKV("status", false);
         return rv;
     }
-    rv.pushKV("status", consensusParams.NetworkUpgradeActive(pindex->nHeight, idx));
+    rv.pushKV("status", pindex && consensusParams.NetworkUpgradeActive(pindex->nHeight, idx));
     return rv;
 }
 


### PR DESCRIPTION
Backports a pretty cool feature for the GUI rpc-console from bitcoin#7783, which makes testing much faster, removing the need for copying/pasting the outputs of the commands.

> Commands can be executed with bracket syntax, example: `getwalletinfo()`.
> Commands can be nested, example: `sendtoaddress(getnewaddress(), 10)`.
> Simple queries are possible: `listunspent()[0][txid]`
> Object values are accessed with a non-quoted string, example: [txid].
>
> Fully backward compatible. `generate 101` is identical to `generate(101)`
> Result value queries indicated with `[]` require the new brackets syntax.
> Comma as argument separator is now also possible: `sendtoaddress,<address>,<amount>`
> Space as argument separator works also with the bracket syntax, example: `sendtoaddress(getnewaddress() 10)
>
> No dept limitation, complex commands are possible:
> `decoderawtransaction(getrawtransaction(getblock(getbestblockhash())[tx][0]))[vout][0][value]`

<br>

<img src="https://user-images.githubusercontent.com/18186894/113241705-8304e400-92af-11eb-9624-87921bb13f0a.png">