### PR TITLE
Refactor block file logic + util.h/cpp moved to util/system.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,7 @@ set(SERVER_SOURCES
         ./src/chain.cpp
         ./src/checkpoints.cpp
         ./src/consensus/tx_verify.cpp
+        ./src/flatfile.cpp
         ./src/httprpc.cpp
         ./src/httpserver.cpp
         ./src/indirectmap.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -417,7 +417,7 @@ set(UTIL_SOURCES
         ./src/arith_uint256.cpp
         ./src/uint256.cpp
         ./src/util/threadnames.cpp
-        ./src/util.cpp
+        ./src/util/system.cpp
         ./src/utilstrencodings.cpp
         ./src/utilmoneystr.cpp
         ./src/utiltime.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -190,6 +190,7 @@ BITCOIN_CORE_H = \
   pairresult.h \
   addressbook.h \
   wallet/db.h \
+  flatfile.h \
   fs.h \
   hash.h \
   httprpc.h \
@@ -326,6 +327,7 @@ libbitcoin_server_a_SOURCES = \
   checkpoints.cpp \
   consensus/params.cpp \
   consensus/tx_verify.cpp \
+  flatfile.cpp \
   consensus/zerocoin_verify.cpp \
   evo/deterministicmns.cpp \
   evo/evodb.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -284,7 +284,7 @@ BITCOIN_CORE_H = \
   uint256.h \
   undo.h \
   util/memory.h \
-  util.h \
+  util/system.h \
   util/macros.h \
   util/threadnames.h \
   utilstrencodings.h \
@@ -548,7 +548,7 @@ libbitcoin_util_a_SOURCES = \
   sync.cpp \
   threadinterrupt.cpp \
   uint256.cpp \
-  util.cpp \
+  util/system.cpp \
   utilmoneystr.cpp \
   util/threadnames.cpp \
   utilstrencodings.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -64,6 +64,7 @@ BITCOIN_TESTS =\
   test/DoS_tests.cpp \
   test/evo_deterministicmns_tests.cpp \
   test/evo_specialtx_tests.cpp \
+  test/flatfile_tests.cpp \
   test/getarg_tests.cpp \
   test/hash_tests.cpp \
   test/key_tests.cpp \

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -14,7 +14,7 @@
 #include "random.h"
 #include "streams.h"
 #include "tinyformat.h"
-#include "util.h"
+#include "util/system.h"
 
 namespace {
 

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -12,7 +12,7 @@
 #include "random.h"
 #include "sync.h"
 #include "timedata.h"
-#include "util.h"
+#include "util/system.h"
 
 #include <map>
 #include <set>

--- a/src/bench/bench_pivx.cpp
+++ b/src/bench/bench_pivx.cpp
@@ -6,7 +6,7 @@
 #include "bench.h"
 
 #include "key.h"
-#include "util.h"
+#include "util/system.h"
 
 int
 main(int argc, char** argv)

--- a/src/bench/checkqueue.cpp
+++ b/src/bench/checkqueue.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "bench.h"
-#include "util.h"
+#include "util/system.h"
 #include "checkqueue.h"
 #include "prevector.h"
 #include "random.h"

--- a/src/bip38.cpp
+++ b/src/bip38.cpp
@@ -8,7 +8,7 @@
 #include "crypto/aes.h"
 #include "hash.h"
 #include "pubkey.h"
-#include "util.h"
+#include "util/system.h"
 #include "utilstrencodings.h"
 #include "random.h"
 

--- a/src/blockassembler.cpp
+++ b/src/blockassembler.cpp
@@ -21,7 +21,7 @@
 #include "spork.h"
 #include "timedata.h"
 #include "txmempool.h"
-#include "util.h"
+#include "util/system.h"
 #include "validation.h"
 #include "validationinterface.h"
 

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -142,9 +142,9 @@ std::string CBlockIndex::ToString() const
         GetBlockHash().ToString());
 }
 
-CDiskBlockPos CBlockIndex::GetBlockPos() const
+FlatFilePos CBlockIndex::GetBlockPos() const
 {
-    CDiskBlockPos ret;
+    FlatFilePos ret;
     if (nStatus & BLOCK_HAVE_DATA) {
         ret.nFile = nFile;
         ret.nPos = nDataPos;
@@ -152,9 +152,9 @@ CDiskBlockPos CBlockIndex::GetBlockPos() const
     return ret;
 }
 
-CDiskBlockPos CBlockIndex::GetUndoPos() const
+FlatFilePos CBlockIndex::GetUndoPos() const
 {
-    CDiskBlockPos ret;
+    FlatFilePos ret;
     if (nStatus & BLOCK_HAVE_UNDO) {
         ret.nFile = nFile;
         ret.nPos = nUndoPos;

--- a/src/chain.h
+++ b/src/chain.h
@@ -11,6 +11,7 @@
 #define BITCOIN_CHAIN_H
 
 #include "chainparams.h"
+#include "flatfile.h"
 #include "optional.h"
 #include "pow.h"
 #include "primitives/block.h"
@@ -85,47 +86,6 @@ public:
         if (nTimeIn > nTimeLast)
             nTimeLast = nTimeIn;
     }
-};
-
-struct CDiskBlockPos {
-    int nFile;
-    unsigned int nPos;
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(VARINT(nFile, VarIntMode::NONNEGATIVE_SIGNED));
-        READWRITE(VARINT(nPos));
-    }
-
-    CDiskBlockPos()
-    {
-        SetNull();
-    }
-
-    CDiskBlockPos(int nFileIn, unsigned int nPosIn)
-    {
-        nFile = nFileIn;
-        nPos = nPosIn;
-    }
-
-    friend bool operator==(const CDiskBlockPos& a, const CDiskBlockPos& b)
-    {
-        return (a.nFile == b.nFile && a.nPos == b.nPos);
-    }
-
-    friend bool operator!=(const CDiskBlockPos& a, const CDiskBlockPos& b)
-    {
-        return !(a == b);
-    }
-
-    void SetNull()
-    {
-        nFile = -1;
-        nPos = 0;
-    }
-    bool IsNull() const { return (nFile == -1); }
 };
 
 enum BlockStatus {

--- a/src/chain.h
+++ b/src/chain.h
@@ -213,8 +213,8 @@ public:
 
     std::string ToString() const;
 
-    CDiskBlockPos GetBlockPos() const;
-    CDiskBlockPos GetUndoPos() const;
+    FlatFilePos GetBlockPos() const;
+    FlatFilePos GetUndoPos() const;
     CBlockHeader GetBlockHeader() const;
     uint256 GetBlockHash() const { return *phashBlock; }
     int64_t GetBlockTime() const { return (int64_t)nTime; }

--- a/src/chain.h
+++ b/src/chain.h
@@ -18,7 +18,7 @@
 #include "timedata.h"
 #include "tinyformat.h"
 #include "uint256.h"
-#include "util.h"
+#include "util/system.h"
 #include "libzerocoin/Denominations.h"
 
 #include <vector>

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -7,7 +7,7 @@
 #include "chainparamsbase.h"
 
 #include "tinyformat.h"
-#include "util.h"
+#include "util/system.h"
 
 #include <assert.h>
 

--- a/src/consensus/params.cpp
+++ b/src/consensus/params.cpp
@@ -5,7 +5,7 @@
 
 #include "consensus/params.h"
 #include "consensus/upgrades.h"
-#include "util.h"
+#include "util/system.h"
 
 namespace Consensus {
 

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -10,7 +10,7 @@
 #include "script/script.h"
 #include "serialize.h"
 #include "streams.h"
-#include "util.h"
+#include "util/system.h"
 #include "utilstrencodings.h"
 #include "version.h"
 

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -13,7 +13,7 @@
 #include "serialize.h"
 #include "streams.h"
 #include <univalue.h>
-#include "util.h"
+#include "util/system.h"
 #include "utilmoneystr.h"
 #include "utilstrencodings.h"
 

--- a/src/crypter.cpp
+++ b/src/crypter.cpp
@@ -9,7 +9,7 @@
 #include "crypto/sha512.h"
 #include "script/script.h"
 #include "script/standard.h"
-#include "util.h"
+#include "util/system.h"
 #include "init.h"
 #include "uint256.h"
 

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -4,7 +4,7 @@
 
 #include "dbwrapper.h"
 
-#include "util.h"
+#include "util/system.h"
 
 #include <leveldb/cache.h>
 #include <leveldb/env.h>

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -9,7 +9,7 @@
 #include "fs.h"
 #include "serialize.h"
 #include "streams.h"
-#include "util.h"
+#include "util/system.h"
 #include "version.h"
 
 #include <typeindex>

--- a/src/flatfile.cpp
+++ b/src/flatfile.cpp
@@ -30,25 +30,24 @@ fs::path FlatFileSeq::FileName(const FlatFilePos& pos) const
     return m_dir / strprintf("%s%05u.dat", m_prefix, pos.nFile);
 }
 
-FILE* FlatFileSeq::Open(const FlatFilePos& pos, bool fReadOnly)
+FILE* FlatFileSeq::Open(const FlatFilePos& pos, bool read_only)
 {
-    if (pos.IsNull())
+    if (pos.IsNull()) {
         return nullptr;
+    }
     fs::path path = FileName(pos);
     fs::create_directories(path.parent_path());
-    FILE* file = fsbridge::fopen(path, fReadOnly ? "rb": "rb+");
-    if (!file && !fReadOnly)
+    FILE* file = fsbridge::fopen(path, read_only ? "rb": "rb+");
+    if (!file && !read_only)
         file = fsbridge::fopen(path, "wb+");
     if (!file) {
         LogPrintf("Unable to open file %s\n", path.string());
         return nullptr;
     }
-    if (pos.nPos) {
-        if (fseek(file, pos.nPos, SEEK_SET)) {
-            LogPrintf("Unable to seek to position %u of %s\n", pos.nPos, path.string());
-            fclose(file);
-            return nullptr;
-        }
+    if (pos.nPos && fseek(file, pos.nPos, SEEK_SET)) {
+        LogPrintf("Unable to seek to position %u of %s\n", pos.nPos, path.string());
+        fclose(file);
+        return nullptr;
     }
     return file;
 }

--- a/src/flatfile.cpp
+++ b/src/flatfile.cpp
@@ -1,4 +1,5 @@
-// Copyright (c) 2019 The Bitcoin Core developers
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2019 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -17,6 +18,11 @@ FlatFileSeq::FlatFileSeq(fs::path dir, const char* prefix, size_t chunk_size) :
     if (chunk_size == 0) {
         throw std::invalid_argument("chunk_size must be positive");
     }
+}
+
+std::string CDiskBlockPos::ToString() const
+{
+    return strprintf("CDiskBlockPos(nFile=%i, nPos=%i)", nFile, nPos);
 }
 
 fs::path FlatFileSeq::FileName(const CDiskBlockPos& pos) const

--- a/src/flatfile.cpp
+++ b/src/flatfile.cpp
@@ -20,17 +20,17 @@ FlatFileSeq::FlatFileSeq(fs::path dir, const char* prefix, size_t chunk_size) :
     }
 }
 
