### PR TITLE
[GUI] Add GUI controls for subtract-fee-from-amount

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -420,6 +420,7 @@ RES_ICONS = \
   qt/pivx/res/img/ic-switch-on.svg \
   qt/pivx/res/img/img-qr-test.png \
   qt/pivx/res/img/ic-check-box.svg \
+  qt/pivx/res/img/ic-check-box-light.svg \
   qt/pivx/res/img/ic-check-box-dark-active.svg \
   qt/pivx/res/img/ic-check-box-indeterminate.svg \
   qt/pivx/res/img/ic-check-box-liliac-indeterminate.svg \

--- a/src/qt/pivx.qrc
+++ b/src/qt/pivx.qrc
@@ -62,6 +62,7 @@
         <file alias="ic-arrow-white-right">pivx/res/img/ic-arrow-white-right.svg</file>
         <file alias="ic-check-active">pivx/res/img/ic-check-active.svg</file>
         <file alias="ic-check-box">pivx/res/img/ic-check-box.svg</file>
+        <file alias="ic-check-box-light">pivx/res/img/ic-check-box-light.svg</file>
         <file alias="ic-check-box-liliac-indeterminate">pivx/res/img/ic-check-box-liliac-indeterminate.svg</file>
         <file alias="ic-check-connect-off">pivx/res/img/ic-check-connect-off.svg</file>
         <file alias="ic-check-connect">pivx/res/img/ic-check-connect.svg</file>

--- a/src/qt/pivx/forms/sendmultirow.ui
+++ b/src/qt/pivx/forms/sendmultirow.ui
@@ -348,6 +348,16 @@ padding:0px;</string>
           <number>0</number>
          </property>
          <item>
+          <widget class="QCheckBox" name="checkboxSubtractFeeFromAmount">
+           <property name="toolTip">
+            <string>The fee will be deducted from the amount being sent. The recipient will receive less PIV than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</string>
+           </property>
+           <property name="text">
+            <string>Subtract fee from amount</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <spacer name="horizontalSpacer">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>

--- a/src/qt/pivx/res/css/style_dark.css
+++ b/src/qt/pivx/res/css/style_dark.css
@@ -2049,7 +2049,7 @@ QCheckBox {
     color:#FFFFFF;
 }
 
