### PR TITLE
[Refactor] One CBaseChainParams should be enough

### DIFF
--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -25,44 +25,6 @@ void AppendParamsHelpMessages(std::string& strUsage, bool debugHelp)
     }
 }
 
-/**
- * Main network
- */
-class CBaseMainParams : public CBaseChainParams
-{
-public:
-    CBaseMainParams()
-    {
-        nRPCPort = 51473;
-    }
-};
-
-/**
- * Testnet (v5)
- */
-class CBaseTestNetParams : public CBaseChainParams
-{
-public:
-    CBaseTestNetParams()
-    {
-        nRPCPort = 51475;
-        strDataDir = "testnet5";
-    }
-};
-
-/*
- * Regression test
- */
-class CBaseRegTestParams : public CBaseChainParams
-{
-public:
-    CBaseRegTestParams()
-    {
-        nRPCPort = 51475;
-        strDataDir = "regtest";
-    }
-};
-
 static std::unique_ptr<CBaseChainParams> globalChainBaseParams;
 
 const CBaseChainParams& BaseParams()
@@ -74,11 +36,11 @@ const CBaseChainParams& BaseParams()
 std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain)
 {
     if (chain == CBaseChainParams::MAIN)
-        return std::unique_ptr<CBaseChainParams>(new CBaseMainParams());
+        return std::make_unique<CBaseChainParams>("", 51473);
     else if (chain == CBaseChainParams::TESTNET)
-        return std::unique_ptr<CBaseChainParams>(new CBaseTestNetParams());
+        return std::make_unique<CBaseChainParams>("testnet5", 51475);
     else if (chain == CBaseChainParams::REGTEST)
-        return std::unique_ptr<CBaseChainParams>(new CBaseRegTestParams());
+        return std::make_unique<CBaseChainParams>("regtest", 51475);
     else
         throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
 }

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -40,7 +40,7 @@ std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain
     else if (chain == CBaseChainParams::TESTNET)
         return std::make_unique<CBaseChainParams>("testnet5", 51475);
     else if (chain == CBaseChainParams::REGTEST)
-        return std::make_unique<CBaseChainParams>("regtest", 51475);
+        return std::make_unique<CBaseChainParams>("regtest", 51477);
     else
         throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
 }

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -27,9 +27,10 @@ public:
     const std::string& DataDir() const { return strDataDir; }
     int RPCPort() const { return nRPCPort; }
 
-protected:
-    CBaseChainParams() {}
+    CBaseChainParams() = delete;
+    CBaseChainParams(const std::string& data_dir, int rpc_port) : nRPCPort(rpc_port), strDataDir(data_dir) {}
 
+private:
     int nRPCPort;
     std::string strDataDir;
 };


### PR DESCRIPTION
Coming from https://github.com/bitcoin/bitcoin/pull/12128

> There's no need for class hierarchy with CBaseChainParams, it is just a struct with 2 fields.
> This starts as a +10-43 diff

Since we already require c++14, can use `std::make_unique` directly.

Note: I did not change the regtest RPC port here, but maybe this is the perfect opportunity to do so if we want it to not conflict with testnet's RPC port