### PR TITLE
[Backport] Serialization framework updates

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -262,6 +262,7 @@ BITCOIN_CORE_H = \
   script/standard.h \
   script/script_error.h \
   serialize.h \
+  span.h \
   spork.h \
   sporkdb.h \
   sporkid.h \

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -83,7 +83,7 @@ bool DeserializeDB(Stream& stream, Data& data, bool fCheckSum = true)
         unsigned char pchMsgTmp[4];
         verifier >> pchMsgTmp;
         // ... verify the network matches ours
-        if (memcmp(pchMsgTmp, Params().MessageStart(), sizeof(pchMsgTmp)))
+        if (memcmp(pchMsgTmp, Params().MessageStart(), sizeof(pchMsgTmp)) != 0)
             return error("%s: Invalid network magic number", __func__);
 
         // de-serialize data

--- a/src/addrdb.h
+++ b/src/addrdb.h
@@ -45,15 +45,7 @@ public:
         nCreateTime = nCreateTimeIn;
     }
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(nVersion);
-        READWRITE(nCreateTime);
-        READWRITE(nBanUntil);
-        READWRITE(banReason);
-    }
+    SERIALIZE_METHODS(CBanEntry, obj) { READWRITE(obj.nVersion, obj.nCreateTime, obj.nBanUntil, obj.banReason); }
 
     void SetNull()
     {

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -55,15 +55,11 @@ private:
     friend class CAddrMan;
 
 public:
-    ADD_SERIALIZE_METHODS;
 
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(CAddrInfo, obj)
     {
-        READWRITEAS(CAddress, *this);
-        READWRITE(source);
-        READWRITE(nLastSuccess);
-        READWRITE(nAttempts);
+        READWRITEAS(CAddress, obj);
+        READWRITE(obj.source, obj.nLastSuccess, obj.nAttempts);
     }
 
     void Init()
@@ -310,7 +306,7 @@ public:
      * This format is more complex, but significantly smaller (at most 1.5 MiB), and supports
      * changes to the ADDRMAN_ parameters without breaking the on-disk structure.
      *
-     * We don't use ADD_SERIALIZE_METHODS since the serialization and deserialization code has
+     * We don't use SERIALIZE_METHODS since the serialization and deserialization code has
      * very little in common.
      */
     template <typename Stream>

--- a/src/bench/prevector.cpp
+++ b/src/bench/prevector.cpp
@@ -22,6 +22,7 @@
 struct nontrivial_t {
     int x;
     nontrivial_t() :x(-1) {}
+    SERIALIZE_METHODS(nontrivial_t, obj) { READWRITE(obj.x); }
 };
 static_assert(!IS_TRIVIALLY_CONSTRUCTIBLE<nontrivial_t>::value,
               "expected nontrivial_t to not be trivially constructible");

--- a/src/bloom.h
+++ b/src/bloom.h
@@ -33,11 +33,11 @@ enum bloomflags {
 /**
  * BloomFilter is a probabilistic filter which SPV clients provide
  * so that we can filter the transactions we sends them.
- * 
+ *
  * This allows for significantly more efficient transaction and block downloads.
- * 
+ *
  * Because bloom filters are probabilistic, an SPV node can increase the false-
- * positive rate, making us send them transactions which aren't actually theirs, 
+ * positive rate, making us send them transactions which aren't actually theirs,
  * allowing clients to trade more bandwidth for more privacy by obfuscating which
  * keys are owned by them.
  */
@@ -66,16 +66,7 @@ public:
     CBloomFilter(unsigned int nElements, double nFPRate, unsigned int nTweak, unsigned char nFlagsIn);
     CBloomFilter() : isFull(true), isEmpty(false), nHashFuncs(0), nTweak(0), nFlags(0) {}
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(vData);
-        READWRITE(nHashFuncs);
-        READWRITE(nTweak);
-        READWRITE(nFlags);
-    }
+    SERIALIZE_METHODS(CBloomFilter, obj) { READWRITE(obj.vData, obj.nHashFuncs, obj.nTweak, obj.nFlags); }
 
     void insert(const std::vector<unsigned char>& vKey);
     void insert(const COutPoint& outpoint);

--- a/src/budget/budgetdb.cpp
+++ b/src/budget/budgetdb.cpp
@@ -93,7 +93,6 @@ CBudgetDB::ReadResult CBudgetDB::Read(CBudgetManager& objToLoad, bool fDryRun)
     }
 
     int version;
-    unsigned char pchMsgTmp[4];
     std::string strMagicMessageTmp;
     try {
         // de-serialize file header
@@ -106,12 +105,12 @@ CBudgetDB::ReadResult CBudgetDB::Read(CBudgetManager& objToLoad, bool fDryRun)
             return IncorrectMagicMessage;
         }
 
-
         // de-serialize file header (network specific magic number) and ..
-        ssObj >> FLATDATA(pchMsgTmp);
+        std::vector<unsigned char> pchMsgTmp(4);
+        ssObj >> MakeSpan(pchMsgTmp);
 
         // ... verify the network matches ours
-        if (memcmp(pchMsgTmp, Params().MessageStart(), sizeof(pchMsgTmp))) {
+        if (memcmp(pchMsgTmp.data(), Params().MessageStart(), pchMsgTmp.size()) != 0) {
             error("%s : Invalid network magic number", __func__);
             return IncorrectMagicNumber;
         }

--- a/src/budget/budgetmanager.h
+++ b/src/budget/budgetmanager.h
@@ -166,30 +166,23 @@ public:
     // Remove proposal/budget by FeeTx (called when a block is disconnected)
     void RemoveByFeeTxId(const uint256& feeTxId);
 
-    ADD_SERIALIZE_METHODS;
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(CBudgetManager, obj)
     {
         {
-            LOCK(cs_proposals);
-            READWRITE(mapProposals);
-            READWRITE(mapFeeTxToProposal);
+            LOCK(obj.cs_proposals);
+            READWRITE(obj.mapProposals, obj.mapFeeTxToProposal);
         }
         {
-            LOCK(cs_votes);
-            READWRITE(mapSeenProposalVotes);
-            READWRITE(mapOrphanProposalVotes);
+            LOCK(obj.cs_votes);
+            READWRITE(obj.mapSeenProposalVotes, obj.mapOrphanProposalVotes);
         }
         {
-            LOCK(cs_budgets);
-            READWRITE(mapFinalizedBudgets);
-            READWRITE(mapFeeTxToBudget);
-            READWRITE(mapUnconfirmedFeeTx);
+            LOCK(obj.cs_budgets);
+            READWRITE(obj.mapFinalizedBudgets, obj.mapFeeTxToBudget, obj.mapUnconfirmedFeeTx);
         }
         {
-            LOCK(cs_finalizedvotes);
-            READWRITE(mapSeenFinalizedBudgetVotes);
-            READWRITE(mapOrphanFinalizedBudgetVotes);
+            LOCK(obj.cs_finalizedvotes);
+            READWRITE(obj.mapSeenFinalizedBudgetVotes, obj.mapOrphanFinalizedBudgetVotes);
         }
     }
 };

--- a/src/budget/budgetproposal.h
+++ b/src/budget/budgetproposal.h
@@ -106,19 +106,17 @@ public:
     }
 
     // Serialization for local DB
-    ADD_SERIALIZE_METHODS;
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(CBudgetProposal, obj)
     {
-        READWRITE(LIMITED_STRING(strProposalName, 20));
-        READWRITE(LIMITED_STRING(strURL, 64));
-        READWRITE(nBlockStart);
-        READWRITE(nBlockEnd);
-        READWRITE(nAmount);
-        READWRITE(address);
-        READWRITE(nFeeTXHash);
-        READWRITE(nTime);
-        READWRITE(mapVotes);
+        READWRITE(LIMITED_STRING(obj.strProposalName, 20));
+        READWRITE(LIMITED_STRING(obj.strURL, 64));
+        READWRITE(obj.nBlockStart);
+        READWRITE(obj.nBlockEnd);
+        READWRITE(obj.nAmount);
+        READWRITE(obj.address);
+        READWRITE(obj.nFeeTXHash);
+        READWRITE(obj.nTime);
+        READWRITE(obj.mapVotes);
     }
 
     // Serialization for network messages.

--- a/src/budget/budgetvote.h
+++ b/src/budget/budgetvote.h
@@ -17,7 +17,7 @@
 class CBudgetVote : public CSignedMessage
 {
 public:
-    enum VoteDirection {
+    enum VoteDirection : uint32_t {
         VOTE_ABSTAIN = 0,
         VOTE_YES = 1,
         VOTE_NO = 2
@@ -64,20 +64,7 @@ public:
     void SetTime(const int64_t& _nTime) { nTime = _nTime; }
     void SetValid(bool _fValid) { fValid = _fValid; }
 
-    ADD_SERIALIZE_METHODS;
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(vin);
-        READWRITE(nProposalHash);
-        int nVoteInt = (int) nVote;
-        READWRITE(nVoteInt);
-        if (ser_action.ForRead())
-            nVote = (VoteDirection) nVoteInt;
-        READWRITE(nTime);
-        READWRITE(vchSig);
-        READWRITE(nMessVersion);
-    }
+    SERIALIZE_METHODS(CBudgetVote, obj) { READWRITE(obj.vin, obj.nProposalHash, Using<CustomUintFormatter<4>>(obj.nVote), obj.nTime, obj.vchSig, obj.nMessVersion); }
 };
 
 #endif // BUDGET_VOTE_H

--- a/src/budget/budgetvote.h
+++ b/src/budget/budgetvote.h
@@ -76,12 +76,7 @@ public:
             nVote = (VoteDirection) nVoteInt;
         READWRITE(nTime);
         READWRITE(vchSig);
-        try
-        {
-            READWRITE(nMessVersion);
-        } catch (...) {
-            nMessVersion = MessageVersion::MESS_VER_STRMESS;
-        }
+        READWRITE(nMessVersion);
     }
 };
 

--- a/src/budget/finalizedbudget.h
+++ b/src/budget/finalizedbudget.h
@@ -106,18 +106,16 @@ public:
     }
 
     // Serialization for local DB
-    ADD_SERIALIZE_METHODS;
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(CFinalizedBudget, obj)
     {
-        READWRITE(LIMITED_STRING(strBudgetName, 20));
-        READWRITE(nFeeTXHash);
-        READWRITE(nTime);
-        READWRITE(nBlockStart);
-        READWRITE(vecBudgetPayments);
-        READWRITE(fAutoChecked);
-        READWRITE(mapVotes);
-        READWRITE(strProposals);
+        READWRITE(LIMITED_STRING(obj.strBudgetName, 20));
+        READWRITE(obj.nFeeTXHash);
+        READWRITE(obj.nTime);
+        READWRITE(obj.nBlockStart);
+        READWRITE(obj.vecBudgetPayments);
+        READWRITE(obj.fAutoChecked);
+        READWRITE(obj.mapVotes);
+        READWRITE(obj.strProposals);
     }
 
     // Serialization for network messages.
@@ -155,16 +153,8 @@ public:
         nAmount(_nAmount)
     {}
 
-    ADD_SERIALIZE_METHODS;
-
     //for saving to the serialized db
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(payee);
-        READWRITE(nAmount);
-        READWRITE(nProposalHash);
-    }
+    SERIALIZE_METHODS(CTxBudgetPayment, obj) { READWRITE(obj.payee, obj.nAmount, obj.nProposalHash); }
 
     // compare payments by proposal hash
     inline bool operator>(const CTxBudgetPayment& other) const

--- a/src/budget/finalizedbudgetvote.h
+++ b/src/budget/finalizedbudgetvote.h
@@ -55,12 +55,7 @@ public:
         READWRITE(nBudgetHash);
         READWRITE(nTime);
         READWRITE(vchSig);
-        try
-        {
-            READWRITE(nMessVersion);
-        } catch (...) {
-            nMessVersion = MessageVersion::MESS_VER_STRMESS;
-        }
+        READWRITE(nMessVersion);
     }
 };
 

--- a/src/budget/finalizedbudgetvote.h
+++ b/src/budget/finalizedbudgetvote.h
@@ -47,16 +47,7 @@ public:
     void SetTime(const int64_t& _nTime) { nTime = _nTime; }
     void SetValid(bool _fValid) { fValid = _fValid; }
 
-    ADD_SERIALIZE_METHODS;
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(vin);
-        READWRITE(nBudgetHash);
-        READWRITE(nTime);
-        READWRITE(vchSig);
-        READWRITE(nMessVersion);
-    }
+    SERIALIZE_METHODS(CFinalizedBudgetVote, obj) { READWRITE(obj.vin, obj.nBudgetHash, obj.nTime, obj.vchSig, obj.nMessVersion); }
 };
 
 #endif // FINALIZED_BUDGET_VOTE_H

--- a/src/chain.h
+++ b/src/chain.h
@@ -41,18 +41,15 @@ public:
     uint64_t nTimeFirst;       //!< earliest time of block in file
     uint64_t nTimeLast;        //!< latest time of block in file
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(CBlockFileInfo, obj)
     {
-        READWRITE(VARINT(nBlocks));
-        READWRITE(VARINT(nSize));
-        READWRITE(VARINT(nUndoSize));
-        READWRITE(VARINT(nHeightFirst));
-        READWRITE(VARINT(nHeightLast));
-        READWRITE(VARINT(nTimeFirst));
-        READWRITE(VARINT(nTimeLast));
+        READWRITE(VARINT(obj.nBlocks));
+        READWRITE(VARINT(obj.nSize));
+        READWRITE(VARINT(obj.nUndoSize));
+        READWRITE(VARINT(obj.nHeightFirst));
+        READWRITE(VARINT(obj.nHeightLast));
+        READWRITE(VARINT(obj.nTimeFirst));
+        READWRITE(VARINT(obj.nTimeLast));
     }
 
     void SetNull()

--- a/src/chain.h
+++ b/src/chain.h
@@ -283,13 +283,13 @@ public:
     {
         int nSerVersion = s.GetVersion();
         if (!(s.GetType() & SER_GETHASH))
-            READWRITE(VARINT(nSerVersion, VarIntMode::NONNEGATIVE_SIGNED));
+            READWRITE(VARINT_MODE(nSerVersion, VarIntMode::NONNEGATIVE_SIGNED));
 
-        READWRITE(VARINT(nHeight, VarIntMode::NONNEGATIVE_SIGNED));
+        READWRITE(VARINT_MODE(nHeight, VarIntMode::NONNEGATIVE_SIGNED));
         READWRITE(VARINT(nStatus));
         READWRITE(VARINT(nTx));
         if (nStatus & (BLOCK_HAVE_DATA | BLOCK_HAVE_UNDO))
-            READWRITE(VARINT(nFile, VarIntMode::NONNEGATIVE_SIGNED));
+            READWRITE(VARINT_MODE(nFile, VarIntMode::NONNEGATIVE_SIGNED));
         if (nStatus & BLOCK_HAVE_DATA)
             READWRITE(VARINT(nDataPos));
         if (nStatus & BLOCK_HAVE_UNDO)

--- a/src/chain.h
+++ b/src/chain.h
@@ -310,7 +310,7 @@ public:
             // Serialization with CLIENT_VERSION = 4009901
             std::map<libzerocoin::CoinDenomination, int64_t> mapZerocoinSupply;
             int64_t nMoneySupply = 0;
-            SER_READ(obj, nMoneySupply);
+            READWRITE(nMoneySupply);
             READWRITE(obj.nFlags);
             READWRITE(obj.nVersion);
             READWRITE(obj.vStakeModifier);
@@ -320,7 +320,7 @@ public:
             READWRITE(obj.nBits);
             READWRITE(obj.nNonce);
             if (obj.nVersion > 3) {
-                SER_READ(obj, mapZerocoinSupply);
+                READWRITE(mapZerocoinSupply);
                 if (obj.nVersion < 7) READWRITE(obj.nAccumulatorCheckpoint);
             }
         } else if (ser_action.ForRead()) {
@@ -328,8 +328,8 @@ public:
             int64_t nMint = 0;
             uint256 hashNext{};
             int64_t nMoneySupply = 0;
-            SER_READ(obj, nMint);
-            SER_READ(obj, nMoneySupply);
+            READWRITE(nMint);
+            READWRITE(nMoneySupply);
             READWRITE(obj.nFlags);
             if (!Params().GetConsensus().NetworkUpgradeActive(obj.nHeight, Consensus::UPGRADE_V3_4)) {
                 uint64_t nStakeModifier = 0;
@@ -337,18 +337,18 @@ public:
                 SER_READ(obj, obj.SetStakeModifier(nStakeModifier, obj.GeneratedStakeModifier()));
             } else {
                 uint256 nStakeModifierV2;
-                SER_READ(obj, nStakeModifierV2);
+                READWRITE(nStakeModifierV2);
                 SER_READ(obj, obj.SetStakeModifier(nStakeModifierV2));
             }
             if (obj.IsProofOfStake()) {
                 COutPoint prevoutStake;
                 unsigned int nStakeTime = 0;
-                SER_READ(obj, prevoutStake);
-                SER_READ(obj, nStakeTime);
+                READWRITE(prevoutStake);
+                READWRITE(nStakeTime);
             }
             READWRITE(obj.nVersion);
             READWRITE(obj.hashPrev);
-            SER_READ(obj, hashNext);
+            READWRITE(hashNext);
             READWRITE(obj.hashMerkleRoot);
             READWRITE(obj.nTime);
             READWRITE(obj.nBits);
@@ -357,8 +357,8 @@ public:
                 std::map<libzerocoin::CoinDenomination, int64_t> mapZerocoinSupply;
                 std::vector<libzerocoin::CoinDenomination> vMintDenominationsInBlock;
                 READWRITE(obj.nAccumulatorCheckpoint);
-                SER_READ(obj, mapZerocoinSupply);
-                SER_READ(obj, vMintDenominationsInBlock);
+                READWRITE(mapZerocoinSupply);
+                READWRITE(vMintDenominationsInBlock);
             }
         }
     }

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -429,7 +429,7 @@ bool CCoinsViewCache::PruneInvalidEntries()
     return Flush();
 }
 
-static const size_t MAX_OUTPUTS_PER_BLOCK = MAX_BLOCK_SIZE_CURRENT /  ::GetSerializeSize(CTxOut(), SER_NETWORK, PROTOCOL_VERSION); // TODO: merge with similar definition in undo.h.
+static const size_t MAX_OUTPUTS_PER_BLOCK = MAX_BLOCK_SIZE_CURRENT /  ::GetSerializeSize(CTxOut(), PROTOCOL_VERSION); // TODO: merge with similar definition in undo.h.
 
 const Coin& AccessByTxid(const CCoinsViewCache& view, const uint256& txid)
 {

--- a/src/coins.h
+++ b/src/coins.h
@@ -69,7 +69,7 @@ public:
         assert(!IsSpent());
         uint32_t code = nHeight * 4 + (fCoinBase ? 2 : 0) + (fCoinStake ? 1 : 0);
         ::Serialize(s, VARINT(code));
-        ::Serialize(s, CTxOutCompressor(REF(out)));
+        ::Serialize(s, Using<TxOutCompression>(out));
     }
 
     template<typename Stream>
@@ -79,7 +79,7 @@ public:
         nHeight = code >> 2;
         fCoinBase = code & 2;
         fCoinStake = code & 1;
