### PR TITLE
[Validation][RPC] ProUpReg and ProUpRev special tx types

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -761,6 +761,9 @@ bool CDeterministicMNManager::BuildNewListFromBlock(const CBlock& block, const C
             if (!dmn) {
                 return _state.DoS(100, false, REJECT_INVALID, "bad-protx-hash");
             }
+            if (newList.HasUniqueProperty(pl.keyIDOperator) && newList.GetUniquePropertyMN(pl.keyIDOperator)->proTxHash != pl.proTxHash) {
+                return _state.DoS(100, false, REJECT_DUPLICATE, "bad-protx-dup-operator-key");
+            }
             auto newState = std::make_shared<CDeterministicMNState>(*dmn->pdmnState);
             if (newState->keyIDOperator != pl.keyIDOperator) {
                 // reset all operator related fields and put MN into PoSe-banned state in case the operator key changes

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -55,7 +55,7 @@ void CDeterministicMNState::ToJson(UniValue& obj) const
     obj.pushKV("PoSeBanHeight", nPoSeBanHeight);
     obj.pushKV("revocationReason", nRevocationReason);
     obj.pushKV("ownerAddress", EncodeDestination(keyIDOwner));
-    obj.pushKV("operatorAddress", EncodeDestination(keyIDOperator));
+    obj.pushKV("operatorAddress", keyIDOperator == CKeyID() ? "" : EncodeDestination(keyIDOperator));
     obj.pushKV("votingAddress", EncodeDestination(keyIDVoting));
 
     CTxDestination dest1;

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -31,6 +31,9 @@ public:
     int nPoSeRevivedHeight{-1};
     int nPoSeBanHeight{-1};
     uint16_t nRevocationReason{0};
+    /* !TODO: after introducing ProUpRev enum:
+    uint16_t nRevocationReason{ProUpRevPL::REASON_NOT_SPECIFIED};
+    */
 
     // the block hash X blocks after registration, used in quorum calculations
     uint256 confirmedHash;
@@ -77,6 +80,22 @@ public:
         READWRITE(obj.scriptOperatorPayout);
     }
 
+    void ResetOperatorFields()
+    {
+        keyIDOperator = CKeyID();
+        addr = CService();
+        scriptOperatorPayout = CScript();
+        nRevocationReason = 0;
+        /* !TODO: after introducing ProUpRev enum:
+        nRevocationReason = ProUpRevPL::REASON_NOT_SPECIFIED;
+        */
+    }
+    void BanIfNotBanned(int height)
+    {
+        if (nPoSeBanHeight == -1) {
+            nPoSeBanHeight = height;
+        }
+    }
     void UpdateConfirmedHash(const uint256& _proTxHash, const uint256& _confirmedHash)
     {
         confirmedHash = _confirmedHash;

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -30,10 +30,7 @@ public:
     int nPoSePenalty{0};
     int nPoSeRevivedHeight{-1};
     int nPoSeBanHeight{-1};
-    uint16_t nRevocationReason{0};
-    /* !TODO: after introducing ProUpRev enum:
     uint16_t nRevocationReason{ProUpRevPL::REASON_NOT_SPECIFIED};
-    */
 
     // the block hash X blocks after registration, used in quorum calculations
     uint256 confirmedHash;
@@ -85,10 +82,7 @@ public:
         keyIDOperator = CKeyID();
         addr = CService();
         scriptOperatorPayout = CScript();
-        nRevocationReason = 0;
-        /* !TODO: after introducing ProUpRev enum:
         nRevocationReason = ProUpRevPL::REASON_NOT_SPECIFIED;
-        */
     }
     void BanIfNotBanned(int height)
     {

--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -82,7 +82,9 @@ static bool CheckCollateralOut(const CTxOut& out, const ProRegPL& pl, CValidatio
     }
     // don't allow reuse of collateral key for other keys (don't allow people to put the collateral key onto an online server)
     // this check applies to internal and external collateral, but internal collaterals are not necessarely a P2PKH
-    if (collateralDestRet == CTxDestination(pl.keyIDOwner) || collateralDestRet == CTxDestination(pl.keyIDVoting)) {
+    if (collateralDestRet == CTxDestination(pl.keyIDOwner) ||
+            collateralDestRet == CTxDestination(pl.keyIDVoting) ||
+            collateralDestRet == CTxDestination(pl.keyIDOperator)) {
         return state.DoS(10, false, REJECT_INVALID, "bad-protx-collateral-reuse");
     }
     // check collateral amount
@@ -334,6 +336,120 @@ void ProUpServPL::ToJson(UniValue& obj) const
     if (ExtractDestination(scriptOperatorPayout, dest)) {
         obj.pushKV("operatorPayoutAddress", EncodeDestination(dest));
     }
+    obj.pushKV("inputsHash", inputsHash.ToString());
+}
+
+// Provider Update Registrar Payload
+
+bool CheckProUpRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state)
+{
+    assert(tx.nType == CTransaction::TxType::PROUPREG);
+
+    ProUpRegPL pl;
+    if (!GetTxPayload(tx, pl)) {
+        return state.DoS(100, false, REJECT_INVALID, "bad-protx-payload");
+    }
+
+    if (pl.nVersion == 0 || pl.nVersion > ProUpRegPL::CURRENT_VERSION) {
+        return state.DoS(100, false, REJECT_INVALID, "bad-protx-version");
+    }
+    if (pl.nMode != 0) {
+        return state.DoS(100, false, REJECT_INVALID, "bad-protx-mode");
+    }
+
+    if (pl.keyIDOperator.IsNull()) {
+        return state.DoS(10, false, REJECT_INVALID, "bad-protx-operator-key-null");
+    }
+    if (pl.keyIDVoting.IsNull()) {
+        return state.DoS(10, false, REJECT_INVALID, "bad-protx-voting-key-null");
+    }
+    // !TODO: enable other scripts
+    if (!pl.scriptPayout.IsPayToPublicKeyHash()) {
+        return state.DoS(10, false, REJECT_INVALID, "bad-protx-payee");
+    }
+
+    CTxDestination payoutDest;
+    if (!ExtractDestination(pl.scriptPayout, payoutDest)) {
+        // should not happen as we checked script types before
+        return state.DoS(10, false, REJECT_INVALID, "bad-protx-payee-dest");
+    }
+
+    // don't allow reuse of payee key for other keys
+    if (payoutDest == CTxDestination(pl.keyIDVoting) || payoutDest == CTxDestination(pl.keyIDOperator)) {
+        return state.DoS(10, false, REJECT_INVALID, "bad-protx-payee-reuse");
+    }
+
+    if (!CheckInputsHash(tx, pl, state)) {
+        return false;
+    }
+
+    if (pindexPrev) {
+        auto mnList = deterministicMNManager->GetListForBlock(pindexPrev);
+        auto dmn = mnList.GetMN(pl.proTxHash);
+        if (!dmn) {
+            return state.DoS(100, false, REJECT_INVALID, "bad-protx-hash");
+        }
+
+        // don't allow reuse of payee key for owner key
+        if (payoutDest == CTxDestination(dmn->pdmnState->keyIDOwner)) {
+            return state.DoS(10, false, REJECT_INVALID, "bad-protx-payee-reuse");
+        }
+
+        Coin coin;
+        if (!GetUTXOCoin(dmn->collateralOutpoint, coin)) {
+            // this should never happen (there would be no dmn otherwise)
+            return state.DoS(100, false, REJECT_INVALID, "bad-protx-collateral");
+        }
+
+        // don't allow reuse of collateral key for other keys (don't allow people to put the payee key onto an online server)
+        CTxDestination collateralTxDest;
+        if (!ExtractDestination(coin.out.scriptPubKey, collateralTxDest)) {
+            return state.DoS(100, false, REJECT_INVALID, "bad-protx-collateral-dest");
+        }
+        if (collateralTxDest == CTxDestination(dmn->pdmnState->keyIDOwner) ||
+                collateralTxDest == CTxDestination(pl.keyIDVoting) ||
+                collateralTxDest == CTxDestination(pl.keyIDOperator)) {
+            return state.DoS(10, false, REJECT_INVALID, "bad-protx-collateral-reuse");
+        }
+
+        if (mnList.HasUniqueProperty(pl.keyIDOperator)) {
+            auto otherDmn = mnList.GetUniquePropertyMN(pl.keyIDOperator);
+            if (pl.proTxHash != otherDmn->proTxHash) {
+                return state.DoS(10, false, REJECT_DUPLICATE, "bad-protx-dup-key");
+            }
+        }
+
+        if (!CheckHashSig(pl, dmn->pdmnState->keyIDOwner, state)) {
+            // pass the state returned by the function above
+            return false;
+        }
+
+    }
+
+    return true;
+}
+
+std::string ProUpRegPL::ToString() const
+{
+    CTxDestination dest;
+    std::string payee = ExtractDestination(scriptPayout, dest) ?
+                        EncodeDestination(dest) : "unknown";
+    return strprintf("ProUpRegPL(nVersion=%d, proTxHash=%s, operatorAddress=%s, votingAddress=%s, payoutAddress=%s)",
+        nVersion, proTxHash.ToString(), EncodeDestination(keyIDOperator), EncodeDestination(keyIDVoting), payee);
+}
+
+void ProUpRegPL::ToJson(UniValue& obj) const
+{
+    obj.clear();
+    obj.setObject();
+    obj.pushKV("version", nVersion);
+    obj.pushKV("proTxHash", proTxHash.ToString());
+    obj.pushKV("votingAddress", EncodeDestination(keyIDVoting));
+    CTxDestination dest;
+    if (ExtractDestination(scriptPayout, dest)) {
+        obj.pushKV("payoutAddress", EncodeDestination(dest));
+    }
+    obj.pushKV("operatorAddress", EncodeDestination(keyIDOperator));
     obj.pushKV("inputsHash", inputsHash.ToString());
 }
 

--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -384,6 +384,12 @@ bool CheckProUpRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVal
     }
 
     if (pindexPrev) {
+        // ProUpReg txes are disabled when the legacy system is still active
+        // !TODO: remove after complete transition to DMN
+        if (!deterministicMNManager->LegacyMNObsolete(pindexPrev->nHeight + 1)) {
+            return state.DoS(10, false, REJECT_INVALID, "spork-21-inactive");
+        }
+
         auto mnList = deterministicMNManager->GetListForBlock(pindexPrev);
         auto dmn = mnList.GetMN(pl.proTxHash);
         if (!dmn) {

--- a/src/evo/providertx.h
+++ b/src/evo/providertx.h
@@ -114,9 +114,43 @@ public:
 public:
     SERIALIZE_METHODS(ProUpRegPL, obj)
     {
-        READWRITE(obj.nVersion, obj.proTxHash, obj.nMode,
-        		     obj.keyIDOperator, obj.keyIDVoting,
-			     obj.scriptPayout, obj.inputsHash);
+        READWRITE(obj.nVersion, obj.proTxHash, obj.nMode, obj.keyIDOperator, obj.keyIDVoting, obj.scriptPayout, obj.inputsHash);
+        if (!(s.GetType() & SER_GETHASH)) {
+            READWRITE(obj.vchSig);
+        }
+    }
+
+public:
+    std::string ToString() const;
+    void ToJson(UniValue& obj) const;
+};
+
+// Provider-Update-Revoke tx payload
+class ProUpRevPL
+{
+public:
+    static const uint16_t CURRENT_VERSION = 1;
+
+    // these are just informational and do not have any effect on the revocation
+    enum {
+        REASON_NOT_SPECIFIED = 0,
+        REASON_TERMINATION_OF_SERVICE = 1,
+        REASON_COMPROMISED_KEYS = 2,
+        REASON_CHANGE_OF_KEYS = 3,
+        REASON_LAST = REASON_CHANGE_OF_KEYS
+    };
+
+public:
+    uint16_t nVersion{CURRENT_VERSION}; // message version
+    uint256 proTxHash;
+    uint16_t nReason{REASON_NOT_SPECIFIED};
+    uint256 inputsHash; // replay protection
+    std::vector<unsigned char> vchSig;
+
+public:
+    SERIALIZE_METHODS(ProUpRevPL, obj)
+    {
+        READWRITE(obj.nVersion, obj.proTxHash, obj.nReason, obj.inputsHash);
         if (!(s.GetType() & SER_GETHASH)) {
             READWRITE(obj.vchSig);
         }
@@ -130,6 +164,7 @@ public:
 bool CheckProRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state);
 bool CheckProUpServTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state);
 bool CheckProUpRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state);
