### PR TITLE
[Backport] Bump default block version to 10 (no enforcement)

### DIFF
--- a/src/blockassembler.cpp
+++ b/src/blockassembler.cpp
@@ -494,7 +494,7 @@ void IncrementExtraNonce(std::shared_ptr<CBlock>& pblock, const CBlockIndex* pin
 int32_t ComputeBlockVersion(const Consensus::Params& consensus, int nHeight)
 {
     if (NetworkUpgradeActive(nHeight, consensus, Consensus::UPGRADE_V5_0)) {
-        return CBlockHeader::CURRENT_VERSION;    // v9
+        return CBlockHeader::CURRENT_VERSION;       // v10 (since 5.1.99)
     } else if (consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V4_0)) {
         return 7;
     } else if (consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V3_4)) {

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -23,7 +23,7 @@ class CBlockHeader
 {
 public:
     // header
-    static const int32_t CURRENT_VERSION=9;
+    static const int32_t CURRENT_VERSION=10;    // since v5.1.99
     int32_t nVersion;
     uint256 hashPrevBlock;
     uint256 hashMerkleRoot;

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -32,8 +32,8 @@ MY_SUBVERSION = b"/python-mininode-tester:0.0.3/"
 MY_RELAY = 1 # from version 70001 onwards, fRelay should be appended to version messages (BIP37)
 
 MAX_INV_SZ = 50000
-MAX_BLOCK_BASE_SIZE = 1000000
-CURRENT_BLK_VERSION = 7
+MAX_BLOCK_BASE_SIZE = 2000000
+CURRENT_BLK_VERSION = 10
 
 COIN = 100000000 # 1 btc in satoshis
 


### PR DESCRIPTION
Backports 84261bcc6c4b58db4e36ef6ef1838d2743e19f3a (#2434)