-        ::Unserialize(s, CTxOutCompressor(out));
+        ::Unserialize(s, Using<TxOutCompression>(out));
     }
 
     bool IsSpent() const {

--- a/src/compressor.cpp
+++ b/src/compressor.cpp
@@ -10,7 +10,15 @@
 #include "pubkey.h"
 #include "script/standard.h"
 
-bool CScriptCompressor::IsToKeyID(CKeyID& hash) const
+/*
+ * These check for scripts for which a special case with a shorter encoding is defined.
+ * They are implemented separately from the CScript test, as these test for exact byte
+ * sequence correspondences, and are more strict. For example, IsToPubKey also verifies
+ * whether the public key is valid (as invalid ones cannot be represented in compressed
+ * form).
+ */
+
+static bool IsToKeyID(const CScript& script, CKeyID &hash)
 {
     if (script.size() == 25 && script[0] == OP_DUP && script[1] == OP_HASH160 && script[2] == 20 && script[23] == OP_EQUALVERIFY && script[24] == OP_CHECKSIG) {
         memcpy(&hash, &script[3], 20);
@@ -19,7 +27,7 @@ bool CScriptCompressor::IsToKeyID(CKeyID& hash) const
     return false;
 }
 
-bool CScriptCompressor::IsToScriptID(CScriptID& hash) const
+static bool IsToScriptID(const CScript& script, CScriptID &hash)
 {
     if (script.size() == 23 && script[0] == OP_HASH160 && script[1] == 20 && script[22] == OP_EQUAL) {
         memcpy(&hash, &script[2], 20);
@@ -28,7 +36,7 @@ bool CScriptCompressor::IsToScriptID(CScriptID& hash) const
     return false;
 }
 
-bool CScriptCompressor::IsToPubKey(CPubKey& pubkey) const
+static bool IsToPubKey(const CScript& script, CPubKey &pubkey)
 {
     if (script.size() == 35 && script[0] == 33 && script[34] == OP_CHECKSIG && (script[1] == 0x02 || script[1] == 0x03)) {
         pubkey.Set(&script[1], &script[34]);
@@ -41,24 +49,24 @@ bool CScriptCompressor::IsToPubKey(CPubKey& pubkey) const
     return false;
 }
 
-bool CScriptCompressor::Compress(std::vector<unsigned char>& out) const
+bool CompressScript(const CScript& script, std::vector<unsigned char> &out)
 {
     CKeyID keyID;
-    if (IsToKeyID(keyID)) {
+    if (IsToKeyID(script, keyID)) {
         out.resize(21);
         out[0] = 0x00;
         memcpy(&out[1], &keyID, 20);
         return true;
     }
     CScriptID scriptID;
-    if (IsToScriptID(scriptID)) {
+    if (IsToScriptID(script, scriptID)) {
         out.resize(21);
         out[0] = 0x01;
         memcpy(&out[1], &scriptID, 20);
         return true;
     }
     CPubKey pubkey;
-    if (IsToPubKey(pubkey)) {
+    if (IsToPubKey(script, pubkey)) {
         out.resize(33);
         memcpy(&out[1], &pubkey[1], 32);
         if (pubkey[0] == 0x02 || pubkey[0] == 0x03) {
@@ -72,7 +80,7 @@ bool CScriptCompressor::Compress(std::vector<unsigned char>& out) const
     return false;
 }
 
-unsigned int CScriptCompressor::GetSpecialSize(unsigned int nSize) const
+unsigned int GetSpecialScriptSize(unsigned int nSize)
 {
     if (nSize == 0 || nSize == 1)
         return 20;
@@ -81,7 +89,7 @@ unsigned int CScriptCompressor::GetSpecialSize(unsigned int nSize) const
     return 0;
 }
 
-bool CScriptCompressor::Decompress(unsigned int nSize, const std::vector<unsigned char>& in)
+bool DecompressScript(CScript& script, unsigned int nSize, const std::vector<unsigned char> &in)
 {
     switch (nSize) {
     case 0x00:
@@ -135,7 +143,7 @@ bool CScriptCompressor::Decompress(unsigned int nSize, const std::vector<unsigne
 // * if e==9, we only know the resulting number is not zero, so output 1 + 10*(n - 1) + 9
 // (this is decodable, as d is in [1-9] and e is in [0-9])
 
-uint64_t CTxOutCompressor::CompressAmount(uint64_t n)
+uint64_t CompressAmount(uint64_t n)
 {
     if (n == 0)
         return 0;
@@ -154,7 +162,7 @@ uint64_t CTxOutCompressor::CompressAmount(uint64_t n)
     }
 }
 
-uint64_t CTxOutCompressor::DecompressAmount(uint64_t x)
+uint64_t DecompressAmount(uint64_t x)
 {
     // x = 0  OR  x = 1+10*(9*n + d - 1) + e  OR  x = 1+10*(n - 1) + 9
     if (x == 0)

--- a/src/compressor.h
+++ b/src/compressor.h
@@ -10,6 +10,7 @@
 #include "primitives/transaction.h"
 #include "script/script.h"
 #include "serialize.h"
+#include "span.h"
 
 class CKeyID;
 class CPubKey;
@@ -63,12 +64,12 @@ public:
     {
         std::vector<unsigned char> compr;
         if (Compress(compr)) {
-            s << CFlatData(compr);
+            s << MakeSpan(compr);
             return;
         }
         unsigned int nSize = script.size() + nSpecialScripts;
         s << VARINT(nSize);
-        s << CFlatData(script);
+        s << MakeSpan(script);
     }
 
     template <typename Stream>
@@ -78,7 +79,7 @@ public:
         s >> VARINT(nSize);
         if (nSize < nSpecialScripts) {
             std::vector<unsigned char> vch(GetSpecialSize(nSize), 0x00);
-            s >> CFlatData(vch);
+            s >> MakeSpan(vch);
             Decompress(nSize, vch);
             return;
         }
@@ -89,7 +90,7 @@ public:
             s.ignore(nSize);
         } else {
             script.resize(nSize);
-            s >> CFlatData(script);
+            s >> MakeSpan(script);
         }
     }
 };

--- a/src/compressor.h
+++ b/src/compressor.h
@@ -16,6 +16,13 @@ class CKeyID;
 class CPubKey;
 class CScriptID;
 
+bool CompressScript(const CScript& script, std::vector<unsigned char> &out);
+unsigned int GetSpecialScriptSize(unsigned int nSize);
+bool DecompressScript(CScript& script, unsigned int nSize, const std::vector<unsigned char> &out);
+
+uint64_t CompressAmount(uint64_t nAmount);
+uint64_t DecompressAmount(uint64_t nAmount);
+
 /** Compact serializer for scripts.
  *
  *  It detects common cases and encodes them much more efficiently.
@@ -38,24 +45,7 @@ private:
      */
     static const unsigned int nSpecialScripts = 6;
 
-    CScript& script;
-
-protected:
-    /**
-     * These check for scripts for which a special case with a shorter encoding is defined.
-     * They are implemented separately from the CScript test, as these test for exact byte
-     * sequence correspondences, and are more strict. For example, IsToPubKey also verifies
-     * whether the public key is valid (as invalid ones cannot be represented in compressed
-     * form).
-     */
-    bool IsToKeyID(CKeyID& hash) const;
-    bool IsToScriptID(CScriptID& hash) const;
-    bool IsToPubKey(CPubKey& pubkey) const;
-
-    bool Compress(std::vector<unsigned char>& out) const;
-    unsigned int GetSpecialSize(unsigned int nSize) const;
-    bool Decompress(unsigned int nSize, const std::vector<unsigned char>& out);
-
+    CScript &script;
 public:
     CScriptCompressor(CScript& scriptIn) : script(scriptIn) {}
 
@@ -63,7 +53,7 @@ public:
     void Serialize(Stream& s) const
     {
         std::vector<unsigned char> compr;
-        if (Compress(compr)) {
+        if (CompressScript(script, compr)) {
             s << MakeSpan(compr);
             return;
         }
@@ -78,9 +68,9 @@ public:
         unsigned int nSize = 0;
         s >> VARINT(nSize);
         if (nSize < nSpecialScripts) {
-            std::vector<unsigned char> vch(GetSpecialSize(nSize), 0x00);
+            std::vector<unsigned char> vch(GetSpecialScriptSize(nSize), 0x00);
             s >> MakeSpan(vch);
-            Decompress(nSize, vch);
+            DecompressScript(script, nSize, vch);
             return;
         }
         nSize -= nSpecialScripts;
@@ -102,10 +92,7 @@ private:
     CTxOut& txout;
 
 public:
-    static uint64_t CompressAmount(uint64_t nAmount);
-    static uint64_t DecompressAmount(uint64_t nAmount);
-
-    CTxOutCompressor(CTxOut& txoutIn) : txout(txoutIn) {}
+    explicit CTxOutCompressor(CTxOut &txoutIn) : txout(txoutIn) { }
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/compressor.h
+++ b/src/compressor.h
@@ -12,10 +12,6 @@
 #include "serialize.h"
 #include "span.h"
 
-class CKeyID;
-class CPubKey;
-class CScriptID;
-
 bool CompressScript(const CScript& script, std::vector<unsigned char> &out);
 unsigned int GetSpecialScriptSize(unsigned int nSize);
 bool DecompressScript(CScript& script, unsigned int nSize, const std::vector<unsigned char> &out);
@@ -34,9 +30,8 @@ uint64_t DecompressAmount(uint64_t nAmount);
  *  Other scripts up to 121 bytes require 1 byte + script length. Above
  *  that, scripts up to 16505 bytes require 2 bytes + script length.
  */
-class CScriptCompressor
+struct ScriptCompression
 {
-private:
     /**
      * make this static for now (there are only 6 special scripts defined)
      * this can potentially be extended together with a new nVersion for
@@ -45,13 +40,8 @@ private:
      */
     static const unsigned int nSpecialScripts = 6;
 
-    CScript &script;
-public:
-    CScriptCompressor(CScript& scriptIn) : script(scriptIn) {}
-
-    template <typename Stream>
-    void Serialize(Stream& s) const
-    {
+    template<typename Stream>
+    void Ser(Stream &s, const CScript& script) {
         std::vector<unsigned char> compr;
         if (CompressScript(script, compr)) {
             s << MakeSpan(compr);
@@ -62,9 +52,8 @@ public:
         s << MakeSpan(script);
     }
 
-    template <typename Stream>
-    void Unserialize(Stream& s)
-    {
+    template<typename Stream>
+    void Unser(Stream &s, CScript& script) {
         unsigned int nSize = 0;
         s >> VARINT(nSize);
         if (nSize < nSpecialScripts) {
@@ -85,31 +74,24 @@ public:
     }
 };
 
-/** wrapper for CTxOut that provides a more compact serialization */
-class CTxOutCompressor
+struct AmountCompression
 {
-private:
-    CTxOut& txout;
-
-public:
-    explicit CTxOutCompressor(CTxOut &txoutIn) : txout(txoutIn) { }
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    template<typename Stream, typename I> void Ser(Stream& s, I val)
     {
-        if (!ser_action.ForRead()) {
-            uint64_t nVal = CompressAmount(txout.nValue);
-            READWRITE(VARINT(nVal));
-        } else {
-            uint64_t nVal = 0;
-            READWRITE(VARINT(nVal));
-            txout.nValue = DecompressAmount(nVal);
-        }
-        CScriptCompressor cscript(REF(txout.scriptPubKey));
-        READWRITE(cscript);
+        s << VARINT(CompressAmount(val));
     }
+    template<typename Stream, typename I> void Unser(Stream& s, I& val)
+    {
+        uint64_t v;
+        s >> VARINT(v);
+        val = DecompressAmount(v);
+    }
+};
+
+/** wrapper for CTxOut that provides a more compact serialization */
+struct TxOutCompression
+{
+    FORMATTER_METHODS(CTxOut, obj) { READWRITE(Using<AmountCompression>(obj.nValue), Using<ScriptCompression>(obj.scriptPubKey)); }
 };
 
 #endif // BITCOIN_COMPRESSOR_H

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -167,7 +167,7 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry)
     entry.pushKV("txid", tx.GetHash().GetHex());
     entry.pushKV("version", tx.nVersion);
     entry.pushKV("type", tx.nType);
-    entry.pushKV("size", (int)::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION));
+    entry.pushKV("size", (int)::GetSerializeSize(tx, PROTOCOL_VERSION));
     entry.pushKV("locktime", (int64_t)tx.nLockTime);
 
     UniValue vin(UniValue::VARR);

--- a/src/crypter.h
+++ b/src/crypter.h
@@ -46,17 +46,7 @@ public:
     //! such as the various parameters to scrypt
     std::vector<unsigned char> vchOtherDerivationParameters;
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(vchCryptedKey);
-        READWRITE(vchSalt);
-        READWRITE(nDerivationMethod);
-        READWRITE(nDeriveIterations);
-        READWRITE(vchOtherDerivationParameters);
-    }
+    SERIALIZE_METHODS(CMasterKey, obj) { READWRITE(obj.vchCryptedKey, obj.vchSalt, obj.nDerivationMethod, obj.nDeriveIterations, obj.vchOtherDerivationParameters); }
 
     CMasterKey()
     {

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -607,7 +607,7 @@ public:
     template <typename V>
     void Write(const CDataStream& ssKey, const V& v)
     {
-        auto valueMemoryUsage = ::GetSerializeSize(v, SER_DISK, CLIENT_VERSION);
+        auto valueMemoryUsage = ::GetSerializeSize(v, CLIENT_VERSION);
         if (deletes.erase(ssKey)) {
             memoryUsage -= ssKey.size();
         }

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -57,30 +57,24 @@ public:
         scriptOperatorPayout = pl.scriptOperatorPayout;
     }
     template <typename Stream>
-    CDeterministicMNState(deserialize_type, Stream& s)
-    {
-        s >> *this;
-    }
+    CDeterministicMNState(deserialize_type, Stream& s) { s >> *this; }
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(CDeterministicMNState, obj)
     {
-        READWRITE(nRegisteredHeight);
-        READWRITE(nLastPaidHeight);
-        READWRITE(nPoSePenalty);
-        READWRITE(nPoSeRevivedHeight);
-        READWRITE(nPoSeBanHeight);
-        READWRITE(nRevocationReason);
-        READWRITE(confirmedHash);
-        READWRITE(confirmedHashWithProRegTxHash);
-        READWRITE(keyIDOwner);
-        READWRITE(keyIDOperator);
-        READWRITE(keyIDVoting);
-        READWRITE(addr);
-        READWRITE(scriptPayout);
-        READWRITE(scriptOperatorPayout);
+        READWRITE(obj.nRegisteredHeight);
+        READWRITE(obj.nLastPaidHeight);
+        READWRITE(obj.nPoSePenalty);
+        READWRITE(obj.nPoSeRevivedHeight);
+        READWRITE(obj.nPoSeBanHeight);
+        READWRITE(obj.nRevocationReason);
+        READWRITE(obj.confirmedHash);
+        READWRITE(obj.confirmedHashWithProRegTxHash);
+        READWRITE(obj.keyIDOwner);
+        READWRITE(obj.keyIDOperator);
+        READWRITE(obj.keyIDVoting);
+        READWRITE(obj.addr);
+        READWRITE(obj.scriptPayout);
+        READWRITE(obj.scriptOperatorPayout);
     }
 
     void UpdateConfirmedHash(const uint256& _proTxHash, const uint256& _confirmedHash)

--- a/src/evo/providertx.h
+++ b/src/evo/providertx.h
@@ -38,25 +38,23 @@ public:
     std::vector<unsigned char> vchSig;
 
 public:
-    ADD_SERIALIZE_METHODS;
 
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(ProRegPL, obj)
     {
-        READWRITE(nVersion);
-        READWRITE(nType);
-        READWRITE(nMode);
-        READWRITE(collateralOutpoint);
-        READWRITE(addr);
-        READWRITE(keyIDOwner);
-        READWRITE(keyIDOperator);
-        READWRITE(keyIDVoting);
-        READWRITE(scriptPayout);
-        READWRITE(nOperatorReward);
-        READWRITE(scriptOperatorPayout);
-        READWRITE(inputsHash);
+        READWRITE(obj.nVersion);
+        READWRITE(obj.nType);
+        READWRITE(obj.nMode);
+        READWRITE(obj.collateralOutpoint);
+        READWRITE(obj.addr);
+        READWRITE(obj.keyIDOwner);
+        READWRITE(obj.keyIDOperator);
+        READWRITE(obj.keyIDVoting);
+        READWRITE(obj.scriptPayout);
+        READWRITE(obj.nOperatorReward);
+        READWRITE(obj.scriptOperatorPayout);
+        READWRITE(obj.inputsHash);
         if (!(s.GetType() & SER_GETHASH)) {
-            READWRITE(vchSig);
+            READWRITE(obj.vchSig);
         }
     }
 
@@ -82,18 +80,11 @@ public:
     std::vector<unsigned char> vchSig;
 
 public:
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(ProUpServPL, obj)
     {
-        READWRITE(nVersion);
-        READWRITE(proTxHash);
-        READWRITE(addr);
-        READWRITE(scriptOperatorPayout);
-        READWRITE(inputsHash);
+        READWRITE(obj.nVersion, obj.proTxHash, obj.addr, obj.scriptOperatorPayout, obj.inputsHash);
         if (!(s.GetType() & SER_GETHASH)) {
-            READWRITE(vchSig);
+            READWRITE(obj.vchSig);
         }
     }
 

--- a/src/flatfile.h
+++ b/src/flatfile.h
@@ -16,13 +16,7 @@ struct FlatFilePos
     int nFile;
     unsigned int nPos;
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(VARINT_MODE(nFile, VarIntMode::NONNEGATIVE_SIGNED));
-        READWRITE(VARINT(nPos));
-    }
+    SERIALIZE_METHODS(FlatFilePos, obj) { READWRITE(VARINT_MODE(obj.nFile, VarIntMode::NONNEGATIVE_SIGNED), VARINT(obj.nPos)); }
 
     FlatFilePos() : nFile(-1), nPos(0) {}
 

--- a/src/flatfile.h
+++ b/src/flatfile.h
@@ -20,7 +20,7 @@ struct FlatFilePos
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(VARINT(nFile, VarIntMode::NONNEGATIVE_SIGNED));
+        READWRITE(VARINT_MODE(nFile, VarIntMode::NONNEGATIVE_SIGNED));
         READWRITE(VARINT(nPos));
     }
 

--- a/src/libzerocoin/Coin.h
+++ b/src/libzerocoin/Coin.h
@@ -75,13 +75,7 @@ public:
      */
     bool validate() const;
 
-    ADD_SERIALIZE_METHODS;
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(value);
-        READWRITE(denomination);
-    }
+    SERIALIZE_METHODS(PublicCoin, obj) { READWRITE(obj.value, obj.denomination); }
 
 private:
     const ZerocoinParams* params;

--- a/src/libzerocoin/CoinRandomnessSchnorrSignature.h
+++ b/src/libzerocoin/CoinRandomnessSchnorrSignature.h
@@ -39,13 +39,7 @@ public:
      */
     bool Verify(const ZerocoinParams* zcparams, const CBigNum& S, const CBigNum& C, const uint256 msghash) const;
 
-    ADD_SERIALIZE_METHODS;
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(alpha);
-        READWRITE(beta);
-    }
+    SERIALIZE_METHODS(CoinRandomnessSchnorrSignature, obj) { READWRITE(obj.alpha, obj.beta); }
 
 private:
     // signature components

--- a/src/libzerocoin/CoinSpend.h
+++ b/src/libzerocoin/CoinSpend.h
@@ -107,27 +107,15 @@ public:
     CBigNum CalculateValidSerial(ZerocoinParams* params);
     std::string ToString() const;
 
-    ADD_SERIALIZE_METHODS;
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(CoinSpend, obj)
     {
-        READWRITE(denomination);
-        READWRITE(ptxHash);
-        READWRITE(accChecksum);
-        READWRITE(accCommitmentToCoinValue);
-        READWRITE(serialCommitmentToCoinValue);
-        READWRITE(coinSerialNumber);
-        READWRITE(accumulatorPoK);
-        READWRITE(serialNumberSoK);
-        READWRITE(commitmentPoK);
-
+        READWRITE(obj.denomination, obj.ptxHash, obj.accChecksum, obj.accCommitmentToCoinValue);
+        READWRITE(obj.serialCommitmentToCoinValue, obj.coinSerialNumber, obj.accumulatorPoK);
+        READWRITE(obj.serialNumberSoK, obj.commitmentPoK);
         try {
-            READWRITE(version);
-            READWRITE(pubkey);
-            READWRITE(vchSig);
-            READWRITE(spendType);
+            READWRITE(obj.version, obj.pubkey, obj.vchSig, obj.spendType);
         } catch (...) {
-            version = 1;
+            SER_READ(obj, obj.version = 1);
         }
     }
 

--- a/src/libzerocoin/CoinSpend.h
+++ b/src/libzerocoin/CoinSpend.h
@@ -32,14 +32,11 @@ namespace libzerocoin
 class AccumulatorProofOfKnowledge {
 public:
     AccumulatorProofOfKnowledge() {};
-    ADD_SERIALIZE_METHODS;
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(C_e); READWRITE(C_u); READWRITE(C_r); READWRITE(st_1); READWRITE(st_2); READWRITE(st_3);
-        READWRITE(t_1); READWRITE(t_2); READWRITE(t_3); READWRITE(t_4); READWRITE(s_alpha); READWRITE(s_beta);
-        READWRITE(s_zeta); READWRITE(s_sigma); READWRITE(s_eta); READWRITE(s_epsilon);
-        READWRITE(s_delta); READWRITE(s_xi); READWRITE(s_phi); READWRITE(s_gamma); READWRITE(s_psi);
+    SERIALIZE_METHODS(AccumulatorProofOfKnowledge, obj) {
+        READWRITE(obj.C_e, obj.C_u, obj.C_r, obj.st_1, obj.st_2, obj.st_3);
+        READWRITE(obj.t_1, obj.t_2, obj.t_3, obj.t_4, obj.s_alpha, obj.s_beta);
+        READWRITE(obj.s_zeta, obj.s_sigma, obj.s_eta, obj.s_epsilon);
+        READWRITE(obj.s_delta, obj.s_xi, obj.s_phi, obj.s_gamma, obj.s_psi);
     }
 private:
     CBigNum C_e, C_u, C_r;
@@ -55,14 +52,7 @@ private:
 class SerialNumberSignatureOfKnowledge {
 public:
     SerialNumberSignatureOfKnowledge(){};
-    ADD_SERIALIZE_METHODS;
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(s_notprime);
-        READWRITE(sprime);
-        READWRITE(hash);
-    }
+    SERIALIZE_METHODS(SerialNumberSignatureOfKnowledge, obj) { READWRITE(obj.s_notprime, obj.sprime, obj.hash); }
 private:
     uint256 hash;
     std::vector<CBigNum> s_notprime;
@@ -74,12 +64,7 @@ private:
 class CommitmentProofOfKnowledge {
 public:
     CommitmentProofOfKnowledge() {};
-    ADD_SERIALIZE_METHODS;
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(S1); READWRITE(S2); READWRITE(S3); READWRITE(challenge);
-    }
+    SERIALIZE_METHODS(CommitmentProofOfKnowledge, obj) { READWRITE(obj.S1,obj.S2, obj.S3, obj.challenge); }
 private:
     CBigNum S1, S2, S3, challenge;
 };

--- a/src/libzerocoin/Commitment.h
+++ b/src/libzerocoin/Commitment.h
@@ -54,12 +54,7 @@ private:
     CBigNum randomness;
     const CBigNum contents;
 
-    ADD_SERIALIZE_METHODS;
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(commitmentValue); READWRITE(randomness); READWRITE(contents);
-    }
+    SERIALIZE_METHODS(Commitment, obj) { READWRITE(obj.commitmentValue, obj.randomness, obj.contents); }
 };
 } /* namespace libzerocoin */
 #endif /* COMMITMENT_H_ */

--- a/src/libzerocoin/Params.h
+++ b/src/libzerocoin/Params.h
@@ -56,14 +56,7 @@ public:
 	 */
 	CBigNum groupOrder;
 
-	ADD_SERIALIZE_METHODS;
-  template <typename Stream, typename Operation>  inline void SerializationOp(Stream& s, Operation ser_action) {
-		    READWRITE(initialized);
-		    READWRITE(g);
-		    READWRITE(h);
-		    READWRITE(modulus);
-		    READWRITE(groupOrder);
-	}	
+    SERIALIZE_METHODS(IntegerGroupParams, obj) { READWRITE(obj.initialized, obj.g , obj.h, obj.modulus, obj.groupOrder); }
 };
 
 class AccumulatorAndProofParams {
@@ -134,23 +127,15 @@ public:
 	 */
 	uint32_t k_prime;
 
-	/**
-	 * Security parameter.
-	 * The statistical zero-knowledgeness of the accumulator proof.
-	 */
-	uint32_t k_dprime;
-	ADD_SERIALIZE_METHODS;
-  template <typename Stream, typename Operation>  inline void SerializationOp(Stream& s, Operation ser_action) {
-	    READWRITE(initialized);
-	    READWRITE(accumulatorModulus);
-	    READWRITE(accumulatorBase);
-	    READWRITE(accumulatorPoKCommitmentGroup);
-	    READWRITE(accumulatorQRNCommitmentGroup);
-	    READWRITE(minCoinValue);
-	    READWRITE(maxCoinValue);
-	    READWRITE(k_prime);
-	    READWRITE(k_dprime);
-  }
+    /**
+     * Security parameter.
+     * The statistical zero-knowledgeness of the accumulator proof.
+     */
+    uint32_t k_dprime;
+    SERIALIZE_METHODS(AccumulatorAndProofParams, obj) {
+        READWRITE(obj.initialized, obj.accumulatorModulus, obj.accumulatorBase, obj.accumulatorPoKCommitmentGroup);
+        READWRITE(obj.accumulatorQRNCommitmentGroup, obj.minCoinValue, obj.maxCoinValue, obj.k_prime, obj.k_dprime);
+    }
 };
 
 class ZerocoinParams {
@@ -203,16 +188,10 @@ public:
 	 * proofs.
 	 */
 	uint32_t zkp_hash_len;
-	
-	ADD_SERIALIZE_METHODS;
-  template <typename Stream, typename Operation>  inline void SerializationOp(Stream& s, Operation ser_action) {
-	    READWRITE(initialized);
-	    READWRITE(accumulatorParams);
-	    READWRITE(coinCommitmentGroup);
-	    READWRITE(serialNumberSoKCommitmentGroup);
-	    READWRITE(zkp_iterations);
-	    READWRITE(zkp_hash_len);
-	}
+
+    SERIALIZE_METHODS(ZerocoinParams, obj) {
+        READWRITE(obj.initialized, obj.accumulatorParams, obj.coinCommitmentGroup, obj.serialNumberSoKCommitmentGroup, obj.zkp_iterations, obj.zkp_hash_len);
+    }
 };
 
 } /* namespace libzerocoin */

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -5,7 +5,6 @@
 
 #include "masternode-payments.h"
 
-#include "addrman.h"
 #include "chainparams.h"
 #include "evo/deterministicmns.h"
 #include "fs.h"
@@ -112,7 +111,6 @@ CMasternodePaymentDB::ReadResult CMasternodePaymentDB::Read(CMasternodePayments&
     }
 
     int version;
-    unsigned char pchMsgTmp[4];
     std::string strMagicMessageTmp;
     try {
         // de-serialize file header
@@ -125,12 +123,12 @@ CMasternodePaymentDB::ReadResult CMasternodePaymentDB::Read(CMasternodePayments&
             return IncorrectMagicMessage;
         }
 
-
         // de-serialize file header (network specific magic number) and ..
-        ssObj >> FLATDATA(pchMsgTmp);
+        std::vector<unsigned char> pchMsgTmp(4);
+        ssObj >> MakeSpan(pchMsgTmp);
 
         // ... verify the network matches ours
-        if (memcmp(pchMsgTmp, Params().MessageStart(), sizeof(pchMsgTmp))) {
+        if (memcmp(pchMsgTmp.data(), Params().MessageStart(), pchMsgTmp.size()) != 0) {
             error("%s : Invalid network magic number", __func__);
             return IncorrectMagicNumber;
         }

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -194,12 +194,7 @@ public:
         READWRITE(nBlockHeight);
         READWRITE(payee);
         READWRITE(vchSig);
-        try
-        {
-            READWRITE(nMessVersion);
-        } catch (...) {
-            nMessVersion = MessageVersion::MESS_VER_STRMESS;
-        }
+        READWRITE(nMessVersion);
     }
 
     std::string ToString()

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -80,14 +80,7 @@ public:
         nVotes = nVotesIn;
     }
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(scriptPubKey);
-        READWRITE(nVotes);
-    }
+    SERIALIZE_METHODS(CMasternodePayee, obj) { READWRITE(obj.scriptPubKey, obj.nVotes); }
 };
 
 // Keep track of votes for payees from masternodes
@@ -152,14 +145,7 @@ public:
     bool IsTransactionValid(const CTransaction& txNew);
     std::string GetRequiredPaymentsString();
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(nBlockHeight);
-        READWRITE(vecPayments);
-    }
+    SERIALIZE_METHODS(CMasternodeBlockPayees, obj) { READWRITE(obj.nBlockHeight, obj.vecPayments); }
 };
 
 // for storing the winning payments