+bool CheckProUpRevTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state);
 
 // If tx is a ProRegTx, return the collateral outpoint in outRet.
 bool GetProRegCollateral(const CTransactionRef& tx, COutPoint& outRet);

--- a/src/evo/providertx.h
+++ b/src/evo/providertx.h
@@ -132,7 +132,7 @@ public:
     static const uint16_t CURRENT_VERSION = 1;
 
     // these are just informational and do not have any effect on the revocation
-    enum {
+    enum RevocationReason {
         REASON_NOT_SPECIFIED = 0,
         REASON_TERMINATION_OF_SERVICE = 1,
         REASON_COMPROMISED_KEYS = 2,

--- a/src/evo/providertx.h
+++ b/src/evo/providertx.h
@@ -66,6 +66,8 @@ public:
     void ToJson(UniValue& obj) const;
 };
 
+// Provider-Update-Service tx payload
+
 class ProUpServPL
 {
 public:
@@ -93,8 +95,41 @@ public:
     void ToJson(UniValue& obj) const;
 };
 
+// Provider-Update-Registrar tx payload
+class ProUpRegPL
+{
+public:
+    static const uint16_t CURRENT_VERSION = 1;
+
+public:
+    uint16_t nVersion{CURRENT_VERSION}; // message version
+    uint256 proTxHash;
+    uint16_t nMode{0}; // only 0 supported for now
+    CKeyID keyIDOperator;
+    CKeyID keyIDVoting;
+    CScript scriptPayout;
+    uint256 inputsHash; // replay protection
+    std::vector<unsigned char> vchSig;
+
+public:
+    SERIALIZE_METHODS(ProUpRegPL, obj)
+    {
+        READWRITE(obj.nVersion, obj.proTxHash, obj.nMode,
+        		     obj.keyIDOperator, obj.keyIDVoting,
+			     obj.scriptPayout, obj.inputsHash);
+        if (!(s.GetType() & SER_GETHASH)) {
+            READWRITE(obj.vchSig);
+        }
+    }
+
+public:
+    std::string ToString() const;
+    void ToJson(UniValue& obj) const;
+};
+
 bool CheckProRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state);
 bool CheckProUpServTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state);
