### PR TITLE
[Build] Remove un-used variable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1152,8 +1152,6 @@ else
   fi
 fi
 
-LIBSAPLING_LIBS="-lgmp -lboost_system-mt -lcrypto -lsodium"
-
 dnl univalue check
 
 need_bundled_univalue=yes
@@ -1223,7 +1221,7 @@ AM_CONDITIONAL([HAVE_RUST_TARGET], [test -n "$RUST_TARGET"])
 AX_CHECK_COMPILE_FLAG([-fno-strict-aliasing],[CXXFLAGS="$CXXFLAGS -fno-strict-aliasing"])
 AX_CHECK_COMPILE_FLAG([-Wno-builtin-declaration-mismatch],[CXXFLAGS="$CXXFLAGS -Wno-builtin-declaration-mismatch"],,[[$CXXFLAG_WERROR]])
 
-LIBZCASH_LIBS="$BOOST_SYSTEM_LIB $CRYPTO_LIBS $SODIUM_LIBS $RUST_LIBS"
+LIBZCASH_LIBS="$BOOST_SYSTEM_LIB $SODIUM_LIBS $RUST_LIBS"
 
 AC_MSG_CHECKING([whether to build pivxd])
 AM_CONDITIONAL([BUILD_BITCOIND], [test x$build_bitcoind = xyes])
@@ -1490,7 +1488,6 @@ AC_SUBST(EVENT_LIBS)
 AC_SUBST(EVENT_PTHREADS_LIBS)
 AC_SUBST(SODIUM_LIBS)
 AC_SUBST(ZMQ_LIBS)
-AC_SUBST(LIBSAPLING_LIBS)
 AC_SUBST(LIBZCASH_LIBS)
 AC_SUBST(PROTOBUF_LIBS)
 AC_SUBST(QR_LIBS)


### PR DESCRIPTION
`LIBSAPLING_LIBS` is defined but never used (`LIBZCASH_LIBS` is what is
used instead). Also, `LIBZCASH_LIBS` is needlessly including
`CRYPTO_LIBS` so clean that up.