@@ -290,14 +276,7 @@ public:
     void FillBlockPayee(CMutableTransaction& txCoinbase, CMutableTransaction& txCoinstake, const CBlockIndex* pindexPrev, bool fProofOfStake) const;
     std::string ToString() const;
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(mapMasternodePayeeVotes);
-        READWRITE(mapMasternodeBlocks);
-    }
+    SERIALIZE_METHODS(CMasternodePayments, obj) { READWRITE(obj.mapMasternodePayeeVotes, obj.mapMasternodeBlocks); }
 };
 
 

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -185,17 +185,7 @@ public:
         payee = payeeIn;
     }
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(vinMasternode);
-        READWRITE(nBlockHeight);
-        READWRITE(payee);
-        READWRITE(vchSig);
-        READWRITE(nMessVersion);
-    }
+    SERIALIZE_METHODS(CMasternodePaymentWinner, obj) { READWRITE(obj.vinMasternode, obj.nBlockHeight, obj.payee, obj.vchSig, obj.nMessVersion); }
 
     std::string ToString()
     {

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -57,12 +57,7 @@ public:
         READWRITE(blockHash);
         READWRITE(sigTime);
         READWRITE(vchSig);
-        try
-        {
-            READWRITE(nMessVersion);
-        } catch (...) {
-            nMessVersion = MessageVersion::MESS_VER_STRMESS;
-        }
+        READWRITE(nMessVersion);
     }
 
     uint256 GetHash() const;

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -281,20 +281,17 @@ public:
     bool Sign(const std::string strSignKey);
     bool CheckSignature() const;
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(CMasternodeBroadcast, obj)
     {
-        READWRITE(vin);
-        READWRITE(addr);
-        READWRITE(pubKeyCollateralAddress);
-        READWRITE(pubKeyMasternode);
-        READWRITE(vchSig);
-        READWRITE(sigTime);
-        READWRITE(protocolVersion);
-        READWRITE(lastPing);
-        READWRITE(nMessVersion);
+        READWRITE(obj.vin);
+        READWRITE(obj.addr);
+        READWRITE(obj.pubKeyCollateralAddress);
+        READWRITE(obj.pubKeyMasternode);
+        READWRITE(obj.vchSig);
+        READWRITE(obj.sigTime);
+        READWRITE(obj.protocolVersion);
+        READWRITE(obj.lastPing);
+        READWRITE(obj.nMessVersion);
     }
 
     /// Create Masternode broadcast, needs to be relayed manually after that

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -48,17 +48,7 @@ public:
     CMasternodePing();
     CMasternodePing(const CTxIn& newVin, const uint256& nBlockHash, uint64_t _sigTime);
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(vin);
-        READWRITE(blockHash);
-        READWRITE(sigTime);
-        READWRITE(vchSig);
-        READWRITE(nMessVersion);
-    }
+    SERIALIZE_METHODS(CMasternodePing, obj) { READWRITE(obj.vin, obj.blockHash, obj.sigTime, obj.vchSig, obj.nMessVersion); }
 
     uint256 GetHash() const;
 
@@ -153,23 +143,12 @@ public:
 
     arith_uint256 CalculateScore(const uint256& hash) const;
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(CMasternode, obj)
     {
-        LOCK(cs);
-
-        READWRITE(vin);
-        READWRITE(addr);
-        READWRITE(pubKeyCollateralAddress);
-        READWRITE(pubKeyMasternode);
-        READWRITE(vchSig);
-        READWRITE(sigTime);
-        READWRITE(protocolVersion);
-        READWRITE(lastPing);
-        READWRITE(nScanningErrorCount);
-        READWRITE(nLastScanningErrorBlockHeight);
+        LOCK(obj.cs);
+        READWRITE(obj.vin, obj.addr, obj.pubKeyCollateralAddress);
+        READWRITE(obj.pubKeyMasternode, obj.vchSig, obj.sigTime, obj.protocolVersion);
+        READWRITE(obj.lastPing, obj.nScanningErrorCount, obj.nLastScanningErrorBlockHeight);
     }
 
     template <typename Stream>

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -123,7 +123,6 @@ CMasternodeDB::ReadResult CMasternodeDB::Read(CMasternodeMan& mnodemanToLoad)
     }
 
     int version;
-    unsigned char pchMsgTmp[4];
     std::string strMagicMessageTmp;
     try {
         // de-serialize file header
@@ -137,10 +136,11 @@ CMasternodeDB::ReadResult CMasternodeDB::Read(CMasternodeMan& mnodemanToLoad)
         }
 
         // de-serialize file header (network specific magic number) and ..
-        ssMasternodes >> FLATDATA(pchMsgTmp);
+        std::vector<unsigned char> pchMsgTmp(4);
+        ssMasternodes >> MakeSpan(pchMsgTmp);
 
         // ... verify the network matches ours
-        if (memcmp(pchMsgTmp, Params().MessageStart(), sizeof(pchMsgTmp))) {
+        if (memcmp(pchMsgTmp.data(), Params().MessageStart(), pchMsgTmp.size()) != 0) {
             error("%s : Invalid network magic number", __func__);
             return IncorrectMagicNumber;
         }

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -93,20 +93,17 @@ public:
     // TODO: Remove this from serialization
     int64_t nDsqCount;
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(CMasternodeMan, obj)
     {
-        LOCK(cs);
-        READWRITE(mapMasternodes);
-        READWRITE(mAskedUsForMasternodeList);
-        READWRITE(mWeAskedForMasternodeList);
-        READWRITE(mWeAskedForMasternodeListEntry);
-        READWRITE(nDsqCount);
+        LOCK(obj.cs);
+        READWRITE(obj.mapMasternodes);
+        READWRITE(obj.mAskedUsForMasternodeList);
+        READWRITE(obj.mWeAskedForMasternodeList);
+        READWRITE(obj.mWeAskedForMasternodeListEntry);
+        READWRITE(obj.nDsqCount);
 
-        READWRITE(mapSeenMasternodeBroadcast);
-        READWRITE(mapSeenMasternodePing);
+        READWRITE(obj.mapSeenMasternodeBroadcast);
+        READWRITE(obj.mapSeenMasternodePing);
     }
 
     CMasternodeMan();

--- a/src/merkleblock.cpp
+++ b/src/merkleblock.cpp
@@ -12,6 +12,24 @@
 #include "utilstrencodings.h"
 
 
+std::vector<unsigned char> BitsToBytes(const std::vector<bool>& bits)
+{
+    std::vector<unsigned char> ret((bits.size() + 7) / 8);
+    for (unsigned int p = 0; p < bits.size(); p++) {
+        ret[p / 8] |= bits[p] << (p % 8);
+    }
+    return ret;
+}
+
+std::vector<bool> BytesToBits(const std::vector<unsigned char>& bytes)
+{
+    std::vector<bool> ret(bytes.size() * 8);
+    for (unsigned int p = 0; p < ret.size(); p++) {
+        ret[p] = (bytes[p / 8] & (1 << (p % 8))) != 0;
+    }
+    return ret;
+}
+
 CMerkleBlock::CMerkleBlock(const CBlock& block, CBloomFilter& filter)
 {
     header = block.GetBlockHeader();

--- a/src/merkleblock.h
+++ b/src/merkleblock.h
@@ -14,6 +14,10 @@
 
 #include <vector>
 
+// Helper functions for serialization.
+std::vector<unsigned char> BitsToBytes(const std::vector<bool>& bits);
+std::vector<bool> BytesToBits(const std::vector<unsigned char>& bytes);
+
 /** Data structure that represents a partial merkle tree.
  *
  * It represents a subset of the txid's of a known block, in a way that
@@ -82,28 +86,15 @@ protected:
     uint256 TraverseAndExtract(int height, unsigned int pos, unsigned int& nBitsUsed, unsigned int& nHashUsed, std::vector<uint256>& vMatch);
 
 public:
-    /** serialization implementation */
-    ADD_SERIALIZE_METHODS;
 
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(CPartialMerkleTree, obj)
     {
-        READWRITE(nTransactions);
-        READWRITE(vHash);
-        std::vector<unsigned char> vBytes;
-        if (ser_action.ForRead()) {
-            READWRITE(vBytes);
-            CPartialMerkleTree& us = *(const_cast<CPartialMerkleTree*>(this));
-            us.vBits.resize(vBytes.size() * 8);
-            for (unsigned int p = 0; p < us.vBits.size(); p++)
-                us.vBits[p] = (vBytes[p / 8] & (1 << (p % 8))) != 0;
-            us.fBad = false;
-        } else {
-            vBytes.resize((vBits.size() + 7) / 8);
-            for (unsigned int p = 0; p < vBits.size(); p++)
-                vBytes[p / 8] |= vBits[p] << (p % 8);
-            READWRITE(vBytes);
-        }
+        READWRITE(obj.nTransactions, obj.vHash);
+        std::vector<unsigned char> bytes;
+        SER_WRITE(obj, bytes = BitsToBytes(obj.vBits));
+        READWRITE(bytes);
+        SER_READ(obj, obj.vBits = BytesToBits(bytes));
+        SER_READ(obj, obj.fBad = false);
     }
 
     /** Construct a partial merkle tree from a list of transaction id's, and a mask that selects a subset of them */
@@ -143,14 +134,8 @@ public:
 
     CMerkleBlock() {}
 
-    ADD_SERIALIZE_METHODS;
+    SERIALIZE_METHODS(CMerkleBlock, obj) { READWRITE(obj.header, obj.txn); }
 
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(header);
-        READWRITE(txn);
-    }
 };
 
 #endif // BITCOIN_MERKLEBLOCK_H

--- a/src/messagesigner.h
+++ b/src/messagesigner.h
@@ -12,7 +12,7 @@
 extern const std::string strMessageMagic;
 
 enum MessageVersion {
-        MESS_VER_STRMESS    = 0,
+        MESS_VER_STRMESS    = 0, // old format
         MESS_VER_HASH       = 1,
 };
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -188,7 +188,7 @@ void BitcoinMiner(CWallet* pwallet, bool fProofOfStake)
         IncrementExtraNonce(pblock, pindexPrev->nHeight + 1, nExtraNonce);
 
         LogPrintf("Running PIVXMiner with %u transactions in block (%u bytes)\n", pblock->vtx.size(),
-            ::GetSerializeSize(*pblock, SER_NETWORK, PROTOCOL_VERSION));
+            ::GetSerializeSize(*pblock, PROTOCOL_VERSION));
 
         //
         // Search

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -90,13 +90,7 @@ public:
     friend bool operator!=(const CNetAddr& a, const CNetAddr& b);
     friend bool operator<(const CNetAddr& a, const CNetAddr& b);
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(ip);
-    }
+    SERIALIZE_METHODS(CNetAddr, obj) { READWRITE(obj.ip); }
 
     friend class CSubNet;
 };
@@ -128,15 +122,7 @@ public:
     friend bool operator!=(const CSubNet& a, const CSubNet& b);
     friend bool operator<(const CSubNet& a, const CSubNet& b);
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(network);
-        READWRITE(netmask);
-        READWRITE(valid);
-    }
+    SERIALIZE_METHODS(CSubNet, obj) { READWRITE(obj.network, obj.netmask, obj.valid); }
 };
 
 /** A combination of a network address (CNetAddr) and a (TCP) port */
@@ -166,13 +152,7 @@ public:
     CService(const struct in6_addr& ipv6Addr, unsigned short port);
     CService(const struct sockaddr_in6& addr);
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(ip);
-        READWRITE(Using<BigEndianFormatter<2>>(port));
-    }
+    SERIALIZE_METHODS(CService, obj) { READWRITE(obj.ip, Using<BigEndianFormatter<2>>(obj.port)); }
 };
 
 #endif // PIVX_NETADDRESS_H

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -143,7 +143,7 @@ public:
 class CService : public CNetAddr
 {
 protected:
-    unsigned short port; // host order
+    uint16_t port; // host order
 
 public:
     CService();
@@ -172,13 +172,7 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action)
     {
         READWRITE(ip);
-
-        // TODO: introduce native support for BE serialization in serialize.h
-        unsigned short portN = htons(port);
-        READWRITE(Span<unsigned char>((unsigned char*)&portN, 2));
-        if (ser_action.ForRead()) {
-            port = ntohs(portN);
-        }
+        READWRITE(WrapBigEndian(port));
     }
 };
 

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -12,6 +12,7 @@
 
 #include "compat.h"
 #include "serialize.h"
+#include "span.h"
 
 #include <stdint.h>
 #include <string>
@@ -171,10 +172,13 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action)
     {
         READWRITE(ip);
+
+        // TODO: introduce native support for BE serialization in serialize.h
         unsigned short portN = htons(port);
-        READWRITE(FLATDATA(portN));
-        if (ser_action.ForRead())
+        READWRITE(Span<unsigned char>((unsigned char*)&portN, 2));
+        if (ser_action.ForRead()) {
             port = ntohs(portN);
+        }
     }
 };
 

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -169,10 +169,9 @@ public:
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
+    inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(ip);
-        READWRITE(WrapBigEndian(port));
+        READWRITE(Using<BigEndianFormatter<2>>(port));
     }
 };
 

--- a/src/policy/feerate.h
+++ b/src/policy/feerate.h
@@ -36,13 +36,7 @@ public:
     CFeeRate& operator+=(const CFeeRate& a) { nSatoshisPerK += a.nSatoshisPerK; return *this; }
     std::string ToString() const;
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(nSatoshisPerK);
-    }
+    SERIALIZE_METHODS(CFeeRate, obj) { READWRITE(obj.nSatoshisPerK); }
 };
 
 #endif //  PIVX_POLICY_FEERATE_H

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -31,7 +31,7 @@ CAmount GetDustThreshold(const CTxOut& txout, const CFeeRate& dustRelayFeeIn)
     if (txout.scriptPubKey.IsUnspendable())
         return 0;
 
-    size_t nSize = GetSerializeSize(txout, SER_DISK, 0);
+    size_t nSize = GetSerializeSize(txout, 0);
     nSize += (32 + 4 + 1 + 107 + 4); // the 148 mentioned above
     return dustRelayFeeIn.GetFee(nSize);
 }

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -422,13 +422,18 @@ public:
         return first;
     }
 
-    void push_back(const T& value) {
+    template<typename... Args>
+    void emplace_back(Args&&... args) {
         size_type new_size = size() + 1;
         if (capacity() < new_size) {
             change_capacity(new_size + (new_size >> 1));
         }
-        new(item_ptr(size())) T(value);
+        new(item_ptr(size())) T(std::forward<Args>(args)...);
         _size++;
+    }
+
+    void push_back(const T& value) {
+        emplace_back(value);
     }
 
     void pop_back() {

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -38,24 +38,16 @@ public:
         SetNull();
     }
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(nVersion);
-        READWRITE(hashPrevBlock);
-        READWRITE(hashMerkleRoot);
-        READWRITE(nTime);
-        READWRITE(nBits);
-        READWRITE(nNonce);
+    SERIALIZE_METHODS(CBlockHeader, obj) {
+        READWRITE(obj.nVersion, obj.hashPrevBlock, obj.hashMerkleRoot, obj.nTime, obj.nBits, obj.nNonce);
 
         //zerocoin active, header changes to include accumulator checksum
-        if(nVersion > 3 && nVersion < 7)
-            READWRITE(nAccumulatorCheckpoint);
+        if(obj.nVersion > 3 && obj.nVersion < 7)
+            READWRITE(obj.nAccumulatorCheckpoint);
 
         // Sapling active
-        if (nVersion >= 8)
-            READWRITE(hashFinalSaplingRoot);
+        if (obj.nVersion >= 8)
+            READWRITE(obj.hashFinalSaplingRoot);
     }
 
     void SetNull()
@@ -107,14 +99,12 @@ public:
         *(static_cast<CBlockHeader*>(this)) = header;
     }
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITEAS(CBlockHeader, *this);
-        READWRITE(vtx);
-        if(vtx.size() > 1 && vtx[1]->IsCoinStake())
-            READWRITE(vchBlockSig);
+    SERIALIZE_METHODS(CBlock, obj)
+    {
+        READWRITEAS(CBlockHeader, obj);
+        READWRITE(obj.vtx);
+        if(obj.vtx.size() > 1 && obj.vtx[1]->IsCoinStake())
+            READWRITE(obj.vchBlockSig);
     }
 
     void SetNull()
