### PR TITLE
[wallet] Kill AvailableCoinsType enum

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -1002,7 +1002,9 @@ bool WalletModel::getMNCollateralCandidate(COutPoint& outPoint)
 {
     CWallet::AvailableCoinsFilter coinsFilter;
     coinsFilter.fIncludeDelegated = false;
-    coinsFilter.nCoinType = ONLY_10000;
+    coinsFilter.nMaxOutValue = Params().GetConsensus().nMNCollateralAmt;
+    coinsFilter.nMinOutValue = coinsFilter.nMaxOutValue;
+    coinsFilter.fIncludeLocked = true;
     std::vector<COutput> vCoins;
     wallet->AvailableCoins(&vCoins, nullptr, coinsFilter);
     for (const COutput& out : vCoins) {

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -518,7 +518,6 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
                                                   nChangePosInOut,
                                                   strFailReason,
                                                   coinControl,
-                                                  ALL_COINS,
                                                   true,
                                                   0,
                                                   fIncludeDelegations,

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -545,7 +545,9 @@ UniValue getmasternodeoutputs (const JSONRPCRequest& request)
     // Find possible candidates
     CWallet::AvailableCoinsFilter coinsFilter;
     coinsFilter.fIncludeDelegated = false;
-    coinsFilter.nCoinType = ONLY_10000;
+    coinsFilter.nMaxOutValue = Params().GetConsensus().nMNCollateralAmt;
+    coinsFilter.nMinOutValue = coinsFilter.nMaxOutValue;
+    coinsFilter.fIncludeLocked = true;
     std::vector<COutput> possibleCoins;
     pwallet->AvailableCoins(&possibleCoins, nullptr, coinsFilter);
 

--- a/src/sapling/sapling_operation.cpp
+++ b/src/sapling/sapling_operation.cpp
@@ -297,7 +297,6 @@ OperationResult SaplingOperation::loadUtxos(TxValues& txValues)
     if (fromAddress.isFromTAddress()) destinations.insert(fromAddress.fromTaddr);
     CWallet::AvailableCoinsFilter coinsFilter(fIncludeDelegated,
                                               false,
-                                              ALL_COINS,
                                               true,
                                               true,
                                               &destinations,

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1005,7 +1005,7 @@ static void SendMoney(CWallet* const pwallet, const CTxDestination& address, CAm
     CReserveKey reservekey(pwallet);
     CAmount nFeeRequired;
     std::string strError;
-    if (!pwallet->CreateTransaction(scriptPubKey, nValue, tx, reservekey, nFeeRequired, strError, nullptr, ALL_COINS, (CAmount)0)) {
+    if (!pwallet->CreateTransaction(scriptPubKey, nValue, tx, reservekey, nFeeRequired, strError, nullptr, (CAmount)0)) {
         if (nValue + nFeeRequired > pwallet->GetAvailableBalance())
             strError = strprintf("Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!", FormatMoney(nFeeRequired));
         LogPrintf("%s: %s\n", __func__, strError);
@@ -1219,7 +1219,7 @@ static UniValue CreateColdStakeDelegation(CWallet* const pwallet, const UniValue
         CAmount nFeeRequired;
         CScript scriptPubKey = fV6Enforced ? GetScriptForStakeDelegation(*stakeKey, ownerKey)
                                            : GetScriptForStakeDelegationLOF(*stakeKey, ownerKey);
-        if (!pwallet->CreateTransaction(scriptPubKey, nValue, txNew, reservekey, nFeeRequired, strError, nullptr, ALL_COINS, (CAmount)0, fUseDelegated)) {
+        if (!pwallet->CreateTransaction(scriptPubKey, nValue, txNew, reservekey, nFeeRequired, strError, nullptr, (CAmount)0, fUseDelegated)) {
             if (nValue + nFeeRequired > currBalance)
                 strError = strprintf("Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!", FormatMoney(nFeeRequired));
             LogPrintf("%s : %s\n", __func__, strError);
@@ -2284,7 +2284,6 @@ static UniValue legacy_sendmany(CWallet* const pwallet, const UniValue& sendTo, 
     int nChangePosInOut = -1;
     bool fCreated = pwallet->CreateTransaction(vecSend, txNew, keyChange, nFeeRequired, nChangePosInOut, strFailReason,
                                                nullptr,     // coinControl
-                                               ALL_COINS,   // inputType
                                                true,        // sign
                                                0,           // nFeePay
                                                fIncludeDelegated);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2581,9 +2581,6 @@ CWallet::OutputAvailabilityResult CWallet::CheckOutputAvailability(
 {
     OutputAvailabilityResult res;
 
-    // Check for only 10k utxo
-    if (nCoinType == ONLY_10000 && output.nValue != Params().GetConsensus().nMNCollateralAmt) return res;
-
     // Check for stakeable utxo
     if (nCoinType == STAKEABLE_COINS && output.IsZerocoinMint()) return res;
 
@@ -2596,7 +2593,7 @@ CWallet::OutputAvailabilityResult CWallet::CheckOutputAvailability(
     if (mine == ISMINE_NO) return res;
 
     // Skip locked utxo
-    if (!fIncludeLocked && IsLockedCoin(wtxid, outIndex) && nCoinType != ONLY_10000) return res;
+    if (!fIncludeLocked && IsLockedCoin(wtxid, outIndex)) return res;
 
     // Check if we should include zero value utxo
     if (output.nValue <= 0) return res;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2581,9 +2581,6 @@ CWallet::OutputAvailabilityResult CWallet::CheckOutputAvailability(
 {
     OutputAvailabilityResult res;
 
-    // Check for stakeable utxo
-    if (nCoinType == STAKEABLE_COINS && output.IsZerocoinMint()) return res;
-
     // Check if the utxo was spent.
     if (IsSpent(wtxid, outIndex)) return res;
 
@@ -2641,9 +2638,6 @@ bool CWallet::AvailableCoins(std::vector<COutput>* pCoins,      // --> populates
             int nDepth;
             if (!CheckTXAvailability(pcoin, coinsFilter.fOnlyConfirmed, nDepth, m_last_block_processed_height))
                 continue;
-
-            // Check min depth requirement for stake inputs
-            if (coinsFilter.nCoinType == STAKEABLE_COINS && nDepth < Params().GetConsensus().nStakeMinDepth) continue;
 
             // Check min depth filtering requirements
             if (nDepth < coinsFilter.minDepth) continue;
@@ -2803,7 +2797,7 @@ bool CWallet::StakeableCoins(std::vector<CStakeableOutput>* pCoins)
                     pcoin->tx->vout[index],
                     index,
                     wtxid,
-                    STAKEABLE_COINS,
+                    ALL_COINS,
                     nullptr, // coin control
                     false,   // fIncludeDelegated
                     fIncludeColdStaking,

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -121,7 +121,6 @@ enum WalletFeature {
 
 enum AvailableCoinsType {
     ALL_COINS = 1,
-    ONLY_10000 = 5,                                 // find masternode outputs including locked ones (use with caution)
     STAKEABLE_COINS = 6                             // UTXO's that are valid for staking
 };
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -121,7 +121,6 @@ enum WalletFeature {
 
 enum AvailableCoinsType {
     ALL_COINS = 1,
-    STAKEABLE_COINS = 6                             // UTXO's that are valid for staking
 };
 
 /** A key pool entry */

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -119,10 +119,6 @@ enum WalletFeature {
     FEATURE_LATEST = FEATURE_SAPLING
 };
 
-enum AvailableCoinsType {
-    ALL_COINS = 1,
-};
-
 /** A key pool entry */
 class CKeyPool
 {
@@ -639,7 +635,6 @@ private:
     OutputAvailabilityResult CheckOutputAvailability(const CTxOut& output,
                                                      const unsigned int outIndex,
                                                      const uint256& wtxid,
-                                                     AvailableCoinsType nCoinType,
                                                      const CCoinControl* coinControl,
                                                      const bool fCoinsSelected,
                                                      const bool fIncludeColdStaking,
@@ -770,7 +765,6 @@ public:
         AvailableCoinsFilter() {}
         AvailableCoinsFilter(bool _fIncludeDelegated,
                              bool _fIncludeColdStaking,
-                             AvailableCoinsType _nCoinType,
                              bool _fOnlyConfirmed,
                              bool _fOnlySpendable,
                              std::set<CTxDestination>* _onlyFilteredDest,
@@ -779,7 +773,6 @@ public:
                              CAmount _nMaxOutValue = 0) :
                 fIncludeDelegated(_fIncludeDelegated),
                 fIncludeColdStaking(_fIncludeColdStaking),
-                nCoinType(_nCoinType),
                 fOnlyConfirmed(_fOnlyConfirmed),
                 fOnlySpendable(_fOnlySpendable),
                 onlyFilteredDest(_onlyFilteredDest),
@@ -789,7 +782,6 @@ public:
 
         bool fIncludeDelegated{true};
         bool fIncludeColdStaking{false};
-        AvailableCoinsType nCoinType{ALL_COINS};
         bool fOnlyConfirmed{true};
         bool fOnlySpendable{false};
         std::set<CTxDestination>* onlyFilteredDest{nullptr};
@@ -1009,14 +1001,13 @@ public:
         int& nChangePosInOut,
         std::string& strFailReason,
         const CCoinControl* coinControl = NULL,
-        AvailableCoinsType coin_type = ALL_COINS,
         bool sign = true,
         CAmount nFeePay = 0,
         bool fIncludeDelegated = false,
         bool* fStakeDelegationVoided = nullptr,
         int nExtraSize = 0);
 
-    bool CreateTransaction(CScript scriptPubKey, const CAmount& nValue, CTransactionRef& tx, CReserveKey& reservekey, CAmount& nFeeRet, std::string& strFailReason, const CCoinControl* coinControl = NULL, AvailableCoinsType coin_type = ALL_COINS, CAmount nFeePay = 0, bool fIncludeDelegated = false);
+    bool CreateTransaction(CScript scriptPubKey, const CAmount& nValue, CTransactionRef& tx, CReserveKey& reservekey, CAmount& nFeeRet, std::string& strFailReason, const CCoinControl* coinControl = NULL, CAmount nFeePay = 0, bool fIncludeDelegated = false);
 
     // enumeration for CommitResult (return status of CommitTransaction)
     enum CommitStatus


### PR DESCRIPTION
Negative PR ☕, applying the same functionality cleaner. Removing the old and redundant `AvailableCoinsType` enum.