### PR TITLE
[RPC] Provider-Register transactions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,7 @@ set(SERVER_SOURCES
         ./src/rpc/misc.cpp
         ./src/rpc/net.cpp
         ./src/rpc/rawtransaction.cpp
+        ./src/rpc/rpcevo.cpp
         ./src/rpc/server.cpp
         ./src/script/sigcache.cpp
         ./src/script/ismine.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -357,6 +357,7 @@ libbitcoin_server_a_SOURCES = \
   rpc/misc.cpp \
   rpc/net.cpp \
   rpc/rawtransaction.cpp \
+  rpc/rpcevo.cpp \
   rpc/server.cpp \
   script/sigcache.cpp \
   script/ismine.cpp \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -144,6 +144,7 @@ public:
         consensus.nFutureTimeDriftPoS = 180;
         consensus.nMasternodeCountDrift = 20;       // num of MN we allow the see-saw payments to be off by
         consensus.nMaxMoneyOut = 21000000 * COIN;
+        consensus.nMNCollateralAmt = 10000 * COIN;
         consensus.nPoolMaxTransactions = 3;
         consensus.nProposalEstablishmentTime = 60 * 60 * 24;    // must be at least a day old to make it into a budget
         consensus.nStakeMinAge = 60 * 60;
@@ -285,6 +286,7 @@ public:
         consensus.nFutureTimeDriftPoS = 180;
         consensus.nMasternodeCountDrift = 20;       // num of MN we allow the see-saw payments to be off by
         consensus.nMaxMoneyOut = 21000000 * COIN;
+        consensus.nMNCollateralAmt = 10000 * COIN;
         consensus.nPoolMaxTransactions = 3;
         consensus.nProposalEstablishmentTime = 60 * 5;  // at least 5 min old to make it into a budget
         consensus.nStakeMinAge = 60 * 60;
@@ -409,6 +411,7 @@ public:
         consensus.nFutureTimeDriftPoS = 180;
         consensus.nMasternodeCountDrift = 4;        // num of MN we allow the see-saw payments to be off by
         consensus.nMaxMoneyOut = 43199500 * COIN;
+        consensus.nMNCollateralAmt = 100 * COIN;
         consensus.nPoolMaxTransactions = 2;
         consensus.nProposalEstablishmentTime = 60 * 5;  // at least 5 min old to make it into a budget
         consensus.nStakeMinAge = 0;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -98,6 +98,7 @@ struct Params {
     int nFutureTimeDriftPoS;
     int nMasternodeCountDrift;
     CAmount nMaxMoneyOut;
+    CAmount nMNCollateralAmt;
     int nPoolMaxTransactions;
     int64_t nProposalEstablishmentTime;
     int nStakeMinAge;

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -90,14 +90,15 @@ void CDeterministicMN::ToJson(UniValue& obj) const
     obj.pushKV("collateralHash", collateralOutpoint.hash.ToString());
     obj.pushKV("collateralIndex", (int)collateralOutpoint.n);
 
+    std::string collateralAddressStr = "";
     Coin coin;
     if (GetUTXOCoin(collateralOutpoint, coin)) {
         CTxDestination dest;
         if (ExtractDestination(coin.out.scriptPubKey, dest)) {
-            obj.pushKV("collateralAddress", EncodeDestination(dest));
+            collateralAddressStr = EncodeDestination(dest);
         }
     }
-
+    obj.pushKV("collateralAddress", collateralAddressStr);
     obj.pushKV("operatorReward", (double)nOperatorReward / 100);
     obj.pushKV("dmnstate", stateObj);
 }

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -10,7 +10,7 @@
 #include "core_io.h"
 #include "evo/specialtx.h"
 #include "guiinterface.h"
-#include "masternode.h" // for MN_COLL_AMT, MasternodeCollateralMinConf
+#include "masternode.h" // for MasternodeCollateralMinConf
 #include "masternodeman.h" // for mnodeman (!TODO: remove)
 #include "script/standard.h"
 #include "spork.h"
@@ -662,7 +662,8 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, const C
             }
 
             Coin coin;
