### PR TITLE
[CMake] Add hints path for user-installed cargo bindir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,12 +11,12 @@ if(CCACHE_PROGRAM)
 endif()
 
 # Search for the cargo and rustc compilers required to build libzcashrust
-find_program(CARGO_PROGRAM cargo REQUIRED)
+find_program(CARGO_PROGRAM cargo REQUIRED HINTS ~/.cargo/bin)
 if(CARGO_PROGRAM)
     message(STATUS "Found cargo: ${CARGO_PROGRAM}")
 endif()
 
-find_program(RUSTC_PROGRAM rustc REQUIRED)
+find_program(RUSTC_PROGRAM rustc REQUIRED HINTS ~/.cargo/bin)
 if(RUSTC_PROGRAM)
     message(STATUS "Found rustc: ${RUSTC_PROGRAM}")
 endif()


### PR DESCRIPTION
Linux systems installing the Rust toolchain via rustup place the
binaries in `~/.cargo/bin`, which CMake doesn't always check by default.

This addresses the issue by adding that path to the HINTS directive.

-----------------

This issue presents itself most notably in windows WSL environments where the underlaying WSL system
has installed a rust toolchain via rustup, and should have zero effect on depends/CI/gitian based builds.