### PR TITLE
[Build] Clean coverage files from budget and evo paths

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -704,10 +704,12 @@ endif
 CLEANFILES = $(EXTRA_LIBRARIES)
 
 CLEANFILES += *.gcda *.gcno
+CLEANFILES += budget/*.gcda budget/*.gcno
 CLEANFILES += compat/*.gcda compat/*.gcno
 CLEANFILES += consensus/*.gcda consensus/*.gcno
 CLEANFILES += crc32c/src/*.gcda crc32c/src/*.gcno
 CLEANFILES += crypto/*.gcda crypto/*.gcno
+CLEANFILES += evo/*.gcda evo/*.gcno
 CLEANFILES += interfaces/*.gcda interfaces/*.gcno
 CLEANFILES += legacy/*.gcda legacy/*.gcno
 CLEANFILES += libzerocoin/*.gcda libzerocoin/*.gcno


### PR DESCRIPTION
Ensure that coverage files are properly cleaned from the `budget` and `evo` paths during `make clean` or `make distclean`