### PR TITLE
[BugFix] Fix failing p2p_invalid_block.py.

### DIFF
--- a/test/functional/p2p_invalid_block.py
+++ b/test/functional/p2p_invalid_block.py
@@ -106,7 +106,7 @@ class InvalidBlockRequestTest(PivxTestFramework):
         block3.rehash()
         block3.solve()
 
-        node.p2p.send_blocks_and_test([block3], node, success=False, reject_reason='bad-cb-amount')
+        node.p2p.send_blocks_and_test([block3], node, success=False, reject_reason='bad-blk-amount')
 
 
         # Complete testing of CVE-2012-2459 by sending the original block.


### PR DESCRIPTION
Fixing the master's failing `p2p_invalid_block.py` functional test. It's due a recently merged error code name modification: `bad-cb-amount` -> `bad-blk-amount`.

PD: Will work on the area in the upcoming days, planning to do some structural changes and add coverage for the new coinbase amount errors at least.