### PR TITLE
[GUI] BugFix, disappearing text in comboboxes.

### DIFF
--- a/src/qt/pivx/dashboardwidget.cpp
+++ b/src/qt/pivx/dashboardwidget.cpp
@@ -69,9 +69,9 @@ DashboardWidget::DashboardWidget(PIVXGUI* parent) :
     setCssProperty({ui->comboBoxMonths,  ui->comboBoxYears}, "btn-combo-chart-selected");
 
     ui->comboBoxMonths->setView(new QListView());
-    ui->comboBoxMonths->setStyleSheet("selection-background-color:transparent; selection-color:transparent;");
+    ui->comboBoxMonths->setStyleSheet("selection-background-color:transparent;");
     ui->comboBoxYears->setView(new QListView());
-    ui->comboBoxYears->setStyleSheet("selection-background-color:transparent; selection-color:transparent;");
+    ui->comboBoxYears->setStyleSheet("selection-background-color:transparent;");
     ui->pushButtonYear->setChecked(true);
 
     setCssProperty(ui->pushButtonChartArrow, "btn-chart-arrow");

--- a/src/qt/pivx/qtutils.cpp
+++ b/src/qt/pivx/qtutils.cpp
@@ -11,7 +11,6 @@
 #include <QFile>
 #include <QGraphicsDropShadowEffect>
 #include <QListView>
-#include <QStyle>
 
 Qt::Modifier SHORT_KEY
 #ifdef Q_OS_MAC
@@ -100,7 +99,7 @@ bool openDialogWithOpaqueBackgroundFullScreen(QDialog* widget, PIVXGUI* gui)
     return res;
 }
 
-QPixmap encodeToQr(QString str, QString& errorStr, QColor qrColor)
+QPixmap encodeToQr(const QString& str, QString& errorStr, const QColor& qrColor)
 {
     if (!str.isEmpty()) {
         // limit URI length
@@ -230,28 +229,18 @@ void updateStyle(QWidget* widget)
 
 QColor getRowColor(bool isLightTheme, bool isHovered, bool isSelected)
 {
-    if (isLightTheme) {
-        if (isSelected) {
-            return QColor("#25b088ff");
-        } else if (isHovered) {
-            return QColor("#25bababa");
-        } else {
-            return QColor("#ffffff");
-        }
+    if (isSelected) {
+        return QColor("#25b088ff");
+    } else if (isHovered) {
+        return QColor("#25bababa");
     } else {
-        if (isSelected) {
-            return QColor("#25b088ff");
-        } else if (isHovered) {
-            return QColor("#25bababa");
-        } else {
-            return QColor("#0f0b16");
-        }
+        return isLightTheme ? QColor("#ffffff") : QColor("#0f0b16");
     }
 }
 
 void initComboBox(QComboBox* combo, QLineEdit* lineEdit, QString cssClass)
 {
-    setCssProperty(combo, cssClass);
+    setCssProperty(combo, std::move(cssClass));
     combo->setEditable(true);
     if (lineEdit) {
         lineEdit->setReadOnly(true);
@@ -284,7 +273,7 @@ void initCssEditLine(QLineEdit* edit, bool isDialog)
     else
         setCssEditLine(edit, true, false);
     setShadow(edit);
-    edit->setAttribute(Qt::WA_MacShowFocusRect, 0);
+    edit->setAttribute(Qt::WA_MacShowFocusRect, false);
 }
 
 void setCssEditLine(QLineEdit* edit, bool isValid, bool forceUpdate)
@@ -339,14 +328,14 @@ void setCssSubtitleScreen(QWidget* wid)
     setCssProperty(wid, "text-subtitle", false);
 }
 
-void setCssProperty(std::initializer_list<QWidget*> args, QString value)
+void setCssProperty(std::initializer_list<QWidget*> args, const QString& value)
 {
     for (QWidget* w : args) {
         setCssProperty(w, value);
     }
 }
 
-void setCssProperty(QWidget* wid, QString value, bool forceUpdate)
+void setCssProperty(QWidget* wid, const QString& value, bool forceUpdate)
 {
     wid->setProperty("cssClass", value);
     forceUpdateStyle(wid, forceUpdate);

--- a/src/qt/pivx/qtutils.cpp
+++ b/src/qt/pivx/qtutils.cpp
@@ -258,7 +258,7 @@ void initComboBox(QComboBox* combo, QLineEdit* lineEdit, QString cssClass)
         lineEdit->setAlignment(Qt::AlignRight);
         combo->setLineEdit(lineEdit);
     }
-    combo->setStyleSheet("selection-background-color:transparent; selection-color:transparent;");
+    combo->setStyleSheet("selection-background-color:transparent;");
     combo->setView(new QListView());
 }
 

--- a/src/qt/pivx/qtutils.h
+++ b/src/qt/pivx/qtutils.h
@@ -40,7 +40,7 @@ bool openDialogWithOpaqueBackground(QDialog* widget, PIVXGUI* gui, double posX =
 bool openDialogWithOpaqueBackgroundFullScreen(QDialog* widget, PIVXGUI* gui);
 
 //
-QPixmap encodeToQr(QString str, QString& errorStr, QColor qrColor = Qt::black);
+QPixmap encodeToQr(const QString& str, QString& errorStr, const QColor& qrColor = Qt::black);
 
 // Helpers
 void updateStyle(QWidget* widget);
@@ -71,8 +71,8 @@ void setCssTitleScreen(QLabel* label);
 void setCssSubtitleScreen(QWidget* wid);
 void setCssTextBodyDialog(std::initializer_list<QWidget*> args);
 void setCssTextBodyDialog(QWidget* widget);
-void setCssProperty(std::initializer_list<QWidget*> args, QString value);
-void setCssProperty(QWidget* wid, QString value, bool forceUpdate = false);
+void setCssProperty(std::initializer_list<QWidget*> args, const QString& value);
+void setCssProperty(QWidget* wid, const QString& value, bool forceUpdate = false);
 void forceUpdateStyle(QWidget* widget, bool forceUpdate);
 void forceUpdateStyle(std::initializer_list<QWidget*> args);
 

--- a/src/qt/pivx/res/css/style_dark.css
+++ b/src/qt/pivx/res/css/style_dark.css
@@ -1944,6 +1944,7 @@ QComboBox[cssClass="btn-combo-chart"] {
     font-size:16px;
     border:1px solid #bababa;
     color: #707070;
+    selection-color:#707070;
     text-align: right;
     border-radius:2px;
 }
@@ -2169,6 +2170,7 @@ QComboBox[cssClass="btn-combo"] {
     font-size:16px;
     border:1px solid #0f0b16;
     color: #707070;
+    selection-color:#707070;
     text-align: right;
 }
 

--- a/src/qt/pivx/res/css/style_light.css
+++ b/src/qt/pivx/res/css/style_light.css
@@ -2170,6 +2170,7 @@ QComboBox[cssClass="btn-combo"] {
     font-size:16px;
     border:1px solid #ffffff;
     color: #707070;
+    selection-color:#707070;
     text-align: right;
 }
 


### PR DESCRIPTION
Essentially, every combo box in the application has set the selection-color property to transparent, so the text "disappear" (turns invisible) when the mouse highlight it.

Fixes #1172.