### PR TITLE
[Consensus] Introduce 5.2 nuparams and use them to guard new P2CS rules

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -200,6 +200,8 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_V3_4].nActivationHeight          = 1967000;
         consensus.vUpgrades[Consensus::UPGRADE_V4_0].nActivationHeight          = 2153200;
         consensus.vUpgrades[Consensus::UPGRADE_V5_0].nActivationHeight          = 2700500;
+        consensus.vUpgrades[Consensus::UPGRADE_V5_2].nActivationHeight =
+                Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
         consensus.vUpgrades[Consensus::UPGRADE_V6_0].nActivationHeight =
                 Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
 
@@ -338,6 +340,8 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_V3_4].nActivationHeight          = 201;
         consensus.vUpgrades[Consensus::UPGRADE_V4_0].nActivationHeight          = 201;
         consensus.vUpgrades[Consensus::UPGRADE_V5_0].nActivationHeight          = 201;
+        consensus.vUpgrades[Consensus::UPGRADE_V5_2].nActivationHeight =
+                Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
         consensus.vUpgrades[Consensus::UPGRADE_V6_0].nActivationHeight =
                 Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
 
@@ -469,6 +473,7 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_V4_0].nActivationHeight          =
                 Consensus::NetworkUpgrade::ALWAYS_ACTIVE;
         consensus.vUpgrades[Consensus::UPGRADE_V5_0].nActivationHeight          = 300;