-QCheckBox:checked  {
+QCheckBox:checked {
     spacing: 5px;
     font-size:18px;
     color:#b088ff;
@@ -2082,6 +2082,32 @@ QCheckBox[cssClass="btn-watch-password"]::indicator:unchecked {
 
 QCheckBox[cssClass="btn-watch-password"]::indicator:checked {
     image: url("://ic-watch-password-white");
+}
+
+QCheckBox[cssClass="combo-light"] {
+    spacing: 5px;
+    font-size:18px;
+    color: #807b8a;
+}
+
+QCheckBox[cssClass="combo-light"]:checked {
+    spacing: 5px;
+    font-size:18px;
+    color:#b088ff;
+}
+
+QCheckBox[cssClass="combo-light"]::indicator:unchecked {
+    image: url("://ic-check-box-light");
+}
+
+QCheckBox[cssClass="combo-light"]:hover {
+    spacing: 5px;
+    font-size:18px;
+    color: #bababa;
+}
+
+QCheckBox[cssClass="combo-light"]::indicator:unchecked:hover {
+    image: url("://ic-check-box");
 }
 
 /*HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH

--- a/src/qt/pivx/res/css/style_dark.css
+++ b/src/qt/pivx/res/css/style_dark.css
@@ -3068,6 +3068,11 @@ HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH*/
     color: #5c4b7d;
 }
 
+*[cssClass="btn-list-menu"]:checked{
+    font-size:16px;
+    color:#b088ff;
+}
+
 
 
 /*HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH

--- a/src/qt/pivx/res/css/style_light.css
+++ b/src/qt/pivx/res/css/style_light.css
@@ -2049,7 +2049,7 @@ QCheckBox {
     color:#707070;
 }
 
-QCheckBox:checked  {
+QCheckBox:checked {
     spacing: 5px;
     font-size:18px;
     color:#5c4b7d;
@@ -2082,6 +2082,28 @@ QCheckBox[cssClass="btn-watch-password"]::indicator:unchecked {
 
 QCheckBox[cssClass="btn-watch-password"]::indicator:checked {
     image: url("://ic-watch-password");
+}
+
+QCheckBox[cssClass="combo-light"] {
+    spacing: 5px;
+    font-size:18px;
+    color:#bababa;
+}
+
+QCheckBox[cssClass="combo-light"]:checked {
+    spacing: 5px;
+    font-size:18px;
+    color:#707070;
+}
+
+QCheckBox[cssClass="combo-light"]:hover {
+    spacing: 5px;
+    font-size:18px;
+    color: #707070;
+}
+
+QCheckBox[cssClass="combo-light"]::indicator:unchecked:hover {
+    image: url("://ic-check-box-light");
 }
 
 /*HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH

--- a/src/qt/pivx/res/css/style_light.css
+++ b/src/qt/pivx/res/css/style_light.css
@@ -3066,6 +3066,11 @@ HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH*/
     color: #5c4b7d;
 }
 
+*[cssClass="btn-list-menu"]:checked{
+    font-size:16px;
+    color: #b088ff;
+}
+
 
 /*HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH
 HH        EMPTY LIST

--- a/src/qt/pivx/res/img/ic-check-box-light.svg
+++ b/src/qt/pivx/res/img/ic-check-box-light.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <defs>
+        <style type="text/css">
+            .cls-1{fill:#807b8a;fill-rule:evenodd;opacity:.997}.cls-2{fill:none}
+        </style>
+    </defs>
+    <g id="check_box" transform="translate(-420 -576)">
+        <path id="checkbox" d="M22.556 5.444v17.112H5.444V5.444zm0-2.444H5.444A2.452 2.452 0 0 0 3 5.444v17.112A2.452 2.452 0 0 0 5.444 25h17.112A2.452 2.452 0 0 0 25 22.556V5.444A2.452 2.452 0 0 0 22.556 3z" class="cls-1" transform="translate(418 574)"/>
+        <path id="Rectangle_4539" d="M0 0h24v24H0z" class="cls-2" data-name="Rectangle 4539" transform="translate(420 576)"/>
+    </g>
+</svg>

--- a/src/qt/pivx/send.cpp
+++ b/src/qt/pivx/send.cpp
@@ -863,14 +863,19 @@ void SendWidget::onMenuClicked(SendMultiRow* entry)
         this->menu = new TooltipMenu(window, this);
         this->menu->setCopyBtnText(tr("Add Memo"));
         this->menu->setEditBtnText(tr("Save contact"));
-        this->menu->setMinimumSize(this->menu->width() + 30,this->menu->height());
+        this->menu->setLastBtnVisible(true);
+        this->menu->setLastBtnText(tr("Subtract fee"));
+        this->menu->setMinimumHeight(157);
+        this->menu->setMinimumSize(this->menu->width() + 30, this->menu->height());
         connect(this->menu, &TooltipMenu::message, this, &AddressesWidget::message);
         connect(this->menu, &TooltipMenu::onEditClicked, this, &SendWidget::onContactMultiClicked);
         connect(this->menu, &TooltipMenu::onDeleteClicked, this, &SendWidget::onDeleteClicked);
         connect(this->menu, &TooltipMenu::onCopyClicked, this, &SendWidget::onEntryMemoClicked);
+        connect(this->menu, &TooltipMenu::onLastClicked, this, &SendWidget::onSubtractFeeFromAmountChecked);
     } else {
         this->menu->hide();
     }
+    this->menu->setLastBtnCheckable(true, entry->getSubtractFeeFromAmount());
     menu->move(pos);
     menu->show();
 }
@@ -929,6 +934,13 @@ void SendWidget::onEntryMemoClicked()
     if (focusedEntry) {
         focusedEntry->launchMemoDialog();
         menu->setCopyBtnText(tr("Memo"));
+    }
+}
+
+void SendWidget::onSubtractFeeFromAmountChecked()
+{
+    if (focusedEntry) {
+        focusedEntry->toggleSubtractFeeFromAmount();
     }
 }
 

--- a/src/qt/pivx/send.h
+++ b/src/qt/pivx/send.h
@@ -81,6 +81,7 @@ private Q_SLOTS:
     void onContactMultiClicked();
     void onDeleteClicked();
     void onEntryMemoClicked();
+    void onSubtractFeeFromAmountChecked();
     void onResetCustomOptions(bool fRefreshAmounts);
     void onResetSettings();
 

--- a/src/qt/pivx/sendconfirmdialog.cpp
+++ b/src/qt/pivx/sendconfirmdialog.cpp
@@ -183,14 +183,26 @@ void TxDetailDialog::setData(WalletModel *_model, WalletModelTransaction* _tx)
     this->model = _model;
     this->tx = _tx;
     CAmount txFee = tx->getTransactionFee();
-    CAmount totalAmount = tx->getTotalTransactionAmount() + txFee;
 
     // inputs label
     CTransactionRef walletTx = tx->getTransaction();
     setInputsType(walletTx);
 
+    bool fSubtractFee = false;
+    const QList<SendCoinsRecipient>& recipients = tx->getRecipients();
+    for (const SendCoinsRecipient& rec : recipients) {
+        if (rec.fSubtractFee) {
+            fSubtractFee = true;
+            break;
+        }
+    }
+
+    CAmount totalAmount = tx->getTotalTransactionAmount();
+    if (!fSubtractFee) totalAmount += txFee;
+
     ui->textAmount->setText(BitcoinUnits::formatWithUnit(nDisplayUnit, totalAmount, false, BitcoinUnits::separatorAlways) + " (Fee included)");
-    int nRecipients = tx->getRecipients().size();
+
+    int nRecipients = recipients.size();
     if (nRecipients == 1) {
         const SendCoinsRecipient& recipient = tx->getRecipients().at(0);
         if (recipient.isP2CS) {

--- a/src/qt/pivx/sendmultirow.cpp
+++ b/src/qt/pivx/sendmultirow.cpp
@@ -225,6 +225,7 @@ SendCoinsRecipient SendMultiRow::getValue()
     recipient.amount = getAmountValue();
     auto dest = Standard::DecodeDestination(recipient.address.toStdString());
     recipient.isShieldedAddr = boost::get<libzcash::SaplingPaymentAddress>(&dest);
+    recipient.fSubtractFee = getSubtractFeeFromAmount();
     return recipient;
 }
 
@@ -263,6 +264,11 @@ int SendMultiRow::getNumber()
     return number;
 }
 
+bool SendMultiRow::getSubtractFeeFromAmount() const
+{
+    return ui->checkboxSubtractFeeFromAmount->isChecked();
+}
+
 void SendMultiRow::setAddress(const QString& address)
 {
     ui->lineEditAddress->setText(address);
@@ -272,6 +278,12 @@ void SendMultiRow::setAddress(const QString& address)
 void SendMultiRow::setAmount(const QString& amount)
 {
     ui->lineEditAmount->setText(amount);
+}
+
+void SendMultiRow::toggleSubtractFeeFromAmount()
+{
+    bool old = ui->checkboxSubtractFeeFromAmount->isChecked();
+    ui->checkboxSubtractFeeFromAmount->setChecked(!old);
 }
 
 void SendMultiRow::setAddressAndLabelOrDescription(const QString& address, const QString& message)

--- a/src/qt/pivx/sendmultirow.cpp
+++ b/src/qt/pivx/sendmultirow.cpp
@@ -34,6 +34,8 @@ SendMultiRow::SendMultiRow(PIVXGUI* _window, PWidget *parent) :
     // future: when we get a designer, this should have another icon. A "memo" icon instead of a "+"
     setCssProperty(ui->btnAddMemo, "btn-secundary-add");
 
+    setCssProperty(ui->checkboxSubtractFeeFromAmount, "combo-light");
+
     // Button menu
     setCssProperty(ui->btnMenu, "btn-menu");
     ui->btnMenu->setVisible(false);

--- a/src/qt/pivx/sendmultirow.h
+++ b/src/qt/pivx/sendmultirow.h
@@ -50,11 +50,13 @@ public:
     void setAmount(const QString& amount);
     void setAddressAndLabelOrDescription(const QString& address, const QString& message);
     void setFocus();
+    void toggleSubtractFeeFromAmount();
 
     QRect getEditLineRect();
     int getEditHeight();
     int getEditWidth();
     int getMenuBtnWidth();
+    bool getSubtractFeeFromAmount() const;
 
     // Return true if memo was set and false if it was cleared.
     bool launchMemoDialog();

--- a/src/qt/pivx/tooltipmenu.cpp
+++ b/src/qt/pivx/tooltipmenu.cpp
@@ -40,6 +40,12 @@ void TooltipMenu::setLastBtnText(QString btnText, int minHeight){
     ui->btnLast->setMinimumHeight(minHeight);
 }
 
+void TooltipMenu::setLastBtnCheckable(bool checkable, bool isChecked)
+{
+    ui->btnLast->setCheckable(checkable);
+    ui->btnLast->setChecked(isChecked);
+}
+
 void TooltipMenu::setCopyBtnVisible(bool visible){
     ui->btnCopy->setVisible(visible);
 }

--- a/src/qt/pivx/tooltipmenu.h
+++ b/src/qt/pivx/tooltipmenu.h
@@ -39,6 +39,7 @@ public:
     void setDeleteBtnVisible(bool visible);
     void setEditBtnVisible(bool visible);
     void setLastBtnVisible(bool visible);
+    void setLastBtnCheckable(bool checkable, bool isChecked);
 
 Q_SIGNALS:
     void onDeleteClicked();

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -488,7 +488,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
                 // Regular P2PK or P2PKH
                 scriptPubKey = GetScriptForDestination(out);
             }
-            vecSend.emplace_back(scriptPubKey, rcp.amount, false);
+            vecSend.emplace_back(scriptPubKey, rcp.amount, rcp.fSubtractFee);
 
             total += rcp.amount;
         }
@@ -598,9 +598,9 @@ OperationResult WalletModel::PrepareShieldedTransaction(WalletModelTransaction* 
                                                         const CCoinControl* coinControl)
 {
     // Load shieldedAddrRecipients.
-    bool fSubtractFeeFromAmount{false};
     std::vector<SendManyRecipient> recipients;
     for (const auto& recipient : modelTransaction->getRecipients()) {
+        bool fSubtractFeeFromAmount = recipient.fSubtractFee;
         if (recipient.isShieldedAddr) {
             auto pa = KeyIO::DecodeSaplingPaymentAddress(recipient.address.toStdString());
             if (!pa) return errorOut("Error, invalid shielded address");

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -71,6 +71,9 @@ public:
     // Quick flag to not have to check the address type more than once.
     bool isShieldedAddr{false};
 
+    // Whether to subtract the tx fee from this recipient
+    bool fSubtractFee{false};
+
     // Amount
     CAmount amount{0};
     // If from a payment request, this is used for storing the memo

--- a/src/qt/walletmodeltransaction.cpp
+++ b/src/qt/walletmodeltransaction.cpp
@@ -43,6 +43,15 @@ void WalletModelTransaction::setTransactionFee(const CAmount& newFee)
     fee = newFee;
 }
 
+unsigned int WalletModelTransaction::subtractFeeFromRecipents() const
+{
+    unsigned int count = 0;
+    for (const SendCoinsRecipient& rcp : recipients) {
+        if (rcp.fSubtractFee) count++;
+    }
+    return count;
+}
+
 CAmount WalletModelTransaction::getTotalTransactionAmount()
 {
     CAmount totalTransactionAmount = 0;

--- a/src/qt/walletmodeltransaction.h
+++ b/src/qt/walletmodeltransaction.h
@@ -39,6 +39,9 @@ public:
 
     CTransactionRef& getTransaction();
 
+    // return the number of recipients with subtract-fee-from-amount
+    unsigned int subtractFeeFromRecipents() const;
+
     // Whether should create a +v2 tx or go simple and create a v1.
     bool useV2{false};
     bool fIsStakeDelegationVoided{false};


### PR DESCRIPTION
Follow up to #2341.
As per title, add controls for this feature in the graphical interface.

For the moment, it's a simple checkbox, which is visible in case of single recipient.
The confirmation dialog shows the difference in the "total amount" (paid) when the fee is subtracted, or not, from the recipient amount (in the example, sending `1.00 PIV`).

<div>
<img src="https://user-images.githubusercontent.com/18186894/116305097-99fdff80-a7a3-11eb-83a7-35d3d25b8881.png" width="700px"/>

<img src="https://user-images.githubusercontent.com/18186894/116305490-23adcd00-a7a4-11eb-92dc-4b5a68089653.png" width="700px"/>
</div>

---

When there are multiple recipients, the checkbox is hidden, and controlled by a checkable button inside the contextual menu.

<div>
<img src="https://user-images.githubusercontent.com/18186894/116305579-44762280-a7a4-11eb-84dc-30ac3a7f29ce.png" width="600px" margin="center"/>
</div>


Maybe this is not very intuitive, or pretty, but it does the job.
Later on, possibly with the help of @Neoperol, we can design a better placement for these controls.

Closes #894
Closes #2196 

Obviously based on top of
- [x] #2341 

which must be reviewed before this one.

