### PR TITLE
[Rand] Use thread-safe atomic in perfmon seeder

### DIFF
--- a/src/randomenv.cpp
+++ b/src/randomenv.cpp
@@ -19,6 +19,7 @@
 #endif
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <climits>
 #include <thread>
@@ -73,10 +74,11 @@ void RandAddSeedPerfmon(CSHA512& hasher)
     // Seed with the entire set of perfmon data
 
     // This can take up to 2 seconds, so only do it every 10 minutes
-    static int64_t nLastPerfmon;
-    if (GetTime() < nLastPerfmon + 10 * 60)
-        return;
-    nLastPerfmon = GetTime();
+    static std::atomic<std::chrono::seconds> last_perfmon{std::chrono::seconds{0}};
+    auto last_time = last_perfmon.load();
+    auto current_time = GetTime<std::chrono::seconds>();
+    if (current_time < last_time + std::chrono::minutes{10}) return;
+    last_perfmon = current_time;
 
     std::vector<unsigned char> vData(250000, 0);
     long ret = 0;


### PR DESCRIPTION
Follow-up to #2278 now that #2300 has been merged. This pulls in one of the aforementioned commits (https://github.com/bitcoin/bitcoin/commit/64e1e022cedf6776c5dffd488ca2e766adca5dc3) that was purposely left out of #2278