+bool CheckProUpRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state);
 
 // If tx is a ProRegTx, return the collateral outpoint in outRet.
 bool GetProRegCollateral(const CTransactionRef& tx, COutPoint& outRet);

--- a/src/evo/specialtx.cpp
+++ b/src/evo/specialtx.cpp
@@ -77,6 +77,10 @@ bool CheckSpecialTxNoContext(const CTransaction& tx, CValidationState& state)
             // provider-update-service
             return CheckProUpServTx(tx, nullptr, state);
         }
+        case CTransaction::TxType::PROUPREG: {
+            // provider-update-registrar
+            return CheckProUpRegTx(tx, nullptr, state);
+        }
     }
 
     return state.DoS(10, error("%s: special tx %s with invalid type %d", __func__, tx.GetHash().ToString(), tx.nType),
@@ -112,6 +116,10 @@ bool CheckSpecialTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVali
         case CTransaction::TxType::PROUPSERV: {
             // provider-update-service
             return CheckProUpServTx(tx, pindexPrev, state);
+        }
+        case CTransaction::TxType::PROUPREG: {
+            // provider-update-registrar
+            return CheckProUpRegTx(tx, pindexPrev, state);
         }
     }
 

--- a/src/evo/specialtx.cpp
+++ b/src/evo/specialtx.cpp
@@ -81,6 +81,10 @@ bool CheckSpecialTxNoContext(const CTransaction& tx, CValidationState& state)
             // provider-update-registrar
             return CheckProUpRegTx(tx, nullptr, state);
         }
