### PR TITLE
[Depends] Bump miniupnpc to 2.2.2

### DIFF
--- a/depends/packages/miniupnpc.mk
+++ b/depends/packages/miniupnpc.mk
@@ -1,8 +1,9 @@
 package=miniupnpc
-$(package)_version=2.0.20180203
+$(package)_version=2.2.2
 $(package)_download_path=https://miniupnp.tuxfamily.org/files/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=90dda8c7563ca6cd4a83e23b3c66dbbea89603a1675bfdb852897c2c9cc220b7
+$(package)_sha256_hash=888fb0976ba61518276fe1eda988589c700a3f2a69d71089260d75562afd3687
+$(package)_patches=dont_leak_info.patch
 
 define $(package)_set_vars
 $(package)_build_opts=CC="$($(package)_cc)"
@@ -12,9 +13,7 @@ $(package)_build_env+=CFLAGS="$($(package)_cflags) $($(package)_cppflags)" AR="$
 endef
 
 define $(package)_preprocess_cmds
-  mkdir dll && \
-  sed -e 's|MINIUPNPC_VERSION_STRING \"version\"|MINIUPNPC_VERSION_STRING \"$($(package)_version)\"|' -e 's|OS/version|$(host)|' miniupnpcstrings.h.in > miniupnpcstrings.h && \
-  sed -i.old "s|miniupnpcstrings.h: miniupnpcstrings.h.in wingenminiupnpcstrings|miniupnpcstrings.h: miniupnpcstrings.h.in|" Makefile.mingw
+  patch -p1 < $($(package)_patch_dir)/dont_leak_info.patch
 endef
 
 define $(package)_build_cmds

--- a/depends/patches/miniupnpc/dont_leak_info.patch
+++ b/depends/patches/miniupnpc/dont_leak_info.patch
@@ -1,0 +1,32 @@
+commit 8815452257437ba36607d0e2381c01142d1c7bb0
+Author: fanquake <fanquake@gmail.com>
+Date:   Thu Nov 19 10:51:19 2020 +0800
+
+    Don't leak OS and miniupnpc version info in User-Agent
+
+diff --git a//minisoap.c b/minisoap.c
+index 7860667..775580b 100644
+--- a/minisoap.c
++++ b/minisoap.c
+@@ -90,7 +90,7 @@ int soapPostSubmit(SOCKET fd,
+ 	headerssize = snprintf(headerbuf, sizeof(headerbuf),
+                        "POST %s HTTP/%s\r\n"
+ 	                   "Host: %s%s\r\n"
+-					   "User-Agent: " OS_STRING ", " UPNP_VERSION_STRING ", MiniUPnPc/" MINIUPNPC_VERSION_STRING "\r\n"
++					   "User-Agent: " UPNP_VERSION_STRING "\r\n"
+ 	                   "Content-Length: %d\r\n"
+ 					   "Content-Type: text/xml\r\n"
+ 					   "SOAPAction: \"%s\"\r\n"
+diff --git a/miniwget.c b/miniwget.c
+index d5b7970..05aeb9c 100644
+--- a/miniwget.c
++++ b/miniwget.c
+@@ -444,7 +444,7 @@ miniwget3(const char * host,
+                  "GET %s HTTP/%s\r\n"
+ 			     "Host: %s:%d\r\n"
+ 				 "Connection: Close\r\n"
+-				 "User-Agent: " OS_STRING ", " UPNP_VERSION_STRING ", MiniUPnPc/" MINIUPNPC_VERSION_STRING "\r\n"
++				 "User-Agent: " UPNP_VERSION_STRING "\r\n"
+ 
+ 				 "\r\n",
+ 			   path, httpversion, host, port);

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -18,7 +18,7 @@ These are the dependencies currently used by PIVX Core. You can find instruction
 | libjpeg |  |  |  |  | [Yes](https://github.com/pivx-project/pivx/blob/master/depends/packages/qt.mk#L65) |
 | libpng |  |  |  |  | [Yes](https://github.com/pivx-project/pivx/blob/master/depends/packages/qt.mk#L64) |
 | librsvg | |  |  |  |  |
-| MiniUPnPc | [2.0.20180203](http://miniupnp.free.fr/files) |  | No |  |  |
+| MiniUPnPc | [2.2.2](https://miniupnp.tuxfamily.org/files) |  | No |  |  |
 | OpenSSL | [1.0.1k](https://www.openssl.org/source) |  | Yes |  |  |
 | GMP | [6.1.2](https://gmplib.org/) | | No | | |
 | PCRE |  |  |  |  | [Yes](https://github.com/pivx-project/pivx/blob/master/depends/packages/qt.mk#L66) |


### PR DESCRIPTION
Coming from https://github.com/bitcoin/bitcoin/pull/20421

Creating the dll subdir is no-longer required.
We can also drop our wingen patch.