### PR TITLE
[BugFix][GUI] Fix minimize and close bugs

### DIFF
--- a/src/qt/pivx/pivxgui.cpp
+++ b/src/qt/pivx/pivxgui.cpp
@@ -352,10 +352,14 @@ void PIVXGUI::closeEvent(QCloseEvent* event)
     if (clientModel && clientModel->getOptionsModel()) {
         if (!clientModel->getOptionsModel()->getMinimizeOnClose()) {
             QApplication::quit();
+        } else {
+            QMainWindow::showMinimized();
+            event->ignore();
         }
     }
-#endif
+#else
     QMainWindow::closeEvent(event);
+#endif
 }
 
 


### PR DESCRIPTION
> To ensure the GUI closes when the "Minimize on close" window option is disabled, and the "Minimize to the tray instead of the taskbar" window option is enabled, remove a check made against the "Minimize to the tray instead of the taskbar" value, made during GUI closure.
To ensure the GUI minimizes to the taskbar when the "Minimize on close" window option is enabled, and the "Minimize to the tray instead of the taskbar" window option is disabled, minimize the GUI and ignore the closure event.

Small adaptation of 05242e937d3fc0144029ccf3b14f98662400dd60

refs https://github.com/PIVX-Project/PIVX/issues/2371#issuecomment-835833535