@@ -171,14 +161,12 @@ struct CBlockLocator
         vHave = vHaveIn;
     }
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    SERIALIZE_METHODS(CBlockLocator, obj)
+    {
         int nVersion = s.GetVersion();
         if (!(s.GetType() & SER_GETHASH))
             READWRITE(nVersion);
-        READWRITE(vHave);
+        READWRITE(obj.vHave);
     }
 
     void SetNull()

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -252,7 +252,7 @@ unsigned int CTransaction::CalculateModifiedSize(unsigned int nTxSize) const
     // Providing any more cleanup incentive than making additional inputs free would
     // risk encouraging people to create junk outputs to redeem later.
     if (nTxSize == 0)
-        nTxSize = ::GetSerializeSize(*this, SER_NETWORK, PROTOCOL_VERSION);
+        nTxSize = ::GetSerializeSize(*this, PROTOCOL_VERSION);
     for (std::vector<CTxIn>::const_iterator it(vin.begin()); it != vin.end(); ++it)
     {
         unsigned int offset = 41U + std::min(110U, (unsigned int)it->scriptSig.size());
@@ -264,7 +264,7 @@ unsigned int CTransaction::CalculateModifiedSize(unsigned int nTxSize) const
 
 unsigned int CTransaction::GetTotalSize() const
 {
-    return ::GetSerializeSize(*this, SER_NETWORK, PROTOCOL_VERSION);
+    return ::GetSerializeSize(*this, PROTOCOL_VERSION);
 }
 
 std::string CTransaction::ToString() const

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -39,13 +39,7 @@ public:
     BaseOutPoint(const uint256& hashIn, const uint32_t nIn, bool isTransparentIn = true) :
         hash(hashIn), n(nIn), isTransparent(isTransparentIn) { }
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(hash);
-        READWRITE(n);
-    }
+    SERIALIZE_METHODS(BaseOutPoint, obj) { READWRITE(obj.hash, obj.n); }
 
     void SetNull() { hash.SetNull(); n = (uint32_t) -1; }
     bool IsNull() const { return (hash.IsNull() && n == (uint32_t) -1); }
@@ -110,14 +104,7 @@ public:
     explicit CTxIn(COutPoint prevoutIn, CScript scriptSigIn=CScript(), uint32_t nSequenceIn=SEQUENCE_FINAL);
     CTxIn(uint256 hashPrevTx, uint32_t nOut, CScript scriptSigIn=CScript(), uint32_t nSequenceIn=SEQUENCE_FINAL);
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(prevout);
-        READWRITE(scriptSig);
-        READWRITE(nSequence);
-    }
+    SERIALIZE_METHODS(CTxIn, obj) { READWRITE(obj.prevout, obj.scriptSig, obj.nSequence); }
 
     bool IsFinal() const { return nSequence == SEQUENCE_FINAL; }
     bool IsNull() const { return prevout.IsNull() && scriptSig.empty() && IsFinal(); }
@@ -159,13 +146,7 @@ public:
 
     CTxOut(const CAmount& nValueIn, CScript scriptPubKeyIn);
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(nValue);
-        READWRITE(scriptPubKey);
-    }
+    SERIALIZE_METHODS(CTxOut, obj) { READWRITE(obj.nValue, obj.scriptPubKey); }
 
     void SetNull()
     {

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -43,16 +43,7 @@ public:
     std::string GetCommand() const;
     bool IsValid(const MessageStartChars& messageStart) const;
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(pchMessageStart);
-        READWRITE(pchCommand);
-        READWRITE(nMessageSize);
-        READWRITE(pchChecksum);
-    }
+    SERIALIZE_METHODS(CMessageHeader, obj) { READWRITE(obj.pchMessageStart, obj.pchCommand, obj.nMessageSize, obj.pchChecksum); }
 
     // TODO: make private (improves encapsulation)
 public:
@@ -319,23 +310,19 @@ public:
 
     void Init();
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(CAddress, obj)
     {
-        if (ser_action.ForRead())
-            Init();
+        SER_READ(obj, obj.Init());
         int nVersion = s.GetVersion();
-        if (s.GetType() & SER_DISK)
+        if (s.GetType() & SER_DISK) {
             READWRITE(nVersion);
+        }
         if ((s.GetType() & SER_DISK) ||
-            (nVersion >= CADDR_TIME_VERSION && !(s.GetType() & SER_GETHASH)))
-            READWRITE(nTime);
-        uint64_t nServicesInt = nServices;
-        READWRITE(nServicesInt);
-        nServices = static_cast<ServiceFlags>(nServicesInt);
-        READWRITEAS(CService, *this);
+            (nVersion >= CADDR_TIME_VERSION && !(s.GetType() & SER_GETHASH))) {
+            READWRITE(obj.nTime);
+        }
+        READWRITE(Using<CustomUintFormatter<8>>(obj.nServices));
+        READWRITEAS(CService, obj);
     }
 
     // TODO: make private (improves encapsulation)
@@ -353,14 +340,7 @@ public:
     CInv();
     CInv(int typeIn, const uint256& hashIn);
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(type);
-        READWRITE(hash);
-    }
+    SERIALIZE_METHODS(CInv, obj) { READWRITE(obj.type, obj.hash); }
 
     friend bool operator<(const CInv& a, const CInv& b);
 

--- a/src/qt/recentrequeststablemodel.h
+++ b/src/qt/recentrequeststablemodel.h
@@ -25,20 +25,11 @@ public:
     QDateTime date;
     SendCoinsRecipient recipient;
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        unsigned int nDate = date.toTime_t();
-
-        READWRITE(nVersion);
-        READWRITE(id);
-        READWRITE(nDate);
-        READWRITE(recipient);
-
-        if (ser_action.ForRead())
-            date = QDateTime::fromTime_t(nDate);
+    SERIALIZE_METHODS(RecentRequestEntry, obj) {
+        unsigned int date_timet;
+        SER_WRITE(obj, date_timet = obj.date.toTime_t());
+        READWRITE(obj.nVersion, obj.id, date_timet, obj.recipient);
+        SER_READ(obj, obj.date = QDateTime::fromTime_t(date_timet));
     }
 };
 

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -85,30 +85,21 @@ public:
     static const int CURRENT_VERSION = 1;
     int nVersion;
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(SendCoinsRecipient, obj)
     {
-        std::string sAddress = address.toStdString();
-        std::string sLabel = label.toStdString();
-        std::string sMessage = message.toStdString();
-        std::string sAuthenticatedMerchant = authenticatedMerchant.toStdString();
+        std::string address_str, label_str, message_str, auth_merchant_str;
 
-        READWRITE(this->nVersion);
-        READWRITE(sAddress);
-        READWRITE(sLabel);
-        READWRITE(amount);
-        READWRITE(sMessage);
-        READWRITE(sPaymentRequest);
-        READWRITE(sAuthenticatedMerchant);
+        SER_WRITE(obj, address_str = obj.address.toStdString());
+        SER_WRITE(obj, label_str = obj.label.toStdString());
+        SER_WRITE(obj, message_str = obj.message.toStdString());
+        SER_WRITE(obj, auth_merchant_str = obj.authenticatedMerchant.toStdString());
 
-        if (ser_action.ForRead()) {
-            address = QString::fromStdString(sAddress);
-            label = QString::fromStdString(sLabel);
-            message = QString::fromStdString(sMessage);
-            authenticatedMerchant = QString::fromStdString(sAuthenticatedMerchant);
-        }
+        READWRITE(obj.nVersion, address_str, label_str, obj.amount, message_str, obj.sPaymentRequest, auth_merchant_str);
+
+        SER_READ(obj, obj.address = QString::fromStdString(address_str));
+        SER_READ(obj, obj.label = QString::fromStdString(label_str));
+        SER_READ(obj, obj.message = QString::fromStdString(message_str));
+        SER_READ(obj, obj.authenticatedMerchant = QString::fromStdString(auth_merchant_str));
     }
 };
 

--- a/src/qt/walletmodeltransaction.cpp
+++ b/src/qt/walletmodeltransaction.cpp
@@ -30,7 +30,7 @@ CTransactionRef& WalletModelTransaction::getTransaction()
 
 unsigned int WalletModelTransaction::getTransactionSize()
 {
-    return (!walletTransaction ? 0 : (::GetSerializeSize(*walletTransaction, SER_NETWORK, PROTOCOL_VERSION)));
+    return (!walletTransaction ? 0 : (::GetSerializeSize(*walletTransaction, PROTOCOL_VERSION)));
 }
 
 CAmount WalletModelTransaction::getTransactionFee()

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -46,18 +46,13 @@ struct CCoin {
     uint32_t nHeight;
     CTxOut out;
 
-    ADD_SERIALIZE_METHODS;
-
     CCoin() : nHeight(0) {}
     CCoin(Coin&& in) : nHeight(in.nHeight), out(std::move(in.out)) {}
 
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(CCoin, obj)
     {
         uint32_t nTxVerDummy = 0;
-        READWRITE(nTxVerDummy);
-        READWRITE(nHeight);
-        READWRITE(out);
+        READWRITE(nTxVerDummy, obj.nHeight, obj.out);
     }
 };
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -137,7 +137,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     if (chainActive.Contains(blockindex))
         confirmations = chainActive.Height() - blockindex->nHeight + 1;
     result.pushKV("confirmations", confirmations);
-    result.pushKV("size", (int)::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION));
+    result.pushKV("size", (int)::GetSerializeSize(block, PROTOCOL_VERSION));
     result.pushKV("height", blockindex->nHeight);
     result.pushKV("version", block.nVersion);
     result.pushKV("merkleroot", block.hashMerkleRoot.GetHex());
@@ -1361,7 +1361,7 @@ UniValue getblockindexstats(const JSONRPCRequest& request) {
                 continue;
 
             // Transaction size
-            nBytes += GetSerializeSize(tx, SER_NETWORK, CLIENT_VERSION);
+            nBytes += GetSerializeSize(tx, CLIENT_VERSION);
 
             // Transparent inputs
             for (unsigned int j = 0; j < tx.vin.size(); j++) {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -710,7 +710,7 @@ static void ApplyStats(CCoinsStats &stats, CHashWriter& ss, const uint256& hash,
     for (const auto& output : outputs) {
         ss << VARINT(output.first + 1);
         ss << output.second.out.scriptPubKey;
-        ss << VARINT(output.second.out.nValue, VarIntMode::NONNEGATIVE_SIGNED);
+        ss << VARINT_MODE(output.second.out.nValue, VarIntMode::NONNEGATIVE_SIGNED);
         stats.nTransactionOutputs++;
         stats.nTotalAmount += output.second.out.nValue;
     }

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -742,9 +742,7 @@ UniValue mnbudgetrawvote(const JSONRPCRequest& request)
     vote.SetVchSig(vchSig);
 
     if (!vote.CheckSignature(pmn->pubKeyMasternode.GetID())) {
-        // try old message version
-        vote.nMessVersion = MessageVersion::MESS_VER_STRMESS;
-        if (!vote.CheckSignature(pmn->pubKeyMasternode.GetID())) return "Failure to verify signature.";
+        return "Failure to verify signature.";
     }
 
     std::string strError;

--- a/src/sapling/address.h
+++ b/src/sapling/address.h
@@ -30,13 +30,7 @@ public:
     SaplingPaymentAddress() {}
     SaplingPaymentAddress(const diversifier_t& _d, const uint256& _pk_d) : d(_d), pk_d(_pk_d) { }
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(d);
-        READWRITE(pk_d);
-    }
+    SERIALIZE_METHODS(SaplingPaymentAddress, obj) { READWRITE(obj.d, obj.pk_d); }
 
     //! Get the 256-bit SHA256d hash of this payment address.
     uint256 GetHash() const;
@@ -68,14 +62,7 @@ public:
     SaplingFullViewingKey() : ak(), nk(), ovk() { }
     SaplingFullViewingKey(uint256 ak, uint256 nk, uint256 ovk) : ak(ak), nk(nk), ovk(ovk) { }
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(ak);
-        READWRITE(nk);
-        READWRITE(ovk);
-    }
+    SERIALIZE_METHODS(SaplingFullViewingKey, obj) { READWRITE(obj.ak, obj.nk, obj.ovk); }
 
     //! Get the fingerprint of this full viewing key (as defined in ZIP 32).
     uint256 GetFingerprint() const;
@@ -103,14 +90,7 @@ public:
     SaplingExpandedSpendingKey() : ask(), nsk(), ovk() { }
     SaplingExpandedSpendingKey(uint256 ask, uint256 nsk, uint256 ovk) : ask(ask), nsk(nsk), ovk(ovk) { }
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(ask);
-        READWRITE(nsk);
-        READWRITE(ovk);
-    }
+    SERIALIZE_METHODS(SaplingExpandedSpendingKey, obj) { READWRITE(obj.ask, obj.nsk, obj.ovk); }
 
     SaplingFullViewingKey full_viewing_key() const;
     bool IsNull() { return ask.IsNull() && nsk.IsNull() && ovk.IsNull(); }

--- a/src/sapling/incrementalmerkletree.h
+++ b/src/sapling/incrementalmerkletree.h
@@ -23,33 +23,35 @@ public:
     std::vector<std::vector<bool>> authentication_path;
     std::vector<bool> index;
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    template<typename Stream>
+    void Serialize(Stream &s) const
     {
         std::vector<std::vector<unsigned char>> pathBytes;
         uint64_t indexInt;
-        if (ser_action.ForRead()) {
-            READWRITE(pathBytes);
-            READWRITE(indexInt);
-            MerklePath &us = *(const_cast<MerklePath*>(this));
-            for (size_t i = 0; i < pathBytes.size(); i++) {
-                us.authentication_path.push_back(convertBytesVectorToVector(pathBytes[i]));
-                us.index.push_back((indexInt >> ((pathBytes.size() - 1) - i)) & 1);
+        assert(authentication_path.size() == index.size());
+        pathBytes.resize(authentication_path.size());
+        for (size_t i = 0; i < authentication_path.size(); i++) {
+            pathBytes[i].resize((authentication_path[i].size()+7)/8);
+            for (unsigned int p = 0; p < authentication_path[i].size(); p++) {
+                pathBytes[i][p / 8] |= authentication_path[i][p] << (7-(p % 8));
             }
-        } else {
-            assert(authentication_path.size() == index.size());
-            pathBytes.resize(authentication_path.size());
-            for (size_t i = 0; i < authentication_path.size(); i++) {
-                pathBytes[i].resize((authentication_path[i].size()+7)/8);
-                for (unsigned int p = 0; p < authentication_path[i].size(); p++) {
-                    pathBytes[i][p / 8] |= authentication_path[i][p] << (7-(p % 8));
-                }
-            }
-            indexInt = convertVectorToInt(index);
-            READWRITE(pathBytes);
-            READWRITE(indexInt);
+        }
+        indexInt = convertVectorToInt(index);
+        ::Serialize(s, pathBytes);
+        ::Serialize(s, indexInt);
+    }
+
+    template<typename Stream>
+    void Unserialize(Stream &s)
+    {
+        std::vector<std::vector<unsigned char>> pathBytes;
+        uint64_t indexInt;
+        ::Unserialize(s, pathBytes);
+        ::Unserialize(s, indexInt);
+        MerklePath &us = *(const_cast<MerklePath*>(this));
+        for (size_t i = 0; i < pathBytes.size(); i++) {
+            us.authentication_path.push_back(convertBytesVectorToVector(pathBytes[i]));
+            us.index.push_back((indexInt >> ((pathBytes.size() - 1) - i)) & 1);
         }
     }
 
@@ -110,16 +112,10 @@ public:
         return IncrementalWitness<Depth, Hash>(*this);
     }
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(IncrementalMerkleTree, obj)
     {
-        READWRITE(left);
-        READWRITE(right);
-        READWRITE(parents);
-
-        wfcheck();
+        READWRITE(obj.left, obj.right, obj.parents);
+        obj.wfcheck();
     }
 
     static Hash empty_root() {
@@ -181,16 +177,10 @@ public:
 
     void append(Hash obj);
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(IncrementalWitness, obj)
     {
-        READWRITE(tree);
-        READWRITE(filled);
-        READWRITE(cursor);
-
-        cursor_depth = tree.next_depth(filled.size());
+        READWRITE(obj.tree, obj.filled, obj.cursor);
+        SER_READ(obj, obj.cursor_depth = obj.tree.next_depth(obj.filled.size()));
     }
 
     template <size_t D, typename H>

--- a/src/sapling/note.h
+++ b/src/sapling/note.h
@@ -89,10 +89,8 @@ public:
 
     boost::optional<SaplingNote> note(const SaplingIncomingViewingKey& ivk) const;
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    SERIALIZE_METHODS(SaplingNotePlaintext, obj)
+    {
         unsigned char leadingByte = 0x01;
         READWRITE(leadingByte);
 
@@ -100,10 +98,10 @@ public:
             throw std::ios_base::failure("lead byte of SaplingNotePlaintext is not recognized");
         }
 
-        READWRITE(d);           // 11 bytes
-        READWRITE(value_);      // 8 bytes
-        READWRITE(rcm);         // 32 bytes
-        READWRITE(memo_);       // 512 bytes
+        READWRITE(obj.d);           // 11 bytes
+        READWRITE(obj.value_);      // 8 bytes
+        READWRITE(obj.rcm);         // 32 bytes
+        READWRITE(obj.memo_);       // 512 bytes
     }
 
     boost::optional<SaplingNotePlaintextEncryptionResult> encrypt(const uint256& pk_d) const;
@@ -121,12 +119,10 @@ public:
         esk(_esk)
     {}
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(pk_d);        // 8 bytes
-        READWRITE(esk);         // 8 bytes
+    SERIALIZE_METHODS(SaplingOutgoingPlaintext, obj)
+    {
+        READWRITE(obj.pk_d);        // 8 bytes
+        READWRITE(obj.esk);         // 8 bytes
     }
 
     static boost::optional<SaplingOutgoingPlaintext> decrypt(

--- a/src/sapling/sapling_operation.cpp
+++ b/src/sapling/sapling_operation.cpp
@@ -569,7 +569,7 @@ OperationResult CheckTransactionSize(std::vector<SendManyRecipient>& recipients,
         }
     }
     CTransaction tx(mtx);
-    size_t txsize = GetSerializeSize(tx, SER_NETWORK, tx.nVersion) + CTXOUT_REGULAR_SIZE * nTransparentOuts;
+    size_t txsize = tx.GetTotalSize() + CTXOUT_REGULAR_SIZE * nTransparentOuts;
     if (fromTaddr) {
         txsize += CTXIN_SPEND_DUST_SIZE;
         txsize += CTXOUT_REGULAR_SIZE;      // There will probably be taddr change

--- a/src/sapling/sapling_transaction.h
+++ b/src/sapling/sapling_transaction.h
@@ -52,17 +52,7 @@ public:
 
     SpendDescription() {}
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(cv);
-        READWRITE(anchor);
-        READWRITE(nullifier);
-        READWRITE(rk);
-        READWRITE(zkproof);
-        READWRITE(spendAuthSig);
-    }
+    SERIALIZE_METHODS(SpendDescription, obj) { READWRITE(obj.cv, obj.anchor, obj.nullifier, obj.rk, obj.zkproof, obj.spendAuthSig); }
 
     friend bool operator==(const SpendDescription& a, const SpendDescription& b)
     {
@@ -97,17 +87,7 @@ public:
 
     OutputDescription() {}
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(cv);
-        READWRITE(cmu);
-        READWRITE(ephemeralKey);
-        READWRITE(encCiphertext);
-        READWRITE(outCiphertext);
-        READWRITE(zkproof);
-    }
+    SERIALIZE_METHODS(OutputDescription, obj) { READWRITE(obj.cv, obj.cmu, obj.ephemeralKey, obj.encCiphertext, obj.outCiphertext, obj.zkproof); }
 
     friend bool operator==(const OutputDescription& a, const OutputDescription& b)
     {

--- a/src/sapling/sapling_transaction.h
+++ b/src/sapling/sapling_transaction.h
@@ -117,16 +117,7 @@ public:
     std::vector<OutputDescription> vShieldedOutput;
     binding_sig_t bindingSig = {{0}};
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(*const_cast<CAmount*>(&valueBalance));
-        READWRITE(*const_cast<std::vector<SpendDescription>*>(&vShieldedSpend));
-        READWRITE(*const_cast<std::vector<OutputDescription>*>(&vShieldedOutput));
-        READWRITE(*const_cast<binding_sig_t*>(&bindingSig));
-    }
+    SERIALIZE_METHODS(SaplingTxData, obj) { READWRITE(obj.valueBalance, obj.vShieldedSpend, obj.vShieldedOutput, obj.bindingSig); }
 
     explicit SaplingTxData() : valueBalance(0), vShieldedSpend(), vShieldedOutput() { }
     explicit SaplingTxData(const SaplingTxData& from) : valueBalance(from.valueBalance), vShieldedSpend(from.vShieldedSpend), vShieldedOutput(from.vShieldedOutput), bindingSig(from.bindingSig) {}

--- a/src/sapling/saplingscriptpubkeyman.h
+++ b/src/sapling/saplingscriptpubkeyman.h
@@ -93,22 +93,19 @@ public:
      */
     Optional<uint256> nullifier;
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(SaplingNoteData, obj)
     {
         int nVersion = s.GetVersion();
         if (!(s.GetType() & SER_GETHASH)) {
             READWRITE(nVersion);
         }
-        READWRITE(ivk);
-        READWRITE(nullifier);
-        READWRITE(witnesses);
-        READWRITE(witnessHeight);
-        READWRITE(amount);
-        READWRITE(address);
-        READWRITE(memo);
+        READWRITE(obj.ivk);
+        READWRITE(obj.nullifier);
+        READWRITE(obj.witnesses);
+        READWRITE(obj.witnessHeight);
+        READWRITE(obj.amount);
+        READWRITE(obj.address);
+        READWRITE(obj.memo);
     }
 
     friend bool operator==(const SaplingNoteData& a, const SaplingNoteData& b) {

--- a/src/sapling/zip32.h
+++ b/src/sapling/zip32.h
@@ -57,17 +57,7 @@ struct SaplingExtendedFullViewingKey {
     libzcash::SaplingFullViewingKey fvk;
     uint256 dk;
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(depth);
-        READWRITE(parentFVKTag);
-        READWRITE(childIndex);
-        READWRITE(chaincode);
-        READWRITE(fvk);
-        READWRITE(dk);
-    }
+    SERIALIZE_METHODS(SaplingExtendedFullViewingKey, obj) { READWRITE(obj.depth, obj.parentFVKTag, obj.childIndex, obj.chaincode, obj.fvk, obj.dk); }
 
     boost::optional<SaplingExtendedFullViewingKey> Derive(uint32_t i) const;
 
@@ -103,17 +93,7 @@ struct SaplingExtendedSpendingKey {
     libzcash::SaplingExpandedSpendingKey expsk;
     uint256 dk;
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(depth);
-        READWRITE(parentFVKTag);
-        READWRITE(childIndex);
-        READWRITE(chaincode);
-        READWRITE(expsk);
-        READWRITE(dk);
-    }
+    SERIALIZE_METHODS(SaplingExtendedSpendingKey, obj) { READWRITE(obj.depth, obj.parentFVKTag, obj.childIndex, obj.chaincode, obj.expsk, obj.dk); }
 
     static SaplingExtendedSpendingKey Master(const HDSeed& seed);
 

--- a/src/script/bitcoinconsensus.cpp
+++ b/src/script/bitcoinconsensus.cpp
@@ -81,7 +81,7 @@ int bitcoinconsensus_verify_script(const unsigned char *scriptPubKey, unsigned i
         CTransaction tx(deserialize, stream);
         if (nIn >= tx.vin.size())
             return set_error(err, bitcoinconsensus_ERR_TX_INDEX);
-        if (GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION) != txToLen)
+        if (GetSerializeSize(tx, PROTOCOL_VERSION) != txToLen)
             return set_error(err, bitcoinconsensus_ERR_TX_SIZE_MISMATCH);
 
          // Regardless of the verification result, the tx did not error.

--- a/src/script/keyorigin.h
+++ b/src/script/keyorigin.h
@@ -18,13 +18,7 @@ struct KeyOriginInfo
         return std::equal(std::begin(a.fingerprint), std::end(a.fingerprint), std::begin(b.fingerprint)) && a.path == b.path;
     }
 
-    ADD_SERIALIZE_METHODS;
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(fingerprint);
-        READWRITE(path);
-    }
+    SERIALIZE_METHODS(KeyOriginInfo, obj) { READWRITE(obj.fingerprint, obj.path); }
 
     void clear()
     {

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -396,12 +396,7 @@ public:
     CScript(std::vector<unsigned char>::const_iterator pbegin, std::vector<unsigned char>::const_iterator pend) : CScriptBase(pbegin, pend) { }
     CScript(const unsigned char* pbegin, const unsigned char* pend) : CScriptBase(pbegin, pend) { }
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITEAS(CScriptBase, *this);
-    }
+    SERIALIZE_METHODS(CScript, obj) { READWRITEAS(CScriptBase, obj); }
 
     CScript& operator+=(const CScript& b)
     {

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -643,7 +643,7 @@ BigEndian<I> WrapBigEndian(I& n) { return BigEndian<I>(n); }
  * as a vector of VarInt-encoded integers.
  *
  * V is not required to be an std::vector type. It works for any class that
- * exposes a value_type, size, reserve, push_back, and const iterators.
+ * exposes a value_type, size, reserve, emplace_back, back, and const iterators.
  */
 template<class Formatter>
 struct VectorFormatter
@@ -651,15 +651,17 @@ struct VectorFormatter
     template<typename Stream, typename V>
     void Ser(Stream& s, const V& v)
     {
+        Formatter formatter;
         WriteCompactSize(s, v.size());
         for (const typename V::value_type& elem : v) {
-            s << Using<Formatter>(elem);
+            formatter.Ser(s, elem);
         }
     }
 
     template<typename Stream, typename V>
     void Unser(Stream& s, V& v)
     {
+        Formatter formatter;
         v.clear();
         size_t size = ReadCompactSize(s);
         size_t allocated = 0;
@@ -671,9 +673,8 @@ struct VectorFormatter
             allocated = std::min(size, allocated + MAX_VECTOR_ALLOCATE / sizeof(typename V::value_type));
             v.reserve(allocated);
             while (v.size() < allocated) {
-                typename V::value_type val;
-                s >> Using<Formatter>(val);
-                v.push_back(std::move(val));
+                v.emplace_back();
+                formatter.Unser(s, v.back());
             }
         }
     };

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -87,6 +87,11 @@ template<typename Stream> inline void ser_writedata16(Stream &s, uint16_t obj)
     obj = htole16(obj);
     s.write((char*)&obj, 2);
 }
