### PR TITLE
[test] validation_block_tests: Correcting BOOST_ASSERT_MSG usage for dynamic messages.

### DIFF
--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -14,6 +14,8 @@
 #include "validation.h"
 #include "validationinterface.h"
 
+#define ASSERT_WITH_MSG(cond, msg) if (!cond) { BOOST_ERROR(msg); }
+
 struct RegtestingSetup : public TestingSetup {
     RegtestingSetup() : TestingSetup(CBaseChainParams::REGTEST) {}
 };
@@ -157,7 +159,7 @@ BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
                     if (state.GetRejectReason() == "duplicate" ||
                         state.GetRejectReason() == "prevblk-not-found" ||
                         state.GetRejectReason() == "bad-prevblk") continue;
-                    BOOST_ASSERT_MSG(processed,  ("Error: " + state.GetRejectReason()).c_str());
+                    ASSERT_WITH_MSG(!processed,  ("Error: " + state.GetRejectReason()).c_str());
                 }
             }
         });


### PR DESCRIPTION
Bug discovered checking GA failing reason in #2314 --> [job](https://github.com/PIVX-Project/PIVX/pull/2314/checks?check_run_id=2509761057)

Essentially, `BOOST_ASSERT_MSG` only prints static string messages. As we are inputting a dynamic message, the value isn't being printed if the test fails.
So, have added a new function `ASSERT_WITH_MSG(cond, msg)`  to support dynamic error messages.