### PR TITLE
[WIP] Decrease chain indexes RAM usage using Optional values.

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -236,7 +236,7 @@ public:
     //! block header
     int nVersion{0};
     uint256 hashMerkleRoot{};
-    uint256 hashFinalSaplingRoot{};
+    Optional<uint256> hashFinalSaplingRoot{};
     unsigned int nTime{0};
     unsigned int nBits{0};
     unsigned int nNonce{0};
@@ -360,7 +360,13 @@ public:
 
             // Sapling blocks
             if (this->nVersion >= 8) {
-                READWRITE(hashFinalSaplingRoot);
+                if (ser_action.ForRead()) {
+                    uint256 _hashFinalSaplingRoot;
+                    READWRITE(_hashFinalSaplingRoot);
+                    hashFinalSaplingRoot = _hashFinalSaplingRoot;
+                } else {
+                    READWRITE(*hashFinalSaplingRoot);
+                }
                 READWRITE(nSaplingValue);
             }
 

--- a/src/chain.h
+++ b/src/chain.h
@@ -240,7 +240,7 @@ public:
     unsigned int nTime{0};
     unsigned int nBits{0};
     unsigned int nNonce{0};
-    uint256 nAccumulatorCheckpoint{};
+    Optional<uint256> nAccumulatorCheckpoint{};
 
     //! (memory only) Sequential id assigned to distinguish order in which blocks are received.
     uint32_t nSequenceId{0};
@@ -348,8 +348,15 @@ public:
             READWRITE(nTime);
             READWRITE(nBits);
             READWRITE(nNonce);