+template<typename Stream> inline void ser_writedata16be(Stream &s, uint16_t obj)
+{
+    obj = htobe16(obj);
+    s.write((char*)&obj, 2);
+}
 template<typename Stream> inline void ser_writedata32(Stream &s, uint32_t obj)
 {
     obj = htole32(obj);
@@ -108,6 +113,12 @@ template<typename Stream> inline uint16_t ser_readdata16(Stream &s)
     uint16_t obj;
     s.read((char*)&obj, 2);
     return le16toh(obj);
+}
+template<typename Stream> inline uint16_t ser_readdata16be(Stream &s)
+{
+    uint16_t obj;
+    s.read((char*)&obj, 2);
+    return be16toh(obj);
 }
 template<typename Stream> inline uint32_t ser_readdata32(Stream &s)
 {
@@ -461,6 +472,40 @@ public:
     }
 };
 
+/** Serialization wrapper class for big-endian integers.
+ *
+ * Use this wrapper around integer types that are stored in memory in native
+ * byte order, but serialized in big endian notation. This is only intended
+ * to implement serializers that are compatible with existing formats, and
+ * its use is not recommended for new data structures.
+ *
+ * Only 16-bit types are supported for now.
+ */
+template<typename I>
+class BigEndian
+{
+protected:
+    I& m_val;
+public:
+    explicit BigEndian(I& val) : m_val(val)
+    {
+        static_assert(std::is_unsigned<I>::value, "BigEndian type must be unsigned integer");
+        static_assert(sizeof(I) == 2 && std::numeric_limits<I>::min() == 0 && std::numeric_limits<I>::max() == std::numeric_limits<uint16_t>::max(), "Unsupported BigEndian size");
+    }
+
+    template<typename Stream>
+    void Serialize(Stream& s) const
+    {
+        ser_writedata16be(s, m_val);
+    }
+
+    template<typename Stream>
+    void Unserialize(Stream& s)
+    {
+        m_val = ser_readdata16be(s);
+    }
+};
+
 class CCompactSize
 {
 protected:
@@ -511,6 +556,9 @@ public:
 
 template<VarIntMode Mode=VarIntMode::DEFAULT, typename I>
 CVarInt<Mode, I> WrapVarInt(I& n) { return CVarInt<Mode, I>{n}; }
+
+template<typename I>
+BigEndian<I> WrapBigEndian(I& n) { return BigEndian<I>(n); }
 
 /**
  * Forward declarations

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -198,6 +198,28 @@ template<typename X> const X& ReadWriteAsHelper(const X& x) { return x; }
         SerializationOp(s, CSerActionUnserialize());                                  \
     }
 
+/**
+ * Implement the Serialize and Unserialize methods by delegating to a single templated
+ * static method that takes the to-be-(de)serialized object as a parameter. This approach
+ * has the advantage that the constness of the object becomes a template parameter, and
+ * thus allows a single implementation that sees the object as const for serializing
+ * and non-const for deserializing, without casts.
+ */
+#define SERIALIZE_METHODS(cls, obj)                                                 \
+    template<typename Stream>                                                       \
+    void Serialize(Stream& s) const                                                 \
+    {                                                                               \
+        static_assert(std::is_same<const cls&, decltype(*this)>::value, "Serialize type mismatch"); \
+        SerializationOps(*this, s, CSerActionSerialize());                          \
+    }                                                                               \
+    template<typename Stream>                                                       \
+    void Unserialize(Stream& s)                                                     \
+    {                                                                               \
+        static_assert(std::is_same<cls&, decltype(*this)>::value, "Unserialize type mismatch"); \
+        SerializationOps(*this, s, CSerActionUnserialize());                        \
+    }                                                                               \
+    template<typename Stream, typename Type, typename Operation>                    \
+    static inline void SerializationOps(Type& obj, Stream& s, Operation ser_action) \
 
 /*
  * Basic Types

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -187,6 +187,8 @@ template<typename X> const X& ReadWriteAsHelper(const X& x) { return x; }
 
 #define READWRITE(...) (::SerReadWriteMany(s, ser_action, __VA_ARGS__))
 #define READWRITEAS(type, obj) (::SerReadWriteMany(s, ser_action, ReadWriteAsHelper<type>(obj)))
+#define SER_READ(obj, code) ::SerRead(s, ser_action, obj, [&](Stream& s, typename std::remove_const<Type>::type& obj) { code; })
+#define SER_WRITE(obj, code) ::SerWrite(s, ser_action, obj, [&](Stream& s, const Type& obj) { code; })
 
 /**
  * Implement three methods for serializable objects. These are actually wrappers over
@@ -1225,6 +1227,28 @@ template<typename Stream, typename... Args>
 inline void SerReadWriteMany(Stream& s, CSerActionUnserialize ser_action, Args&&... args)
 {
     ::UnserializeMany(s, args...);
+}
+
+template<typename Stream, typename Type, typename Fn>
+inline void SerRead(Stream& s, CSerActionSerialize ser_action, Type&&, Fn&&)
+{
+}
+
+template<typename Stream, typename Type, typename Fn>
+inline void SerRead(Stream& s, CSerActionUnserialize ser_action, Type&& obj, Fn&& fn)
+{
+    fn(s, std::forward<Type>(obj));
+}
+
+template<typename Stream, typename Type, typename Fn>
+inline void SerWrite(Stream& s, CSerActionSerialize ser_action, Type&& obj, Fn&& fn)
+{
+    fn(s, std::forward<Type>(obj));
+}
+
+template<typename Stream, typename Type, typename Fn>
+inline void SerWrite(Stream& s, CSerActionUnserialize ser_action, Type&&, Fn&&)
+{
 }
 
 template<typename I>

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -542,6 +542,28 @@ struct VarIntFormatter
     }
 };
 
+template<int Bytes>
+struct CustomUintFormatter
+{
+    static_assert(Bytes > 0 && Bytes <= 8, "CustomUintFormatter Bytes out of range");
+    static constexpr uint64_t MAX = 0xffffffffffffffff >> (8 * (8 - Bytes));
+
+    template <typename Stream, typename I> void Ser(Stream& s, I v)
+    {
+        if (v < 0 || v > MAX) throw std::ios_base::failure("CustomUintFormatter value out of range");
+        uint64_t raw = htole64(v);
+        s.write((const char*)&raw, Bytes);
+    }
+
+    template <typename Stream, typename I> void Unser(Stream& s, I& v)
+    {
+        static_assert(std::numeric_limits<I>::max() >= MAX && std::numeric_limits<I>::min() <= 0, "CustomUintFormatter type too small");
+        uint64_t raw = 0;
+        s.read((char*)&raw, Bytes);
+        v = le64toh(raw);
+    }
+};
+
 /** Serialization wrapper class for big-endian integers.
  *
  * Use this wrapper around integer types that are stored in memory in native

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -52,26 +52,6 @@ static const unsigned int MAX_VECTOR_ALLOCATE = 5000000;
 struct deserialize_type {};
 constexpr deserialize_type deserialize {};
 
-/**
- * Used to bypass the rule against non-const reference to temporary
- * where it makes sense with wrappers.
- */
-template <typename T>
-inline T& REF(const T& val)
-{
-    return const_cast<T&>(val);
-}
-
-/**
- * Used to acquire a non-const pointer "this" to generate bodies
- * of const serialization operations from a template
- */
-template <typename T>
-inline T* NCONST_PTR(const T* val)
-{
-    return const_cast<T*>(val);
-}
-
 //! Safely convert odd char pointer types to standard ones.
 inline char* CharCast(char* c) { return c; }
 inline char* CharCast(unsigned char* c) { return (char*)c; }
@@ -189,24 +169,6 @@ template<typename X> const X& ReadWriteAsHelper(const X& x) { return x; }
 #define READWRITEAS(type, obj) (::SerReadWriteMany(s, ser_action, ReadWriteAsHelper<type>(obj)))
 #define SER_READ(obj, code) ::SerRead(s, ser_action, obj, [&](Stream& s, typename std::remove_const<Type>::type& obj) { code; })
 #define SER_WRITE(obj, code) ::SerWrite(s, ser_action, obj, [&](Stream& s, const Type& obj) { code; })
-
-/**
- * Implement three methods for serializable objects. These are actually wrappers over
- * "SerializationOp" template, which implements the body of each class' serialization
- * code. Adding "ADD_SERIALIZE_METHODS" in the body of the class causes these wrappers to be
- * added as members.
- */
-#define ADD_SERIALIZE_METHODS                                                         \
-    template <typename Stream>                                                        \
-    void Serialize(Stream& s) const                                                   \
-    {                                                                                 \
-        NCONST_PTR(this)->SerializationOp(s, CSerActionSerialize());                  \
-    }                                                                                 \
-    template <typename Stream>                                                        \
-    void Unserialize(Stream& s)                                                       \
-    {                                                                                 \
-        SerializationOp(s, CSerActionUnserialize());                                  \
-    }
 
 /**
  * Implement the Ser and Unser methods needed for implementing a formatter (see Using below).
@@ -1136,7 +1098,7 @@ void Unserialize(Stream& is, std::shared_ptr<T>& p)
 }
 
 /**
- * Support for ADD_SERIALIZE_METHODS and READWRITE macro
+ * Support for SERIALIZE_METHODS and READWRITE macro.
  */
 struct CSerActionSerialize {
     constexpr bool ForRead() const { return false; }

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -547,7 +547,7 @@ struct VarIntFormatter
     }
 };
 
-template<int Bytes>
+template<int Bytes, bool BigEndian = false>
 struct CustomUintFormatter
 {
     static_assert(Bytes > 0 && Bytes <= 8, "CustomUintFormatter Bytes out of range");
@@ -556,52 +556,30 @@ struct CustomUintFormatter
     template <typename Stream, typename I> void Ser(Stream& s, I v)
     {
         if (v < 0 || v > MAX) throw std::ios_base::failure("CustomUintFormatter value out of range");
-        uint64_t raw = htole64(v);
-        s.write((const char*)&raw, Bytes);
+        if (BigEndian) {
+            uint64_t raw = htobe64(v);
+            s.write(((const char*)&raw) + 8 - Bytes, Bytes);
+        } else {
+            uint64_t raw = htole64(v);
+            s.write((const char*)&raw, Bytes);
+        }
     }
 
     template <typename Stream, typename I> void Unser(Stream& s, I& v)
     {
         static_assert(std::numeric_limits<I>::max() >= MAX && std::numeric_limits<I>::min() <= 0, "CustomUintFormatter type too small");
         uint64_t raw = 0;
-        s.read((char*)&raw, Bytes);
-        v = le64toh(raw);
+        if (BigEndian) {
+            s.read(((char*)&raw) + 8 - Bytes, Bytes);
+            v = be64toh(raw);
+        } else {
+            s.read((char*)&raw, Bytes);
+            v = le64toh(raw);
+        }
     }
 };
 
-/** Serialization wrapper class for big-endian integers.
- *
- * Use this wrapper around integer types that are stored in memory in native
- * byte order, but serialized in big endian notation. This is only intended
- * to implement serializers that are compatible with existing formats, and
- * its use is not recommended for new data structures.
- *
- * Only 16-bit types are supported for now.
- */
-template<typename I>
-class BigEndian
-{
-protected:
-    I& m_val;
-public:
-    explicit BigEndian(I& val) : m_val(val)
-    {
-        static_assert(std::is_unsigned<I>::value, "BigEndian type must be unsigned integer");
-        static_assert(sizeof(I) == 2 && std::numeric_limits<I>::min() == 0 && std::numeric_limits<I>::max() == std::numeric_limits<uint16_t>::max(), "Unsupported BigEndian size");
-    }
-
-    template<typename Stream>
-    void Serialize(Stream& s) const
-    {
-        ser_writedata16be(s, m_val);
-    }
-
-    template<typename Stream>
-    void Unserialize(Stream& s)
-    {
-        m_val = ser_readdata16be(s);
-    }
-};
+template<int Bytes> using BigEndianFormatter = CustomUintFormatter<Bytes, true>;
 
 /** Formatter for integers in CompactSize format. */
 struct CompactSizeFormatter
@@ -655,9 +633,6 @@ public:
             s.write((char*)string.data(), string.size());
     }
 };
-
-template<typename I>
-BigEndian<I> WrapBigEndian(I& n) { return BigEndian<I>(n); }
 
 /** Formatter to serialize/deserialize vector elements using another formatter
  *

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -567,14 +567,15 @@ struct CustomUintFormatter
 
     template <typename Stream, typename I> void Unser(Stream& s, I& v)
     {
-        static_assert(std::numeric_limits<I>::max() >= MAX && std::numeric_limits<I>::min() <= 0, "CustomUintFormatter type too small");
+        using U = typename std::conditional<std::is_enum<I>::value, std::underlying_type<I>, std::common_type<I>>::type::type;
+        static_assert(std::numeric_limits<U>::max() >= MAX && std::numeric_limits<U>::min() <= 0, "Assigned type too small");
         uint64_t raw = 0;
         if (BigEndian) {
             s.read(((char*)&raw) + 8 - Bytes, Bytes);
-            v = be64toh(raw);
+            v = static_cast<I>(be64toh(raw));
         } else {
             s.read((char*)&raw, Bytes);
-            v = le64toh(raw);
+            v = static_cast<I>(le64toh(raw));
         }
     }
 };

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -470,6 +470,32 @@ I ReadVarInt(Stream& is)
     }
 }
 
+/** Simple wrapper class to serialize objects using a formatter; used by Using(). */
+template<typename Formatter, typename T>
+class Wrapper
+{
+    static_assert(std::is_lvalue_reference<T>::value, "Wrapper needs an lvalue reference type T");
+protected:
+    T m_object;
+public:
+    explicit Wrapper(T obj) : m_object(obj) {}
+    template<typename Stream> void Serialize(Stream &s) const { Formatter().Ser(s, m_object); }
+    template<typename Stream> void Unserialize(Stream &s) { Formatter().Unser(s, m_object); }
+};
+
+/** Cause serialization/deserialization of an object to be done using a specified formatter class.
+ *
+ * To use this, you need a class Formatter that has public functions Ser(stream, const object&) for
+ * serialization, and Unser(stream, object&) for deserialization. Serialization routines (inside
+ * READWRITE, or directly with << and >> operators), can then use Using<Formatter>(object).
+ *
+ * This works by constructing a Wrapper<Formatter, T>-wrapped version of object, where T is
+ * const during serialization, and non-const during deserialization, which maintains const
+ * correctness.
+ */
+template<typename Formatter, typename T>
+static inline Wrapper<Formatter, T&> Using(T&& t) { return Wrapper<Formatter, T&>(t); }
+
 #define VARINT(obj, ...) WrapVarInt<__VA_ARGS__>(REF(obj))
 #define COMPACTSIZE(obj) CCompactSize(REF(obj))
 #define LIMITED_STRING(obj,n) LimitedString< n >(REF(obj))

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -522,12 +522,13 @@ public:
 template<typename Formatter, typename T>
 static inline Wrapper<Formatter, T&> Using(T&& t) { return Wrapper<Formatter, T&>(t); }
 
-#define VARINT(obj, ...) Using<VarIntFormatter<__VA_ARGS__>>(obj)
+#define VARINT_MODE(obj, mode) Using<VarIntFormatter<mode>>(obj)
+#define VARINT(obj) Using<VarIntFormatter<VarIntMode::DEFAULT>>(obj)
 #define COMPACTSIZE(obj) CCompactSize(REF(obj))
 #define LIMITED_STRING(obj,n) LimitedString< n >(REF(obj))
 
 /** Serialization wrapper class for integers in VarInt format. */
