### PR TITLE
[Core] Add reindex-chainstate startup option

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -93,6 +93,13 @@ For nodes on low-memory systems, the database cache can be changed back to 100 M
 Note that the database cache setting has the most performance impact during initial sync of a node, and when catching up after downtime.
 
 
+Reindexing changes
+------------------
+
+It is now possible to only redo validation, without rebuilding the block index, using the command line option `-reindex-chainstate` (in addition to `-reindex` which does both).
+This new option is useful when the blocks on disk are assumed to be fine, but the chainstate is still corrupted. It is also useful for benchmarks.
+
+
 GUI changes
 -----------
 

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -80,6 +80,19 @@ The `getwalletinfo` RPC method returns the name of the wallet used for the query
 Note that while multi-wallet is now fully supported, the RPC multi-wallet interface should be considered unstable for version 6.0.0, and there may backwards-incompatible changes in future versions.
 
 
+Database cache memory increased
+--------------------------------
+
+As a result of growth of the UTXO set, performance with the prior default database cache of 100 MiB has suffered.
+For this reason the default was changed to 300 MiB in this release.
+For nodes on low-memory systems, the database cache can be changed back to 100 MiB (or to another value) by either:
+- Adding `dbcache=100` in pivx.conf
+- Adding `-dbcache=100` startup flag
+- Changing it in the GUI under `Settings → Options → Main → Size of database cache`
+
+Note that the database cache setting has the most performance impact during initial sync of a node, and when catching up after downtime.
+
+
 GUI changes
 -----------
 

--- a/src/consensus/zerocoin_verify.cpp
+++ b/src/consensus/zerocoin_verify.cpp
@@ -7,7 +7,6 @@
 #include "chainparams.h"
 #include "consensus/consensus.h"
 #include "guiinterface.h"        // for ui_interface
-#include "init.h"                // for ShutdownRequested()
 #include "invalid.h"
 #include "script/interpreter.h"
 #include "spork.h"               // for sporkManager

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1653,10 +1653,6 @@ bool AppInitMain()
 
                 if (!is_coinsview_empty) {
                     uiInterface.InitMessage(_("Verifying blocks..."));
-
-                    // Flag sent to validation code to let it know it can skip certain checks
-                    fVerifyingBlocks = true;
-
                     {
                         LOCK(cs_main);
                         CBlockIndex *tip = chainActive.Tip();
@@ -1672,18 +1668,15 @@ bool AppInitMain()
                     if (!CVerifyDB().VerifyDB(pcoinsdbview, gArgs.GetArg("-checklevel", DEFAULT_CHECKLEVEL),
                             gArgs.GetArg("-checkblocks", DEFAULT_CHECKBLOCKS))) {
                         strLoadError = _("Corrupted block database detected");
-                        fVerifyingBlocks = false;
                         break;
                     }
                 }
             } catch (const std::exception& e) {
                 LogPrintf("%s\n", e.what());
                 strLoadError = _("Error opening block database");
-                fVerifyingBlocks = false;
                 break;
             }
 
-            fVerifyingBlocks = false;
             fLoaded = true;
             LogPrintf(" block index %15dms\n", GetTimeMillis() - load_block_index_start_time);
         } while (false);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -442,6 +442,8 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-blocksdir=<dir>", _("Specify directory to hold blocks subdirectory for *.dat files (default: <datadir>)"));
     strUsage += HelpMessageOpt("-blocknotify=<cmd>", _("Execute command when the best block changes (%s in cmd is replaced by block hash)"));
     strUsage += HelpMessageOpt("-checkblocks=<n>", strprintf(_("How many blocks to check at startup (default: %u, 0 = all)"), DEFAULT_CHECKBLOCKS));
+    strUsage += HelpMessageOpt("-checklevel=<n>", strprintf("How thorough the block verification of -checkblocks is (0-4, default: %u)", DEFAULT_CHECKLEVEL));
+
     strUsage += HelpMessageOpt("-conf=<file>", strprintf(_("Specify configuration file (default: %s)"), PIVX_CONF_FILENAME));
     if (mode == HMM_BITCOIND) {
 #if !defined(WIN32)
@@ -1666,8 +1668,8 @@ bool AppInitMain()
                         }
                     }
 
