### PR TITLE
[Refactor] Combine scriptPubKey and amount as CTxOut in CScriptCheck

### DIFF
--- a/src/test/script_P2SH_tests.cpp
+++ b/src/test/script_P2SH_tests.cpp
@@ -113,8 +113,7 @@ BOOST_AUTO_TEST_CASE(sign)
         for (int j = 0; j < 8; j++) {
             CScript sigSave = txTo[i].vin[0].scriptSig;
             txTo[i].vin[0].scriptSig = txTo[j].vin[0].scriptSig;
-            const CTxOut& output = txFrom.vout[txTo[i].vin[0].prevout.n];
-            bool sigOK = CScriptCheck(output.scriptPubKey, output.nValue, txTo[i], 0, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC,
+            bool sigOK = CScriptCheck(txFrom.vout[txTo[i].vin[0].prevout.n], txTo[i], 0, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC,
                                       false, &precomTxData)();
             if (i == j)
                 BOOST_CHECK_MESSAGE(sigOK, strprintf("VerifySignature %d %d", i, j));

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -390,8 +390,7 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction) {
 
     for(uint32_t i = 0; i < mtx.vin.size(); i++) {
         std::vector<CScriptCheck> vChecks;
-        const CTxOut& output = coins[tx.vin[i].prevout.n].out;
-        CScriptCheck check(output.scriptPubKey, output.nValue, tx, i, SCRIPT_VERIFY_P2SH, false, &precomTxData);
+        CScriptCheck check(coins[tx.vin[i].prevout.n].out, tx, i, SCRIPT_VERIFY_P2SH, false, &precomTxData);
         vChecks.emplace_back();
         check.swap(vChecks.back());
         control.Add(vChecks);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1071,7 +1071,7 @@ void UpdateCoins(const CTransaction& tx, CCoinsViewCache &inputs, int nHeight, b
 bool CScriptCheck::operator()()
 {
     const CScript& scriptSig = ptxTo->vin[nIn].scriptSig;
-    return VerifyScript(scriptSig, out.scriptPubKey, nFlags, CachingTransactionSignatureChecker(ptxTo, nIn, out.nValue, cacheStore, *precomTxData), ptxTo->GetRequiredSigVersion(), &error);
+    return VerifyScript(scriptSig, m_tx_out.scriptPubKey, nFlags, CachingTransactionSignatureChecker(ptxTo, nIn, m_tx_out.nValue, cacheStore, *precomTxData), ptxTo->GetRequiredSigVersion(), &error);
 }
 
 int GetSpendHeight(const CCoinsViewCache& inputs)

--- a/src/validation.h
+++ b/src/validation.h
@@ -285,7 +285,7 @@ Optional<int> GetUTXOHeight(const COutPoint& outpoint);
 class CScriptCheck
 {
 private:
-    CTxOut out;
+    CTxOut m_tx_out;
     const CTransaction* ptxTo;
     unsigned int nIn;
     unsigned int nFlags;
@@ -296,7 +296,7 @@ private:
 public:
     CScriptCheck() : ptxTo(0), nIn(0), nFlags(0), cacheStore(false), error(SCRIPT_ERR_UNKNOWN_ERROR), precomTxData(nullptr) {}
     CScriptCheck(const CTxOut& outIn, const CTransaction& txToIn, unsigned int nInIn, unsigned int nFlagsIn, bool cacheIn, PrecomputedTransactionData* cachedHashesIn) :
-        out(outIn),
+        m_tx_out(outIn),
         ptxTo(&txToIn),
         nIn(nInIn),
         nFlags(nFlagsIn),
@@ -309,7 +309,7 @@ public:
     void swap(CScriptCheck& check)
     {
         std::swap(ptxTo, check.ptxTo);
-        std::swap(out, check.out);
+        std::swap(m_tx_out, check.m_tx_out);
         std::swap(nIn, check.nIn);
         std::swap(nFlags, check.nFlags);
         std::swap(cacheStore, check.cacheStore);

--- a/src/validation.h
+++ b/src/validation.h
@@ -285,8 +285,7 @@ Optional<int> GetUTXOHeight(const COutPoint& outpoint);
 class CScriptCheck
 {
 private:
-    CScript scriptPubKey;
-    CAmount amount;
+    CTxOut out;
     const CTransaction* ptxTo;
     unsigned int nIn;
     unsigned int nFlags;
@@ -295,10 +294,9 @@ private:
     PrecomputedTransactionData *precomTxData;
 
 public:
-    CScriptCheck() : amount(0), ptxTo(0), nIn(0), nFlags(0), cacheStore(false), error(SCRIPT_ERR_UNKNOWN_ERROR), precomTxData(nullptr) {}
-    CScriptCheck(const CScript& scriptPubKeyIn, const CAmount amountIn, const CTransaction& txToIn, unsigned int nInIn, unsigned int nFlagsIn, bool cacheIn, PrecomputedTransactionData* cachedHashesIn) :
-        scriptPubKey(scriptPubKeyIn),
-        amount(amountIn),
+    CScriptCheck() : ptxTo(0), nIn(0), nFlags(0), cacheStore(false), error(SCRIPT_ERR_UNKNOWN_ERROR), precomTxData(nullptr) {}
+    CScriptCheck(const CTxOut& outIn, const CTransaction& txToIn, unsigned int nInIn, unsigned int nFlagsIn, bool cacheIn, PrecomputedTransactionData* cachedHashesIn) :
+        out(outIn),
         ptxTo(&txToIn),
         nIn(nInIn),
         nFlags(nFlagsIn),
@@ -310,9 +308,8 @@ public:
 
     void swap(CScriptCheck& check)
     {
-        scriptPubKey.swap(check.scriptPubKey);
         std::swap(ptxTo, check.ptxTo);
-        std::swap(amount, check.amount);
+        std::swap(out, check.out);
         std::swap(nIn, check.nIn);
         std::swap(nFlags, check.nFlags);
         std::swap(cacheStore, check.cacheStore);


### PR DESCRIPTION
Straightforward. Coming from bitcoin#10953

> This simplifies CScriptCheck by combining scriptPubKey and amount