### PR TITLE
[RPC] Add query options to listunspent rpc call.

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -49,6 +49,16 @@ Notable Changes
 A new init option flag '-blocksdir' will allow one to keep the blockfiles external from the data directory.
 
 
+Low-level RPC changes
+---------------------
+
+- The `listunspent` RPC now takes a `query_options` argument (see [PR 2317](https://github.com/PIVX-Project/PIVX/pull/2317)), which is a JSON object
+  containing one or more of the following members:
+  - `minimumAmount` - a number specifying the minimum value of each UTXO
+  - `maximumAmount` - a number specifying the maximum value of each UTXO
+  - `maximumCount` - a number specifying the minimum number of UTXOs
+  - `minimumSumAmount` - a number specifying the minimum sum value of all UTXOs
+
 #### Show wallet's auto-combine settings in getwalletinfo
 
 `getwalletinfo` now has two additional return fields. `autocombine_enabled` (boolean) and `autocombine_threshold` (numeric) that will show the auto-combine threshold and whether or not it is currently enabled.

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -89,6 +89,7 @@ static const CRPCConvertParam vRPCConvertParams[] = {
     { "listunspent", 1 },
     { "listunspent", 2 },
     { "listunspent", 3 },
+    { "listunspent", 4 },
     { "listshieldunspent", 0 },
     { "listshieldunspent", 1 },
     { "listshieldunspent", 2 },

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -78,6 +78,13 @@ void RPCTypeCheck(const UniValue& params,
     }
 }
 
+void RPCTypeCheckArgument(const UniValue& value, const UniValueType& typeExpected)
+{
+    if (!typeExpected.typeAny && value.type() != typeExpected.type) {
+        throw JSONRPCError(RPC_TYPE_ERROR, strprintf("Expected type %s, got %s", uvTypeName(typeExpected.type), uvTypeName(value.type())));
+    }
+}
+
 void RPCTypeCheckObj(const UniValue& o,
     const std::map<std::string, UniValueType>& typesExpected,
     bool fAllowNull,

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -76,6 +76,11 @@ void RPCTypeCheck(const UniValue& params,
                   const std::list<UniValue::VType>& typesExpected, bool fAllowNull=false);
 
 /**
+ * Type-check one argument; throws JSONRPCError if wrong type given.
+ */
+void RPCTypeCheckArgument(const UniValue& value, const UniValueType& typeExpected);
+
+/**
  * Check for expected keys/value types in an Object.
  */
 void RPCTypeCheckObj(const UniValue& o,

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3428,22 +3428,25 @@ UniValue listunspent(const JSONRPCRequest& request)
                 + HelpExampleRpc("listunspent", "6, 9999999, [] , 1, { \"minimumAmount\": 0.005 } ")
                 );
 
-    RPCTypeCheck(request.params, {UniValue::VNUM, UniValue::VNUM, UniValue::VARR, UniValue::VNUM});
-
     // Make sure the results are valid at least up to the most recent block
     // the user could have gotten from another RPC command prior to now
     pwalletMain->BlockUntilSyncedToCurrentChain();
 
     int nMinDepth = 1;
-    if (request.params.size() > 0)
+    if (request.params.size() > 0) {
+        RPCTypeCheckArgument(request.params[0], UniValue::VNUM);
         nMinDepth = request.params[0].get_int();
+    }
 
     int nMaxDepth = 9999999;
-    if (request.params.size() > 1)
+    if (request.params.size() > 1) {
+        RPCTypeCheckArgument(request.params[1], UniValue::VNUM);
         nMaxDepth = request.params[1].get_int();
+    }
 
     std::set<CTxDestination> destinations;
     if (request.params.size() > 2) {
+        RPCTypeCheckArgument(request.params[2], UniValue::VARR);
         UniValue inputs = request.params[2].get_array();
         for (unsigned int inx = 0; inx < inputs.size(); inx++) {
             const UniValue& input = inputs[inx];
@@ -3459,6 +3462,7 @@ UniValue listunspent(const JSONRPCRequest& request)
     // List watch only utxo
     int nWatchonlyConfig = 1;
     if(request.params.size() > 3) {
+        RPCTypeCheckArgument(request.params[3], UniValue::VNUM);
         nWatchonlyConfig = request.params[3].get_int();
         if (nWatchonlyConfig > 2 || nWatchonlyConfig < 1)
             nWatchonlyConfig = 1;
@@ -3467,6 +3471,15 @@ UniValue listunspent(const JSONRPCRequest& request)
     CWallet::AvailableCoinsFilter coinFilter;
     if (request.params.size() > 4) {
         const UniValue& options = request.params[4].get_obj();
+
+        RPCTypeCheckObj(options,
+            {
+                    {"minimumAmount", UniValueType()},
+                    {"maximumAmount", UniValueType()},
+                    {"minimumSumAmount", UniValueType()},
+                    {"maximumCount", UniValueType(UniValue::VNUM)},
+            },
+            true, true);
 
         if (options.exists("minimumAmount")) {
             coinFilter.nMinOutValue = AmountFromValue(options["minimumAmount"]);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2576,6 +2576,7 @@ bool CWallet::AvailableCoins(std::vector<COutput>* pCoins,      // --> populates
 
     {
         LOCK(cs_wallet);
+        CAmount nTotal = 0;
         for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it) {
             const uint256& wtxid = it->first;
             const CWalletTx* pcoin = &(*it).second;
@@ -2596,6 +2597,9 @@ bool CWallet::AvailableCoins(std::vector<COutput>* pCoins,      // --> populates
 
                 // Filter by value if needed
                 if (coinsFilter.nMaxOutValue > 0 && output.nValue > coinsFilter.nMaxOutValue) {
+                    continue;
+                }
+                if (coinsFilter.nMinOutValue > 0 && output.nValue < coinsFilter.nMinOutValue) {
                     continue;
                 }
 
@@ -2625,6 +2629,20 @@ bool CWallet::AvailableCoins(std::vector<COutput>* pCoins,      // --> populates
                 // found valid coin
                 if (!pCoins) return true;
                 pCoins->emplace_back(pcoin, (int) i, nDepth, res.spendable, res.solvable);
+
+                // Checks the sum amount of all UTXO's.
+                if (coinsFilter.nMinimumSumAmount != 0) {
+                    nTotal += output.nValue;
+
+                    if (nTotal >= coinsFilter.nMinimumSumAmount) {
+                        return true;
+                    }
+                }
+
+                // Checks the maximum number of UTXO's.
+                if (coinsFilter.nMaximumCount > 0 && pCoins->size() >= coinsFilter.nMaximumCount) {
+                    return true;
+                }
             }
         }
         return (pCoins && !pCoins->empty());

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -798,7 +798,10 @@ public:
         int minDepth{0};
         bool fIncludeLocked{false};
         // Select outputs with value <= nMaxOutValue
-        CAmount nMaxOutValue{0};
+        CAmount nMaxOutValue{0}; // 0 means not active
+        CAmount nMinOutValue{0}; // 0 means not active
+        CAmount nMinimumSumAmount{0}; // 0 means not active
+        unsigned int nMaximumCount{0}; // 0 means not active
     };
 
     //! >> Available coins (generic)


### PR DESCRIPTION
Adaptation of #8952

This PR adds a new optional JSON options for `listunspent` RPC call:

* Return unspents greater or equal than a specific amount in PIV: minimumAmount.
* Return unspents lower or equal than a specific amount in PIV: maximumAmount.
* Return unspents with a total number lower or equal than a specific number: maximumCount.
* Return unspents which total is greater or equal than a specific amount in PIV: minimumSumAmount.

```
> pivx-cli help listunspent
...
5. query options    (json, optional) JSON with query options
    {
      "minimumAmount"    (numeric or string, default=0) Minimum value of each UTXO in PIV
      "maximumAmount"    (numeric or string, default=unlimited) Maximum value of each UTXO in PIV
      "maximumCount"     (numeric or string, default=0=unlimited) Maximum number of UTXOs
      "minimumSumAmount" (numeric or string, default=unlimited) Minimum sum value all UTXOs in PIV
    }
...
```