### PR TITLE
[Tests][Refactoring] Remove mocked budget manager in budget_tests

### DIFF
--- a/src/budget/budgetmanager.cpp
+++ b/src/budget/budgetmanager.cpp
@@ -217,18 +217,22 @@ bool CBudgetManager::AddFinalizedBudget(CFinalizedBudget& finalizedBudget)
     }
 
     SetBudgetProposalsStr(finalizedBudget);
-    {
-        LOCK(cs_budgets);
-        mapFinalizedBudgets.emplace(nHash, finalizedBudget);
-        // Add to feeTx index
-        mapFeeTxToBudget.emplace(feeTxId, nHash);
-        // Remove the budget from the unconfirmed map, if it was there
-        if (mapUnconfirmedFeeTx.count(nHash))
-            mapUnconfirmedFeeTx.erase(nHash);
-    }
+    ForceAddFinalizedBudget(nHash, feeTxId, finalizedBudget);
+
     LogPrint(BCLog::MNBUDGET,"%s: finalized budget %s [%s (%s)] added\n",
             __func__, nHash.ToString(), finalizedBudget.GetName(), finalizedBudget.GetProposalsStr());
     return true;
+}
+
+void CBudgetManager::ForceAddFinalizedBudget(const uint256& nHash, const uint256& feeTxId, const CFinalizedBudget& finalizedBudget)
+{
+    LOCK(cs_budgets);
+    mapFinalizedBudgets.emplace(nHash, finalizedBudget);
+    // Add to feeTx index
+    mapFeeTxToBudget.emplace(feeTxId, nHash);
+    // Remove the budget from the unconfirmed map, if it was there
+    if (mapUnconfirmedFeeTx.count(nHash))
+        mapUnconfirmedFeeTx.erase(nHash);
 }
 
 bool CBudgetManager::AddProposal(CBudgetProposal& budgetProposal)

--- a/src/budget/budgetmanager.h
+++ b/src/budget/budgetmanager.h
@@ -119,6 +119,7 @@ public:
     bool IsBudgetPaymentBlock(int nBlockHeight, int& nCountThreshold) const;
     bool AddProposal(CBudgetProposal& budgetProposal);
     bool AddFinalizedBudget(CFinalizedBudget& finalizedBudget);
+    void ForceAddFinalizedBudget(const uint256& nHash, const uint256& feeTxId, const CFinalizedBudget& finalizedBudget);
     uint256 SubmitFinalBudget();
 
     bool UpdateProposal(const CBudgetVote& vote, CNode* pfrom, std::string& strError);

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -74,9 +74,8 @@ void CSporkManager::LoadSporksFromDB()
         }
 
         // add spork to memory
-        AddSporkMessage(spork);
-        mapSporks[spork.GetHash()] = spork;
-        mapSporksActive[spork.nSporkID] = spork;
+        AddOrUpdateSporkMessage(spork);
+
         std::time_t result = spork.nValue;
         // If SPORK Value is greater than 1,000,000 assume it's actually a Date and then convert to a more readable format
         std::string sporkName = sporkManager.GetSporkNameByID(spork.nSporkID);
@@ -173,7 +172,7 @@ int CSporkManager::ProcessSporkMsg(CSporkMessage& spork)
     LogPrintf("%s : got %s spork %d (%s) with value %d (signed at %d)\n", __func__,
               strStatus, spork.nSporkID, sporkName, spork.nValue, spork.nTimeSigned);
 
-    AddSporkMessage(spork);
+    AddOrUpdateSporkMessage(spork);
     spork.Relay();
 
     // PIVX: add to spork database.
@@ -207,14 +206,14 @@ bool CSporkManager::UpdateSpork(SporkId nSporkID, int64_t nValue)
 
     if(spork.Sign(strMasterPrivKey)){
         spork.Relay();
-        AddSporkMessage(spork);
+        AddOrUpdateSporkMessage(spork);
         return true;
     }
 
     return false;
 }
 
-void CSporkManager::AddSporkMessage(const CSporkMessage& spork)
+void CSporkManager::AddOrUpdateSporkMessage(const CSporkMessage& spork)
 {
     LOCK(cs);
     mapSporks[spork.GetHash()] = spork;

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -74,6 +74,7 @@ void CSporkManager::LoadSporksFromDB()
         }
 
         // add spork to memory