+        case CTransaction::TxType::PROUPREV: {
+            // provider-update-revoke
+            return CheckProUpRevTx(tx, nullptr, state);
+        }
     }
 
     return state.DoS(10, error("%s: special tx %s with invalid type %d", __func__, tx.GetHash().ToString(), tx.nType),
@@ -120,6 +124,10 @@ bool CheckSpecialTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CVali
         case CTransaction::TxType::PROUPREG: {
             // provider-update-registrar
             return CheckProUpRegTx(tx, pindexPrev, state);
+        }
+        case CTransaction::TxType::PROUPREV: {
+            // provider-update-revoke
+            return CheckProUpRevTx(tx, pindexPrev, state);
         }
     }
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -256,6 +256,7 @@ public:
         PROREG = 1,
         PROUPSERV = 2,
         PROUPREG = 3,
+        PROUPREV = 4,
     };
 
     static const int16_t CURRENT_VERSION = TxVersion::LEGACY;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -255,6 +255,7 @@ public:
         NORMAL = 0,
         PROREG = 1,
         PROUPSERV = 2,
+        PROUPREG = 3,
     };
 
     static const int16_t CURRENT_VERSION = TxVersion::LEGACY;

--- a/src/random.h
+++ b/src/random.h
@@ -182,6 +182,9 @@ public:
     /** Generate random bytes. */
     std::vector<unsigned char> randbytes(size_t len);
 
+    /** Generate a random 16-bit integer. */
+    uint16_t rand16() { return randbits(16); }
+
     /** Generate a random 32-bit integer. */
     uint32_t rand32() noexcept { return randbits(32); }
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -62,6 +62,11 @@ static void PayloadToJSON(const CTransaction& tx, UniValue& entry)
             PayloadToJSON(tx, pl, entry);
             break;
         }
+        case CTransaction::TxType::PROUPREV: {
+            ProUpRevPL pl;
+            PayloadToJSON(tx, pl, entry);
+            break;
+        }
     }
 }
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -57,6 +57,11 @@ static void PayloadToJSON(const CTransaction& tx, UniValue& entry)
             PayloadToJSON(tx, pl, entry);
             break;
         }
