### PR TITLE
[BugFix] Fixing sapling_wallet.py getshieldbalance race condition.

### DIFF
--- a/test/functional/sapling_wallet.py
+++ b/test/functional/sapling_wallet.py
@@ -153,6 +153,7 @@ class WalletSaplingTest(PivxTestFramework):
         sleep(1)
         self.deactivate_spork(0, SPORK_20)
         self.nodes[0].reconsiderblock(tip_hash)
+        self.nodes[0].syncwithvalidationinterfacequeue()
         assert_equal(tip_hash, self.nodes[0].getbestblockhash())    # Block connected
         assert_equal(self.nodes[0].getshieldbalance(saplingAddr0), Decimal('30'))
         self.log.info("Reconnected after deactivation of SPORK_20. Balance restored.")


### PR DESCRIPTION
Fixing a race condition inside the `sapling_wallet.py` functional test.

As the wallet now is processing blocks in a worker thread and not in the main one, if the scheduler thread tasks processing isn't fast enough to process the new block, there can be a race condition between the `reconsiderblock` and the wallet `getshieldedbalance` check that comes right after it inside the test.
Solved it adding the validation interface queue sync call.

This issue happened in master's GA --> https://github.com/PIVX-Project/PIVX/runs/2426500390 .