### PR TITLE
[Refactoring] Move automatic-wallet-backup code out of init.cpp

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -871,12 +871,7 @@ bool AppInitBasicSetup()
         return UIError("Error: Initializing networking failed");
 
 #ifndef WIN32
-    if (gArgs.GetBoolArg("-sysperms", false)) {
-#ifdef ENABLE_WALLET
-        if (!gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET))
-            return UIError("Error: -sysperms is not allowed in combination with enabled wallet functionality");
-#endif
-    } else {
+    if (!gArgs.GetBoolArg("-sysperms", false)) {
         umask(077);
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -839,7 +839,6 @@ namespace { // Variables internal to initialization process only
     ServiceFlags nLocalServices = NODE_NETWORK;
 
     std::string strWalletFile;
-    bool fDisableWallet = false;
 }
 
 bool AppInitBasicSetup()
@@ -1137,18 +1136,14 @@ bool AppInitParameterInteraction()
     setvbuf(stdout, NULL, _IOLBF, 0); /// ***TODO*** do we still need this after -printtoconsole is gone?
 
     RegisterAllCoreRPCCommands(tableRPC);
+
     // Staking needs a CWallet instance, so make sure wallet is enabled
 #ifdef ENABLE_WALLET
-    bool fDisableWallet = gArgs.GetBoolArg("-disablewallet", false);
-    if (fDisableWallet) {
-#endif
-        if (gArgs.SoftSetBoolArg("-staking", false))
-            LogPrintf("AppInit2 : parameter interaction: wallet functionality not enabled -> setting -staking=0\n");
-#ifdef ENABLE_WALLET
-    } else {
-        // Register wallet RPC commands
-        RegisterWalletRPCCommands(tableRPC);
-    }
+    // Register wallet RPC commands
+    RegisterWalletRPCCommands(tableRPC);
+#else
+    if (gArgs.SoftSetBoolArg("-staking", false))
+        LogPrintf("AppInit2 : parameter interaction: wallet functionality not enabled -> setting -staking=0\n");
 #endif
 
     nConnectTimeout = gArgs.GetArg("-timeout", DEFAULT_CONNECT_TIMEOUT);
@@ -1315,7 +1310,7 @@ bool AppInitMain()
 
 // ********************************************************* Step 5: Backup wallet and verify wallet database integrity
 #ifdef ENABLE_WALLET
-    if (!fDisableWallet) {
+    // not fixing indentation as this block of code will be moved away from here in the following commits
         fs::path backupDir = GetDataDir() / "backups";
         if (!fs::exists(backupDir)) {
             // Always create backup folder to not confuse the operating system's file browser
@@ -1422,7 +1417,6 @@ bool AppInitMain()
         if (!CWallet::Verify())
             return false;
 
-    }  // (!fDisableWallet)
 #endif // ENABLE_WALLET
 
     // ********************************************************* Step 6: network initialization

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -873,7 +873,7 @@ bool AppInitBasicSetup()
 #ifndef WIN32
     if (gArgs.GetBoolArg("-sysperms", false)) {
 #ifdef ENABLE_WALLET
-        if (!gArgs.GetBoolArg("-disablewallet", false))
+        if (!gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET))
             return UIError("Error: -sysperms is not allowed in combination with enabled wallet functionality");
 #endif
     } else {

--- a/src/qt/pivx/pivxgui.cpp
+++ b/src/qt/pivx/pivxgui.cpp
@@ -59,7 +59,7 @@ PIVXGUI::PIVXGUI(const NetworkStyle* networkStyle, QWidget* parent) :
 
 #ifdef ENABLE_WALLET
     /* if compiled with wallet support, -disablewallet can still disable the wallet */
-    enableWallet = !gArgs.GetBoolArg("-disablewallet", false);
+    enableWallet = !gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET);
 #else
     enableWallet = false;
 #endif // ENABLE_WALLET

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4154,6 +4154,10 @@ static const CRPCCommand commands[] =
 
 void RegisterWalletRPCCommands(CRPCTable &tableRPC)
 {
-    for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++)
+    if (gArgs.GetBoolArg("-disablewallet", false)) {
+        return;
+    }
+    for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++) {
         tableRPC.appendCommand(commands[vcidx].name, &commands[vcidx]);
+    }
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -650,6 +650,10 @@ bool CWallet::ParameterInteraction()
         return true;
     }
 