+        AddSporkMessage(spork);
         mapSporks[spork.GetHash()] = spork;
         mapSporksActive[spork.nSporkID] = spork;
         std::time_t result = spork.nValue;
@@ -131,7 +132,6 @@ int CSporkManager::ProcessSporkMsg(CSporkMessage& spork)
         return 0;
     }
 
-    uint256 hash = spork.GetHash();
     std::string sporkName = sporkManager.GetSporkNameByID(spork.nSporkID);
     std::string strStatus;
     {
@@ -173,11 +173,7 @@ int CSporkManager::ProcessSporkMsg(CSporkMessage& spork)
     LogPrintf("%s : got %s spork %d (%s) with value %d (signed at %d)\n", __func__,
               strStatus, spork.nSporkID, sporkName, spork.nValue, spork.nTimeSigned);
 
-    {
-        LOCK(cs);
-        mapSporks[hash] = spork;
-        mapSporksActive[spork.nSporkID] = spork;
-    }
+    AddSporkMessage(spork);
     spork.Relay();
 
     // PIVX: add to spork database.

--- a/src/spork.h
+++ b/src/spork.h
@@ -111,7 +111,7 @@ public:
     // Create/Sign/Relay the spork message, and update the maps
     bool UpdateSpork(SporkId nSporkID, int64_t nValue);
     // Add spork message to mapSporks and mapSporksActive
-    void AddSporkMessage(const CSporkMessage& spork);
+    void AddOrUpdateSporkMessage(const CSporkMessage& spork);
 
     bool IsSporkActive(SporkId nSporkID);
     std::string GetSporkNameByID(SporkId id);

--- a/src/spork.h
+++ b/src/spork.h
@@ -108,7 +108,6 @@ public:
 
     void ProcessSpork(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
     int64_t GetSporkValue(SporkId nSporkID);
-    void ExecuteSpork(SporkId nSporkID, int nValue);
     // Create/Sign/Relay the spork message, and update the maps
     bool UpdateSpork(SporkId nSporkID, int64_t nValue);
     // Add spork message to mapSporks and mapSporksActive

--- a/src/test/budget_tests.cpp
+++ b/src/test/budget_tests.cpp
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(block_value)
     // enable SPORK_13
     int64_t nTime = GetTime() - 10;
     const CSporkMessage& spork = CSporkMessage(SPORK_13_ENABLE_SUPERBLOCKS, nTime + 1, nTime);
-    sporkManager.AddSporkMessage(spork);
+    sporkManager.AddOrUpdateSporkMessage(spork);
     BOOST_CHECK(sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS));
 
     // regular block
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE(block_value)
 
     // disable SPORK_13
     const CSporkMessage& spork2 = CSporkMessage(SPORK_13_ENABLE_SUPERBLOCKS, 4070908800ULL, nTime + 1);
-    sporkManager.AddSporkMessage(spork2);
+    sporkManager.AddOrUpdateSporkMessage(spork2);
     BOOST_CHECK(!sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS));
 
     // check with spork disabled
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE(IsCoinbaseValueValid_test)
     // enable SPORK_8
     int64_t nTime = GetTime() - 10;
     const CSporkMessage& spork = CSporkMessage(SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT, nTime + 1, nTime);
-    sporkManager.AddSporkMessage(spork);
+    sporkManager.AddOrUpdateSporkMessage(spork);
     BOOST_CHECK(sporkManager.IsSporkActive(SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT));
 
     // Underpaying with SPORK_8 enabled

--- a/src/test/budget_tests.cpp
+++ b/src/test/budget_tests.cpp
@@ -14,30 +14,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-class BudgetManagerTest : CBudgetManager
-{
-public:
-    void ForceAddFinalizedBudget(CFinalizedBudget& finalizedBudget)
-    {
-        LOCK(cs_budgets);
-        const uint256& nHash = finalizedBudget.GetHash();
-        mapFinalizedBudgets.emplace(nHash, finalizedBudget);
-        mapFeeTxToBudget.emplace(finalizedBudget.GetFeeTXHash(), nHash);
-    }
-
-    bool IsBlockValueValid(int nHeight, CAmount nExpectedValue, CAmount nMinted, bool fSporkActive = true)
-    {
-        // suppose masternodeSync is complete
-        if (fSporkActive) {
-            // add current payee amount to the expected block value
-            CAmount expectedPayAmount;
-            if (GetExpectedPayeeAmount(nHeight, expectedPayAmount)) {
-                nExpectedValue += expectedPayAmount;
-            }
-        }
-        return nMinted <= nExpectedValue;
-    }
-};
 
 BOOST_FIXTURE_TEST_SUITE(budget_tests, TestingSetup)
 
