### PR TITLE
[Bugfix] the end of a reorged chain is invalid when connect fails

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2287,8 +2287,9 @@ static bool ActivateBestChainStep(CValidationState& state, CBlockIndex* pindexMo
             if (!ConnectTip(state, pindexConnect, (pindexConnect == pindexMostWork) ? pblock : std::shared_ptr<const CBlock>(), connectTrace, disconnectpool)) {
                 if (state.IsInvalid()) {
                     // The block violates a consensus rule.
-                    if (!state.CorruptionPossible())
-                        InvalidChainFound(vpindexToConnect.back());
+                    if (!state.CorruptionPossible()) {
+                        InvalidChainFound(vpindexToConnect.front());
+                    }
                     state = CValidationState();
                     fInvalidFound = true;
                     fContinue = false;


### PR DESCRIPTION
Found this bug fix investigating master's GA test failure reason. Not related to it but still a bug-fix.

> When an invalid block is found during a reorg, we know the last of the blocks in
the was-to-be-connected chain is invalid, but not necessarily the first. As
vpIndexToConnect is ordered in decreasing height, the end of the reorg is the
front of the vector, and not the back.

This has no direct impact, only affects the warning logging system.
Coming from #13185.