### PR TITLE
[Docs] [Qt] RPC-Console nested commands documentation

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -44,6 +44,35 @@ Notable Changes
 
 (Developers: add your notes here as part of your pull requests whenever possible)
 
+GUI changes
+-----------
+
+### RPC-Console
+
+The GUI RPC-Console now accepts "parenthesized syntax", nested commands, and simple queries (see [PR #2282](https://github.com/PIVX-Project/PIVX/pull/2282).
+A new command `help-console` (available only on the GUI console) documents how to use it:
+
+```
+This console accepts RPC commands using the standard syntax.
+    example:    getblockhash 0
+
+This console can also accept RPC commands using parenthesized syntax.
+    example:    getblockhash(0)
+
+Commands may be nested when specified with the parenthesized syntax.
+    example:    getblock(getblockhash(0) true)
+
+A space or a comma can be used to delimit arguments for either syntax.
+    example:    getblockhash 0
+                getblockhash,0
+
+Named results can be queried with a non-quoted key string in brackets.
+    example:    getblock(getblockhash(0) true)[tx]
+
+Results without keys can be queried using an integer in brackets.
+    example:    getblock(getblockhash(0),true)[tx][0]
+```
+
 #### Allow to optional specify the directory for the blocks storage
 
 A new init option flag '-blocksdir' will allow one to keep the blockfiles external from the data directory.

--- a/src/qt/pivx/settings/settingsconsolewidget.cpp
+++ b/src/qt/pivx/settings/settingsconsolewidget.cpp
@@ -179,6 +179,7 @@ void SettingsConsoleWidget::loadClientModel()
             wordList << ("help " + commandList[i]).c_str();
         }
 
+        wordList << "help-console";
         wordList.sort();
         autoCompleter = new QCompleter(wordList, this);
         autoCompleter->setModelSorting(QCompleter::CaseSensitivelySortedModel);
@@ -224,7 +225,8 @@ void SettingsConsoleWidget::clear(bool clearHistory)
 
     messageInternal(RPCExecutor::CMD_REPLY, (tr("Welcome to the PIVX RPC console.") + "<br>" +
                         tr("Use up and down arrows to navigate history, and %1 to clear screen.").arg("<b>"+clsKey+"</b>") + "<br>" +
-                        tr("Type <b>help</b> for an overview of available commands.") +
+                        tr("Type %1 for an overview of available commands.").arg("<b>help</b>") + "<br>" +
+                        tr("For more information on using this console type %1.").arg("<b>help-console</b>") +
                         "<br><span class=\"secwarning\"><br>" +
                         tr("WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.") +
                         "</span>"),

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -290,6 +290,7 @@ void RPCConsole::setClientModel(ClientModel* model)
             wordList << ("help " + commandList[i]).c_str();
         }
 
+        wordList << "help-console";
         wordList.sort();
         autoCompleter = new QCompleter(wordList, this);
         autoCompleter->setModelSorting(QCompleter::CaseSensitivelySortedModel);
@@ -414,7 +415,8 @@ void RPCConsole::clear()
 
     message(RPCExecutor::CMD_REPLY, (tr("Welcome to the PIVX RPC console.") + "<br>" +
                         tr("Use up and down arrows to navigate history, and %1 to clear screen.").arg("<b>"+clsKey+"</b>") + "<br>" +
-                        tr("Type <b>help</b> for an overview of available commands.") +
+                        tr("Type %1 for an overview of available commands.").arg("<b>help</b>") + "<br>" +
+                        tr("For more information on using this console type %1.").arg("<b>help-console</b>") +
                         "<br><span class=\"secwarning\"><br>" +
                         tr("WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.") +
                         "</span>"),

--- a/src/qt/rpcexecutor.cpp
+++ b/src/qt/rpcexecutor.cpp
@@ -32,6 +32,31 @@ void RPCExecutor::request(const QString& command)
     {
         std::string result;
         std::string executableCommand = command.toStdString() + "\n";
+
+        // Catch the console-only-help command before RPC call is executed and reply with help text as-if a RPC reply.
+        if(executableCommand == "help-console\n")
+        {
+            Q_EMIT reply(CMD_REPLY, QString(("\n"
+                "This console accepts RPC commands using the standard syntax.\n"
+                "   example:    getblockhash 0\n\n"
+
+                "This console can also accept RPC commands using parenthesized syntax.\n"
+                "   example:    getblockhash(0)\n\n"
+
+                "Commands may be nested when specified with the parenthesized syntax.\n"
+                "   example:    getblock(getblockhash(0) true)\n\n"
+
+                "A space or a comma can be used to delimit arguments for either syntax.\n"
+                "   example:    getblockhash 0\n"
+                "               getblockhash,0\n\n"
+
+                "Named results can be queried with a non-quoted key string in brackets.\n"
+                "   example:    getblock(getblockhash(0) true)[tx]\n\n"
+
+                "Results without keys can be queried using an integer in brackets.\n"
+                "   example:    getblock(getblockhash(0),true)[tx][0]\n\n")));
+            return;
+        }
         if(!ExecuteCommandLine(result, executableCommand))
         {
             Q_EMIT reply(CMD_ERROR, QString("Parse error: unbalanced ' or \""));


### PR DESCRIPTION
Follow up to #2282

First commit backports bitcoin#11698, adding:
- a line to the initial message text at the top of the debug console
- a pseudo-command `help-console` which is hooked after parsing the request, but before executing the RPC thread

Second commit updates the release notes.