+        case CTransaction::TxType::PROUPREG: {
+            ProUpRegPL pl;
+            PayloadToJSON(tx, pl, entry);
+            break;
+        }
     }
 }
 

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -412,7 +412,7 @@ static UniValue ProTxRegister(const JSONRPCRequest& request, bool fSignAndSend)
                 (fSignAndSend ? (
                         "\"txid\"                 (string) The transaction id.\n"
                         "\nExamples:\n"
-                        + HelpExampleCli("protx_register", "...!TODO...")
+                        + HelpExampleCli("protx_register", "\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\" 0 \"168.192.1.100:51472\" \"DMJRSsuU9zfyrvxVaAEFQqK4MxZg6vgeS6\" \"DMJRSsuU9zfyrvxVaAEFQqK4MxZg6vgeS6\" \"DMJRSsuU9zfyrvxVaAEFQqK4MxZg6vgeS6\" \"DMJRSsuU9zfyrvxVaAEFQqK4MxZg6vgeS6\"")
                         ) : (
                         "{                        (json object)\n"
                         "  \"tx\" :                 (string) The serialized ProTx in hex format.\n"
@@ -420,7 +420,7 @@ static UniValue ProTxRegister(const JSONRPCRequest& request, bool fSignAndSend)
                         "  \"signMessage\" :        (string) The string message that needs to be signed with the collateral key\n"
                         "}\n"
                         "\nExamples:\n"
-                        + HelpExampleCli("protx_register_prepare", "...!TODO...")
+                        + HelpExampleCli("protx_register_prepare", "\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\" 0 \"168.192.1.100:51472\" \"DMJRSsuU9zfyrvxVaAEFQqK4MxZg6vgeS6\" \"DMJRSsuU9zfyrvxVaAEFQqK4MxZg6vgeS6\" \"DMJRSsuU9zfyrvxVaAEFQqK4MxZg6vgeS6\" \"DMJRSsuU9zfyrvxVaAEFQqK4MxZg6vgeS6\"")
                         )
                 )
         );
@@ -573,7 +573,7 @@ UniValue protx_register_fund(const JSONRPCRequest& request)
                 "\nResult:\n"
                 "\"txid\"                        (string) The transaction id.\n"
                 "\nExamples:\n"
-                + HelpExampleCli("protx_register_fund", "...!TODO...")
+                + HelpExampleCli("protx_register_fund", "\"DKHHBsuU9zfxxxVaqqqQqK4MxZg6vzpf8\" \"168.192.1.100:51472\" \"DMJRSsuU9zfyrvxVaAEFQqK4MxZg6vgeS6\" \"DMJRSsuU9zfyrvxVaAEFQqK4MxZg6vgeS6\" \"DMJRSsuU9zfyrvxVaAEFQqK4MxZg6vgeS6\" \"DMJRSsuU9zfyrvxVaAEFQqK4MxZg6vgeS6\"")
         );
     }
     CheckEvoUpgradeEnforcement();
@@ -708,9 +708,10 @@ UniValue protx_list(const JSONRPCRequest& request)
                 "                                 at the height specified.\n"
                 "4. \"height\"                 (numeric, optional) If height is not specified, it defaults to the current chain-tip.\n"
                 "\nResult:\n"
-                "\"...!TODO..."
+                "[...]                         (list) List of protx txids or, if detailed=true, list of json objects.\n"
                 "\nExamples:\n"
-                + HelpExampleCli("protx_list", "...!TODO...")
+                + HelpExampleCli("protx_list", "")
+                + HelpExampleCli("protx_list", "true false false 200000")
         );
     }
 
@@ -779,7 +780,7 @@ UniValue protx_update_service(const JSONRPCRequest& request)
                 "\nResult:\n"
                 "\"txid\"                        (string) The transaction id.\n"
                 "\nExamples:\n"
-                + HelpExampleCli("protx_update_service", "...!TODO...")
+                + HelpExampleCli("protx_update_service", "\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\" \"168.192.1.100:51472\"")
         );
     }
     CheckEvoUpgradeEnforcement();
@@ -856,7 +857,7 @@ UniValue protx_update_registrar(const JSONRPCRequest& request)
                 "\nResult:\n"
                 "\"txid\"                        (string) The transaction id.\n"
                 "\nExamples:\n"
-                + HelpExampleCli("protx_update_registrar", "...!TODO...")
+                + HelpExampleCli("protx_update_registrar", "\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\" \"DMJRSsuU9zfyrvxVaAEFQqK4MxZg6vgeS6\" \"DMJRSsuU9zfyrvxVaAEFQqK4MxZg6vgeS6\" \"DMJRSsuU9zfyrvxVaAEFQqK4MxZg6vgeS6\"")
         );
     }
     CheckEvoUpgradeEnforcement();
@@ -924,7 +925,8 @@ UniValue protx_revoke(const JSONRPCRequest& request)
                 "\nResult:\n"
                 "\"txid\"                        (string) The transaction id.\n"
                 "\nExamples:\n"
-                + HelpExampleCli("protx_revoke", "...!TODO...")
+                + HelpExampleCli("protx_revoke", "\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\"")
+                + HelpExampleCli("protx_revoke", "\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\" \"\" 2")
         );
     }
     CheckEvoUpgradeEnforcement();

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -862,6 +862,10 @@ UniValue protx_update_registrar(const JSONRPCRequest& request)
     }
     CheckEvoUpgradeEnforcement();
 
+    if (!deterministicMNManager->LegacyMNObsolete()) {
+        throw JSONRPCError(RPC_MISC_ERROR, "Legacy masternode system still active. ProUpReg transactions are not accepted yet.");
+    }
+
     EnsureWalletIsUnlocked(pwallet);
     // Make sure the results are valid at least up to the most recent block
     // the user could have gotten from another RPC command prior to now

