### PR TITLE
[Test] Coverage for zc transactions rejection in mempool and blocks.

### DIFF
--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -3,6 +3,8 @@
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 #include "test/test_pivx.h"
+#include "blockassembler.h"
+#include "consensus/merkle.h"
 #include "primitives/transaction.h"
 #include "sapling/sapling_validation.h"
 #include "test/librust/utiltest.h"
@@ -103,6 +105,63 @@ BOOST_AUTO_TEST_CASE(test_simple_shielded_invalid)
 
     // Switch back to mainnet parameters as originally selected in test fixture
     SelectParams(CBaseChainParams::MAIN);
+}
+
+void CheckBlockZcRejection(const std::shared_ptr<CBlock>& pblock, CMutableTransaction& mtx)
+{
+    pblock->vtx.emplace_back(MakeTransactionRef(mtx));
+    pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
+    CValidationState state;
+    BOOST_CHECK(!ProcessNewBlock(state, nullptr, pblock, nullptr));
+    BOOST_CHECK(!state.IsValid());
+    BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-blk-with-zc");
+}
+
+void CheckMempoolZcRejection(CMutableTransaction& mtx)
+{
+    LOCK(cs_main);
+    CValidationState state;
+    BOOST_CHECK(!AcceptToMemoryPool(
+            mempool, state, MakeTransactionRef(mtx), true, nullptr, false, true));
+    BOOST_CHECK(!state.IsValid());
+    BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-tx-with-zc");
+}
+
+BOOST_AUTO_TEST_CASE(zerocoin_rejection_tests)
+{
+    SelectParams(CBaseChainParams::REGTEST);
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_V5_0, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    const CChainParams& chainparams = Params();
+
+    std::unique_ptr<CBlockTemplate> pblocktemplate;
+    CScript scriptPubKey = CScript() << OP_DUP << OP_HASH160 << ParseHex("8d5b4f83212214d6ef693e02e6d71969fddad976") << OP_EQUALVERIFY << OP_CHECKSIG;
+    BOOST_CHECK(pblocktemplate = BlockAssembler(Params(), false).CreateNewBlock(scriptPubKey, pwalletMain, false));
+    pblocktemplate->block.hashPrevBlock = chainparams.GetConsensus().hashGenesisBlock;
+
+    // Base tx
+    CMutableTransaction mtx;
+    CTxIn vin;
+    vin.prevout = COutPoint(UINT256_ZERO, 0);
+    mtx.vin.emplace_back(vin);
+
+    // Zerocoin mints rejection test
+    mtx.vout.emplace_back();
+    mtx.vout[0].scriptPubKey = CScript() << OP_ZEROCOINMINT <<
+                                         CBigNum::randBignum(chainparams.GetConsensus().Zerocoin_Params(false)->coinCommitmentGroup.groupOrder).getvch();
+    mtx.vout[0].nValue = 1 * COIN;
+    CheckBlockZcRejection(std::make_shared<CBlock>(pblocktemplate->block), mtx);
+    CheckMempoolZcRejection(mtx);
+
+    // Zerocoin spends rejection test
+    mtx.vout[0].scriptPubKey = scriptPubKey;
+    mtx.vin[0].scriptSig = CScript() << OP_ZEROCOINSPEND;
+    CheckBlockZcRejection(std::make_shared<CBlock>(pblocktemplate->block), mtx);
+    CheckMempoolZcRejection(mtx);
+
+    // Zerocoin public spends rejection test
+    mtx.vin[0].scriptSig = CScript() << OP_ZEROCOINPUBLICSPEND;
+    CheckBlockZcRejection(std::make_shared<CBlock>(pblocktemplate->block), mtx);
+    CheckMempoolZcRejection(mtx);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -412,7 +412,8 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState &state, const C
 
     // Zerocoin txes are not longer accepted in the mempool.
     if (hasTxZerocoins) {
-        return state.DoS(100, error("%s : v5 upgrade enforced, zerocoin disabled", __func__));
+        return state.DoS(100, error("%s : v5 upgrade enforced, zerocoin disabled", __func__),
+                         REJECT_INVALID, "bad-tx-with-zc");
     }
 
     // Check transaction
@@ -2883,7 +2884,8 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
         // No need to check for zerocoin anymore after sapling, they are networkely disabled
         // and checkpoints are preventing the chain for any massive reorganization.
         if (fSaplingActive && tx.ContainsZerocoins()) {
-            return state.DoS(100, error("%s : v5 upgrade enforced, zerocoin disabled", __func__));
+            return state.DoS(100, error("%s : v5 upgrade enforced, zerocoin disabled", __func__),
+                             REJECT_INVALID, "bad-blk-with-zc");
         }
     }
 


### PR DESCRIPTION
Safe-belt for the post-v5 zerocoin cleanup that is being done. Unit test ensuring that we are rejecting zc txs in the mempool and inside new blocks.