-std::string CDiskBlockPos::ToString() const
+std::string FlatFilePos::ToString() const
 {
-    return strprintf("CDiskBlockPos(nFile=%i, nPos=%i)", nFile, nPos);
+    return strprintf("FlatFilePos(nFile=%i, nPos=%i)", nFile, nPos);
 }
 
-fs::path FlatFileSeq::FileName(const CDiskBlockPos& pos) const
+fs::path FlatFileSeq::FileName(const FlatFilePos& pos) const
 {
     return m_dir / strprintf("%s%05u.dat", m_prefix, pos.nFile);
 }
 
-FILE* FlatFileSeq::Open(const CDiskBlockPos& pos, bool fReadOnly)
+FILE* FlatFileSeq::Open(const FlatFilePos& pos, bool fReadOnly)
 {
     if (pos.IsNull())
         return nullptr;
@@ -53,7 +53,7 @@ FILE* FlatFileSeq::Open(const CDiskBlockPos& pos, bool fReadOnly)
     return file;
 }
 
-size_t FlatFileSeq::Allocate(const CDiskBlockPos& pos, size_t add_size, bool& out_of_space)
+size_t FlatFileSeq::Allocate(const FlatFilePos& pos, size_t add_size, bool& out_of_space)
 {
     out_of_space = false;
 
@@ -79,7 +79,7 @@ size_t FlatFileSeq::Allocate(const CDiskBlockPos& pos, size_t add_size, bool& ou
     return 0;
 }
 
-bool FlatFileSeq::Flush(const CDiskBlockPos& pos, bool finalize)
+bool FlatFileSeq::Flush(const FlatFilePos& pos, bool finalize)
 {
     FILE* file = Open(FlatFilePos(pos.nFile, 0)); // Avoid fseek to nPos
     if (!file) {

--- a/src/flatfile.cpp
+++ b/src/flatfile.cpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <stdexcept>
+
+#include "flatfile.h"
+#include "logging.h"
+#include "tinyformat.h"
+#include "util.h"
+
+FlatFileSeq::FlatFileSeq(fs::path dir, const char* prefix, size_t chunk_size) :
+    m_dir(std::move(dir)),
+    m_prefix(prefix),
+    m_chunk_size(chunk_size)
+{
+    if (chunk_size == 0) {
+        throw std::invalid_argument("chunk_size must be positive");
+    }
+}
+
+fs::path FlatFileSeq::FileName(const CDiskBlockPos& pos) const
+{
+    return m_dir / strprintf("%s%05u.dat", m_prefix, pos.nFile);
+}
+
+FILE* FlatFileSeq::Open(const CDiskBlockPos& pos, bool fReadOnly)
+{
+    if (pos.IsNull())
+        return nullptr;
+    fs::path path = FileName(pos);
+    fs::create_directories(path.parent_path());
+    FILE* file = fsbridge::fopen(path, fReadOnly ? "rb": "rb+");
+    if (!file && !fReadOnly)
+        file = fsbridge::fopen(path, "wb+");
+    if (!file) {
+        LogPrintf("Unable to open file %s\n", path.string());
+        return nullptr;
+    }
+    if (pos.nPos) {
+        if (fseek(file, pos.nPos, SEEK_SET)) {
+            LogPrintf("Unable to seek to position %u of %s\n", pos.nPos, path.string());
+            fclose(file);
+            return nullptr;
+        }
+    }
+    return file;
+}

--- a/src/flatfile.cpp
+++ b/src/flatfile.cpp
@@ -8,7 +8,7 @@
 #include "flatfile.h"
 #include "logging.h"
 #include "tinyformat.h"
-#include "util.h"
+#include "util/system.h"
 
 FlatFileSeq::FlatFileSeq(fs::path dir, const char* prefix, size_t chunk_size) :
     m_dir(std::move(dir)),

--- a/src/flatfile.cpp
+++ b/src/flatfile.cpp
@@ -46,3 +46,29 @@ FILE* FlatFileSeq::Open(const CDiskBlockPos& pos, bool fReadOnly)
     }
     return file;
 }
+
+size_t FlatFileSeq::Allocate(const CDiskBlockPos& pos, size_t add_size, bool& out_of_space)
+{
+    out_of_space = false;
+
+    unsigned int n_old_chunks = (pos.nPos + m_chunk_size - 1) / m_chunk_size;
+    unsigned int n_new_chunks = (pos.nPos + add_size + m_chunk_size - 1) / m_chunk_size;
+    if (n_new_chunks > n_old_chunks) {
+        size_t old_size = pos.nPos;
+        size_t new_size = n_new_chunks * m_chunk_size;
+        size_t inc_size = new_size - old_size;
+
+        if (CheckDiskSpace(m_dir, inc_size)) {
+            FILE *file = Open(pos);
+            if (file) {
+                LogPrintf("Pre-allocating up to position 0x%x in %s%05u.dat\n", new_size, m_prefix, pos.nFile);
+                AllocateFileRange(file, pos.nPos, inc_size);
+                fclose(file);
+                return inc_size;
+            }
+        } else {
+            out_of_space = true;
+        }
+    }
+    return 0;
+}

--- a/src/flatfile.h
+++ b/src/flatfile.h
@@ -45,6 +45,15 @@ public:
      * @return The number of bytes successfully allocated.
      */
     size_t Allocate(const CDiskBlockPos& pos, size_t add_size, bool& out_of_space);
+
+    /**
+     * Commit a file to disk, and optionally truncate off extra pre-allocated bytes if final.
+     *
+     * @param[in] pos The first unwritten position in the file to be flushed.
+     * @param[in] finalize True if no more data will be written to this file.
+     * @return true on success, false on failure.
+     */
+    bool Flush(const CDiskBlockPos& pos, bool finalize = false);
 };
 
 #endif // BITCOIN_FLATFILE_H

--- a/src/flatfile.h
+++ b/src/flatfile.h
@@ -24,14 +24,12 @@ struct FlatFilePos
         READWRITE(VARINT(nPos));
     }
 
-    FlatFilePos() {
-        SetNull();
-    }
+    FlatFilePos() : nFile(-1), nPos(0) {}
 
-    FlatFilePos(int nFileIn, unsigned int nPosIn) {
-        nFile = nFileIn;
-        nPos = nPosIn;
-    }
+    FlatFilePos(int nFileIn, unsigned int nPosIn) :
+        nFile(nFileIn),
+        nPos(nPosIn)
+    {}
 
     friend bool operator==(const FlatFilePos &a, const FlatFilePos &b) {
         return (a.nFile == b.nFile && a.nPos == b.nPos);
@@ -72,7 +70,7 @@ public:
     fs::path FileName(const FlatFilePos& pos) const;
 
     /** Open a handle to the file at the given position. */
-    FILE* Open(const FlatFilePos& pos, bool fReadOnly = false);
+    FILE* Open(const FlatFilePos& pos, bool read_only = false);
 
     /**
      * Allocate additional space in a file after the given starting position. The amount allocated

--- a/src/flatfile.h
+++ b/src/flatfile.h
@@ -34,6 +34,17 @@ public:
 
     /** Open a handle to the file at the given position. */
     FILE* Open(const CDiskBlockPos& pos, bool fReadOnly = false);
+
+    /**
+     * Allocate additional space in a file after the given starting position. The amount allocated
+     * will be the minimum multiple of the sequence chunk size greater than add_size.
+     *
+     * @param[in] pos The starting position that bytes will be allocated after.
+     * @param[in] add_size The minimum number of bytes to be allocated.
+     * @param[out] out_of_space Whether the allocation failed due to insufficient disk space.
+     * @return The number of bytes successfully allocated.
+     */
+    size_t Allocate(const CDiskBlockPos& pos, size_t add_size, bool& out_of_space);
 };
 
 #endif // BITCOIN_FLATFILE_H