--- a/src/test/evo_specialtx_tests.cpp
+++ b/src/test/evo_specialtx_tests.cpp
@@ -58,6 +58,18 @@ static ProUpServPL GetRandomProUpServPayload()
     return pl;
 }
 
+static ProUpRegPL GetRandomProUpRegPayload()
+{
+    ProUpRegPL pl;
+    pl.proTxHash = GetRandHash();
+    pl.keyIDOperator = GetRandomKeyID();
+    pl.keyIDVoting = GetRandomKeyID();
+    pl.scriptPayout = GetRandomScript();
+    pl.inputsHash = GetRandHash();
+    pl.vchSig = InsecureRandBytes(63);
+    return pl;
+}
+
 BOOST_AUTO_TEST_CASE(protx_validation_test)
 {
     CMutableTransaction mtx;
@@ -142,6 +154,22 @@ BOOST_AUTO_TEST_CASE(proupserv_setpayload_test)
     BOOST_CHECK(pl.proTxHash == pl2.proTxHash);
     BOOST_CHECK(pl.addr  == pl2.addr);
     BOOST_CHECK(pl.scriptOperatorPayout == pl2.scriptOperatorPayout);
+    BOOST_CHECK(pl.inputsHash == pl2.inputsHash);
+    BOOST_CHECK(pl.vchSig == pl2.vchSig);
+}
+
+BOOST_AUTO_TEST_CASE(proupreg_setpayload_test)
+{
+    const ProUpRegPL& pl = GetRandomProUpRegPayload();
+
+    CMutableTransaction mtx;
+    SetTxPayload(mtx, pl);
+    ProUpRegPL pl2;
+    BOOST_CHECK(GetTxPayload(mtx, pl2));
+    BOOST_CHECK(pl.proTxHash == pl2.proTxHash);
+    BOOST_CHECK(pl.keyIDOperator == pl2.keyIDOperator);
+    BOOST_CHECK(pl.keyIDVoting == pl2.keyIDVoting);
+    BOOST_CHECK(pl.scriptPayout == pl2.scriptPayout);
     BOOST_CHECK(pl.inputsHash == pl2.inputsHash);
     BOOST_CHECK(pl.vchSig == pl2.vchSig);
 }

--- a/src/test/evo_specialtx_tests.cpp
+++ b/src/test/evo_specialtx_tests.cpp
@@ -70,6 +70,16 @@ static ProUpRegPL GetRandomProUpRegPayload()
     return pl;
 }
 
+static ProUpRevPL GetRandomProUpRevPayload()
+{
+    ProUpRevPL pl;
+    pl.proTxHash = GetRandHash();
+    pl.nReason = InsecureRand16();
+    pl.inputsHash = GetRandHash();
+    pl.vchSig = InsecureRandBytes(63);
+    return pl;
+}
+
 BOOST_AUTO_TEST_CASE(protx_validation_test)
 {
     CMutableTransaction mtx;
@@ -170,6 +180,20 @@ BOOST_AUTO_TEST_CASE(proupreg_setpayload_test)
     BOOST_CHECK(pl.keyIDOperator == pl2.keyIDOperator);
     BOOST_CHECK(pl.keyIDVoting == pl2.keyIDVoting);
     BOOST_CHECK(pl.scriptPayout == pl2.scriptPayout);
+    BOOST_CHECK(pl.inputsHash == pl2.inputsHash);
+    BOOST_CHECK(pl.vchSig == pl2.vchSig);
+}
+
+BOOST_AUTO_TEST_CASE(prouprev_setpayload_test)
+{
+    const ProUpRevPL& pl = GetRandomProUpRevPayload();
+
+    CMutableTransaction mtx;
+    SetTxPayload(mtx, pl);
+    ProUpRevPL pl2;
+    BOOST_CHECK(GetTxPayload(mtx, pl2));
+    BOOST_CHECK(pl.proTxHash == pl2.proTxHash);
+    BOOST_CHECK(pl.nReason == pl2.nReason);
     BOOST_CHECK(pl.inputsHash == pl2.inputsHash);
     BOOST_CHECK(pl.vchSig == pl2.vchSig);
 }

--- a/src/test/test_pivx.h
+++ b/src/test/test_pivx.h
@@ -23,6 +23,7 @@ static inline void SeedInsecureRand(bool deterministic = false)
     insecure_rand_ctx = FastRandomContext(deterministic);
 }
 
+static inline uint16_t InsecureRand16() { return insecure_rand_ctx.rand16(); }
 static inline uint32_t InsecureRand32() { return insecure_rand_ctx.rand32(); }
 static inline uint256 InsecureRand256() { return insecure_rand_ctx.rand256(); }
 static inline uint64_t InsecureRandBits(int bits) { return insecure_rand_ctx.randbits(bits); }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -412,6 +412,14 @@ void CTxMemPool::addUncheckedSpecialTx(const CTransaction& tx)
             break;
         }
 
