### PR TITLE
Fix MN activation when the node received the mnb before initialize the MN.

### DIFF
--- a/src/activemasternode.h
+++ b/src/activemasternode.h
@@ -99,7 +99,7 @@ public:
     CKey privKeyMasternode;
 
     // Initialized while registering Masternode
-    Optional<CTxIn> vin;
+    Optional<CTxIn> vin{nullopt};
     CService service;
 
     /// Manage status of main Masternode


### PR DESCRIPTION
If the node already has the MN stored and the activation process is triggered (via the startup flag or the RPC command), the node's `activeMasternode` will get stalled waiting until (1) the MN list gets cleaned/refreshed and someone else in the network sends the MN again or (2) until someone else enable the MN (which is not possible as this node is being enabled solely to send the ping to enable the MN..)

This is the reason why someone in the past added the `activeMasternode::EnableHotColdMasterNode` call inside the mnb message receive (which now is redundant), to force the activation as the MN enablement process was totally stalled.