-template<VarIntMode Mode=VarIntMode::DEFAULT>
+template<VarIntMode Mode>
 struct VarIntFormatter
 {
     template<typename Stream, typename I> void Ser(Stream &s, I v)

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -830,6 +830,20 @@ inline void Unserialize(Stream& is, T&& a)
     a.Unserialize(is);
 }
 
+/** Default formatter. Serializes objects as themselves.
+ *
+ * The vector/prevector serialization code passes this to VectorFormatter
+ * to enable reusing that logic. It shouldn't be needed elsewhere.
+ */
+struct DefaultFormatter
+{
+    template<typename Stream, typename T>
+    static void Ser(Stream& s, const T& t) { Serialize(s, t); }
+
+    template<typename Stream, typename T>
+    static void Unser(Stream& s, T& t) { Unserialize(s, t); }
+};
+
 
 /**
  * string
@@ -903,9 +917,7 @@ void Serialize_impl(Stream& os, const prevector<N, T>& v, const unsigned char&)
 template<typename Stream, unsigned int N, typename T, typename V>
 void Serialize_impl(Stream& os, const prevector<N, T>& v, const V&)
 {
-    WriteCompactSize(os, v.size());
-    for (typename prevector<N, T>::const_iterator vi = v.begin(); vi != v.end(); ++vi)
-        ::Serialize(os, (*vi));
+    Serialize(os, Using<VectorFormatter<DefaultFormatter>>(v));
 }
 
 template<typename Stream, unsigned int N, typename T>
@@ -934,19 +946,7 @@ void Unserialize_impl(Stream& is, prevector<N, T>& v, const unsigned char&)
 template<typename Stream, unsigned int N, typename T, typename V>
 void Unserialize_impl(Stream& is, prevector<N, T>& v, const V&)
 {
-    v.clear();
-    unsigned int nSize = ReadCompactSize(is);
-    unsigned int i = 0;
-    unsigned int nMid = 0;
-    while (nMid < nSize)
-    {
-        nMid += MAX_VECTOR_ALLOCATE / sizeof(T);
-        if (nMid > nSize)
-            nMid = nSize;
-        v.resize_uninitialized(nMid);
-        for (; i < nMid; ++i)
-            Unserialize(is, v[i]);
-    }
+    Unserialize(is, Using<VectorFormatter<DefaultFormatter>>(v));
 }
 
 template<typename Stream, unsigned int N, typename T>
@@ -971,9 +971,7 @@ void Serialize_impl(Stream& os, const std::vector<T, A>& v, const unsigned char&
 template <typename Stream, typename T, typename A, typename V>
 void Serialize_impl(Stream& os, const std::vector<T, A>& v, const V&)
 {
-    WriteCompactSize(os, v.size());
-    for (typename std::vector<T, A>::const_iterator vi = v.begin(); vi != v.end(); ++vi)
-        ::Serialize(os, (*vi));
+    Serialize(os, Using<VectorFormatter<DefaultFormatter>>(v));
 }
 
 template <typename Stream, typename T, typename A>
@@ -1001,18 +999,7 @@ void Unserialize_impl(Stream& is, std::vector<T, A>& v, const unsigned char&)
 template <typename Stream, typename T, typename A, typename V>
 void Unserialize_impl(Stream& is, std::vector<T, A>& v, const V&)
 {
-    v.clear();
-    unsigned int nSize = ReadCompactSize(is);
-    unsigned int i = 0;
-    unsigned int nMid = 0;
-    while (nMid < nSize) {
-        nMid += MAX_VECTOR_ALLOCATE / sizeof(T);
-        if (nMid > nSize)
-            nMid = nSize;
-        v.resize(nMid);
-        for (; i < nMid; i++)
-            Unserialize(is, v[i]);
-    }
+    Unserialize(is, Using<VectorFormatter<DefaultFormatter>>(v));
 }
 
 template <typename Stream, typename T, typename A>

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -199,6 +199,30 @@ template<typename X> const X& ReadWriteAsHelper(const X& x) { return x; }
     }
 
 /**
+ * Implement the Ser and Unser methods needed for implementing a formatter (see Using below).
+ *
+ * Both Ser and Unser are delegated to a single static method SerializationOps, which is polymorphic
+ * in the serialized/deserialized type (allowing it to be const when serializing, and non-const when
+ * deserializing).
+ *
+ * Example use:
+ *   struct FooFormatter {
+ *     FORMATTER_METHODS(Class, obj) { READWRITE(obj.val1, VARINT(obj.val2)); }
+ *   }
+ *   would define a class FooFormatter that defines a serialization of Class objects consisting
+ *   of serializing its val1 member using the default serialization, and its val2 member using
+ *   VARINT serialization. That FooFormatter can then be used in statements like
+ *   READWRITE(Using<FooFormatter>(obj.bla)).
+ */
+#define FORMATTER_METHODS(cls, obj) \
+    template<typename Stream> \
+    static void Ser(Stream& s, const cls& obj) { SerializationOps(obj, s, CSerActionSerialize()); } \
+    template<typename Stream> \
+    static void Unser(Stream& s, cls& obj) { SerializationOps(obj, s, CSerActionUnserialize()); } \
+    template<typename Stream, typename Type, typename Operation> \
+    static inline void SerializationOps(Type& obj, Stream& s, Operation ser_action) \
+
+/**
  * Implement the Serialize and Unserialize methods by delegating to a single templated
  * static method that takes the to-be-(de)serialized object as a parameter. This approach
  * has the advantage that the constness of the object becomes a template parameter, and
@@ -210,16 +234,15 @@ template<typename X> const X& ReadWriteAsHelper(const X& x) { return x; }
     void Serialize(Stream& s) const                                                 \
     {                                                                               \
         static_assert(std::is_same<const cls&, decltype(*this)>::value, "Serialize type mismatch"); \
-        SerializationOps(*this, s, CSerActionSerialize());                          \
+        Ser(s, *this);                                                              \
     }                                                                               \
     template<typename Stream>                                                       \
     void Unserialize(Stream& s)                                                     \
     {                                                                               \
         static_assert(std::is_same<cls&, decltype(*this)>::value, "Unserialize type mismatch"); \
-        SerializationOps(*this, s, CSerActionUnserialize());                        \
+        Unser(s, *this);                                                            \
     }                                                                               \
-    template<typename Stream, typename Type, typename Operation>                    \
-    static inline void SerializationOps(Type& obj, Stream& s, Operation ser_action) \
+    FORMATTER_METHODS(cls, obj)
 
 /*
  * Basic Types

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -140,24 +140,28 @@ inline uint64_t ser_double_to_uint64(double x)
 {
     uint64_t tmp;
     std::memcpy(&tmp, &x, sizeof(x));
+    static_assert(sizeof(tmp) == sizeof(x), "double and uint64_t assumed to have the same size");
     return tmp;
 }
 inline uint32_t ser_float_to_uint32(float x)
 {
     uint32_t tmp;
     std::memcpy(&tmp, &x, sizeof(x));
+    static_assert(sizeof(tmp) == sizeof(x), "float and uint32_t assumed to have the same size");
     return tmp;
 }
 inline double ser_uint64_to_double(uint64_t y)
 {
     double tmp;
     std::memcpy(&tmp, &y, sizeof(y));
+    static_assert(sizeof(tmp) == sizeof(y), "double and uint64_t assumed to have the same size");
     return tmp;
 }
 inline float ser_uint32_to_float(uint32_t y)
 {
     float tmp;
     std::memcpy(&tmp, &y, sizeof(y));
+    static_assert(sizeof(tmp) == sizeof(y), "float and uint32_t assumed to have the same size");
     return tmp;
 }
 

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -532,7 +532,7 @@ static inline Wrapper<Formatter, T&> Using(T&& t) { return Wrapper<Formatter, T&
 #define VARINT_MODE(obj, mode) Using<VarIntFormatter<mode>>(obj)
 #define VARINT(obj) Using<VarIntFormatter<VarIntMode::DEFAULT>>(obj)
 #define COMPACTSIZE(obj) Using<CompactSizeFormatter>(obj)
-#define LIMITED_STRING(obj,n) LimitedString< n >(REF(obj))
+#define LIMITED_STRING(obj,n) Using<LimitedStringFormatter<n>>(obj)
 
 /** Serialization wrapper class for integers in VarInt format. */
 template<VarIntMode Mode>
@@ -616,33 +616,24 @@ struct CompactSizeFormatter
     }
 };
 
-template <size_t Limit>
-class LimitedString
+template<size_t Limit>
+struct LimitedStringFormatter
 {
-protected:
-    std::string& string;
-
-public:
-    LimitedString(std::string& _string) : string(_string) {}
-
-    template <typename Stream>
-    void Unserialize(Stream& s)
+    template<typename Stream>
+    void Unser(Stream& s, std::string& v)
     {
         size_t size = ReadCompactSize(s);
         if (size > Limit) {
             throw std::ios_base::failure("String length limit exceeded");
         }
-        string.resize(size);
-        if (size != 0)
-            s.read((char*)string.data(), size);
+        v.resize(size);
+        if (size != 0) s.read((char*)v.data(), size);
     }
 
-    template <typename Stream>
-    void Serialize(Stream& s) const
+    template<typename Stream>
+    void Ser(Stream& s, const std::string& v)
     {
-        WriteCompactSize(s, string.size());
-        if (!string.empty())
-            s.write((char*)string.data(), string.size());
+        s << v;
     }
 };
 

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -626,6 +626,53 @@ public:
 template<typename I>
 BigEndian<I> WrapBigEndian(I& n) { return BigEndian<I>(n); }
 
+/** Formatter to serialize/deserialize vector elements using another formatter
+ *
+ * Example:
+ *   struct X {
+ *     std::vector<uint64_t> v;
+ *     SERIALIZE_METHODS(X, obj) { READWRITE(Using<VectorFormatter<VarInt>>(obj.v)); }
+ *   };
+ * will define a struct that contains a vector of uint64_t, which is serialized
+ * as a vector of VarInt-encoded integers.
+ *
+ * V is not required to be an std::vector type. It works for any class that
+ * exposes a value_type, size, reserve, push_back, and const iterators.
+ */
+template<class Formatter>
+struct VectorFormatter
+{
+    template<typename Stream, typename V>
+    void Ser(Stream& s, const V& v)
+    {
+        WriteCompactSize(s, v.size());
+        for (const typename V::value_type& elem : v) {
+            s << Using<Formatter>(elem);
+        }
+    }
+
+    template<typename Stream, typename V>
+    void Unser(Stream& s, V& v)
+    {
+        v.clear();
+        size_t size = ReadCompactSize(s);
+        size_t allocated = 0;
+        while (allocated < size) {
+            // For DoS prevention, do not blindly allocate as much as the stream claims to contain.
+            // Instead, allocate in 5MiB batches, so that an attacker actually needs to provide
+            // X MiB of data to make us allocate X+5 Mib.
+            static_assert(sizeof(typename V::value_type) <= MAX_VECTOR_ALLOCATE, "Vector element size too large");
+            allocated = std::min(size, allocated + MAX_VECTOR_ALLOCATE / sizeof(typename V::value_type));
+            v.reserve(allocated);
+            while (v.size() < allocated) {
+                typename V::value_type val;
+                s >> Using<Formatter>(val);
+                v.push_back(std::move(val));
+            }
+        }
+    };
+};
+
 /**
  * Forward declarations
  */

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -496,27 +496,22 @@ public:
 template<typename Formatter, typename T>
 static inline Wrapper<Formatter, T&> Using(T&& t) { return Wrapper<Formatter, T&>(t); }
 
-#define VARINT(obj, ...) WrapVarInt<__VA_ARGS__>(REF(obj))
+#define VARINT(obj, ...) Using<VarIntFormatter<__VA_ARGS__>>(obj)
 #define COMPACTSIZE(obj) CCompactSize(REF(obj))
 #define LIMITED_STRING(obj,n) LimitedString< n >(REF(obj))
 
-template<VarIntMode Mode, typename I>
-class CVarInt
+/** Serialization wrapper class for integers in VarInt format. */
+template<VarIntMode Mode=VarIntMode::DEFAULT>
+struct VarIntFormatter
 {
-protected:
-    I& n;
-
-public:
-    CVarInt(I& nIn) : n(nIn) {}
-
-    template<typename Stream>
-    void Serialize(Stream& s) const {
-        WriteVarInt<Stream,Mode,I>(s, n);
+    template<typename Stream, typename I> void Ser(Stream &s, I v)
+    {
+        WriteVarInt<Stream,Mode,typename std::remove_cv<I>::type>(s, v);
     }
 
-    template<typename Stream>
-    void Unserialize(Stream& s) {
-        n = ReadVarInt<Stream,Mode,I>(s);
+    template<typename Stream, typename I> void Unser(Stream& s, I& v)
+    {
+        v = ReadVarInt<Stream,Mode,typename std::remove_cv<I>::type>(s);
     }
 };
 
@@ -601,9 +596,6 @@ public:
             s.write((char*)string.data(), string.size());
     }
 };
-
-template<VarIntMode Mode=VarIntMode::DEFAULT, typename I>
-CVarInt<Mode, I> WrapVarInt(I& n) { return CVarInt<Mode, I>{n}; }
 
 template<typename I>
 BigEndian<I> WrapBigEndian(I& n) { return BigEndian<I>(n); }

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -524,7 +524,7 @@ static inline Wrapper<Formatter, T&> Using(T&& t) { return Wrapper<Formatter, T&
 
 #define VARINT_MODE(obj, mode) Using<VarIntFormatter<mode>>(obj)
 #define VARINT(obj) Using<VarIntFormatter<VarIntMode::DEFAULT>>(obj)
-#define COMPACTSIZE(obj) CCompactSize(REF(obj))
+#define COMPACTSIZE(obj) Using<CompactSizeFormatter>(obj)
 #define LIMITED_STRING(obj,n) LimitedString< n >(REF(obj))
 
 /** Serialization wrapper class for integers in VarInt format. */
@@ -576,21 +576,26 @@ public:
     }
 };
 
-class CCompactSize
+/** Formatter for integers in CompactSize format. */
+struct CompactSizeFormatter
 {
-protected:
-    uint64_t &n;
-public:
-    CCompactSize(uint64_t& nIn) : n(nIn) { }
-
-    template<typename Stream>
-    void Serialize(Stream &s) const {
-        WriteCompactSize<Stream>(s, n);
+    template<typename Stream, typename I>
+    void Unser(Stream& s, I& v)
+    {
+        uint64_t n = ReadCompactSize<Stream>(s);
+        if (n < std::numeric_limits<I>::min() || n > std::numeric_limits<I>::max()) {
+            throw std::ios_base::failure("CompactSize exceeds limit of type");
+        }
+        v = n;
     }
 
-    template<typename Stream>
-    void Unserialize(Stream& s) {
-        n = ReadCompactSize<Stream>(s);
+    template<typename Stream, typename I>
+    void Ser(Stream& s, I v)
+    {
+        static_assert(std::is_unsigned<I>::value, "CompactSize only supported for unsigned integers");
+        static_assert(std::numeric_limits<I>::max() <= std::numeric_limits<uint64_t>::max(), "CompactSize only supports 64-bit integers and below");
+
+        WriteCompactSize<Stream>(s, v);
     }
 };
 

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <array>
 #include <assert.h>
+#include <cstring>
 #include <ios>
 #include <limits>
 #include <list>
@@ -137,27 +138,27 @@ template<typename Stream> inline uint64_t ser_readdata64(Stream &s)
 }
 inline uint64_t ser_double_to_uint64(double x)
 {
-    union { double x; uint64_t y; } tmp;
-    tmp.x = x;
-    return tmp.y;
+    uint64_t tmp;
+    std::memcpy(&tmp, &x, sizeof(x));
+    return tmp;
 }
 inline uint32_t ser_float_to_uint32(float x)
 {
-    union { float x; uint32_t y; } tmp;
-    tmp.x = x;
-    return tmp.y;
+    uint32_t tmp;
+    std::memcpy(&tmp, &x, sizeof(x));
+    return tmp;
 }
 inline double ser_uint64_to_double(uint64_t y)
 {
-    union { double x; uint64_t y; } tmp;
-    tmp.y = y;
-    return tmp.x;
+    double tmp;
+    std::memcpy(&tmp, &y, sizeof(y));
+    return tmp;
 }
 inline float ser_uint32_to_float(uint32_t y)
 {
-    union { float x; uint32_t y; } tmp;
-    tmp.y = y;
-    return tmp.x;
+    float tmp;
+    std::memcpy(&tmp, &y, sizeof(y));
+    return tmp;
 }
 
 

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -34,6 +34,9 @@ class CScript;
 
 static const unsigned int MAX_SIZE = 0x02000000;
 
+/** Maximum amount of memory (in bytes) to allocate at once when deserializing vectors. */
+static const unsigned int MAX_VECTOR_ALLOCATE = 5000000;
+
 /**
  * Dummy data type to identify deserializing constructors.
  *
@@ -890,7 +893,7 @@ void Unserialize_impl(Stream& is, prevector<N, T>& v, const V&)
     unsigned int nMid = 0;
     while (nMid < nSize)
     {
-        nMid += 5000000 / sizeof(T);
+        nMid += MAX_VECTOR_ALLOCATE / sizeof(T);
         if (nMid > nSize)
             nMid = nSize;
         v.resize_uninitialized(nMid);
@@ -956,7 +959,7 @@ void Unserialize_impl(Stream& is, std::vector<T, A>& v, const V&)
     unsigned int i = 0;
     unsigned int nMid = 0;
     while (nMid < nSize) {
-        nMid += 5000000 / sizeof(T);
+        nMid += MAX_VECTOR_ALLOCATE / sizeof(T);
         if (nMid > nSize)
             nMid = nSize;
         v.resize(nMid);

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -549,6 +549,15 @@ struct VarIntFormatter
     }
 };
 
+/** Serialization wrapper class for custom integers and enums.
+ *
+ * It permits specifying the serialized size (1 to 8 bytes) and endianness.
+ *
+ * Use the big endian mode for values that are stored in memory in native
+ * byte order, but serialized in big endian notation. This is only intended
+ * to implement serializers that are compatible with existing formats, and
+ * its use is not recommended for new data structures.
+ */
 template<int Bytes, bool BigEndian = false>
 struct CustomUintFormatter
 {

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -1134,15 +1134,17 @@ size_t GetSerializeSize(const T& t, int nVersion = 0)
     return (CSizeComputer(nVersion) << t).size();
 }
 
-template <typename S, typename T>
-size_t GetSerializeSize(const S& s, const T& t)
+template <typename... T>
+size_t GetSerializeSizeMany(int nVersion, const T&... t)
 {
-    return (CSizeComputer(s.GetVersion()) << t).size();
+    CSizeComputer sc(nVersion);
+    SerializeMany(sc, t...);
+    return sc.size();
 }
 
 /**
-  * optional
-  */
+* optional
+*/
 template<typename T>
 unsigned int GetSerializeSize(const Optional<T> &item)
 {

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -27,6 +27,7 @@
 #include "libzerocoin/SpendType.h"
 #include "optional.h"
 #include "prevector.h"
+#include "span.h"
 #include "sporkid.h"
 
 class CScript;
@@ -49,7 +50,7 @@ constexpr deserialize_type deserialize {};
 
 /**
  * Used to bypass the rule against non-const reference to temporary
- * where it makes sense with wrappers such as CFlatData or CTxDB
+ * where it makes sense with wrappers.
  */
 template <typename T>
 inline T& REF(const T& val)
@@ -203,6 +204,8 @@ template<typename Stream> inline void Serialize(Stream& s, float a   ) { ser_wri
 template<typename Stream> inline void Serialize(Stream& s, double a  ) { ser_writedata64(s, ser_double_to_uint64(a)); }
 template<typename Stream, int N> inline void Serialize(Stream& s, const char (&a)[N]) { s.write(a, N); }
 template<typename Stream, int N> inline void Serialize(Stream& s, const unsigned char (&a)[N]) { s.write(CharCast(a), N); }
+template<typename Stream> inline void Serialize(Stream& s, const Span<const unsigned char>& span) { s.write(CharCast(span.data()), span.size()); }
+template<typename Stream> inline void Serialize(Stream& s, const Span<unsigned char>& span) { s.write(CharCast(span.data()), span.size()); }
 
 template<typename Stream> inline void Unserialize(Stream& s, char& a    ) { a = ser_readdata8(s); } // TODO Get rid of bare char
 template<typename Stream> inline void Unserialize(Stream& s, int8_t& a  ) { a = ser_readdata8(s); }
@@ -217,6 +220,7 @@ template<typename Stream> inline void Unserialize(Stream& s, float& a   ) { a = 
 template<typename Stream> inline void Unserialize(Stream& s, double& a  ) { a = ser_uint64_to_double(ser_readdata64(s)); }
 template<typename Stream, int N> inline void Unserialize(Stream& s, char (&a)[N]) { s.read(a, N); }
 template<typename Stream, int N> inline void Unserialize(Stream& s, unsigned char (&a)[N]) { s.read(CharCast(a), N); }
+template<typename Stream> inline void Unserialize(Stream& s, Span<unsigned char>& span) { s.read(CharCast(span.data()), span.size()); }
 
 template<typename Stream> inline void Serialize(Stream& s, bool a)    { char f=a; ser_writedata8(s, f); }
 template<typename Stream> inline void Unserialize(Stream& s, bool& a) { char f=ser_readdata8(s); a=f; }
@@ -433,51 +437,9 @@ I ReadVarInt(Stream& is)
     }
 }
 
-#define FLATDATA(obj) CFlatData((char*)&(obj), (char*)&(obj) + sizeof(obj))
 #define VARINT(obj, ...) WrapVarInt<__VA_ARGS__>(REF(obj))
 #define COMPACTSIZE(obj) CCompactSize(REF(obj))
 #define LIMITED_STRING(obj,n) LimitedString< n >(REF(obj))
-
-/**
- * Wrapper for serializing arrays and POD.
- */
-class CFlatData
-{
-protected:
-    char* pbegin;
-    char* pend;
-
-public:
-    CFlatData(void* pbeginIn, void* pendIn) : pbegin((char*)pbeginIn), pend((char*)pendIn) {}
-    template <class T, class TAl>
-    explicit CFlatData(std::vector<T, TAl>& v)
-    {
-        pbegin = (char*)v.data();
-        pend = (char*)(v.data() + v.size());
-    }
-    template <unsigned int N, typename T, typename S, typename D>
-    explicit CFlatData(prevector<N, T, S, D> &v)
-    {
-        pbegin = (char*)v.data();
-        pend = (char*)(v.data() + v.size());
-    }
-    char* begin() { return pbegin; }
-    const char* begin() const { return pbegin; }
-    char* end() { return pend; }
-    const char* end() const { return pend; }
-
-    template <typename Stream>
-    void Serialize(Stream& s) const
-    {
-        s.write(pbegin, pend - pbegin);
-    }
-
-    template <typename Stream>
-    void Unserialize(Stream& s)
-    {
-        s.read(pbegin, pend - pbegin);
-    }
-};
 
 template<VarIntMode Mode, typename I>
 class CVarInt

--- a/src/span.h
+++ b/src/span.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SPAN_H
+#define BITCOIN_SPAN_H
+
+#include <type_traits>
+#include <cstddef>
+
+/** A Span is an object that can refer to a contiguous sequence of objects.
+ *
+ * It implements a subset of C++20's std::span.
+ */
+template<typename C>
+class Span
+{
+    C* m_data;
+    std::ptrdiff_t m_size;
+
+public:
+    constexpr Span() noexcept : m_data(nullptr), m_size(0) {}
+    constexpr Span(C* data, std::ptrdiff_t size) noexcept : m_data(data), m_size(size) {}
+
+    constexpr C* data() const noexcept { return m_data; }
+    constexpr std::ptrdiff_t size() const noexcept { return m_size; }
+};
+
+/** Create a span to a container exposing data() and size().
+ *
+ * This correctly deals with constness: the returned Span's element type will be
+ * whatever data() returns a pointer to. If either the passed container is const,
+ * or its element type is const, the resulting span will have a const element type.
+ *
+ * std::span will have a constructor that implements this functionality directly.
+ */
+template<typename V>
+constexpr Span<typename std::remove_pointer<decltype(std::declval<V>().data())>::type> MakeSpan(V& v) { return Span<typename std::remove_pointer<decltype(std::declval<V>().data())>::type>(v.data(), v.size()); }
+
+#endif

--- a/src/spork.h
+++ b/src/spork.h
@@ -94,14 +94,7 @@ private:
 public:
     CSporkManager();
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(mapSporksActive);
-        // we don't serialize private key to prevent its leakage
-    }
+    SERIALIZE_METHODS(CSporkManager, obj) { READWRITE(obj.mapSporksActive); }
 
     void Clear();
     void LoadSporksFromDB();

--- a/src/spork.h
+++ b/src/spork.h
@@ -72,12 +72,7 @@ public:
         READWRITE(nValue);
         READWRITE(nTimeSigned);
         READWRITE(vchSig);
-        try
-        {
-            READWRITE(nMessVersion);
-        } catch (...) {
-            nMessVersion = MessageVersion::MESS_VER_STRMESS;
-        }
+        READWRITE(nMessVersion);
     }
 };
 

