### PR TITLE
[Net_Processing] Cleaner block processing workflow

### DIFF
--- a/src/blockassembler.cpp
+++ b/src/blockassembler.cpp
@@ -226,7 +226,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         if (chainActive.Tip() != pindexPrev) return nullptr; // new block came in, move on
 
         CValidationState state;
-        if (!TestBlockValidity(state, *pblock, pindexPrev, false, false)) {
+        if (!TestBlockValidity(state, *pblock, pindexPrev, false, false, false)) {
             throw std::runtime_error(
                     strprintf("%s: TestBlockValidity failed: %s", __func__, FormatStateMessage(state)));
         }

--- a/src/blocksignature.cpp
+++ b/src/blocksignature.cpp
@@ -40,7 +40,7 @@ bool SignBlock(CBlock& block, const CKeyStore& keystore)
     return SignBlockWithKey(block, key);
 }
 
-bool CheckBlockSignature(const CBlock& block, const bool enableP2PKH)
+bool CheckBlockSignature(const CBlock& block)
 {
     if (block.IsProofOfWork())
         return block.vchBlockSig.empty();
@@ -63,13 +63,6 @@ bool CheckBlockSignature(const CBlock& block, const bool enableP2PKH)
         const CTxOut& txout = block.vtx[1]->vout[1];
         if (!Solver(txout.scriptPubKey, whichType, vSolutions))
             return false;
-
-        if (!enableP2PKH) {
-            // Before v5 activation, P2PKH was always failing.
-            if (whichType == TX_PUBKEYHASH) {
-                return false;
-            }
-        }
 
         if (whichType == TX_PUBKEY) {
             valtype& vchPubKey = vSolutions[0];

--- a/src/blocksignature.h
+++ b/src/blocksignature.h
@@ -11,6 +11,6 @@
 
 bool SignBlockWithKey(CBlock& block, const CKey& key);
 bool SignBlock(CBlock& block, const CKeyStore& keystore);
-bool CheckBlockSignature(const CBlock& block, const bool enableP2PKH);
+bool CheckBlockSignature(const CBlock& block);
 
 #endif //PIVX_BLOCKSIGNATURE_H

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -94,7 +94,7 @@ public:
     std::vector<unsigned char> vchBlockSig;
 
     // memory only
-    mutable bool fChecked;
+    mutable bool fChecked{false};
 
     CBlock()
     {

--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -72,14 +72,9 @@ CBlock CreateDummyBlockWithSignature(CKey stakingKey, BlockSignatureType type, b
     return block;
 }
 
-bool TestBlockSignaturePreEnforcementV5(const CBlock& block)
+bool TestBlockSignature(const CBlock& block)
 {
-    return CheckBlockSignature(block, false);
-}
-
-bool TestBlockSignaturePostEnforcementV5(const CBlock& block)
-{
-    return CheckBlockSignature(block, true);
+    return CheckBlockSignature(block);
 }
 
 BOOST_AUTO_TEST_CASE(block_signature_test)
@@ -89,27 +84,19 @@ BOOST_AUTO_TEST_CASE(block_signature_test)
         stakingKey.MakeNewKey(true);
         bool useInputP2PK = i % 2 == 0;
 
-        // Test P2PK block signature pre enforcement.
+        // Test P2PK block signature
         CBlock block = CreateDummyBlockWithSignature(stakingKey, BlockSignatureType::P2PK, useInputP2PK);
-        BOOST_CHECK(TestBlockSignaturePreEnforcementV5(block));
+        BOOST_CHECK(TestBlockSignature(block));
 
-        // Test P2PK block signature post enforcement
-        block = CreateDummyBlockWithSignature(stakingKey, BlockSignatureType::P2PK, useInputP2PK);
-        BOOST_CHECK(TestBlockSignaturePostEnforcementV5(block));
-
-        // Test P2PKH block signature pre enforcement ---> must fail.
-        block = CreateDummyBlockWithSignature(stakingKey, BlockSignatureType::P2PKH, useInputP2PK);
-        BOOST_CHECK(!TestBlockSignaturePreEnforcementV5(block));
-
-        // Test P2PKH block signature post enforcement
+        // Test P2PKH block signature
         block = CreateDummyBlockWithSignature(stakingKey, BlockSignatureType::P2PKH, useInputP2PK);
         if (useInputP2PK) {
             // If it's using a P2PK scriptsig as input and a P2PKH output
             // The block doesn't contain the public key to verify the sig anywhere.
             // Must fail.
-            BOOST_CHECK(!TestBlockSignaturePostEnforcementV5(block));
+            BOOST_CHECK(!TestBlockSignature(block));
         } else {
-            BOOST_CHECK(TestBlockSignaturePostEnforcementV5(block));
+            BOOST_CHECK(TestBlockSignature(block));
         }
     }
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3350,16 +3350,6 @@ bool ProcessNewBlock(CValidationState& state, CNode* pfrom, const std::shared_pt
             return error ("%s : CheckBlock FAILED for block %s, %s", __func__, pblock->GetHash().GetHex(), FormatStateMessage(state));
         }
 
-        // Request sync if needed
-        if (pblock->GetHash() != consensus.hashGenesisBlock && !pfrom) {
-            // if we get this far, check if the prev block is our prev block, if not then request sync and return false
-            BlockMap::iterator mi = mapBlockIndex.find(pblock->hashPrevBlock);
-            if (mi == mapBlockIndex.end()) {
-                g_connman->PushMessage(pfrom, CNetMsgMaker(pfrom->GetSendVersion()).Make(NetMsgType::GETBLOCKS, chainActive.GetLocator(), UINT256_ZERO));
-                return false;
-            }
-        }
-
         // Store to disk
         CBlockIndex* pindex = nullptr;
         bool ret = AcceptBlock(*pblock, state, &pindex, dbp);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3093,7 +3093,7 @@ bool AcceptBlockHeader(const CBlock& block, CValidationState& state, CBlockIndex
     return true;
 }
 
-bool AcceptBlock(const CBlock& block, CValidationState& state, CBlockIndex** ppindex, CDiskBlockPos* dbp, bool fAlreadyCheckedBlock)
+bool AcceptBlock(const CBlock& block, CValidationState& state, CBlockIndex** ppindex, CDiskBlockPos* dbp)
 {
     AssertLockHeld(cs_main);
 
@@ -3126,7 +3126,7 @@ bool AcceptBlock(const CBlock& block, CValidationState& state, CBlockIndex** ppi
         return true;
     }
 
-    if ((!fAlreadyCheckedBlock && !CheckBlock(block, state)) || !ContextualCheckBlock(block, state, pindex->pprev)) {
+    if (!CheckBlock(block, state) || !ContextualCheckBlock(block, state, pindex->pprev)) {
         if (state.IsInvalid() && !state.CorruptionPossible()) {
             pindex->nStatus |= BLOCK_FAILED_VALID;
             setDirtyBlockIndex.insert(pindex);
@@ -3369,7 +3369,7 @@ bool ProcessNewBlock(CValidationState& state, CNode* pfrom, const std::shared_pt
 
         // Store to disk
         CBlockIndex* pindex = nullptr;
-        bool ret = AcceptBlock(*pblock, state, &pindex, dbp, checked);
+        bool ret = AcceptBlock(*pblock, state, &pindex, dbp);
         if (fAccepted) *fAccepted = ret;
         CheckBlockIndex();
         if (!ret) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3340,15 +3340,12 @@ bool ProcessNewBlock(CValidationState& state, CNode* pfrom, const std::shared_pt
     // Preliminary checks
     int64_t nStartTime = GetTimeMillis();
     const Consensus::Params& consensus = Params().GetConsensus();
+    int newHeight = 0;
 
     // check block
     bool checked = CheckBlock(*pblock, state);
 
-    // For now, we need the tip to know whether p2pkh block signatures are accepted or not.
-    // After 5.0, this can be removed and replaced by the enforcement block time.
-    const int newHeight = chainActive.Height() + 1;
-    const bool enableP2PKH = consensus.NetworkUpgradeActive(newHeight, Consensus::UPGRADE_V5_0);
-    if (!CheckBlockSignature(*pblock, enableP2PKH))
+    if (!CheckBlockSignature(*pblock))
         return error("%s : bad proof-of-stake block signature", __func__);
 
     if (pblock->GetHash() != consensus.hashGenesisBlock && pfrom != NULL) {
@@ -3375,6 +3372,7 @@ bool ProcessNewBlock(CValidationState& state, CNode* pfrom, const std::shared_pt
         if (!ret) {
             return error("%s : AcceptBlock FAILED", __func__);
         }
+        newHeight = pindex->nHeight;
     }
 
     if (!ActivateBestChain(state, pblock, checked))

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1425,11 +1425,11 @@ static int64_t nTimeTotal = 0;
 /** Apply the effects of this block (with given index) on the UTXO set represented by coins.
  *  Validity checks that depend on the UTXO set are also done; ConnectBlock()
  *  can fail if those validity checks fail (among other reasons). */
-static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pindex, CCoinsViewCache& view, bool fJustCheck = false, bool fAlreadyChecked = false)
+static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pindex, CCoinsViewCache& view, bool fJustCheck = false)
 {
     AssertLockHeld(cs_main);
     // Check it again in case a previous version let a bad block in
-    if (!fAlreadyChecked && !CheckBlock(block, state, !fJustCheck, !fJustCheck, !fJustCheck)) {
+    if (!CheckBlock(block, state, !fJustCheck, !fJustCheck, !fJustCheck)) {
         if (state.CorruptionPossible()) {
             // We don't write down blocks to disk if they may have been
             // corrupted, so this should be impossible unless we're having hardware
@@ -2055,14 +2055,11 @@ public:
  *
  * The block is added to connectTrace if connection succeeds.
  */
-bool static ConnectTip(CValidationState& state, CBlockIndex* pindexNew, const std::shared_ptr<const CBlock>& pblock, bool fAlreadyChecked, ConnectTrace& connectTrace, DisconnectedBlockTransactions &disconnectpool)
+bool static ConnectTip(CValidationState& state, CBlockIndex* pindexNew, const std::shared_ptr<const CBlock>& pblock, ConnectTrace& connectTrace, DisconnectedBlockTransactions &disconnectpool)
 {
     AssertLockHeld(cs_main);
     AssertLockHeld(mempool.cs);
     assert(pindexNew->pprev == chainActive.Tip());
-
-    if (pblock == NULL)
-        fAlreadyChecked = false;
 
     // Read block from disk.
     int64_t nTime1 = GetTimeMicros();
@@ -2084,7 +2081,7 @@ bool static ConnectTip(CValidationState& state, CBlockIndex* pindexNew, const st
     LogPrint(BCLog::BENCH, "  - Load block from disk: %.2fms [%.2fs]\n", (nTime2 - nTime1) * 0.001, nTimeReadFromDisk * 0.000001);
     {
         CCoinsViewCache view(pcoinsTip);
-        bool rv = ConnectBlock(blockConnecting, state, pindexNew, view, false, fAlreadyChecked);
+        bool rv = ConnectBlock(blockConnecting, state, pindexNew, view, false);
         GetMainSignals().BlockChecked(blockConnecting, state);
         if (!rv) {
             if (state.IsInvalid())
@@ -2205,12 +2202,10 @@ static void PruneBlockIndexCandidates()
  * Try to make some progress towards making pindexMostWork the active block.
  * pblock is either NULL or a pointer to a CBlock corresponding to pindexMostWork.
  */
-static bool ActivateBestChainStep(CValidationState& state, CBlockIndex* pindexMostWork, const std::shared_ptr<const CBlock>& pblock, bool fAlreadyChecked, bool& fInvalidFound, ConnectTrace& connectTrace)
+static bool ActivateBestChainStep(CValidationState& state, CBlockIndex* pindexMostWork, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, ConnectTrace& connectTrace)
 {
     AssertLockHeld(cs_main);
     AssertLockHeld(mempool.cs);
-    if (pblock == NULL)
-        fAlreadyChecked = false;
     const CBlockIndex* pindexOldTip = chainActive.Tip();
     const CBlockIndex* pindexFork = chainActive.FindFork(pindexMostWork);
 
@@ -2246,7 +2241,7 @@ static bool ActivateBestChainStep(CValidationState& state, CBlockIndex* pindexMo
 
         // Connect new blocks.
         for (CBlockIndex* pindexConnect : reverse_iterate(vpindexToConnect)) {
-            if (!ConnectTip(state, pindexConnect, (pindexConnect == pindexMostWork) ? pblock : std::shared_ptr<const CBlock>(), fAlreadyChecked, connectTrace, disconnectpool)) {
+            if (!ConnectTip(state, pindexConnect, (pindexConnect == pindexMostWork) ? pblock : std::shared_ptr<const CBlock>(), connectTrace, disconnectpool)) {
                 if (state.IsInvalid()) {
                     // The block violates a consensus rule.
                     if (!state.CorruptionPossible())
@@ -2295,7 +2290,7 @@ static bool ActivateBestChainStep(CValidationState& state, CBlockIndex* pindexMo
  * that is already loaded (to avoid loading it again from disk).
  */
 
-bool ActivateBestChain(CValidationState& state, std::shared_ptr<const CBlock> pblock, bool fAlreadyChecked)
+bool ActivateBestChain(CValidationState& state, std::shared_ptr<const CBlock> pblock)
 {
     // Note that while we're often called here from ProcessNewBlock, this is
     // far from a guarantee. Things in the P2P/RPC will often end up calling
@@ -2342,7 +2337,7 @@ bool ActivateBestChain(CValidationState& state, std::shared_ptr<const CBlock> pb
 
                 bool fInvalidFound = false;
                 std::shared_ptr<const CBlock> nullBlockPtr;
-                if (!ActivateBestChainStep(state, pindexMostWork, pblock && pblock->GetHash() == pindexMostWork->GetBlockHash() ? pblock : nullBlockPtr, fAlreadyChecked, fInvalidFound, connectTrace))
+                if (!ActivateBestChainStep(state, pindexMostWork, pblock && pblock->GetHash() == pindexMostWork->GetBlockHash() ? pblock : nullBlockPtr, fInvalidFound, connectTrace))
                     return false;
                 blocks_connected = true;
 
@@ -3378,7 +3373,7 @@ bool ProcessNewBlock(CValidationState& state, CNode* pfrom, const std::shared_pt
         newHeight = pindex->nHeight;
     }
 
-    if (!ActivateBestChain(state, pblock, checked))
+    if (!ActivateBestChain(state, pblock))
         return error("%s : ActivateBestChain failed", __func__);
 
     if (!fLiteMode) {

--- a/src/validation.h
+++ b/src/validation.h
@@ -209,7 +209,7 @@ double ConvertBitsToDouble(unsigned int nBits);
 int64_t GetMasternodePayment();
 
 /** Find the best known block, and make it the tip of the block chain */
-bool ActivateBestChain(CValidationState& state, std::shared_ptr<const CBlock> pblock = std::shared_ptr<const CBlock>(), bool fAlreadyChecked = false);
+bool ActivateBestChain(CValidationState& state, std::shared_ptr<const CBlock> pblock = std::shared_ptr<const CBlock>());
 CAmount GetBlockValue(int nHeight);
 
 /** Create a new block index entry for a given block hash */

--- a/src/validation.h
+++ b/src/validation.h
@@ -334,7 +334,7 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
 bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIndex* pindexPrev);
 
 /** Check a block is completely valid from start to finish (only works on top of our current best block, with cs_main held) */
-bool TestBlockValidity(CValidationState& state, const CBlock& block, CBlockIndex* pindexPrev, bool fCheckPOW = true, bool fCheckMerkleRoot = true);
+bool TestBlockValidity(CValidationState& state, const CBlock& block, CBlockIndex* pindexPrev, bool fCheckPOW = true, bool fCheckMerkleRoot = true, bool fCheckBlockSig = true);
 
 /** Store block on disk. If dbp is provided, the file is known to already reside on disk */
 bool AcceptBlock(const CBlock& block, CValidationState& state, CBlockIndex** pindex, CDiskBlockPos* dbp = NULL, bool fAlreadyCheckedBlock = false);

--- a/src/validation.h
+++ b/src/validation.h
@@ -337,7 +337,7 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
 bool TestBlockValidity(CValidationState& state, const CBlock& block, CBlockIndex* pindexPrev, bool fCheckPOW = true, bool fCheckMerkleRoot = true, bool fCheckBlockSig = true);
 
 /** Store block on disk. If dbp is provided, the file is known to already reside on disk */
-bool AcceptBlock(const CBlock& block, CValidationState& state, CBlockIndex** pindex, CDiskBlockPos* dbp = NULL, bool fAlreadyCheckedBlock = false);
+bool AcceptBlock(const CBlock& block, CValidationState& state, CBlockIndex** pindex, CDiskBlockPos* dbp = NULL);
 bool AcceptBlockHeader(const CBlock& block, CValidationState& state, CBlockIndex** ppindex = nullptr, CBlockIndex* pindexPrev = nullptr);
 
 


### PR DESCRIPTION
Grouped several improvements to the block processing workflow. Cleaning redundancies, extra data requests, unneeded pieces of code and adding missing locks to critical sections.

Briefly describing the commits:

1) Remove the now unneeded, due v5 enforcement, P2PKH flag from `CheckBlockSignature`.
2) Move `CheckBlockSignature` inside `CheckBlock`.
3) Remove redundant `fAlreadyCheckedBlock` and exclusively use the `CBlock::fChecked` correct flag.
4) Add missing `cs_main` lock for `CheckBlock` function call in `ProcessNewBlock`.
5) Remove redundant, and never used, block sync request in `ProcessNewBlock` (check commit message for the precise description).
6) Add missing `cs_main` lock for block sync request in `ProcessMessage`.

This is part of a chain of PRs over the area that will continue doing, next one will most likely be a bit more invasive but will try to keep it atomic enough due the importance of the area been modified.