### PR TITLE
[budget] Clean pre-v5 consensus guards for proposal start block and max payment amount

### DIFF
--- a/src/budget/budgetproposal.cpp
+++ b/src/budget/budgetproposal.cpp
@@ -39,12 +39,8 @@ CBudgetProposal::CBudgetProposal(const std::string& name,
         nFeeTXHash(nfeetxhash),
         nTime(0)
 {
-    const int nBlocksPerCycle = Params().GetConsensus().nBudgetCycleBlocks;
-    // !todo: remove this when v5 rules are enforced (nBlockStart is always = to nCycleStart)
-    int nCycleStart = nBlockStart - nBlockStart % nBlocksPerCycle;
-
     // calculate the expiration block
-    nBlockEnd = nCycleStart + (nBlocksPerCycle + 1)  * paycount;
+    nBlockEnd = nBlockStart + (Params().GetConsensus().nBudgetCycleBlocks + 1)  * paycount;
 }
 
 // initialize from network broadcast message
@@ -77,9 +73,9 @@ void CBudgetProposal::SyncVotes(CNode* pfrom, bool fPartial, int& nInvCount) con
     }
 }
 
-bool CBudgetProposal::IsHeavilyDownvoted(bool fNewRules, int mnCount)
+bool CBudgetProposal::IsHeavilyDownvoted(int mnCount)
 {
-    if (GetNays() - GetYeas() > (fNewRules ? 3 : 1) * mnCount / 10) {
+    if (GetNays() - GetYeas() > 3 * mnCount / 10) {
         strInvalid = "Heavily Downvoted";
         return true;
     }
@@ -88,12 +84,9 @@ bool CBudgetProposal::IsHeavilyDownvoted(bool fNewRules, int mnCount)
 
 bool CBudgetProposal::CheckStartEnd()
 {
-    // !TODO: remove (and always use new rules) when all proposals submitted before v5 enforcement are expired.
-    bool fNewRules = Params().GetConsensus().NetworkUpgradeActive(nBlockStart, Consensus::UPGRADE_V5_0);
-
+    // block start must be a superblock
     if (nBlockStart < 0 ||
-            // block start must be a superblock
-            (fNewRules && (nBlockStart % Params().GetConsensus().nBudgetCycleBlocks) != 0)) {
+            nBlockStart % Params().GetConsensus().nBudgetCycleBlocks != 0) {
         strInvalid = "Invalid nBlockStart";
         return false;
     }
@@ -103,7 +96,7 @@ bool CBudgetProposal::CheckStartEnd()
         return false;
     }
 
-    if (fNewRules && GetTotalPaymentCount() > Params().GetConsensus().nMaxProposalPayments) {
+    if (GetTotalPaymentCount() > Params().GetConsensus().nMaxProposalPayments) {
         strInvalid = "Invalid payment count";
         return false;
     }
@@ -170,12 +163,9 @@ bool CBudgetProposal::UpdateValid(int nCurrentHeight, int mnCount)
 {
     fValid = false;
 
-    // !TODO: remove after v5 enforcement and use fixed multiplier (3)
-    bool fNewRules = Params().GetConsensus().NetworkUpgradeActive(nCurrentHeight, Consensus::UPGRADE_V5_0);
-
     // Never kill a proposal before the first superblock
-    if (!fNewRules || nCurrentHeight > nBlockStart) {
-        if (IsHeavilyDownvoted(fNewRules, mnCount)) return false;
+    if (nCurrentHeight > nBlockStart && IsHeavilyDownvoted(mnCount)) {
+        return false;
     }
 
     if (updateExpired(nCurrentHeight)) {

--- a/src/budget/budgetproposal.h
+++ b/src/budget/budgetproposal.h
@@ -37,7 +37,7 @@ private:
     std::string strInvalid;
 
     // Functions used inside UpdateValid()/IsWellFormed - setting strInvalid
-    bool IsHeavilyDownvoted(bool fNewRules, int mnCount);
+    bool IsHeavilyDownvoted(int mnCount);
     bool updateExpired(int nCurrentHeight);
     bool CheckStartEnd();
     bool CheckAmount(const CAmount& nTotalBudget);


### PR DESCRIPTION
Cleaning pre-v5 consensus guards for the proposal start block and max payment amount validation.