### PR TITLE
[Validation][RPC] Provider-Update-Service special tx type

### DIFF
--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -294,7 +294,7 @@ bool CheckProUpServTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVa
             return state.DoS(10, false, REJECT_DUPLICATE, "bad-protx-dup-addr");
         }
 
-        if (pl.scriptOperatorPayout != CScript()) {
+        if (!pl.scriptOperatorPayout.empty()) {
             if (mn->nOperatorReward == 0) {
                 // don't allow to set operator reward payee in case no operatorReward was set
                 return state.DoS(10, false, REJECT_INVALID, "bad-protx-operator-payee");

--- a/src/evo/providertx.h
+++ b/src/evo/providertx.h
@@ -68,7 +68,42 @@ public:
     void ToJson(UniValue& obj) const;
 };
 
+class ProUpServPL
+{
+public:
+    static const uint16_t CURRENT_VERSION = 1;
+
+public:
+    uint16_t nVersion{CURRENT_VERSION}; // message version
+    uint256 proTxHash{UINT256_ZERO};
+    CService addr;
+    CScript scriptOperatorPayout;
+    uint256 inputsHash; // replay protection
+    std::vector<unsigned char> vchSig;
+
+public:
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(nVersion);
+        READWRITE(proTxHash);
+        READWRITE(addr);
+        READWRITE(scriptOperatorPayout);
+        READWRITE(inputsHash);
+        if (!(s.GetType() & SER_GETHASH)) {
+            READWRITE(vchSig);
+        }
+    }
+
+public:
+    std::string ToString() const;
+    void ToJson(UniValue& obj) const;
+};
+
 bool CheckProRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state);
+bool CheckProUpServTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state);
 
 // If tx is a ProRegTx, return the collateral outpoint in outRet.
 bool GetProRegCollateral(const CTransactionRef& tx, COutPoint& outRet);

--- a/src/evo/specialtx.cpp
+++ b/src/evo/specialtx.cpp
@@ -73,6 +73,10 @@ bool CheckSpecialTxNoContext(const CTransaction& tx, CValidationState& state)
             // provider-register
             return CheckProRegTx(tx, nullptr, state);
         }
+        case CTransaction::TxType::PROUPSERV: {
+            // provider-update-service
+            return CheckProUpServTx(tx, nullptr, state);
+        }
     }
 
     return state.DoS(10, error("%s: special tx %s with invalid type %d", __func__, tx.GetHash().ToString(), tx.nType),
@@ -104,6 +108,10 @@ bool CheckSpecialTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVali
         case CTransaction::TxType::PROREG: {
             // provider-register
             return CheckProRegTx(tx, pindexPrev, state);
+        }
+        case CTransaction::TxType::PROUPSERV: {
+            // provider-update-service
+            return CheckProUpServTx(tx, pindexPrev, state);
         }
     }
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -273,6 +273,7 @@ public:
     enum TxType: int16_t {
         NORMAL = 0,
         PROREG = 1,
+        PROUPSERV = 2,
     };
 
     static const int16_t CURRENT_VERSION = TxVersion::LEGACY;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -349,6 +349,11 @@ public:
 
     bool IsNormalType() const { return nType == TxType::NORMAL; }
 
+    bool IsProRegTx() const
+    {
+        return IsSpecialTx() && nType == TxType::PROREG;
+    }
+
     // Ensure that special and sapling fields are signed
     SigVersion GetRequiredSigVersion() const
     {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -52,6 +52,11 @@ static void PayloadToJSON(const CTransaction& tx, UniValue& entry)
             PayloadToJSON(tx, pl, entry);
             break;
         }
+        case CTransaction::TxType::PROUPSERV: {
+            ProUpServPL pl;
+            PayloadToJSON(tx, pl, entry);
+            break;
+        }
     }
 }
 

--- a/src/test/evo_specialtx_tests.cpp
+++ b/src/test/evo_specialtx_tests.cpp
@@ -47,7 +47,18 @@ static ProRegPL GetRandomProRegPayload()
     return pl;
 }
 
-BOOST_AUTO_TEST_CASE(special_tx_validation_test)
+static ProUpServPL GetRandomProUpServPayload()
+{
+    ProUpServPL pl;
+    pl.proTxHash = GetRandHash();
+    BOOST_CHECK(Lookup("127.0.0.1:51472", pl.addr, Params().GetDefaultPort(), false));
+    pl.scriptOperatorPayout = GetRandomScript();
+    pl.inputsHash = GetRandHash();
+    pl.vchSig = InsecureRandBytes(63);
+    return pl;
+}
+
+BOOST_AUTO_TEST_CASE(protx_validation_test)
 {
     CMutableTransaction mtx;
     CValidationState state;
@@ -100,7 +111,7 @@ BOOST_AUTO_TEST_CASE(special_tx_validation_test)
     BOOST_CHECK(CheckSpecialTxNoContext(CTransaction(mtx), state));
 }
 
-BOOST_AUTO_TEST_CASE(providertx_setpayload_test)
+BOOST_AUTO_TEST_CASE(proreg_setpayload_test)
 {
     const ProRegPL& pl = GetRandomProRegPayload();
 
@@ -120,7 +131,22 @@ BOOST_AUTO_TEST_CASE(providertx_setpayload_test)
     BOOST_CHECK(pl.vchSig == pl2.vchSig);
 }
 
