### PR TITLE
[CI] Remove Ubuntu 16.04 usage from GA workflow.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -72,8 +72,8 @@ jobs:
       matrix:
         config:
           - name: Linux
-            os: ubuntu-16.04
-            packages: python3-zmq qtbase5-dev qttools5-dev-tools libqt5svg5-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libqrencode-dev libgmp-dev libsodium-dev cargo
+            os: ubuntu-18.04
+            packages: python3-zmq qttools5-dev qtbase5-dev qttools5-dev-tools libqt5svg5-dev libqt5charts5-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libqrencode-dev libgmp-dev libsodium-dev cargo
             cc: gcc
             cxx: g++
 
@@ -299,17 +299,6 @@ jobs:
             goal: install
             test_runner_extra: "--legacywallet"
             BITCOIN_CONFIG: "--enable-zmq --with-gui=no --enable-glibc-back-compat --enable-reduce-exports --disable-online-rust"
-
-          - name: x86_64 Linux  [GOAL:install]  [xenial]  [no depends only system libs]
-            os: ubuntu-16.04
-            host: x86_64-unknown-linux-gnu
-            apt_get: python3-zmq qtbase5-dev qttools5-dev-tools libqt5svg5-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libqrencode-dev libgmp-dev libsodium-dev cargo
-            unit_tests: true
-            functional_tests: true
-            no_depends: 1
-            goal: install
-            test_runner_extra: "--all --exclude feature_dbcrash"
-            BITCOIN_CONFIG: "--enable-zmq --with-incompatible-bdb --with-gui=qt5 CPPFLAGS=-DDEBUG_LOCKORDER --disable-hardening --disable-asm"
 
           - name: x86_64 Linux  [GOAL:install]  [bionic]  [no depends only system libs]
             os: ubuntu-18.04


### PR DESCRIPTION
The reason behind GA failing in every single PR is https://github.com/actions/virtual-environments/issues/3530 .

Based on https://github.com/actions/virtual-environments/issues/3287:
Ubuntu 16.04 has been deprecated from GA's virtual-environments repository and will be removed on September 20, 2021.

So, this PR is migrating the existing cmake workflow that uses Ubuntu 16.04 to Ubuntu 18.04 and removing the x86_64 Linux xenial job.