### PR TITLE
Replace chainparam nMaxMoneyOut for constant MAX_MONEY.

### DIFF
--- a/src/amount.h
+++ b/src/amount.h
@@ -15,4 +15,16 @@ typedef int64_t CAmount;
 static const CAmount COIN = 100000000;
 static const CAmount CENT = 1000000;
 
+/** No amount larger than this (in satoshi) is valid.
+ *
+ * Note that this constant is *not* the total money supply, which in Bitcoin
+ * currently happens to be less than 21,000,000 PIV for various reasons, but
+ * rather a sanity check. As this sanity check is used by consensus-critical
+ * validation code, the exact value of the MAX_MONEY constant is consensus
+ * critical; in unusual circumstances like a overflow bug that allowed
+ * for the creation of coins out of thin air modification could lead to a fork.
+ * */
+static const CAmount MAX_MONEY = 21000000 * COIN;
+inline bool MoneyRange(const CAmount& nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
+
 #endif //  PIVX_AMOUNT_H

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -143,7 +143,6 @@ public:
         consensus.nFutureTimeDriftPoW = 7200;
         consensus.nFutureTimeDriftPoS = 180;
         consensus.nMasternodeCountDrift = 20;       // num of MN we allow the see-saw payments to be off by
-        consensus.nMaxMoneyOut = 21000000 * COIN;
         consensus.nPoolMaxTransactions = 3;
         consensus.nProposalEstablishmentTime = 60 * 60 * 24;    // must be at least a day old to make it into a budget
         consensus.nStakeMinAge = 60 * 60;
@@ -281,7 +280,6 @@ public:
         consensus.nFutureTimeDriftPoW = 7200;
         consensus.nFutureTimeDriftPoS = 180;
         consensus.nMasternodeCountDrift = 20;       // num of MN we allow the see-saw payments to be off by
-        consensus.nMaxMoneyOut = 21000000 * COIN;
         consensus.nPoolMaxTransactions = 3;
         consensus.nProposalEstablishmentTime = 60 * 5;  // at least 5 min old to make it into a budget
         consensus.nStakeMinAge = 60 * 60;
@@ -403,7 +401,6 @@ public:
         consensus.nFutureTimeDriftPoW = 7200;
         consensus.nFutureTimeDriftPoS = 180;
         consensus.nMasternodeCountDrift = 4;        // num of MN we allow the see-saw payments to be off by
-        consensus.nMaxMoneyOut = 43199500 * COIN;
         consensus.nPoolMaxTransactions = 2;
         consensus.nProposalEstablishmentTime = 60 * 5;  // at least 5 min old to make it into a budget
         consensus.nStakeMinAge = 0;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -97,7 +97,6 @@ struct Params {
     int nFutureTimeDriftPoW;
     int nFutureTimeDriftPoS;
     int nMasternodeCountDrift;
-    CAmount nMaxMoneyOut;
     int nPoolMaxTransactions;
     int64_t nProposalEstablishmentTime;
     int nStakeMinAge;
@@ -129,7 +128,6 @@ struct Params {
 
     int64_t TargetTimespan(const bool fV2 = true) const { return fV2 ? nTargetTimespanV2 : nTargetTimespan; }
     uint256 ProofOfStakeLimit(const bool fV2) const { return fV2 ? posLimitV2 : posLimitV1; }
-    bool MoneyRange(const CAmount& nValue) const { return (nValue >= 0 && nValue <= nMaxMoneyOut); }
     bool IsTimeProtocolV2(const int nHeight) const { return NetworkUpgradeActive(nHeight, UPGRADE_V4_0); }
 
     int FutureBlockTimeDrift(const int nHeight) const

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -90,10 +90,10 @@ bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fCol
             return state.DoS(100, false, REJECT_INVALID, "bad-txns-vout-empty");
         if (txout.nValue < 0)
             return state.DoS(100, false, REJECT_INVALID, "bad-txns-vout-negative");
-        if (txout.nValue > consensus.nMaxMoneyOut)
+        if (txout.nValue > MAX_MONEY)
             return state.DoS(100, false, REJECT_INVALID, "bad-txns-vout-toolarge");
         nValueOut += txout.nValue;
-        if (!consensus.MoneyRange(nValueOut))
+        if (!MoneyRange(nValueOut))
             return state.DoS(100, false, REJECT_INVALID, "bad-txns-txouttotal-toolarge");
         // check cold staking enforcement (for delegations) and value out
         if (txout.scriptPubKey.IsPayToColdStaking()) {

--- a/src/pivx-tx.cpp
+++ b/src/pivx-tx.cpp
@@ -430,7 +430,7 @@ static CAmount AmountFromValue(const UniValue& value)
     if (dAmount <= 0.0 || dAmount > 21000000.0)
         throw std::runtime_error("Invalid amount");
     CAmount nAmount = roundint64(dAmount * COIN);
-    if (!Params().GetConsensus().MoneyRange(nAmount))
+    if (!MoneyRange(nAmount))
         throw std::runtime_error("Amount out of range");
     return nAmount;
 }

--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -311,5 +311,5 @@ QVariant BitcoinUnits::data(const QModelIndex& index, int role) const
 
 CAmount BitcoinUnits::maxMoney()
 {
-    return Params().GetConsensus().nMaxMoneyOut;
+    return MAX_MONEY;
 }

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -112,7 +112,7 @@ CAmount AmountFromValue(const UniValue& value)
     CAmount nAmount;
     if (!ParseFixedPoint(value.getValStr(), 8, &nAmount))
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
-    if (!Params().GetConsensus().MoneyRange(nAmount))
+    if (!MoneyRange(nAmount))
         throw JSONRPCError(RPC_TYPE_ERROR, "Amount out of range");
     return nAmount;
 }

--- a/src/sapling/sapling_validation.cpp
+++ b/src/sapling/sapling_validation.cpp
@@ -56,7 +56,7 @@ bool CheckTransactionWithoutProofVerification(const CTransaction& tx, CValidatio
     }
 
     // Check for overflow valueBalance
-    if (tx.sapData->valueBalance > consensus.nMaxMoneyOut || tx.sapData->valueBalance < -consensus.nMaxMoneyOut) {
+    if (tx.sapData->valueBalance > MAX_MONEY || tx.sapData->valueBalance < -MAX_MONEY) {
         return state.DoS(100, error("%s: abs(tx.sapData->valueBalance) too large", __func__),
                          REJECT_INVALID, "bad-txns-valuebalance-toolarge");
     }
@@ -65,19 +65,19 @@ bool CheckTransactionWithoutProofVerification(const CTransaction& tx, CValidatio
         // NB: negative valueBalance "takes" money from the transparent value pool just as outputs do
         nValueOut += -tx.sapData->valueBalance;
 
-        if (!consensus.MoneyRange(nValueOut)) {
+        if (!MoneyRange(nValueOut)) {
             return state.DoS(100, error("%s: txout total out of range", __func__ ),
                              REJECT_INVALID, "bad-txns-txouttotal-toolarge");
         }
     }
 
-    // Ensure input values do not exceed consensus.nMaxMoneyOut
+    // Ensure input values do not exceed MAX_MONEY
     // We have not resolved the txin values at this stage,
     // but we do know what the shielded tx claim to add
     // to the value pool.
 
     // NB: positive valueBalance "adds" money to the transparent value pool, just as inputs do
-    if (tx.sapData->valueBalance > 0 && !consensus.MoneyRange(tx.sapData->valueBalance)) {
+    if (tx.sapData->valueBalance > 0 && !MoneyRange(tx.sapData->valueBalance)) {
         return state.DoS(100, error("%s: txin total out of range", __func__ ),
                          REJECT_INVALID, "bad-txns-txintotal-toolarge");
     }

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -719,7 +719,7 @@ CAmount SaplingScriptPubKeyMan::GetDebit(const CTransaction& tx, const isminefil
             assert(nd.IsMyNote());        // todo: Add watch only check.
             assert(static_cast<bool>(nd.amount));
             nDebit += *(nd.amount);
-            if (!Params().GetConsensus().MoneyRange(nDebit))
+            if (!MoneyRange(nDebit))
                 throw std::runtime_error("SaplingScriptPubKeyMan::GetDebit() : value out of range");
         }
     }
@@ -741,7 +741,7 @@ CAmount SaplingScriptPubKeyMan::GetShieldedChange(const CWalletTx& wtx) const
         if (!nd.IsMyNote() || !static_cast<bool>(nd.address) || !static_cast<bool>(nd.amount)) continue;
         if (IsNoteSaplingChange(op, *(nd.address))) {
             nChange += *(nd.amount);
-            if (!Params().GetConsensus().MoneyRange(nChange))
+            if (!MoneyRange(nChange))
                 throw std::runtime_error("GetShieldedChange() : value out of range");
         }
     }

--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(subsidy_limit_test)
         /* PoW Phase Two */
         CAmount nSubsidy = GetBlockValue(nHeight + 1);
         BOOST_CHECK(nSubsidy <= 45 * COIN);
-        BOOST_CHECK(Params().GetConsensus().MoneyRange(nSubsidy));
+        BOOST_CHECK(MoneyRange(nSubsidy));
         nSum += nSubsidy;
         BOOST_CHECK(nSum > 0 && nSum <= nMoneySupplyPoWEnd);
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -309,8 +309,8 @@ CAmount GetMinRelayFee(unsigned int nBytes, bool fAllowFree)
             nMinFee = 0;
     }
 
-    if (!Params().GetConsensus().MoneyRange(nMinFee))
-        nMinFee = Params().GetConsensus().nMaxMoneyOut;
+    if (!MoneyRange(nMinFee))
+        nMinFee = MAX_MONEY;
     return nMinFee;
 }
 
@@ -319,8 +319,8 @@ CAmount GetShieldedTxMinFee(const CTransaction& tx)
     assert (tx.IsShieldedTx());
     unsigned int K = DEFAULT_SHIELDEDTXFEE_K;   // Fixed (100) for now
     CAmount nMinFee = ::minRelayTxFee.GetFee(tx.GetTotalSize()) * K;
-    if (!Params().GetConsensus().MoneyRange(nMinFee))
-        nMinFee = Params().GetConsensus().nMaxMoneyOut;
+    if (!MoneyRange(nMinFee))
+        nMinFee = MAX_MONEY;
     return nMinFee;
 }
 