+    if (gArgs.GetBoolArg("-sysperms", false)) {
+        return UIError("-sysperms is not allowed in combination with enabled wallet functionality");
+    }
+
     if (gArgs.IsArgSet("-mintxfee")) {
         CAmount n = 0;
         if (ParseMoney(gArgs.GetArg("-mintxfee", ""), n) && n > 0)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -646,7 +646,7 @@ void CWallet::SyncMetaData(std::pair<typename TxSpendMap<T>::iterator, typename 
 
 bool CWallet::ParameterInteraction()
 {
-    if (gArgs.GetBoolArg("-disablewallet", false)) {
+    if (gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET)) {
         return true;
     }
 
@@ -2067,7 +2067,7 @@ std::set<uint256> CWalletTx::GetConflicts() const
 
 bool CWallet::Verify()
 {
-    if (gArgs.GetBoolArg("-disablewallet", false)) {
+    if (gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET)) {
         return true;
     }
 
@@ -4090,7 +4090,7 @@ std::string CWallet::GetWalletHelpString(bool showDebug)
     strUsage += HelpMessageOpt("-backuppath=<dir|file>", _("Specify custom backup path to add a copy of any wallet backup. If set as dir, every backup generates a timestamped file. If set as file, will rewrite to that file every backup."));
     strUsage += HelpMessageOpt("-createwalletbackups=<n>", strprintf(_("Number of automatic wallet backups (default: %d)"), DEFAULT_CREATEWALLETBACKUPS));
     strUsage += HelpMessageOpt("-custombackupthreshold=<n>", strprintf(_("Number of custom location backups to retain (default: %d)"), DEFAULT_CUSTOMBACKUPTHRESHOLD));
-    strUsage += HelpMessageOpt("-disablewallet", _("Do not load the wallet and disable wallet RPC calls"));
+    strUsage += HelpMessageOpt("-disablewallet", strprintf(_("Do not load the wallet and disable wallet RPC calls (default: %u)"), DEFAULT_DISABLE_WALLET));
     strUsage += HelpMessageOpt("-keypool=<n>", strprintf(_("Set key pool size to <n> (default: %u)"), DEFAULT_KEYPOOL_SIZE));
     strUsage += HelpMessageOpt("-legacywallet", _("On first run, create a legacy wallet instead of a HD wallet"));
     strUsage += HelpMessageOpt("-maxtxfee=<amt>", strprintf(_("Maximum total fees to use in a single wallet transaction, setting too low may abort large transactions (default: %s)"), FormatMoney(maxTxFee)));

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -646,6 +646,10 @@ void CWallet::SyncMetaData(std::pair<typename TxSpendMap<T>::iterator, typename 
 
 bool CWallet::ParameterInteraction()
 {
+    if (gArgs.GetBoolArg("-disablewallet", false)) {
+        return true;
+    }
+
     if (gArgs.IsArgSet("-mintxfee")) {
         CAmount n = 0;
         if (ParseMoney(gArgs.GetArg("-mintxfee", ""), n) && n > 0)
@@ -2063,6 +2067,10 @@ std::set<uint256> CWalletTx::GetConflicts() const
 
 bool CWallet::Verify()
 {
+    if (gArgs.GetBoolArg("-disablewallet", false)) {
+        return true;
+    }
+
     uiInterface.InitMessage(_("Verifying wallet..."));
     std::string walletFile = gArgs.GetArg("-wallet", DEFAULT_WALLET_DAT);
     std::string strDataDir = GetDataDir().string();

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2014 The Bitcoin developers
+// Copyright (c) 2009-2021 The Bitcoin developers
 // Copyright (c) 2014-2015 The Dash developers
-// Copyright (c) 2015-2020 The PIVX developers
+// Copyright (c) 2015-2021 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -4856,3 +4856,20 @@ const CWDestination* CAddressBookIterator::GetDestKey()
 CStakeableOutput::CStakeableOutput(const CWalletTx* txIn, int iIn, int nDepthIn, bool fSpendableIn, bool fSolvableIn,
                                    const CBlockIndex*& _pindex) : COutput(txIn, iIn, nDepthIn, fSpendableIn, fSolvableIn),
                                                                 pindex(_pindex) {}
+
+bool InitAutoBackupWallet()
+{
+    if (gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET)) {
+        return true;
+    }
+
+    std::string strWalletFile = gArgs.GetArg("-wallet", DEFAULT_WALLET_DAT);
+
+    std::string strWarning, strError;
+    if(!AutoBackupWallet(strWalletFile, strWarning, strError)) {
+        if (!strWarning.empty()) UIWarning(strWarning);
+        if (!strError.empty()) return UIError(strError);
+    }
+
+    return true;
+}

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1,12 +1,12 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2014 The Bitcoin developers
+// Copyright (c) 2009-2021 The Bitcoin developers
 // Copyright (c) 2014-2015 The Dash developers
-// Copyright (c) 2015-2020 The PIVX developers
+// Copyright (c) 2015-2021 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_WALLET_H
-#define BITCOIN_WALLET_H
+#ifndef PIVX_WALLET_H
+#define PIVX_WALLET_H
 
 #include "addressbook.h"
 #include "amount.h"
@@ -1267,4 +1267,7 @@ public:
     }
 };
 
-#endif // BITCOIN_WALLET_H
+// !TODO: move to wallet/init.*
+bool InitAutoBackupWallet();
+
+#endif // PIVX_WALLET_H

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -11,6 +11,7 @@
 
 #include "base58.h"
 #include "protocol.h"
+#include "reverse_iterate.h"
 #include "sapling/key_io_sapling.h"
 #include "serialize.h"
 #include "sync.h"
@@ -868,6 +869,97 @@ std::pair<fs::path, fs::path> GetBackupPath(const CWallet& wallet)
         }
     }
     return {pathCustom, pathWithFile};
+}
+
+bool AutoBackupWallet(const std::string& strWalletFile, std::string& strBackupWarning, std::string& strBackupError)
+{
+    strBackupWarning = strBackupError = "";
+
+    int nWalletBackups = gArgs.GetArg("-createwalletbackups", DEFAULT_CREATEWALLETBACKUPS);
+    nWalletBackups = std::max(0, std::min(10, nWalletBackups));
+
+    if (nWalletBackups == 0) {
+        LogPrintf("Automatic wallet backups are disabled!\n");
+        return false;
+    }
+
+    fs::path backupsDir = GetDataDir() / "backups";
+    if (!fs::exists(backupsDir)) {
+        // Always create backup folder to not confuse the operating system's file browser
+        LogPrintf("Creating backup folder %s\n", backupsDir.string());
+        if(!fs::create_directories(backupsDir)) {
+            // smth is wrong, we shouldn't continue until it's resolved
+            strBackupError = strprintf(_("Wasn't able to create wallet backup folder %s!"), backupsDir.string());
+            LogPrintf("%s\n", strBackupError);
+            nWalletBackups = -1;
+            return false;
+        }
+    }
+    // Create backup of the ...
+    std::string dateTimeStr = FormatISO8601DateTimeForBackup(GetTime());
+
+    // ... strWalletFile file
+    fs::path sourceFile = GetDataDir() / strWalletFile;
+    fs::path backupFile = backupsDir / (strWalletFile + dateTimeStr);
+    sourceFile.make_preferred();
+    backupFile.make_preferred();
+    if (fs::exists(backupFile)) {
+        strBackupWarning = _("Failed to create backup, file already exists! This could happen if you restarted wallet in less than 60 seconds. You can continue if you are ok with this.");
+        LogPrintf("%s\n", strBackupWarning);
+        return false;
+    }
+    if(fs::exists(sourceFile)) {
+#if BOOST_VERSION >= 105800
+        try {
+            fs::copy_file(sourceFile, backupFile);
+            LogPrintf("Creating backup of %s -> %s\n", sourceFile.string(), backupFile.string());
+        } catch(fs::filesystem_error &error) {
+            strBackupWarning = strprintf(_("Failed to create backup, error: %s"), error.what());
+            LogPrintf("%s\n", strBackupWarning);
+            nWalletBackups = -1;
+            return false;
+        }
+#else
+        std::ifstream src(sourceFile.string(), std::ios::binary);
+        std::ofstream dst(backupFile.string(), std::ios::binary);
+        dst << src.rdbuf();
+#endif
+    }
+
+    // Keep only the last 10 backups, including the new one of course
+    typedef std::multimap<std::time_t, fs::path> folder_set_t;
+    folder_set_t folder_set;
+    fs::directory_iterator end_iter;
+    backupsDir.make_preferred();
+    // Build map of backup files for current(!) wallet sorted by last write time
+    fs::path currentFile;
+    for (fs::directory_iterator dir_iter(backupsDir); dir_iter != end_iter; ++dir_iter) {
+        // Only check regular files
+        if ( fs::is_regular_file(dir_iter->status())) {
+            currentFile = dir_iter->path().filename();
+            // Only add the backups for the current wallet, e.g. wallet.dat.*
+            if(dir_iter->path().stem().string() == strWalletFile) {
+                folder_set.insert(folder_set_t::value_type(fs::last_write_time(dir_iter->path()), *dir_iter));
+            }
+        }
+    }
+    // Loop backward through backup files and keep the N newest ones (1 <= N <= 10)
+    int counter = 0;
+    for (std::pair<const std::time_t, fs::path> file : reverse_iterate(folder_set)) {
+        counter++;
+        if (counter > nWalletBackups) {
+            // More than nWalletBackups backups: delete oldest one(s)
+            try {
+                fs::remove(file.second);
+                LogPrintf("Old backup deleted: %s\n", file.second);
+            } catch(fs::filesystem_error &error) {
+                strBackupWarning = strprintf(_("Failed to delete backup, error: %s"), error.what());
+                LogPrintf("%s\n", strBackupWarning);
+                return false;
+            }
+        }
+    }
+    return true;
 }
 
 void MultiBackup(const CWallet& wallet, fs::path pathCustom, fs::path pathWithFile, const fs::path& pathSrc)

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -221,6 +221,9 @@ void NotifyBacked(const CWallet& wallet, bool fSuccess, std::string strMessage);
 bool BackupWallet(const CWallet& wallet, const fs::path& strDest);
 bool AttemptBackupWallet(const CWallet& wallet, const fs::path& pathSrc, const fs::path& pathDest);
 
+//! Called during init: Automatic backups of wallet not running (just copying and renaming dat file)
+bool AutoBackupWallet(const std::string& strWalletFile, std::string& strBackupWarning, std::string& strBackupError);
+
 //! Compacts BDB state so that wallet.dat is self-contained (if there are changes)
 void MaybeCompactWalletDB();
 


### PR DESCRIPTION
Simple refactoring. First two commits are coming from bitcoin#8768.
Other commits break up a big chunk of code from init.cpp into more manageable functions in wallet/walletdb.

This will make the implementation of auto-backups for multi-wallets cleaner (will now rebase #2337 on top of this one).