--- a/src/spork.h
+++ b/src/spork.h
@@ -63,17 +63,7 @@ public:
 
     void Relay();
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(nSporkID);
-        READWRITE(nValue);
-        READWRITE(nTimeSigned);
-        READWRITE(vchSig);
-        READWRITE(nMessVersion);
-    }
+    SERIALIZE_METHODS(CSporkMessage, obj) { READWRITE(obj.nSporkID, obj.nValue, obj.nTimeSigned, obj.vchSig, obj.nMessVersion); }
 };
 
 

--- a/src/test/arith_uint256_tests.cpp
+++ b/src/test/arith_uint256_tests.cpp
@@ -597,8 +597,8 @@ BOOST_AUTO_TEST_CASE( methods ) // GetHex SetHex begin() end() size() GetLow64 G
     BOOST_CHECK(R1L.GetLow64()  == R1LLow64);
     BOOST_CHECK(HalfL.GetLow64() ==0x0000000000000000ULL);
     BOOST_CHECK(OneL.GetLow64() ==0x0000000000000001ULL);
-    BOOST_CHECK(GetSerializeSize(R1L, 0, PROTOCOL_VERSION) == 32);
-    BOOST_CHECK(GetSerializeSize(ZeroL, 0,PROTOCOL_VERSION) == 32);
+    BOOST_CHECK(GetSerializeSize(R1L, PROTOCOL_VERSION) == 32);
+    BOOST_CHECK(GetSerializeSize(ZeroL, PROTOCOL_VERSION) == 32);
 
     CDataStream ss(0, PROTOCOL_VERSION);
     ss << R1L;
@@ -645,8 +645,8 @@ BOOST_AUTO_TEST_CASE( methods ) // GetHex SetHex begin() end() size() GetLow64 G
     BOOST_CHECK(R1S.GetLow64()  == R1LLow64);
     BOOST_CHECK(HalfS.GetLow64() ==0x0000000000000000ULL);
     BOOST_CHECK(OneS.GetLow64() ==0x0000000000000001ULL);
-    BOOST_CHECK(GetSerializeSize(R1S, 0, PROTOCOL_VERSION) == 20);
-    BOOST_CHECK(GetSerializeSize(ZeroS, 0, PROTOCOL_VERSION) == 20);
+    BOOST_CHECK(GetSerializeSize(R1S, PROTOCOL_VERSION) == 20);
+    BOOST_CHECK(GetSerializeSize(ZeroS, PROTOCOL_VERSION) == 20);
 
     ss << R1S;
     BOOST_CHECK(ss.str() == std::string(R1Array,R1Array+20));

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -25,16 +25,16 @@
 BOOST_FIXTURE_TEST_SUITE(compress_tests, BasicTestingSetup)
 
 bool static TestEncode(uint64_t in) {
-    return in == CTxOutCompressor::DecompressAmount(CTxOutCompressor::CompressAmount(in));
+    return in == DecompressAmount(CompressAmount(in));
 }
 
 bool static TestDecode(uint64_t in) {
-    return in == CTxOutCompressor::CompressAmount(CTxOutCompressor::DecompressAmount(in));
+    return in == CompressAmount(DecompressAmount(in));
 }
 
 bool static TestPair(uint64_t dec, uint64_t enc) {
-    return CTxOutCompressor::CompressAmount(dec) == enc &&
-           CTxOutCompressor::DecompressAmount(enc) == dec;
+    return CompressAmount(dec) == enc &&
+           DecompressAmount(enc) == dec;
 }
 
 BOOST_AUTO_TEST_CASE(compress_amounts)

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -239,24 +239,26 @@ struct StringContentsSerializer {
     }
     StringContentsSerializer& operator+=(const StringContentsSerializer& s) { return *this += s.str; }
 
-    ADD_SERIALIZE_METHODS;
+    template<typename Stream>
+    void Serialize(Stream& s) const
+    {
+        for (size_t i = 0; i < str.size(); i++) {
+            s << str[i];
+        }
+    }
 
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        if (ser_action.ForRead()) {
-            str.clear();
-            char c = 0;
-            while (true) {
-                try {
-                    READWRITE(c);
-                    str.push_back(c);
-                } catch (const std::ios_base::failure& e) {
-                    break;
-                }
+    template<typename Stream>
+    void Unserialize(Stream& s)
+    {
+        str.clear();
+        char c = 0;
+        while (true) {
+            try {
+                s >> c;
+                str.push_back(c);
+            } catch (const std::ios_base::failure&) {
+                break;
             }
-        } else {
-            for (size_t i = 0; i < str.size(); i++)
-                READWRITE(str[i]);
         }
     }
 };

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -175,7 +175,7 @@ void test_one_input(std::vector<uint8_t> buffer)
         DeserializeFromFuzzingInput(buffer, dbi);
 #elif TXOUTCOMPRESSOR_DESERIALIZE
         CTxOut to;
-        CTxOutCompressor toc(to);
+        auto toc = Using<TxOutCompression>(to);
         DeserializeFromFuzzingInput(buffer, toc);
 #else
 #error Need at least one fuzz target to compile

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -336,7 +336,7 @@ BOOST_AUTO_TEST_CASE(MempoolAncestorIndexingTest)
     tx2.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
     tx2.vout[0].nValue = 2 * COIN;
     pool.addUnchecked(tx2.GetHash(), entry.Fee(20000LL).Priority(9.0).FromTx(tx2));
-    uint64_t tx2Size = ::GetSerializeSize(tx2, SER_NETWORK, PROTOCOL_VERSION);
+    uint64_t tx2Size = ::GetSerializeSize(tx2, PROTOCOL_VERSION);
 
     /* lowest fee */
     CMutableTransaction tx3 = CMutableTransaction();
@@ -384,7 +384,7 @@ BOOST_AUTO_TEST_CASE(MempoolAncestorIndexingTest)
     tx6.vout.resize(1);
     tx6.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
     tx6.vout[0].nValue = 20 * COIN;
-    uint64_t tx6Size = ::GetSerializeSize(tx6, SER_NETWORK, PROTOCOL_VERSION);
+    uint64_t tx6Size = ::GetSerializeSize(tx6, PROTOCOL_VERSION);
 
     pool.addUnchecked(tx6.GetHash(), entry.Fee(0LL).FromTx(tx6));
     BOOST_CHECK_EQUAL(pool.size(), 6);
@@ -403,7 +403,7 @@ BOOST_AUTO_TEST_CASE(MempoolAncestorIndexingTest)
     tx7.vout.resize(1);
     tx7.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
     tx7.vout[0].nValue = 10 * COIN;
-    uint64_t tx7Size = ::GetSerializeSize(tx7, SER_NETWORK, PROTOCOL_VERSION);
+    uint64_t tx7Size = ::GetSerializeSize(tx7, PROTOCOL_VERSION);
 
     /* set the fee to just below tx2's feerate when including ancestor */
     CAmount fee = (20000/tx2Size)*(tx7Size + tx6Size) - 1;
@@ -475,12 +475,12 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     BOOST_CHECK(pool.exists(tx2.GetHash()));
     BOOST_CHECK(pool.exists(tx3.GetHash()));
 
-    pool.TrimToSize(::GetSerializeSize(CTransaction(tx1), SER_NETWORK, PROTOCOL_VERSION)); // mempool is limited to tx1's size in memory usage, so nothing fits
+    pool.TrimToSize(::GetSerializeSize(CTransaction(tx1), PROTOCOL_VERSION)); // mempool is limited to tx1's size in memory usage, so nothing fits
     BOOST_CHECK(!pool.exists(tx1.GetHash()));
     BOOST_CHECK(!pool.exists(tx2.GetHash()));
     BOOST_CHECK(!pool.exists(tx3.GetHash()));
 
-    CFeeRate maxFeeRateRemoved(25000, ::GetSerializeSize(CTransaction(tx3), SER_NETWORK, PROTOCOL_VERSION) + ::GetSerializeSize(CTransaction(tx2), SER_NETWORK, PROTOCOL_VERSION));
+    CFeeRate maxFeeRateRemoved(25000, ::GetSerializeSize(CTransaction(tx3), PROTOCOL_VERSION) + ::GetSerializeSize(CTransaction(tx2), PROTOCOL_VERSION));
     BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), maxFeeRateRemoved.GetFeePerK() + 1000);
 
     CMutableTransaction tx4 = CMutableTransaction();

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
     tx.vin[0].scriptSig = garbage;
     tx.vout.resize(1);
     tx.vout[0].nValue=0LL;
-    CFeeRate baseRate(basefee, ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION));
+    CFeeRate baseRate(basefee, ::GetSerializeSize(tx, PROTOCOL_VERSION));
 
     // Create a fake block
     std::vector<CTransactionRef> block;

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -207,8 +207,8 @@ BOOST_AUTO_TEST_CASE(varints)
     CDataStream ss(SER_DISK, 0);
     CDataStream::size_type size = 0;
     for (int i = 0; i < 100000; i++) {
-        ss << VARINT(i, VarIntMode::NONNEGATIVE_SIGNED);
-        size += ::GetSerializeSize(VARINT(i, VarIntMode::NONNEGATIVE_SIGNED), 0);
+        ss << VARINT_MODE(i, VarIntMode::NONNEGATIVE_SIGNED);
+        size += ::GetSerializeSize(VARINT_MODE(i, VarIntMode::NONNEGATIVE_SIGNED), 0);
         BOOST_CHECK(size == ss.size());
     }
 
@@ -221,7 +221,7 @@ BOOST_AUTO_TEST_CASE(varints)
     // decode
     for (int i = 0; i < 100000; i++) {
         int j = -1;
-        ss >> VARINT(j, VarIntMode::NONNEGATIVE_SIGNED);
+        ss >> VARINT_MODE(j, VarIntMode::NONNEGATIVE_SIGNED);
         BOOST_CHECK_MESSAGE(i == j, "decoded:" << j << " expected:" << i);
     }
 
@@ -235,21 +235,21 @@ BOOST_AUTO_TEST_CASE(varints)
 BOOST_AUTO_TEST_CASE(varints_bitpatterns)
 {
     CDataStream ss(SER_DISK, 0);
-    ss << VARINT(0, VarIntMode::NONNEGATIVE_SIGNED); BOOST_CHECK_EQUAL(HexStr(ss), "00"); ss.clear();
-    ss << VARINT(0x7f, VarIntMode::NONNEGATIVE_SIGNED); BOOST_CHECK_EQUAL(HexStr(ss), "7f"); ss.clear();
-    ss << VARINT((int8_t)0x7f, VarIntMode::NONNEGATIVE_SIGNED); BOOST_CHECK_EQUAL(HexStr(ss), "7f"); ss.clear();
-    ss << VARINT(0x80, VarIntMode::NONNEGATIVE_SIGNED); BOOST_CHECK_EQUAL(HexStr(ss), "8000"); ss.clear();
+    ss << VARINT_MODE(0, VarIntMode::NONNEGATIVE_SIGNED); BOOST_CHECK_EQUAL(HexStr(ss), "00"); ss.clear();
+    ss << VARINT_MODE(0x7f, VarIntMode::NONNEGATIVE_SIGNED); BOOST_CHECK_EQUAL(HexStr(ss), "7f"); ss.clear();
+    ss << VARINT_MODE((int8_t)0x7f, VarIntMode::NONNEGATIVE_SIGNED); BOOST_CHECK_EQUAL(HexStr(ss), "7f"); ss.clear();
+    ss << VARINT_MODE(0x80, VarIntMode::NONNEGATIVE_SIGNED); BOOST_CHECK_EQUAL(HexStr(ss), "8000"); ss.clear();
     ss << VARINT((uint8_t)0x80); BOOST_CHECK_EQUAL(HexStr(ss), "8000"); ss.clear();
-    ss << VARINT(0x1234, VarIntMode::NONNEGATIVE_SIGNED); BOOST_CHECK_EQUAL(HexStr(ss), "a334"); ss.clear();
-    ss << VARINT((int16_t)0x1234, VarIntMode::NONNEGATIVE_SIGNED); BOOST_CHECK_EQUAL(HexStr(ss), "a334"); ss.clear();
-    ss << VARINT(0xffff, VarIntMode::NONNEGATIVE_SIGNED); BOOST_CHECK_EQUAL(HexStr(ss), "82fe7f"); ss.clear();
+    ss << VARINT_MODE(0x1234, VarIntMode::NONNEGATIVE_SIGNED); BOOST_CHECK_EQUAL(HexStr(ss), "a334"); ss.clear();
+    ss << VARINT_MODE((int16_t)0x1234, VarIntMode::NONNEGATIVE_SIGNED); BOOST_CHECK_EQUAL(HexStr(ss), "a334"); ss.clear();
+    ss << VARINT_MODE(0xffff, VarIntMode::NONNEGATIVE_SIGNED); BOOST_CHECK_EQUAL(HexStr(ss), "82fe7f"); ss.clear();
     ss << VARINT((uint16_t)0xffff); BOOST_CHECK_EQUAL(HexStr(ss), "82fe7f"); ss.clear();
-    ss << VARINT(0x123456, VarIntMode::NONNEGATIVE_SIGNED); BOOST_CHECK_EQUAL(HexStr(ss), "c7e756"); ss.clear();
-    ss << VARINT((int32_t)0x123456, VarIntMode::NONNEGATIVE_SIGNED); BOOST_CHECK_EQUAL(HexStr(ss), "c7e756"); ss.clear();
+    ss << VARINT_MODE(0x123456, VarIntMode::NONNEGATIVE_SIGNED); BOOST_CHECK_EQUAL(HexStr(ss), "c7e756"); ss.clear();
+    ss << VARINT_MODE((int32_t)0x123456, VarIntMode::NONNEGATIVE_SIGNED); BOOST_CHECK_EQUAL(HexStr(ss), "c7e756"); ss.clear();
     ss << VARINT(0x80123456U); BOOST_CHECK_EQUAL(HexStr(ss), "86ffc7e756"); ss.clear();
     ss << VARINT((uint32_t)0x80123456U); BOOST_CHECK_EQUAL(HexStr(ss), "86ffc7e756"); ss.clear();
     ss << VARINT(0xffffffff); BOOST_CHECK_EQUAL(HexStr(ss), "8efefefe7f"); ss.clear();
-    ss << VARINT(0x7fffffffffffffffLL, VarIntMode::NONNEGATIVE_SIGNED); BOOST_CHECK_EQUAL(HexStr(ss), "fefefefefefefefe7f"); ss.clear();
+    ss << VARINT_MODE(0x7fffffffffffffffLL, VarIntMode::NONNEGATIVE_SIGNED); BOOST_CHECK_EQUAL(HexStr(ss), "fefefefefefefefe7f"); ss.clear();
     ss << VARINT(0xffffffffffffffffULL); BOOST_CHECK_EQUAL(HexStr(ss), "80fefefefefefefefe7f"); ss.clear();
 }
 

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -19,7 +19,7 @@ void check_ser_rep(T thing, std::vector<unsigned char> expected)
     CDataStream ss(SER_DISK, 0);
     ss << thing;
 
-    BOOST_CHECK(GetSerializeSize(thing, 0, 0) == ss.size());
+    BOOST_CHECK(GetSerializeSize(thing, 0) == ss.size());
 
     std::vector<unsigned char> serialized_representation(ss.begin(), ss.end());
 
@@ -208,13 +208,13 @@ BOOST_AUTO_TEST_CASE(varints)
     CDataStream::size_type size = 0;
     for (int i = 0; i < 100000; i++) {
         ss << VARINT(i, VarIntMode::NONNEGATIVE_SIGNED);
-        size += ::GetSerializeSize(VARINT(i, VarIntMode::NONNEGATIVE_SIGNED), 0, 0);
+        size += ::GetSerializeSize(VARINT(i, VarIntMode::NONNEGATIVE_SIGNED), 0);
         BOOST_CHECK(size == ss.size());
     }
 
     for (uint64_t i = 0;  i < 100000000000ULL; i += 999999937) {
         ss << VARINT(i);
-        size += ::GetSerializeSize(VARINT(i), 0, 0);
+        size += ::GetSerializeSize(VARINT(i), 0);
         BOOST_CHECK(size == ss.size());
     }
 

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -48,15 +48,13 @@ public:
         memcpy(charstrval, charstrvalin, sizeof(charstrval));
     }
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(intval);
-        READWRITE(boolval);
-        READWRITE(stringval);
-        READWRITE(charstrval);
-        READWRITE(txval);
+    SERIALIZE_METHODS(CSerializeMethodsTestSingle, obj)
+    {
+        READWRITE(obj.intval);
+        READWRITE(obj.boolval);
+        READWRITE(obj.stringval);
+        READWRITE(obj.charstrval);
+        READWRITE(obj.txval);
     }
 
     bool operator==(const CSerializeMethodsTestSingle& rhs)
@@ -73,11 +71,10 @@ class CSerializeMethodsTestMany : public CSerializeMethodsTestSingle
 {
 public:
     using CSerializeMethodsTestSingle::CSerializeMethodsTestSingle;
-    ADD_SERIALIZE_METHODS;
 
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(intval, boolval, stringval, charstrval, txval);
+    SERIALIZE_METHODS(CSerializeMethodsTestMany, obj)
+    {
+        READWRITE(obj.intval, obj.boolval, obj.stringval, obj.charstrval, obj.txval);
     }
 };
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -490,7 +490,7 @@ public:
                 ::Unserialize(s, Using<TxOutCompression>(vout[i]));
         }
         // coinbase height
