### PR TITLE
[WIP] Implement rewind block index to last checkpoint functionality

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -259,6 +259,14 @@ bool CBlockTreeDB::WriteBatchSync(const std::vector<std::pair<int, const CBlockF
     return WriteBatch(batch, true);
 }
 
+bool CBlockTreeDB::EraseBatchSync(const std::vector<const CBlockIndex*>& blockinfo) {
+    CDBBatch batch;
+    for (std::vector<const CBlockIndex*>::const_iterator it=blockinfo.begin(); it != blockinfo.end(); it++) {
+        batch.Erase(std::make_pair(DB_BLOCK_INDEX, (*it)->GetBlockHash()));
+    }
+    return WriteBatch(batch, true);
+}
+
 bool CBlockTreeDB::ReadTxIndex(const uint256& txid, CDiskTxPos& pos)
 {
     return Read(std::make_pair(DB_TXINDEX, txid), pos);

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -131,6 +131,7 @@ private:
 public:
     bool WriteBlockIndex(const CDiskBlockIndex& blockindex);
     bool WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*> >& fileInfo, int nLastFile, const std::vector<const CBlockIndex*>& blockinfo);
+    bool EraseBatchSync(const std::vector<const CBlockIndex*>& blockinfo);
     bool ReadBlockFileInfo(int nFile, CBlockFileInfo& fileinfo);
     bool ReadLastBlockFile(int& nFile);
     bool WriteReindexing(bool fReindex);

--- a/src/validation.h
+++ b/src/validation.h
@@ -350,6 +350,9 @@ public:
     bool VerifyDB(CCoinsView* coinsview, int nCheckLevel, int nCheckDepth);
 };
 
+/** Rewind chain up to the last checkpoint */
+bool RewindBlockIndexToLastCheckpoint(const CChainParams& chainparams);
+
 /** Replay blocks that aren't fully applied to the database. */
 bool ReplayBlocks(const CChainParams& params, CCoinsView* view);
 


### PR DESCRIPTION
Adding functionality to rollback the chain up to the last known checkpoint.

As we have a max depth reorg limit, this is useful in many scenarios. The one that happen often is over every upgrade enforcement where users update late and continue running on a forked chain for a long time. With this, they will be able to get back to the main chain just pressing a button in the GUI, without having to invalidate the chain manually nor sync from scratch.

Another future step forward from this PR would be to automate the rewind process but there are several other factors that need to be contemplated in order to do it.

TODO: 
* Add test coverage.
* Add visual connection.
* Add way more checkpoints in the zerocoin active window.