### PR TITLE
[Cleanup] Remove zerocoin mints databasing

### DIFF
--- a/src/legacy/validation_zerocoin_legacy.cpp
+++ b/src/legacy/validation_zerocoin_legacy.cpp
@@ -40,22 +40,6 @@ bool DisconnectZerocoinTx(const CTransaction& tx, CZerocoinDB* zerocoinDB)
 
             }
         }
-
-        if (tx.HasZerocoinMintOutputs()) {
-            //erase all zerocoinmints in this transaction
-            for (const CTxOut &txout : tx.vout) {
-                if (txout.scriptPubKey.empty() || !txout.IsZerocoinMint())
-                    continue;
-
-                libzerocoin::PublicCoin pubCoin(params);
-                CValidationState state;
-                if (!TxOutToPublicCoin(txout, pubCoin, state))
-                    return error("DisconnectBlock(): TxOutToPublicCoin() failed");
-
-                if (!zerocoinDB->EraseCoinMint(pubCoin.getValue()))
-                    return error("DisconnectBlock(): Failed to erase coin mint");
-            }
-        }
     }
     return true;
 }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -376,22 +376,6 @@ bool CZerocoinDB::WriteCoinMintBatch(const std::vector<std::pair<libzerocoin::Pu
     return WriteBatch(batch, true);
 }
 
-bool CZerocoinDB::ReadCoinMint(const CBigNum& bnPubcoin, uint256& hashTx)
-{
-    return ReadCoinMint(GetPubCoinHash(bnPubcoin), hashTx);
-}
-
-bool CZerocoinDB::ReadCoinMint(const uint256& hashPubcoin, uint256& hashTx)
-{
-    return Read(std::make_pair('m', hashPubcoin), hashTx);
-}
-
-bool CZerocoinDB::EraseCoinMint(const CBigNum& bnPubcoin)
-{
-    uint256 hash = GetPubCoinHash(bnPubcoin);
-    return Erase(std::make_pair('m', hash));
-}
-
 bool CZerocoinDB::WriteCoinSpendBatch(const std::vector<std::pair<libzerocoin::CoinSpend, uint256> >& spendInfo)
 {
     CDBBatch batch;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -361,21 +361,6 @@ CZerocoinDB::CZerocoinDB(size_t nCacheSize, bool fMemory, bool fWipe) : CDBWrapp
 {
 }
 
-bool CZerocoinDB::WriteCoinMintBatch(const std::vector<std::pair<libzerocoin::PublicCoin, uint256> >& mintInfo)
-{
-    CDBBatch batch;
-    size_t count = 0;
-    for (std::vector<std::pair<libzerocoin::PublicCoin, uint256> >::const_iterator it=mintInfo.begin(); it != mintInfo.end(); it++) {
-        libzerocoin::PublicCoin pubCoin = it->first;
-        uint256 hash = GetPubCoinHash(pubCoin.getValue());
-        batch.Write(std::make_pair('m', hash), it->second);
-        ++count;
-    }
-
-    LogPrint(BCLog::COINDB, "Writing %u coin mints to db.\n", (unsigned int)count);
-    return WriteBatch(batch, true);
-}
-
 bool CZerocoinDB::WriteCoinSpendBatch(const std::vector<std::pair<libzerocoin::CoinSpend, uint256> >& spendInfo)
 {
     CDBBatch batch;

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -158,13 +158,10 @@ private:
 public:
     /** Write zPIV mints to the zerocoinDB in a batch */
     bool WriteCoinMintBatch(const std::vector<std::pair<libzerocoin::PublicCoin, uint256> >& mintInfo);
-    bool ReadCoinMint(const CBigNum& bnPubcoin, uint256& txHash);
-    bool ReadCoinMint(const uint256& hashPubcoin, uint256& hashTx);
     /** Write zPIV spends to the zerocoinDB in a batch */
     bool WriteCoinSpendBatch(const std::vector<std::pair<libzerocoin::CoinSpend, uint256> >& spendInfo);
     bool ReadCoinSpend(const CBigNum& bnSerial, uint256& txHash);
     bool ReadCoinSpend(const uint256& hashSerial, uint256 &txHash);
-    bool EraseCoinMint(const CBigNum& bnPubcoin);
     bool EraseCoinSpend(const CBigNum& bnSerial);
     bool WipeCoins(std::string strType);
 

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -156,8 +156,6 @@ private:
     void operator=(const CZerocoinDB&);
 
 public:
-    /** Write zPIV mints to the zerocoinDB in a batch */
-    bool WriteCoinMintBatch(const std::vector<std::pair<libzerocoin::PublicCoin, uint256> >& mintInfo);
     /** Write zPIV spends to the zerocoinDB in a batch */
     bool WriteCoinSpendBatch(const std::vector<std::pair<libzerocoin::CoinSpend, uint256> >& spendInfo);
     bool ReadCoinSpend(const CBigNum& bnSerial, uint256& txHash);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1540,7 +1540,6 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
     CDiskTxPos pos(pindex->GetBlockPos(), GetSizeOfCompactSize(block.vtx.size()));
     std::vector<std::pair<uint256, CDiskTxPos> > vPos;
     std::vector<std::pair<libzerocoin::CoinSpend, uint256> > vSpends;
-    std::vector<std::pair<libzerocoin::PublicCoin, uint256> > vMints;
     vPos.reserve(block.vtx.size());
     CBlockUndo blockundo;
     blockundo.vtxundo.reserve(block.vtx.size() - 1);
@@ -1581,19 +1580,6 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
         // If v5 is active, bye bye zerocoin
         if (isV5UpgradeEnforced && tx.ContainsZerocoins()) {
             return state.DoS(100, error("%s : v5 upgrade enforced, zerocoin disabled", __func__));
-        }
-
-        if (tx.HasZerocoinMintOutputs()) {
-            if (consensus.NetworkUpgradeActive(pindex->nHeight, Consensus::UPGRADE_ZC_PUBLIC))
-                return state.DoS(100, error("%s: Mints no longer accepted at height %d", __func__, pindex->nHeight));
-            // parse minted coins
-            for (auto& out : tx.vout) {
-                if (!out.IsZerocoinMint()) continue;
-                libzerocoin::PublicCoin coin(consensus.Zerocoin_Params(false));
-                if (!TxOutToPublicCoin(out, coin, state))
-                    return state.DoS(100, error("%s: failed final check of zerocoinmint for tx %s", __func__, tx.GetHash().GetHex()));
-                vMints.emplace_back(coin, tx.GetHash());
-            }
         }
 
         if (tx.HasZerocoinSpendInputs()) {
@@ -1770,8 +1756,6 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
     // Flush spend/mint info to disk
     if (!vSpends.empty() && !zerocoinDB->WriteCoinSpendBatch(vSpends))
         return AbortNode(state, "Failed to record coin serials to database");
-    if (!vMints.empty() && !zerocoinDB->WriteCoinMintBatch(vMints))
-        return AbortNode(state, "Failed to record new mints to database");
 
     if (fTxIndex)
         if (!pblocktree->WriteTxIndex(vPos))


### PR DESCRIPTION
We should have never databased the "public coins" in the first place, and it's beyond useless now.

With this simple removal we get a 20~25% speedup during they sync of the interested blocks [`863787` -> `1880000`], and, as bonus, we save 60MB of disk space.