--- a/src/flatfile.h
+++ b/src/flatfile.h
@@ -1,12 +1,51 @@
-// Copyright (c) 2019 The Bitcoin Core developers
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2019 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef BITCOIN_FLATFILE_H
 #define BITCOIN_FLATFILE_H
 
-#include "chain.h"
+#include <string>
+
 #include "fs.h"
+#include "serialize.h"
+
+struct CDiskBlockPos
+{
+    int nFile;
+    unsigned int nPos;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITE(VARINT(nFile, VarIntMode::NONNEGATIVE_SIGNED));
+        READWRITE(VARINT(nPos));
+    }
+
+    CDiskBlockPos() {
+        SetNull();
+    }
+
+    CDiskBlockPos(int nFileIn, unsigned int nPosIn) {
+        nFile = nFileIn;
+        nPos = nPosIn;
+    }
+
+    friend bool operator==(const CDiskBlockPos &a, const CDiskBlockPos &b) {
+        return (a.nFile == b.nFile && a.nPos == b.nPos);
+    }
+
+    friend bool operator!=(const CDiskBlockPos &a, const CDiskBlockPos &b) {
+        return !(a == b);
+    }
+
+    void SetNull() { nFile = -1; nPos = 0; }
+    bool IsNull() const { return (nFile == -1); }
+
+    std::string ToString() const;
+};
 
 /**
  * FlatFileSeq represents a sequence of numbered files storing raw data. This class facilitates

--- a/src/flatfile.h
+++ b/src/flatfile.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_FLATFILE_H
+#define BITCOIN_FLATFILE_H
+
+#include "chain.h"
+#include "fs.h"
+
+/**
+ * FlatFileSeq represents a sequence of numbered files storing raw data. This class facilitates
+ * access to and efficient management of these files.
+ */
+class FlatFileSeq
+{
+private:
+    const fs::path m_dir;
+    const char* const m_prefix;
+    const size_t m_chunk_size;
+
+public:
+    /**
+     * Constructor
+     *
+     * @param dir The base directory that all files live in.
+     * @param prefix A short prefix given to all file names.
+     * @param chunk_size Disk space is pre-allocated in multiples of this amount.
+     */
+    FlatFileSeq(fs::path dir, const char* prefix, size_t chunk_size);
+
+    /** Get the name of the file at the given position. */
+    fs::path FileName(const CDiskBlockPos& pos) const;
+
+    /** Open a handle to the file at the given position. */
+    FILE* Open(const CDiskBlockPos& pos, bool fReadOnly = false);
+};
+
+#endif // BITCOIN_FLATFILE_H

--- a/src/flatfile.h
+++ b/src/flatfile.h
@@ -11,7 +11,7 @@
 #include "fs.h"
 #include "serialize.h"
 
-struct CDiskBlockPos
+struct FlatFilePos
 {
     int nFile;
     unsigned int nPos;
@@ -24,20 +24,20 @@ struct CDiskBlockPos
         READWRITE(VARINT(nPos));
     }
 