-            if (!pl.collateralOutpoint.hash.IsNull() && (!GetUTXOCoin(pl.collateralOutpoint, coin) || coin.out.nValue != MN_COLL_AMT)) {
+            const CAmount collAmt = Params().GetConsensus().nMNCollateralAmt;
+            if (!pl.collateralOutpoint.hash.IsNull() && (!GetUTXOCoin(pl.collateralOutpoint, coin) || coin.out.nValue != collAmt)) {
                 // should actually never get to this point as CheckProRegTx should have handled this case.
                 // We do this additional check nevertheless to be 100% sure
                 return _state.DoS(100, false, REJECT_INVALID, "bad-protx-collateral");

--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -57,8 +57,7 @@ static bool CheckStringSig(const Payload& pl, const CKeyID& keyID, CValidationSt
 template <typename Payload>
 static bool CheckInputsHash(const CTransaction& tx, const Payload& pl, CValidationState& state)
 {
-    uint256 inputsHash = CalcTxInputsHash(tx);
-    if (inputsHash != pl.inputsHash) {
+    if (CalcTxInputsHash(tx) != pl.inputsHash) {
         return state.DoS(100, false, REJECT_INVALID, "bad-protx-inputs-hash");
     }
 

--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -77,7 +77,7 @@ static bool CheckCollateralOut(const CTxOut& out, const ProRegPL& pl, CValidatio
         return state.DoS(10, false, REJECT_INVALID, "bad-protx-collateral-reuse");
     }
     // check collateral amount
-    if (out.nValue != MN_COLL_AMT) {
+    if (out.nValue != Params().GetConsensus().nMNCollateralAmt) {
         return state.DoS(100, false, REJECT_INVALID, "bad-protx-collateral-amount");
     }
     return true;

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -194,7 +194,9 @@ bool CMasternode::IsInputAssociatedWithPubkey() const
     uint256 hash;
     if(GetTransaction(vin.prevout.hash, txVin, hash, true)) {
         for (const CTxOut& out : txVin->vout) {
-            if (out.nValue == MN_COLL_AMT && out.scriptPubKey == payee) return true;
+            if (out.nValue == Params().GetConsensus().nMNCollateralAmt &&
+                out.scriptPubKey == payee)
+                return true;
         }
     }
 

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -18,10 +18,6 @@
 /* Depth of the block pinged by masternodes */
 static const unsigned int MNPING_DEPTH = 12;
 
-/* Masternode collateral amount */
-static const CAmount MN_COLL_AMT = 10000 * COIN;
-
-
 class CMasternode;
 class CMasternodeBroadcast;
 class CMasternodePing;

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -189,7 +189,11 @@ public:
         return lastPing.IsNull() ? false : now - lastPing.sigTime < seconds;
     }
 
-    void SetSpent() { fCollateralSpent = true; }
+    void SetSpent()
+    {
+        LOCK(cs);
+        fCollateralSpent = true;
+    }
 
     void Disable()
     {

--- a/src/qt/pivx/masternodewizarddialog.cpp
+++ b/src/qt/pivx/masternodewizarddialog.cpp
@@ -263,7 +263,7 @@ bool MasterNodeWizardDialog::createMN()
         int indexOut = -1;
         for (int i=0; i < (int)walletTx->vout.size(); i++) {
             const CTxOut& out = walletTx->vout[i];
-            if (out.nValue == MN_COLL_AMT) {
+            if (out.nValue == Params().GetConsensus().nMNCollateralAmt) {
                 indexOut = i;
                 break;
             }

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -5,6 +5,7 @@
 
 #include "activemasternode.h"
 #include "db.h"
+#include "evo/deterministicmns.h"
 #include "init.h"
 #include "masternode-payments.h"
 #include "masternode-sync.h"
@@ -315,8 +316,13 @@ void SerializeMNB(UniValue& statusObjRet, const CMasternodeBroadcast& mnb, const
     return SerializeMNB(statusObjRet, mnb, fSuccess, successful, failed);
 }
 
-UniValue startmasternode (const JSONRPCRequest& request)
+UniValue startmasternode(const JSONRPCRequest& request)
 {
+    // Skip after legacy obsolete. !TODO: remove when transition to DMN is complete
+    if (deterministicMNManager->LegacyMNObsolete()) {
+        throw JSONRPCError(RPC_MISC_ERROR, "startmasternode is not supported when deterministic masternode list is active (DIP3)");
+    }
+
     std::string strCommand;
     if (request.params.size() >= 1) {
         strCommand = request.params[0].get_str();

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -858,6 +858,63 @@ UniValue signrawtransaction(const JSONRPCRequest& request)
     return result;
 }
 
+void TryATMP(const CMutableTransaction& mtx, bool fOverrideFees)
+{
+    const uint256& hashTx = mtx.GetHash();
+    std::promise<void> promise;
+
+    { // cs_main scope
+        LOCK(cs_main);
+        CCoinsViewCache& view = *pcoinsTip;
+        bool fHaveChain = false;
+        for (size_t o = 0; !fHaveChain && o < mtx.vout.size(); o++) {
+            const Coin& existingCoin = view.AccessCoin(COutPoint(hashTx, o));
+            fHaveChain = !existingCoin.IsSpent();
+        }
+        bool fHaveMempool = mempool.exists(hashTx);
+        if (!fHaveMempool && !fHaveChain) {
+            CValidationState state;
+            bool fMissingInputs;
+            if (!AcceptToMemoryPool(mempool, state, MakeTransactionRef(std::move(mtx)), true, &fMissingInputs, false, !fOverrideFees)) {
+                if (state.IsInvalid()) {
+                    throw JSONRPCError(RPC_TRANSACTION_REJECTED, strprintf("%s: %s", state.GetRejectReason(), state.GetDebugMessage()));
+                } else {
+                    if (fMissingInputs) {
+                        throw JSONRPCError(RPC_TRANSACTION_ERROR, "Missing inputs");
+                    }
+                    throw JSONRPCError(RPC_TRANSACTION_ERROR, strprintf("%s: %s", state.GetRejectReason(), state.GetDebugMessage()));
+                }
+            } else {
+                // If wallet is enabled, ensure that the wallet has been made aware
+                // of the new transaction prior to returning. This prevents a race
+                // where a user might call sendrawtransaction with a transaction
+                // to/from their wallet, immediately call some wallet RPC, and get
+                // a stale result because callbacks have not yet been processed.
+                CallFunctionInValidationInterfaceQueue([&promise] {
+                    promise.set_value();
+                });
+            }
+        } else if (fHaveChain) {
+            throw JSONRPCError(RPC_TRANSACTION_ALREADY_IN_CHAIN, "transaction already in block chain");
+        }
+
+    } // cs_main
+
+    promise.get_future().wait();
+}
+
+void RelayTx(const uint256& hashTx)
+{
+    if(!g_connman)
+        throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
+
+    CInv inv(MSG_TX, hashTx);
+    g_connman->ForEachNode([&inv](CNode* pnode)
+    {
+        pnode->PushInventory(inv);
+    });
+}
+
 UniValue sendrawtransaction(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
@@ -880,8 +937,6 @@ UniValue sendrawtransaction(const JSONRPCRequest& request)
             "\nSend the transaction (signed hex)\n" + HelpExampleCli("sendrawtransaction", "\"signedhex\"") +
             "\nAs a json rpc call\n" + HelpExampleRpc("sendrawtransaction", "\"signedhex\""));
 
-    std::promise<void> promise;
-
     RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VBOOL});
 
     // parse hex string from parameter
@@ -894,55 +949,8 @@ UniValue sendrawtransaction(const JSONRPCRequest& request)
     if (request.params.size() > 1)
         fOverrideFees = request.params[1].get_bool();
 
-    { // cs_main scope
-    LOCK(cs_main);
-    CCoinsViewCache& view = *pcoinsTip;
-    bool fHaveChain = false;
-    for (size_t o = 0; !fHaveChain && o < mtx.vout.size(); o++) {
-        const Coin& existingCoin = view.AccessCoin(COutPoint(hashTx, o));
-        fHaveChain = !existingCoin.IsSpent();
-    }
-    bool fHaveMempool = mempool.exists(hashTx);
-    if (!fHaveMempool && !fHaveChain) {
-        CValidationState state;
-        bool fMissingInputs;
-        {
-            if (!AcceptToMemoryPool(mempool, state, MakeTransactionRef(std::move(mtx)), true, &fMissingInputs, false, !fOverrideFees)) {
-                if (state.IsInvalid()) {
-                    throw JSONRPCError(RPC_TRANSACTION_REJECTED, strprintf("%s: %s", state.GetRejectReason(), state.GetDebugMessage()));
-                } else {
-                    if (fMissingInputs) {
-                        throw JSONRPCError(RPC_TRANSACTION_ERROR, "Missing inputs");
-                    }
-                    throw JSONRPCError(RPC_TRANSACTION_ERROR, strprintf("%s: %s", state.GetRejectReason(), state.GetDebugMessage()));
-                }
-            } else {
-                // If wallet is enabled, ensure that the wallet has been made aware
-                // of the new transaction prior to returning. This prevents a race
-                // where a user might call sendrawtransaction with a transaction
-                // to/from their wallet, immediately call some wallet RPC, and get
-                // a stale result because callbacks have not yet been processed.
-                CallFunctionInValidationInterfaceQueue([&promise] {
-                    promise.set_value();
-                });
-            }
-        }
-    } else if (fHaveChain) {
-        throw JSONRPCError(RPC_TRANSACTION_ALREADY_IN_CHAIN, "transaction already in block chain");
-    }
-
-    } // cs_main
-
-    promise.get_future().wait();
-
-    if(!g_connman)
-        throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
-
-    CInv inv(MSG_TX, hashTx);
-    g_connman->ForEachNode([&inv](CNode* pnode)
-    {
-        pnode->PushInventory(inv);
-    });
+    TryATMP(mtx, fOverrideFees);
+    RelayTx(hashTx);
 
     return hashTx.GetHex();
 }

--- a/src/rpc/register.h
+++ b/src/rpc/register.h
@@ -23,6 +23,8 @@ void RegisterRawTransactionRPCCommands(CRPCTable& tableRPC);
 void RegisterMasternodeRPCCommands(CRPCTable& tableRPC);
 /** Register budget RPC commands */
 void RegisterBudgetRPCCommands(CRPCTable& tableRPC);
+/** Register Evo RPC commands */
+void RegisterEvoRPCCommands(CRPCTable &tableRPC);
 
 static inline void RegisterAllCoreRPCCommands(CRPCTable& tableRPC)
 {
@@ -33,6 +35,7 @@ static inline void RegisterAllCoreRPCCommands(CRPCTable& tableRPC)
     RegisterRawTransactionRPCCommands(tableRPC);
     RegisterMasternodeRPCCommands(tableRPC);
     RegisterBudgetRPCCommands(tableRPC);
+    RegisterEvoRPCCommands(tableRPC);
 }
 
 #endif

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -144,6 +144,14 @@ static CKey GetKeyFromWallet(CWallet* pwallet, const CKeyID& keyID)
 }
 #endif
 
+static void CheckEvoUpgradeEnforcement()
+{
+    const int nHeight = WITH_LOCK(cs_main, return chainActive.Height(); );
+    if (!Params().GetConsensus().NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V6_0)) {
+        throw JSONRPCError(RPC_MISC_ERROR, "Evo upgrade is not active yet");
+    }
+}
+
 // Allows to specify PIVX address or priv key (as strings). In case of PIVX address, the priv key is taken from the wallet
 static CKey ParsePrivKey(CWallet* pwallet, const std::string &strKeyOrAddress, bool allowAddresses = true) {
     bool isStaking{false}, isShield{false};
@@ -394,6 +402,7 @@ static UniValue ProTxRegister(const JSONRPCRequest& request, bool fSignAndSend)
                 )
         );
     }
+    if (fSignAndSend) CheckEvoUpgradeEnforcement();
 
     EnsureWallet();
     EnsureWalletIsUnlocked();
@@ -484,6 +493,7 @@ UniValue protx_register_submit(const JSONRPCRequest& request)
                 + HelpExampleCli("protx_register_submit", "\"tx\" \"sig\"")
         );
     }