@@ -1104,7 +1104,7 @@ bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoins
 
         // Check for negative or overflow input values
         nValueIn += coin.out.nValue;
-        if (!consensus.MoneyRange(coin.out.nValue) || !consensus.MoneyRange(nValueIn))
+        if (!MoneyRange(coin.out.nValue) || !MoneyRange(nValueIn))
             return state.DoS(100, false, REJECT_INVALID, "bad-txns-inputvalues-outofrange");
     }
 
@@ -1121,7 +1121,7 @@ bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoins
         if (nTxFee < 0)
             return state.DoS(100, false, REJECT_INVALID, "bad-txns-fee-negative");
         nFees += nTxFee;
-        if (!consensus.MoneyRange(nFees))
+        if (!MoneyRange(nFees))
             return state.DoS(100, false, REJECT_INVALID, "bad-txns-fee-outofrange");
     }
     return true;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1671,7 +1671,7 @@ CAmount CWalletTx::GetAvailableCredit(bool fUseCache, const isminefilter& filter
             if (!pwallet->IsSpent(hashTx, i)) {
                 const CTxOut &txout = tx->vout[i];
                 nCredit += pwallet->GetCredit(txout, filter);
-                if (!Params().GetConsensus().MoneyRange(nCredit))
+                if (!MoneyRange(nCredit))
                     throw std::runtime_error(std::string(__func__) + " : value out of range");
             }
         }
