### PR TITLE
[BUG][Tests] mining_pos_* tests calling `generate()` or `generate_pow()`

### DIFF
--- a/test/functional/mining_pos_coldStaking.py
+++ b/test/functional/mining_pos_coldStaking.py
@@ -125,7 +125,7 @@ class PIVX_ColdStakingTest(PivxTestFramework):
                                                              "amount": Decimal('250.00')}], 1)
         self.sync_all()
         for i in range(6):
-            self.mocktime = self.generate_pow(0, self.mocktime)
+            self.mocktime = self.generate_pos(0, self.mocktime)
         self.sync_blocks()
         assert_equal(self.nodes[0].getshieldbalance(), 250)
 

--- a/test/functional/mining_pos_reorg.py
+++ b/test/functional/mining_pos_reorg.py
@@ -68,7 +68,7 @@ class ReorgStakeTest(PivxTestFramework):
         # PIV supply: block rewards
         expected_money_supply = 250.0 * 200
         self.check_money_supply(expected_money_supply)
-        block_time_0 = block_time_1 = self.mocktime
+        initial_time = self.mocktime
 
         # Check balances
         self.log.info("Checking balances...")
@@ -83,9 +83,7 @@ class ReorgStakeTest(PivxTestFramework):
         # Stake one block with node-0 and save the stake input
         self.log.info("Staking 1 block with node 0...")
         initial_unspent_0 = self.nodes[0].listunspent()
-        self.nodes[0].generate(1)
-        block_time_0 += 60
-        set_node_times(self.nodes, block_time_0)
+        self.mocktime = self.generate_pos(0, self.mocktime)
         last_block = self.nodes[0].getblock(self.nodes[0].getbestblockhash())
         assert(len(last_block["tx"]) > 1)   # a PoS block has at least two txes
         coinstake_txid = last_block["tx"][1]
@@ -104,7 +102,7 @@ class ReorgStakeTest(PivxTestFramework):
         # Stake 10 more blocks with node-0 and check balances
         self.log.info("Staking 10 more blocks with node 0...")
         for i in range(10):
-            block_time_0 = self.generate_pos(0, block_time_0)
+            self.mocktime = self.generate_pos(0, self.mocktime)
         expected_balance_0 = initial_balance[0] + DecimalAmt(11 * 250.0)
         assert_equal(self.get_tot_balance(0), expected_balance_0)
         self.log.info("Balance for node 0 checks out.")
@@ -129,10 +127,11 @@ class ReorgStakeTest(PivxTestFramework):
         self.log.info("GOOD: spending the stake input was not possible.")
 
         # Stake 12 blocks with node-1
-        set_node_times(self.nodes, block_time_1)
+        self.mocktime = initial_time
+        set_node_times(self.nodes, self.mocktime)
         self.log.info("Staking 12 blocks with node 1...")
         for i in range(12):
-            block_time_1 = self.generate_pos(1, block_time_1)
+            self.mocktime = self.generate_pos(1, self.mocktime)
         expected_balance_1 = initial_balance[1] + DecimalAmt(12 * 250.0)
         assert_equal(self.get_tot_balance(1), expected_balance_1)
         self.log.info("Balance for node 1 checks out.")
@@ -140,7 +139,7 @@ class ReorgStakeTest(PivxTestFramework):
         # re-connect and sync nodes and check that node-0 and node-2 get on the other chain
         new_best_hash = self.nodes[1].getbestblockhash()
         self.log.info("Connecting and syncing nodes...")
-        set_node_times(self.nodes, block_time_1)
+        set_node_times(self.nodes, self.mocktime)
         connect_nodes_clique(self.nodes)
         self.sync_blocks()
         for i in [0, 2]:
@@ -152,18 +151,19 @@ class ReorgStakeTest(PivxTestFramework):
 
         # check that NOW the original stakeinput is present and spendable
         res, utxo = findUtxoInList(stakeinput["txid"], stakeinput["vout"], self.nodes[0].listunspent())
-        assert (res and utxo["spendable"])
+        assert res and utxo["spendable"]
         self.log.info("Coinstake input %s...%s-%d is spendable again." % (
             stakeinput["txid"][:9], stakeinput["txid"][-4:], stakeinput["vout"]))
         self.nodes[0].sendrawtransaction(rawtx["hex"])
-        self.nodes[1].generate(1)
+        self.sync_mempools()
+        self.mocktime = self.generate_pos(1, self.mocktime)
         self.sync_blocks()
         res, utxo = findUtxoInList(stakeinput["txid"], stakeinput["vout"], self.nodes[0].listunspent())
-        assert (not res or not utxo["spendable"])
+        assert not res
 
-        # Verify that PIV supply was properly updated after the reorgs
+        # Verify that PIV supply was properly updated after the reorgs (including burned fee)
         self.log.info("Check PIV supply...")
-        expected_money_supply += 250.0 * (self.nodes[1].getblockcount() - 200)
+        expected_money_supply += 250.0 * (self.nodes[1].getblockcount() - 200) - 0.01
         self.check_money_supply(expected_money_supply)
         self.log.info("Supply checks out.")
 


### PR DESCRIPTION
instead of `generate_pos()`, which could result in `Couldn't create new blocks` errors, if no stake is found in the current time slot (it can be seen in [this GA job](https://github.com/PIVX-Project/PIVX/runs/2512558131) failure).

Also fix another bug in `mining_pos_reorg`: last tx (spending `stakeinput`) is not mined, due to missing `sync_mempools`.