### PR TITLE
[Consensus] Bump active protocol version to 70922

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4161,13 +4161,13 @@ void static CheckBlockIndex()
 //       it was the one which was commented out
 int ActiveProtocol()
 {
-    // SPORK_14 was used for 70919 (v4.1.1), commented out now.
-    //if (sporkManager.IsSporkActive(SPORK_14_NEW_PROTOCOL_ENFORCEMENT))
-    //        return MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT;
-
-    // SPORK_15 is used for 70920 (v5.0.0)
-    if (sporkManager.IsSporkActive(SPORK_15_NEW_PROTOCOL_ENFORCEMENT_2))
+    // SPORK_14 is used for 70922 (v5.2.0)
+    if (sporkManager.IsSporkActive(SPORK_14_NEW_PROTOCOL_ENFORCEMENT))
             return MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT;
+
+    // SPORK_15 was used for 70921 (v5.0.1), commented out now.
+    //if (sporkManager.IsSporkActive(SPORK_15_NEW_PROTOCOL_ENFORCEMENT_2))
+    //        return MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT;
 
     return MIN_PEER_PROTO_VERSION_BEFORE_ENFORCEMENT;
 }

--- a/src/version.h
+++ b/src/version.h
@@ -11,7 +11,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70921;
+static const int PROTOCOL_VERSION = 70922;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -20,8 +20,8 @@ static const int INIT_PROTO_VERSION = 209;
 static const int GETHEADERS_VERSION = 70077;
 
 //! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION_BEFORE_ENFORCEMENT = 70919;
-static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT = 70921;
+static const int MIN_PEER_PROTO_VERSION_BEFORE_ENFORCEMENT = 70921;
+static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT = 70922;
 
 //! peers with version older than this, could relay invalid (stale) mn pings
 static const int MIN_PEER_CACHEDVERSION = 70921;

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -27,7 +27,7 @@ from test_framework.siphash import siphash256
 from test_framework.util import hex_str_to_bytes, bytes_to_hex_str
 
 MIN_VERSION_SUPPORTED = 60001
-MY_VERSION = 70920
+MY_VERSION = 70922
 MY_SUBVERSION = b"/python-mininode-tester:0.0.3/"
 MY_RELAY = 1 # from version 70001 onwards, fRelay should be appended to version messages (BIP37)
 


### PR DESCRIPTION
Bump active protocol to `70922` for v5.2.0 release.

Note: the comments inside `ActiveProtocol()` weren't updated, but we used SPORK_15 to enforce a bump of two versions: 70920 (v5.0.0 - #1994) and 70921 (v5.0.1 - #2137)