### PR TITLE
[BUG][QA] Don't switch to POS in feature_fee_estimation

### DIFF
--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -167,9 +167,9 @@ class EstimateFeeTest(PivxTestFramework):
         But first we need to use one node to create a lot of outputs
         which we will use to generate our transactions.
         """
-        self.add_nodes(3, extra_args=[["-minrelaytxfee=0.000001"],
-                                      ["-minrelaytxfee=0.000001", "-blockmaxsize=18000"],
-                                      ["-minrelaytxfee=0.000001", "-blockmaxsize=9000"]])
+        self.add_nodes(3, extra_args=[["-nuparams=PoS:9999", "-nuparams=PoS_v2:9999", "-minrelaytxfee=0.000001"],
+                                      ["-nuparams=PoS:9999", "-nuparams=PoS_v2:9999", "-minrelaytxfee=0.000001", "-blockmaxsize=18000"],
+                                      ["-nuparams=PoS:9999", "-nuparams=PoS_v2:9999", "-minrelaytxfee=0.000001", "-blockmaxsize=9000"]])
         # Use node0 to mine blocks for input splitting
         # Node1 mines small blocks but that are bigger than the expected transaction rate.
         # NOTE: the CreateNewBlock code starts counting block size at 1,000 bytes,
@@ -273,6 +273,7 @@ class EstimateFeeTest(PivxTestFramework):
         self.sync_blocks(self.nodes[0:3], wait=.1)
         self.log.info("Final estimates after emptying mempools")
         check_estimates(self.nodes[1], self.fees_per_kb, 2)
+
 
 if __name__ == '__main__':
     EstimateFeeTest().main()


### PR DESCRIPTION
Otherwise, since this test takes more than 250 blocks, some of the  last `generate()` call might raise an exception if the stake isn't found in the first time slot.

Test failure can be seen in this [GA job failure](https://github.com/PIVX-Project/PIVX/runs/2602362137).