@@ -63,20 +39,35 @@ BOOST_AUTO_TEST_CASE(budget_value)
 
 BOOST_AUTO_TEST_CASE(block_value)
 {
-    BudgetManagerTest t_budgetman;
     SelectParams(CBaseChainParams::TESTNET);
     std::string strError;
 
+    // force mnsync complete
+    masternodeSync.RequestedMasternodeAssets = MASTERNODE_SYNC_FINISHED;
+
+    // enable SPORK_13
+    int64_t nTime = GetTime() - 10;
+    const CSporkMessage& spork = CSporkMessage(SPORK_13_ENABLE_SUPERBLOCKS, nTime + 1, nTime);
+    sporkManager.AddSporkMessage(spork);
+    BOOST_CHECK(sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS));
+
     // regular block
     int nHeight = 100;
-    volatile CAmount nExpected = GetBlockValue(nHeight);
-    BOOST_CHECK(t_budgetman.IsBlockValueValid(nHeight, nExpected, nExpected-1));
-    BOOST_CHECK(t_budgetman.IsBlockValueValid(nHeight, nExpected, nExpected));
-    BOOST_CHECK(!t_budgetman.IsBlockValueValid(nHeight, nExpected, nExpected+1));
+    const CAmount nBlockReward = GetBlockValue(nHeight);
+    CAmount nExpectedRet = nBlockReward;
+    CAmount nBudgetAmtRet = 0;
+    BOOST_CHECK(IsBlockValueValid(nHeight, nExpectedRet, nBlockReward-1, nBudgetAmtRet));
+    BOOST_CHECK_EQUAL(nExpectedRet, nBlockReward);
+    BOOST_CHECK_EQUAL(nBudgetAmtRet, 0);
+    BOOST_CHECK(IsBlockValueValid(nHeight, nExpectedRet, nBlockReward, nBudgetAmtRet));
+    BOOST_CHECK_EQUAL(nExpectedRet, nBlockReward);
+    BOOST_CHECK_EQUAL(nBudgetAmtRet, 0);
+    BOOST_CHECK(!IsBlockValueValid(nHeight, nExpectedRet, nBlockReward+1, nBudgetAmtRet));
+    BOOST_CHECK_EQUAL(nExpectedRet, nBlockReward);
+    BOOST_CHECK_EQUAL(nBudgetAmtRet, 0);
 
     // superblock - create the finalized budget with a proposal, and vote on it
     nHeight = 144;
-    nExpected = GetBlockValue(nHeight);
     const CTxIn mnVin(GetRandHash(), 0);
     const CScript payee = GetScriptForDestination(CKeyID(uint160(ParseHex("816115944e077fe7c803cfa57f29b36bf87c1d35"))));
     const CAmount propAmt = 100 * COIN;
@@ -85,20 +76,50 @@ BOOST_AUTO_TEST_CASE(block_value)
     CFinalizedBudget fin("main (test)", 144, {txBudgetPayment}, finTxId);
     const CFinalizedBudgetVote fvote(mnVin, fin.GetHash());
     BOOST_CHECK(fin.AddOrUpdateVote(fvote, strError));
-    t_budgetman.ForceAddFinalizedBudget(fin);
+    g_budgetman.ForceAddFinalizedBudget(fin.GetHash(), fin.GetFeeTXHash(), fin);
 
     // check superblock's block-value