-            if(this->nVersion > 3 && this->nVersion < 7)
-                READWRITE(nAccumulatorCheckpoint);
+            if(this->nVersion > 3 && this->nVersion < 7) {
+                if (ser_action.ForRead()) {
+                    uint256 _nAccumulatorCheckpoint;
+                    READWRITE(_nAccumulatorCheckpoint);
+                    nAccumulatorCheckpoint = _nAccumulatorCheckpoint;
+                } else {
+                    READWRITE(*nAccumulatorCheckpoint);
+                }
+            }
 
             // Sapling blocks
             if (this->nVersion >= 8) {
@@ -372,7 +379,11 @@ public:
             READWRITE(nNonce);
             if(this->nVersion > 3) {
                 READWRITE(mapZerocoinSupply);
-                if(this->nVersion < 7) READWRITE(nAccumulatorCheckpoint);
+                if(this->nVersion < 7) {
+                    uint256 _nAccumulatorCheckpoint;
+                    READWRITE(_nAccumulatorCheckpoint);
+                    nAccumulatorCheckpoint = _nAccumulatorCheckpoint;
+                }
             }
 
         } else if (ser_action.ForRead()) {
@@ -408,7 +419,9 @@ public:
             if(this->nVersion > 3) {
                 std::map<libzerocoin::CoinDenomination, int64_t> mapZerocoinSupply;
                 std::vector<libzerocoin::CoinDenomination> vMintDenominationsInBlock;
-                READWRITE(nAccumulatorCheckpoint);
+                uint256 _nAccumulatorCheckpoint;
+                READWRITE(_nAccumulatorCheckpoint);
+                nAccumulatorCheckpoint = _nAccumulatorCheckpoint;
                 READWRITE(mapZerocoinSupply);
                 READWRITE(vMintDenominationsInBlock);
             }
@@ -501,7 +514,11 @@ public:
             READWRITE(nNonce);
             if(this->nVersion > 3) {
                 READWRITE(mapZerocoinSupply);
-                if(this->nVersion < 7) READWRITE(nAccumulatorCheckpoint);
+                if(this->nVersion < 7) {
+                    uint256 _nAccumulatorCheckpoint;
+                    READWRITE(_nAccumulatorCheckpoint);
+                    nAccumulatorCheckpoint = _nAccumulatorCheckpoint;
+                }
             }
 
         } else {
@@ -526,7 +543,9 @@ public:
             READWRITE(nBits);
             READWRITE(nNonce);
             if(this->nVersion > 3) {
-                READWRITE(nAccumulatorCheckpoint);
+                uint256 _nAccumulatorCheckpoint;
+                READWRITE(_nAccumulatorCheckpoint);
+                nAccumulatorCheckpoint = _nAccumulatorCheckpoint;
                 READWRITE(mapZerocoinSupply);
                 READWRITE(vMintDenominationsInBlock);
             }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -142,9 +142,7 @@ public:
         consensus.nCoinbaseMaturity = 100;
         consensus.nFutureTimeDriftPoW = 7200;
         consensus.nFutureTimeDriftPoS = 180;
-        consensus.nMasternodeCountDrift = 20;       // num of MN we allow the see-saw payments to be off by
         consensus.nMaxMoneyOut = 21000000 * COIN;
-        consensus.nPoolMaxTransactions = 3;
         consensus.nProposalEstablishmentTime = 60 * 60 * 24;    // must be at least a day old to make it into a budget
         consensus.nStakeMinAge = 60 * 60;
         consensus.nStakeMinDepth = 600;
@@ -164,7 +162,6 @@ public:
         consensus.height_last_invalid_UTXO = 894538;
         consensus.height_last_ZC_AccumCheckpoint = 1686240;
         consensus.height_last_ZC_WrappedSerials = 1686229;
-        consensus.height_ZC_RecalcAccumulators = 908000;
 
         // validation by-pass
         consensus.nPivxBadBlockTime = 1471401614;    // Skip nBit validation of Block 259201 per PR #915
@@ -179,8 +176,6 @@ public:
                 "31438167899885040445364023527381951378636564391212010397122822120720357";
         consensus.ZC_MaxPublicSpendsPerTx = 637;    // Assume about 220 bytes each input
         consensus.ZC_MaxSpendsPerTx = 7;            // Assume about 20kb each input
-        consensus.ZC_MinMintConfirmations = 20;
-        consensus.ZC_MinMintFee = 1 * CENT;
         consensus.ZC_MinStakeDepth = 200;
         consensus.ZC_TimeStart = 1508214600;        // October 17, 2017 4:30:00 AM
         consensus.ZC_HeightStart = 863735;
@@ -280,9 +275,7 @@ public:
         consensus.nCoinbaseMaturity = 15;
         consensus.nFutureTimeDriftPoW = 7200;
         consensus.nFutureTimeDriftPoS = 180;
-        consensus.nMasternodeCountDrift = 20;       // num of MN we allow the see-saw payments to be off by
         consensus.nMaxMoneyOut = 21000000 * COIN;
-        consensus.nPoolMaxTransactions = 3;
         consensus.nProposalEstablishmentTime = 60 * 5;  // at least 5 min old to make it into a budget
         consensus.nStakeMinAge = 60 * 60;
         consensus.nStakeMinDepth = 100;
@@ -302,7 +295,6 @@ public:
         consensus.height_last_invalid_UTXO = -1;
         consensus.height_last_ZC_AccumCheckpoint = -1;
         consensus.height_last_ZC_WrappedSerials = -1;
-        consensus.height_ZC_RecalcAccumulators = 999999999;
         consensus.ZC_HeightStart = 0;
 
         // Zerocoin-related params
@@ -314,8 +306,6 @@ public:
                 "31438167899885040445364023527381951378636564391212010397122822120720357";
         consensus.ZC_MaxPublicSpendsPerTx = 637;    // Assume about 220 bytes each input
         consensus.ZC_MaxSpendsPerTx = 7;            // Assume about 20kb each input
-        consensus.ZC_MinMintConfirmations = 20;
-        consensus.ZC_MinMintFee = 1 * CENT;
         consensus.ZC_MinStakeDepth = 200;
         consensus.ZC_TimeStart = 1508214600;        // October 17, 2017 4:30:00 AM
 
@@ -402,9 +392,7 @@ public:
         consensus.nCoinbaseMaturity = 100;
         consensus.nFutureTimeDriftPoW = 7200;
         consensus.nFutureTimeDriftPoS = 180;
-        consensus.nMasternodeCountDrift = 4;        // num of MN we allow the see-saw payments to be off by
         consensus.nMaxMoneyOut = 43199500 * COIN;
-        consensus.nPoolMaxTransactions = 2;
         consensus.nProposalEstablishmentTime = 60 * 5;  // at least 5 min old to make it into a budget
         consensus.nStakeMinAge = 0;
         consensus.nStakeMinDepth = 2;
@@ -428,7 +416,6 @@ public:
         consensus.height_last_invalid_UTXO = -1;
         consensus.height_last_ZC_AccumCheckpoint = 310;     // no checkpoints on regtest
         consensus.height_last_ZC_WrappedSerials = -1;
-        consensus.height_ZC_RecalcAccumulators = 999999999;
 
         // Zerocoin-related params
         consensus.ZC_Modulus = "25195908475657893494027183240048398571429282126204032027777137836043662020707595556264018525880784"
@@ -439,8 +426,6 @@ public:
                 "31438167899885040445364023527381951378636564391212010397122822120720357";
         consensus.ZC_MaxPublicSpendsPerTx = 637;    // Assume about 220 bytes each input
         consensus.ZC_MaxSpendsPerTx = 7;            // Assume about 20kb each input
-        consensus.ZC_MinMintConfirmations = 10;
-        consensus.ZC_MinMintFee = 1 * CENT;
         consensus.ZC_MinStakeDepth = 10;
         consensus.ZC_TimeStart = 0;                 // not implemented on regtest
         consensus.ZC_HeightStart = 0;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -96,9 +96,7 @@ struct Params {
     int nCoinbaseMaturity;
     int nFutureTimeDriftPoW;
     int nFutureTimeDriftPoS;
-    int nMasternodeCountDrift;
     CAmount nMaxMoneyOut;
-    int nPoolMaxTransactions;
     int64_t nProposalEstablishmentTime;
     int nStakeMinAge;
     int nStakeMinDepth;
@@ -118,7 +116,6 @@ struct Params {
     int height_last_invalid_UTXO;
     int height_last_ZC_AccumCheckpoint;
     int height_last_ZC_WrappedSerials;
-    int height_ZC_RecalcAccumulators;
 
     // validation by-pass
     int64_t nPivxBadBlockTime;
@@ -165,8 +162,6 @@ struct Params {
     std::string ZC_Modulus;  // parsed in Zerocoin_Params (either as hex or dec string)
     int ZC_MaxPublicSpendsPerTx;
     int ZC_MaxSpendsPerTx;
-    int ZC_MinMintConfirmations;
-    CAmount ZC_MinMintFee;
     int ZC_MinStakeDepth;
     int ZC_TimeStart;
     int ZC_HeightStart;

--- a/src/legacy/stakemodifier.cpp
+++ b/src/legacy/stakemodifier.cpp
@@ -119,7 +119,7 @@ bool GetOldStakeModifier(CStakeInput* stake, uint64_t& nStakeModifier)
         const int nHeightStop = std::min(chainActive.Height(), Params().GetConsensus().height_last_ZC_AccumCheckpoint-1);
         while (pindexFrom && pindexFrom->nHeight + 1 <= nHeightStop) {
             if (pindexFrom->GetBlockTime() - nTimeBlockFrom > 60 * 60) {
-                nStakeModifier = pindexFrom->nAccumulatorCheckpoint.GetCheapHash();
+                nStakeModifier = pindexFrom->nAccumulatorCheckpoint->GetCheapHash();
                 return true;
             }
             pindexFrom = chainActive.Next(pindexFrom);

--- a/src/legacy/validation_zerocoin_legacy.cpp
+++ b/src/legacy/validation_zerocoin_legacy.cpp
@@ -71,8 +71,8 @@ void DataBaseAccChecksum(const CBlockIndex* pindex, bool fWrite)
         pindex->nAccumulatorCheckpoint == pindex->pprev->nAccumulatorCheckpoint)
         return;
 
-    uint256 accCurr = pindex->nAccumulatorCheckpoint;
-    uint256 accPrev = pindex->pprev->nAccumulatorCheckpoint;
+    uint256 accCurr = *pindex->nAccumulatorCheckpoint;
+    uint256 accPrev = *pindex->pprev->nAccumulatorCheckpoint;
     // add/remove changed checksums to/from DB
     for (int i = (int)libzerocoin::zerocoinDenomList.size()-1; i >= 0; i--) {
         const uint32_t& nChecksum = accCurr.Get32();

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -42,7 +42,7 @@ std::string CBlock::ToString() const
         hashPrevBlock.ToString(),
         hashMerkleRoot.ToString(),
         nTime, nBits, nNonce,
-        hashFinalSaplingRoot.ToString(),
+        hashFinalSaplingRoot->ToString(),
         vtx.size());
     for (unsigned int i = 0; i < vtx.size(); i++)
     {

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -30,7 +30,7 @@ public:
     uint32_t nTime;
     uint32_t nBits;
     uint32_t nNonce;
-    uint256 nAccumulatorCheckpoint;             // only for version 4, 5 and 6.
+    Optional<uint256> nAccumulatorCheckpoint;   // only for version 4, 5 and 6.
     uint256 hashFinalSaplingRoot;               // only for version 8+
 
     CBlockHeader()
@@ -50,8 +50,15 @@ public:
         READWRITE(nNonce);
 
         //zerocoin active, header changes to include accumulator checksum
-        if(nVersion > 3 && nVersion < 7)
-            READWRITE(nAccumulatorCheckpoint);
+        if(nVersion > 3 && nVersion < 7) {
+            if (ser_action.ForRead()) {
+                uint256 _nAccumulatorCheckpoint;
+                READWRITE(_nAccumulatorCheckpoint);
+                nAccumulatorCheckpoint = _nAccumulatorCheckpoint;
+            } else {
+                READWRITE(*nAccumulatorCheckpoint);
+            }
+        }
 
         // Sapling active
         if (nVersion >= 8)
@@ -66,7 +73,7 @@ public:
         nTime = 0;
         nBits = 0;
         nNonce = 0;
-        nAccumulatorCheckpoint.SetNull();
+        nAccumulatorCheckpoint.reset();
         hashFinalSaplingRoot.SetNull();
     }
 

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -31,7 +31,7 @@ public:
     uint32_t nBits;
     uint32_t nNonce;
     Optional<uint256> nAccumulatorCheckpoint;   // only for version 4, 5 and 6.
-    uint256 hashFinalSaplingRoot;               // only for version 8+
+    Optional<uint256> hashFinalSaplingRoot;               // only for version 8+
 
     CBlockHeader()
     {
@@ -61,8 +61,15 @@ public:
         }
 
         // Sapling active
-        if (nVersion >= 8)
-            READWRITE(hashFinalSaplingRoot);
+        if (nVersion >= 8) {
+            if (ser_action.ForRead()) {
+                uint256 _hashFinalSaplingRoot;
+                READWRITE(_hashFinalSaplingRoot);
+                hashFinalSaplingRoot = _hashFinalSaplingRoot;
+            } else {
+                READWRITE(*hashFinalSaplingRoot);
+            }
+        }
     }
 
     void SetNull()
@@ -74,7 +81,7 @@ public:
         nBits = 0;
         nNonce = 0;
         nAccumulatorCheckpoint.reset();
-        hashFinalSaplingRoot.SetNull();
+        hashFinalSaplingRoot.reset();
     }
 
     bool IsNull() const

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -116,7 +116,7 @@ UniValue blockheaderToJSON(const CBlockIndex* blockindex)
     result.pushKV("bits", strprintf("%08x", blockindex->nBits));
     result.pushKV("difficulty", GetDifficulty(blockindex));
     result.pushKV("chainwork", blockindex->nChainWork.GetHex());
-    result.pushKV("acc_checkpoint", blockindex->nAccumulatorCheckpoint.GetHex());
+    result.pushKV("acc_checkpoint", blockindex->nAccumulatorCheckpoint->GetHex());
     // Sapling shield pool value
     result.pushKV("shield_pool_value", ValuePoolDesc(blockindex->nChainSaplingValue, blockindex->nSaplingValue));
     if (blockindex->pprev)
@@ -140,7 +140,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     result.pushKV("height", blockindex->nHeight);
     result.pushKV("version", block.nVersion);
     result.pushKV("merkleroot", block.hashMerkleRoot.GetHex());
-    result.pushKV("acc_checkpoint", block.nAccumulatorCheckpoint.GetHex());
+    result.pushKV("acc_checkpoint", block.nAccumulatorCheckpoint->GetHex());
     result.pushKV("finalsaplingroot", block.hashFinalSaplingRoot.GetHex());
     UniValue txs(UniValue::VARR);
     for (const auto& txIn : block.vtx) {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -141,7 +141,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     result.pushKV("version", block.nVersion);
     result.pushKV("merkleroot", block.hashMerkleRoot.GetHex());
     result.pushKV("acc_checkpoint", block.nAccumulatorCheckpoint->GetHex());
-    result.pushKV("finalsaplingroot", block.hashFinalSaplingRoot.GetHex());
+    result.pushKV("finalsaplingroot", block.hashFinalSaplingRoot->GetHex());
     UniValue txs(UniValue::VARR);
     for (const auto& txIn : block.vtx) {
         const CTransaction& tx = *txIn;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1398,7 +1398,7 @@ DisconnectResult DisconnectBlock(CBlock& block, const CBlockIndex* pindex, CCoin
     // the Sapling activation height. Otherwise, the last anchor was the
     // empty root.
     if (consensus.NetworkUpgradeActive(pindex->pprev->nHeight, Consensus::UPGRADE_V5_0)) {
-        view.PopAnchor(pindex->pprev->hashFinalSaplingRoot);
+        view.PopAnchor(*pindex->pprev->hashFinalSaplingRoot);
     } else {
         view.PopAnchor(SaplingMerkleTree::empty_root());
     }
@@ -1706,7 +1706,7 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
     if (consensus.NetworkUpgradeActive(pindex->nHeight, Consensus::UPGRADE_V5_0)) {
         // If Sapling is active, block.hashFinalSaplingRoot must be the
         // same as the root of the Sapling tree
-        if (block.hashFinalSaplingRoot != sapling_tree.root()) {
+        if (*block.hashFinalSaplingRoot != sapling_tree.root()) {
             return state.DoS(100,
                              error("ConnectBlock(): block's hashFinalSaplingRoot is incorrect (should be Sapling tree root)"),
                              REJECT_INVALID, "bad-sapling-root-in-block");

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1357,7 +1357,7 @@ void CWallet::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const 
                                Params().GetConsensus().NetworkUpgradeActive(pprev->nHeight,
                                                                             Consensus::UPGRADE_V5_0);
         if (isSaplingActive) {
-            assert(pcoinsTip->GetSaplingAnchorAt(pprev->hashFinalSaplingRoot, oldSaplingTree));
+            assert(pcoinsTip->GetSaplingAnchorAt(*pprev->hashFinalSaplingRoot, oldSaplingTree));
         } else {
             assert(pcoinsTip->GetSaplingAnchorAt(SaplingMerkleTree::empty_root(), oldSaplingTree));
         }
@@ -1954,7 +1954,7 @@ CBlockIndex* CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, CBlock
                 if (pindex->pprev) {
                     if (Params().GetConsensus().NetworkUpgradeActive(pindex->pprev->nHeight, Consensus::UPGRADE_V5_0)) {
                         SaplingMerkleTree saplingTree;
-                        assert(pcoinsTip->GetSaplingAnchorAt(pindex->pprev->hashFinalSaplingRoot, saplingTree));
+                        assert(pcoinsTip->GetSaplingAnchorAt(*pindex->pprev->hashFinalSaplingRoot, saplingTree));
                         // Increment note witness caches
                         ChainTipAdded(pindex, &block, saplingTree);
                     }

--- a/src/zpiv/zpos.cpp
+++ b/src/zpiv/zpos.cpp
@@ -64,7 +64,7 @@ const CBlockIndex* CLegacyZPivStake::GetIndexFrom() const
     CBlockIndex* pindex = chainActive[consensus.vUpgrades[Consensus::UPGRADE_ZC].nActivationHeight];
     if (!pindex) return nullptr;
     while (pindex && pindex->nHeight <= consensus.height_last_ZC_AccumCheckpoint) {
-        if (ParseAccChecksum(pindex->nAccumulatorCheckpoint, denom) == nChecksum) {
+        if (ParseAccChecksum(*pindex->nAccumulatorCheckpoint, denom) == nChecksum) {
             // Found. Save to database and return
             zerocoinDB->WriteAccChecksum(nChecksum, denom, pindex->nHeight);
             return pindex;
@@ -101,7 +101,7 @@ bool CLegacyZPivStake::ContextCheck(int nHeight, uint32_t nTime)
     // The checkpoint needs to be from 200 blocks ago
     const int cpHeight = nHeight - 1 - consensus.ZC_MinStakeDepth;
     const libzerocoin::CoinDenomination denom = libzerocoin::AmountToZerocoinDenomination(GetValue());
-    if (ParseAccChecksum(chainActive[cpHeight]->nAccumulatorCheckpoint, denom) != GetChecksum())
+    if (ParseAccChecksum(*chainActive[cpHeight]->nAccumulatorCheckpoint, denom) != GetChecksum())
         return error("%s : accum. checksum at height %d is wrong.", __func__, nHeight);
 
     // All good


### PR DESCRIPTION
As we know, the complete set of block indexes is loaded into RAM at every startup and persists there for the entire software lifecycle, growing with every new connected block.
For this reason, we have to be careful with every member that is added to the `CBlockIndex` class.

 This PR migrates two `uint256` fields, that aren't needed to be initialized for every block index that ever existed, to optional values. Only initializing them in the lapse of time where the data is/was available.
1) The zc accumulator checkpoint: added to the header in the block version 3 and was active up to block version 7.
2) The sapling tree root hash: added to the header in block version 8.

At the moment, block `2,805,593`, this modification results in a RAM usage decrease of **~130mb**.