### PR TITLE
[wallet] Remove now unneeded stake P2PKH->P2PK output forced conversion

### DIFF
--- a/src/stakeinput.cpp
+++ b/src/stakeinput.cpp
@@ -57,7 +57,7 @@ CAmount CPivStake::GetValue() const
     return outputFrom.nValue;
 }
 
-bool CPivStake::CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal, const bool onlyP2PK)
+bool CPivStake::CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal)
 {
     std::vector<valtype> vSolutions;
     txnouttype whichType;
@@ -68,7 +68,6 @@ bool CPivStake::CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmoun
     if (whichType != TX_PUBKEY && whichType != TX_PUBKEYHASH && whichType != TX_COLDSTAKE)
         return error("%s: type=%d (%s) not supported for scriptPubKeyKernel", __func__, whichType, GetTxnOutputType(whichType));
 
-    CScript scriptPubKey;
     CKey key;
     if (whichType == TX_PUBKEYHASH || whichType == TX_COLDSTAKE) {
         // if P2PKH or P2CS check that we have the input private key
@@ -76,17 +75,7 @@ bool CPivStake::CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmoun
             return error("%s: Unable to get staking private key", __func__);
     }
 
-    // Consensus check: P2PKH block signatures were not accepted before v5 update.
-    // This can be removed after v5.0 enforcement
-    if (whichType == TX_PUBKEYHASH && onlyP2PK) {
-        // convert to P2PK inputs
-        scriptPubKey << key.GetPubKey() << OP_CHECKSIG;
-    } else {
-        // keep the same script
-        scriptPubKey = scriptPubKeyKernel;
-    }
-
-    vout.emplace_back(0, scriptPubKey);
+    vout.emplace_back(0, scriptPubKeyKernel);
 
     // Calculate if we need to split the output
     if (pwallet->nStakeSplitThreshold > 0) {
@@ -98,7 +87,7 @@ bool CPivStake::CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmoun
                 nSplit = txSizeMax;
             for (int i = nSplit; i > 1; i--) {
                 LogPrintf("%s: StakeSplit: nTotal = %d; adding output %d of %d\n", __func__, nTotal, (nSplit-i)+2, nSplit);
-                vout.emplace_back(0, scriptPubKey);
+                vout.emplace_back(0, scriptPubKeyKernel);
             }
         }
     }

--- a/src/stakeinput.h
+++ b/src/stakeinput.h
@@ -26,7 +26,7 @@ public:
     virtual bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = UINT256_ZERO) = 0;
     virtual bool GetTxOutFrom(CTxOut& out) const = 0;
     virtual CAmount GetValue() const = 0;
-    virtual bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal, const bool onlyP2PK) = 0;
+    virtual bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) = 0;
     virtual bool IsZPIV() const = 0;
     virtual CDataStream GetUniqueness() const = 0;
     virtual bool ContextCheck(int nHeight, uint32_t nTime) = 0;
@@ -51,7 +51,7 @@ public:
     CAmount GetValue() const override;
     CDataStream GetUniqueness() const override;
     bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = UINT256_ZERO) override;
-    bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal, const bool onlyP2PK) override;
+    bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) override;
     bool IsZPIV() const override { return false; }
     bool ContextCheck(int nHeight, uint32_t nTime) override;
 };

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2169,7 +2169,7 @@ CWallet::Balance CWallet::GetBalance(const int min_depth) const
     return ret;
 }
 
-CAmount CWallet::loopTxsBalance(std::function<void(const uint256&, const CWalletTx&, CAmount&)> method) const
+CAmount CWallet::loopTxsBalance(const std::function<void(const uint256&, const CWalletTx&, CAmount&)>& method) const
 {
     CAmount nTotal = 0;
     {
@@ -3903,7 +3903,7 @@ std::vector<CKeyID> CWallet::GetAffectedKeys(const CScript& spk)
     std::vector<CKeyID> vAffected;
     CAffectedKeysVisitor(*this, vAffected).Process(spk);
     for (const CKeyID& keyid : vAffected) {
-        ret.push_back(keyid);
+        ret.emplace_back(keyid);
     }
     return ret;
 }
@@ -4777,7 +4777,7 @@ Optional<std::pair<
 {
     auto output = this->tx->sapData->vShieldedOutput[op.n];
 
-    for (auto ovk : ovks) {
+    for (const auto& ovk : ovks) {
         auto outPt = libzcash::SaplingOutgoingPlaintext::decrypt(
                 output.outCiphertext,
                 ovk,

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3227,9 +3227,6 @@ bool CWallet::CreateCoinStake(
     pStakerStatus->SetLastTip(pindexPrev);
     pStakerStatus->SetLastCoins((int) availableCoins->size());
 
-    // P2PKH block signatures were not accepted before v5 update.
-    bool onlyP2PK = !consensus.NetworkUpgradeActive(pindexPrev->nHeight + 1, Consensus::UPGRADE_V5_0);
-
     // Kernel Search
     CAmount nCredit;
     CScript scriptPubKeyKernel;
@@ -3277,7 +3274,7 @@ bool CWallet::CreateCoinStake(
 
         // Create the output transaction(s)
         std::vector<CTxOut> vout;
-        if (!stakeInput.CreateTxOuts(this, vout, nCredit, onlyP2PK)) {
+        if (!stakeInput.CreateTxOuts(this, vout, nCredit)) {
             LogPrintf("%s : failed to create output\n", __func__);
             it++;
             continue;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3254,13 +3254,6 @@ bool CWallet::CreateCoinStake(
             continue;
         }
 
-        // This should never happen
-        if (stakeInput.IsZPIV()) {
-            LogPrintf("%s: ERROR - zPOS is disabled\n", __func__);
-            it++;
-            continue;
-        }
-
         nCredit = 0;
 
         nAttempts++;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -977,7 +977,7 @@ public:
     };
     Balance GetBalance(int min_depth = 0) const;
 
-    CAmount loopTxsBalance(std::function<void(const uint256&, const CWalletTx&, CAmount&)>method) const;
+    CAmount loopTxsBalance(const std::function<void(const uint256&, const CWalletTx&, CAmount&)>&method) const;
     CAmount GetAvailableBalance(bool fIncludeDelegated = true, bool fIncludeShielded = true) const;
     CAmount GetAvailableBalance(isminefilter& filter, bool useCache = false, int minDepth = 1) const;
     CAmount GetColdStakingBalance() const;  // delegated coins for which we have the staking key

--- a/src/zpiv/zpos.h
+++ b/src/zpiv/zpos.h
@@ -26,7 +26,7 @@ public:
     CAmount GetValue() const override;
     CDataStream GetUniqueness() const override;
     bool CreateTxIn(CWallet* pwallet, CTxIn& txIn, uint256 hashTxOut = UINT256_ZERO) override { return false; /* creation disabled */}
-    bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal, const bool onlyP2PK) override { return false; /* creation disabled */}
+    bool CreateTxOuts(CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) override { return false; /* creation disabled */}
     bool GetTxOutFrom(CTxOut& out) const override { return false; /* not available */ }
     virtual bool ContextCheck(int nHeight, uint32_t nTime) override;
 };


### PR DESCRIPTION
Since v5 activation, #1700 is active and there is no need to continue checking for the v5 NU enforcement during the coinstake generation in the mining process. This PR removes the extra validations and script conversion inside the wallet.