### PR TITLE
[GUI] Fix Cold Staking address list

### DIFF
--- a/src/qt/pivx/coldstakingwidget.cpp
+++ b/src/qt/pivx/coldstakingwidget.cpp
@@ -212,10 +212,10 @@ void ColdStakingWidget::loadWalletModel()
 
         addressTableModel = walletModel->getAddressTableModel();
         addressesFilter = new AddressFilterProxyModel(AddressTableModel::ColdStaking, this);
-        addressesFilter->sort(sortType, sortOrder);
         addressesFilter->setSourceModel(addressTableModel);
-        ui->listViewStakingAddress->setModelColumn(AddressTableModel::Address);
+        addressesFilter->sort(sortType, sortOrder);
         ui->listViewStakingAddress->setModel(addressesFilter);
+        ui->listViewStakingAddress->setModelColumn(AddressTableModel::Address);
 
         connect(txModel, &TransactionTableModel::txArrived, this, &ColdStakingWidget::onTxArrived);
 


### PR DESCRIPTION
#2209 (specifically https://github.com/PIVX-Project/PIVX/pull/2209/commits/c2d66d024e03012e2be90c3c012c7340e0180eda) introduced a visual bug with the display of cold staking addresses. Instead of showing the address as intended, the label was being duplicated. This restores the intended behavior.

Without this patch:
![Image 050](https://user-images.githubusercontent.com/7393257/115131204-2b52c200-9fab-11eb-8d05-f75ffb634a55.png)
![Image 051](https://user-images.githubusercontent.com/7393257/115131207-2beb5880-9fab-11eb-861a-97fa334f192b.png)

With this patch:
![Image 053](https://user-images.githubusercontent.com/7393257/115131214-3574c080-9fab-11eb-98a4-a6b3690174c8.png)
![Image 052](https://user-images.githubusercontent.com/7393257/115131217-37d71a80-9fab-11eb-9398-7cddc8f5ec68.png)