@@ -1730,7 +1730,7 @@ CAmount CWalletTx::GetLockedCredit() const
             nCredit += pwallet->GetCredit(txout, ISMINE_SPENDABLE);
         }
 
-        if (!Params().GetConsensus().MoneyRange(nCredit))
+        if (!MoneyRange(nCredit))
             throw std::runtime_error("CWalletTx::GetLockedCredit() : value out of range");
     }
 
@@ -4627,14 +4627,14 @@ isminetype CWallet::IsMine(const CTxOut& txout) const
 
 CAmount CWallet::GetCredit(const CTxOut& txout, const isminefilter& filter) const
 {
-    if (!Params().GetConsensus().MoneyRange(txout.nValue))
+    if (!MoneyRange(txout.nValue))
         throw std::runtime_error("CWallet::GetCredit() : value out of range");
     return ((IsMine(txout) & filter) ? txout.nValue : 0);
 }
 
 CAmount CWallet::GetChange(const CTxOut& txout) const
 {
-    if (!Params().GetConsensus().MoneyRange(txout.nValue))
+    if (!MoneyRange(txout.nValue))
         throw std::runtime_error("CWallet::GetChange() : value out of range");
     return (IsChange(txout) ? txout.nValue : 0);
 }
@@ -4669,7 +4669,7 @@ CAmount CWallet::GetDebit(const CTransactionRef& tx, const isminefilter& filter)
     CAmount nDebit = 0;
     for (const CTxIn& txin : tx->vin) {
         nDebit += GetDebit(txin, filter);
-        if (!Params().GetConsensus().MoneyRange(nDebit))
+        if (!MoneyRange(nDebit))
             throw std::runtime_error("CWallet::GetDebit() : value out of range");
     }
 
@@ -4697,7 +4697,7 @@ CAmount CWallet::GetCredit(const CWalletTx& tx, const isminefilter& filter) cons
         }
     }
 
-    if (!Params().GetConsensus().MoneyRange(nCredit))
+    if (!MoneyRange(nCredit))
         throw std::runtime_error("CWallet::GetCredit() : value out of range");
     return nCredit;
 }
@@ -4707,7 +4707,7 @@ CAmount CWallet::GetChange(const CTransactionRef& tx) const
     CAmount nChange = 0;
     for (const CTxOut& txout : tx->vout) {
         nChange += GetChange(txout);
-        if (!Params().GetConsensus().MoneyRange(nChange))
+        if (!MoneyRange(nChange))
             throw std::runtime_error("CWallet::GetChange() : value out of range");
     }
     return nChange;


### PR DESCRIPTION
We have the `nMaxMoneyOut` inside the chainparams because of a forced testnet4 coins creation that surpassed the 40kk PIVs.
As we are now in testnet5 and the 21kk max amount rule is applied in mainnet and testnet equally, we can revive the `MAX_MONEY` global constant.

This PR has no functional changes.