### PR TITLE
[Refactor] Decouple enforcement of cbase payment from block version

### DIFF
--- a/src/blockassembler.cpp
+++ b/src/blockassembler.cpp
@@ -520,7 +520,7 @@ void IncrementExtraNonce(std::shared_ptr<CBlock>& pblock, int nHeight, unsigned 
 int32_t ComputeBlockVersion(const Consensus::Params& consensus, int nHeight)
 {
     if (NetworkUpgradeActive(nHeight, consensus, Consensus::UPGRADE_V5_0)) {
-        return CBlockHeader::CURRENT_VERSION;       // v9 (since PIVX 5.0.1)
+        return CBlockHeader::CURRENT_VERSION;       // v10 (since 5.1.99)
     } else if (consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V4_0)) {
         return 7;
     } else if (consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V3_4)) {

--- a/src/blockassembler.cpp
+++ b/src/blockassembler.cpp
@@ -519,10 +519,8 @@ void IncrementExtraNonce(std::shared_ptr<CBlock>& pblock, int nHeight, unsigned 
 
 int32_t ComputeBlockVersion(const Consensus::Params& consensus, int nHeight)
 {
-    if (NetworkUpgradeActive(nHeight, consensus, Consensus::UPGRADE_V6_0)) {
-        return CBlockHeader::CURRENT_VERSION;    // v10
-    } else if (NetworkUpgradeActive(nHeight, consensus, Consensus::UPGRADE_V5_0)) {
-        return 9;
+    if (NetworkUpgradeActive(nHeight, consensus, Consensus::UPGRADE_V5_0)) {
+        return CBlockHeader::CURRENT_VERSION;       // v9 (since PIVX 5.0.1)
     } else if (consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V4_0)) {
         return 7;
     } else if (consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V3_4)) {

--- a/src/budget/budgetmanager.cpp
+++ b/src/budget/budgetmanager.cpp
@@ -437,7 +437,7 @@ bool CBudgetManager::FillBlockPayee(CMutableTransaction& txCoinbase, CMutableTra
 
     CAmount blockValue = GetBlockValue(nHeight);
 
-    // Starting from PIVX v6.0 masternode and budgets are paid in the coinbase tx of PoS blocks (block v10)
+    // Starting from PIVX v6.0 masternode and budgets are paid in the coinbase tx of PoS blocks
     const bool fPayCoinstake = fProofOfStake &&
                                !Params().GetConsensus().NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V6_0);
 

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -366,7 +366,7 @@ void CMasternodePayments::FillBlockPayee(CMutableTransaction& txCoinbase, CMutab
         return;
     }
 
-    // Starting from PIVX v6.0 masternode and budgets are paid in the coinbase tx (block v10)
+    // Starting from PIVX v6.0 masternode and budgets are paid in the coinbase tx
     const int nHeight = pindexPrev->nHeight + 1;
     bool fPayCoinstake = fProofOfStake && !Params().GetConsensus().NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V6_0);
 

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -31,7 +31,7 @@ bool IsBlockValueValid(int nHeight, CAmount& nExpectedValue, CAmount nMinted, CA
 void FillBlockPayee(CMutableTransaction& txCoinbase, CMutableTransaction& txCoinstake, const CBlockIndex* pindexPrev, bool fProofOfStake);
 
 /**
- * Check coinbase output value for blocks v10+.
+ * Check coinbase output value for blocks after v6.0 enforcement.
  * It must pay the masternode for regular blocks and a proposal during superblocks.
  */
 bool IsCoinbaseValueValid(const CTransactionRef& tx, CAmount nBudgetAmt, CValidationState& _state);

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -23,7 +23,7 @@ class CBlockHeader
 {
 public:
     // header
-    static const int32_t CURRENT_VERSION=10;     //!> Version 10 Masternode/Budget payments in the coinbase
+    static const int32_t CURRENT_VERSION=9;
     int32_t nVersion;
     uint256 hashPrevBlock;
     uint256 hashMerkleRoot;

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -23,7 +23,7 @@ class CBlockHeader
 {
 public:
     // header
-    static const int32_t CURRENT_VERSION=9;
+    static const int32_t CURRENT_VERSION=10;    // since v5.1.99
     int32_t nVersion;
     uint256 hashPrevBlock;
     uint256 hashMerkleRoot;

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -33,7 +33,7 @@ MY_RELAY = 1 # from version 70001 onwards, fRelay should be appended to version 
 
 MAX_INV_SZ = 50000
 MAX_BLOCK_BASE_SIZE = 2000000
-CURRENT_BLK_VERSION = 9
+CURRENT_BLK_VERSION = 10
 
 COIN = 100000000 # 1 btc in satoshis
 

--- a/test/functional/tiertwo_mn_compatibility.py
+++ b/test/functional/tiertwo_mn_compatibility.py
@@ -61,13 +61,12 @@ class MasternodeCompatibilityTest(PivxTier2TestFramework):
         assert_equal(status["status"], "Ready")
 
     """
-    Checks the block at specified height (it must be a v10 block).
+    Checks the block at specified height
     Returns the address of the mn paid (in the coinbase), and the json coinstake tx
     """
     def get_block_mnwinner(self, height):
         blk = self.miner.getblock(self.miner.getblockhash(height), True)
         assert_equal(blk['height'], height)
-        assert_equal(blk['version'], 10)
         cbase_tx = self.miner.getrawtransaction(blk['tx'][0], True)
         assert_equal(len(cbase_tx['vin']), 1)
         cbase_script = height.to_bytes(1 + height // 256, byteorder="little")


### PR DESCRIPTION
New rules shouldn't be enforced with a new block version (e.g. IsCoinbaseValueValid), because there might be blocks with that version *before* the relative network enforcement.
And in this case we don't need to, as the check is already contextual.

First commit removes the dependency on block version 10, and restores the default version to 9.
Second commit simply bumps back the default version to 10. This commit is meant to be backported to 5.2 in order to signal the new release.