### PR TITLE
[RPC] Return command name with 'Method not found' errors

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -233,8 +233,7 @@ UniValue setgenerate(const JSONRPCRequest& request)
             "\nTurn off generation\n" + HelpExampleCli("setgenerate", "false") +
             "\nUsing json rpc\n" + HelpExampleRpc("setgenerate", "true, 1"));
 
-    if (pwalletMain == NULL)
-        throw JSONRPCError(RPC_METHOD_NOT_FOUND, "Method not found (disabled)");
+    EnsureWallet();
 
     if (Params().IsRegTestNet())
         throw JSONRPCError(RPC_INVALID_REQUEST, "Use the generate method instead of setgenerate on regtest");

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -430,7 +430,7 @@ UniValue CRPCTable::execute(const JSONRPCRequest &request) const
     // Find method
     const CRPCCommand* pcmd = tableRPC[request.strMethod];
     if (!pcmd)
-        throw JSONRPCError(RPC_METHOD_NOT_FOUND, "Method not found");
+        throw JSONRPCError(RPC_METHOD_NOT_FOUND, strprintf("Method not found: %s", request.strMethod));
 
     g_rpcSignals.PreCommand(*pcmd);
 

--- a/test/functional/wallet_disable.py
+++ b/test/functional/wallet_disable.py
@@ -19,7 +19,7 @@ class DisableWalletTest (PivxTestFramework):
 
     def run_test (self):
         # Make sure wallet is really disabled
-        assert_raises_rpc_error(-32601, 'Method not found', self.nodes[0].getwalletinfo)
+        assert_raises_rpc_error(-32601, 'Method not found: getwalletinfo', self.nodes[0].getwalletinfo)
         x = self.nodes[0].validateaddress('3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy')
         assert(x['isvalid'] == False)
         x = self.nodes[0].validateaddress('xwMWGTnBNUmGxMm8vfAdbL45bWXyVTYctd')


### PR DESCRIPTION
Simple change, to address the feature requested by @furszy here: https://github.com/PIVX-Project/PIVX/pull/2282#issuecomment-814992542

![Screenshot from 2021-04-08 14-03-33](https://user-images.githubusercontent.com/18186894/114023746-8bdb5400-9873-11eb-9d35-bd9ac4ce84c8.png)
