### PR TITLE
[Trivial] Move evodb_cache Memory Usage logging

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1928,12 +1928,12 @@ void static UpdateTip(CBlockIndex* pindexNew)
     }
 
     const CBlockIndex* pChainTip = chainActive.Tip();
-    LogPrintf("%s: new best=%s  height=%d version=%d  log2_work=%.16f  tx=%lu  date=%s progress=%f  cache=%.1fMiB(%utxo)\n",
+    LogPrintf("%s: new best=%s  height=%d version=%d  log2_work=%.16f  tx=%lu  date=%s progress=%f  cache=%.1fMiB(%utxo)  evodb_cache=%.1fMiB\n",
               __func__,
               pChainTip->GetBlockHash().GetHex(), pChainTip->nHeight, pChainTip->nVersion, log(pChainTip->nChainWork.getdouble()) / log(2.0), (unsigned long)pChainTip->nChainTx,
               DateTimeStrFormat("%Y-%m-%d %H:%M:%S", pChainTip->GetBlockTime()),
-              Checkpoints::GuessVerificationProgress(pChainTip), pcoinsTip->DynamicMemoryUsage() * (1.0 / (1<<20)), pcoinsTip->GetCacheSize());
-    LogPrintf("%s: evodb_cache=%.1fMiB", __func__, evoDb->GetMemoryUsage() * (1.0 / (1<<20)));
+              Checkpoints::GuessVerificationProgress(pChainTip), pcoinsTip->DynamicMemoryUsage() * (1.0 / (1<<20)), pcoinsTip->GetCacheSize(),
+              evoDb->GetMemoryUsage() * (1.0 / (1<<20)));
 
     // Check the version of the last 100 blocks to see if we need to upgrade:
     static bool fWarned = false;


### PR DESCRIPTION
The log message for evodb_cache Memory Usage is missing a newline character, therefore the next log message is concatenated.
Combining  evodb_cache Memory Usage with previous UpdateTip log message.

Before
2021-04-18 07:36:46 UpdateTip: new best=c58f3103a1614981c5ff8fa9738ca2fba90dfcabd80e054b1b5111e5bf439e62  height=2810012 version=8  log2_work=70.0675345724608150  tx=6589582  date=2021-04-18 07:36:45 progress=1.000000  cache=0.0MiB(189txo)
2021-04-18 07:36:46 UpdateTip: evodb_cache=0.0MiBProcessNewBlock : ACCEPTED Block 2810012 in 50 milliseconds with size=686

After
2021-04-18 08:01:07 UpdateTip: new best=afc6d575259aa012ce168872e788c7df8f683a475e30494bd5eccb03b7b32e1b  height=2810042 version=8  log2_work=70.0675359284255421  tx=6589646  date=2021-04-18 08:00:45 progress=1.000000  cache=0.0MiB(5txo)  evodb_cache=0.0MiB
2021-04-18 08:01:07 ProcessNewBlock : ACCEPTED Block 2810042 in 70 milliseconds with size=483