### PR TITLE
[Build] Don't explicitly include generated moc file

### DIFF
--- a/src/qt/pivx/settings/settingsconsolewidget.cpp
+++ b/src/qt/pivx/settings/settingsconsolewidget.cpp
@@ -4,7 +4,6 @@
 
 #include "qt/pivx/settings/settingsconsolewidget.h"
 #include "qt/pivx/settings/forms/ui_settingsconsolewidget.h"
-#include "qt/pivx/settings/moc_settingsconsolewidget.cpp"
 
 #include "qt/pivx/qtutils.h"
 #include "qt/rpcexecutor.h"

--- a/src/qt/rpcexecutor.cpp
+++ b/src/qt/rpcexecutor.cpp
@@ -4,7 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "qt/rpcexecutor.h"
-#include "qt/moc_rpcexecutor.cpp"
+
 #include "rpc/client.h"
 
 #include <univalue.h>


### PR DESCRIPTION
Generated `moc_*.cpp` files are implicitly included by the build systems
 and explicitly including them causes build failures on launchpad.

master build log: https://code.launchpad.net/~pivx/+archive/ubuntu/pivx-unstable/+build/21374623/+files/buildlog_ubuntu-xenial-amd64.pivx_5.0.99~202104091521+git7a538fde9~ubuntu16.04.1_BUILDING.txt.gz

this PR build log: https://code.launchpad.net/~fuzzbawls/+archive/ubuntu/piv-test/+build/21373712/+files/buildlog_ubuntu-xenial-amd64.pivx_5.0.99~202104091140+git696b3c922~ubuntu16.04.1_BUILDING.txt.gz