### PR TITLE
[Build] cmake, fix not found miniupnp error.

### DIFF
--- a/contrib/cmake/FindMiniupnp.cmake
+++ b/contrib/cmake/FindMiniupnp.cmake
@@ -10,6 +10,10 @@ find_path(MINIUPNP_INCLUDE_DIR miniupnpc.h
         PATHS ${MINIUPNP_PREFIX}/include /usr/include /usr/local/include
         PATH_SUFFIXES miniupnpc)
 
+if(NOT EXISTS "${MINIUPNP_INCLUDE_DIR}/miniupnpc.h")
+    set(MINIUPNP_INCLUDE_DIR "${MINIUPNP_INCLUDE_DIR}/miniupnpc/")
+endif()
+
 find_library(MINIUPNP_LIBRARY NAMES miniupnpc libminiupnpc
         PATHS ${MINIUPNP_PREFIX}/lib /usr/lib /usr/local/lib)
 


### PR DESCRIPTION
Fixing CMake error `file STRINGS file "/usr/local/include/miniupnpc.h" cannot be read`. `miniupnpc.h` is inside `miniupnpc/miniupnpc.h` .