-                    // Zerocoin must check at level 4
-                    if (!CVerifyDB().VerifyDB(pcoinsdbview, 4, gArgs.GetArg("-checkblocks", DEFAULT_CHECKBLOCKS))) {
+                    if (!CVerifyDB().VerifyDB(pcoinsdbview, gArgs.GetArg("-checklevel", DEFAULT_CHECKLEVEL),
+                            gArgs.GetArg("-checkblocks", DEFAULT_CHECKBLOCKS))) {
                         strLoadError = _("Corrupted block database detected");
                         fVerifyingBlocks = false;
                         break;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1502,10 +1502,10 @@ bool AppInitMain()
     nTotalCache = std::max(nTotalCache, nMinDbCache << 20); // total cache cannot be less than nMinDbCache
     nTotalCache = std::min(nTotalCache, nMaxDbCache << 20); // total cache cannot be greater than nMaxDbcache
     int64_t nBlockTreeDBCache = nTotalCache / 8;
-    if (nBlockTreeDBCache > (1 << 21) && !gArgs.GetBoolArg("-txindex", DEFAULT_TXINDEX))
-        nBlockTreeDBCache = (1 << 21); // block tree db cache shouldn't be larger than 2 MiB
+    nBlockTreeDBCache = std::min(nBlockTreeDBCache, (gArgs.GetBoolArg("-txindex", DEFAULT_TXINDEX) ? nMaxBlockDBAndTxIndexCache : nMaxBlockDBCache) << 20);
     nTotalCache -= nBlockTreeDBCache;
     int64_t nCoinDBCache = std::min(nTotalCache / 2, (nTotalCache / 4) + (1 << 23)); // use 25%-50% of the remainder for disk cache
+    nCoinDBCache = std::min(nCoinDBCache, nMaxCoinsDBCache << 20); // cap total coins db cache
     nTotalCache -= nCoinDBCache;
     nCoinCacheUsage = nTotalCache; // the rest goes to in-memory cache
     int64_t nEvoDbCache = 1024 * 1024 * 16; // TODO

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1776,9 +1776,13 @@ bool AppInitMain()
         uiInterface.NotifyBlockTip.disconnect(BlockNotifyGenesisWait);
     }
 
-    uiInterface.InitMessage(_("Calculating money supply..."));
     int nChainHeight = WITH_LOCK(cs_main, return chainActive.Height(); );
-    MoneySupply.Update(pcoinsTip->GetTotalAmount(), nChainHeight);
+
+    // Update money supply
+    if (!fReindex && !fReindexChainState) {
+        uiInterface.InitMessage(_("Calculating money supply..."));
+        MoneySupply.Update(pcoinsTip->GetTotalAmount(), nChainHeight);
+    }
 
 
     // ********************************************************* Step 10: setup layer 2 data

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -896,11 +896,7 @@ UniValue verifychain(const JSONRPCRequest& request)
     if (request.params.size() > 0)
         nCheckDepth = request.params[0].get_int();
 
-    fVerifyingBlocks = true;
-    bool fVerified = CVerifyDB().VerifyDB(pcoinsTip, nCheckLevel, nCheckDepth);
-    fVerifyingBlocks = false;
-
-    return fVerified;
+    return CVerifyDB().VerifyDB(pcoinsTip, nCheckLevel, nCheckDepth);
 }
 
 /** Implementation of IsSuperMajority with better feedback */

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -891,8 +891,8 @@ UniValue verifychain(const JSONRPCRequest& request)
 
     LOCK(cs_main);
 
-    int nCheckLevel = 4;
-    int nCheckDepth = gArgs.GetArg("-checkblocks", 288);
+    int nCheckLevel = gArgs.GetArg("-checklevel", DEFAULT_CHECKLEVEL);
+    int nCheckDepth = gArgs.GetArg("-checkblocks", DEFAULT_CHECKBLOCKS);
     if (request.params.size() > 0)
         nCheckDepth = request.params[0].get_int();
 

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -24,13 +24,21 @@ class uint256;
 //! No need to periodic flush if at least this much space still available.
 static constexpr int MAX_BLOCK_COINSDB_USAGE = 10;
 //! -dbcache default (MiB)
-static const int64_t nDefaultDbCache = 100;
+static const int64_t nDefaultDbCache = 300;
 //! -dbbatchsize default (bytes)
 static const int64_t nDefaultDbBatchSize = 16 << 20;
-//! max. -dbcache in (MiB)
+//! max. -dbcache (MiB)
 static const int64_t nMaxDbCache = sizeof(void*) > 4 ? 16384 : 1024;
