### PR TITLE
[Wallet] Basic multiwallet support

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -301,8 +301,6 @@ Threads
 
 - DumpAddresses : Dumps IP addresses of nodes to peers.dat.
 
-- ThreadFlushWalletDB : Close the wallet.dat file if it hasn't been used in 500ms.
-
 - ThreadRPCServer : Remote procedure call handler, listens on port 8332 for connections and services them.
 
 - BitcoinMiner : Generates PIVs (if wallet is enabled).

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -49,12 +49,24 @@ Cold-Staking Re-Activation
 PIVX Core v6.0.0 includes a fix for the vulnerability identified within the cold-staking protocol (see PR [#2258](https://github.com/PIVX-Project/PIVX/pull/2258)).
 Therefore the feature will be re-enabled on the network, via `SPORK_19`, shortly after the upgrade enforcement.
 
-#### Protocol changes
+### Protocol changes
 
 A new opcode (`0xd2`) is introduced (see PR [#2275](https://github.com/PIVX-Project/PIVX/pull/2275)). It enforces the same rules as the legacy cold-staking opcode, but without allowing a "free" script for the last output of the transaction.
 This is in accord with the consensus change introduced with the "Deterministic Masternodes" update, as masternode/budget payments are now outputs of the *coinbase* transaction (rather than the *coinstake*), therefore a "free" output for the coinstake is no longer needed.
 The new opcode takes the name of `OP_CHECKCOLDSTAKEVERIFY`, and the legacy opcode (`0xd1`) is renamed to `OP_CHECKCOLDSTAKEVERIFY_LOF` (last-output-free).
 Scripts with the old opcode are still accepted on the network (the restriction on the last-output is enforced after the script validation in this case), but the client creates new delegations with the new opcode, by default, after the upgrade enforcement.
+
+
+Multi-wallet support
+--------------------
+
+PIVX Core now supports loading multiple, separate wallets (See [PR 2337](https://github.com/PIVX-Project/PIVX/pull/2337)). The wallets are completely separated, with individual balances, keys and received transactions.
+
+Multi-wallet is enabled by using more than one `-wallet` argument when starting PIVX client, either on the command line or in the pivx.conf config file.
+
+**In pivx-qt, only the first wallet will be displayed and accessible for creating and signing transactions.** GUI selectable multiple wallets will be supported in a future version. However, even in 6.0 other loaded wallets will remain synchronized to the node's current tip in the background.
+
+!TODO: update after endpoint support and multi-wallet RPC support
 
 
 GUI changes
@@ -100,6 +112,7 @@ Low-level RPC changes
   - `maximumAmount` - a number specifying the maximum value of each UTXO
   - `maximumCount` - a number specifying the minimum number of UTXOs
   - `minimumSumAmount` - a number specifying the minimum sum value of all UTXOs
+
 
 #### Show wallet's auto-combine settings in getwalletinfo
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -936,24 +936,6 @@ void InitParameterInteraction()
         if (gArgs.SoftSetBoolArg("-discover", false))
             LogPrintf("%s : parameter interaction: -externalip set -> setting -discover=0\n", __func__);
     }
-
-    if (gArgs.GetBoolArg("-salvagewallet", false)) {
-        // Rewrite just private keys: rescan to find transactions
-        if (gArgs.SoftSetBoolArg("-rescan", true))
-            LogPrintf("%s : parameter interaction: -salvagewallet=1 -> setting -rescan=1\n", __func__);
-    }
-
-    int zapwallettxes = gArgs.GetArg("-zapwallettxes", 0);
-    // -zapwallettxes implies dropping the mempool on startup
-    if (zapwallettxes != 0 && gArgs.SoftSetBoolArg("-persistmempool", false)) {
-        LogPrintf("%s: parameter interaction: -zapwallettxes=%s -> setting -persistmempool=0\n", __func__, zapwallettxes);
-    }
-
-    // -zapwallettxes implies a rescan
-    if (zapwallettxes != 0) {
-        if (gArgs.SoftSetBoolArg("-rescan", true))
-            LogPrintf("%s : parameter interaction: -zapwallettxes=%s -> setting -rescan=1\n", __func__, zapwallettxes);
-    }
 }
 
 bool InitNUParams()

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1,10 +1,10 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2015 The Bitcoin developers
+// Copyright (c) 2009-2021 The Bitcoin developers
 // Copyright (c) 2014-2015 The Dash developers
 // Copyright (c) 2011-2013 The PPCoin developers
 // Copyright (c) 2013-2014 The NovaCoin Developers
 // Copyright (c) 2014-2018 The BlackCoin Developers
-// Copyright (c) 2015-2020 The PIVX developers
+// Copyright (c) 2015-2021 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -58,7 +58,6 @@
 #include "zpivchain.h"
 
 #ifdef ENABLE_WALLET
-#include "wallet/db.h"
 #include "wallet/wallet.h"
 #include "wallet/rpcwallet.h"
 
@@ -223,7 +222,7 @@ void PrepareShutdown()
     StopHTTPServer();
 #ifdef ENABLE_WALLET
     if (pwalletMain)
-        bitdb.Flush(false);
+        pwalletMain->Flush(false);
     GenerateBitcoins(false, NULL, 0);
 #endif
     StopMapPort();
@@ -303,7 +302,7 @@ void PrepareShutdown()
     }
 #ifdef ENABLE_WALLET
     if (pwalletMain)
-        bitdb.Flush(true);
+        pwalletMain->Flush(true);
 #endif
 
     if (pEvoNotificationInterface) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1337,11 +1337,8 @@ bool AppInitMain()
         }
     }
 
-// ********************************************************* Step 5: Backup wallet and verify wallet database integrity
+// ********************************************************* Step 5: Verify wallet database integrity
 #ifdef ENABLE_WALLET
-    if (!InitAutoBackupWallet()) {
-        return false;
-    }
     if (!CWallet::Verify()) {
         return false;
     }
@@ -1729,7 +1726,7 @@ bool AppInitMain()
         mempool.ReadFeeEstimates(est_filein);
     fFeeEstimatesInitialized = true;
 
-// ********************************************************* Step 8: load wallet
+// ********************************************************* Step 8: Backup and Load wallet
 #ifdef ENABLE_WALLET
     if (!CWallet::InitLoadWallet())
         return false;

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -251,7 +251,8 @@ bool CMasternodeBroadcast::Create(const std::string& strService,
     }
 
     std::string strError;
-    if (!pwalletMain->GetMasternodeVinAndKeys(txin, pubKeyCollateralAddressNew, keyCollateralAddressNew, strTxHash, strOutputIndex, strError)) {
+    // Use wallet-0 here. Legacy mnb creation can be removed after transition to DMN
+    if (vpwallets.empty() || !vpwallets[0]->GetMasternodeVinAndKeys(txin, pubKeyCollateralAddressNew, keyCollateralAddressNew, strTxHash, strOutputIndex, strError)) {
         strErrorRet = strError; // GetMasternodeVinAndKeys logs this error. Only returned for GUI error notification.
         LogPrint(BCLog::MASTERNODE,"CMasternodeBroadcast::Create -- %s\n", strprintf("Could not allocate txin %s:%s for masternode %s", strTxHash, strOutputIndex, strService));
         return false;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -306,8 +306,8 @@ void GenerateBitcoins(bool fGenerate, CWallet* pwallet, int nThreads)
 void ThreadStakeMinter()
 {
     boost::this_thread::interruption_point();
-    LogPrintf("ThreadStakeMinter started\n");
-    CWallet* pwallet = pwalletMain;
+    LogPrintf("ThreadStakeMinter started. Using wallet-0\n");
+    CWallet* pwallet = vpwallets[0];
     try {
         BitcoinMiner(pwallet, true);
         boost::this_thread::interruption_point();

--- a/src/qt/pivx.cpp
+++ b/src/qt/pivx.cpp
@@ -487,8 +487,9 @@ void BitcoinApplication::initializeResult(int retval)
         window->setClientModel(clientModel);
 
 #ifdef ENABLE_WALLET
-        if (pwalletMain) {
-            walletModel = new WalletModel(pwalletMain, optionsModel);
+        // TODO: Expose secondary wallets
+        if (!vpwallets.empty()) {
+            walletModel = new WalletModel(vpwallets[0], optionsModel);
             walletModel->setClientModel(clientModel);
 
             window->addWallet(PIVXGUI::DEFAULT_WALLET, walletModel);

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -60,7 +60,7 @@ struct CCoin {
     }
 };
 
-extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry);
+extern void TxToJSON(CWallet* const pwallet, const CTransaction& tx, const uint256 hashBlock, UniValue& entry);
 extern UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool txDetails = false);
 extern UniValue mempoolInfoToJSON();
 extern UniValue mempoolToJSON(bool fVerbose = false);
@@ -373,7 +373,7 @@ static bool rest_tx(HTTPRequest* req, const std::string& strURIPart)
 
     case RF_JSON: {
         UniValue objTx(UniValue::VOBJ);
-        TxToJSON(*tx, hashBlock, objTx);
+        TxToJSON(nullptr, *tx, hashBlock, objTx);
         std::string strJSON = objTx.write() + "\n";
         req->WriteHeader("Content-Type", "application/json");
         req->WriteReply(HTTP_OK, strJSON);

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -16,6 +16,7 @@
 #include "utilstrencodings.h"
 #include "validation.h"
 #include "version.h"
+#include "wallet/wallet.h"
 
 #include <boost/algorithm/string.hpp>
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -42,7 +42,7 @@ static std::mutex cs_blockchange;
 static std::condition_variable cond_blockchange;
 static CUpdatedBlock latestblock;
 
-extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry);
+extern void TxToJSON(CWallet* const pwallet, const CTransaction& tx, const uint256 hashBlock, UniValue& entry);
 
 UniValue syncwithvalidationinterfacequeue(const JSONRPCRequest& request)
 {
@@ -147,7 +147,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
         const CTransaction& tx = *txIn;
         if (txDetails) {
             UniValue objTx(UniValue::VOBJ);
-            TxToJSON(tx, UINT256_ZERO, objTx);
+            TxToJSON(nullptr, tx, UINT256_ZERO, objTx);
             txs.push_back(objTx);
         } else
             txs.push_back(tx.GetHash().GetHex());

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -15,6 +15,9 @@
 #include "messagesigner.h"
 #include "rpc/server.h"
 #include "utilmoneystr.h"
+#ifdef ENABLE_WALLET
+#include "wallet/rpcwallet.h"
+#endif
 
 #include <univalue.h>
 

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -97,6 +97,9 @@ void checkBudgetInputs(const UniValue& params, std::string &strProposalName, std
 
 UniValue preparebudget(const JSONRPCRequest& request)
 {
+    if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
+        return NullUniValue;
+
     if (request.fHelp || request.params.size() != 6)
         throw std::runtime_error(
             "preparebudget \"proposal-name\" \"url\" payment-count block-start \"pivx-address\" monthy-payment\n"
@@ -123,7 +126,7 @@ UniValue preparebudget(const JSONRPCRequest& request)
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
-    EnsureWalletIsUnlocked();
+    EnsureWalletIsUnlocked(pwalletMain);
 
     std::string strProposalName;
     std::string strURL;

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -97,6 +97,8 @@ void checkBudgetInputs(const UniValue& params, std::string &strProposalName, std
 
 UniValue preparebudget(const JSONRPCRequest& request)
 {
+    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+
     if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
         return NullUniValue;
 

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -355,9 +355,9 @@ UniValue startmasternode(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_MISC_ERROR, "startmasternode is not supported when deterministic masternode list is active (DIP3)");
     }
 
-    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
 
-    if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     std::string strCommand;
@@ -407,7 +407,7 @@ UniValue startmasternode(const JSONRPCRequest& request)
 
     bool fLock = (request.params[1].get_str() == "true" ? true : false);
 
-    EnsureWalletIsUnlocked(pwalletMain);
+    EnsureWalletIsUnlocked(pwallet);
 
     if (strCommand == "local") {
         if (!fMasterNode) throw std::runtime_error("you must set masternode=1 in the configuration\n");
@@ -415,7 +415,7 @@ UniValue startmasternode(const JSONRPCRequest& request)
         if (activeMasternode.GetStatus() != ACTIVE_MASTERNODE_STARTED) {
             activeMasternode.ResetStatus();
             if (fLock)
-                pwalletMain->Lock();
+                pwallet->Lock();
         }
 
         return activeMasternode.GetStatusMessage();
@@ -444,7 +444,7 @@ UniValue startmasternode(const JSONRPCRequest& request)
             RelayMNB(mnb, fSuccess, successful, failed);
         }
         if (fLock)
-            pwalletMain->Lock();
+            pwallet->Lock();
 
         UniValue returnObj(UniValue::VOBJ);
         returnObj.pushKV("overall", strprintf("Successfully started %d masternodes, failed to start %d, total %d", successful, failed, successful + failed));
@@ -484,7 +484,7 @@ UniValue startmasternode(const JSONRPCRequest& request)
         }
 
         if (fLock)
-            pwalletMain->Lock();
+            pwallet->Lock();
 
         if(!found) {
             statusObj.pushKV("success", false);
@@ -517,9 +517,9 @@ UniValue createmasternodekey (const JSONRPCRequest& request)
 
 UniValue getmasternodeoutputs (const JSONRPCRequest& request)
 {
-    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
 
-    if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || (request.params.size() != 0))
@@ -544,7 +544,7 @@ UniValue getmasternodeoutputs (const JSONRPCRequest& request)
     coinsFilter.fIncludeDelegated = false;
     coinsFilter.nCoinType = ONLY_10000;
     std::vector<COutput> possibleCoins;
-    pwalletMain->AvailableCoins(&possibleCoins, nullptr, coinsFilter);
+    pwallet->AvailableCoins(&possibleCoins, nullptr, coinsFilter);
 
     UniValue ret(UniValue::VARR);
     for (COutput& out : possibleCoins) {
@@ -817,9 +817,9 @@ bool DecodeHexMnb(CMasternodeBroadcast& mnb, std::string strHexMnb) {
 }
 UniValue createmasternodebroadcast(const JSONRPCRequest& request)
 {
-    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
 
-    if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     std::string strCommand;
@@ -829,7 +829,7 @@ UniValue createmasternodebroadcast(const JSONRPCRequest& request)
         throw std::runtime_error(
             "createmasternodebroadcast \"command\" ( \"alias\")\n"
             "\nCreates a masternode broadcast message for one or all masternodes configured in masternode.conf\n" +
-            HelpRequiringPassphrase(pwalletMain) + "\n"
+            HelpRequiringPassphrase(pwallet) + "\n"
 
             "\nArguments:\n"
             "1. \"command\"      (string, required) \"alias\" for single masternode, \"all\" for all masternodes\n"
@@ -860,7 +860,7 @@ UniValue createmasternodebroadcast(const JSONRPCRequest& request)
             "\nExamples:\n" +
             HelpExampleCli("createmasternodebroadcast", "alias mymn1") + HelpExampleRpc("createmasternodebroadcast", "alias mymn1"));
 
-    EnsureWalletIsUnlocked(pwalletMain);
+    EnsureWalletIsUnlocked(pwallet);
 
     if (strCommand == "alias")
     {

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -402,7 +402,7 @@ UniValue startmasternode(const JSONRPCRequest& request)
 
     bool fLock = (request.params[1].get_str() == "true" ? true : false);
 
-    EnsureWalletIsUnlocked();
+    EnsureWalletIsUnlocked(pwalletMain);
 
     if (strCommand == "local") {
         if (!fMasterNode) throw std::runtime_error("you must set masternode=1 in the configuration\n");
@@ -807,6 +807,9 @@ bool DecodeHexMnb(CMasternodeBroadcast& mnb, std::string strHexMnb) {
 }
 UniValue createmasternodebroadcast(const JSONRPCRequest& request)
 {
+    if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
+        return NullUniValue;
+
     std::string strCommand;
     if (request.params.size() >= 1)
         strCommand = request.params[0].get_str();
@@ -814,7 +817,7 @@ UniValue createmasternodebroadcast(const JSONRPCRequest& request)
         throw std::runtime_error(
             "createmasternodebroadcast \"command\" ( \"alias\")\n"
             "\nCreates a masternode broadcast message for one or all masternodes configured in masternode.conf\n" +
-            HelpRequiringPassphrase() + "\n"
+            HelpRequiringPassphrase(pwalletMain) + "\n"
 
             "\nArguments:\n"
             "1. \"command\"      (string, required) \"alias\" for single masternode, \"all\" for all masternodes\n"
@@ -845,7 +848,7 @@ UniValue createmasternodebroadcast(const JSONRPCRequest& request)
             "\nExamples:\n" +
             HelpExampleCli("createmasternodebroadcast", "alias mymn1") + HelpExampleRpc("createmasternodebroadcast", "alias mymn1"));
 
-    EnsureWalletIsUnlocked();
+    EnsureWalletIsUnlocked(pwalletMain);
 
     if (strCommand == "alias")
     {

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -14,6 +14,9 @@
 #include "netbase.h"
 #include "rpc/server.h"
 #include "utilmoneystr.h"
+#ifdef ENABLE_WALLET
+#include "wallet/rpcwallet.h"
+#endif
 
 #include <univalue.h>
 

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -355,6 +355,11 @@ UniValue startmasternode(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_MISC_ERROR, "startmasternode is not supported when deterministic masternode list is active (DIP3)");
     }
 
+    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+
+    if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
+        return NullUniValue;
+
     std::string strCommand;
     if (request.params.size() >= 1) {
         strCommand = request.params[0].get_str();
@@ -512,6 +517,11 @@ UniValue createmasternodekey (const JSONRPCRequest& request)
 
 UniValue getmasternodeoutputs (const JSONRPCRequest& request)
 {
+    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+
+    if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
+        return NullUniValue;
+
     if (request.fHelp || (request.params.size() != 0))
         throw std::runtime_error(
             "getmasternodeoutputs\n"
@@ -807,6 +817,8 @@ bool DecodeHexMnb(CMasternodeBroadcast& mnb, std::string strHexMnb) {
 }
 UniValue createmasternodebroadcast(const JSONRPCRequest& request)
 {
+    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+
     if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
         return NullUniValue;
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -17,6 +17,7 @@
 #include "rpc/server.h"
 #include "validationinterface.h"
 #ifdef ENABLE_WALLET
+#include "wallet/rpcwallet.h"
 #include "wallet/db.h"
 #include "wallet/wallet.h"
 #endif

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -76,6 +76,9 @@ UniValue generateBlocks(const Consensus::Params& consensus,
 
 UniValue generate(const JSONRPCRequest& request)
 {
+    if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
+        return NullUniValue;
+
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 1)
         throw std::runtime_error(
             "generate numblocks\n"
@@ -113,7 +116,7 @@ UniValue generate(const JSONRPCRequest& request)
 
     if (fPoS) {
         // If we are in PoS, wallet must be unlocked.
-        EnsureWalletIsUnlocked();
+        EnsureWalletIsUnlocked(pwalletMain);
     } else {
         // Coinbase key
         reservekey = MakeUnique<CReserveKey>(pwalletMain);
@@ -273,6 +276,9 @@ UniValue getgenerate(const JSONRPCRequest& request)
 
 UniValue setgenerate(const JSONRPCRequest& request)
 {
+    if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
+        return NullUniValue;
+
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
         throw std::runtime_error(
             "setgenerate generate ( genproclimit )\n"
@@ -290,8 +296,6 @@ UniValue setgenerate(const JSONRPCRequest& request)
             "\nCheck the setting\n" + HelpExampleCli("getgenerate", "") +
             "\nTurn off generation\n" + HelpExampleCli("setgenerate", "false") +
             "\nUsing json rpc\n" + HelpExampleRpc("setgenerate", "true, 1"));
-
-    EnsureWallet();
 
     if (Params().IsRegTestNet())
         throw JSONRPCError(RPC_INVALID_REQUEST, "Use the generate method instead of setgenerate on regtest");

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -76,6 +76,8 @@ UniValue generateBlocks(const Consensus::Params& consensus,
 
 UniValue generate(const JSONRPCRequest& request)
 {
+    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+
     if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
         return NullUniValue;
 
@@ -276,6 +278,8 @@ UniValue getgenerate(const JSONRPCRequest& request)
 
 UniValue setgenerate(const JSONRPCRequest& request)
 {
+    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+
     if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
         return NullUniValue;
 
@@ -442,6 +446,8 @@ static UniValue BIP22ValidationResult(const CValidationState& state)
 #ifdef ENABLE_MINING_RPC
 UniValue getblocktemplate(const JSONRPCRequest& request)
 {
+    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+
     if (request.fHelp || request.params.size() > 1)
         throw std::runtime_error(
             "getblocktemplate ( \"jsonrequestobject\" )\n"

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -47,7 +47,7 @@ UniValue getsupplyinfo(const JSONRPCRequest& request);
  **/
 UniValue getinfo(const JSONRPCRequest& request)
 {
-    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
 
     if (request.fHelp || request.params.size() != 0)
         throw std::runtime_error(
@@ -85,7 +85,7 @@ UniValue getinfo(const JSONRPCRequest& request)
             HelpExampleCli("getinfo", "") + HelpExampleRpc("getinfo", ""));
 
 #ifdef ENABLE_WALLET
-    LOCK2(cs_main, pwalletMain ? &pwalletMain->cs_wallet : NULL);
+    LOCK2(cs_main, pwallet ? &pwallet->cs_wallet : NULL);
 #else
     LOCK(cs_main);
 #endif
@@ -116,10 +116,10 @@ UniValue getinfo(const JSONRPCRequest& request)
     obj.pushKV("protocolversion", PROTOCOL_VERSION);
     obj.pushKV("services", services);
 #ifdef ENABLE_WALLET
-    if (pwalletMain) {
-        obj.pushKV("walletversion", pwalletMain->GetVersion());
-        obj.pushKV("balance", ValueFromAmount(pwalletMain->GetAvailableBalance()));
-        obj.pushKV("staking status", (pwalletMain->pStakerStatus->IsActive() ? "Staking Active" : "Staking Not Active"));
+    if (pwallet) {
+        obj.pushKV("walletversion", pwallet->GetVersion());
+        obj.pushKV("balance", ValueFromAmount(pwallet->GetAvailableBalance()));
+        obj.pushKV("staking status", (pwallet->pStakerStatus->IsActive() ? "Staking Active" : "Staking Not Active"));
     }
 #endif
     obj.pushKV("blocks", (int)chainActive.Height());
@@ -137,12 +137,12 @@ UniValue getinfo(const JSONRPCRequest& request)
     obj.pushKV("shieldsupply", supply_info["shieldsupply"]);
 
 #ifdef ENABLE_WALLET
-    if (pwalletMain) {
-        obj.pushKV("keypoololdest", pwalletMain->GetOldestKeyPoolTime());
-        size_t kpExternalSize = pwalletMain->KeypoolCountExternalKeys();
+    if (pwallet) {
+        obj.pushKV("keypoololdest", pwallet->GetOldestKeyPoolTime());
+        size_t kpExternalSize = pwallet->KeypoolCountExternalKeys();
         obj.pushKV("keypoolsize", (int64_t)kpExternalSize);
     }
-    if (pwalletMain && pwalletMain->IsCrypted())
+    if (pwallet && pwallet->IsCrypted())
         obj.pushKV("unlocked_until", nWalletUnlockTime);
     obj.pushKV("paytxfee", ValueFromAmount(payTxFee.GetFeePerK()));
 #endif
@@ -378,7 +378,7 @@ private:
 
 UniValue validateaddress(const JSONRPCRequest& request)
 {
-    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
 
     if (request.fHelp || request.params.size() != 1)
         throw std::runtime_error(
@@ -412,7 +412,7 @@ UniValue validateaddress(const JSONRPCRequest& request)
             HelpExampleRpc("validateaddress", "\"1PSSGeFHDnKNxiEyFrD1wcEaHr9hrQDDWc\""));
 
 #ifdef ENABLE_WALLET
-    LOCK2(cs_main, pwalletMain ? &pwalletMain->cs_wallet : nullptr);
+    LOCK2(cs_main, pwallet ? &pwallet->cs_wallet : nullptr);
 #else
     LOCK(cs_main);
 #endif
@@ -436,7 +436,7 @@ UniValue validateaddress(const JSONRPCRequest& request)
     ret.pushKV("isvalid", isValid);
     if (isValid) {
         ret.pushKV("address", strAddress);
-        UniValue detail = boost::apply_visitor(DescribePaymentAddressVisitor(pwalletMain, isStakingAddress), finalAddress);
+        UniValue detail = boost::apply_visitor(DescribePaymentAddressVisitor(pwallet, isStakingAddress), finalAddress);
         ret.pushKVs(detail);
     }
 
@@ -506,7 +506,7 @@ CScript _createmultisig_redeemScript(CWallet * const pwallet, const UniValue& pa
 
 UniValue createmultisig(const JSONRPCRequest& request)
 {
-    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
 
     if (request.fHelp || request.params.size() < 2 || request.params.size() > 2)
         throw std::runtime_error(
@@ -535,7 +535,7 @@ UniValue createmultisig(const JSONRPCRequest& request)
             HelpExampleRpc("createmultisig", "2, \"[\\\"16sSauSf5pF2UkUwvKGq4qjNRzBZYqgEL5\\\",\\\"171sgjn4YtPu27adkKGrdDwzRTxnRkBfKV\\\"]\""));
 
     // Construct using pay-to-script-hash:
-    CScript inner = _createmultisig_redeemScript(pwalletMain, request.params);
+    CScript inner = _createmultisig_redeemScript(pwallet, request.params);
     CScriptID innerID(inner);
 
     UniValue result(UniValue::VOBJ);

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -18,6 +18,7 @@
 #include "timedata.h"
 #include "util/system.h"
 #ifdef ENABLE_WALLET
+#include "wallet/rpcwallet.h"
 #include "wallet/wallet.h"
 #include "wallet/walletdb.h"
 #endif

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -47,6 +47,8 @@ UniValue getsupplyinfo(const JSONRPCRequest& request);
  **/
 UniValue getinfo(const JSONRPCRequest& request)
 {
+    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+
     if (request.fHelp || request.params.size() != 0)
         throw std::runtime_error(
             "getinfo\n"
@@ -376,6 +378,8 @@ private:
 
 UniValue validateaddress(const JSONRPCRequest& request)
 {
+    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+
     if (request.fHelp || request.params.size() != 1)
         throw std::runtime_error(
             "validateaddress \"pivxaddress\"\n"
@@ -502,6 +506,8 @@ CScript _createmultisig_redeemScript(CWallet * const pwallet, const UniValue& pa
 
 UniValue createmultisig(const JSONRPCRequest& request)
 {
+    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+
     if (request.fHelp || request.params.size() < 2 || request.params.size() > 2)
         throw std::runtime_error(
             "createmultisig nrequired [\"key\",...]\n"

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -143,7 +143,7 @@ UniValue getinfo(const JSONRPCRequest& request)
         obj.pushKV("keypoolsize", (int64_t)kpExternalSize);
     }
     if (pwallet && pwallet->IsCrypted())
-        obj.pushKV("unlocked_until", nWalletUnlockTime);
+        obj.pushKV("unlocked_until", pwallet->nRelockTime);
     obj.pushKV("paytxfee", ValueFromAmount(payTxFee.GetFeePerK()));
 #endif
     obj.pushKV("relayfee", ValueFromAmount(::minRelayTxFee.GetFeePerK()));

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -485,6 +485,11 @@ static void TxInErrorToJSON(const CTxIn& txin, UniValue& vErrorsRet, const std::
 
 UniValue fundrawtransaction(const JSONRPCRequest& request)
 {
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
+        return NullUniValue;
+
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
         throw std::runtime_error(
             "fundrawtransaction \"hexstring\" ( options )\n"
@@ -526,12 +531,9 @@ UniValue fundrawtransaction(const JSONRPCRequest& request)
             + HelpExampleCli("sendrawtransaction", "\"signedtransactionhex\"")
             );
 
-    if (!pwalletMain)
-        throw std::runtime_error("wallet not initialized");
-
     // Make sure the results are valid at least up to the most recent block
     // the user could have gotten from another RPC command prior to now
-    pwalletMain->BlockUntilSyncedToCurrentChain();
+    pwallet->BlockUntilSyncedToCurrentChain();
 
     RPCTypeCheck(request.params, {UniValue::VSTR});
 
@@ -591,7 +593,7 @@ UniValue fundrawtransaction(const JSONRPCRequest& request)
     CMutableTransaction tx(origTx);
     CAmount nFeeOut;
     std::string strFailReason;
-    if(!pwalletMain->FundTransaction(tx, nFeeOut, overrideEstimatedFeerate, feeRate, changePosition, strFailReason, includeWatching, lockUnspents, changeAddress))
+    if(!pwallet->FundTransaction(tx, nFeeOut, overrideEstimatedFeerate, feeRate, changePosition, strFailReason, includeWatching, lockUnspents, changeAddress))
         throw JSONRPCError(RPC_INTERNAL_ERROR, strFailReason);
 
     UniValue result(UniValue::VOBJ);
@@ -604,6 +606,8 @@ UniValue fundrawtransaction(const JSONRPCRequest& request)
 
 UniValue signrawtransaction(const JSONRPCRequest& request)
 {
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 4)
         throw std::runtime_error(
             "signrawtransaction \"hexstring\" ( [{\"txid\":\"id\",\"vout\":n,\"scriptPubKey\":\"hex\",\"redeemScript\":\"hex\"},...] [\"privatekey1\",...] sighashtype )\n"
@@ -613,7 +617,7 @@ UniValue signrawtransaction(const JSONRPCRequest& request)
             "The third optional argument (may be null) is an array of base58-encoded private\n"
             "keys that, if given, will be the only keys used to sign the transaction.\n"
 #ifdef ENABLE_WALLET
-            + HelpRequiringPassphrase(pwalletMain) + "\n"
+            + HelpRequiringPassphrase(pwallet) + "\n"
 #endif
 
             "\nArguments:\n"
@@ -662,7 +666,7 @@ UniValue signrawtransaction(const JSONRPCRequest& request)
             HelpExampleCli("signrawtransaction", "\"myhex\"") + HelpExampleRpc("signrawtransaction", "\"myhex\""));
 
 #ifdef ENABLE_WALLET
-    LOCK2(cs_main, pwalletMain ? &pwalletMain->cs_wallet : NULL);
+    LOCK2(cs_main, pwallet ? &pwallet->cs_wallet : NULL);
 #else
     LOCK(cs_main);
 #endif
@@ -730,8 +734,8 @@ UniValue signrawtransaction(const JSONRPCRequest& request)
         }
     }
 #ifdef ENABLE_WALLET
-    else if (pwalletMain)
-        EnsureWalletIsUnlocked(pwalletMain);
+    else if (pwallet)
+        EnsureWalletIsUnlocked(pwallet);
 #endif
 
     // Add previous txouts given in the RPC call:
@@ -801,7 +805,7 @@ UniValue signrawtransaction(const JSONRPCRequest& request)
     }
 
 #ifdef ENABLE_WALLET
-    const CKeyStore& keystore = ((fGivenKeys || !pwalletMain) ? tempKeystore : *pwalletMain);
+    const CKeyStore& keystore = ((fGivenKeys || !pwallet) ? tempKeystore : *pwallet);
 #else
     const CKeyStore& keystore = tempKeystore;
 #endif

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -25,6 +25,7 @@
 #ifdef ENABLE_WALLET
 #include "sapling/address.h"
 #include "sapling/key_io_sapling.h"
+#include "wallet/rpcwallet.h"
 #include "wallet/wallet.h"
 #endif
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -253,7 +253,8 @@ UniValue getrawtransaction(const JSONRPCRequest& request)
 
     UniValue result(UniValue::VOBJ);
     if (blockindex) result.pushKV("in_active_chain", in_active_chain);
-    TxToJSON(pwalletMain, *tx, hash_block, result);
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    TxToJSON(pwallet, *tx, hash_block, result);
     return result;
 }
 
@@ -421,7 +422,8 @@ UniValue decoderawtransaction(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
 
     UniValue result(UniValue::VOBJ);
-    TxToJSON(pwalletMain, CTransaction(std::move(mtx)), UINT256_ZERO, result);
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    TxToJSON(pwallet, CTransaction(std::move(mtx)), UINT256_ZERO, result);
 
     return result;
 }

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -375,6 +375,8 @@ static ProRegPL ParseProRegPLParams(const UniValue& params, unsigned int paramId
 // handles protx_register, and protx_register_prepare
 static UniValue ProTxRegister(const JSONRPCRequest& request, bool fSignAndSend)
 {
+    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+
     if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
         return NullUniValue;
 
@@ -493,6 +495,8 @@ UniValue protx_register_prepare(const JSONRPCRequest& request)
 
 UniValue protx_register_submit(const JSONRPCRequest& request)
 {
+    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+
     if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
         return NullUniValue;
 
@@ -541,6 +545,8 @@ UniValue protx_register_submit(const JSONRPCRequest& request)
 
 UniValue protx_register_fund(const JSONRPCRequest& request)
 {
+    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+
     if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
         return NullUniValue;
 
@@ -706,7 +712,7 @@ UniValue protx_list(const JSONRPCRequest& request)
     CheckEvoUpgradeEnforcement();
 
 #ifdef ENABLE_WALLET
-    CWallet* const pwallet = pwalletMain;
+    CWallet* const pwallet = GetWalletForJSONRPCRequest(request);
 #else
     CWallet* const pwallet = nullptr;
 #endif

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -317,7 +317,6 @@ static std::string SignAndSendSpecialTx(CWallet* const pwallet, CMutableTransact
 // Parses inputs (starting from index paramIdx) and returns ProReg payload
 static ProRegPL ParseProRegPLParams(const UniValue& params, unsigned int paramIdx)
 {
-    assert(pwalletMain);
     assert(params.size() > paramIdx + 4);
     assert(params.size() < paramIdx + 8);
     ProRegPL pl;
@@ -375,9 +374,9 @@ static ProRegPL ParseProRegPLParams(const UniValue& params, unsigned int paramId
 // handles protx_register, and protx_register_prepare
 static UniValue ProTxRegister(const JSONRPCRequest& request, bool fSignAndSend)
 {
-    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
 
-    if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() < 7 || request.params.size() > 9) {
@@ -392,7 +391,7 @@ static UniValue ProTxRegister(const JSONRPCRequest& request, bool fSignAndSend)
                     "key and then passed to \"protx_register_submit\".\n"
                     "The collateral is specified through \"collateralHash\" and \"collateralIndex\" and must be an unspent transaction output.\n"
                 )
-                + HelpRequiringPassphrase(pwalletMain) + "\n"
+                + HelpRequiringPassphrase(pwallet) + "\n"
                 "\nArguments:\n"
                 + GetHelpString(1, collateralHash)
                 + GetHelpString(2, collateralIndex)
@@ -422,10 +421,10 @@ static UniValue ProTxRegister(const JSONRPCRequest& request, bool fSignAndSend)
     }
     if (fSignAndSend) CheckEvoUpgradeEnforcement();
 
-    EnsureWalletIsUnlocked(pwalletMain);
+    EnsureWalletIsUnlocked(pwallet);
     // Make sure the results are valid at least up to the most recent block
     // the user could have gotten from another RPC command prior to now
-    pwalletMain->BlockUntilSyncedToCurrentChain();
+    pwallet->BlockUntilSyncedToCurrentChain();
 
     const uint256& collateralHash = ParseHashV(request.params[0], "collateralHash");
     const int32_t collateralIndex = request.params[1].get_int();
@@ -459,19 +458,19 @@ static UniValue ProTxRegister(const JSONRPCRequest& request, bool fSignAndSend)
         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("collateral type not supported: %s-%d", collateralHash.ToString(), collateralIndex));
     }
     CKey keyCollateral;
-    if (fSignAndSend && !pwalletMain->GetKey(*keyID, keyCollateral)) {
+    if (fSignAndSend && !pwallet->GetKey(*keyID, keyCollateral)) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("collateral key not in wallet: %s", EncodeDestination(txDest)));
     }
 
     // make sure fee calculation works
     pl.vchSig.resize(CPubKey::COMPACT_SIGNATURE_SIZE);
 
-    FundSpecialTx(pwalletMain, tx, pl);
+    FundSpecialTx(pwallet, tx, pl);
 
     if (fSignAndSend) {
         SignSpecialTxPayloadByString(pl, keyCollateral); // prove we own the collateral
         // check the payload, add the tx inputs sigs, and send the tx.
-        return SignAndSendSpecialTx(pwalletMain, tx, pl);
+        return SignAndSendSpecialTx(pwallet, tx, pl);
     }
     // external signing with collateral key
     pl.vchSig.clear();
@@ -495,9 +494,9 @@ UniValue protx_register_prepare(const JSONRPCRequest& request)
 
 UniValue protx_register_submit(const JSONRPCRequest& request)
 {
-    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
 
-    if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() != 2) {
@@ -505,7 +504,7 @@ UniValue protx_register_submit(const JSONRPCRequest& request)
                 "protx_register_submit \"tx\" \"sig\"\n"
                 "\nSubmits the specified ProTx to the network. This command will also sign the inputs of the transaction\n"
                 "which were previously added by \"protx_register_prepare\" to cover transaction fees\n"
-                + HelpRequiringPassphrase(pwalletMain) + "\n"
+                + HelpRequiringPassphrase(pwallet) + "\n"
                 "\nArguments:\n"
                 "1. \"tx\"                 (string, required) The serialized transaction previously returned by \"protx_register_prepare\"\n"
                 "2. \"sig\"                (string, required) The signature signed with the collateral key. Must be in base64 format.\n"
@@ -517,10 +516,10 @@ UniValue protx_register_submit(const JSONRPCRequest& request)
     }
     CheckEvoUpgradeEnforcement();
 
-    EnsureWalletIsUnlocked(pwalletMain);
+    EnsureWalletIsUnlocked(pwallet);
     // Make sure the results are valid at least up to the most recent block
     // the user could have gotten from another RPC command prior to now
-    pwalletMain->BlockUntilSyncedToCurrentChain();
+    pwallet->BlockUntilSyncedToCurrentChain();
 
     CMutableTransaction tx;
     if (!DecodeHexTx(tx, request.params[0].get_str())) {
@@ -540,14 +539,14 @@ UniValue protx_register_submit(const JSONRPCRequest& request)
     pl.vchSig = DecodeBase64(request.params[1].get_str().c_str());
 
     // check the payload, add the tx inputs sigs, and send the tx.
-    return SignAndSendSpecialTx(pwalletMain, tx, pl);
+    return SignAndSendSpecialTx(pwallet, tx, pl);
 }
 
 UniValue protx_register_fund(const JSONRPCRequest& request)
 {
-    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
 
-    if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
         return NullUniValue;
 
     if (request.fHelp || request.params.size() < 6 || request.params.size() > 8) {
@@ -555,7 +554,7 @@ UniValue protx_register_fund(const JSONRPCRequest& request)
                 "protx_register_fund \"collateralAddress\" \"ipAndPort\" \"ownerAddress\" \"operatorAddress\" \"votingAddress\" \"payoutAddress\" (operatorReward \"operatorPayoutAddress\")\n"
                 "\nCreates, funds and sends a ProTx to the network. The resulting transaction will move 10000 PIV\n"
                 "to the address specified by collateralAddress and will then function as masternode collateral.\n"
-                + HelpRequiringPassphrase(pwalletMain) + "\n"
+                + HelpRequiringPassphrase(pwallet) + "\n"
                 "\nArguments:\n"
                 + GetHelpString(1, collateralAddress)
                 + GetHelpString(2, ipAndPort_register)
@@ -573,10 +572,10 @@ UniValue protx_register_fund(const JSONRPCRequest& request)
     }
     CheckEvoUpgradeEnforcement();
 
-    EnsureWalletIsUnlocked(pwalletMain);
+    EnsureWalletIsUnlocked(pwallet);
     // Make sure the results are valid at least up to the most recent block
     // the user could have gotten from another RPC command prior to now
-    pwalletMain->BlockUntilSyncedToCurrentChain();
+    pwallet->BlockUntilSyncedToCurrentChain();
 
     const CTxDestination& collateralDest(ParsePubKeyIDFromAddress(request.params[0].get_str()));
     const CScript& collateralScript = GetScriptForDestination(collateralDest);
@@ -590,7 +589,7 @@ UniValue protx_register_fund(const JSONRPCRequest& request)
     tx.nType = CTransaction::TxType::PROREG;
     tx.vout.emplace_back(collAmt, collateralScript);
 
-    FundSpecialTx(pwalletMain, tx, pl);
+    FundSpecialTx(pwallet, tx, pl);
 
     for (uint32_t i = 0; i < tx.vout.size(); i++) {
         if (tx.vout[i].nValue == collAmt && tx.vout[i].scriptPubKey == collateralScript) {
@@ -602,7 +601,7 @@ UniValue protx_register_fund(const JSONRPCRequest& request)
     // update payload on tx (with final collateral outpoint)
     pl.vchSig.clear();
     // check the payload, add the tx inputs sigs, and send the tx.
-    return SignAndSendSpecialTx(pwalletMain, tx, pl);
+    return SignAndSendSpecialTx(pwallet, tx, pl);
 }
 
 #endif  //ENABLE_WALLET

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -188,7 +188,7 @@ bool ParseBool(const UniValue& o, std::string strKey)
  * Note: This interface may still be subject to change.
  */
 
-std::string CRPCTable::help(std::string strCommand) const
+std::string CRPCTable::help(const std::string& strCommand, const JSONRPCRequest& helpreq) const
 {
     std::string strRet;
     std::string category;
@@ -199,14 +199,17 @@ std::string CRPCTable::help(std::string strCommand) const
         vCommands.emplace_back(entry.second->category + entry.first, entry.second);
     std::sort(vCommands.begin(), vCommands.end());
 
+    JSONRPCRequest jreq(helpreq);
+    jreq.fHelp = true;
+    jreq.params = UniValue();
+
     for (const std::pair<std::string, const CRPCCommand*>& command : vCommands) {
         const CRPCCommand* pcmd = command.second;
         std::string strMethod = pcmd->name;
         if ((strCommand != "" || pcmd->category == "hidden") && strMethod != strCommand)
             continue;
+        jreq.strMethod = strMethod;
         try {
-            JSONRPCRequest jreq;
-            jreq.fHelp = true;
             rpcfn_type pfn = pcmd->actor;
             if (setDone.insert(pfn).second)
                 (*pfn)(jreq);
@@ -248,7 +251,7 @@ UniValue help(const JSONRPCRequest& jsonRequest)
     if (jsonRequest.params.size() > 0)
         strCommand = jsonRequest.params[0].get_str();
 
-    return tableRPC.help(strCommand);
+    return tableRPC.help(strCommand, jsonRequest);
 }
 
 

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -194,13 +194,18 @@ extern int64_t nWalletUnlockTime;
 extern CAmount AmountFromValue(const UniValue& value);
 extern UniValue ValueFromAmount(const CAmount& amount);
 extern double GetDifficulty(const CBlockIndex* blockindex = NULL);
-extern std::string HelpRequiringPassphrase();
 extern std::string HelpExampleCli(std::string methodname, std::string args);
 extern std::string HelpExampleRpc(std::string methodname, std::string args);
 
-extern void EnsureWalletIsUnlocked(bool fAllowAnonOnly = false);
-// Ensure the wallet's existence.
-extern void EnsureWallet();
+// Needed even with !ENABLE_WALLET, to pass (ignored) pointers around
+class CWallet;
+
+#ifdef ENABLE_WALLET
+// New code should accessing the wallet should be under the ../wallet/ directory
+std::string HelpRequiringPassphrase(CWallet* const pwallet);
+bool EnsureWalletIsAvailable(CWallet* const pwallet, bool avoidException);
+void EnsureWalletIsUnlocked(CWallet *pwallet, bool fAllowAnonOnly = false);
+#endif
 
 bool StartRPC();
 void InterruptRPC();

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -196,17 +196,6 @@ extern double GetDifficulty(const CBlockIndex* blockindex = NULL);
 extern std::string HelpExampleCli(std::string methodname, std::string args);
 extern std::string HelpExampleRpc(std::string methodname, std::string args);
 
-// Needed even with !ENABLE_WALLET, to pass (ignored) pointers around
-class CWallet;
-CWallet* GetWalletForJSONRPCRequest(const JSONRPCRequest& request);
-
-#ifdef ENABLE_WALLET
-// New code should accessing the wallet should be under the ../wallet/ directory
-std::string HelpRequiringPassphrase(CWallet* const pwallet);
-bool EnsureWalletIsAvailable(CWallet* const pwallet, bool avoidException);
-void EnsureWalletIsUnlocked(CWallet *pwallet, bool fAllowAnonOnly = false);
-#endif
-
 bool StartRPC();
 void InterruptRPC();
 void StopRPC();

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -151,7 +151,7 @@ private:
 public:
     CRPCTable();
     const CRPCCommand* operator[](const std::string& name) const;
-    std::string help(std::string name) const;
+    std::string help(const std::string& name, const JSONRPCRequest& helpreq) const;
 
     /**
      * Execute a method.

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -190,7 +190,6 @@ extern std::vector<unsigned char> ParseHexO(const UniValue& o, std::string strKe
 extern int ParseInt(const UniValue& o, std::string strKey);
 extern bool ParseBool(const UniValue& o, std::string strKey);
 
-extern int64_t nWalletUnlockTime;
 extern CAmount AmountFromValue(const UniValue& value);
 extern UniValue ValueFromAmount(const CAmount& amount);
 extern double GetDifficulty(const CBlockIndex* blockindex = NULL);

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -199,10 +199,10 @@ extern std::string HelpExampleRpc(std::string methodname, std::string args);
 
 // Needed even with !ENABLE_WALLET, to pass (ignored) pointers around
 class CWallet;
+CWallet* GetWalletForJSONRPCRequest(const JSONRPCRequest& request);
 
 #ifdef ENABLE_WALLET
 // New code should accessing the wallet should be under the ../wallet/ directory
-CWallet* GetWalletForJSONRPCRequest(const JSONRPCRequest& request);
 std::string HelpRequiringPassphrase(CWallet* const pwallet);
 bool EnsureWalletIsAvailable(CWallet* const pwallet, bool avoidException);
 void EnsureWalletIsUnlocked(CWallet *pwallet, bool fAllowAnonOnly = false);

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -202,6 +202,7 @@ class CWallet;
 
 #ifdef ENABLE_WALLET
 // New code should accessing the wallet should be under the ../wallet/ directory
+CWallet* GetWalletForJSONRPCRequest(const JSONRPCRequest& request);
 std::string HelpRequiringPassphrase(CWallet* const pwallet);
 bool EnsureWalletIsAvailable(CWallet* const pwallet, bool avoidException);
 void EnsureWalletIsUnlocked(CWallet *pwallet, bool fAllowAnonOnly = false);

--- a/src/test/librust/sapling_rpc_wallet_tests.cpp
+++ b/src/test/librust/sapling_rpc_wallet_tests.cpp
@@ -25,6 +25,8 @@
 
 #include <univalue.h>
 
+extern CWallet* pwalletMain;
+
 extern UniValue CallRPC(std::string args); // Implemented in rpc_tests.cpp
 
 namespace {

--- a/src/test/librust/sapling_rpc_wallet_tests.cpp
+++ b/src/test/librust/sapling_rpc_wallet_tests.cpp
@@ -25,7 +25,6 @@
 
 #include <univalue.h>
 
-extern CWallet* pwalletMain;
 
 extern UniValue CallRPC(std::string args); // Implemented in rpc_tests.cpp
 
@@ -57,6 +56,8 @@ BOOST_FIXTURE_TEST_SUITE(sapling_rpc_wallet_tests, WalletTestingSetup)
 BOOST_AUTO_TEST_CASE(rpc_wallet_sapling_validateaddress)
 {
     SelectParams(CBaseChainParams::MAIN);
+    vpwallets.insert(vpwallets.begin(), pwalletMain.get());
+
     UniValue retValue;
 
     // Check number of args
@@ -83,6 +84,8 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_sapling_validateaddress)
     BOOST_CHECK_EQUAL(b, false);
     BOOST_CHECK_EQUAL(find_value(resultObj, "diversifier").get_str(), "e1fd627f1b9a8e4c7e6657");
     BOOST_CHECK_EQUAL(find_value(resultObj, "diversifiedtransmissionkey").get_str(), "d35e0d0897edbd3cf02b3d2327622a14c685534dbd2d3f4f4fa3e0e56cc2f008");
+
+    vpwallets.erase(vpwallets.begin());
 }
 
 BOOST_AUTO_TEST_CASE(rpc_wallet_getbalance)
@@ -92,6 +95,7 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_getbalance)
         pwalletMain->SetMinVersion(FEATURE_SAPLING);
         pwalletMain->SetupSPKM(false);
     }
+    vpwallets.insert(vpwallets.begin(), pwalletMain.get());
 
     BOOST_CHECK_THROW(CallRPC("getshieldbalance too many args"), std::runtime_error);
     BOOST_CHECK_THROW(CallRPC("getshieldbalance invalidaddress"), std::runtime_error);
@@ -111,6 +115,8 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_getbalance)
     BOOST_CHECK_THROW(CallRPC("listreceivedbyshieldaddress DMKU6mc52un1MThGCsnNwAtEvncaTdAuaZ 0"), std::runtime_error);
     // don't have the spending key
     BOOST_CHECK_THROW(CallRPC("listreceivedbyshieldaddress ps1u87kylcmn28yclnx2uy0psnvuhs2xn608ukm6n2nshrpg2nzyu3n62ls8j77m9cgp40dx40evej 1"), std::runtime_error);
+
+    vpwallets.erase(vpwallets.begin());
 }
 
 BOOST_AUTO_TEST_CASE(rpc_wallet_sapling_importkey_paymentaddress)
@@ -120,6 +126,7 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_sapling_importkey_paymentaddress)
         pwalletMain->SetMinVersion(FEATURE_SAPLING);
         pwalletMain->SetupSPKM(false);
     }
+    vpwallets.insert(vpwallets.begin(), pwalletMain.get());
 
     auto testAddress = [](const std::string& key) {
         UniValue ret;
@@ -137,6 +144,7 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_sapling_importkey_paymentaddress)
                 "8uqmqlx8ccxpsw7ae243quhwr0zyekrrc520gs9z0j8pm954c3cev2yvp29vrc"
                 "0zweu7stxkwhp593p6drheps9uhz9pvkrfgvpxzte8d60uzw0qxadnsc77tcd");
 
+    vpwallets.erase(vpwallets.begin());
 }
 
 /*
@@ -149,6 +157,8 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_sapling_importexport)
         pwalletMain->SetMinVersion(FEATURE_SAPLING);
         pwalletMain->SetupSPKM(false);
     }
+    vpwallets.insert(vpwallets.begin(), pwalletMain.get());
+
     UniValue retValue;
     int n1 = 1000; // number of times to import/export
     int n2 = 1000; // number of addresses to create and list
@@ -223,15 +233,17 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_sapling_importexport)
     BOOST_CHECK((int) listaddrs.size() == numAddrs);
     BOOST_CHECK(myaddrs == listaddrs);
 
+    vpwallets.erase(vpwallets.begin());
 }
 
 // Check if address is of given type and spendable from our wallet.
-void CheckHaveAddr(const libzcash::PaymentAddress& addr) {
+void CheckHaveAddr(std::unique_ptr<CWallet>& pwallet, const libzcash::PaymentAddress& addr)
+{
 
     BOOST_CHECK(IsValidPaymentAddress(addr));
     auto addr_of_type = boost::get<libzcash::SaplingPaymentAddress>(&addr);
     BOOST_ASSERT(addr_of_type != nullptr);
-    BOOST_CHECK(pwalletMain->HaveSpendingKeyForPaymentAddress(*addr_of_type));
+    BOOST_CHECK(pwallet->HaveSpendingKeyForPaymentAddress(*addr_of_type));
 }
 
 BOOST_AUTO_TEST_CASE(rpc_wallet_getnewshieldaddress)
@@ -241,12 +253,15 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_getnewshieldaddress)
         pwalletMain->SetMinVersion(FEATURE_SAPLING);
         pwalletMain->SetupSPKM(false);
     }
+    vpwallets.insert(vpwallets.begin(), pwalletMain.get());
 
     // No parameter defaults to sapling address
     UniValue addr = CallRPC("getnewshieldaddress");
-    CheckHaveAddr(KeyIO::DecodePaymentAddress(addr.get_str()));
+    CheckHaveAddr(pwalletMain, KeyIO::DecodePaymentAddress(addr.get_str()));
     // Too many arguments will throw with the help
     BOOST_CHECK_THROW(CallRPC("getnewshieldaddress many args"), std::runtime_error);
+
+    vpwallets.erase(vpwallets.begin());
 }
 
 BOOST_AUTO_TEST_CASE(rpc_shieldsendmany_parameters)
@@ -256,6 +271,7 @@ BOOST_AUTO_TEST_CASE(rpc_shieldsendmany_parameters)
         pwalletMain->SetMinVersion(FEATURE_SAPLING);
         pwalletMain->SetupSPKM(false);
     }
+    vpwallets.insert(vpwallets.begin(), pwalletMain.get());
 
     BOOST_CHECK_THROW(CallRPC("shieldsendmany"), std::runtime_error);
     BOOST_CHECK_THROW(CallRPC("shieldsendmany toofewargs"), std::runtime_error);
@@ -308,16 +324,20 @@ BOOST_AUTO_TEST_CASE(rpc_shieldsendmany_parameters)
     std::string zaddr1 = KeyIO::EncodePaymentAddress(pa);
     BOOST_CHECK_THROW(CallRPC(std::string("shieldsendmany DMKU6mc52un1MThGCsnNwAtEvncaTdAuaZ ")
                               + "[{\"address\":\"" + zaddr1 + "\", \"amount\":123.456}]"), std::runtime_error);
+
+    vpwallets.erase(vpwallets.begin());
 }
 
+// TODO: test private methods
 BOOST_AUTO_TEST_CASE(saplingOperationTests)
 {
     {
         LOCK2(cs_main, pwalletMain->cs_wallet);
         pwalletMain->SetupSPKM(false);
     }
-
     auto consensusParams = Params().GetConsensus();
+    vpwallets.insert(vpwallets.begin(), pwalletMain.get());
+
     UniValue retValue;
 
     // add keys manually
@@ -330,7 +350,7 @@ BOOST_AUTO_TEST_CASE(saplingOperationTests)
     // there are no utxos to spend
     {
         std::vector<SendManyRecipient> recipients = { SendManyRecipient(zaddr1, COIN, "DEADBEEF") };
-        SaplingOperation operation(consensusParams, 1, pwalletMain);
+        SaplingOperation operation(consensusParams, 1, pwalletMain.get());
         operation.setFromAddress(taddr1);
         auto res = operation.setRecipients(recipients)->buildAndSend(ret);
         BOOST_CHECK(!res);
@@ -340,7 +360,7 @@ BOOST_AUTO_TEST_CASE(saplingOperationTests)
     // minconf cannot be zero when sending from zaddr
     {
         std::vector<SendManyRecipient> recipients = { SendManyRecipient(zaddr1, COIN, "DEADBEEF") };
-        SaplingOperation operation(consensusParams, 1, pwalletMain);
+        SaplingOperation operation(consensusParams, 1, pwalletMain.get());
         operation.setFromAddress(zaddr1);
         auto res = operation.setRecipients(recipients)->setMinDepth(0)->buildAndSend(ret);
         BOOST_CHECK(!res);
@@ -350,7 +370,7 @@ BOOST_AUTO_TEST_CASE(saplingOperationTests)
     // there are no unspent notes to spend
     {
         std::vector<SendManyRecipient> recipients = { SendManyRecipient(taddr1, COIN) };
-        SaplingOperation operation(consensusParams, 1, pwalletMain);
+        SaplingOperation operation(consensusParams, 1, pwalletMain.get());
         operation.setFromAddress(zaddr1);
         auto res = operation.setRecipients(recipients)->buildAndSend(ret);
         BOOST_CHECK(!res);
@@ -385,6 +405,8 @@ BOOST_AUTO_TEST_CASE(saplingOperationTests)
         const std::string& errStr = res.getError();
         BOOST_CHECK(errStr.find("too big") != std::string::npos);
     }
+
+    vpwallets.erase(vpwallets.begin());
 }
 
 
@@ -394,6 +416,7 @@ BOOST_AUTO_TEST_CASE(rpc_shieldsendmany_taddr_to_sapling)
         LOCK2(cs_main, pwalletMain->cs_wallet);
         pwalletMain->SetupSPKM(false);
     }
+    vpwallets.insert(vpwallets.begin(), pwalletMain.get());
 
     UniValue retValue;
 
@@ -411,7 +434,7 @@ BOOST_AUTO_TEST_CASE(rpc_shieldsendmany_taddr_to_sapling)
     CMutableTransaction mtx;
     mtx.vout.emplace_back(5 * COIN, GetScriptForDestination(taddr));
     // Add to wallet and get the updated wtx
-    CWalletTx wtxIn(pwalletMain, MakeTransactionRef(mtx));
+    CWalletTx wtxIn(pwalletMain.get(), MakeTransactionRef(mtx));
     pwalletMain->LoadToWallet(wtxIn);
     CWalletTx& wtx = pwalletMain->mapWallet.at(mtx.GetHash());
 
@@ -433,7 +456,7 @@ BOOST_AUTO_TEST_CASE(rpc_shieldsendmany_taddr_to_sapling)
     BOOST_CHECK_MESSAGE(pwalletMain->GetAvailableBalance() > 0, "tx not confirmed");
 
     std::vector<SendManyRecipient> recipients = { SendManyRecipient(zaddr1, 1 * COIN, "ABCD") };
-    SaplingOperation operation(consensusParams, nextBlockHeight, pwalletMain);
+    SaplingOperation operation(consensusParams, nextBlockHeight, pwalletMain.get());
     operation.setFromAddress(taddr);
     BOOST_CHECK(operation.setRecipients(recipients)
                          ->setMinDepth(0)
@@ -441,7 +464,7 @@ BOOST_AUTO_TEST_CASE(rpc_shieldsendmany_taddr_to_sapling)
 
     // try from auto-selected transparent address
     std::vector<SendManyRecipient> recipients2 = { SendManyRecipient(zaddr1, 1 * COIN, "ABCD") };
-    SaplingOperation operation2(consensusParams, nextBlockHeight, pwalletMain);
+    SaplingOperation operation2(consensusParams, nextBlockHeight, pwalletMain.get());
     BOOST_CHECK(operation2.setSelectTransparentCoins(true)
                           ->setRecipients(recipients2)
                           ->setMinDepth(0)
@@ -472,6 +495,7 @@ BOOST_AUTO_TEST_CASE(rpc_shieldsendmany_taddr_to_sapling)
     // Tear down
     chainActive.SetTip(nullptr);
     mapBlockIndex.erase(blockHash);
+    vpwallets.erase(vpwallets.begin());
 }
 
 BOOST_AUTO_TEST_CASE(rpc_wallet_encrypted_wallet_sapzkeys)
@@ -484,6 +508,7 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_encrypted_wallet_sapzkeys)
         pwalletMain->SetMinVersion(FEATURE_SAPLING);
         pwalletMain->SetupSPKM(false);
     }
+    vpwallets.insert(vpwallets.begin(), pwalletMain.get());
 
     // wallet should currently be empty
     std::set<libzcash::SaplingPaymentAddress> addrs;
@@ -532,8 +557,7 @@ BOOST_AUTO_TEST_CASE(rpc_wallet_encrypted_wallet_sapzkeys)
     arr = retValue.get_array();
     BOOST_CHECK((int) arr.size() == n+1);
 
-    // We can't simulate over RPC the wallet closing and being reloaded
-    // but there are tests for this in gtest.
+    vpwallets.erase(vpwallets.begin());
 }
 
 BOOST_AUTO_TEST_CASE(rpc_listshieldunspent_parameters)
@@ -542,6 +566,7 @@ BOOST_AUTO_TEST_CASE(rpc_listshieldunspent_parameters)
         LOCK(pwalletMain->cs_wallet);
         pwalletMain->SetupSPKM(false);
     }
+    vpwallets.insert(vpwallets.begin(), pwalletMain.get());
 
     UniValue retValue;
 
@@ -583,6 +608,8 @@ BOOST_AUTO_TEST_CASE(rpc_listshieldunspent_parameters)
 
     // duplicate address error
     BOOST_CHECK_THROW(CallRPC("listshieldunspent 1 999 false [\"" + myzaddr + "\", \"" + myzaddr + "\"]"), std::runtime_error);
+
+    vpwallets.erase(vpwallets.begin());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/librust/sapling_test_fixture.cpp
+++ b/src/test/librust/sapling_test_fixture.cpp
@@ -13,3 +13,8 @@ SaplingTestingSetup::SaplingTestingSetup(const std::string& chainName) : Testing
 SaplingTestingSetup::~SaplingTestingSetup()
 {
 }
+
+SaplingRegTestingSetup::SaplingRegTestingSetup() : SaplingTestingSetup(CBaseChainParams::REGTEST)
+{
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_V5_0, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+}

--- a/src/test/librust/sapling_test_fixture.h
+++ b/src/test/librust/sapling_test_fixture.h
@@ -16,5 +16,13 @@ struct SaplingTestingSetup : public TestingSetup
     ~SaplingTestingSetup();
 };
 
+/**
+ * Regtest setup with sapling always active
+ */
+struct SaplingRegTestingSetup : public SaplingTestingSetup
+{
+    SaplingRegTestingSetup();
+};
+
 
 #endif //PIVX_SAPLING_TEST_FIXTURE_H

--- a/src/test/librust/sapling_wallet_tests.cpp
+++ b/src/test/librust/sapling_wallet_tests.cpp
@@ -25,6 +25,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+extern CWallet* pwalletMain;
+
 void setupWallet(CWallet& wallet)
 {
     wallet.SetMinVersion(FEATURE_SAPLING);

--- a/src/test/librust/sapling_wallet_tests.cpp
+++ b/src/test/librust/sapling_wallet_tests.cpp
@@ -25,8 +25,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-extern CWallet* pwalletMain;
-
 void setupWallet(CWallet& wallet)
 {
     wallet.SetMinVersion(FEATURE_SAPLING);

--- a/src/test/librust/sapling_wallet_tests.cpp
+++ b/src/test/librust/sapling_wallet_tests.cpp
@@ -70,10 +70,10 @@ uint256 GetWitnessesAndAnchors(CWallet& wallet,
     return saplingAnchor;
 }
 
-BOOST_FIXTURE_TEST_SUITE(sapling_wallet_tests, WalletTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(sapling_wallet_tests, WalletRegTestingSetup)
 
 BOOST_AUTO_TEST_CASE(SetSaplingNoteAddrsInCWalletTx) {
-    auto consensusParams = RegtestActivateSapling();
+    auto consensusParams = Params().GetConsensus();
 
     CWallet& wallet = *pwalletMain;
     LOCK(wallet.cs_wallet);
@@ -124,9 +124,6 @@ BOOST_AUTO_TEST_CASE(SetSaplingNoteAddrsInCWalletTx) {
     BOOST_CHECK(nullifier == wtx.mapSaplingNoteData[op].nullifier);
     BOOST_CHECK(nd.witnessHeight == wtx.mapSaplingNoteData[op].witnessHeight);
     BOOST_CHECK(witness == wtx.mapSaplingNoteData[op].witnesses.front());
-
-    // Revert to default
-    RegtestDeactivateSapling();
 }
 
 // Cannot add note data for an index which does not exist in tx.vShieldedOutput
@@ -142,8 +139,9 @@ BOOST_AUTO_TEST_CASE(SetInvalidSaplingNoteDataInCWalletTx) {
     BOOST_CHECK_THROW(wtx.SetSaplingNoteData(noteData), std::logic_error);
 }
 
-BOOST_AUTO_TEST_CASE(FindMySaplingNotes) {
-    auto consensusParams = RegtestActivateSapling();
+BOOST_AUTO_TEST_CASE(FindMySaplingNotes)
+{
+    auto consensusParams = Params().GetConsensus();
 
     CWallet& wallet = *pwalletMain;
     LOCK(wallet.cs_wallet);
@@ -175,14 +173,12 @@ BOOST_AUTO_TEST_CASE(FindMySaplingNotes) {
     BOOST_CHECK(wallet.HaveSaplingSpendingKey(extfvk));
     noteMap = wallet.GetSaplingScriptPubKeyMan()->FindMySaplingNotes(*wtx.tx).first;
     BOOST_CHECK_EQUAL(2, noteMap.size());
-
-    // Revert to default
-    RegtestDeactivateSapling();
 }
 
 // Generate note A and spend to create note B, from which we spend to create two conflicting transactions
-BOOST_AUTO_TEST_CASE(GetConflictedSaplingNotes) {
-    auto consensusParams = RegtestActivateSapling();
+BOOST_AUTO_TEST_CASE(GetConflictedSaplingNotes)
+{
+    auto consensusParams = Params().GetConsensus();
 
     CWallet& wallet = *pwalletMain;
     LOCK2(cs_main, wallet.cs_wallet);
@@ -296,15 +292,13 @@ BOOST_AUTO_TEST_CASE(GetConflictedSaplingNotes) {
     BOOST_CHECK(std::set<uint256>({hash2, hash3}) == c3);
 
     // Tear down
-    chainActive.SetTip(NULL);
+    chainActive.SetTip(nullptr);
     mapBlockIndex.erase(blockHash);
-
-    // Revert to default
-    RegtestDeactivateSapling();
 }
 
-BOOST_AUTO_TEST_CASE(SaplingNullifierIsSpent) {
-    auto consensusParams = RegtestActivateSapling();
+BOOST_AUTO_TEST_CASE(SaplingNullifierIsSpent)
+{
+    auto consensusParams = Params().GetConsensus();
 
     CWallet& wallet = *pwalletMain;
     LOCK2(cs_main, wallet.cs_wallet);
@@ -357,15 +351,13 @@ BOOST_AUTO_TEST_CASE(SaplingNullifierIsSpent) {
     BOOST_CHECK(wallet.GetSaplingScriptPubKeyMan()->IsSaplingSpent(nullifier));
 
     // Tear down
-    chainActive.SetTip(NULL);
+    chainActive.SetTip(nullptr);
     mapBlockIndex.erase(blockHash);
-
-    // Revert to default
-    RegtestDeactivateSapling();
 }
 
-BOOST_AUTO_TEST_CASE(NavigateFromSaplingNullifierToNote) {
-    auto consensusParams = RegtestActivateSapling();
+BOOST_AUTO_TEST_CASE(NavigateFromSaplingNullifierToNote)
+{
+    auto consensusParams = Params().GetConsensus();
 
     CWallet& wallet = *pwalletMain;
     LOCK2(cs_main, wallet.cs_wallet);
@@ -454,16 +446,14 @@ BOOST_AUTO_TEST_CASE(NavigateFromSaplingNullifierToNote) {
     }
 
     // Tear down
-    chainActive.SetTip(NULL);
+    chainActive.SetTip(nullptr);
     mapBlockIndex.erase(blockHash);
-
-    // Revert to default
-    RegtestDeactivateSapling();
 }
 
 // Create note A, spend A to create note B, spend and verify note B is from me.
-BOOST_AUTO_TEST_CASE(SpentSaplingNoteIsFromMe) {
-    auto consensusParams = RegtestActivateSapling();
+BOOST_AUTO_TEST_CASE(SpentSaplingNoteIsFromMe)
+{
+    auto consensusParams = Params().GetConsensus();
 
     CWallet& wallet = *pwalletMain;
     LOCK2(cs_main, wallet.cs_wallet);
@@ -601,16 +591,14 @@ BOOST_AUTO_TEST_CASE(SpentSaplingNoteIsFromMe) {
     BOOST_CHECK(wallet.GetSaplingScriptPubKeyMan()->mapSaplingNullifiersToNotes.count(nullifier2));
 
     // Tear down
-    chainActive.SetTip(NULL);
+    chainActive.SetTip(nullptr);
     mapBlockIndex.erase(blockHash);
     mapBlockIndex.erase(blockHash2);
-
-    // Revert to default
-    RegtestDeactivateSapling();
 }
 
-BOOST_AUTO_TEST_CASE(CachedWitnessesEmptyChain) {
-    auto consensusParams = RegtestActivateSapling();
+BOOST_AUTO_TEST_CASE(CachedWitnessesEmptyChain)
+{
+    auto consensusParams = Params().GetConsensus();
 
     CWallet& wallet = *pwalletMain;
     {
@@ -646,13 +634,11 @@ BOOST_AUTO_TEST_CASE(CachedWitnessesEmptyChain) {
 
     // Until zcash#1302 is implemented, this should triggger an assertion
     BOOST_CHECK_THROW(wallet.DecrementNoteWitnesses(&index), std::runtime_error);
-
-    // Revert to default
-    RegtestDeactivateSapling();
 }
 
-BOOST_AUTO_TEST_CASE(CachedWitnessesChainTip) {
-    auto consensusParams = RegtestActivateSapling();
+BOOST_AUTO_TEST_CASE(CachedWitnessesChainTip)
+{
+    auto consensusParams = Params().GetConsensus();
 
     libzcash::SaplingExtendedSpendingKey sk = GetTestMasterSaplingSpendingKey();
     CWallet& wallet = *pwalletMain;
@@ -730,9 +716,9 @@ BOOST_AUTO_TEST_CASE(CachedWitnessesChainTip) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(CachedWitnessesDecrementFirst) {
-    auto consensusParams = RegtestActivateSapling();
-
+BOOST_AUTO_TEST_CASE(CachedWitnessesDecrementFirst)
+{
+    auto consensusParams = Params().GetConsensus();
     libzcash::SaplingExtendedSpendingKey sk = GetTestMasterSaplingSpendingKey();
     CWallet& wallet = *pwalletMain;
     {
@@ -798,8 +784,9 @@ BOOST_AUTO_TEST_CASE(CachedWitnessesDecrementFirst) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(CachedWitnessesCleanIndex) {
-    auto consensusParams = RegtestActivateSapling();
+BOOST_AUTO_TEST_CASE(CachedWitnessesCleanIndex)
+{
+    auto consensusParams = Params().GetConsensus();
 
     libzcash::SaplingExtendedSpendingKey sk = GetTestMasterSaplingSpendingKey();
     CWallet& wallet = *pwalletMain;
@@ -874,8 +861,9 @@ BOOST_AUTO_TEST_CASE(CachedWitnessesCleanIndex) {
     }
 }
 
-BOOST_AUTO_TEST_CASE(ClearNoteWitnessCache) {
-    auto consensusParams = RegtestActivateSapling();
+BOOST_AUTO_TEST_CASE(ClearNoteWitnessCache)
+{
+    auto consensusParams = Params().GetConsensus();
 
     libzcash::SaplingExtendedSpendingKey sk = GetTestMasterSaplingSpendingKey();
     CWallet& wallet = *pwalletMain;
@@ -922,8 +910,9 @@ BOOST_AUTO_TEST_CASE(ClearNoteWitnessCache) {
     BOOST_CHECK_EQUAL(0, wallet.GetSaplingScriptPubKeyMan()->nWitnessCacheSize);
 }
 
-BOOST_AUTO_TEST_CASE(UpdatedSaplingNoteData) {
-    auto consensusParams = RegtestActivateSapling();
+BOOST_AUTO_TEST_CASE(UpdatedSaplingNoteData)
+{
+    auto consensusParams = Params().GetConsensus();
 
     CWallet& wallet = *pwalletMain;
     // Need to lock cs_main for now due the lock ordering. future: revamp all of this function to only lock where is needed.
@@ -1028,15 +1017,13 @@ BOOST_AUTO_TEST_CASE(UpdatedSaplingNoteData) {
     BOOST_CHECK(wtx.mapSaplingNoteData[sop1].witnesses.front() == testNote.tree.witness());
 
     // Tear down
-    chainActive.SetTip(NULL);
+    chainActive.SetTip(nullptr);
     mapBlockIndex.erase(blockHash);
-
-    // Revert to default
-    RegtestDeactivateSapling();
 }
 
-BOOST_AUTO_TEST_CASE(MarkAffectedSaplingTransactionsDirty) {
-    auto consensusParams = RegtestActivateSapling();
+BOOST_AUTO_TEST_CASE(MarkAffectedSaplingTransactionsDirty)
+{
+    auto consensusParams = Params().GetConsensus();
 
     CWallet& wallet = *pwalletMain;
     LOCK2(cs_main, wallet.cs_wallet);
@@ -1140,16 +1127,13 @@ BOOST_AUTO_TEST_CASE(MarkAffectedSaplingTransactionsDirty) {
     BOOST_CHECK(!wallet.mapWallet.at(hash).IsAmountCached(CWalletTx::AmountType::DEBIT, ISMINE_SPENDABLE));
 
     // Tear down
-    chainActive.SetTip(NULL);
+    chainActive.SetTip(nullptr);
     mapBlockIndex.erase(blockHash);
-
-    // Revert to default
-    RegtestDeactivateSapling();
 }
 
 BOOST_AUTO_TEST_CASE(GetNotes)
 {
-    auto consensusParams = RegtestActivateSapling();
+    auto consensusParams = Params().GetConsensus();
 
     CWallet& wallet = *pwalletMain;
     libzcash::SaplingPaymentAddress pk;
@@ -1238,9 +1222,6 @@ BOOST_AUTO_TEST_CASE(GetNotes)
     LOCK(cs_main);
     chainActive.SetTip(nullptr);
     mapBlockIndex.erase(blockHash);
-
-    // Revert to default
-    RegtestDeactivateSapling();
 }
 
 // TODO: Back port WriteWitnessCache & SetBestChainIgnoresTxsWithoutShieldedData test cases.

--- a/src/test/librust/transaction_builder_tests.cpp
+++ b/src/test/librust/transaction_builder_tests.cpp
@@ -13,11 +13,11 @@
 #include <univalue.h>
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(sapling_transaction_builder_tests, SaplingTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(sapling_transaction_builder_tests, SaplingRegTestingSetup)
 
 BOOST_AUTO_TEST_CASE(TransparentToSapling)
 {
-    auto consensusParams = RegtestActivateSapling();
+    auto consensusParams = Params().GetConsensus();
 
     CBasicKeyStore keystore;
     CKey tsk = AddTestCKeyToKeyStore(keystore);
@@ -49,13 +49,11 @@ BOOST_AUTO_TEST_CASE(TransparentToSapling)
     CValidationState state;
     BOOST_CHECK(SaplingValidation::ContextualCheckTransaction(tx, state, Params(), 2, true, false));
     BOOST_CHECK_EQUAL(state.GetRejectReason(), "");
-
-    // Revert to default
-    RegtestDeactivateSapling();
 }
 
-BOOST_AUTO_TEST_CASE(SaplingToSapling) {
-    auto consensusParams = RegtestActivateSapling();
+BOOST_AUTO_TEST_CASE(SaplingToSapling)
+{
+    auto consensusParams = Params().GetConsensus();
 
     auto sk = libzcash::SaplingSpendingKey::random();
     auto expsk = sk.expanded_spending_key();
@@ -101,45 +99,33 @@ BOOST_AUTO_TEST_CASE(SaplingToSapling) {
     BOOST_CHECK_EQUAL(tx2.sapData->valueBalance, 10000000);
     BOOST_CHECK(SaplingValidation::ContextualCheckTransaction(tx2, state, Params(), 3, true, false));
     BOOST_CHECK_EQUAL(state.GetRejectReason(), "");
-
-    // Revert to default
-    RegtestDeactivateSapling();
 }
 
 BOOST_AUTO_TEST_CASE(ThrowsOnTransparentInputWithoutKeyStore)
 {
-    SelectParams(CBaseChainParams::REGTEST);
-    auto consensusParams = Params().GetConsensus();
-
-    auto builder = TransactionBuilder(consensusParams, 1);
+    auto builder = TransactionBuilder(Params().GetConsensus(), 1);
     BOOST_CHECK_THROW(builder.AddTransparentInput(COutPoint(), CScript(), 1), std::runtime_error);
 }
 
 BOOST_AUTO_TEST_CASE(RejectsInvalidTransparentOutput)
 {
-    SelectParams(CBaseChainParams::REGTEST);
-    auto consensusParams = Params().GetConsensus();
-
     // Default CTxDestination type is an invalid address
     CTxDestination taddr;
-    auto builder = TransactionBuilder(consensusParams, 1);
+    auto builder = TransactionBuilder(Params().GetConsensus(), 1);
     BOOST_CHECK_THROW(builder.AddTransparentOutput(taddr, 50), std::runtime_error);
 }
 
 BOOST_AUTO_TEST_CASE(RejectsInvalidTransparentChangeAddress)
 {
-    SelectParams(CBaseChainParams::REGTEST);
-    auto consensusParams = Params().GetConsensus();
-
     // Default CTxDestination type is an invalid address
     CTxDestination taddr;
-    auto builder = TransactionBuilder(consensusParams, 1);
+    auto builder = TransactionBuilder(Params().GetConsensus(), 1);
     BOOST_CHECK_THROW(builder.SendChangeTo(taddr), std::runtime_error);
 }
 
 BOOST_AUTO_TEST_CASE(FailsWithNegativeChange)
 {
-    auto consensusParams = RegtestActivateSapling();
+    auto consensusParams = Params().GetConsensus();
 
     // Generate dummy Sapling address
     auto sk = libzcash::SaplingSpendingKey::random();
@@ -179,14 +165,11 @@ BOOST_AUTO_TEST_CASE(FailsWithNegativeChange)
     // Succeeds if there is sufficient input
     builder.AddTransparentInput(COutPoint(), scriptPubKey, 10000);
     BOOST_CHECK(builder.Build().IsTx());
-
-    // Revert to default
-    RegtestDeactivateSapling();
 }
 
 BOOST_AUTO_TEST_CASE(ChangeOutput)
 {
-    auto consensusParams = RegtestActivateSapling();
+    auto consensusParams = Params().GetConsensus();
 
     // Generate dummy Sapling address
     auto sk = libzcash::SaplingSpendingKey::random();
@@ -260,14 +243,11 @@ BOOST_AUTO_TEST_CASE(ChangeOutput)
         BOOST_CHECK_EQUAL(tx.sapData->valueBalance, 0);
         BOOST_CHECK_EQUAL(tx.vout[0].nValue, 15000000);
     }
-
-    // Revert to default
-    RegtestDeactivateSapling();
 }
 
 BOOST_AUTO_TEST_CASE(SetFee)
 {
-    auto consensusParams = RegtestActivateSapling();
+    auto consensusParams = Params().GetConsensus();
 
     // Generate dummy Sapling address
     auto sk = libzcash::SaplingSpendingKey::random();
@@ -292,14 +272,10 @@ BOOST_AUTO_TEST_CASE(SetFee)
         BOOST_CHECK_EQUAL(tx.sapData->vShieldedOutput.size(), 2);
         BOOST_CHECK_EQUAL(tx.sapData->valueBalance, COIN);
     }
-
-    // Revert to default
-    RegtestDeactivateSapling();
 }
 
 BOOST_AUTO_TEST_CASE(CheckSaplingTxVersion)
 {
-    SelectParams(CBaseChainParams::REGTEST);
     auto consensusParams = Params().GetConsensus();
 
     auto sk = libzcash::SaplingSpendingKey::random();

--- a/src/test/librust/utiltest.cpp
+++ b/src/test/librust/utiltest.cpp
@@ -13,16 +13,6 @@
 
 static const std::string T_SECRET_REGTEST = "cND2ZvtabDbJ1gucx9GWH6XT9kgTAqfb6cotPt5Q5CyxVDhid2EN";
 
-const Consensus::Params& RegtestActivateSapling() {
-    SelectParams(CBaseChainParams::REGTEST);
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_V5_0, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
-    return Params().GetConsensus();
-}
-
-void RegtestDeactivateSapling() {
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_V5_0, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
-}
-
 libzcash::SaplingExtendedSpendingKey GetTestMasterSaplingSpendingKey() {
     std::vector<unsigned char, secure_allocator<unsigned char>> rawSeed(32);
     HDSeed seed(rawSeed);

--- a/src/test/librust/utiltest.h
+++ b/src/test/librust/utiltest.h
@@ -28,9 +28,6 @@ struct TransparentInput {
     CAmount amount;
 };
 
-const Consensus::Params& RegtestActivateSapling();
-
-void RegtestDeactivateSapling();
 
 libzcash::SaplingExtendedSpendingKey GetTestMasterSaplingSpendingKey();
 

--- a/src/test/librust/wallet_zkeys_tests.cpp
+++ b/src/test/librust/wallet_zkeys_tests.cpp
@@ -12,6 +12,8 @@
 #include "util/system.h"
 #include <boost/test/unit_test.hpp>
 
+extern CWallet* pwalletMain;
+
 /**
  * This test covers methods on CWallet
  * GenerateNewZKey()

--- a/src/test/librust/wallet_zkeys_tests.cpp
+++ b/src/test/librust/wallet_zkeys_tests.cpp
@@ -12,8 +12,6 @@
 #include "util/system.h"
 #include <boost/test/unit_test.hpp>
 
-extern CWallet* pwalletMain;
-
 /**
  * This test covers methods on CWallet
  * GenerateNewZKey()
@@ -172,7 +170,7 @@ BOOST_AUTO_TEST_CASE(WriteCryptedSaplingZkeyDirectToDb) {
     BOOST_CHECK_EQUAL(DB_LOAD_OK, wallet2.LoadWallet(fFirstRun));
 
     // Confirm it's not the same as the other wallet
-    BOOST_CHECK(pwalletMain != &wallet2);
+    BOOST_CHECK(pwalletMain.get() != &wallet2);
     BOOST_CHECK(wallet2.HasSaplingSPKM());
 
     // wallet should have two keys

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -17,6 +17,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+extern CWallet* pwalletMain;
+
 // future: this should be MAINNET.
 BOOST_FIXTURE_TEST_SUITE(miner_tests, WalletRegTestingSetup)
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -17,7 +17,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-extern CWallet* pwalletMain;
 
 // future: this should be MAINNET.
 BOOST_FIXTURE_TEST_SUITE(miner_tests, WalletRegTestingSetup)
@@ -91,7 +90,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     Checkpoints::fEnabled = false;
 
     // Simple block creation, nothing special yet:
-    BOOST_CHECK(pblocktemplate = BlockAssembler(Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey, pwalletMain, false));
+    BOOST_CHECK(pblocktemplate = BlockAssembler(Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey, pwalletMain.get(), false));
     // Set genesis block
     pblocktemplate->block.hashPrevBlock = chainparams.GetConsensus().hashGenesisBlock;
 
@@ -117,7 +116,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     }
 
     // Just to make sure we can still make simple blocks
-    BOOST_CHECK(pblocktemplate = BlockAssembler(Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey, pwalletMain, false));
+    BOOST_CHECK(pblocktemplate = BlockAssembler(Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey, pwalletMain.get(), false));
 
     // block sigops > limit: 2000 CHECKMULTISIG + 1
     tx.vin.resize(1);
@@ -135,7 +134,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         mempool.addUnchecked(hash, entry.Fee(1000000).Time(GetTime()).SpendsCoinbaseOrCoinstake(spendsCoinbase).FromTx(tx));
         tx.vin[0].prevout.hash = hash;
     }
-    BOOST_CHECK_EXCEPTION(pblocktemplate = BlockAssembler(Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey, pwalletMain, false), std::runtime_error, HasReason("bad-blk-sigops"));
+    BOOST_CHECK_EXCEPTION(pblocktemplate = BlockAssembler(Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey, pwalletMain.get(), false), std::runtime_error, HasReason("bad-blk-sigops"));
     mempool.clear();
 
     tx.vin[0].prevout.hash = txFirst[0]->GetHash();
@@ -148,7 +147,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         mempool.addUnchecked(hash, entry.Fee(1000000).Time(GetTime()).SpendsCoinbaseOrCoinstake(spendsCoinbase).SigOps(20).FromTx(tx));
         tx.vin[0].prevout.hash = hash;
     }
-    BOOST_CHECK(pblocktemplate = BlockAssembler(Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey, pwalletMain, false));
+    BOOST_CHECK(pblocktemplate = BlockAssembler(Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey, pwalletMain.get(), false));
     mempool.clear();
 
     // block size > limit
@@ -168,13 +167,13 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         mempool.addUnchecked(hash, entry.Fee(1000000).Time(GetTime()).SpendsCoinbaseOrCoinstake(spendsCoinbase).FromTx(tx));
         tx.vin[0].prevout.hash = hash;
     }
-    BOOST_CHECK(pblocktemplate = BlockAssembler(Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey, pwalletMain, false));
+    BOOST_CHECK(pblocktemplate = BlockAssembler(Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey, pwalletMain.get(), false));
     mempool.clear();
 
     // orphan in mempool, template creation fails
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Fee(1000000).Time(GetTime()).FromTx(tx));
-    BOOST_CHECK_EXCEPTION(pblocktemplate = BlockAssembler(Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey, pwalletMain, false), std::runtime_error, HasReason("bad-txns-inputs-missingorspent"));
+    BOOST_CHECK_EXCEPTION(pblocktemplate = BlockAssembler(Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey, pwalletMain.get(), false), std::runtime_error, HasReason("bad-txns-inputs-missingorspent"));
     mempool.clear();
 
     // child with higher priority than parent
@@ -191,7 +190,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.vout[0].nValue = 5900000000LL;
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Fee(400000000LL).Time(GetTime()).SpendsCoinbaseOrCoinstake(true).FromTx(tx));
-    BOOST_CHECK(pblocktemplate = BlockAssembler(Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey, pwalletMain, false));
+    BOOST_CHECK(pblocktemplate = BlockAssembler(Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey, pwalletMain.get(), false));
     mempool.clear();
 
     // coinbase in mempool, template creation fails
@@ -202,7 +201,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     hash = tx.GetHash();
     // give it a fee so it'll get mined
     mempool.addUnchecked(hash, entry.Fee(100000).Time(GetTime()).SpendsCoinbaseOrCoinstake(false).FromTx(tx));
-    BOOST_CHECK_EXCEPTION(pblocktemplate = BlockAssembler(Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey, pwalletMain, false), std::runtime_error, HasReason("bad-cb-multiple"));
+    BOOST_CHECK_EXCEPTION(pblocktemplate = BlockAssembler(Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey, pwalletMain.get(), false), std::runtime_error, HasReason("bad-cb-multiple"));
     mempool.clear();
 
     // invalid (pre-p2sh) txn in mempool, template creation fails
@@ -220,7 +219,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Fee(1000000).Time(GetTime()).SpendsCoinbaseOrCoinstake(false).FromTx(tx));
      // Should throw block-validation-failed
-    BOOST_CHECK_EXCEPTION(pblocktemplate = BlockAssembler(Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey, pwalletMain, false), std::runtime_error, HasReason("block-validation-failed"));
+    BOOST_CHECK_EXCEPTION(pblocktemplate = BlockAssembler(Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey, pwalletMain.get(), false), std::runtime_error, HasReason("block-validation-failed"));
     mempool.clear();
 
     // double spend txn pair in mempool, template creation fails
@@ -233,7 +232,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.vout[0].scriptPubKey = CScript() << OP_2;
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Fee(100000000L).Time(GetTime()).SpendsCoinbaseOrCoinstake(true).FromTx(tx));
-    BOOST_CHECK_EXCEPTION(pblocktemplate = BlockAssembler(Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey, pwalletMain, false), std::runtime_error, HasReason("bad-txns-inputs-missingorspent"));
+    BOOST_CHECK_EXCEPTION(pblocktemplate = BlockAssembler(Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey, pwalletMain.get(), false), std::runtime_error, HasReason("bad-txns-inputs-missingorspent"));
     mempool.clear();
 
     // non-final txs in mempool
@@ -264,7 +263,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     mempool.addUnchecked(hash, entry.Fee(100000000L).Time(GetTime()).SpendsCoinbaseOrCoinstake(true).FromTx(tx2));
     { LOCK(cs_main); BOOST_CHECK(!CheckFinalTx(MakeTransactionRef(tx2), LOCKTIME_MEDIAN_TIME_PAST)); }
 
-    BOOST_CHECK(pblocktemplate = BlockAssembler(Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey, pwalletMain, false));
+    BOOST_CHECK(pblocktemplate = BlockAssembler(Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey, pwalletMain.get(), false));
 
     // Neither tx should have make it into the template.
     BOOST_CHECK_EQUAL(pblocktemplate->block.vtx.size(), 1);
@@ -281,7 +280,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     //BOOST_CHECK(CheckFinalTx(tx));
     //BOOST_CHECK(CheckFinalTx(tx2));
 
-    BOOST_CHECK(pblocktemplate = BlockAssembler(Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey, pwalletMain, false));
+    BOOST_CHECK(pblocktemplate = BlockAssembler(Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey, pwalletMain.get(), false));
     BOOST_CHECK_EQUAL(pblocktemplate->block.vtx.size(), 3);
 
     WITH_LOCK(cs_main, chainActive.Tip()->nHeight--);

--- a/src/test/script_P2CS_tests.cpp
+++ b/src/test/script_P2CS_tests.cpp
@@ -307,7 +307,7 @@ BOOST_AUTO_TEST_CASE(fake_script_test)
 {
     BOOST_ASSERT(!g_IsV6Active);
 
-    CWallet& wallet = *pwalletMain;
+    CWallet& wallet = *vpwallets[0];
     LOCK(wallet.cs_wallet);
     setupWallet(wallet);
     CKey stakerKey;         // dummy staker key (not in the wallet)

--- a/src/test/script_P2CS_tests.cpp
+++ b/src/test/script_P2CS_tests.cpp
@@ -307,7 +307,7 @@ BOOST_AUTO_TEST_CASE(fake_script_test)
 {
     BOOST_ASSERT(!g_IsV6Active);
 
-    CWallet& wallet = *vpwallets[0];
+    CWallet& wallet = *pwalletMain;
     LOCK(wallet.cs_wallet);
     setupWallet(wallet);
     CKey stakerKey;         // dummy staker key (not in the wallet)

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -122,7 +122,7 @@ BOOST_FIXTURE_TEST_CASE(zerocoin_rejection_tests, RegTestingSetup)
 
     std::unique_ptr<CBlockTemplate> pblocktemplate;
     CScript scriptPubKey = CScript() << OP_DUP << OP_HASH160 << ParseHex("8d5b4f83212214d6ef693e02e6d71969fddad976") << OP_EQUALVERIFY << OP_CHECKSIG;
-    BOOST_CHECK(pblocktemplate = BlockAssembler(Params(), false).CreateNewBlock(scriptPubKey, pwalletMain, false));
+    BOOST_CHECK(pblocktemplate = BlockAssembler(Params(), false).CreateNewBlock(scriptPubKey, vpwallets[0], false));
     pblocktemplate->block.hashPrevBlock = chainparams.GetConsensus().hashGenesisBlock;
 
     // Base tx

--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -7,6 +7,7 @@
 #include "primitives/transaction.h"
 #include "sapling/sapling_validation.h"
 #include "test/librust/utiltest.h"
+#include "wallet/test/wallet_test_fixture.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -115,14 +116,14 @@ void CheckMempoolZcRejection(CMutableTransaction& mtx)
 /*
  * Running on regtest to have v5 upgrade enforced at block 1 and test in-block zc rejection
  */
-BOOST_FIXTURE_TEST_CASE(zerocoin_rejection_tests, RegTestingSetup)
+BOOST_FIXTURE_TEST_CASE(zerocoin_rejection_tests, WalletRegTestingSetup)
 {
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_V5_0, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     const CChainParams& chainparams = Params();
 
     std::unique_ptr<CBlockTemplate> pblocktemplate;
     CScript scriptPubKey = CScript() << OP_DUP << OP_HASH160 << ParseHex("8d5b4f83212214d6ef693e02e6d71969fddad976") << OP_EQUALVERIFY << OP_CHECKSIG;
-    BOOST_CHECK(pblocktemplate = BlockAssembler(Params(), false).CreateNewBlock(scriptPubKey, vpwallets[0], false));
+    BOOST_CHECK(pblocktemplate = BlockAssembler(Params(), false).CreateNewBlock(scriptPubKey, pwalletMain.get(), false));
     pblocktemplate->block.hashPrevBlock = chainparams.GetConsensus().hashGenesisBlock;
 
     // Base tx

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -146,7 +146,7 @@ void CDBEnv::MakeMock()
     fMockDb = true;
 }
 
-CDBEnv::VerifyResult CDBEnv::Verify(const std::string& strFile, bool (*recoverFunc)(const std::string& strFile))
+CDBEnv::VerifyResult CDBEnv::Verify(const std::string& strFile, recoverFunc_type recoverFunc, std::string& out_backup_filename)
 {
     LOCK(cs_db);
     assert(mapFileUseCount.count(strFile) == 0);
@@ -159,11 +159,11 @@ CDBEnv::VerifyResult CDBEnv::Verify(const std::string& strFile, bool (*recoverFu
         return RECOVER_FAIL;
 
     // Try to recover:
-    bool fRecovered = (*recoverFunc)(strFile);
+    bool fRecovered = (*recoverFunc)(strFile, out_backup_filename);
     return (fRecovered ? RECOVER_OK : RECOVER_FAIL);
 }
 
-bool CDB::Recover(const std::string& filename, void *callbackDataIn, bool (*recoverKVcallback)(void* callbackData, CDataStream ssKey, CDataStream ssValue))
+bool CDB::Recover(const std::string& filename, void *callbackDataIn, bool (*recoverKVcallback)(void* callbackData, CDataStream ssKey, CDataStream ssValue), std::string& newFilename)
 {
     // Recovery procedure:
     // move wallet file to wallet.timestamp.bak
@@ -173,7 +173,7 @@ bool CDB::Recover(const std::string& filename, void *callbackDataIn, bool (*reco
     // Set -rescan so any missing transactions will be
     // found.
     int64_t now = GetTime();
-    std::string newFilename = strprintf("wallet.%d.bak", now);
+    newFilename = strprintf("wallet.%d.bak", now);
 
     int result = bitdb.dbenv->dbrename(NULL, filename.c_str(), NULL,
                                        newFilename.c_str(), DB_AUTO_COMMIT);
@@ -257,16 +257,17 @@ bool CDB::VerifyEnvironment(const std::string& walletFile, const fs::path& dataD
     return true;
 }
 
-bool CDB::VerifyDatabaseFile(const std::string& walletFile, const fs::path& dataDir, std::string& warningStr, std::string& errorStr, bool (*recoverFunc)(const std::string& strFile))
+bool CDB::VerifyDatabaseFile(const std::string& walletFile, const fs::path& dataDir, std::string& warningStr, std::string& errorStr, CDBEnv::recoverFunc_type recoverFunc)
 {
     if (fs::exists(dataDir / walletFile)) {
-        CDBEnv::VerifyResult r = bitdb.Verify(walletFile, recoverFunc);
+        std::string backup_filename;
+        CDBEnv::VerifyResult r = bitdb.Verify(walletFile, recoverFunc, backup_filename);
         if (r == CDBEnv::RECOVER_OK) {
-            warningStr = strprintf(("Warning: Wallet file corrupt, data salvaged!"
+            warningStr = strprintf(_("Warning: Wallet file corrupt, data salvaged!"
                                      " Original %s saved as %s in %s; if"
                                      " your balance or transactions are incorrect you should"
                                      " restore from a backup."),
-                                   walletFile, "wallet.{timestamp}.bak", dataDir);
+                                   walletFile, backup_filename, dataDir);
         }
         if (r == CDBEnv::RECOVER_FAIL) {
             errorStr = strprintf(("%s corrupt, salvage failed"), walletFile);

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -166,14 +166,14 @@ CDBEnv::VerifyResult CDBEnv::Verify(const std::string& strFile, recoverFunc_type
 bool CDB::Recover(const std::string& filename, void *callbackDataIn, bool (*recoverKVcallback)(void* callbackData, CDataStream ssKey, CDataStream ssValue), std::string& newFilename)
 {
     // Recovery procedure:
-    // move wallet file to wallet.timestamp.bak
+    // move wallet file to walletfilename.timestamp.bak
     // Call Salvage with fAggressive=true to
     // get as much data as possible.
     // Rewrite salvaged data to fresh wallet file
     // Set -rescan so any missing transactions will be
     // found.
     int64_t now = GetTime();
-    newFilename = strprintf("wallet.%d.bak", now);
+    newFilename = strprintf("%s.%d.bak", filename, now);
 
     int result = bitdb.dbenv->dbrename(NULL, filename.c_str(), NULL,
                                        newFilename.c_str(), DB_AUTO_COMMIT);

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -428,6 +428,16 @@ void CDB::Flush()
     env->dbenv->txn_checkpoint(nMinutes ? gArgs.GetArg("-dblogsize", 100) * 1024 : 0, nMinutes, 0);
 }
 
+void CWalletDBWrapper::IncrementUpdateCounter()
+{
+    ++nUpdateCounter;
+}
+
+unsigned int CWalletDBWrapper::GetUpdateCounter()
+{
+    return nUpdateCounter.load();
+}
+
 void CDB::Close()
 {
     if (!pdb)

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -433,11 +433,6 @@ void CWalletDBWrapper::IncrementUpdateCounter()
     ++nUpdateCounter;
 }
 
-unsigned int CWalletDBWrapper::GetUpdateCounter()
-{
-    return nUpdateCounter.load();
-}
-
 void CDB::Close()
 {
     if (!pdb)

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2014 The Bitcoin developers
-// Copyright (c) 2019-2020 The PIVX developers
+// Copyright (c) 2009-2021 The Bitcoin developers
+// Copyright (c) 2019-2021 The PIVX developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2014 The Bitcoin developers
-// Copyright (c) 2019-2020 The PIVX developers
+// Copyright (c) 2009-2021 The Bitcoin developers
+// Copyright (c) 2019-2021 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -96,13 +96,13 @@ class CWalletDBWrapper
     friend class CDB;
 public:
     /** Create dummy DB handle */
-    CWalletDBWrapper(): env(nullptr)
+    CWalletDBWrapper() : nLastSeen(0), nLastFlushed(0), nLastWalletUpdate(0), env(nullptr)
     {
     }
 
     /** Create DB handle to real database */
     CWalletDBWrapper(CDBEnv *env_in, const std::string &strFile_in):
-        env(env_in), strFile(strFile_in)
+        nLastSeen(0), nLastFlushed(0), nLastWalletUpdate(0), env(env_in), strFile(strFile_in)
     {
     }
 
@@ -123,13 +123,16 @@ public:
     void Flush(bool shutdown);
 
     void IncrementUpdateCounter();
+    std::atomic<unsigned int> nUpdateCounter;
+    unsigned int nLastSeen;
+    unsigned int nLastFlushed;
+    int64_t nLastWalletUpdate;
     unsigned int GetUpdateCounter();
 
 private:
     /** BerkeleyDB specific */
     CDBEnv *env;
     std::string strFile;
-    std::atomic<unsigned int> nUpdateCounter;
 
     /** Return whether this database handle is a dummy for testing.
      * Only to be used at a low level, application should ideally not care

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -55,9 +55,11 @@ public:
      * Returns true if strFile is OK.
      */
     enum VerifyResult { VERIFY_OK,
-        RECOVER_OK,
-        RECOVER_FAIL };
-    VerifyResult Verify(const std::string& strFile, bool (*recoverFunc)(const std::string& strFile));
+                        RECOVER_OK,
+                        RECOVER_FAIL };
+    typedef bool (*recoverFunc_type)(const std::string& strFile, std::string& out_backup_filename);
+    VerifyResult Verify(const std::string& strFile, recoverFunc_type recoverFunc, std::string& out_backup_filename);
+
     /**
      * Salvage data from a file that Verify says is bad.
      * fAggressive sets the DB_AGGRESSIVE flag (see berkeley DB->verify() method documentation).
@@ -159,7 +161,7 @@ public:
 
     void Flush();
     void Close();
-    static bool Recover(const std::string& filename, void *callbackDataIn, bool (*recoverKVcallback)(void* callbackData, CDataStream ssKey, CDataStream ssValue));
+    static bool Recover(const std::string& filename, void *callbackDataIn, bool (*recoverKVcallback)(void* callbackData, CDataStream ssKey, CDataStream ssValue), std::string& out_backup_filename);
 
     /* flush the wallet passively (TRY_LOCK)
        ideal to be called periodically */
@@ -167,7 +169,7 @@ public:
     /* verifies the database environment */
     static bool VerifyEnvironment(const std::string& walletFile, const fs::path& dataDir, std::string& errorStr);
     /* verifies the database file */
-    static bool VerifyDatabaseFile(const std::string& walletFile, const fs::path& dataDir, std::string& warningStr, std::string& errorStr, bool (*recoverFunc)(const std::string& strFile));
+    static bool VerifyDatabaseFile(const std::string& walletFile, const fs::path& dataDir, std::string& warningStr, std::string& errorStr, CDBEnv::recoverFunc_type recoverFunc);
 
 private:
     CDB(const CDB&);

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -14,6 +14,7 @@
 #include "sync.h"
 #include "version.h"
 
+#include <atomic>
 #include <map>
 #include <string>
 #include <vector>
@@ -121,10 +122,14 @@ public:
      */
     void Flush(bool shutdown);
 
+    void IncrementUpdateCounter();
+    unsigned int GetUpdateCounter();
+
 private:
     /** BerkeleyDB specific */
     CDBEnv *env;
     std::string strFile;
+    std::atomic<unsigned int> nUpdateCounter;
 
     /** Return whether this database handle is a dummy for testing.
      * Only to be used at a low level, application should ideally not care

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -15,7 +15,9 @@
 #include "util/system.h"
 #include "utilstrencodings.h"
 #include "utiltime.h"
-#include "wallet/wallet.h"
+#include "wallet/rpcwallet.h"
+#include "wallet.h"
+#include "validation.h"
 
 #include <fstream>
 #include <secp256k1.h>

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -76,6 +76,8 @@ bool IsStakingDerPath(KeyOriginInfo keyOrigin)
 
 UniValue importprivkey(const JSONRPCRequest& request)
 {
+    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+
     if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
         return NullUniValue;
 
@@ -149,6 +151,8 @@ UniValue importprivkey(const JSONRPCRequest& request)
 
 UniValue abortrescan(const JSONRPCRequest& request)
 {
+    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+
     if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
         return NullUniValue;
 
@@ -201,6 +205,8 @@ static void ImportAddress(CWallet* const pwallet, const CTxDestination& dest, co
 
 UniValue importaddress(const JSONRPCRequest& request)
 {
+    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+
     if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
         return NullUniValue;
 
@@ -266,6 +272,8 @@ UniValue importaddress(const JSONRPCRequest& request)
 
 UniValue importpubkey(const JSONRPCRequest& request)
 {
+    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+
     if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
         return NullUniValue;
 
@@ -321,6 +329,8 @@ UniValue importpubkey(const JSONRPCRequest& request)
 // TODO: Needs further review over the HD flow, staking addresses and multisig import.
 UniValue importwallet(const JSONRPCRequest& request)
 {
+    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+
     if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
         return NullUniValue;
 
@@ -446,6 +456,8 @@ UniValue importwallet(const JSONRPCRequest& request)
 
 UniValue dumpprivkey(const JSONRPCRequest& request)
 {
+    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+
     if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
         return NullUniValue;
 
@@ -484,6 +496,8 @@ UniValue dumpprivkey(const JSONRPCRequest& request)
 
 UniValue dumpwallet(const JSONRPCRequest& request)
 {
+    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+
     if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
         return NullUniValue;
 
@@ -943,6 +957,8 @@ static int64_t GetImportTimestamp(const UniValue& data, int64_t now)
 
 UniValue importmulti(const JSONRPCRequest& mainRequest)
 {
+    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(mainRequest);
+
     if (!EnsureWalletIsAvailable(pwalletMain, mainRequest.fHelp))
         return NullUniValue;
 
@@ -1097,6 +1113,8 @@ UniValue importmulti(const JSONRPCRequest& mainRequest)
 
 UniValue bip38encrypt(const JSONRPCRequest& request)
 {
+    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+
     if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
         return NullUniValue;
 
@@ -1146,6 +1164,8 @@ UniValue bip38encrypt(const JSONRPCRequest& request)
 
 UniValue bip38decrypt(const JSONRPCRequest& request)
 {
+    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+
     if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
         return NullUniValue;
 
@@ -1220,6 +1240,8 @@ UniValue bip38decrypt(const JSONRPCRequest& request)
 
 UniValue importsaplingkey(const JSONRPCRequest& request)
 {
+    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+
     if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
         return NullUniValue;
 
@@ -1320,6 +1342,8 @@ UniValue importsaplingkey(const JSONRPCRequest& request)
 
 UniValue importsaplingviewingkey(const JSONRPCRequest& request)
 {
+    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+
     if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
         return NullUniValue;
 
@@ -1424,6 +1448,8 @@ UniValue importsaplingviewingkey(const JSONRPCRequest& request)
 
 UniValue exportsaplingviewingkey(const JSONRPCRequest& request)
 {
+    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+
     if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
         return NullUniValue;
 
@@ -1465,6 +1491,8 @@ UniValue exportsaplingviewingkey(const JSONRPCRequest& request)
 
 UniValue exportsaplingkey(const JSONRPCRequest& request)
 {
+    CWallet * const pwalletMain = GetWalletForJSONRPCRequest(request);
+
     if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))
         return NullUniValue;
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -5,6 +5,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "wallet/rpcwallet.h"
+
 #include "addressbook.h"
 #include "amount.h"
 #include "base58.h"
@@ -17,21 +19,17 @@
 #include "net.h"
 #include "policy/feerate.h"
 #include "rpc/server.h"
-#include "timedata.h"
-#include "util/system.h"
-#include "utilmoneystr.h"
-#include "wallet.h"
-#include "walletdb.h"
-#include "zpivchain.h"
-
 #include "sapling/sapling_operation.h"
 #include "sapling/transaction_builder.h"
 #include "sapling/key_io_sapling.h"
+#include "spork.h"
+#include "timedata.h"
+#include "utilmoneystr.h"
+#include "wallet/wallet.h"
+#include "wallet/walletdb.h"
+#include "zpivchain.h"
 
 #include <stdint.h>
-
-#include "spork.h"
-
 #include <univalue.h>
 
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4208,35 +4208,6 @@ UniValue getautocombinethreshold(const JSONRPCRequest& request)
     return result;
 }
 
-UniValue printAddresses()
-{
-    std::vector<COutput> vCoins;
-    pwalletMain->AvailableCoins(&vCoins);
-    std::map<std::string, double> mapAddresses;
-    for (const COutput& out : vCoins) {
-        CTxDestination utxoAddress;
-        ExtractDestination(out.tx->tx->vout[out.i].scriptPubKey, utxoAddress);
-        std::string strAdd = EncodeDestination(utxoAddress);
-
-        if (mapAddresses.find(strAdd) == mapAddresses.end()) //if strAdd is not already part of the map
-            mapAddresses[strAdd] = (double)out.tx->tx->vout[out.i].nValue / (double)COIN;
-        else
-            mapAddresses[strAdd] += (double)out.tx->tx->vout[out.i].nValue / (double)COIN;
-    }
-
-    UniValue ret(UniValue::VARR);
-    for (std::map<std::string, double>::const_iterator it = mapAddresses.begin(); it != mapAddresses.end(); ++it) {
-        UniValue obj(UniValue::VOBJ);
-        const std::string* strAdd = &(*it).first;
-        const double* nBalance = &(*it).second;
-        obj.pushKV("Address ", *strAdd);
-        obj.pushKV("Balance ", *nBalance);
-        ret.push_back(obj);
-    }
-
-    return ret;
-}
-
 UniValue getsaplingnotescount(const JSONRPCRequest& request)
 {
     if (!EnsureWalletIsAvailable(pwalletMain, request.fHelp))

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -36,7 +36,8 @@
 
 CWallet* GetWalletForJSONRPCRequest(const JSONRPCRequest& request)
 {
-    return pwalletMain;
+    // TODO: Some way to access secondary wallets
+    return vpwallets.empty() ? nullptr : vpwallets[0];
 }
 
 std::string HelpRequiringPassphrase(CWallet* const pwallet)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3427,7 +3427,7 @@ UniValue walletpassphrase(const JSONRPCRequest& request)
 
     if (nSleepTime > 0) {
         pwallet->nRelockTime = GetTime () + nSleepTime;
-        RPCRunLater ("lockwallet", std::bind (LockWallet, pwallet), nSleepTime);
+        RPCRunLater (strprintf("lockwallet(%s)", pwallet->GetName()), std::bind (LockWallet, pwallet), nSleepTime);
     }
 
     return NullUniValue;

--- a/src/wallet/rpcwallet.h
+++ b/src/wallet/rpcwallet.h
@@ -1,12 +1,28 @@
-// Copyright (c) 2016 The Bitcoin Core developers
+// Copyright (c) 2016-2021 The Bitcoin Core developers
+// Copyright (c) 2021 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#ifndef PIVX_WALLET_RPCWALLET_H
+#define PIVX_WALLET_RPCWALLET_H
 
-#ifndef BITCOIN_WALLET_RPCWALLET_H
-#define BITCOIN_WALLET_RPCWALLET_H
+#include <string>
 
 class CRPCTable;
+class CWallet;
+class JSONRPCRequest;
 
 void RegisterWalletRPCCommands(CRPCTable &tableRPC);
 
-#endif //BITCOIN_WALLET_RPCWALLET_H
+/**
+ * Figures out what wallet, if any, to use for a JSONRPCRequest.
+ *
+ * @param[in] request JSONRPCRequest that wishes to access a wallet
+ * @return NULL if no wallet should be used, or a pointer to the CWallet
+ */
+CWallet* GetWalletForJSONRPCRequest(const JSONRPCRequest& request);
+
+std::string HelpRequiringPassphrase(CWallet* const pwallet);
+bool EnsureWalletIsAvailable(CWallet* const pwallet, bool avoidException);
+void EnsureWalletIsUnlocked(CWallet* const pwallet, bool fAllowAnonOnly = false);
+
+#endif //PIVX_WALLET_RPCWALLET_H

--- a/src/wallet/test/wallet_sapling_transactions_validations_tests.cpp
+++ b/src/wallet/test/wallet_sapling_transactions_validations_tests.cpp
@@ -13,6 +13,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+extern CWallet* pwalletMain;
+
 /*
  * A text fixture with a preloaded 100-blocks regtest chain, with sapling activating at block 101,
  * and a wallet containing the key used for the coinbase outputs.

--- a/src/wallet/test/wallet_shielded_balances_tests.cpp
+++ b/src/wallet/test/wallet_shielded_balances_tests.cpp
@@ -17,8 +17,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-extern CWallet* pwalletMain;
-
 CAmount fee = COIN; // Hardcoded fee
 
 BOOST_FIXTURE_TEST_SUITE(wallet_shielded_balances_tests, WalletTestingSetup)

--- a/src/wallet/test/wallet_shielded_balances_tests.cpp
+++ b/src/wallet/test/wallet_shielded_balances_tests.cpp
@@ -17,6 +17,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+extern CWallet* pwalletMain;
+
 CAmount fee = COIN; // Hardcoded fee
 
 BOOST_FIXTURE_TEST_SUITE(wallet_shielded_balances_tests, WalletTestingSetup)

--- a/src/wallet/test/wallet_shielded_balances_tests.cpp
+++ b/src/wallet/test/wallet_shielded_balances_tests.cpp
@@ -134,7 +134,7 @@ BOOST_AUTO_TEST_CASE(GetShieldedSimpleCachedCreditAndDebit)
     //////// Credit ////////
     ///////////////////////
 
-    auto consensusParams = RegtestActivateSapling();
+    auto consensusParams = Params().GetConsensus();
 
     // Main wallet
     CWallet &wallet = *pwalletMain;
@@ -191,9 +191,6 @@ BOOST_AUTO_TEST_CASE(GetShieldedSimpleCachedCreditAndDebit)
     // Checks that the only shielded output of this tx is change.
     BOOST_CHECK(wallet.GetSaplingScriptPubKeyMan()->IsNoteSaplingChange(
             SaplingOutPoint(wtxDebitUpdated.GetHash(), 0), pa));
-
-    // Revert to default
-    RegtestDeactivateSapling();
 }
 
 libzcash::SaplingPaymentAddress getNewDummyShieldedAddress()
@@ -237,7 +234,7 @@ CWalletTx& buildTxAndLoadToWallet(CWallet& wallet, const libzcash::SaplingExtend
  */
 BOOST_AUTO_TEST_CASE(VerifyShieldedToRemoteShieldedCachedBalance)
 {
-    auto consensusParams = RegtestActivateSapling();
+    auto consensusParams = Params().GetConsensus();
 
     // Main wallet
     CWallet &wallet = *pwalletMain;
@@ -280,9 +277,6 @@ BOOST_AUTO_TEST_CASE(VerifyShieldedToRemoteShieldedCachedBalance)
     // Plus, change should be same and be cached as well
     BOOST_CHECK_EQUAL(wtxDebitUpdated.GetShieldedChange(), expectedShieldedChange);
     BOOST_CHECK(wtxDebitUpdated.fShieldedChangeCached);
-
-    // Revert to default
-    RegtestDeactivateSapling();
 }
 
 struct FakeBlock
@@ -320,7 +314,7 @@ FakeBlock SimpleFakeMine(CWalletTx& wtx, SaplingMerkleTree& currentTree, CWallet
  */
 BOOST_AUTO_TEST_CASE(GetShieldedAvailableCredit)
 {
-    auto consensusParams = RegtestActivateSapling();
+    auto consensusParams = Params().GetConsensus();
 
     // Main wallet
     CWallet &wallet = *pwalletMain;

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -8,9 +8,6 @@
 #include "rpc/server.h"
 #include "wallet/db.h"
 #include "wallet/rpcwallet.h"
-#include "wallet/wallet.h"
-
-CWallet *pwalletMain;
 
 WalletTestingSetup::WalletTestingSetup(const std::string& chainName):
         SaplingTestingSetup(chainName)
@@ -19,18 +16,16 @@ WalletTestingSetup::WalletTestingSetup(const std::string& chainName):
 
     bool fFirstRun;
     std::unique_ptr<CWalletDBWrapper> dbw(new CWalletDBWrapper(&bitdb, "wallet_test.dat"));
-    pwalletMain = new CWallet(std::move(dbw));
+    pwalletMain = MakeUnique<CWallet>(std::move(dbw));
     pwalletMain->LoadWallet(fFirstRun);
-    RegisterValidationInterface(pwalletMain);
+    RegisterValidationInterface(pwalletMain.get());
 
     RegisterWalletRPCCommands(tableRPC);
 }
 
 WalletTestingSetup::~WalletTestingSetup()
 {
-    UnregisterValidationInterface(pwalletMain);
-    delete pwalletMain;
-    pwalletMain = nullptr;
+    UnregisterValidationInterface(pwalletMain.get());
 
     bitdb.Flush(true);
     bitdb.Reset();

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -1,5 +1,5 @@
-// Copyright (c) 2016 The Bitcoin Core developers
-// Copyright (c) 2020 The PIVX developers
+// Copyright (c) 2016-2021 The Bitcoin Core developers
+// Copyright (c) 2020-2021 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -7,34 +7,29 @@
 
 #include "rpc/server.h"
 #include "wallet/db.h"
-#include "wallet/wallet.h"
 #include "wallet/rpcwallet.h"
-
-void clean()
-{
-    delete pwalletMain;
-    pwalletMain = nullptr;
-
-    bitdb.Flush(true);
-    bitdb.Reset();
-}
+#include "wallet/wallet.h"
 
 WalletTestingSetup::WalletTestingSetup(const std::string& chainName):
         SaplingTestingSetup(chainName)
 {
-    clean(); // todo: research why we have an initialized bitdb here.
     bitdb.MakeMock();
-    RegisterWalletRPCCommands(tableRPC);
 
     bool fFirstRun;
     std::unique_ptr<CWalletDBWrapper> dbw(new CWalletDBWrapper(&bitdb, "wallet_test.dat"));
     pwalletMain = new CWallet(std::move(dbw));
     pwalletMain->LoadWallet(fFirstRun);
     RegisterValidationInterface(pwalletMain);
+
+    RegisterWalletRPCCommands(tableRPC);
 }
 
 WalletTestingSetup::~WalletTestingSetup()
 {
     UnregisterValidationInterface(pwalletMain);
-    clean();
+    delete pwalletMain;
+    pwalletMain = nullptr;
+
+    bitdb.Flush(true);
+    bitdb.Reset();
 }

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -10,6 +10,8 @@
 #include "wallet/rpcwallet.h"
 #include "wallet/wallet.h"
 
+CWallet *pwalletMain;
+
 WalletTestingSetup::WalletTestingSetup(const std::string& chainName):
         SaplingTestingSetup(chainName)
 {

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -1,11 +1,13 @@
-// Copyright (c) 2016 The Bitcoin Core developers
+// Copyright (c) 2016-2021 The Bitcoin Core developers
+// Copyright (c) 2020-2021 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_WALLET_TEST_FIXTURE_H
-#define BITCOIN_WALLET_TEST_FIXTURE_H
+#ifndef PIVX_WALLET_TEST_FIXTURE_H
+#define PIVX_WALLET_TEST_FIXTURE_H
 
 #include "test/librust/sapling_test_fixture.h"
+
 
 /** Testing setup and teardown for wallet.
  */
@@ -20,5 +22,5 @@ struct WalletRegTestingSetup : public WalletTestingSetup
     WalletRegTestingSetup() : WalletTestingSetup(CBaseChainParams::REGTEST) {}
 };
 
-#endif
+#endif // PIVX_WALLET_TEST_FIXTURE_H
 

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -7,6 +7,7 @@
 #define PIVX_WALLET_TEST_FIXTURE_H
 
 #include "test/librust/sapling_test_fixture.h"
+#include "wallet/wallet.h"
 
 
 /** Testing setup and teardown for wallet.
@@ -15,6 +16,8 @@ struct WalletTestingSetup : public SaplingTestingSetup
 {
     WalletTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
     ~WalletTestingSetup();
+
+    std::unique_ptr<CWallet> pwalletMain;
 };
 
 struct WalletRegTestingSetup : public WalletTestingSetup

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -22,8 +22,6 @@ extern UniValue importmulti(const JSONRPCRequest& request);
 extern UniValue dumpwallet(const JSONRPCRequest& request);
 extern UniValue importwallet(const JSONRPCRequest& request);
 
-extern CWallet* pwalletMain;
-
 // how many times to run all the tests to have a chance to catch errors that only show up with particular random shuffles
 #define RUN_TESTS 100
 
@@ -39,7 +37,7 @@ BOOST_FIXTURE_TEST_SUITE(wallet_tests, WalletTestingSetup)
 
 static std::vector<COutput> vCoins;
 
-static void add_coin(const CAmount& nValue, int nAge = 6*24, bool fIsFromMe = false, int nInput=0)
+static void add_coin(std::unique_ptr<CWallet>& pwallet, const CAmount& nValue, int nAge = 6*24, bool fIsFromMe = false, int nInput=0)
 {
     static int nextLockTime = 0;
     CMutableTransaction tx;
@@ -51,7 +49,7 @@ static void add_coin(const CAmount& nValue, int nAge = 6*24, bool fIsFromMe = fa
         // so stop vin being empty, and cache a non-zero Debit to fake out IsFromMe()
         tx.vin.resize(1);
     }
-    std::unique_ptr<CWalletTx> wtx(new CWalletTx(pwalletMain, MakeTransactionRef(std::move(tx))));
+    std::unique_ptr<CWalletTx> wtx(new CWalletTx(pwallet.get(), MakeTransactionRef(std::move(tx))));
     if (fIsFromMe) {
         wtx->m_amounts[CWalletTx::DEBIT].Set(ISMINE_SPENDABLE, 1);
     }
@@ -87,7 +85,7 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         // with an empty wallet we can't even pay one cent
         BOOST_CHECK(!pwalletMain->SelectCoinsMinConf( 1 * CENT, 1, 6, vCoins, setCoinsRet, nValueRet));
 
-        add_coin(1*CENT, 4);        // add a new 1 cent coin
+        add_coin(pwalletMain, 1*CENT, 4);        // add a new 1 cent coin
 
         // with a new 1 cent coin, we still can't find a mature 1 cent
         BOOST_CHECK(!pwalletMain->SelectCoinsMinConf( 1 * CENT, 1, 6, vCoins, setCoinsRet, nValueRet));
@@ -96,7 +94,7 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         BOOST_CHECK(pwalletMain->SelectCoinsMinConf( 1 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 1 * CENT);
 
-        add_coin(2*CENT);           // add a mature 2 cent coin
+        add_coin(pwalletMain, 2*CENT);           // add a mature 2 cent coin
 
         // we can't make 3 cents of mature coins
         BOOST_CHECK(!pwalletMain->SelectCoinsMinConf( 3 * CENT, 1, 6, vCoins, setCoinsRet, nValueRet));
@@ -105,9 +103,9 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         BOOST_CHECK(pwalletMain->SelectCoinsMinConf( 3 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 3 * CENT);
 
-        add_coin(5*CENT);           // add a mature 5 cent coin,
-        add_coin(10*CENT, 3, true); // a new 10 cent coin sent from one of our own addresses
-        add_coin(20*CENT);          // and a mature 20 cent coin
+        add_coin(pwalletMain, 5*CENT);           // add a mature 5 cent coin,
+        add_coin(pwalletMain, 10*CENT, 3, true); // a new 10 cent coin sent from one of our own addresses
+        add_coin(pwalletMain, 20*CENT);          // and a mature 20 cent coin
 
         // now we have new: 1+10=11 (of which 10 was self-sent), and mature: 2+5+20=27.  total = 38
 
@@ -145,11 +143,11 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         // now clear out the wallet and start again to test choosing between subsets of smaller coins and the next biggest coin
         empty_wallet();
 
-        add_coin( 6*CENT);
-        add_coin( 7*CENT);
-        add_coin( 8*CENT);
-        add_coin(20*CENT);
-        add_coin(30*CENT); // now we have 6+7+8+20+30 = 71 cents total
+        add_coin(pwalletMain,  6*CENT);
+        add_coin(pwalletMain,  7*CENT);
+        add_coin(pwalletMain,  8*CENT);
+        add_coin(pwalletMain, 20*CENT);
+        add_coin(pwalletMain, 30*CENT); // now we have 6+7+8+20+30 = 71 cents total
 
         // check that we have 71 and not 72
         BOOST_CHECK(pwalletMain->SelectCoinsMinConf(71 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
@@ -160,14 +158,14 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         BOOST_CHECK_EQUAL(nValueRet, 20 * CENT); // we should get 20 in one coin
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U);
 
-        add_coin( 5*CENT); // now we have 5+6+7+8+20+30 = 75 cents total
+        add_coin(pwalletMain,  5*CENT); // now we have 5+6+7+8+20+30 = 75 cents total
 
         // now if we try making 16 cents again, the smaller coins can make 5+6+7 = 18 cents, better than the next biggest coin, 20
         BOOST_CHECK(pwalletMain->SelectCoinsMinConf(16 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 18 * CENT); // we should get 18 in 3 coins
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 3U);
 
-        add_coin( 18*CENT); // now we have 5+6+7+8+18+20+30
+        add_coin(pwalletMain,  18*CENT); // now we have 5+6+7+8+18+20+30
 
         // and now if we try making 16 cents again, the smaller coins can make 5+6+7 = 18 cents, the same as the next biggest coin, 18
         BOOST_CHECK(pwalletMain->SelectCoinsMinConf(16 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
@@ -180,10 +178,10 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 2U);
 
         // check that the smallest bigger coin is used
-        add_coin( 1*COIN);
-        add_coin( 2*COIN);
-        add_coin( 3*COIN);
-        add_coin( 4*COIN); // now we have 5+6+7+8+18+20+30+100+200+300+400 = 1094 cents
+        add_coin(pwalletMain,  1*COIN);
+        add_coin(pwalletMain,  2*COIN);
+        add_coin(pwalletMain,  3*COIN);
+        add_coin(pwalletMain,  4*COIN); // now we have 5+6+7+8+18+20+30+100+200+300+400 = 1094 cents
         BOOST_CHECK(pwalletMain->SelectCoinsMinConf(95 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 1 * COIN);  // we should get 1 BTC in 1 coin
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U);
@@ -194,11 +192,11 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
 
         // empty the wallet and start again, now with fractions of a cent, to test sub-cent change avoidance
         empty_wallet();
-        add_coin(0.1*CENT);
-        add_coin(0.2*CENT);
-        add_coin(0.3*CENT);
-        add_coin(0.4*CENT);
-        add_coin(0.5*CENT);
+        add_coin(pwalletMain, 0.1*CENT);
+        add_coin(pwalletMain, 0.2*CENT);
+        add_coin(pwalletMain, 0.3*CENT);
+        add_coin(pwalletMain, 0.4*CENT);
+        add_coin(pwalletMain, 0.5*CENT);
 
         // try making 1 cent from 0.1 + 0.2 + 0.3 + 0.4 + 0.5 = 1.5 cents
         // we'll get sub-cent change whatever happens, so can expect 1.0 exactly
@@ -206,15 +204,15 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         BOOST_CHECK_EQUAL(nValueRet, 1 * CENT);
 
         // but if we add a bigger coin, making it possible to avoid sub-cent change, things change:
-        add_coin(1111*CENT);
+        add_coin(pwalletMain, 1111*CENT);
 
         // try making 1 cent from 0.1 + 0.2 + 0.3 + 0.4 + 0.5 + 1111 = 1112.5 cents
         BOOST_CHECK(pwalletMain->SelectCoinsMinConf(1 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 1 * CENT); // we should get the exact amount
 
         // if we add more sub-cent coins:
-        add_coin(0.6*CENT);
-        add_coin(0.7*CENT);
+        add_coin(pwalletMain, 0.6*CENT);
+        add_coin(pwalletMain, 0.7*CENT);
 
         // and try again to make 1.0 cents, we can still make 1.0 cents
         BOOST_CHECK(pwalletMain->SelectCoinsMinConf(1 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
@@ -224,7 +222,7 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         // they tried to consolidate 10 50k coins into one 500k coin, and ended up with 50k in change
         empty_wallet();
         for (int j = 0; j < 20; j++)
-            add_coin(50000 * COIN);
+            add_coin(pwalletMain, 50000 * COIN);
 
         BOOST_CHECK(pwalletMain->SelectCoinsMinConf(500000 * COIN, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 500000 * COIN); // we should get the exact amount
@@ -235,29 +233,29 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
 
         // sometimes it will fail, and so we use the next biggest coin:
         empty_wallet();
-        add_coin(0.5 * CENT);
-        add_coin(0.6 * CENT);
-        add_coin(0.7 * CENT);
-        add_coin(1111 * CENT);
+        add_coin(pwalletMain, 0.5 * CENT);
+        add_coin(pwalletMain, 0.6 * CENT);
+        add_coin(pwalletMain, 0.7 * CENT);
+        add_coin(pwalletMain, 1111 * CENT);
         BOOST_CHECK(pwalletMain->SelectCoinsMinConf(1 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 1111 * CENT); // we get the bigger coin
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U);
 
         // but sometimes it's possible, and we use an exact subset (0.4 + 0.6 = 1.0)
         empty_wallet();
-        add_coin(0.4 * CENT);
-        add_coin(0.6 * CENT);
-        add_coin(0.8 * CENT);
-        add_coin(1111 * CENT);
+        add_coin(pwalletMain, 0.4 * CENT);
+        add_coin(pwalletMain, 0.6 * CENT);
+        add_coin(pwalletMain, 0.8 * CENT);
+        add_coin(pwalletMain, 1111 * CENT);
         BOOST_CHECK(pwalletMain->SelectCoinsMinConf(1 * CENT, 1, 1, vCoins, setCoinsRet, nValueRet));
         BOOST_CHECK_EQUAL(nValueRet, 1 * CENT);   // we should get the exact amount
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 2U); // in two coins 0.4+0.6
 
         // test avoiding sub-cent change
         empty_wallet();
-        add_coin(0.0005 * COIN);
-        add_coin(0.01 * COIN);
-        add_coin(1 * COIN);
+        add_coin(pwalletMain, 0.0005 * COIN);
+        add_coin(pwalletMain, 0.01 * COIN);
+        add_coin(pwalletMain, 1 * COIN);
 
         // trying to make 1.0001 from these three coins
         BOOST_CHECK(pwalletMain->SelectCoinsMinConf(1.0001 * COIN, 1, 1, vCoins, setCoinsRet, nValueRet));
@@ -273,7 +271,7 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         {
             empty_wallet();
             for (int i2 = 0; i2 < 100; i2++)
-                add_coin(COIN);
+                add_coin(pwalletMain, COIN);
 
             // picking 50 from 100 coins doesn't depend on the shuffle,
             // but does depend on randomness in the stochastic approximation code
@@ -296,7 +294,11 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
             // add 75 cents in small change.  not enough to make 90 cents,
             // then try making 90 cents.  there are multiple competing "smallest bigger" coins,
             // one of which should be picked at random
-            add_coin( 5*CENT); add_coin(10*CENT); add_coin(15*CENT); add_coin(20*CENT); add_coin(25*CENT);
+            add_coin(pwalletMain,  5*CENT);
+            add_coin(pwalletMain, 10*CENT);
+            add_coin(pwalletMain, 15*CENT);
+            add_coin(pwalletMain, 20*CENT);
+            add_coin(pwalletMain, 25*CENT);
 
             fails = 0;
             for (int j = 0; j < RANDOM_REPEATS; j++)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -25,7 +25,7 @@
 #include <future>
 #include <boost/algorithm/string/replace.hpp>
 
-CWallet* pwalletMain = nullptr;
+std::vector<CWalletRef> vpwallets;
 /**
  * Settings
  */
@@ -4344,7 +4344,6 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
 bool CWallet::InitLoadWallet()
 {
     if (gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET)) {
-        pwalletMain = nullptr;
         LogPrintf("Wallet disabled!\n");
         return true;
     }
@@ -4361,7 +4360,7 @@ bool CWallet::InitLoadWallet()
     if (!pwallet) {
         return false;
     }
-    pwalletMain = pwallet;
+    vpwallets.emplace_back(pwallet);
     return true;
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4309,7 +4309,7 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
         }
         LogPrintf("Rescan completed in %15dms\n", GetTimeMillis() - nWalletRescanTime);
         walletInstance->SetBestChain(chainActive.GetLocator());
-        CWalletDB::IncrementUpdateCounter();
+        walletInstance->dbw->IncrementUpdateCounter();
 
         // Restore wallet transaction metadata after -zapwallettxes=1
         if (gArgs.GetBoolArg("-zapwallettxes", false) && gArgs.GetArg("-zapwallettxes", "1") != "2") {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2121,8 +2121,9 @@ bool CWallet::Verify()
         }
 
         std::string strError;
-        if (!CWalletDB::VerifyEnvironment(walletFile, GetDataDir().string(), strError))
+        if (!CWalletDB::VerifyEnvironment(walletFile, GetDataDir().string(), strError)) {
             return UIError(strError);
+        }
 
         if (gArgs.GetBoolArg("-salvagewallet", false)) {
             // Recover readable keypairs:
@@ -2133,14 +2134,16 @@ bool CWallet::Verify()
             // tx status. If lock can't be taken, tx confirmation status may be not
             // reliable.
             LOCK(cs_main);
-            if (!CWalletDB::Recover(walletFile, (void *)&dummyWallet, CWalletDB::RecoverKeysOnlyFilter, backup_filename))
+            if (!CWalletDB::Recover(walletFile, (void *)&dummyWallet, CWalletDB::RecoverKeysOnlyFilter, backup_filename)) {
                 return false;
+            }
         }
 
         std::string strWarning;
         bool dbV = CWalletDB::VerifyDatabaseFile(walletFile, GetDataDir().string(), strWarning, strError);
-        if (!strWarning.empty())
+        if (!strWarning.empty()) {
             UIWarning(strWarning);
+        }
         if (!dbV) {
             return UIError(strError);
         }
@@ -2153,16 +2156,19 @@ void CWallet::ResendWalletTransactions(CConnman* connman)
 {
     // Do this infrequently and randomly to avoid giving away
     // that these are our transactions.
-    if (GetTime() < nNextResend)
+    if (GetTime() < nNextResend) {
         return;
+    }
     bool fFirst = (nNextResend == 0);
     nNextResend = GetTime() + GetRand(30 * 60);
-    if (fFirst)
+    if (fFirst) {
         return;
+    }
 
     // Only do it if there's been a new block since last time
-    if (nTimeBestReceived < nLastResend)
+    if (nTimeBestReceived < nLastResend) {
         return;
+    }
     nLastResend = GetTime();
 
     // Rebroadcast any of our txes that aren't in a block yet
@@ -2175,8 +2181,9 @@ void CWallet::ResendWalletTransactions(CConnman* connman)
             CWalletTx& wtx = item.second;
             // Don't rebroadcast until it's had plenty of time that
             // it should have gotten in already by now.
-            if (nTimeBestReceived - (int64_t)wtx.nTimeReceived > 5 * 60)
+            if (nTimeBestReceived - (int64_t)wtx.nTimeReceived > 5 * 60) {
                 mapSorted.emplace(wtx.nTimeReceived, &wtx);
+            }
         }
         for (std::pair<const unsigned int, CWalletTx*> & item : mapSorted) {
             CWalletTx& wtx = *item.second;
@@ -4256,8 +4263,9 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
             LogPrintf("Performing wallet upgrade to %i\n", FEATURE_LATEST);
             nMaxVersion = FEATURE_LATEST;
             walletInstance->SetMinVersion(FEATURE_LATEST); // permanently upgrade the wallet immediately
-        } else
+        } else {
             LogPrintf("Allowing wallet upgrade up to %i\n", nMaxVersion);
+        }
         if (nMaxVersion < walletInstance->GetVersion()) {
             UIError("Cannot downgrade wallet\n");
             return nullptr;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2069,6 +2069,11 @@ std::set<uint256> CWalletTx::GetConflicts() const
     return result;
 }
 
+void CWallet::Flush(bool shutdown)
+{
+    bitdb.Flush(shutdown);
+}
+
 bool CWallet::Verify()
 {
     if (gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET)) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4351,6 +4351,12 @@ bool CWallet::InitLoadWallet()
 
     std::string walletFile = gArgs.GetArg("-wallet", DEFAULT_WALLET_DAT);
 
+    if (walletFile.find_first_of("/\\") != std::string::npos) {
+        return UIError(_("-wallet parameter must only specify a filename (not a path)"));
+    } else if (SanitizeString(walletFile, SAFE_CHARS_FILENAME) != walletFile) {
+        return UIError(_("Invalid characters in -wallet filename"));
+    }
+
     CWallet * const pwallet = CreateWalletFromFile(walletFile);
     if (!pwallet) {
         return false;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4395,8 +4395,12 @@ bool CWallet::InitLoadWallet()
         // automatic backups
         std::string strWarning, strError;
         if(!AutoBackupWallet(walletFile, strWarning, strError)) {
-            if (!strWarning.empty()) UIWarning(strWarning);
-            if (!strError.empty()) return UIError(strError);
+            if (!strWarning.empty()) {
+                UIWarning(strprintf("%s: %s", walletFile, strWarning));
+            }
+            if (!strError.empty()) {
+                return UIError(strprintf("%s: %s", walletFile, strError));
+            }
         }
 
         CWallet * const pwallet = CreateWalletFromFile(walletFile);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2097,12 +2097,13 @@ bool CWallet::Verify()
         if (gArgs.GetBoolArg("-salvagewallet", false)) {
             // Recover readable keypairs:
             CWallet dummyWallet;
+            std::string backup_filename;
             // Even if we don't use this lock in this function, we want to preserve
             // lock order in LoadToWallet if query of chain state is needed to know
             // tx status. If lock can't be taken, tx confirmation status may be not
             // reliable.
             LOCK(cs_main);
-            if (!CWalletDB::Recover(walletFile, (void *)&dummyWallet, CWalletDB::RecoverKeysOnlyFilter))
+            if (!CWalletDB::Recover(walletFile, (void *)&dummyWallet, CWalletDB::RecoverKeysOnlyFilter, backup_filename))
                 return false;
         }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -45,7 +45,7 @@
 #include <vector>
 
 typedef CWallet* CWalletRef;
-extern CWalletRef pwalletMain;
+extern std::vector<CWalletRef> vpwallets;
 
 /**
  * Settings

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1276,7 +1276,4 @@ public:
     }
 };
 
-// !TODO: move to wallet/init.*
-bool InitAutoBackupWallet();
-
 #endif // PIVX_WALLET_H

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -934,9 +934,12 @@ public:
     bool LoadWatchOnly(const CScript& dest);
 
     //! Lock Wallet
+    //! Holds a timestamp at which point the wallet is scheduled (externally) to be relocked. Caller must arrange for actual relocking to occur via Lock().
+    int64_t nRelockTime;
     bool Lock();
     bool Unlock(const SecureString& strWalletPassphrase, bool anonimizeOnly = false);
     bool Unlock(const CKeyingMaterial& vMasterKeyIn);
+
     bool ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase, const SecureString& strNewWalletPassphrase);
     bool EncryptWallet(const SecureString& strWalletPassphrase);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1128,6 +1128,9 @@ public:
     //! Get wallet transactions that conflict with given transaction (spend same outputs)
     std::set<uint256> GetConflicts(const uint256& txid) const;
 
+    //! Flush wallet (bitdb flush)
+    void Flush(bool shutdown=false);
+
     //! Verify the wallet database and perform salvage if required
     static bool Verify();
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -797,24 +797,22 @@ void MaybeCompactWalletDB()
         return;
     }
 
-    /* TODO: fix me
-    CWalletDBWrapper& dbh = pwalletMain->GetDBHandle();
+    for (CWalletRef pwallet : vpwallets) {
+        CWalletDBWrapper& dbh = pwallet->GetDBHandle();
 
-    static unsigned int nLastSeen = dbh.GetUpdateCounter();
-    static unsigned int nLastFlushed = dbh.GetUpdateCounter();
-    static int64_t nLastWalletUpdate = GetTime();
+        unsigned int nUpdateCounter = dbh.nUpdateCounter;
+        if (dbh.nLastSeen != nUpdateCounter) {
+            dbh.nLastSeen = nUpdateCounter;
+            dbh.nLastWalletUpdate = GetTime();
+        }
 
-    if (nLastSeen != dbh.GetUpdateCounter()) {
-        nLastSeen = dbh.GetUpdateCounter();
-        nLastWalletUpdate = GetTime();
-    }
-
-    if (nLastFlushed != dbh.GetUpdateCounter() && GetTime() - nLastWalletUpdate >= 2) {
-        if (CDB::PeriodicFlush(dbh)) {
-            nLastFlushed = dbh.GetUpdateCounter();
+        if (dbh.nLastFlushed != nUpdateCounter && GetTime() - dbh.nLastWalletUpdate >= 2) {
+            if (CDB::PeriodicFlush(dbh)) {
+                dbh.nLastFlushed = nUpdateCounter;
+            }
         }
     }
-    */
+
     fOneThread = false;
 }
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -797,6 +797,7 @@ void MaybeCompactWalletDB()
         return;
     }
 
+    /* TODO: fix me
     CWalletDBWrapper& dbh = pwalletMain->GetDBHandle();
 
     static unsigned int nLastSeen = dbh.GetUpdateCounter();
@@ -813,6 +814,7 @@ void MaybeCompactWalletDB()
             nLastFlushed = dbh.GetUpdateCounter();
         }
     }
+    */
     fOneThread = false;
 }
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -260,7 +260,7 @@ bool CWalletDB::ErasePool(int64_t nPool)
 
 bool CWalletDB::WriteMinVersion(int nVersion)
 {
-    return batch.Write(std::string(DBKeys::MINVERSION), nVersion);
+    return WriteIC(std::string(DBKeys::MINVERSION), nVersion);
 }
 
 bool CWalletDB::WriteHDChain(const CHDChain& chain)

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1063,16 +1063,16 @@ bool AttemptBackupWallet(const CWallet& wallet, const fs::path& pathSrc, const f
 //
 // Try to (very carefully!) recover wallet file if there is a problem.
 //
-bool CWalletDB::Recover(const std::string& filename, void *callbackDataIn, bool (*recoverKVcallback)(void* callbackData, CDataStream ssKey, CDataStream ssValue))
+bool CWalletDB::Recover(const std::string& filename, void *callbackDataIn, bool (*recoverKVcallback)(void* callbackData, CDataStream ssKey, CDataStream ssValue), std::string& out_backup_filename)
 {
-    return CDB::Recover(filename, callbackDataIn, recoverKVcallback);
+    return CDB::Recover(filename, callbackDataIn, recoverKVcallback, out_backup_filename);
 }
 
-bool CWalletDB::Recover(const std::string& filename)
+bool CWalletDB::Recover(const std::string& filename, std::string& out_backup_filename)
 {
     // recover without a key filter callback
     // results in recovering all record types
-    return CWalletDB::Recover(filename, NULL, NULL);
+    return CWalletDB::Recover(filename, NULL, NULL, out_backup_filename);
 }
 
 bool CWalletDB::RecoverKeysOnlyFilter(void *callbackData, CDataStream ssKey, CDataStream ssValue)

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -207,9 +207,9 @@ public:
     DBErrors FindWalletTx(CWallet* pwallet, std::vector<uint256>& vTxHash, std::vector<CWalletTx>& vWtx);
     DBErrors ZapWalletTx(CWallet* pwallet, std::vector<CWalletTx>& vWtx);
     /* Try to (very carefully!) recover wallet database (with a possible key type filter) */
-    static bool Recover(const std::string& filename, void *callbackDataIn, bool (*recoverKVcallback)(void* callbackData, CDataStream ssKey, CDataStream ssValue));
-    /* Recover convenience-function to bypass the key filter callback, called when verify failes, recoveres everything */
-    static bool Recover(const std::string& filename);
+    static bool Recover(const std::string& filename, void *callbackDataIn, bool (*recoverKVcallback)(void* callbackData, CDataStream ssKey, CDataStream ssValue), std::string& out_backup_filename);
+    /* Recover convenience-function to bypass the key filter callback, called when verify fails, recovers everything */
+    static bool Recover(const std::string& filename, std::string& out_backup_filename);
     /* Recover filter (used as callback), will only let keys (cryptographical keys) as KV/key-type pass through */
     static bool RecoverKeysOnlyFilter(void *callbackData, CDataStream ssKey, CDataStream ssValue);
     /* Function to determin if a certain KV/key-type is a key (cryptographical key) type */

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -121,7 +121,7 @@ private:
         if (!batch.Write(key, value, fOverwrite)) {
             return false;
         }
-        IncrementUpdateCounter();
+        m_dbw.IncrementUpdateCounter();
         return true;
     }
 
@@ -131,13 +131,14 @@ private:
         if (!batch.Erase(key)) {
             return false;
         }
-        IncrementUpdateCounter();
+        m_dbw.IncrementUpdateCounter();
         return true;
     }
 
 public:
     CWalletDB(CWalletDBWrapper& dbw, const char* pszMode = "r+", bool _fFlushOnClose = true) :
-        batch(dbw, pszMode, _fFlushOnClose)
+        batch(dbw, pszMode, _fFlushOnClose),
+        m_dbw(dbw)
     {
     }
 
@@ -218,9 +219,6 @@ public:
     /* verifies the database file */
     static bool VerifyDatabaseFile(const std::string& walletFile, const fs::path& dataDir, std::string& warningStr, std::string& errorStr);
 
-    static void IncrementUpdateCounter();
-    static unsigned int GetUpdateCounter();
-
     //! Begin a new transaction
     bool TxnBegin();
     //! Commit current transaction
@@ -233,6 +231,7 @@ public:
     bool WriteVersion(int nVersion);
 private:
     CDB batch;
+    CWalletDBWrapper& m_dbw;
 
     CWalletDB(const CWalletDB&);
     void operator=(const CWalletDB&);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -1,11 +1,11 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2013 The Bitcoin developers
-// Copyright (c) 2016-2020 The PIVX developers
+// Copyright (c) 2009-2021 The Bitcoin developers
+// Copyright (c) 2016-2021 The PIVX developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_WALLETDB_H
-#define BITCOIN_WALLETDB_H
+#ifndef PIVX_WALLETDB_H
+#define PIVX_WALLETDB_H
 
 #include "amount.h"
 #include "wallet/db.h"
@@ -247,4 +247,4 @@ bool AutoBackupWallet(const std::string& strWalletFile, std::string& strBackupWa
 //! Compacts BDB state so that wallet.dat is self-contained (if there are changes)
 void MaybeCompactWalletDB();
 
-#endif // BITCOIN_WALLETDB_H
+#endif // PIVX_WALLETDB_H

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -114,6 +114,27 @@ public:
  */
 class CWalletDB
 {
+private:
+    template <typename K, typename T>
+    bool WriteIC(const K& key, const T& value, bool fOverwrite = true)
+    {
+        if (!batch.Write(key, value, fOverwrite)) {
+            return false;
+        }
+        IncrementUpdateCounter();
+        return true;
+    }
+
+    template <typename K>
+    bool EraseIC(const K& key)
+    {
+        if (!batch.Erase(key)) {
+            return false;
+        }
+        IncrementUpdateCounter();
+        return true;
+    }
+
 public:
     CWalletDB(CWalletDBWrapper& dbw, const char* pszMode = "r+", bool _fFlushOnClose = true) :
         batch(dbw, pszMode, _fFlushOnClose)


### PR DESCRIPTION
Quite a bit of refactoring to bring us a little closer to upstream in the wallet/walletdb area, introducing basic support for multiple wallets.
The PIVX client can now be started with more than one `-wallet` argument (either as startup flags, or as multiple lines in pivx.conf). The wallets will be all loaded and kept separated, with individual balances, keys and received transactions.

Even though only the first wallet will be used in the GUI/RPC for the moment (selectable wallets will be added later), all other loaded wallets will remain synchronized to the node's current tip and update their internal data.

Bulk of changes coming from:
- bitcoin/bitcoin#8775 RPC refactoring: Access wallet using new GetWalletForJSONRPCRequest
- bitcoin/bitcoin#8694 Basic multiwallet support
- bitcoin/bitcoin#11713 Fix for mismatched extern definition in wallet tests
- bitcoin/bitcoin#11781 tests: move pwalletMain to wallet test fixture