### PR TITLE
[GUI] Fix invalid MN collateral amount and align every static 10k PIV strings.

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -94,6 +94,11 @@ QString ClientModel::getMasternodesCount()
     return cachedMasternodeCountString;
 }
 
+CAmount ClientModel::getMNCollateralRequiredAmount()
+{
+    return Params().GetConsensus().nMNCollateralAmt;
+}
+
 int ClientModel::getNumBlocks()
 {
     if (!cacheTip) {

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -101,6 +101,9 @@ public:
     // Future todo: implement an event based update and remove the lock requirement.
     QString getMasternodesCount();
 
+    // Return the specific chain amount value for the MN collateral output.
+    CAmount getMNCollateralRequiredAmount();
+
 private:
     // Listeners
     std::unique_ptr<interfaces::Handler> m_handler_show_progress;

--- a/src/qt/pivx/forms/masternodewizarddialog.ui
+++ b/src/qt/pivx/forms/masternodewizarddialog.ui
@@ -712,9 +712,6 @@
           </item>
           <item>
            <widget class="QLabel" name="labelMessage1a">
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;To create a PIVX Masternode you must dedicate 10,000 PIV (the unit of PIVX) to the network (however, these coins are still yours and will never leave your possession). &lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;You can deactivate the node and unlock the coins at any time.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
             <property name="alignment">
              <set>Qt::AlignHCenter|Qt::AlignTop</set>
             </property>
@@ -844,9 +841,6 @@
           </item>
           <item>
            <widget class="QLabel" name="labelMessage3">
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A transaction of 10,000 PIV will be made&lt;/p&gt;&lt;p&gt;to a new empty address in your wallet.&lt;/p&gt;&lt;p&gt;The Address is labeled under the master node's name.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
             <property name="alignment">
              <set>Qt::AlignHCenter|Qt::AlignTop</set>
             </property>

--- a/src/qt/pivx/masternodeswidget.cpp
+++ b/src/qt/pivx/masternodeswidget.cpp
@@ -18,12 +18,9 @@
 #include "masternode-sync.h"
 #include "masternodeconfig.h"
 #include "masternodeman.h"
-#include "sync.h"
 #include "wallet/wallet.h"
-#include "askpassphrasedialog.h"
 #include "util/system.h"
 #include "qt/pivx/optionbutton.h"
-#include <iostream>
 #include <fstream>
 
 #define DECORATION_SIZE 65
@@ -476,12 +473,14 @@ void MasterNodesWidget::onCreateMNClicked()
         return;
     }
 
-    if (walletModel->getBalance() <= (COIN * 10000)) {
-        inform(tr("Not enough balance to create a masternode, 10,000 %1 required.").arg(CURRENCY_UNIT.c_str()));
+    CAmount mnCollateralAmount = clientModel->getMNCollateralRequiredAmount();
+    if (walletModel->getBalance() <= mnCollateralAmount) {
+        inform(tr("Not enough balance to create a masternode, %1 required.")
+            .arg(GUIUtil::formatBalance(mnCollateralAmount, BitcoinUnits::PIV)));
         return;
     }
     showHideOp(true);
-    MasterNodeWizardDialog *dialog = new MasterNodeWizardDialog(walletModel, window);
+    MasterNodeWizardDialog *dialog = new MasterNodeWizardDialog(walletModel, clientModel, window);
     if (openDialogWithOpaqueBackgroundY(dialog, window, 5, 7)) {
         if (dialog->isOk) {
             // Update list

--- a/src/qt/pivx/masternodewizarddialog.cpp
+++ b/src/qt/pivx/masternodewizarddialog.cpp
@@ -213,7 +213,7 @@ bool MasterNodeWizardDialog::createMN()
         SendCoinsRecipient sendCoinsRecipient(
                 QString::fromStdString(dest.ToString()),
                 QString::fromStdString(alias),
-                CAmount(10000) * COIN,
+                Params().GetConsensus().nMNCollateralAmt,
                 "");
 
         // Send the 10 tx to one of your address

--- a/src/qt/pivx/masternodewizarddialog.cpp
+++ b/src/qt/pivx/masternodewizarddialog.cpp
@@ -6,6 +6,7 @@
 #include "qt/pivx/forms/ui_masternodewizarddialog.h"
 
 #include "activemasternode.h"
+#include "clientmodel.h"
 #include "optionsmodel.h"
 #include "pairresult.h"
 #include "qt/pivx/mnmodel.h"
@@ -17,15 +18,23 @@
 #include <QIntValidator>
 #include <QHostAddress>
 #include <QRegularExpression>
-#include <QRegularExpressionValidator>
 
-MasterNodeWizardDialog::MasterNodeWizardDialog(WalletModel *model, QWidget *parent) :
+static inline QString formatParagraph(const QString& str) {
+    return "<p align=\"justify\" style=\"text-align:center;\">" + str + "</p>";
+}
+
+static inline QString formatHtmlContent(const QString& str) {
+    return "<html><body>" + str + "</body></html>";
+}
+
+MasterNodeWizardDialog::MasterNodeWizardDialog(WalletModel* model, ClientModel* _clientModel, QWidget *parent) :
     FocusedDialog(parent),
     ui(new Ui::MasterNodeWizardDialog),
     icConfirm1(new QPushButton()),
     icConfirm3(new QPushButton()),
     icConfirm4(new QPushButton()),
-    walletModel(model)
+    walletModel(model),
+    clientModel(_clientModel)
 {
     ui->setupUi(this);
 
@@ -50,9 +59,20 @@ MasterNodeWizardDialog::MasterNodeWizardDialog(WalletModel *model, QWidget *pare
     setCssProperty(ui->labelMessage1a, "text-main-grey");
     setCssProperty(ui->labelMessage1b, "text-main-purple");
 
+    QString collateralAmountStr = GUIUtil::formatBalance(clientModel->getMNCollateralRequiredAmount());
+    ui->labelMessage1a->setText(formatHtmlContent(
+                formatParagraph(tr("To create a PIVX Masternode you must dedicate %1 (the unit of PIVX) "
+                        "to the network (however, these coins are still yours and will never leave your possession).").arg(collateralAmountStr)) +
+                formatParagraph(tr("You can deactivate the node and unlock the coins at any time."))));
+
     // Frame 3
     setCssProperty(ui->labelTitle3, "text-title-dialog");
     setCssProperty(ui->labelMessage3, "text-main-grey");
+
+    ui->labelMessage3->setText(formatHtmlContent(
+                formatParagraph(tr("A transaction of %1 will be made").arg(collateralAmountStr)) +
+                formatParagraph(tr("to a new empty address in your wallet.")) +
+                formatParagraph(tr("The Address is labeled under the master node's name."))));
 
     initCssEditLine(ui->lineEditName);
     // MN alias must not contain spaces or "#" character
@@ -213,7 +233,7 @@ bool MasterNodeWizardDialog::createMN()
         SendCoinsRecipient sendCoinsRecipient(
                 QString::fromStdString(dest.ToString()),
                 QString::fromStdString(alias),
-                Params().GetConsensus().nMNCollateralAmt,
+                clientModel->getMNCollateralRequiredAmount(),
                 "");
 
         // Send the 10 tx to one of your address
@@ -263,7 +283,7 @@ bool MasterNodeWizardDialog::createMN()
         int indexOut = -1;
         for (int i=0; i < (int)walletTx->vout.size(); i++) {
             const CTxOut& out = walletTx->vout[i];
-            if (out.nValue == Params().GetConsensus().nMNCollateralAmt) {
+            if (out.nValue == clientModel->getMNCollateralRequiredAmount()) {
                 indexOut = i;
                 break;
             }

--- a/src/qt/pivx/masternodewizarddialog.h
+++ b/src/qt/pivx/masternodewizarddialog.h
@@ -12,6 +12,7 @@
 #include "qt/pivx/pwidget.h"
 
 class WalletModel;
+class ClientModel;
 
 namespace Ui {
 class MasterNodeWizardDialog;
@@ -23,7 +24,9 @@ class MasterNodeWizardDialog : public FocusedDialog, public PWidget::Translator
     Q_OBJECT
 
 public:
-    explicit MasterNodeWizardDialog(WalletModel *walletMode, QWidget *parent = nullptr);
+    explicit MasterNodeWizardDialog(WalletModel* walletMode,
+                                    ClientModel* clientModel,
+                                    QWidget *parent = nullptr);
     ~MasterNodeWizardDialog();
     void showEvent(QShowEvent *event) override;
     QString translate(const char *msg) override { return tr(msg); }
@@ -43,7 +46,8 @@ private:
     SnackBar *snackBar = nullptr;
     int pos = 0;
 
-    WalletModel *walletModel = nullptr;
+    WalletModel* walletModel{nullptr};
+    ClientModel* clientModel{nullptr};
     bool createMN();
     void inform(QString text);
     void initBtn(std::initializer_list<QPushButton*> args);

--- a/src/qt/pivx/pivxgui.cpp
+++ b/src/qt/pivx/pivxgui.cpp
@@ -251,6 +251,7 @@ void PIVXGUI::setClientModel(ClientModel* _clientModel)
         topBar->setClientModel(clientModel);
         dashboard->setClientModel(clientModel);
         sendWidget->setClientModel(clientModel);
+        masterNodesWidget->setClientModel(clientModel);
         settingsWidget->setClientModel(clientModel);
 
         // Receive and report messages from client model
@@ -600,7 +601,7 @@ int PIVXGUI::getNavWidth()
 void PIVXGUI::openFAQ(SettingsFaqWidget::Section section)
 {
     showHide(true);
-    SettingsFaqWidget* dialog = new SettingsFaqWidget(this);
+    SettingsFaqWidget* dialog = new SettingsFaqWidget(this, clientModel);
     dialog->setSection(section);
     openDialogWithOpaqueBackgroundFullScreen(dialog, this);
     dialog->deleteLater();

--- a/src/qt/pivx/settings/settingsfaqwidget.cpp
+++ b/src/qt/pivx/settings/settingsfaqwidget.cpp
@@ -4,13 +4,16 @@
 
 #include "qt/pivx/settings/settingsfaqwidget.h"
 #include "qt/pivx/settings/forms/ui_settingsfaqwidget.h"
-#include <QScrollBar>
-#include <QMetaObject>
+#include "clientmodel.h"
 #include "qt/pivx/qtutils.h"
 
-SettingsFaqWidget::SettingsFaqWidget(PIVXGUI *parent) :
+#include <QScrollBar>
+#include <QMetaObject>
+
+SettingsFaqWidget::SettingsFaqWidget(PIVXGUI* parent, ClientModel* _model) :
     QDialog(parent),
-    ui(new Ui::SettingsFaqWidget)
+    ui(new Ui::SettingsFaqWidget),
+    clientModel(_model)
 {
     ui->setupUi(this);
     this->setStyleSheet(parent->styleSheet());
@@ -113,9 +116,10 @@ SettingsFaqWidget::SettingsFaqWidget(PIVXGUI *parent) :
     QString masternodeContent = formatFAQContent(
         formatFAQParagraph(
             tr("A masternode is a computer running a full node PIVX core wallet with a "
-               "requirement of 10,000 PIV secured collateral to provide extra services "
+               "requirement of %1 secured collateral to provide extra services "
                "to the network and in return, receive a portion of the block reward "
-               "regularly. These services include:") +
+               "regularly. These services include:")
+                .arg(GUIUtil::formatBalance(clientModel->getMNCollateralRequiredAmount(), BitcoinUnits::PIV)) +
             formatFAQUnorderedList(
                 formatFAQListItem(tr("A decentralized governance (Proposal Voting)")) +
                 formatFAQListItem(tr("A decentralized budgeting system (Treasury)")) +
@@ -135,7 +139,8 @@ SettingsFaqWidget::SettingsFaqWidget(PIVXGUI *parent) :
         formatFAQParagraph(
             tr("Requirements:") +
             formatFAQUnorderedList(
-                formatFAQListItem(tr("10,000 PIV per single Masternode instance")) +
+                formatFAQListItem(tr("%1 per single Masternode instance")
+                        .arg(GUIUtil::formatBalance(clientModel->getMNCollateralRequiredAmount(), BitcoinUnits::PIV))) +
                 formatFAQListItem(tr("Must be stored in a core wallet")) +
                 formatFAQListItem(tr("Need dedicated IP address")) +
                 formatFAQListItem(tr("Masternode wallet to remain online")))));
@@ -143,10 +148,11 @@ SettingsFaqWidget::SettingsFaqWidget(PIVXGUI *parent) :
 
     QString mNControllerContent = formatFAQContent(
         formatFAQParagraph(
-            tr("A Masternode Controller wallet is where the 10,000 PIV collateral "
+            tr("A Masternode Controller wallet is where the %1 collateral "
                "can reside during a Controller-Remote masternode setup. It is a wallet "
                "that can activate the remote masternode wallet(s) and allows you to keep "
-               "your collateral coins offline while the remote masternode remains online.")));
+               "your collateral coins offline while the remote masternode remains online.")
+                    .arg(GUIUtil::formatBalance(clientModel->getMNCollateralRequiredAmount(), BitcoinUnits::PIV))));
     ui->labelContent_MNController->setText(mNControllerContent);
 
 

--- a/src/qt/pivx/settings/settingsfaqwidget.h
+++ b/src/qt/pivx/settings/settingsfaqwidget.h
@@ -8,6 +8,7 @@
 #include <QDialog>
 
 class PIVXGUI;
+class ClientModel;
 
 namespace Ui {
 class SettingsFaqWidget;
@@ -26,7 +27,7 @@ public:
         MNCONTROLLER
     };
 
-    explicit SettingsFaqWidget(PIVXGUI *parent = nullptr);
+    explicit SettingsFaqWidget(PIVXGUI* parent, ClientModel* _model);
     ~SettingsFaqWidget();
 
     void showEvent(QShowEvent *event) override;
@@ -38,6 +39,7 @@ private Q_SLOTS:
     void onFaqClicked(const QWidget* const widget);
 private:
     Ui::SettingsFaqWidget *ui;
+    ClientModel* clientModel{nullptr};
     Section section = INTRO;
 
     // This needs to be edited if changes are made to the Section enum.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2528,7 +2528,7 @@ bool CWallet::GetMasternodeVinAndKeys(CTxIn& txinRet, CPubKey& pubKeyRet, CKey& 
 
     // Masternode collateral value
     if (txOut.nValue != Params().GetConsensus().nMNCollateralAmt) {
-        strError = "Invalid collateral tx value, must be 10,000 PIV";
+        strError = strprintf("Invalid collateral tx value, must be %s PIV", FormatMoney(Params().GetConsensus().nMNCollateralAmt));
         return error("%s: tx %s, index %d not a masternode collateral", __func__, strTxHash, nOutputIndex);
     }
 


### PR DESCRIPTION
Since #2296, we have a different masternode collateral output amount for regtest. As the GUI has the 10k value harcoded in some places, the masternode creation wizard got broken and there are some misaligned strings as well.

This PR fixes it and aligns every static 10k PIV string to be set dynamically consuming the chain params value.