### PR TITLE
[GA] Workaround missing apt dependency

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -90,7 +90,8 @@ jobs:
       - name: Setup Environment
         run: |
           if [[ ${{ matrix.config.os }} = ubuntu* ]]; then
-            sudo apt-get update
+            sudo apt-add-repository "ppa:ondrej/php" -y
+            sudo apt-get --yes update
             sudo apt-get install --no-install-recommends --no-upgrade -qq "$APT_BASE" ${{ matrix.config.packages }}
           fi
           if [[ ${{ matrix.config.os }} = macos* ]]; then
@@ -331,7 +332,8 @@ jobs:
 
       - name: Setup Environment
         run: |
-          sudo apt-get update
+          sudo apt-add-repository "ppa:ondrej/php" -y
+          sudo apt-get --yes update
           sudo apt-get install --no-install-recommends --no-upgrade -qq "$APT_BASE" ${{ matrix.config.apt_get }}
 
       - name: depends cache files


### PR DESCRIPTION
Github Actions recently released new image versions for Ubuntu 16.04 and
18.04 that introduced a missing package dependency issue.

This is a workaround that simply re-adds the dependent PPA repository
back to the apt sources.

Ref: https://github.com/actions/virtual-environments/issues/3317