### PR TITLE
[Build] Bump gitian descriptor version to 5.2

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -1,5 +1,5 @@
 ---
-name: "pivx-linux-5.1"
+name: "pivx-linux-5.2"
 enable_cache: true
 distro: "ubuntu"
 suites:

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -1,5 +1,5 @@
 ---
-name: "pivx-osx-5.1"
+name: "pivx-osx-5.2"
 enable_cache: true
 distro: "ubuntu"
 suites:

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -1,5 +1,5 @@
 ---
-name: "pivx-win-5.1"
+name: "pivx-win-5.2"
 enable_cache: true
 distro: "ubuntu"
 suites:


### PR DESCRIPTION
Based on top of #2429 so that GA tests pass properly, this sets the gitian descriptor version to `5.2` to match the branch version.

- [x] #2429 