### PR TITLE
[validation] Removing unneeded block serialization and signal from ABC

### DIFF
--- a/src/guiinterface.h
+++ b/src/guiinterface.h
@@ -100,9 +100,6 @@ public:
     /** New block has been accepted */
     boost::signals2::signal<void(bool fInitialDownload, const CBlockIndex* newTip)> NotifyBlockTip;
 
-    /** New block has been accepted and is over a certain size */
-    boost::signals2::signal<void(int size, const uint256& hash)> NotifyBlockSize;
-
     /** Banlist did change. */
     boost::signals2::signal<void (void)> BannedListChanged;
 };

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -422,7 +422,6 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-version", _("Print version and exit"));
     strUsage += HelpMessageOpt("-alertnotify=<cmd>", _("Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)"));
     strUsage += HelpMessageOpt("-blocknotify=<cmd>", _("Execute command when the best block changes (%s in cmd is replaced by block hash)"));
-    strUsage += HelpMessageOpt("-blocksizenotify=<cmd>", _("Execute command when the best block changes and its size is over (%s in cmd is replaced by block hash, %d with the block size)"));
     strUsage += HelpMessageOpt("-checkblocks=<n>", strprintf(_("How many blocks to check at startup (default: %u, 0 = all)"), DEFAULT_CHECKBLOCKS));
     strUsage += HelpMessageOpt("-conf=<file>", strprintf(_("Specify configuration file (default: %s)"), PIVX_CONF_FILENAME));
     if (mode == HMM_BITCOIND) {
@@ -620,16 +619,6 @@ static void BlockNotifyCallback(bool initialSync, const CBlockIndex *pBlockIndex
         std::thread t(runCommand, strCmd);
         t.detach(); // thread runs free
     }
-}
-
-static void BlockSizeNotifyCallback(int size, const uint256& hashNewTip)
-{
-    std::string strCmd = gArgs.GetArg("-blocksizenotify", "");
-
-    boost::replace_all(strCmd, "%s", hashNewTip.GetHex());
-    boost::replace_all(strCmd, "%d", std::to_string(size));
-    std::thread t(runCommand, strCmd);
-    t.detach(); // thread runs free
 }
 
 ////////////////////////////////////////////////////
@@ -1785,9 +1774,6 @@ bool AppInitMain()
 
     if (gArgs.IsArgSet("-blocknotify"))
         uiInterface.NotifyBlockTip.connect(BlockNotifyCallback);
-
-    if (gArgs.IsArgSet("-blocksizenotify"))
-        uiInterface.NotifyBlockSize.connect(BlockSizeNotifyCallback);
 
     // scan for better chains in the block chain database, that are not yet connected in the active best chain
     CValidationState state;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2241,12 +2241,8 @@ bool ActivateBestChain(CValidationState& state, std::shared_ptr<const CBlock> pb
 
         const CBlockIndex *pindexFork;
         bool fInitialDownload;
-        while (true) {
-            TRY_LOCK(cs_main, lockMain);
-            if (!lockMain) {
-                MilliSleep(50);
-                continue;
-            }
+        {
+            LOCK(cs_main);
             ConnectTrace connectTrace(mempool); // Destructed before cs_main is unlocked
 
             CBlockIndex *pindexOldTip = chainActive.Tip();
@@ -2268,8 +2264,6 @@ bool ActivateBestChain(CValidationState& state, std::shared_ptr<const CBlock> pb
                 assert(trace.pblock && trace.pindex);
                 GetMainSignals().BlockConnected(trace.pblock, trace.pindex, trace.conflictedTxs);
             }
-
-            break;
         }
 
         // Notify external listeners about the new tip.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2271,17 +2271,8 @@ bool ActivateBestChain(CValidationState& state, std::shared_ptr<const CBlock> pb
 
         // Always notify the UI if a new block tip was connected
         if (pindexFork != pindexNewTip) {
-
             // Notify the UI
             uiInterface.NotifyBlockTip(fInitialDownload, pindexNewTip);
-
-            unsigned size = 0;
-            if (pblock)
-                size = GetSerializeSize(*pblock, SER_NETWORK, PROTOCOL_VERSION);
-            // If the size is over 1 MB notify external listeners, and it is within the last 5 minutes
-            if (size > MAX_BLOCK_SIZE_LEGACY && pblock->GetBlockTime() > GetAdjustedTime() - 300) {
-                uiInterface.NotifyBlockSize(static_cast<int>(size), pindexNewTip->GetBlockHash());
-            }
         }
 
     } while (pindexMostWork != chainActive.Tip());


### PR DESCRIPTION
Essentially, we are re-serializing every new connected block tip, locking `cs_main` for its whole time, just to calculate the block size and broadcast a notification for external listeners if the block size is above 1mb..

Which well.. can easily be done from outside of the core, listening the new block arrival signal without having the most important node's processing thread calculating it, blocking `cs_main` for its whole time.
Plus, block arrive serialized from the network and from disk, there was no need to waste resources forcing a re-serialization for this neither.

What this fix means: 
The synchronization process will be faster. So, this can easily get into v5.1.0 release.