+    CheckEvoUpgradeEnforcement();
 
     EnsureWallet();
     EnsureWalletIsUnlocked();
@@ -535,6 +545,7 @@ UniValue protx_register_fund(const JSONRPCRequest& request)
                 + HelpExampleCli("protx_register_fund", "...!TODO...")
         );
     }
+    CheckEvoUpgradeEnforcement();
 
     EnsureWallet();
     EnsureWalletIsUnlocked();
@@ -671,6 +682,8 @@ UniValue protx_list(const JSONRPCRequest& request)
                 + HelpExampleCli("protx_list", "...!TODO...")
         );
     }
+
+    CheckEvoUpgradeEnforcement();
 
 #ifdef ENABLE_WALLET
     CWallet* const pwallet = pwalletMain;

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -1,0 +1,589 @@
+// Copyright (c) 2018-2021 The Dash Core developers
+// Copyright (c) 2021 The PIVX Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "core_io.h"
+#include "destination_io.h"
+#include "evo/specialtx.h"
+#include "evo/providertx.h"
+#include "masternode.h"
+#include "messagesigner.h"
+#include "netbase.h"
+#include "pubkey.h" // COMPACT_SIGNATURE_SIZE
+#include "rpc/server.h"
+#include "utilmoneystr.h"
+#include "validation.h"
+
+#ifdef ENABLE_WALLET
+#include "coincontrol.h"
+#include "wallet/wallet.h"
+#include "wallet/rpcwallet.h"
+
+extern UniValue signrawtransaction(const JSONRPCRequest& request);
+extern UniValue sendrawtransaction(const JSONRPCRequest& request);
+#endif//ENABLE_WALLET
+
+enum ProRegParam {
+    collateralAddress,
+    collateralHash,
+    collateralIndex,
+    ipAndPort_register,
+    ipAndPort_update,
+    operatorAddress_register,
+    operatorAddress_update,
+    operatorPayoutAddress_register,
+    operatorPayoutAddress_update,
+    operatorReward,
+    operatorKey,
+    ownerAddress,
+    ownerKey,
+    proTxHash,
+    payoutAddress_register,
+    payoutAddress_update,
+    votingAddress_register,
+    votingAddress_update,
+};
+
+static const std::map<ProRegParam, std::string> mapParamHelp = {
+        {collateralAddress,
+            "%d. \"collateralAddress\"     (string, required) The PIVX address to send the collateral to.\n"
+        },
+        {collateralHash,
+            "%d. \"collateralHash\"        (string, required) The collateral transaction hash.\n"
+        },
+        {collateralIndex,
+            "%d. collateralIndex           (numeric, required) The collateral transaction output index.\n"
+        },
+        {ipAndPort_register,
+            "%d. \"ipAndPort\"             (string, required) IP and port in the form \"IP:PORT\".\n"
+            "                                Must be unique on the network. Can be set to 0, which will require a ProUpServTx afterwards.\n"
+        },
+        {ipAndPort_update,
+            "%d. \"ipAndPort\"             (string, required) IP and port in the form \"IP:PORT\".\n"
+            "                                If set to an empty string, the currently active ip is reused.\n"
+        },
+        {operatorAddress_register,
+            "%d. \"operatorAddress\"       (string, required) The operator key address. The private key does not have to be known by your wallet.\n"
+            "                                If set to an empty string, ownerAddr will be used.\n"
+        },
+        {operatorAddress_update,
+            "%d. \"operatorAddress\"       (string, required) The operator key address. The private key does not have to be known by your wallet.\n"
+            "                                 It has to match the private key which can be used later to update the service.\n"
+            "                                 If set to an empty string, the currently active operator key is reused.\n"
+        },
+        {operatorKey,
+            "%d. \"operatorKey\"           (string, optional) The operator key associated with the operator address of the masternode.\n"
+            "                                If not specified, or set to an empty string, then the mn key must be known by your wallet, in order to sign the tx.\n"
+        },
+        {operatorPayoutAddress_register,
+            "%d. \"operatorPayoutAddress\" (string, optional) The address used for operator reward payments.\n"
+            "                                Only allowed when the ProRegTx had a non-zero operatorReward value.\n"
+            "                                If set to an empty string, the operatorAddress is used.\n"
+        },
+        {operatorPayoutAddress_update,
+            "%d. \"operatorPayoutAddress\" (string, optional) The address used for operator reward payments.\n"
+            "                                Only allowed when the ProRegTx had a non-zero operatorReward value.\n"
+            "                                If set to an empty string, the currently active one is reused.\n"
+        },
+        {operatorReward,
+            "%d. \"operatorReward\"        (numeric, optional) The fraction in %% to share with the operator. The value must be\n"
+            "                                between 0.00 and 100.00. If not set, it takes the default value of 0.0\n"
+        },
+        {ownerAddress,
+            "%d. \"ownerAddress\"          (string, required) The PIVX address to use for payee updates and proposal voting.\n"
+            "                                The private key belonging to this address must be known in your wallet, in order to send updates.\n"
+            "                                The address must not be already registered, and must differ from the collateralAddress\n"
+        },
+        {ownerKey,
+            "%d. \"ownerKey\"              (string, optional) The owner key associated with the operator address of the masternode.\n"
+            "                                If not specified, or set to an empty string, then the mn key must be known by your wallet, in order to sign the tx.\n"
+        },
+        {payoutAddress_register,
+            "%d. \"payoutAddress\"          (string, required) The PIVX address to use for masternode reward payments.\n"
+        },
+        {payoutAddress_update,
+            "%d. \"payoutAddress\"          (string, required) The PIVX address to use for masternode reward payments.\n"
+            "                                 If set to an empty string, the currently active payout address is reused.\n"
+        },
+        {proTxHash,
+            "%d. \"proTxHash\"              (string, required) The hash of the initial ProRegTx.\n"
+        },
+        {votingAddress_register,
+            "%d. \"votingAddress\"          (string, required) The voting key address. The private key does not have to be known by your wallet.\n"
+            "                                 It has to match the private key which is later used when voting on proposals.\n"
+            "                                 If set to an empty string, ownerAddress will be used.\n"
+        },
+        {votingAddress_update,
+            "%d. \"votingAddress\"          (string, required) The voting key address. The private key does not have to be known by your wallet.\n"
+            "                                 It has to match the private key which is later used when voting on proposals.\n"
+            "                                 If set to an empty string, the currently active voting key address is reused.\n"
+        },
+    };
+
+std::string GetHelpString(int nParamNum, ProRegParam p)
+{
+    auto it = mapParamHelp.find(p);
+    if (it == mapParamHelp.end())
+        throw std::runtime_error(strprintf("FIXME: WRONG PARAM: %d!", (int)p));
+
+    return strprintf(it->second, nParamNum);
+}
+
+#ifdef ENABLE_WALLET
+static CKey GetKeyFromWallet(CWallet* pwallet, const CKeyID& keyID)
+{
+    assert(pwallet);
+    CKey key;
+    if (!pwallet->GetKey(keyID, key)) {
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY,
+                           strprintf("key for address %s not in wallet", EncodeDestination(keyID)));
+    }
+    return key;
+}
+#endif
+
+// Allows to specify PIVX address or priv key (as strings). In case of PIVX address, the priv key is taken from the wallet
+static CKey ParsePrivKey(CWallet* pwallet, const std::string &strKeyOrAddress, bool allowAddresses = true) {
+    bool isStaking{false}, isShield{false};
+    const CWDestination& cwdest = Standard::DecodeDestination(strKeyOrAddress, isStaking, isShield);
+    if (isStaking) {
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "cold staking addresses not supported");
+    }
+    if (isShield) {
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "shield addresses not supported");
+    }
+    const CTxDestination* dest = Standard::GetTransparentDestination(cwdest);
+    if (allowAddresses && IsValidDestination(*dest)) {
+#ifdef ENABLE_WALLET
+        if (!pwallet) {
+            throw std::runtime_error("addresses not supported when wallet is disabled");
+        }
+        EnsureWalletIsUnlocked(pwallet);
+        const CKeyID* keyID = boost::get<CKeyID>(dest);
+        assert (keyID != nullptr);  // we just checked IsValidDestination
+        return GetKeyFromWallet(pwallet, *keyID);
+#else   // ENABLE_WALLET
+        throw std::runtime_error("addresses not supported in no-wallet builds");
+#endif  // ENABLE_WALLET
+    }
+
+    CKey key = DecodeSecret(strKeyOrAddress);
+    if (!key.IsValid()) throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid private key encoding");
+    return key;
+}
+
+static CKeyID ParsePubKeyIDFromAddress(const std::string& strAddress)
+{
+    bool isStaking{false}, isShield{false};
+    const CWDestination& cwdest = Standard::DecodeDestination(strAddress, isStaking, isShield);
+    if (isStaking) {
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "cold staking addresses not supported");
+    }
+    if (isShield) {
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "shield addresses not supported");
+    }
+    const CKeyID* keyID = boost::get<CKeyID>(Standard::GetTransparentDestination(cwdest));
+    if (!keyID) {
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("invalid PIVX address %s", strAddress));
+    }
+    return *keyID;
+}
+
+#ifdef ENABLE_WALLET
+
+template<typename SpecialTxPayload>
+static void FundSpecialTx(CWallet* pwallet, CMutableTransaction& tx, SpecialTxPayload& payload)
+{
+    assert(pwallet != nullptr);
+    SetTxPayload(tx, payload);
+
+    static CTxOut dummyTxOut(0, CScript() << OP_RETURN);
+    std::vector<CRecipient> vecSend;
+    bool dummyTxOutAdded = false;
+
+    if (tx.vout.empty()) {
+        // add dummy txout as CreateTransaction requires at least one recipient
+        tx.vout.emplace_back(dummyTxOut);
+        dummyTxOutAdded = true;
+    }
+
+    CAmount nFee;
+    CFeeRate feeRate = CFeeRate(0);
+    int nChangePos = -1;
+    std::string strFailReason;
+    std::set<int> setSubtractFeeFromOutputs;
+    if (!pwallet->FundTransaction(tx, nFee, false, feeRate, nChangePos, strFailReason, false, false))
+        throw JSONRPCError(RPC_INTERNAL_ERROR, strFailReason);
+
+    if (dummyTxOutAdded && tx.vout.size() > 1) {
+        // FundTransaction added a change output, so we don't need the dummy txout anymore
+        // Removing it results in slight overpayment of fees, but we ignore this for now (as it's a very low amount)
+        auto it = std::find(tx.vout.begin(), tx.vout.end(), dummyTxOut);
+        assert(it != tx.vout.end());
+        tx.vout.erase(it);
+    }
+
+    UpdateSpecialTxInputsHash(tx, payload);
+}
+
+template<typename SpecialTxPayload>
+static void UpdateSpecialTxInputsHash(const CMutableTransaction& tx, SpecialTxPayload& payload)
+{
+    payload.inputsHash = CalcTxInputsHash(tx);
+}
+
+template<typename SpecialTxPayload>
+static void SignSpecialTxPayloadByHash(const CMutableTransaction& tx, SpecialTxPayload& payload, const CKey& key)
+{
+    payload.vchSig.clear();
+
+    uint256 hash = ::SerializeHash(payload);
+    if (!CHashSigner::SignHash(hash, key, payload.vchSig)) {
+        throw JSONRPCError(RPC_INTERNAL_ERROR, "failed to sign special tx payload");
+    }
+}
+
+template<typename SpecialTxPayload>
+static void SignSpecialTxPayloadByString(SpecialTxPayload& payload, const CKey& key)
+{
+    payload.vchSig.clear();
+
+    std::string m = payload.MakeSignString();
+    if (!CMessageSigner::SignMessage(m, payload.vchSig, key)) {
+        throw JSONRPCError(RPC_INTERNAL_ERROR, "failed to sign special tx payload");
+    }
+}
+
+static std::string SignAndSendSpecialTx(CMutableTransaction& tx, const ProRegPL& pl)
+{
+    EnsureWallet();
+    EnsureWalletIsUnlocked();
+
+    SetTxPayload(tx, pl);
+
+    CValidationState state;
+    if (!CheckSpecialTx(tx, GetChainTip(), state)) {
+        throw std::runtime_error(FormatStateMessage(state));
+    }
+
+    CDataStream ds(SER_NETWORK, PROTOCOL_VERSION);
+    ds << tx;
+
+    JSONRPCRequest signRequest;
+    signRequest.params.setArray();
+    signRequest.params.push_back(HexStr(ds.begin(), ds.end()));
+    UniValue signResult = signrawtransaction(signRequest);
+
+    if (!signResult["complete"].get_bool()) {
+        std::ostringstream ss;
+        ss << "failed to sign special tx: ";
+        UniValue errors = signResult["errors"].get_array();
+        for (unsigned int i = 0; i < errors.size(); i++) {
+            if (i > 0) ss << " - ";
+            ss << errors[i].get_str();
+        }
+        throw JSONRPCError(RPC_INTERNAL_ERROR, ss.str());
+    }
+
+    JSONRPCRequest sendRequest;
+    sendRequest.params.setArray();
+    sendRequest.params.push_back(signResult["hex"].get_str());
+    return sendrawtransaction(sendRequest).get_str();
+}
+
+// Parses inputs (starting from index paramIdx) and returns ProReg payload
+static ProRegPL ParseProRegPLParams(const UniValue& params, unsigned int paramIdx)
+{
+    assert(pwalletMain);
+    assert(params.size() > paramIdx + 4);
+    assert(params.size() < paramIdx + 8);
+    ProRegPL pl;
+
+    // ip and port
+    const std::string& strIpPort = params[paramIdx].get_str();
+    if (!strIpPort.empty()) {
+        if (!Lookup(strIpPort.c_str(), pl.addr, Params().GetDefaultPort(), false)) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("invalid network address %s", strIpPort));
+        }
+    }
+
+    // addresses/keys
+    const std::string& strAddOwner = params[paramIdx + 1].get_str();
+    const std::string& strAddOperator = params[paramIdx + 2].get_str();
+    const std::string& strAddVoting = params[paramIdx + 3].get_str();
+    pl.keyIDOwner = ParsePubKeyIDFromAddress(strAddOwner);
+    pl.keyIDOperator = pl.keyIDOwner;
+    if (!strAddOperator.empty()) {
+        pl.keyIDOperator = ParsePubKeyIDFromAddress(strAddOperator);
+    }
+    pl.keyIDVoting = pl.keyIDOwner;
+    if (!strAddVoting.empty()) {
+        pl.keyIDVoting = ParsePubKeyIDFromAddress(strAddVoting);
+    }
+
+    // payout script (!TODO: add support for P2CS)
+    const std::string& strAddPayee = params[paramIdx + 4].get_str();
+    pl.scriptPayout = GetScriptForDestination(CTxDestination(ParsePubKeyIDFromAddress(strAddPayee)));
+
+    // operator reward
+    pl.nOperatorReward = 0;
+    if (params.size() > paramIdx + 5) {
+        int64_t operReward = 0;
+        if (!ParseFixedPoint(params[paramIdx + 5].getValStr(), 2, &operReward)) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "operatorReward must be a number");
+        }
+        if (operReward < 0 || operReward > 10000) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "operatorReward must be between 0.00 and 100.00");
+        }
+        pl.nOperatorReward = (uint16_t)operReward;
+        if (params.size() > paramIdx + 6) {
+            // operator reward payout script
+            const std::string& strAddOpPayee = params[paramIdx + 6].get_str();
+            if (pl.nOperatorReward > 0 && !strAddOpPayee.empty()) {
+                pl.scriptOperatorPayout = GetScriptForDestination(CTxDestination(ParsePubKeyIDFromAddress(strAddOpPayee)));
+            } else if (!strAddOpPayee.empty()) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "operatorPayoutAddress must be empty when operatorReward is 0");
+            }
+        }
+    }
+    return pl;
+}
+
+// handles protx_register, and protx_register_prepare
+static UniValue ProTxRegister(const JSONRPCRequest& request, bool fSignAndSend)
+{
+    if (request.fHelp || request.params.size() < 7 || request.params.size() > 9) {
+        throw std::runtime_error(
+                (fSignAndSend ?
+                    "protx_register \"collateralHash\" collateralIndex \"ipAndPort\" \"ownerAddress\" \"operatorAddress\" \"votingAddress\" \"payoutAddress\" (operatorReward \"operatorPayoutAddress\")\n"
+                    "The collateral is specified through \"collateralHash\" and \"collateralIndex\" and must be an unspent\n"
+                    "transaction output spendable by this wallet. It must also not be used by any other masternode.\n"
+                        :
+                    "protx_register_prepare \"collateralHash\" collateralIndex \"ipAndPort\" \"ownerAddress\" \"operatorAddress\" \"votingAddress\" \"payoutAddress\" (operatorReward \"operatorPayoutAddress\")\n"
+                    "\nCreates an unsigned ProTx and returns it. The ProTx must be signed externally with the collateral\n"
+                    "key and then passed to \"protx_register_submit\".\n"
+                    "The collateral is specified through \"collateralHash\" and \"collateralIndex\" and must be an unspent transaction output.\n"
+                )
+                + HelpRequiringPassphrase() + "\n"
+                "\nArguments:\n"
+                + GetHelpString(1, collateralHash)
+                + GetHelpString(2, collateralIndex)
+                + GetHelpString(3, ipAndPort_register)
+                + GetHelpString(4, ownerAddress)
+                + GetHelpString(5, operatorAddress_register)
+                + GetHelpString(6, votingAddress_register)
+                + GetHelpString(7, payoutAddress_register)
+                + GetHelpString(8, operatorReward)
+                + GetHelpString(9, operatorPayoutAddress_register) +
+                "\nResult:\n" +
+                (fSignAndSend ? (
+                        "\"txid\"                 (string) The transaction id.\n"
+                        "\nExamples:\n"
+                        + HelpExampleCli("protx_register", "...!TODO...")
+                        ) : (
+                        "{                        (json object)\n"
+                        "  \"tx\" :                 (string) The serialized ProTx in hex format.\n"
+                        "  \"collateralAddress\" :  (string) The collateral address.\n"
+                        "  \"signMessage\" :        (string) The string message that needs to be signed with the collateral key\n"
+                        "}\n"
+                        "\nExamples:\n"
+                        + HelpExampleCli("protx_register_prepare", "...!TODO...")
+                        )
+                )
+        );
+    }
+
+    EnsureWallet();
+    EnsureWalletIsUnlocked();
+    // Make sure the results are valid at least up to the most recent block
+    // the user could have gotten from another RPC command prior to now
+    pwalletMain->BlockUntilSyncedToCurrentChain();
+
+    const uint256& collateralHash = ParseHashV(request.params[0], "collateralHash");
+    const int32_t collateralIndex = request.params[1].get_int();
+    if (collateralIndex < 0) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("invalid collateral index (negative): %d", collateralIndex));
+    }
+
+    ProRegPL pl = ParseProRegPLParams(request.params, 2);
+    pl.nVersion = ProRegPL::CURRENT_VERSION;
+    pl.collateralOutpoint = COutPoint(collateralHash, (uint32_t)collateralIndex);
+
+    CMutableTransaction tx;
+    tx.nVersion = CTransaction::TxVersion::SAPLING;
+    tx.nType = CTransaction::TxType::PROREG;
+
+    // referencing unspent collateral outpoint
+    Coin coin;
+    {
+        LOCK(cs_main);
+        if (!GetUTXOCoin(pl.collateralOutpoint, coin)) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("collateral not found: %s-%d", collateralHash.ToString(), collateralIndex));
+        }
+    }
+    if (coin.out.nValue != MN_COLL_AMT) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("collateral %s-%d with invalid value %d", collateralHash.ToString(), collateralIndex, coin.out.nValue));
+    }
+    CTxDestination txDest;
+    ExtractDestination(coin.out.scriptPubKey, txDest);
+    const CKeyID* keyID = boost::get<CKeyID>(&txDest);
+    if (!keyID) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("collateral type not supported: %s-%d", collateralHash.ToString(), collateralIndex));
+    }
+    CKey keyCollateral;
+    if (fSignAndSend && !pwalletMain->GetKey(*keyID, keyCollateral)) {
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("collateral key not in wallet: %s", EncodeDestination(txDest)));
+    }
+
+    // make sure fee calculation works
+    pl.vchSig.resize(CPubKey::COMPACT_SIGNATURE_SIZE);
+
+    FundSpecialTx(pwalletMain, tx, pl);
+
+    if (fSignAndSend) {
+        SignSpecialTxPayloadByString(pl, keyCollateral); // prove we own the collateral
+        // check the payload, add the tx inputs sigs, and send the tx.
+        return SignAndSendSpecialTx(tx, pl);
+    }
+    // external signing with collateral key
+    pl.vchSig.clear();
+    SetTxPayload(tx, pl);
+    UniValue ret(UniValue::VOBJ);
+    ret.pushKV("tx", EncodeHexTx(tx));
+    ret.pushKV("collateralAddress", EncodeDestination(txDest));
+    ret.pushKV("signMessage", pl.MakeSignString());
+    return ret;
+}
+
+UniValue protx_register(const JSONRPCRequest& request)
+{
+    return ProTxRegister(request, true);
+}
+
+UniValue protx_register_prepare(const JSONRPCRequest& request)
+{
+    return ProTxRegister(request, false);
+}
+
+UniValue protx_register_submit(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() != 2) {
+        throw std::runtime_error(
+                "protx_register_submit \"tx\" \"sig\"\n"
+                "\nSubmits the specified ProTx to the network. This command will also sign the inputs of the transaction\n"
+                "which were previously added by \"protx_register_prepare\" to cover transaction fees\n"
+                + HelpRequiringPassphrase() + "\n"
+                "\nArguments:\n"
+                "1. \"tx\"                 (string, required) The serialized transaction previously returned by \"protx_register_prepare\"\n"
+                "2. \"sig\"                (string, required) The signature signed with the collateral key. Must be in base64 format.\n"
+                "\nResult:\n"
+                "\"txid\"                  (string) The transaction id.\n"
+                "\nExamples:\n"
+                + HelpExampleCli("protx_register_submit", "\"tx\" \"sig\"")
+        );
+    }
+
+    EnsureWallet();
+    EnsureWalletIsUnlocked();
+    // Make sure the results are valid at least up to the most recent block
+    // the user could have gotten from another RPC command prior to now
+    pwalletMain->BlockUntilSyncedToCurrentChain();
+
+    CMutableTransaction tx;
+    if (!DecodeHexTx(tx, request.params[0].get_str())) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "transaction not deserializable");
+    }
+    if (tx.nType != CTransaction::TxType::PROREG) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "transaction not a ProRegTx");
+    }
+    ProRegPL pl;
+    if (!GetTxPayload(tx, pl)) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "transaction payload not deserializable");
+    }
+    if (!pl.vchSig.empty()) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "payload signature not empty");
+    }
+
+    pl.vchSig = DecodeBase64(request.params[1].get_str().c_str());
+
+    // check the payload, add the tx inputs sigs, and send the tx.
+    return SignAndSendSpecialTx(tx, pl);
+}
+
+UniValue protx_register_fund(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() < 6 || request.params.size() > 8) {
+        throw std::runtime_error(
+                "protx_register_fund \"collateralAddress\" \"ipAndPort\" \"ownerAddress\" \"operatorAddress\" \"votingAddress\" \"payoutAddress\" (operatorReward \"operatorPayoutAddress\")\n"
+                "\nCreates, funds and sends a ProTx to the network. The resulting transaction will move 10000 PIV\n"
+                "to the address specified by collateralAddress and will then function as masternode collateral.\n"
+                + HelpRequiringPassphrase() + "\n"
+                "\nArguments:\n"
+                + GetHelpString(1, collateralAddress)
+                + GetHelpString(2, ipAndPort_register)
+                + GetHelpString(3, ownerAddress)
+                + GetHelpString(4, operatorAddress_register)
+                + GetHelpString(5, votingAddress_register)
+                + GetHelpString(6, payoutAddress_register)
+                + GetHelpString(7, operatorReward)
+                + GetHelpString(8, operatorPayoutAddress_register) +
+                "\nResult:\n"
+                "\"txid\"                        (string) The transaction id.\n"
+                "\nExamples:\n"
+                + HelpExampleCli("protx_register_fund", "...!TODO...")
+        );
+    }
+
+    EnsureWallet();
+    EnsureWalletIsUnlocked();
+    // Make sure the results are valid at least up to the most recent block
+    // the user could have gotten from another RPC command prior to now
+    pwalletMain->BlockUntilSyncedToCurrentChain();
+
+    const CTxDestination& collateralDest(ParsePubKeyIDFromAddress(request.params[0].get_str()));
+    const CScript& collateralScript = GetScriptForDestination(collateralDest);
+
+    ProRegPL pl = ParseProRegPLParams(request.params, 1);
+    pl.nVersion = ProRegPL::CURRENT_VERSION;
+
+    CMutableTransaction tx;
+    tx.nVersion = CTransaction::TxVersion::SAPLING;
+    tx.nType = CTransaction::TxType::PROREG;
+    tx.vout.emplace_back(MN_COLL_AMT, collateralScript);
+
+    FundSpecialTx(pwalletMain, tx, pl);
+
+    for (uint32_t i = 0; i < tx.vout.size(); i++) {
+        if (tx.vout[i].nValue == MN_COLL_AMT && tx.vout[i].scriptPubKey == collateralScript) {
+            pl.collateralOutpoint.n = i;
+            break;
+        }
+    }
+    assert(pl.collateralOutpoint.n != (uint32_t) -1);
+    // update payload on tx (with final collateral outpoint)
+    pl.vchSig.clear();
+    // check the payload, add the tx inputs sigs, and send the tx.
+    return SignAndSendSpecialTx(tx, pl);
+}
+
+#endif  //ENABLE_WALLET
+
+
+static const CRPCCommand commands[] =
+{ //  category       name                              actor (function)
+  //  -------------- --------------------------------- ------------------------
+#ifdef ENABLE_WALLET
+    { "evo",         "protx_register",                 &protx_register,         {}  },
+    { "evo",         "protx_register_fund",            &protx_register_fund,    {}  },
+    { "evo",         "protx_register_prepare",         &protx_register_prepare, {}  },
+    { "evo",         "protx_register_submit",          &protx_register_submit,  {}  },
+#endif  //ENABLE_WALLET
+};
+
+void RegisterEvoRPCCommands(CRPCTable &tableRPC)
+{
+    for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++) {
+        tableRPC.appendCommand(commands[vcidx].name, &commands[vcidx]);
+    }
+}

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -8,7 +8,6 @@
 #include "evo/specialtx.h"
 #include "evo/providertx.h"
 #include "evo/deterministicmns.h"