-    BOOST_CHECK(t_budgetman.IsBlockValueValid(nHeight, nExpected, nExpected));
-    BOOST_CHECK(t_budgetman.IsBlockValueValid(nHeight, nExpected, nExpected+propAmt-1));
-    BOOST_CHECK(t_budgetman.IsBlockValueValid(nHeight, nExpected, nExpected+propAmt));
-    BOOST_CHECK(!t_budgetman.IsBlockValueValid(nHeight, nExpected, nExpected+propAmt+1));
+    nExpectedRet = nBlockReward;
+    nBudgetAmtRet = 0;
+    BOOST_CHECK(IsBlockValueValid(nHeight, nExpectedRet, nBlockReward, nBudgetAmtRet));
+    BOOST_CHECK_EQUAL(nExpectedRet, nBlockReward + propAmt);
+    BOOST_CHECK_EQUAL(nBudgetAmtRet, propAmt);
+    nExpectedRet = nBlockReward;
+    nBudgetAmtRet = 0;
+    BOOST_CHECK(IsBlockValueValid(nHeight, nExpectedRet, nBlockReward+propAmt-1, nBudgetAmtRet));
+    BOOST_CHECK_EQUAL(nExpectedRet, nBlockReward + propAmt);
+    BOOST_CHECK_EQUAL(nBudgetAmtRet, propAmt);
+    nExpectedRet = nBlockReward;
+    nBudgetAmtRet = 0;
+    BOOST_CHECK(IsBlockValueValid(nHeight, nExpectedRet, nBlockReward+propAmt, nBudgetAmtRet));
+    BOOST_CHECK_EQUAL(nExpectedRet, nBlockReward + propAmt);
+    BOOST_CHECK_EQUAL(nBudgetAmtRet, propAmt);
+    nExpectedRet = nBlockReward;
+    nBudgetAmtRet = 0;
+    BOOST_CHECK(!IsBlockValueValid(nHeight, nExpectedRet, nBlockReward+propAmt+1, nBudgetAmtRet));
+    BOOST_CHECK_EQUAL(nExpectedRet, nBlockReward + propAmt);
+    BOOST_CHECK_EQUAL(nBudgetAmtRet, propAmt);
+
+    // disable SPORK_13
+    const CSporkMessage& spork2 = CSporkMessage(SPORK_13_ENABLE_SUPERBLOCKS, 4070908800ULL, nTime + 1);
+    sporkManager.AddSporkMessage(spork2);
+    BOOST_CHECK(!sporkManager.IsSporkActive(SPORK_13_ENABLE_SUPERBLOCKS));
 
     // check with spork disabled
-    nExpected = GetBlockValue(nHeight);
-    BOOST_CHECK(t_budgetman.IsBlockValueValid(nHeight, nExpected, nExpected-1, false));
-    BOOST_CHECK(t_budgetman.IsBlockValueValid(nHeight, nExpected, nExpected, false));
-    BOOST_CHECK(!t_budgetman.IsBlockValueValid(nHeight, nExpected, nExpected+1, false));
-    BOOST_CHECK(!t_budgetman.IsBlockValueValid(nHeight, nExpected, nExpected+propAmt, false));
+    nExpectedRet = nBlockReward;
+    nBudgetAmtRet = 0;
+    BOOST_CHECK(IsBlockValueValid(nHeight, nExpectedRet, nBlockReward, nBudgetAmtRet));
+    BOOST_CHECK_EQUAL(nExpectedRet, nBlockReward);
+    BOOST_CHECK_EQUAL(nBudgetAmtRet, 0);
+    BOOST_CHECK(!IsBlockValueValid(nHeight, nExpectedRet, nBlockReward+propAmt-1, nBudgetAmtRet));
+    BOOST_CHECK_EQUAL(nExpectedRet, nBlockReward);
+    BOOST_CHECK_EQUAL(nBudgetAmtRet, 0);
+    BOOST_CHECK(!IsBlockValueValid(nHeight, nExpectedRet, nBlockReward+propAmt, nBudgetAmtRet));
+    BOOST_CHECK_EQUAL(nExpectedRet, nBlockReward);
+    BOOST_CHECK_EQUAL(nBudgetAmtRet, 0);
+    BOOST_CHECK(!IsBlockValueValid(nHeight, nExpectedRet, nBlockReward+propAmt+1, nBudgetAmtRet));
+    BOOST_CHECK_EQUAL(nExpectedRet, nBlockReward);
+    BOOST_CHECK_EQUAL(nBudgetAmtRet, 0);
 }
 
 static CScript GetRandomP2PKH()


### PR DESCRIPTION
Extracted from:

- [x] #2274 

and based on top of it.

Forcing the update of the spork message and finalized budget, we can test the actual `IsBlockValueValid` function.

This also refactors the spork code to update the maps in a single place, as suggested by @furszy here https://github.com/PIVX-Project/PIVX/pull/2274#discussion_r623126302.