-//! min. -dbcache in (MiB)
+//! min. -dbcache (MiB)
 static const int64_t nMinDbCache = 4;
+//! Max memory allocated to block tree DB specific cache, if no -txindex (MiB)
+static const int64_t nMaxBlockDBCache = 2;
+//! Max memory allocated to block tree DB specific cache, if -txindex (MiB)
+// Unlike for the UTXO database, for the txindex scenario the leveldb cache make
+// a meaningful difference: https://github.com/bitcoin/bitcoin/pull/8273#issuecomment-229601991
+static const int64_t nMaxBlockDBAndTxIndexCache = 1024;
+//! Max memory allocated to coin DB specific cache (MiB)
+static const int64_t nMaxCoinsDBCache = 8;
 
 struct CDiskTxPos : public FlatFilePos
 {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3122,7 +3122,8 @@ static bool AcceptBlock(const CBlock& block, CValidationState& state, CBlockInde
 {
     AssertLockHeld(cs_main);
 
-    CBlockIndex*& pindex = *ppindex;
+    CBlockIndex* pindexDummy = nullptr;
+    CBlockIndex*& pindex = ppindex ? *ppindex : pindexDummy;
 
     const Consensus::Params& consensus = Params().GetConsensus();
 
@@ -3973,7 +3974,7 @@ bool LoadExternalBlockFile(FILE* fileIn, FlatFilePos* dbp)
                     if (state.IsError())
                         break;
                 } else if (hash != Params().GetConsensus().hashGenesisBlock && mapBlockIndex[hash]->nHeight % 1000 == 0) {
-                    LogPrintf("Block Import: already had block %s at height %d\n", hash.ToString(), mapBlockIndex[hash]->nHeight);
+                    LogPrint(BCLog::REINDEX, "Block Import: already had block %s at height %d\n", hash.ToString(), mapBlockIndex[hash]->nHeight);
                 }
 
                 // Recursively process earlier encountered successors of this block
@@ -3986,7 +3987,7 @@ bool LoadExternalBlockFile(FILE* fileIn, FlatFilePos* dbp)
                     while (range.first != range.second) {
                         std::multimap<uint256, FlatFilePos>::iterator it = range.first;
                         if (ReadBlockFromDisk(block, it->second)) {
-                            LogPrintf("%s: Processing out of order child %s of %s\n", __func__, block.GetHash().ToString(),
+                            LogPrint(BCLog::REINDEX, "%s: Processing out of order child %s of %s\n", __func__, block.GetHash().ToString(),
                                 head.ToString());
                             CValidationState dummy;
                             std::shared_ptr<const CBlock> block_ptr = std::make_shared<const CBlock>(block);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1586,8 +1586,7 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
         }
 
         if (tx.HasZerocoinSpendInputs()) {
-            int nHeightTx = 0;
-            uint256 txid = tx.GetHash();
+            const uint256& txid = tx.GetHash();
             vSpendsInBlock.emplace_back(txid);
 
             //Check for double spending of serial #'s
@@ -3119,7 +3118,7 @@ bool AcceptBlockHeader(const CBlock& block, CValidationState& state, CBlockIndex
     return true;
 }
 
-bool AcceptBlock(const CBlock& block, CValidationState& state, CBlockIndex** ppindex, FlatFilePos* dbp)
+static bool AcceptBlock(const CBlock& block, CValidationState& state, CBlockIndex** ppindex, const FlatFilePos* dbp)
 {
     AssertLockHeld(cs_main);
 
@@ -3349,15 +3348,15 @@ bool AcceptBlock(const CBlock& block, CValidationState& state, CBlockIndex** ppi
     try {
         unsigned int nBlockSize = ::GetSerializeSize(block, SER_DISK, CLIENT_VERSION);
         FlatFilePos blockPos;
-        if (dbp != NULL)
+        if (dbp != nullptr)
             blockPos = *dbp;
-        if (!FindBlockPos(state, blockPos, nBlockSize + 8, nHeight, block.GetBlockTime(), dbp != NULL))
-            return error("AcceptBlock() : FindBlockPos failed");
-        if (dbp == NULL)
+        if (!FindBlockPos(state, blockPos, nBlockSize + 8, nHeight, block.GetBlockTime(), dbp != nullptr))
+            return error("%s : FindBlockPos failed", __func__);
+        if (dbp == nullptr)
             if (!WriteBlockToDisk(block, blockPos))
                 return AbortNode(state, "Failed to write block");
         if (!ReceivedBlockTransactions(block, state, pindex, blockPos))
-            return error("AcceptBlock() : ReceivedBlockTransactions failed");
+            return error("%s : ReceivedBlockTransactions failed", __func__);
     } catch (const std::runtime_error& e) {
         return AbortNode(state, std::string("System error: ") + e.what());
     }
@@ -3365,7 +3364,7 @@ bool AcceptBlock(const CBlock& block, CValidationState& state, CBlockIndex** ppi
     return true;
 }
 
-bool ProcessNewBlock(CValidationState& state, const std::shared_ptr<const CBlock> pblock, FlatFilePos* dbp, bool* fAccepted)
+bool ProcessNewBlock(CValidationState& state, const std::shared_ptr<const CBlock> pblock, const FlatFilePos* dbp, bool* fAccepted)
 {
     AssertLockNotHeld(cs_main);
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -148,7 +148,6 @@ extern bool fCheckBlockIndex;
 extern size_t nCoinCacheUsage;
 extern CFeeRate minRelayTxFee;
 extern int64_t nMaxTipAge;
-extern bool fVerifyingBlocks;
 
 extern bool fLargeWorkForkFound;
 extern bool fLargeWorkInvalidChainFound;

--- a/src/validation.h
+++ b/src/validation.h
@@ -77,7 +77,7 @@ static const unsigned int MAX_ZEROCOIN_TX_SIZE = 150000;
 /** Maximum kilobytes for transactions to store for processing during reorg */
 static const unsigned int MAX_DISCONNECTED_TX_POOL_SIZE = 20000;
 /** Default for -checkblocks */
-static const signed int DEFAULT_CHECKBLOCKS = 10;
+static const signed int DEFAULT_CHECKBLOCKS = 6;
 /** The maximum size of a blk?????.dat file (since 0.8) */
 static const unsigned int MAX_BLOCKFILE_SIZE = 0x8000000; // 128 MiB
 /** The pre-allocation chunk size for blk?????.dat files (since 0.8) */

--- a/src/validation.h
+++ b/src/validation.h
@@ -78,6 +78,7 @@ static const unsigned int MAX_ZEROCOIN_TX_SIZE = 150000;
 static const unsigned int MAX_DISCONNECTED_TX_POOL_SIZE = 20000;
 /** Default for -checkblocks */
 static const signed int DEFAULT_CHECKBLOCKS = 6;
+static const unsigned int DEFAULT_CHECKLEVEL = 3;
 /** The maximum size of a blk?????.dat file (since 0.8) */
 static const unsigned int MAX_BLOCKFILE_SIZE = 0x8000000; // 128 MiB
 /** The pre-allocation chunk size for blk?????.dat files (since 0.8) */

--- a/src/validation.h
+++ b/src/validation.h
@@ -167,11 +167,11 @@ extern CBlockIndex* pindexBestHeader;
  * @param[out]  state      This may be set to an Error state if any error occurred processing it, including during validation/connection/etc of otherwise unrelated blocks during reorganisation; or it may be set to an Invalid state if pblock is itself invalid (but this is not guaranteed even when the block is checked). If you want to *possibly* get feedback on whether pblock is valid, you must also install a CValidationInterface - this will have its BlockChecked method called whenever *any* block completes validation.
  * @param[in]   pfrom      The node which we are receiving the block from; it is added to mapBlockSource and may be penalised if the block is invalid.
  * @param[in]   pblock     The block we want to process.
- * @param[out]  dbp        If pblock is stored to disk (or already there), this will be set to its location.
+ * @param[out]  dbp        The already known disk position of pblock, or nullptr if not yet stored.
  * @param[out]  fAccepted  Whether the block is accepted or not
  * @return True if state.IsValid()
  */
-bool ProcessNewBlock(CValidationState& state, const std::shared_ptr<const CBlock> pblock, FlatFilePos* dbp, bool* fAccepted = nullptr);
+bool ProcessNewBlock(CValidationState& state, const std::shared_ptr<const CBlock> pblock, const FlatFilePos* dbp, bool* fAccepted = nullptr);
 
 /** Open a block file (blk?????.dat) */
 FILE* OpenBlockFile(const FlatFilePos& pos, bool fReadOnly = false);
@@ -336,8 +336,6 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
 /** Check a block is completely valid from start to finish (only works on top of our current best block, with cs_main held) */
 bool TestBlockValidity(CValidationState& state, const CBlock& block, CBlockIndex* pindexPrev, bool fCheckPOW = true, bool fCheckMerkleRoot = true, bool fCheckBlockSig = true);
 
-/** Store block on disk. If dbp is provided, the file is known to already reside on disk */
-bool AcceptBlock(const CBlock& block, CValidationState& state, CBlockIndex** pindex, FlatFilePos* dbp = NULL);
 bool AcceptBlockHeader(const CBlock& block, CValidationState& state, CBlockIndex** ppindex = nullptr, CBlockIndex* pindexPrev = nullptr);
 
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4123,7 +4123,6 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
     }
 
     uiInterface.InitMessage(_("Loading wallet..."));
-    fVerifyingBlocks = true;
 
     int64_t nStart = GetTimeMillis();
     bool fFirstRun = true;
@@ -4290,7 +4289,6 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
             }
         }
     }
-    fVerifyingBlocks = false;
 
     return walletInstance;
 }

--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -19,17 +19,23 @@ class ReindexTest(PivxTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 1
 
-    def reindex(self):
+    def reindex(self, justchainstate=False):
         self.nodes[0].generate(3)
         blockcount = self.nodes[0].getblockcount()
+        self.log.info("Stopping node...")
         self.stop_nodes()
-        extra_args = [["-reindex", "-checkblockindex=1"]]
+        extra_args = [["-reindex-chainstate" if justchainstate else "-reindex", "-checkblockindex=1"]]
+        self.log.info("Reindexing %s [block count: %d]" % (
+            "chainstate" if justchainstate else "blocks", blockcount))
         self.start_nodes(extra_args)
         assert_equal(self.nodes[0].getblockcount(), blockcount)  # start_node is blocking on reindex
         self.log.info("Success")
 
     def run_test(self):
-        self.reindex()
+        self.reindex(False)
+        self.reindex(True)
+        self.reindex(False)
+        self.reindex(True)
 
 if __name__ == '__main__':
     ReindexTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -69,6 +69,7 @@ BASE_SCRIPTS= [
     'mining_pos_coldStaking.py',                # ~ 220 sec
     'wallet_import_rescan.py',                  # ~ 204 sec
     'p2p_invalid_block.py',                     # ~ 213 sec
+    'feature_reindex.py',                       # ~ 205 sec
     'feature_logging.py',                       # ~ 195 sec
     'wallet_multiwallet.py',                    # ~ 190 sec
     'wallet_abandonconflict.py',                # ~ 188 sec
@@ -88,7 +89,6 @@ BASE_SCRIPTS= [
     # vv Tests less than 2m vv
     'wallet_upgrade.py',                        # ~ 119 sec
     'p2p_disconnect_ban.py',                    # ~ 118 sec
-    'feature_reindex.py',                       # ~ 110 sec
     'interface_http.py',                        # ~ 105 sec
     'feature_blockhashcache.py',                # ~ 100 sec
     'p2p_invalid_tx.py',                        # ~ 98 sec


### PR DESCRIPTION
This was attempted already in #1864 and #1907.
Third time's a charm.

Now the speed is acceptable and (unlike what was happening in #1907) the process can be interrupted.
Further, as it is performed in ThreadImport, the GUI is open and functional during the chainstate reindex, instead of being seemingly stuck at the splash screen.

This PR also includes a few improvements coming from bitcoin#10919, bitcoin#8273, bitcoin#8136 and bitcoin#8611.

Here's a quick comparison of the data I had testing here (empty wallet with GUI, empty pivx.conf / default values).
The reindexes have been performed with 0 network connections.

<table>
<tr>
<th>Mainnet (height=2847011)</th><th>Master</th><th>this PR</th>
</tr><tr>
<td>online sync</td><td>8 hr 13 min</td><td>6 hr 42 min</td>
</tr><tr>
<td>-reindex (offline)</td><td>7 hr 14 min</td><td>6 hr 21 min</td>
</tr><tr>
<td>-reindex-chainstate (offline)</td><td>N/A</td><td>6 hr 13 min</td>
</tr><tr>
<td>startup (synced node)</td><td>100 sec</td><td>83 sec</td>
</tr><tr>
<td>RAM (synced node)</td><td>1.65 GiB</td><td>1.5 GiB</td>    
</tr><tr>
<td>utxo_cache (synced node)</td><td>28.9MiB</td><td>39.5MiB</td>
</tr>
</table> 