-#include "masternode.h"
 #include "messagesigner.h"
 #include "netbase.h"
 #include "policy/policy.h"
@@ -119,7 +118,7 @@ static CMutableTransaction CreateProRegTx(Optional<COutPoint> optCollateralOut, 
     tx.nType = CTransaction::TxType::PROREG;
     FundTransaction(tx, utxos, scriptPayout,
                     GetScriptForDestination(coinbaseKey.GetPubKey().GetID()),
-                    (optCollateralOut ? 0 : MN_COLL_AMT));
+                    (optCollateralOut ? 0 : Params().GetConsensus().nMNCollateralAmt));
 
     pl.inputsHash = CalcTxInputsHash(tx);
     SetTxPayload(tx, pl);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1714,6 +1714,7 @@ CAmount CWalletTx::GetLockedCredit() const
 
     CAmount nCredit = 0;
     uint256 hashTx = GetHash();
+    const CAmount collAmt = Params().GetConsensus().nMNCollateralAmt;
     for (unsigned int i = 0; i < tx->vout.size(); i++) {
         const CTxOut& txout = tx->vout[i];
 
@@ -1726,7 +1727,7 @@ CAmount CWalletTx::GetLockedCredit() const
         }
 
         // Add masternode collaterals which are handled like locked coins
-        else if (fMasterNode && tx->vout[i].nValue == MN_COLL_AMT) {
+        else if (fMasterNode && tx->vout[i].nValue == collAmt) {
             nCredit += pwallet->GetCredit(txout, ISMINE_SPENDABLE);
         }
 
@@ -2467,7 +2468,7 @@ bool CWallet::GetMasternodeVinAndKeys(CTxIn& txinRet, CPubKey& pubKeyRet, CKey& 
     CTxOut txOut = wtx->tx->vout[nOutputIndex];
 
     // Masternode collateral value
-    if (txOut.nValue != MN_COLL_AMT) {
+    if (txOut.nValue != Params().GetConsensus().nMNCollateralAmt) {
         strError = "Invalid collateral tx value, must be 10,000 PIV";
         return error("%s: tx %s, index %d not a masternode collateral", __func__, strTxHash, nOutputIndex);
     }
@@ -2522,7 +2523,7 @@ CWallet::OutputAvailabilityResult CWallet::CheckOutputAvailability(
     OutputAvailabilityResult res;
 
     // Check for only 10k utxo
-    if (nCoinType == ONLY_10000 && output.nValue != MN_COLL_AMT) return res;
+    if (nCoinType == ONLY_10000 && output.nValue != Params().GetConsensus().nMNCollateralAmt) return res;
 
     // Check for stakeable utxo
     if (nCoinType == STAKEABLE_COINS && output.IsZerocoinMint()) return res;

--- a/test/functional/tiertwo_masternode_activation.py
+++ b/test/functional/tiertwo_masternode_activation.py
@@ -47,7 +47,7 @@ class MasternodeActivationTest(PivxTier2TestFramework):
         mnCollateralOutput = self.ownerOne.getmasternodeoutputs()[0]
         assert_equal(mnCollateralOutput["txhash"], self.mnOneTxHash)
         mnCollateralOutputIndex = mnCollateralOutput["outputidx"]
-        send_value = satoshi_round(10000 - 0.001)
+        send_value = satoshi_round(100 - 0.001)
         inputs = [{'txid' : self.mnOneTxHash, 'vout' : mnCollateralOutputIndex}]
         outputs = {}
         outputs[self.ownerOne.getnewaddress()] = float(send_value)

--- a/test/functional/tiertwo_masternode_ping.py
+++ b/test/functional/tiertwo_masternode_ping.py
@@ -43,12 +43,12 @@ class MasternodePingTest(PivxTestFramework):
         self.log.info("funding masternode controller...")
         masternodeAlias = "mnode"
         mnAddress = owner.getnewaddress(masternodeAlias)
-        collateralTxId = miner.sendtoaddress(mnAddress, Decimal('10000'))
+        collateralTxId = miner.sendtoaddress(mnAddress, Decimal('100'))
         miner.generate(2)
         self.sync_blocks()
         time.sleep(1)
         collateral_rawTx = owner.getrawtransaction(collateralTxId, 1)
-        assert_equal(owner.getbalance(), Decimal('10000'))
+        assert_equal(owner.getbalance(), Decimal('100'))
         assert_greater_than(collateral_rawTx["confirmations"], 0)
 
         # Block time can be up to median time past +1. We might need to wait...


### PR DESCRIPTION
Extracted from #2267. Based on top of
- [x] #2273

Implement `protx_register` and `protx_list` RPC commands. 
Add DMN support to `listmasternodes`.
Deprecate `startmasternode` after SPORK_21 activation.