+        case CTransaction::TxType::PROUPREV: {
+            ProUpRevPL pl;
+            bool ok = GetTxPayload(tx, pl);
+            assert(ok);
+            mapProTxRefs.emplace(pl.proTxHash, txid);
+            break;
+        }
+
     }
 }
 
@@ -526,6 +534,14 @@ void CTxMemPool::removeUncheckedSpecialTx(const CTransaction& tx)
             assert(ok);
             eraseProTxRef(pl.proTxHash, txid);
             mapProTxPubKeyIDs.erase(pl.keyIDOperator);
+            break;
+        }
+
+        case CTransaction::TxType::PROUPREV: {
+            ProUpRevPL pl;
+            bool ok = GetTxPayload(tx, pl);
+            assert(ok);
+            eraseProTxRef(pl.proTxHash, txid);
             break;
         }
 

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1389,6 +1389,11 @@ class Masternode(object):
         self.proTx = None
         self.collateral = None
 
+    def revoked(self):
+        self.ipport = "[::]:0"
+        self.operator = ""
+        self.operator_key = None
+
     def __repr__(self):
         return "Masternode(idx=%d, owner=%s, operator=%s, voting=%s, ip=%s, payee=%s, opkey=%s, protx=%s, collateral=%s)" % (
             self.idx, str(self.owner), str(self.operator), str(self.voting), str(self.ipport),

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1323,7 +1323,14 @@ class PivxTestFramework():
         self.nodes[idx].syncwithvalidationinterfacequeue()
         mnlist = self.nodes[idx].listmasternodes()
         if len(mnlist) != len(mns):
-            raise Exception("Invalid mn list on node %d:\n%s\nExpected:%s" % (idx, str(mnlist), str(mns)))
+            mnlist_l = [[x['proTxHash'], x['dmnstate']['service']] for x in mnlist]
+            mns_l = [[x.proTx, x.ipport] for x in mns]
+            strErr = ""
+            for x in [x for x in mnlist_l if x not in mns_l]:
+                strErr += "Mn %s is not expected\n" % str(x)
+            for x in [x for x in mns_l if x not in mnlist_l]:
+                strErr += "Expect Mn %s not found\n" % str(x)
+            raise Exception("Invalid mn list on node %d:\n%s" % (idx, strErr))
         protxs = {x["proTxHash"]: x for x in mnlist}
         for mn in mns:
             if mn.proTx not in protxs:

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1324,10 +1324,19 @@ class PivxTestFramework():
         mnlist = self.nodes[idx].listmasternodes()
         if len(mnlist) != len(mns):
             raise Exception("Invalid mn list on node %d:\n%s\nExpected:%s" % (idx, str(mnlist), str(mns)))
-        protxs = [x["proTxHash"] for x in mnlist]
+        protxs = {x["proTxHash"]: x for x in mnlist}
         for mn in mns:
             if mn.proTx not in protxs:
                 raise Exception("ProTx for mn %d (%s) not found in the list of node %d" % (mn.idx, mn.proTx, idx))
+            mn2 = protxs[mn.proTx]
+            collateral = mn.collateral.to_json()
+            assert_equal(mn.owner, mn2["dmnstate"]["ownerAddress"])
+            assert_equal(mn.operator, mn2["dmnstate"]["operatorAddress"])
+            assert_equal(mn.voting, mn2["dmnstate"]["votingAddress"])
+            assert_equal(mn.ipport, mn2["dmnstate"]["service"])
+            assert_equal(mn.payee, mn2["dmnstate"]["payoutAddress"])
+            assert_equal(collateral["txid"], mn2["collateralHash"])
+            assert_equal(collateral["vout"], mn2["collateralIndex"])
 
     def check_proreg_payload(self, dmn, json_tx):
         assert "payload" in json_tx

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -558,7 +558,6 @@ def find_vout_for_address(node, txid, addr):
     raise RuntimeError("Vout not found for address: txid=%s, addr=%s" % (txid, addr))
 
 ### PIVX specific utils ###
-vZC_DENOMS = [1, 5, 10, 50, 100, 500, 1000, 5000]
 DEFAULT_FEE = 0.01
 SPORK_ACTIVATION_TIME = 1563253447
 SPORK_DEACTIVATION_TIME = 4070908800

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -150,7 +150,7 @@ TIERTWO_SCRIPTS = [
     'tiertwo_governance_reorg.py',              # ~ 361 sec
     'tiertwo_masternode_activation.py',         # ~ 352 sec
     'tiertwo_masternode_ping.py',               # ~ 293 sec
-    'tiertwo_reorg_mempool.py',                 # ~ 107 sec
+    'tiertwo_reorg_mempool.py',                 # ~ 97 sec
 ]
 
 SAPLING_SCRIPTS = [

--- a/test/functional/tiertwo_deterministicmns.py
+++ b/test/functional/tiertwo_deterministicmns.py
@@ -154,8 +154,8 @@ class DIP3Test(PivxTestFramework):
         for i in range(3):
             idx = 2 + len(mns) + i
             add_and_key = []
-            add_and_key.append(miner.getnewaddress("oper-%d-key" % idx))
-            add_and_key.append(miner.dumpprivkey(add_and_key[0]))
+            add_and_key.append(controller.getnewaddress("oper-%d-key" % idx))
+            add_and_key.append(controller.dumpprivkey(add_and_key[0]))
             self.nodes[idx].initmasternode(add_and_key[1], "", True)
             op_keys.append(add_and_key)
             time.sleep(1)
@@ -344,11 +344,13 @@ class DIP3Test(PivxTestFramework):
         self.check_mn_list(mns)
         self.log.info("Update payout address...")
         old_payee = mns[2].payee
-        old_mn2_bal = self.get_addr_balance(controller, old_payee)
         mns[2].payee = controller.getnewaddress()
         controller.protx_update_registrar(mns[2].proTx, "", "", mns[2].payee)
         self.sync_mempools([miner, controller])
-        miner.generate(len(mns))
+        miner.generate(1)
+        self.sync_blocks()
+        old_mn2_bal = self.get_addr_balance(controller, old_payee)
+        miner.generate(len(mns)-1)
         self.sync_blocks()
         self.check_mn_list(mns)
         # Check payment to new address
@@ -357,6 +359,50 @@ class DIP3Test(PivxTestFramework):
         assert_equal(self.get_addr_balance(controller, mns[2].payee), Decimal('3'))
         # The PoSe banned node didn't receive any more payment
         assert_equal(self.get_addr_balance(controller, mns[0].payee), old_mn0_balance)
+
+        # Test ProUpRev txes
+        self.log.info("Trying to revoke a non-existent masternode...")
+        assert_raises_rpc_error(-8, "not found", miner.protx_revoke,
+                                "%064x" % getrandbits(256))
+        self.log.info("Trying to revoke with invalid reason...")
+        assert_raises_rpc_error(-8, "invalid reason", controller.protx_revoke, mns[3].proTx, "", 100)
+        self.log.info("Revoke masternode...")
+        # Controller should already have the key (as it was generated there), no need to pass it
+        controller.protx_revoke(mns[3].proTx, "", 1)
+        mns[3].revoked()
+        self.sync_mempools([miner, controller])
+        miner.generate(1)
+        self.sync_blocks()
+        self.check_mn_list(mns)
+        old_mn3_bal = self.get_addr_balance(controller, mns[3].payee)
+        self.log.info("Revoke masternode (with external key)...")
+        miner.protx_revoke(mns[4].proTx, mns[4].operator_key, 2)
+        mns[4].revoked()
+        miner.generate(1)
+        self.sync_blocks()
+        self.check_mn_list(mns)
+        old_mn4_bal = self.get_addr_balance(controller, mns[4].payee)
+        miner.generate(len(mns) + 1)
+        self.sync_blocks()
+        self.check_mn_list(mns)
+        # Check (no) payments
+        self.log.info("Checking payments...")
+        assert_equal(self.get_addr_balance(controller, mns[3].payee), old_mn3_bal)
+        assert_equal(self.get_addr_balance(controller, mns[4].payee), old_mn4_bal)
+
+        # Test reviving a masternode
+        self.log.info("Reviving a masternode...")
+        mns[3].operator = controller.getnewaddress()
+        mns[3].operator_key = controller.dumpprivkey(mns[3].operator)
+        miner.protx_update_registrar(mns[3].proTx, mns[3].operator, "", "", controller.dumpprivkey(mns[3].owner))
+        miner.generate(1)
+        mns[3].ipport = "127.0.0.1:3000"
+        miner.protx_update_service(mns[3].proTx, mns[3].ipport, "", mns[3].operator_key)
+        miner.generate(len(mns))
+        self.sync_blocks()
+        self.check_mn_list(mns)
+        self.log.info("Checking payments...")
+        assert_equal(self.get_addr_balance(controller, mns[3].payee), old_mn3_bal + Decimal('3'))
 
         self.log.info("All good.")
 


### PR DESCRIPTION
Built on top of:
- [x] #2349

This concludes the first DMN-milestone list https://github.com/PIVX-Project/PIVX/pull/2267#issuecomment-807546678.

Here we introduce the last two payloads and transaction types, adding relative RPC commands, and updating the tests:

- `PROUPREG` (provider-update-registrar) submitted by the owner (the payload must be signed with the owner key) to update the operator key and/or the voting key and/or the payout address.

- `PROUPREV` (provider-update-revoke) submitted by the operator, to revoke the service, and put the mn in PoSe-banned state (e.g. in case of compromised keys). The masternode can be "revived" later, by sending a ProUpReg tx, which sets a new operator key, and then a ProUpServ tx (signed with the new operator key), which sets the new IP address for the masternode. 