+        consensus.vUpgrades[Consensus::UPGRADE_V5_2].nActivationHeight          = 300;
         consensus.vUpgrades[Consensus::UPGRADE_V6_0].nActivationHeight =
                 Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -34,6 +34,7 @@ enum UpgradeIndex : uint32_t {
     UPGRADE_V3_4,
     UPGRADE_V4_0,
     UPGRADE_V5_0,
+    UPGRADE_V5_2,
     UPGRADE_V6_0,
     UPGRADE_TESTDUMMY,
     // NOTE: Also add new upgrades to NetworkUpgradeInfo in upgrades.cpp

--- a/src/consensus/upgrades.cpp
+++ b/src/consensus/upgrades.cpp
@@ -54,6 +54,10 @@ const struct NUInfo NetworkUpgradeInfo[Consensus::MAX_NETWORK_UPGRADES] = {
                 /*.strInfo =*/ "Sapling Shield - start block v8 - start transaction v3",
         },
         {
+                /*.strName =*/ "PIVX_v5.2",
+                /*.strInfo =*/ "new cold-staking rules",
+        },
+        {
                 /*.strName =*/ "v6_evo",
                 /*.strInfo =*/ "Deterministic Masternodes",
         },

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1342,7 +1342,7 @@ bool TransactionSignatureChecker::CheckLockTime(const CScriptNum& nLockTime) con
 
 bool TransactionSignatureChecker::CheckColdStake(bool fAllowLastOutputFree, const CScript& prevoutScript, std::vector<valtype>& stack, unsigned int flags, ScriptError* serror) const
 {
-    if (g_IsV6Active) {
+    if (g_newP2CSRules) {
         // the stack can contain only <sig> <pk> <pkh> at this point
         if ((int)stack.size() != 3) {
             return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -227,22 +227,22 @@ bool CScript::IsPayToScriptHash() const
 }
 
 // contextual flag to guard the new rules for P2CS.
-// can be removed once v6 enforcement is activated.
-std::atomic<bool> g_IsV6Active{false};
+// can be removed once v5.2 enforcement is activated.
+std::atomic<bool> g_newP2CSRules{false};
 
 // P2CS script: either with or without last output free
 bool CScript::IsPayToColdStaking() const
 {
     return (this->size() == 51 &&
-            (!g_IsV6Active || (*this)[0] == OP_DUP) &&
-            (!g_IsV6Active || (*this)[1] == OP_HASH160) &&
+            (!g_newP2CSRules || (*this)[0] == OP_DUP) &&
+            (!g_newP2CSRules || (*this)[1] == OP_HASH160) &&
             (*this)[2] == OP_ROT &&
-            (!g_IsV6Active || (*this)[3] == OP_IF) &&
+            (!g_newP2CSRules || (*this)[3] == OP_IF) &&
             ((*this)[4] == OP_CHECKCOLDSTAKEVERIFY || (*this)[4] == OP_CHECKCOLDSTAKEVERIFY_LOF) &&
             (*this)[5] == 0x14 &&
-            (!g_IsV6Active || (*this)[26] == OP_ELSE) &&
+            (!g_newP2CSRules || (*this)[26] == OP_ELSE) &&
             (*this)[27] == 0x14 &&
-            (!g_IsV6Active || (*this)[48] == OP_ENDIF) &&
+            (!g_newP2CSRules || (*this)[48] == OP_ENDIF) &&
             (*this)[49] == OP_EQUALVERIFY &&
             (*this)[50] == OP_CHECKSIG);
 }

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -664,7 +664,7 @@ public:
 };
 
 // contextual flag to guard the new rules for P2CS.
-// can be removed once v6 enforcement is activated.
-extern std::atomic<bool> g_IsV6Active;
+// can be removed once v5.2 enforcement is activated.
+extern std::atomic<bool> g_newP2CSRules;
 
 #endif // BITCOIN_SCRIPT_SCRIPT_H

--- a/src/test/script_P2CS_tests.cpp
+++ b/src/test/script_P2CS_tests.cpp
@@ -305,7 +305,7 @@ static void setupWallet(CWallet& wallet)
 
 BOOST_AUTO_TEST_CASE(fake_script_test)
 {
-    BOOST_ASSERT(!g_IsV6Active);
+    BOOST_ASSERT(!g_newP2CSRules);
 
     CWallet& wallet = *pwalletMain;
     LOCK(wallet.cs_wallet);
@@ -322,7 +322,7 @@ BOOST_AUTO_TEST_CASE(fake_script_test)
     const CScript& scriptP2CS = GetFakeLockingScript(stakerId, ownerId);
 
     // Create prev transaction:
-    // It has two outputs. The first one is spent before v6.
+    // It has two outputs. The first one is spent before v5.2.
     // The second one is tested after v6 enforcement.
     CMutableTransaction txFrom;
     txFrom.vout.resize(2);
@@ -361,8 +361,8 @@ BOOST_AUTO_TEST_CASE(fake_script_test)
     wallet.AddToWallet({&wallet, MakeTransactionRef(CTransaction(tx))});
     BOOST_CHECK_EQUAL(wallet.GetWalletTx(txFrom.GetHash())->GetAvailableCredit(false, ISMINE_SPENDABLE_TRANSPARENT), amtIn);
 
-    // Now let's activate v6
-    g_IsV6Active = true;
+    // Now let's activate new rules
+    g_newP2CSRules = true;
 
     // it does NOT pass IsPayToColdStaking
     BOOST_CHECK_MESSAGE(!scriptP2CS.IsPayToColdStaking(), "Fake script passes as P2CS");

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1921,7 +1921,7 @@ void static UpdateTip(CBlockIndex* pindexNew)
 {
     AssertLockHeld(cs_main);
     chainActive.SetTip(pindexNew);
-    g_IsV6Active = Params().GetConsensus().NetworkUpgradeActive(pindexNew->nHeight, Consensus::UPGRADE_V6_0);
+    g_newP2CSRules = Params().GetConsensus().NetworkUpgradeActive(pindexNew->nHeight, Consensus::UPGRADE_V5_2);
 
     // New best block
     mempool.AddTransactionsUpdated(1);
@@ -3625,7 +3625,7 @@ bool LoadChainTip(const CChainParams& chainparams)
     const CBlockIndex* pChainTip = chainActive.Tip();
 
     // initial global flag update
-    g_IsV6Active = Params().GetConsensus().NetworkUpgradeActive(pChainTip->nHeight, Consensus::UPGRADE_V5_0);
+    g_newP2CSRules = Params().GetConsensus().NetworkUpgradeActive(pChainTip->nHeight, Consensus::UPGRADE_V5_2);
 
     LogPrintf("Loaded best chain: hashBestChain=%s height=%d date=%s progress=%f\n",
             pChainTip->GetBlockHash().GetHex(), pChainTip->nHeight,


### PR DESCRIPTION
As per title:
- first commit introduces `UPGRADE_V5_2` params (with `NO_ACTIVATION_HEIGHT` for now).
- second commit sets the `g_IsV6Active` flag (used to guard the new P2CS rules) based on 5.2 enforcement, and renames it to `g_newP2CSRules`.