-    CDiskBlockPos() {
+    FlatFilePos() {
         SetNull();
     }
 
-    CDiskBlockPos(int nFileIn, unsigned int nPosIn) {
+    FlatFilePos(int nFileIn, unsigned int nPosIn) {
         nFile = nFileIn;
         nPos = nPosIn;
     }
 
-    friend bool operator==(const CDiskBlockPos &a, const CDiskBlockPos &b) {
+    friend bool operator==(const FlatFilePos &a, const FlatFilePos &b) {
         return (a.nFile == b.nFile && a.nPos == b.nPos);
     }
 
-    friend bool operator!=(const CDiskBlockPos &a, const CDiskBlockPos &b) {
+    friend bool operator!=(const FlatFilePos &a, const FlatFilePos &b) {
         return !(a == b);
     }
 
@@ -69,10 +69,10 @@ public:
     FlatFileSeq(fs::path dir, const char* prefix, size_t chunk_size);
 
     /** Get the name of the file at the given position. */
-    fs::path FileName(const CDiskBlockPos& pos) const;
+    fs::path FileName(const FlatFilePos& pos) const;
 
     /** Open a handle to the file at the given position. */
-    FILE* Open(const CDiskBlockPos& pos, bool fReadOnly = false);
+    FILE* Open(const FlatFilePos& pos, bool fReadOnly = false);
 
     /**
      * Allocate additional space in a file after the given starting position. The amount allocated
@@ -83,7 +83,7 @@ public:
      * @param[out] out_of_space Whether the allocation failed due to insufficient disk space.
      * @return The number of bytes successfully allocated.
      */
-    size_t Allocate(const CDiskBlockPos& pos, size_t add_size, bool& out_of_space);
+    size_t Allocate(const FlatFilePos& pos, size_t add_size, bool& out_of_space);
 
     /**
      * Commit a file to disk, and optionally truncate off extra pre-allocated bytes if final.
@@ -92,7 +92,7 @@ public:
      * @param[in] finalize True if no more data will be written to this file.
      * @return true on success, false on failure.
      */
-    bool Flush(const CDiskBlockPos& pos, bool finalize = false);
+    bool Flush(const FlatFilePos& pos, bool finalize = false);
 };
 
 #endif // BITCOIN_FLATFILE_H

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -13,7 +13,7 @@
 #include "rpc/server.h"
 #include "random.h"
 #include "sync.h"
-#include "util.h"
+#include "util/system.h"
 #include "utilstrencodings.h"
 #include "guiinterface.h"
 

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -7,7 +7,7 @@
 
 #include "chainparamsbase.h"
 #include "compat.h"
-#include "util.h"
+#include "util/system.h"
 #include "netbase.h"
 #include "rpc/protocol.h" // For HTTP status codes
 #include "sync.h"

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -50,7 +50,7 @@
 #include "torcontrol.h"
 #include "guiinterface.h"
 #include "guiinterfaceutil.h"
-#include "util.h"
+#include "util/system.h"
 #include "utilmoneystr.h"
 #include "util/threadnames.h"
 #include "validation.h"

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -688,7 +688,7 @@ void ThreadImport(const std::vector<fs::path>& vImportFiles)
         CImportingNow imp;
         int nFile = 0;
         while (true) {
-            CDiskBlockPos pos(nFile, 0);
+            FlatFilePos pos(nFile, 0);
             if (!fs::exists(GetBlockPosFilename(pos)))
                 break; // No block files left to reindex
             FILE* file = OpenBlockFile(pos, true);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1735,11 +1735,11 @@ bool AppInitMain()
 #endif
     // ********************************************************* Step 9: import blocks
 
-    if (!CheckDiskSpace(/* additional_bytes */ 0, /* blocks_dir */ false)) {
+    if (!CheckDiskSpace(GetDataDir())) {
         UIError(strprintf(_("Error: Disk space is low for %s"), GetDataDir()));
         return false;
     }
-    if (!CheckDiskSpace(/* additional_bytes */ 0, /* blocks_dir */ true)) {
+    if (!CheckDiskSpace(GetBlocksDir())) {
         UIError(strprintf(_("Error: Disk space is low for %s"), GetBlocksDir()));
         return false;
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -689,7 +689,7 @@ void ThreadImport(const std::vector<fs::path>& vImportFiles)
         int nFile = 0;
         while (true) {
             CDiskBlockPos pos(nFile, 0);
-            if (!fs::exists(GetBlockPosFilename(pos, "blk")))
+            if (!fs::exists(GetBlockPosFilename(pos)))
                 break; // No block files left to reindex
             FILE* file = OpenBlockFile(pos, true);
             if (!file)

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -12,7 +12,7 @@
 #include "policy/policy.h"
 #include "script/interpreter.h"
 #include "stakeinput.h"
-#include "util.h"
+#include "util/system.h"
 #include "utilmoneystr.h"
 #include "validation.h"
 #include "zpivchain.h"

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -10,7 +10,7 @@
 #include "key.h"
 #include "script/script.h"
 #include "script/standard.h"
-#include "util.h"
+#include "util/system.h"
 
 
 bool CKeyStore::AddKey(const CKey& key)

--- a/src/libzerocoin/Coin.h
+++ b/src/libzerocoin/Coin.h
@@ -17,7 +17,7 @@
 #include "Params.h"
 #include "amount.h"
 #include "bignum.h"
-#include "util.h"
+#include "util/system.h"
 #include "key.h"
 
 namespace libzerocoin

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -15,7 +15,7 @@
 #include "net_processing.h"
 #include "spork.h"
 #include "sync.h"
-#include "util.h"
+#include "util/system.h"
 #include "utilmoneystr.h"
 
 

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -12,7 +12,7 @@
 #include "masternodeman.h"
 #include "netmessagemaker.h"
 #include "spork.h"
-#include "util.h"
+#include "util/system.h"
 #include "addrman.h"
 // clang-format on
 

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -11,7 +11,7 @@
 #include "masternodeman.h"
 #include "netbase.h"
 #include "sync.h"
-#include "util.h"
+#include "util/system.h"
 #include "wallet/wallet.h"
 
 #define MASTERNODE_MIN_CONFIRMATIONS_REGTEST 1

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -13,7 +13,7 @@
 #include "serialize.h"
 #include "sync.h"
 #include "timedata.h"
-#include "util.h"
+#include "util/system.h"
 
 /* Depth of the block pinged by masternodes */
 static const unsigned int MNPING_DEPTH = 12;

--- a/src/masternodeconfig.cpp
+++ b/src/masternodeconfig.cpp
@@ -6,7 +6,7 @@
 
 #include "fs.h"
 #include "netbase.h"
-#include "util.h"
+#include "util/system.h"
 #include "guiinterface.h"
 #include <base58.h>
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -16,7 +16,7 @@
 #include "netmessagemaker.h"
 #include "net_processing.h"
 #include "spork.h"
-#include "util.h"
+#include "util/system.h"
 
 #include <boost/thread/thread.hpp>
 

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -13,7 +13,7 @@
 #include "masternode.h"
 #include "net.h"
 #include "sync.h"
-#include "util.h"
+#include "util/system.h"
 
 #define MASTERNODES_DUMP_SECONDS (15 * 60)
 #define MASTERNODES_DSEG_SECONDS (3 * 60 * 60)

--- a/src/messagesigner.cpp
+++ b/src/messagesigner.cpp
@@ -7,7 +7,7 @@
 #include "hash.h"
 #include "messagesigner.h"
 #include "tinyformat.h"
-#include "util.h"
+#include "util/system.h"
 #include "utilstrencodings.h"
 
 const std::string strMessageMagic = "DarkNet Signed Message:\n";

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -20,7 +20,7 @@
 #include "primitives/block.h"
 #include "primitives/transaction.h"
 #include "timedata.h"
-#include "util.h"
+#include "util/system.h"
 #include "utilmoneystr.h"
 #ifdef ENABLE_WALLET
 #include "wallet/wallet.h"

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -14,7 +14,7 @@
 #include "sync.h"
 #include "uint256.h"
 #include "random.h"
-#include "util.h"
+#include "util/system.h"
 #include "utilstrencodings.h"
 
 #include <atomic>

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -8,7 +8,7 @@
 #include "noui.h"
 
 #include "guiinterface.h"
-#include "util.h"
+#include "util/system.h"
 
 #include <cstdio>
 #include <stdint.h>

--- a/src/pivx-cli.cpp
+++ b/src/pivx-cli.cpp
@@ -10,7 +10,7 @@
 #include "fs.h"
 #include "rpc/client.h"
 #include "rpc/protocol.h"
-#include "util.h"
+#include "util/system.h"
 #include "utilstrencodings.h"
 
 #include <stdio.h>

--- a/src/pivx-tx.cpp
+++ b/src/pivx-tx.cpp
@@ -14,7 +14,7 @@
 #include "script/script.h"
 #include "script/sign.h"
 #include <univalue.h>
-#include "util.h"
+#include "util/system.h"
 #include "utilmoneystr.h"
 #include "utilstrencodings.h"
 

--- a/src/pivxd.cpp
+++ b/src/pivxd.cpp
@@ -12,7 +12,7 @@
 #include "masternodeconfig.h"
 #include "noui.h"
 #include "rpc/server.h"
-#include "util.h"
+#include "util/system.h"
 
 #include <stdio.h>
 

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -10,7 +10,7 @@
 #include "primitives/transaction.h"
 #include "streams.h"
 #include "txmempool.h"
-#include "util.h"
+#include "util/system.h"
 
 void TxConfirmStats::Initialize(std::vector<double>& defaultBuckets,
                                 unsigned int maxConfirms, double _decay)

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -9,7 +9,7 @@
 
 #include "consensus/tx_verify.h" // for IsFinal()
 #include "tinyformat.h"
-#include "util.h"
+#include "util/system.h"
 #include "utilstrencodings.h"
 #include "validation.h"
 

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -11,7 +11,7 @@
 #include "chainparams.h"
 #include "primitives/block.h"
 #include "uint256.h"
-#include "util.h"
+#include "util/system.h"
 
 #include <math.h>
 

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -11,7 +11,7 @@
 #include "script/sign.h"
 #include "tinyformat.h"
 #include "utilstrencodings.h"
-#include "util.h"
+#include "util/system.h"
 
 uint256 CBlockHeader::GetHash() const
 {

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -7,7 +7,7 @@
 
 #include "protocol.h"
 
-#include "util.h"
+#include "util/system.h"
 #include "utilstrencodings.h"
 
 #ifndef WIN32

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -19,7 +19,7 @@
 #include "net.h"
 #include "netbase.h"
 #include "guiinterface.h"
-#include "util.h"
+#include "util/system.h"
 #include "warnings.h"
 
 #include <stdint.h>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -17,7 +17,7 @@
 #include "protocol.h"
 #include "script/script.h"
 #include "script/standard.h"
-#include "util.h"
+#include "util/system.h"
 
 #ifdef WIN32
 #ifdef _WIN32_WINNT

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -10,7 +10,7 @@
 #include "fs.h"
 #include "guiutil.h"
 
-#include "util.h"
+#include "util/system.h"
 #include "qt/pivx/qtutils.h"
 
 #include <QFileDialog>

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -18,7 +18,7 @@
 #include "net.h"
 #include "netbase.h"
 #include "txdb.h" // for -dbcache defaults
-#include "util.h"
+#include "util/system.h"
 
 #ifdef ENABLE_WALLET
 #include "masternodeconfig.h"

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -14,7 +14,7 @@
 #include "base58.h"
 #include "chainparams.h"
 #include "guiinterface.h"
-#include "util.h"
+#include "util/system.h"
 #include "wallet/wallet.h"
 
 #include <cstdlib>

--- a/src/qt/pivx.cpp
+++ b/src/qt/pivx.cpp
@@ -33,7 +33,7 @@
 #include "init.h"
 #include "rpc/server.h"
 #include "guiinterface.h"
-#include "util.h"
+#include "util/system.h"
 #include "warnings.h"
 
 #ifdef ENABLE_WALLET

--- a/src/qt/pivx/masternodeswidget.cpp
+++ b/src/qt/pivx/masternodeswidget.cpp
@@ -21,7 +21,7 @@
 #include "sync.h"
 #include "wallet/wallet.h"
 #include "askpassphrasedialog.h"
-#include "util.h"
+#include "util/system.h"
 #include "qt/pivx/optionbutton.h"
 #include <iostream>
 #include <fstream>

--- a/src/qt/pivx/pivxgui.cpp
+++ b/src/qt/pivx/pivxgui.cpp
@@ -19,7 +19,7 @@
 #include "qt/pivx/defaultdialog.h"
 
 #include "init.h"
-#include "util.h"
+#include "util/system.h"
 
 #include <QApplication>
 #include <QColor>

--- a/src/qt/pivx/settings/settingsconsolewidget.cpp
+++ b/src/qt/pivx/settings/settingsconsolewidget.cpp
@@ -13,7 +13,7 @@
 
 #include "chainparams.h"
 #include "sapling/key_io_sapling.h"
-#include "util.h"
+#include "util/system.h"
 #include "utilitydialog.h"
 
 #ifdef ENABLE_WALLET

--- a/src/qt/pivx/settings/settingsinformationwidget.cpp
+++ b/src/qt/pivx/settings/settingsinformationwidget.cpp
@@ -8,7 +8,7 @@
 #include "clientmodel.h"
 #include "chainparams.h"
 #include "db.h"
-#include "util.h"
+#include "util/system.h"
 #include "guiutil.h"
 #include "qt/pivx/qtutils.h"
 

--- a/src/qt/pivx/splash.cpp
+++ b/src/qt/pivx/splash.cpp
@@ -10,7 +10,7 @@
 #include "init.h"
 #include "guiinterface.h"
 #include "networkstyle.h"
-#include "util.h"
+#include "util/system.h"
 #include "version.h"
 #include "guiutil.h"
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -15,7 +15,7 @@
 
 #include "chainparams.h"
 #include "netbase.h"
-#include "util.h"
+#include "util/system.h"
 #ifdef ENABLE_WALLET
 #include "wallet/wallet.h"
 #endif // ENABLE_WALLET

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -8,7 +8,7 @@
 #include "config/pivx-config.h"
 #endif
 
-#include "util.h"
+#include "util/system.h"
 #include "uritests.h"
 
 #include <QCoreApplication>

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -16,7 +16,7 @@
 #include "interfaces/handler.h"
 #include "sync.h"
 #include "uint256.h"
-#include "util.h"
+#include "util/system.h"
 #include "wallet/wallet.h"
 
 #include <algorithm>

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -15,7 +15,7 @@
 #include "intro.h"
 #include "guiutil.h"
 #include "qt/pivx/qtutils.h"
-#include "util.h"
+#include "util/system.h"
 
 #include <stdio.h>
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -18,7 +18,7 @@
 #include "rpc/server.h"
 #include "sync.h"
 #include "txdb.h"
-#include "util.h"
+#include "util/system.h"
 #include "utilmoneystr.h"
 #include "utilstrencodings.h"
 #include "hash.h"

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -16,7 +16,7 @@
 #include "rpc/server.h"
 #include "spork.h"
 #include "timedata.h"
-#include "util.h"
+#include "util/system.h"
 #ifdef ENABLE_WALLET
 #include "wallet/wallet.h"
 #include "wallet/walletdb.h"

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -14,7 +14,7 @@
 #include "sync.h"
 #include "timedata.h"
 #include "guiinterface.h"
-#include "util.h"
+#include "util/system.h"
 #include "version.h"
 #include "validation.h"
 

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -9,7 +9,7 @@
 
 #include "random.h"
 #include "tinyformat.h"
-#include "util.h"
+#include "util/system.h"
 #include "utilstrencodings.h"
 #include "utiltime.h"
 #include "version.h"

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -13,7 +13,7 @@
 #include "random.h"
 #include "sync.h"
 #include "guiinterface.h"
-#include "util.h"
+#include "util/system.h"
 #include "utilstrencodings.h"
 
 #ifdef ENABLE_WALLET

--- a/src/sapling/crypter_sapling.cpp
+++ b/src/sapling/crypter_sapling.cpp
@@ -7,7 +7,7 @@
 
 #include "script/script.h"
 #include "script/standard.h"
-#include "util.h"
+#include "util/system.h"
 #include "uint256.h"
 
 #include "wallet/wallet.h"

--- a/src/sapling/sapling_validation.cpp
+++ b/src/sapling/sapling_validation.cpp
@@ -8,7 +8,7 @@
 #include "consensus/consensus.h" // for MAX_BLOCK_SIZE_CURRENT
 #include "script/interpreter.h" // for SigHash
 #include "consensus/validation.h" // for CValidationState
-#include "util.h" // for error()
+#include "util/system.h" // for error()
 #include "consensus/upgrades.h" // for CurrentEpochBranchId()
 
 #include <librustzcash.h>

--- a/src/script/ismine.cpp
+++ b/src/script/ismine.cpp
@@ -11,7 +11,7 @@
 #include "script/script.h"
 #include "script/sign.h"
 #include "script/standard.h"
-#include "util.h"
+#include "util/system.h"
 
 
 

--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -11,7 +11,7 @@
 #include "pubkey.h"
 #include "random.h"
 #include "uint256.h"
-#include "util.h"
+#include "util/system.h"
 
 #include <boost/thread/thread.hpp>
 

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -12,7 +12,7 @@
 #include "primitives/transaction.h"
 #include "script/standard.h"
 #include "uint256.h"
-#include "util.h"
+#include "util/system.h"
 
 typedef std::vector<unsigned char> valtype;
 

--- a/src/spork.h
+++ b/src/spork.h
@@ -13,7 +13,7 @@
 #include "net.h"
 #include "sporkid.h"
 #include "sync.h"
-#include "util.h"
+#include "util/system.h"
 
 #include "protocol.h"
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -96,6 +96,7 @@ set(BITCOIN_TESTS
         ${CMAKE_CURRENT_SOURCE_DIR}/DoS_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/evo_deterministicmns_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/evo_specialtx_tests.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/flatfile_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/getarg_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/hash_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/key_tests.cpp

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -17,7 +17,7 @@
 #include "pow.h"
 #include "script/sign.h"
 #include "serialize.h"
-#include "util.h"
+#include "util/system.h"
 #include "validation.h"
 
 #include <stdint.h>

--- a/src/test/alert_tests.cpp
+++ b/src/test/alert_tests.cpp
@@ -8,7 +8,7 @@
 //
 
 #include "chainparams.h"
-#include "util.h"
+#include "util/system.h"
 
 #include "test/test_bitcoin.h"
 

--- a/src/test/allocator_tests.cpp
+++ b/src/test/allocator_tests.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "util.h"
+#include "util/system.h"
 
 #include "support/allocators/zeroafterfree.h"
 #include "test/test_pivx.h"

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -12,7 +12,7 @@
 #include "key.h"
 #include "script/script.h"
 #include "uint256.h"
-#include "util.h"
+#include "util/system.h"
 #include "utilstrencodings.h"
 #include "test/test_pivx.h"
 

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -13,7 +13,7 @@
 #include "serialize.h"
 #include "streams.h"
 #include "uint256.h"
-#include "util.h"
+#include "util/system.h"
 #include "utilstrencodings.h"
 #include "test/test_pivx.h"
 

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "compressor.h"
-#include "util.h"
+#include "util/system.h"
 #include "test/test_pivx.h"
 
 #include <stdint.h>

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -24,7 +24,7 @@ BOOST_FIXTURE_TEST_SUITE(dbwrapper_tests, BasicTestingSetup)
 BOOST_AUTO_TEST_CASE(dbwrapper)
 {
     {
-        fs::path ph = fs::temp_directory_path() / fs::unique_path();
+        fs::path ph = SetDataDir(std::string("dbwrapper"));
         CDBWrapper dbw(ph, (1 << 20), true, false);
         char key = 'k';
         uint256 in = GetRandHash();
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_basic_data)
 BOOST_AUTO_TEST_CASE(dbwrapper_batch)
 {
     {
-        fs::path ph = fs::temp_directory_path() / fs::unique_path();
+        fs::path ph = SetDataDir(std::string("dbwrapper_batch"));
         CDBWrapper dbw(ph, (1 << 20), true, false);
 
         char key = 'i';
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_batch)
 BOOST_AUTO_TEST_CASE(dbwrapper_iterator)
 {
     {
-        fs::path ph = fs::temp_directory_path() / fs::unique_path();
+        fs::path ph = SetDataDir(std::string("dbwrapper_iterator"));
         CDBWrapper dbw(ph, (1 << 20), true, false);
 
         // The two keys are intentionally chosen for ordering

--- a/src/test/flatfile_tests.cpp
+++ b/src/test/flatfile_tests.cpp
@@ -1,0 +1,123 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "flatfile.h"
+#include "test/test_pivx.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(flatfile_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(flatfile_filename)
+{
+    auto data_dir = SetDataDir("flatfile_test");
+
+    FlatFilePos pos(456, 789);
+
+    FlatFileSeq seq1(data_dir, "a", 16 * 1024);
+    BOOST_CHECK_EQUAL(seq1.FileName(pos), data_dir / "a00456.dat");
+
+    FlatFileSeq seq2(data_dir / "a", "b", 16 * 1024);
+    BOOST_CHECK_EQUAL(seq2.FileName(pos), data_dir / "a" / "b00456.dat");
+}
+
+BOOST_AUTO_TEST_CASE(flatfile_open)
+{
+    auto data_dir = SetDataDir("flatfile_test");
+    FlatFileSeq seq(data_dir, "a", 16 * 1024);
+
+    std::string line1("A purely peer-to-peer version of electronic cash would allow online "
+                      "payments to be sent directly from one party to another without going "
+                      "through a financial institution.");
+    std::string line2("Digital signatures provide part of the solution, but the main benefits are "
+                      "lost if a trusted third party is still required to prevent double-spending.");
+
+    size_t pos1 = 0;
+    size_t pos2 = pos1 + GetSerializeSize(line1, CLIENT_VERSION);
+
+    // Write first line to file.
+    {
+        CAutoFile file(seq.Open(FlatFilePos(0, pos1)), SER_DISK, CLIENT_VERSION);
+        file << LIMITED_STRING(line1, 256);
+    }
+
+    // Attempt to append to file opened in read-only mode.
+    {
+        CAutoFile file(seq.Open(FlatFilePos(0, pos2), true), SER_DISK, CLIENT_VERSION);
+        BOOST_CHECK_THROW(file << LIMITED_STRING(line2, 256), std::ios_base::failure);
+    }
+
+    // Append second line to file.
+    {
+        CAutoFile file(seq.Open(FlatFilePos(0, pos2)), SER_DISK, CLIENT_VERSION);
+        file << LIMITED_STRING(line2, 256);
+    }
+
+    // Read text from file in read-only mode.
+    {
+        std::string text;
+        CAutoFile file(seq.Open(FlatFilePos(0, pos1), true), SER_DISK, CLIENT_VERSION);
+
+        file >> LIMITED_STRING(text, 256);
+        BOOST_CHECK_EQUAL(text, line1);
+
+        file >> LIMITED_STRING(text, 256);
+        BOOST_CHECK_EQUAL(text, line2);
+    }
+
+    // Read text from file with position offset.
+    {
+        std::string text;
+        CAutoFile file(seq.Open(FlatFilePos(0, pos2)), SER_DISK, CLIENT_VERSION);
+
+        file >> LIMITED_STRING(text, 256);
+        BOOST_CHECK_EQUAL(text, line2);
+    }
+
+    // Ensure another file in the sequence has no data.
+    {
+        std::string text;
+        CAutoFile file(seq.Open(FlatFilePos(1, pos2)), SER_DISK, CLIENT_VERSION);
+        BOOST_CHECK_THROW(file >> LIMITED_STRING(text, 256), std::ios_base::failure);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(flatfile_allocate)
+{
+    auto data_dir = SetDataDir("flatfile_test");
+    FlatFileSeq seq(data_dir, "a", 100);
+
+    bool out_of_space;
+
+    BOOST_CHECK_EQUAL(seq.Allocate(FlatFilePos(0, 0), 1, out_of_space), 100);
+    BOOST_CHECK_EQUAL(fs::file_size(seq.FileName(FlatFilePos(0, 0))), 100);
+    BOOST_CHECK(!out_of_space);
+
+    BOOST_CHECK_EQUAL(seq.Allocate(FlatFilePos(0, 99), 1, out_of_space), 0);
+    BOOST_CHECK_EQUAL(fs::file_size(seq.FileName(FlatFilePos(0, 99))), 100);
+    BOOST_CHECK(!out_of_space);
+
+    BOOST_CHECK_EQUAL(seq.Allocate(FlatFilePos(0, 99), 2, out_of_space), 101);
+    BOOST_CHECK_EQUAL(fs::file_size(seq.FileName(FlatFilePos(0, 99))), 200);
+    BOOST_CHECK(!out_of_space);
+}
+
+BOOST_AUTO_TEST_CASE(flatfile_flush)
+{
+    auto data_dir = SetDataDir("flatfile_test");
+    FlatFileSeq seq(data_dir, "a", 100);
+
+    bool out_of_space;
+    seq.Allocate(FlatFilePos(0, 0), 1, out_of_space);
+
+    // Flush without finalize should not truncate file.
+    seq.Flush(FlatFilePos(0, 1));
+    BOOST_CHECK_EQUAL(fs::file_size(seq.FileName(FlatFilePos(0, 1))), 100);
+
+    // Flush with finalize should truncate file.
+    seq.Flush(FlatFilePos(0, 1), true);
+    BOOST_CHECK_EQUAL(fs::file_size(seq.FileName(FlatFilePos(0, 1))), 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -3,7 +3,7 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "util.h"
+#include "util/system.h"
 #include "test/test_pivx.h"
 
 #include <string>

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -8,7 +8,7 @@
 #include "base58.h"
 #include "script/script.h"
 #include "uint256.h"
-#include "util.h"
+#include "util/system.h"
 #include "utilstrencodings.h"
 #include "test_pivx.h"
 

--- a/src/test/librust/wallet_zkeys_tests.cpp
+++ b/src/test/librust/wallet_zkeys_tests.cpp
@@ -9,7 +9,7 @@
 #include "sapling/address.h"
 #include "wallet/wallet.h"
 #include "wallet/walletdb.h"
-#include "util.h"
+#include "util/system.h"
 #include <boost/test/unit_test.hpp>
 
 /**

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -6,7 +6,7 @@
 
 #include "policy/feerate.h"
 #include "txmempool.h"
-#include "util.h"
+#include "util/system.h"
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -11,7 +11,7 @@
 #include "miner.h"
 #include "pubkey.h"
 #include "uint256.h"
-#include "util.h"
+#include "util/system.h"
 #include "validation.h"
 #include "wallet/wallet.h"
 

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -6,7 +6,7 @@
 #include "policy/fees.h"
 #include "txmempool.h"
 #include "uint256.h"
-#include "util.h"
+#include "util/system.h"
 
 #include "test/test_pivx.h"
 

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -8,7 +8,7 @@
 
 #include "base58.h"
 #include "netbase.h"
-#include "util.h"
+#include "util/system.h"
 
 #include "test/test_pivx.h"
 

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -11,7 +11,7 @@
 #include "serialize.h"
 #include "script/script.h"
 #include "script/interpreter.h"
-#include "util.h"
+#include "util/system.h"
 #include "validation.h"
 #include "version.h"
 

--- a/src/test/skiplist_tests.cpp
+++ b/src/test/skiplist_tests.cpp
@@ -5,7 +5,7 @@
 
 #include "test/test_pivx.h"
 
-#include "util.h"
+#include "util/system.h"
 #include "validation.h"
 
 #include <vector>

--- a/src/test/test_pivx.h
+++ b/src/test/test_pivx.h
@@ -38,6 +38,11 @@ struct BasicTestingSetup {
 
     BasicTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
     ~BasicTestingSetup();
+
+    fs::path SetDataDir(const std::string& name);
+
+private:
+    const fs::path m_path_root;
 };
 
 /** Testing setup that configures a complete environment.
@@ -47,7 +52,6 @@ struct BasicTestingSetup {
 class CConnman;
 struct TestingSetup: public BasicTestingSetup {
     CCoinsViewDB *pcoinsdbview;
-    fs::path pathTemp;
     boost::thread_group threadGroup;
     CConnman* connman;
     CScheduler scheduler;

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -3,7 +3,7 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "util.h"
+#include "util/system.h"
 
 #include "clientversion.h"
 #include "primitives/transaction.h"

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -9,7 +9,7 @@
 #include "guiinterface.h"
 #include "netaddress.h"
 #include "sync.h"
-#include "util.h"
+#include "util/system.h"
 #include "warnings.h"
 
 

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -10,7 +10,7 @@
 #include "utilstrencodings.h"
 #include "netbase.h"
 #include "net.h"
-#include "util.h"
+#include "util/system.h"
 #include "crypto/hmac_sha256.h"
 
 #include <vector>

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -9,7 +9,7 @@
 #include "random.h"
 #include "pow.h"
 #include "uint256.h"
-#include "util.h"
+#include "util/system.h"
 #include "zpiv/zerocoin.h"
 
 #include <stdint.h>

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -32,7 +32,7 @@ static const int64_t nMaxDbCache = sizeof(void*) > 4 ? 16384 : 1024;
 //! min. -dbcache in (MiB)
 static const int64_t nMinDbCache = 4;
 
-struct CDiskTxPos : public CDiskBlockPos
+struct CDiskTxPos : public FlatFilePos
 {
     unsigned int nTxOffset; // after header
 
@@ -41,11 +41,11 @@ struct CDiskTxPos : public CDiskBlockPos
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action)
     {
-        READWRITEAS(CDiskBlockPos, *this);
+        READWRITEAS(FlatFilePos, *this);
         READWRITE(VARINT(nTxOffset));
     }
 
-    CDiskTxPos(const CDiskBlockPos& blockIn, unsigned int nTxOffsetIn) : CDiskBlockPos(blockIn.nFile, blockIn.nPos), nTxOffset(nTxOffsetIn)
+    CDiskTxPos(const FlatFilePos& blockIn, unsigned int nTxOffsetIn) : FlatFilePos(blockIn.nFile, blockIn.nPos), nTxOffset(nTxOffsetIn)
     {
     }
 
@@ -56,7 +56,7 @@ struct CDiskTxPos : public CDiskBlockPos
 
     void SetNull()
     {
-        CDiskBlockPos::SetNull();
+        FlatFilePos::SetNull();
         nTxOffset = 0;
     }
 };

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -14,7 +14,7 @@
 #include "reverse_iterate.h"
 #include "streams.h"
 #include "timedata.h"
-#include "util.h"
+#include "util/system.h"
 #include "utilmoneystr.h"
 #include "utiltime.h"
 #include "version.h"

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -95,12 +95,12 @@ ArgsManager gArgs;
 bool fDaemon = false;
 CTranslationInterface translationInterface;
 
-bool CheckDiskSpace(const fs::path& dir, uint64_t nAdditionalBytes)
+bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes)
 {
-    constexpr uint64_t nMinDiskSpace = 52428800; // 50 MiB
+    constexpr uint64_t min_disk_space = 52428800; // 50 MiB
 
-    uint64_t nFreeBytesAvailable = fs::space(dir).available;
-    return nFreeBytesAvailable >= nMinDiskSpace + nAdditionalBytes;
+    uint64_t free_bytes_available = fs::space(dir).available;
+    return free_bytes_available >= min_disk_space + additional_bytes;
 }
 
 /**

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -95,6 +95,14 @@ ArgsManager gArgs;
 bool fDaemon = false;
 CTranslationInterface translationInterface;
 
+bool CheckDiskSpace(const fs::path& dir, uint64_t nAdditionalBytes)
+{
+    constexpr uint64_t nMinDiskSpace = 52428800; // 50 MiB
+
+    uint64_t nFreeBytesAvailable = fs::space(dir).available;
+    return nFreeBytesAvailable >= nMinDiskSpace + nAdditionalBytes;
+}
+
 /**
  * Interpret a string argument as a boolean.
  *

--- a/src/util.h
+++ b/src/util.h
@@ -86,6 +86,7 @@ bool FileCommit(FILE* file);
 bool TruncateFile(FILE* file, unsigned int length);
 int RaiseFileDescriptorLimit(int nMinFD);
 void AllocateFileRange(FILE* file, unsigned int offset, unsigned int length);
+bool CheckDiskSpace(const fs::path& dir, uint64_t nAdditionalBytes = 0);
 bool RenameOver(fs::path src, fs::path dest);
 bool TryCreateDirectories(const fs::path& p);
 fs::path GetDefaultDataDir();

--- a/src/util.h
+++ b/src/util.h
@@ -86,7 +86,7 @@ bool FileCommit(FILE* file);
 bool TruncateFile(FILE* file, unsigned int length);
 int RaiseFileDescriptorLimit(int nMinFD);
 void AllocateFileRange(FILE* file, unsigned int offset, unsigned int length);
-bool CheckDiskSpace(const fs::path& dir, uint64_t nAdditionalBytes = 0);
+bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes = 0);
 bool RenameOver(fs::path src, fs::path dest);
 bool TryCreateDirectories(const fs::path& p);
 fs::path GetDefaultDataDir();

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -9,7 +9,7 @@
 #include "config/pivx-config.h"
 #endif
 
-#include "util.h"
+#include "util/system.h"
 
 #include "chainparamsbase.h"
 #include "random.h"

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -9,8 +9,8 @@
  * Server/client environment: argument handling, config file parsing,
  * thread wrappers
  */
-#ifndef BITCOIN_UTIL_H
-#define BITCOIN_UTIL_H
+#ifndef BITCOIN_UTIL_SYSTEM_H
+#define BITCOIN_UTIL_SYSTEM_H
 
 #if defined(HAVE_CONFIG_H)
 #include "config/pivx-config.h"
@@ -293,4 +293,4 @@ fs::path AbsPathForConfigVal(const fs::path& path, bool net_specific = true);
  */
 int ScheduleBatchPriority(void);
 
-#endif // BITCOIN_UTIL_H
+#endif // BITCOIN_UTIL_SYSTEM_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1429,25 +1429,12 @@ void static FlushBlockFile(bool fFinalize = false)
 {
     LOCK(cs_LastBlockFile);
 
-    CDiskBlockPos posOld(nLastBlockFile, 0);
+    CDiskBlockPos block_pos_old(nLastBlockFile, vinfoBlockFile[nLastBlockFile].nSize);
+    CDiskBlockPos undo_pos_old(nLastBlockFile, vinfoBlockFile[nLastBlockFile].nUndoSize);
+
     bool status = true;
-
-    FILE* fileOld = OpenBlockFile(posOld);
-    if (fileOld) {
-        if (fFinalize)
-            status &= TruncateFile(fileOld, vinfoBlockFile[nLastBlockFile].nSize);
-        status &= FileCommit(fileOld);
-        fclose(fileOld);
-    }
-
-    fileOld = OpenUndoFile(posOld);
-    if (fileOld) {
-        if (fFinalize)
-            status &= TruncateFile(fileOld, vinfoBlockFile[nLastBlockFile].nUndoSize);
-        status &= FileCommit(fileOld);
-        fclose(fileOld);
-    }
-
+    status &= BlockFileSeq().Flush(block_pos_old, fFinalize);
+    status &= UndoFileSeq().Flush(undo_pos_old, fFinalize);
     if (!status) {
         AbortNode("Flushing block file to disk failed. This is likely the result of an I/O error.");
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -45,7 +45,7 @@
 #include "txdb.h"
 #include "txmempool.h"
 #include "undo.h"
-#include "util.h"
+#include "util/system.h"
 #include "utilmoneystr.h"
 #include "validationinterface.h"
 #include "warnings.h"

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1853,8 +1853,9 @@ bool static FlushStateToDisk(CValidationState& state, FlushStateMode mode)
         // Write blocks and block index to disk.
         if (fDoFullFlush || fPeriodicWrite) {
             // Depend on nMinDiskSpace to ensure we can write block index
-            if (!CheckDiskSpace(0, true))
-                return state.Error("out of disk space");
+            if (!CheckDiskSpace(GetBlocksDir())) {
+                return AbortNode(state, "Disk space is low!", _("Error: Disk space is low!"));
+            }
             // First make sure all block and undo data is flushed to disk.
             FlushBlockFile();
             // Then update all block file information (which may refer to block and undo files).
@@ -1885,8 +1886,9 @@ bool static FlushStateToDisk(CValidationState& state, FlushStateMode mode)
             // twice (once in the log, and once in the tables). This is already
             // an overestimation, as most will delete an existing entry or
             // overwrite one. Still, use a conservative safety factor of 2.
-            if (!CheckDiskSpace(48 * 2 * 2 * pcoinsTip->GetCacheSize()))
-                return state.Error("out of disk space");
+            if (!CheckDiskSpace(GetDataDir(), 48 * 2 * 2 * pcoinsTip->GetCacheSize())) {
+                return AbortNode(state, "Disk space is low!", _("Error: Disk space is low!"));
+            }
             // Flush the chainstate (which may refer to block index entries).
             if (!pcoinsTip->Flush())
                 return AbortNode(state, "Failed to write to coin database");
@@ -2659,15 +2661,16 @@ bool FindBlockPos(CValidationState& state, CDiskBlockPos& pos, unsigned int nAdd
         unsigned int nOldChunks = (pos.nPos + BLOCKFILE_CHUNK_SIZE - 1) / BLOCKFILE_CHUNK_SIZE;
         unsigned int nNewChunks = (vinfoBlockFile[nFile].nSize + BLOCKFILE_CHUNK_SIZE - 1) / BLOCKFILE_CHUNK_SIZE;
         if (nNewChunks > nOldChunks) {
-            if (CheckDiskSpace(nNewChunks * BLOCKFILE_CHUNK_SIZE - pos.nPos, true)) {
+            if (CheckDiskSpace(GetBlocksDir(), nNewChunks * BLOCKFILE_CHUNK_SIZE - pos.nPos)) {
                 FILE* file = OpenBlockFile(pos);
                 if (file) {
                     LogPrintf("Pre-allocating up to position 0x%x in blk%05u.dat\n", nNewChunks * BLOCKFILE_CHUNK_SIZE, pos.nFile);
                     AllocateFileRange(file, pos.nPos, nNewChunks * BLOCKFILE_CHUNK_SIZE - pos.nPos);
                     fclose(file);
                 }
-            } else
-                return state.Error("out of disk space");
+            } else {
+                return AbortNode("Disk space is low!", _("Error: Disk space is low!"));
+            }
         }
     }
 
@@ -2689,15 +2692,16 @@ bool FindUndoPos(CValidationState& state, int nFile, CDiskBlockPos& pos, unsigne
     unsigned int nOldChunks = (pos.nPos + UNDOFILE_CHUNK_SIZE - 1) / UNDOFILE_CHUNK_SIZE;
     unsigned int nNewChunks = (nNewSize + UNDOFILE_CHUNK_SIZE - 1) / UNDOFILE_CHUNK_SIZE;
     if (nNewChunks > nOldChunks) {
-        if (CheckDiskSpace(nNewChunks * UNDOFILE_CHUNK_SIZE - pos.nPos, true)) {
+        if (CheckDiskSpace(GetBlocksDir(), nNewChunks * UNDOFILE_CHUNK_SIZE - pos.nPos)) {
             FILE* file = OpenUndoFile(pos);
             if (file) {
                 LogPrintf("Pre-allocating up to position 0x%x in rev%05u.dat\n", nNewChunks * UNDOFILE_CHUNK_SIZE, pos.nFile);
                 AllocateFileRange(file, pos.nPos, nNewChunks * UNDOFILE_CHUNK_SIZE - pos.nPos);
                 fclose(file);
             }
-        } else
-            return state.Error("out of disk space");
+        } else {
+            return AbortNode(state, "Disk space is low!", _("Error: Disk space is low!"));
+        }
     }
 
     return true;
@@ -3465,17 +3469,6 @@ bool TestBlockValidity(CValidationState& state, const CBlock& block, CBlockIndex
     if (!ConnectBlock(block, state, &indexDummy, viewNew, true))
         return false;
     assert(state.IsValid());
-
-    return true;
-}
-
-bool CheckDiskSpace(uint64_t nAdditionalBytes, bool blocks_dir)
-{
-    uint64_t nFreeBytesAvailable = fs::space(blocks_dir ? GetBlocksDir() : GetDataDir()).available;
-
-    // Check for nMinDiskSpace bytes (currently 50MB)
-    if (nFreeBytesAvailable < nMinDiskSpace + nAdditionalBytes)
-        return AbortNode("Disk space is low!", _("Error: Disk space is low!"));
 
     return true;
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3472,29 +3472,6 @@ bool TestBlockValidity(CValidationState& state, const CBlock& block, CBlockIndex
     return true;
 }
 
-FILE* OpenDiskFile(const CDiskBlockPos& pos, const char* prefix, bool fReadOnly)
-{
-    if (pos.IsNull())
-        return NULL;
-    fs::path path = GetBlockPosFilename(pos, prefix);
-    fs::create_directories(path.parent_path());
-    FILE* file = fsbridge::fopen(path, "rb+");
-    if (!file && !fReadOnly)
-        file = fsbridge::fopen(path, "wb+");
-    if (!file) {
-        LogPrintf("Unable to open file %s\n", path.string());
-        return NULL;
-    }
-    if (pos.nPos) {
-        if (fseek(file, pos.nPos, SEEK_SET)) {
-            LogPrintf("Unable to seek to position %u of %s\n", pos.nPos, path.string());
-            fclose(file);
-            return NULL;
-        }
-    }
-    return file;
-}
-
 static FlatFileSeq BlockFileSeq()
 {
     return FlatFileSeq(GetBlocksDir(), "blk", BLOCKFILE_CHUNK_SIZE);
@@ -3507,12 +3484,12 @@ static FlatFileSeq UndoFileSeq()
 
 FILE* OpenBlockFile(const CDiskBlockPos& pos, bool fReadOnly)
 {
-    return OpenDiskFile(pos, "blk", fReadOnly);
+    return BlockFileSeq().Open(pos, fReadOnly);
 }
 
 FILE* OpenUndoFile(const CDiskBlockPos& pos, bool fReadOnly)
 {
-    return OpenDiskFile(pos, "rev", fReadOnly);
+    return UndoFileSeq().Open(pos, fReadOnly);
 }
 
 fs::path GetBlockPosFilename(const CDiskBlockPos &pos)

--- a/src/validation.h
+++ b/src/validation.h
@@ -171,16 +171,16 @@ extern CBlockIndex* pindexBestHeader;
  * @param[out]  fAccepted  Whether the block is accepted or not
  * @return True if state.IsValid()
  */
-bool ProcessNewBlock(CValidationState& state, CNode* pfrom, const std::shared_ptr<const CBlock> pblock, CDiskBlockPos* dbp, bool* fAccepted = nullptr);
+bool ProcessNewBlock(CValidationState& state, CNode* pfrom, const std::shared_ptr<const CBlock> pblock, FlatFilePos* dbp, bool* fAccepted = nullptr);
 
 /** Open a block file (blk?????.dat) */
-FILE* OpenBlockFile(const CDiskBlockPos& pos, bool fReadOnly = false);
+FILE* OpenBlockFile(const FlatFilePos& pos, bool fReadOnly = false);
 /** Open an undo file (rev?????.dat) */
-FILE* OpenUndoFile(const CDiskBlockPos& pos, bool fReadOnly = false);
+FILE* OpenUndoFile(const FlatFilePos& pos, bool fReadOnly = false);
 /** Translation to a filesystem path */
-fs::path GetBlockPosFilename(const CDiskBlockPos &pos);
+fs::path GetBlockPosFilename(const FlatFilePos &pos);
 /** Import blocks from an external file */
-bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos* dbp = NULL);
+bool LoadExternalBlockFile(FILE* fileIn, FlatFilePos* dbp = NULL);
 /** Ensures we have a genesis block in the block tree, possibly writing one to disk. */
 bool LoadGenesisBlock();
 /** Load the block tree and coins database from disk,
@@ -321,8 +321,8 @@ public:
 
 
 /** Functions for disk access for blocks */
-bool WriteBlockToDisk(const CBlock& block, CDiskBlockPos& pos);
-bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos);
+bool WriteBlockToDisk(const CBlock& block, FlatFilePos& pos);
+bool ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos);
 bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex);
 
 
@@ -340,7 +340,7 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
 bool TestBlockValidity(CValidationState& state, const CBlock& block, CBlockIndex* pindexPrev, bool fCheckPOW = true, bool fCheckMerkleRoot = true, bool fCheckBlockSig = true);
 
 /** Store block on disk. If dbp is provided, the file is known to already reside on disk */
-bool AcceptBlock(const CBlock& block, CValidationState& state, CBlockIndex** pindex, CDiskBlockPos* dbp = NULL);
+bool AcceptBlock(const CBlock& block, CValidationState& state, CBlockIndex** pindex, FlatFilePos* dbp = NULL);
 bool AcceptBlockHeader(const CBlock& block, CValidationState& state, CBlockIndex** ppindex = nullptr, CBlockIndex* pindexPrev = nullptr);
 
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -178,7 +178,7 @@ FILE* OpenBlockFile(const CDiskBlockPos& pos, bool fReadOnly = false);
 /** Open an undo file (rev?????.dat) */
 FILE* OpenUndoFile(const CDiskBlockPos& pos, bool fReadOnly = false);
 /** Translation to a filesystem path */
-fs::path GetBlockPosFilename(const CDiskBlockPos& pos, const char* prefix);
+fs::path GetBlockPosFilename(const CDiskBlockPos &pos);
 /** Import blocks from an external file */
 bool LoadExternalBlockFile(FILE* fileIn, CDiskBlockPos* dbp = NULL);
 /** Ensures we have a genesis block in the block tree, possibly writing one to disk. */

--- a/src/validation.h
+++ b/src/validation.h
@@ -159,9 +159,6 @@ extern CMoneySupply MoneySupply;
 /** Best header we've seen so far (used for getheaders queries' starting points). */
 extern CBlockIndex* pindexBestHeader;
 
-/** Minimum disk space required - used in CheckDiskSpace() */
-static const uint64_t nMinDiskSpace = 52428800;
-
 /**
  * Process an incoming block. This only returns after the best known valid
  * block is made active. Note that it does not, however, guarantee that the
@@ -175,8 +172,7 @@ static const uint64_t nMinDiskSpace = 52428800;
  * @return True if state.IsValid()
  */
 bool ProcessNewBlock(CValidationState& state, CNode* pfrom, const std::shared_ptr<const CBlock> pblock, CDiskBlockPos* dbp, bool* fAccepted = nullptr);
-/** Check whether enough disk space is available for an incoming block */
-bool CheckDiskSpace(uint64_t nAdditionalBytes = 0, bool blocks_dir = false);
+
 /** Open a block file (blk?????.dat) */
 FILE* OpenBlockFile(const CDiskBlockPos& pos, bool fReadOnly = false);
 /** Open an undo file (rev?????.dat) */

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -10,7 +10,7 @@
 #include "guiinterfaceutil.h"
 #include "hash.h"
 #include "protocol.h"
-#include "util.h"
+#include "util/system.h"
 #include "utilstrencodings.h"
 
 #include <stdint.h>

--- a/src/wallet/hdchain.cpp
+++ b/src/wallet/hdchain.cpp
@@ -7,7 +7,7 @@
 #include "base58.h"
 #include "chainparams.h"
 #include "tinyformat.h"
-#include "util.h"
+#include "util/system.h"
 #include "utilstrencodings.h"
 
 bool CHDChain::SetNull()

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -12,7 +12,7 @@
 #include "script/script.h"
 #include "script/standard.h"
 #include "sync.h"
-#include "util.h"
+#include "util/system.h"
 #include "utilstrencodings.h"
 #include "utiltime.h"
 #include "wallet/wallet.h"

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -18,7 +18,7 @@
 #include "policy/feerate.h"
 #include "rpc/server.h"
 #include "timedata.h"
-#include "util.h"
+#include "util/system.h"
 #include "utilmoneystr.h"
 #include "wallet.h"
 #include "walletdb.h"

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -412,6 +412,8 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
     SetMockTime(KEY_TIME);
     coinbaseTxns.emplace_back(*CreateAndProcessBlock({}, GetScriptForRawPubKey(coinbaseKey.GetPubKey())).vtx[0]);
 
+    std::string backup_file = (SetDataDir("importwallet_rescan") / "wallet.backup").string();
+
     // Import key into wallet and call dumpwallet to create backup file.
     {
         CWallet wallet;
@@ -423,7 +425,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
 
         JSONRPCRequest request;
         request.params.setArray();
-        request.params.push_back((pathTemp / "wallet.backup").string());
+        request.params.push_back(backup_file);
         ::pwalletMain = &wallet;
         ::dumpwallet(request);
     }
@@ -435,7 +437,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
 
         JSONRPCRequest request;
         request.params.setArray();
-        request.params.push_back((pathTemp / "wallet.backup").string());
+        request.params.push_back(backup_file);
         ::pwalletMain = &wallet;
         ::importwallet(request);
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -18,7 +18,7 @@
 #include "script/sign.h"
 #include "scheduler.h"
 #include "spork.h"
-#include "util.h"
+#include "util/system.h"
 #include "utilmoneystr.h"
 #include "zpivchain.h"
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -24,7 +24,7 @@
 #include "primitives/transaction.h"
 #include "sapling/address.h"
 #include "guiinterface.h"
-#include "util.h"
+#include "util/system.h"
 #include "util/memory.h"
 #include "utilstrencodings.h"
 #include "validationinterface.h"

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -15,7 +15,7 @@
 #include "sapling/key_io_sapling.h"
 #include "serialize.h"
 #include "sync.h"
-#include "util.h"
+#include "util/system.h"
 #include "utiltime.h"
 #include "wallet/wallet.h"
 

--- a/src/warnings.cpp
+++ b/src/warnings.cpp
@@ -7,7 +7,7 @@
 
 #include "sync.h"
 #include "clientversion.h"
-#include "util.h"
+#include "util/system.h"
 
 RecursiveMutex cs_warnings;
 std::string strMiscWarning;

--- a/src/zmq/zmqabstractnotifier.cpp
+++ b/src/zmq/zmqabstractnotifier.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "zmqabstractnotifier.h"
-#include "util.h"
+#include "util/system.h"
 
 
 CZMQAbstractNotifier::~CZMQAbstractNotifier()

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -7,7 +7,7 @@
 
 #include "version.h"
 #include "streams.h"
-#include "util.h"
+#include "util/system.h"
 
 void zmqError(const char *str)
 {

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -5,7 +5,7 @@
 #include "zmqpublishnotifier.h"
 
 #include "chainparams.h"
-#include "util.h"
+#include "util/system.h"
 #include "crypto/common.h"
 #include "validation.h"     // cs_main
 

--- a/src/zpiv/mintpool.cpp
+++ b/src/zpiv/mintpool.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "mintpool.h"
-#include "util.h"
+#include "util/system.h"
 
 
 CMintPool::CMintPool()


### PR DESCRIPTION
This is part of the block logic refactoring and encapsulation work coming from upstream (work started in #2326 and #2328 due the possible blocks db corruption issue). 
Needed for two future works: (1) faster block validation using a new cache structure and (2) the future possible custom BIP157 (new sync protocol that supersedes BIP37 for light clients -- pending research needed after finishing v6.0 priorities --)

Essentially, it's encapsulating the sequenced files open/read/write functionalities inside a new `flatfile` module,  and extending the unit test coverage to validate its correct behavior.

Adapted the following PRs:

* #15118.
* #13145.
* Plus added `util.h/cpp` files mv to `util/system.h` & `util/system.cpp`.