-        ::Unserialize(s, VARINT(nHeight, VarIntMode::NONNEGATIVE_SIGNED));
+        ::Unserialize(s, VARINT_MODE(nHeight, VarIntMode::NONNEGATIVE_SIGNED));
     }
 };
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -38,19 +38,7 @@ struct CoinEntry
     char key;
     explicit CoinEntry(const COutPoint* ptr) : outpoint(const_cast<COutPoint*>(ptr)), key(DB_COIN)  {}
 
-    template<typename Stream>
-    void Serialize(Stream &s) const {
-        s << key;
-        s << outpoint->hash;
-        s << VARINT(outpoint->n);
-    }
-
-    template<typename Stream>
-    void Unserialize(Stream& s) {
-        s >> key;
-        s >> outpoint->hash;
-        s >> VARINT(outpoint->n);
-    }
+    SERIALIZE_METHODS(CoinEntry, obj) { READWRITE(obj.key, obj.outpoint->hash, VARINT(obj.outpoint->n)); }
 };
 
 }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -487,7 +487,7 @@ public:
         vout.assign(vAvail.size(), CTxOut());
         for (unsigned int i = 0; i < vAvail.size(); i++) {
             if (vAvail[i])
-                ::Unserialize(s, CTxOutCompressor(vout[i]));
+                ::Unserialize(s, Using<TxOutCompression>(vout[i]));
         }
         // coinbase height
         ::Unserialize(s, VARINT(nHeight, VarIntMode::NONNEGATIVE_SIGNED));

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -44,13 +44,10 @@ struct CDiskTxPos : public FlatFilePos
 {
     unsigned int nTxOffset; // after header
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(CDiskTxPos, obj)
     {
-        READWRITEAS(FlatFilePos, *this);
-        READWRITE(VARINT(nTxOffset));
+        READWRITEAS(FlatFilePos, obj);
+        READWRITE(VARINT(obj.nTxOffset));
     }
 
     CDiskTxPos(const FlatFilePos& blockIn, unsigned int nTxOffsetIn) : FlatFilePos(blockIn.nFile, blockIn.nPos), nTxOffset(nTxOffsetIn)

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -28,7 +28,7 @@ CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& _tx, const CAmount& _nFe
                                  bool _spendsCoinbaseOrCoinstake, unsigned int _sigOps) :
      tx(MakeTransactionRef(_tx)), nFee(_nFee), nTime(_nTime), entryPriority(_entryPriority), entryHeight(_entryHeight), hadNoDependencies(poolHasNoInputsOf), inChainInputValue(_inChainInputValue), spendsCoinbaseOrCoinstake(_spendsCoinbaseOrCoinstake), sigOpCount(_sigOps)
 {
-    nTxSize = ::GetSerializeSize(*_tx, SER_NETWORK, PROTOCOL_VERSION);
+    nTxSize = ::GetSerializeSize(*_tx, PROTOCOL_VERSION);
     nModSize = _tx->CalculateModifiedSize(nTxSize);
     nUsageSize = _tx->DynamicMemoryUsage();
     hasZerocoins = _tx->ContainsZerocoins();

--- a/src/undo.h
+++ b/src/undo.h
@@ -13,57 +13,42 @@
 #include "primitives/transaction.h"
 #include "serialize.h"
 
-/** Undo information for a CTxIn
+/** Formatter for undo information for a CTxIn
+ *
  *  Contains the prevout's CTxOut being spent, and its metadata as well
  *  (coinbase/coinstake or not, height). The serialization contains a
  *  dummy value of zero. This is be compatible with older versions which
  *  expect to see the transaction version there.
  */
-class TxInUndoSerializer
+struct TxInUndoFormatter
 {
-    const Coin* txout;
-
-public:
-    template <typename Stream>
-    void Serialize(Stream& s) const {
-        ::Serialize(s, VARINT(txout->nHeight * 4 + (txout->fCoinBase ? 2u : 0u) + (txout->fCoinStake ? 1u : 0u)));
-        if (txout->nHeight > 0) {
+    template<typename Stream>
+    void Ser(Stream &s, const Coin& txout) {
+        ::Serialize(s, VARINT(txout.nHeight * 4 + (txout.fCoinBase ? 2u : 0u) + (txout.fCoinStake ? 1u : 0u)));
+        if (txout.nHeight > 0) {
             // Required to maintain compatibility with older undo format.
             ::Serialize(s, (unsigned char)0);
         }
-        ::Serialize(s, Using<TxOutCompression>(REF(txout->out)));
+        ::Serialize(s, Using<TxOutCompression>(txout.out));
     }
 
-    TxInUndoSerializer(const Coin* coin) : txout(coin) {}
-};
-
-class TxInUndoDeserializer
-{
-    Coin* txout;
-
-public:
-    template <typename Stream>
-    void Unserialize(Stream& s)
-    {
+    template<typename Stream>
+    void Unser(Stream &s, Coin& txout) {
         unsigned int nCode = 0;
         ::Unserialize(s, VARINT(nCode));
-        txout->nHeight = nCode >> 2;
-        txout->fCoinBase = nCode & 2;
-        txout->fCoinStake = nCode & 1;
-        if (txout->nHeight > 0) {
+        txout.nHeight = nCode >> 2;
+        txout.fCoinBase = nCode & 2;
+        txout.fCoinStake = nCode & 1;
+        if (txout.nHeight > 0) {
             // Old versions stored the version number for the last spend of
             // a transaction's outputs. Non-final spends were indicated with
             // height = 0.
             unsigned int nVersionDummy;
             ::Unserialize(s, VARINT(nVersionDummy));
         }
-        ::Unserialize(s, Using<TxOutCompression>(REF(txout->out)));
+        ::Unserialize(s, Using<TxOutCompression>(txout.out));
     }
-
-    TxInUndoDeserializer(Coin* coin) : txout(coin) {}
 };
-
-static const size_t MAX_INPUTS_PER_BLOCK = MAX_BLOCK_SIZE_CURRENT / ::GetSerializeSize(CTxIn(), PROTOCOL_VERSION);
 
 /** Undo information for a CTransaction */
 class CTxUndo
@@ -72,31 +57,7 @@ public:
     // undo information for all txins
     std::vector<Coin> vprevout;
 
-    template <typename Stream>
-    void Serialize(Stream& s) const
-    {
-        // TODO: avoid reimplementing vector serializer
-        uint64_t count = vprevout.size();
-        ::Serialize(s, COMPACTSIZE(REF(count)));
-        for (const auto& prevout : vprevout) {
-            ::Serialize(s, TxInUndoSerializer(&prevout));
-        }
-    }
-
-    template <typename Stream>
-    void Unserialize(Stream& s)
-    {
-        // TODO: avoid reimplementing vector deserializer
-        uint64_t count = 0;
-        ::Unserialize(s, COMPACTSIZE(count));
-        if (count > MAX_INPUTS_PER_BLOCK) {
-            throw std::ios_base::failure("Too many input undo records");
-        }
-        vprevout.resize(count);
-        for (auto& prevout : vprevout) {
-            ::Unserialize(s, TxInUndoDeserializer(&prevout));
-        }
-    }
+    SERIALIZE_METHODS(CTxUndo, obj) { READWRITE(Using<VectorFormatter<TxInUndoFormatter>>(obj.vprevout)); }
 };
 
 /** Undo information for a CBlock */
@@ -105,13 +66,7 @@ class CBlockUndo
 public:
     std::vector<CTxUndo> vtxundo; // for all but the coinbase
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(vtxundo);
-    }
+    SERIALIZE_METHODS(CBlockUndo, obj) { READWRITE(obj.vtxundo); }
 };
 
 #endif // BITCOIN_UNDO_H

--- a/src/undo.h
+++ b/src/undo.h
@@ -63,7 +63,7 @@ public:
     TxInUndoDeserializer(Coin* coin) : txout(coin) {}
 };
 
-static const size_t MAX_INPUTS_PER_BLOCK = MAX_BLOCK_SIZE_CURRENT / ::GetSerializeSize(CTxIn(), SER_NETWORK, PROTOCOL_VERSION);
+static const size_t MAX_INPUTS_PER_BLOCK = MAX_BLOCK_SIZE_CURRENT / ::GetSerializeSize(CTxIn(), PROTOCOL_VERSION);
 
 /** Undo information for a CTransaction */
 class CTxUndo

--- a/src/undo.h
+++ b/src/undo.h
@@ -31,7 +31,7 @@ public:
             // Required to maintain compatibility with older undo format.
             ::Serialize(s, (unsigned char)0);
         }
-        ::Serialize(s, CTxOutCompressor(REF(txout->out)));
+        ::Serialize(s, Using<TxOutCompression>(REF(txout->out)));
     }
 
     TxInUndoSerializer(const Coin* coin) : txout(coin) {}
@@ -57,7 +57,7 @@ public:
             unsigned int nVersionDummy;
             ::Unserialize(s, VARINT(nVersionDummy));
         }
-        ::Unserialize(s, CTxOutCompressor(REF(txout->out)));
+        ::Unserialize(s, Using<TxOutCompression>(REF(txout->out)));
     }
 
     TxInUndoDeserializer(Coin* coin) : txout(coin) {}

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -791,7 +791,7 @@ bool WriteBlockToDisk(const CBlock& block, FlatFilePos& pos)
         return error("WriteBlockToDisk : OpenBlockFile failed");
 
     // Write index header
-    unsigned int nSize = GetSerializeSize(fileout, block);
+    unsigned int nSize = GetSerializeSize(block, fileout.GetVersion());
     fileout << Params().MessageStart() << nSize;
 
     // Write block
@@ -1228,7 +1228,7 @@ bool UndoWriteToDisk(const CBlockUndo& blockundo, FlatFilePos& pos, const uint25
         return error("%s : OpenUndoFile failed", __func__);
 
     // Write index header
-    unsigned int nSize = GetSerializeSize(fileout, blockundo);
+    unsigned int nSize = GetSerializeSize(blockundo, fileout.GetVersion());
     fileout << Params().MessageStart() << nSize;
 
     // Write undo data

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1679,7 +1679,7 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
         }
 
         vPos.emplace_back(tx.GetHash(), pos);
-        pos.nTxOffset += ::GetSerializeSize(tx, SER_DISK, CLIENT_VERSION);
+        pos.nTxOffset += ::GetSerializeSize(tx, CLIENT_VERSION);
     }
 
     // Push new tree anchor
@@ -1752,7 +1752,7 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
     if (pindex->GetUndoPos().IsNull() || !pindex->IsValid(BLOCK_VALID_SCRIPTS)) {
         if (pindex->GetUndoPos().IsNull()) {
             FlatFilePos diskPosBlock;
-            if (!FindUndoPos(state, pindex->nFile, diskPosBlock, ::GetSerializeSize(blockundo, SER_DISK, CLIENT_VERSION) + 40))
+            if (!FindUndoPos(state, pindex->nFile, diskPosBlock, ::GetSerializeSize(blockundo, CLIENT_VERSION) + 40))
                 return error("ConnectBlock() : FindUndoPos failed");
             if (!UndoWriteToDisk(blockundo, diskPosBlock, pindex->pprev->GetBlockHash()))
                 return AbortNode(state, "Failed to write undo data");
@@ -2778,7 +2778,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
 
     // Size limits
     unsigned int nMaxBlockSize = MAX_BLOCK_SIZE_CURRENT;
-    const unsigned int nBlockSize = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
+    const unsigned int nBlockSize = ::GetSerializeSize(block, PROTOCOL_VERSION);
     if (block.vtx.empty() || block.vtx.size() > nMaxBlockSize || nBlockSize > nMaxBlockSize)
         return state.DoS(100, false, REJECT_INVALID, "bad-blk-length", false, "size limits failed");
 
@@ -3345,7 +3345,7 @@ static bool AcceptBlock(const CBlock& block, CValidationState& state, CBlockInde
 
     // Write block to history file
     try {
-        unsigned int nBlockSize = ::GetSerializeSize(block, SER_DISK, CLIENT_VERSION);
+        unsigned int nBlockSize = ::GetSerializeSize(block, CLIENT_VERSION);
         FlatFilePos blockPos;
         if (dbp != nullptr)
             blockPos = *dbp;
@@ -3401,7 +3401,7 @@ bool ProcessNewBlock(CValidationState& state, const std::shared_ptr<const CBlock
     }
 
     LogPrintf("%s : ACCEPTED Block %ld in %ld milliseconds with size=%d\n", __func__, newHeight, GetTimeMillis() - nStartTime,
-              GetSerializeSize(*pblock, SER_DISK, CLIENT_VERSION));
+              GetSerializeSize(*pblock, CLIENT_VERSION));
 
     return true;
 }
@@ -3890,7 +3890,7 @@ bool LoadGenesisBlock()
     try {
         CBlock& block = const_cast<CBlock&>(Params().GenesisBlock());
         // Start new block file
-        unsigned int nBlockSize = ::GetSerializeSize(block, SER_DISK, CLIENT_VERSION);
+        unsigned int nBlockSize = ::GetSerializeSize(block, CLIENT_VERSION);
         FlatFilePos blockPos;
         CValidationState state;
         if (!FindBlockPos(state, blockPos, nBlockSize + 8, 0, block.GetBlockTime()))

--- a/src/wallet/hdchain.h
+++ b/src/wallet/hdchain.h
@@ -35,21 +35,14 @@ public:
     uint32_t nInternalChainCounter{0};
     uint32_t nStakingChainCounter{0};
     // Chain counter type
-    uint8_t chainType;
+    uint8_t chainType{HDChain::ChainCounterType::Standard};
 
     CHDChain(const uint8_t& _chainType = HDChain::ChainCounterType::Standard) : chainType(_chainType) { SetNull(); }
 
-    ADD_SERIALIZE_METHODS;
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(CHDChain, obj)
     {
-        READWRITE(nVersion);
-        READWRITE(seed_id);
-        READWRITE(nExternalChainCounter);
-        READWRITE(nInternalChainCounter);
-        READWRITE(nStakingChainCounter);
-        if (nVersion == 1) chainType = HDChain::ChainCounterType::Standard;
-        else READWRITE(chainType);
+        READWRITE(obj.nVersion, obj.seed_id, obj.nExternalChainCounter, obj.nInternalChainCounter, obj.nStakingChainCounter);
+        if (obj.nVersion > 1) READWRITE(obj.chainType);
     }
 
     bool SetNull();

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2955,7 +2955,7 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, bool ov
     coinControl.nFeeRate = specificFeeRate;
 
     const int nExtraSize = tx.isSaplingVersion() ?
-            (int)(GetSerializeSizeNetwork(tx.sapData) + GetSerializeSizeNetwork(tx.extraPayload)) : 0;
+            (int)(GetSerializeSize(tx.sapData) + GetSerializeSize(tx.extraPayload)) : 0;
 
     for (const CTxIn& txin : tx.vin) {
         coinControl.Select(txin.prevout);
@@ -3174,7 +3174,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend,
                 }
 
                 // account for additional payloads in fee calculation
-                const unsigned int nBytes = ::GetSerializeSize(txNew, SER_NETWORK, PROTOCOL_VERSION) + nExtraSize;
+                const unsigned int nBytes = ::GetSerializeSize(txNew, PROTOCOL_VERSION) + nExtraSize;
                 CAmount nFeeNeeded = std::max(nFeePay, GetMinimumFee(nBytes, nTxConfirmTarget, mempool));
 
                 // Remove scriptSigs to eliminate the fee calculation dummy signatures
@@ -3234,7 +3234,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend,
         }
 
         // Limit size
-        if (::GetSerializeSize(txNew, SER_NETWORK, PROTOCOL_VERSION) >= MAX_STANDARD_TX_SIZE) {
+        if (::GetSerializeSize(txNew, PROTOCOL_VERSION) >= MAX_STANDARD_TX_SIZE) {
             strFailReason = _("Transaction too large");
             return false;
         }
@@ -3342,7 +3342,7 @@ bool CWallet::CreateCoinStake(
         txNew.vin.emplace_back(stakeInput.GetTxIn());
 
         // Limit size
-        unsigned int nBytes = ::GetSerializeSize(txNew, SER_NETWORK, PROTOCOL_VERSION);
+        unsigned int nBytes = ::GetSerializeSize(txNew, PROTOCOL_VERSION);
         if (nBytes >= DEFAULT_BLOCK_MAX_SIZE / 5)
             return error("%s : exceeded coinstake size limit", __func__);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -153,7 +153,7 @@ public:
         READWRITE(vchPubKey);
         if (ser_action.ForRead()) {
             try {
-                READWRITE(FLATDATA(type));
+                READWRITE(Span<unsigned char>((unsigned char*)&type, 1));
                 READWRITE(m_pre_split);
             } catch (std::ios_base::failure&) {
                 /* Set as external address if we can't read the type boolean
@@ -162,7 +162,7 @@ public:
                 m_pre_split = true;
             }
         } else {
-            READWRITE(FLATDATA(type));
+            READWRITE(Span<unsigned char>((unsigned char*)&type, 1));
             READWRITE(m_pre_split);
         }
     }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -141,29 +141,37 @@ public:
     bool IsExternal() const { return type == HDChain::ChangeType::EXTERNAL; }
     bool IsStaking() const { return type == HDChain::ChangeType::STAKING; }
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    template<typename Stream>
+    void Serialize(Stream& s) const
     {
         int nVersion = s.GetVersion();
-        if (!(s.GetType() & SER_GETHASH))
-            READWRITE(nVersion);
-        READWRITE(nTime);
-        READWRITE(vchPubKey);
-        if (ser_action.ForRead()) {
-            try {
-                READWRITE(Span<unsigned char>((unsigned char*)&type, 1));
-                READWRITE(m_pre_split);
-            } catch (std::ios_base::failure&) {
-                /* Set as external address if we can't read the type boolean
-                   (this will be the case for any wallet before the HD chain) */
-                type = HDChain::ChangeType::EXTERNAL;
-                m_pre_split = true;
-            }
-        } else {
-            READWRITE(Span<unsigned char>((unsigned char*)&type, 1));
-            READWRITE(m_pre_split);
+        if (!(s.GetType() & SER_GETHASH)) {
+            s << nVersion;
+        }
+        s << nTime << vchPubKey << Span<unsigned char>((unsigned char*)&type, 1) << m_pre_split;
+    }
+
+    template<typename Stream>
+    void Unserialize(Stream& s)
+    {
+        int nVersion = s.GetVersion();
+        if (!(s.GetType() & SER_GETHASH)) {
+            s >> nVersion;
+        }
+        s >> nTime >> vchPubKey;
+        try {
+            s >> Span<unsigned char>((unsigned char*)&type, 1);
+        } catch (std::ios_base::failure&) {
+            /* flag as external address if we can't read the internal boolean
+               (this will be the case for any wallet before the HD chain split version) */
+            type = HDChain::ChangeType::EXTERNAL;
+        }
+        try {
+            s >> m_pre_split;
+        } catch (std::ios_base::failure&) {
+            /* flag as pre-split address if we can't read the m_pre_split boolean
+               (this will be the case for any wallet prior to the HD chain upgrade) */
+            m_pre_split = true;
         }
     }
 };

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -80,16 +80,11 @@ public:
         nCreateTime = nCreateTime_;
     }
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(CKeyMetadata, obj)
     {
-        READWRITE(nVersion);
-        READWRITE(nCreateTime);
-        if (HasKeyOrigin()) {
-            READWRITE(hd_seed_id);
-            READWRITE(key_origin);
+        READWRITE(obj.nVersion, obj.nCreateTime);
+        if (obj.HasKeyOrigin()) {
+            READWRITE(obj.hd_seed_id, obj.key_origin);
         }
     }
 

--- a/src/zpiv/zpivmodule.h
+++ b/src/zpiv/zpivmodule.h
@@ -44,29 +44,18 @@ public:
     unsigned int outputIndex = -1;
     libzerocoin::PublicCoin pubCoin;
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-
-        READWRITE(version);
-
-        if (version < PUBSPEND_SCHNORR) {
-            READWRITE(coinSerialNumber);
-            READWRITE(randomness);
-            READWRITE(pubkey);
-            READWRITE(vchSig);
-
+    SERIALIZE_METHODS(PublicCoinSpend, obj) {
+        READWRITE(obj.version);
+        if (obj.version < PUBSPEND_SCHNORR) {
+            READWRITE(obj.coinSerialNumber, obj.randomness, obj.pubkey, obj.vchSig);
         } else {
-            READWRITE(coinVersion);
-            if (coinVersion < libzerocoin::PUBKEY_VERSION) {
-                READWRITE(coinSerialNumber);
+            READWRITE(obj.coinVersion);
+            if (obj.coinVersion < libzerocoin::PUBKEY_VERSION) {
+                READWRITE(obj.coinSerialNumber);
+            } else {
+                READWRITE(obj.pubkey, obj.vchSig);
             }
-            else {
-                READWRITE(pubkey);
-                READWRITE(vchSig);
-            }
-            READWRITE(schnorrSig);
+            READWRITE(obj.schnorrSig);
         }
     }
 };


### PR DESCRIPTION
Decoupled from #2411, built on top of #2359.

Focused on creating the Span class and updating the serialization framework and every object using it up to latest upstream structure (3-4 years ahead of what we currently are in master). We will be up-to-date with them in the area after finishing with #2411 entirely (there are few more updates to the serialization code that comes down #2411 commits line that cannot cherry-pick here).

Adapted the following PRs:

*  #12886.
*  #12916.
*  #13558.
*  #17850.
*  #17896.
*  #12752.
*  #17957.
*  #18021.
*  #18087.
*  #18112 (only from 353f3762 that we don't support).
*  #18167.
*  #18317.
*  #19032.