-BOOST_AUTO_TEST_CASE(providertx_checkstringsig_test)
+BOOST_AUTO_TEST_CASE(proupserv_setpayload_test)
+{
+    const ProUpServPL& pl = GetRandomProUpServPayload();
+
+    CMutableTransaction mtx;
+    SetTxPayload(mtx, pl);
+    ProUpServPL pl2;
+    BOOST_CHECK(GetTxPayload(mtx, pl2));
+    BOOST_CHECK(pl.proTxHash == pl2.proTxHash);
+    BOOST_CHECK(pl.addr  == pl2.addr);
+    BOOST_CHECK(pl.scriptOperatorPayout == pl2.scriptOperatorPayout);
+    BOOST_CHECK(pl.inputsHash == pl2.inputsHash);
+    BOOST_CHECK(pl.vchSig == pl2.vchSig);
+}
+
+BOOST_AUTO_TEST_CASE(proreg_checkstringsig_test)
 {
     ProRegPL pl = GetRandomProRegPayload();
     pl.vchSig.clear();

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -665,6 +665,7 @@ public:
     std::vector<TxMempoolInfo> infoAll() const;
 
     bool existsProviderTxConflict(const CTransaction &tx) const;
+    void removeProTxReferences(const uint256& proTxHash, MemPoolRemovalReason reason);
 
     /** Estimate fee rate needed to get into the next nBlocks
      *  If no answer can be given at nBlocks, return an estimate

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -557,10 +557,6 @@ public:
     void removeForReorg(const CCoinsViewCache* pcoins, unsigned int nMemPoolHeight, int flags);
     void removeWithAnchor(const uint256& invalidRoot);
     void removeConflicts(const CTransaction& tx);
-    void removeProTxPubKeyConflicts(const CTransaction &tx, const CKeyID &keyId);
-    void removeProTxCollateralConflicts(const CTransaction &tx, const COutPoint &collateralOutpoint);
-    void removeProTxSpentCollateralConflicts(const CTransaction &tx);
-    void removeProTxConflicts(const CTransaction &tx);
     void removeForBlock(const std::vector<CTransactionRef>& vtx, unsigned int nBlockHeight,
                         bool fCurrentEstimate = true);
 
@@ -735,6 +731,15 @@ private:
      *  removal.
      */
     void removeUnchecked(txiter entry, MemPoolRemovalReason reason = MemPoolRemovalReason::UNKNOWN);
+
+    /** Special txes **/
+    void addUncheckedSpecialTx(const CTransaction& tx);
+    void removeUncheckedSpecialTx(const CTransaction& tx);
+    void removeProTxPubKeyConflicts(const CTransaction &tx, const CKeyID &keyId);
+    void removeProTxCollateralConflicts(const CTransaction &tx, const COutPoint &collateralOutpoint);
+    void removeProTxSpentCollateralConflicts(const CTransaction &tx);
+    void removeProTxConflicts(const CTransaction &tx);
+
 };
 
 /** 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -360,6 +360,11 @@ void UpdateMempoolForReorg(DisconnectedBlockTransactions &disconnectpool, bool f
     // been previously seen in a block.
     auto it = disconnectpool.queuedTx.get<insertion_order>().rbegin();
     while (it != disconnectpool.queuedTx.get<insertion_order>().rend()) {
+        // if we are resurrecting a ProReg tx, we need to evict any special transaction that
+        // depends on it (which would not be accepted in the mempool, with the current chain)
+        if ((*it)->IsProRegTx()) {
+            mempool.removeProTxReferences((*it)->GetHash(), MemPoolRemovalReason::REORG);
+        }
         // ignore validation errors in resurrected transactions
         CValidationState stateDummy;
         if (!fAddToMempool || (*it)->IsCoinBase() || (*it)->IsCoinStake() ||

--- a/test/functional/tiertwo_reorg_mempool.py
+++ b/test/functional/tiertwo_reorg_mempool.py
@@ -258,12 +258,12 @@ class TiertwoReorgMempoolTest(PivxTestFramework):
         self.check_mn_list_on_node(0, mnsB)
         self.check_mn_list_on_node(1, mnsB)
 
+        self.log.info("Checking mempool...")
+        mempoolA = nodeA.getrawmempool()
         # The first mempool proReg tx has been removed from nodeA's mempool due to
         # conflicts with the masternodes of chain B, now connected.
         # The fourth mempool proReg tx has been removed because the collateral it
         # was referencing has been disconnected.
-        self.log.info("Checking mempool...")
-        mempoolA = nodeA.getrawmempool()
         assert mempool_dmn1.proTx not in mempoolA
         assert mempool_dmn2.proTx in mempoolA
         assert mempool_dmn3.proTx in mempoolA
@@ -273,7 +273,6 @@ class TiertwoReorgMempoolTest(PivxTestFramework):
         # The second mempool proUpServ tx has been removed as it was meant to update
         # a masternode that is not in the deterministic list anymore.
         assert proupserv1_txid not in mempoolA
-        # !TODO: fix me - failing because we don't evict ProTx depending on resurrected ProReg
         assert proupserv2_txid not in mempoolA
         assert proupserv3_txid in mempoolA
         # The mempool contains also all the ProReg from the disconnected blocks,


### PR DESCRIPTION
Exctracted from #2267
This PR:
- introduces the `PROUPSERV` payload and transaction type.
This special transaction is submitted by the operator (the payload must be signed with the operator key) to update the IP/port fields.
If the original ProReg transaction set a non-zero operatorReward, this payload can also be used to update the operator's payout address.

- adds the new RPC `protx_update_service` to create ProUpServ transactions

- adds unit and functional testing

Builds on top of:
- [x] #2345 