### PR TITLE
[Test] Extended test coverage for chain reorg during superblock and payments order.

### DIFF
--- a/src/blockassembler.cpp
+++ b/src/blockassembler.cpp
@@ -171,7 +171,8 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
                                                CWallet* pwallet,
                                                bool fProofOfStake,
                                                std::vector<CStakeableOutput>* availableCoins,
-                                               bool fNoMempoolTx)
+                                               bool fNoMempoolTx,
+                                               bool fTestValidity)
 {
     resetBlock();
 
@@ -242,7 +243,8 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         if (chainActive.Tip() != pindexPrev) return nullptr; // new block came in, move on
 
         CValidationState state;
-        if (!TestBlockValidity(state, *pblock, pindexPrev, false, false, false)) {
+        if (fTestValidity &&
+            !TestBlockValidity(state, *pblock, pindexPrev, false, false, false)) {
             throw std::runtime_error(
                     strprintf("%s: TestBlockValidity failed: %s", __func__, FormatStateMessage(state)));
         }

--- a/src/blockassembler.h
+++ b/src/blockassembler.h
@@ -69,7 +69,8 @@ public:
                                    CWallet* pwallet = nullptr,
                                    bool fProofOfStake = false,
                                    std::vector<CStakeableOutput>* availableCoins = nullptr,
-                                   bool fNoMempoolTx = false);
+                                   bool fNoMempoolTx = false,
+                                   bool fTestValidity = true);
 
 private:
     // utility functions

--- a/src/budget/budgetmanager.h
+++ b/src/budget/budgetmanager.h
@@ -99,7 +99,7 @@ public:
 
     int ProcessBudgetVoteSync(const uint256& nProp, CNode* pfrom);
     int ProcessProposal(CBudgetProposal& proposal);
-    int ProcessFinalizedBudget(CFinalizedBudget& finalbudget);
+    int ProcessFinalizedBudget(CFinalizedBudget& finalbudget, CNode* pfrom);
 
     bool ProcessProposalVote(CBudgetVote& proposal, CNode* pfrom, CValidationState& state);
     bool ProcessFinalizedBudgetVote(CFinalizedBudgetVote& vote, CNode* pfrom, CValidationState& state);
@@ -121,7 +121,7 @@ public:
     bool IsBudgetPaymentBlock(int nBlockHeight) const;
     bool IsBudgetPaymentBlock(int nBlockHeight, int& nCountThreshold) const;
     bool AddProposal(CBudgetProposal& budgetProposal);
-    bool AddFinalizedBudget(CFinalizedBudget& finalizedBudget);
+    bool AddFinalizedBudget(CFinalizedBudget& finalizedBudget, CNode* pfrom = nullptr);
     void ForceAddFinalizedBudget(const uint256& nHash, const uint256& feeTxId, const CFinalizedBudget& finalizedBudget);
     uint256 SubmitFinalBudget();
 

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -769,6 +769,93 @@ UniValue mnfinalbudgetsuggest(const JSONRPCRequest& request)
     return (budgetHash.IsNull()) ? NullUniValue : budgetHash.ToString();
 }
 
+UniValue createrawmnfinalbudget(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() > 4)
+        throw std::runtime_error(
+                "createrawmnfinalbudget\n"
+                "\nTry to submit the raw budget finalization\n"
+                "returns the budget hash if it was broadcasted sucessfully"
+                "\nArguments:\n"
+                "1. \"budgetname\"    (string, required) finalization name\n"
+                "2. \"blockstart\"    (numeric, required) superblock height\n"
+                "3. \"proposals\"     (string, required) A json array of json objects\n"
+                "     [\n"
+                "       {\n"
+                "         \"proposalid\":\"id\",  (string, required) The proposal id\n"
+                "         \"payee\":n,         (hex, required) The payee script\n"
+                "         \"amount\":n            (numeric, optional) The payee amount\n"
+                "       }\n"
+                "       ,...\n"
+                "     ]\n"
+                "4. \"feetxid\"    (string, optional) the transaction fee hash\n"
+                ""
+                "\nResult:\n"
+                "{\n"
+                    "\"result\"     (string) Budget suggest broadcast or error\n"
+                    "\"id\"         (string) id of the fee tx or the finalized budget\n"
+                "}\n"
+                ); // future: add examples.
+
+    if (!Params().IsRegTestNet()) {
+        throw JSONRPCError(RPC_MISC_ERROR, "command available only for RegTest network");
+    }
+
+    // future: add inputs error checking..
+    std::string budName = request.params[0].get_str();
+    int nBlockStart = request.params[1].get_int();
+    std::vector<CTxBudgetPayment> vecTxBudgetPayments;
+    UniValue budgetVec = request.params[2].get_array();
+    for (unsigned int idx = 0; idx < budgetVec.size(); idx++) {
+        const UniValue& prop = budgetVec[idx].get_obj();
+        uint256 propId = ParseHashO(prop, "proposalid");
+        std::vector<unsigned char> scriptData(ParseHexO(prop, "payee"));
+        CScript payee = CScript(scriptData.begin(), scriptData.end());
+        CAmount amount = AmountFromValue(find_value(prop, "amount"));
+        vecTxBudgetPayments.emplace_back(propId, payee, amount);
+    }
+
+    Optional<uint256> txFeeId = nullopt;
+    if (request.params.size() > 3) {
+        txFeeId = ParseHashV(request.params[3], "parameter 4");
+    }
+
+    if (!txFeeId) {
+        CFinalizedBudget tempBudget(budName, nBlockStart, vecTxBudgetPayments, UINT256_ZERO);
+        const uint256& budgetHash = tempBudget.GetHash();
+
+        // create fee tx
+        CTransactionRef wtx;
+        CReserveKey keyChange(vpwallets[0]);
+        if (!vpwallets[0]->CreateBudgetFeeTX(wtx, budgetHash, keyChange, true)) {
+            throw std::runtime_error("Can't make collateral transaction");
+        }
+        // Send the tx to the network
+        const CWallet::CommitResult& res = vpwallets[0]->CommitTransaction(wtx, keyChange, g_connman.get());
+        UniValue ret(UniValue::VOBJ);
+        if (res.status == CWallet::CommitStatus::OK) {
+            ret.pushKV("result", "tx_fee_sent");
+            ret.pushKV("id", wtx->GetHash().ToString());
+        } else {
+            ret.pushKV("result", "error");
+        }
+        return ret;
+    }
+
+    UniValue ret(UniValue::VOBJ);
+    // Collateral tx already exists, see if it's mature enough.
+    CFinalizedBudget fb(budName, nBlockStart, vecTxBudgetPayments, *txFeeId);
+    if (g_budgetman.AddFinalizedBudget(fb)) {
+        fb.Relay();
+        ret.pushKV("result", "fin_budget_sent");
+        ret.pushKV("id", fb.GetHash().ToString());
+    } else {
+        // future: add proper error
+        ret.pushKV("result", "error");
+    }
+    return ret;
+}
+
 UniValue mnfinalbudget(const JSONRPCRequest& request)
 {
     std::string strCommand;
@@ -879,6 +966,7 @@ static const CRPCCommand commands[] =
 
     /* Not shown in help */
     { "hidden",             "mnfinalbudgetsuggest",   &mnfinalbudgetsuggest,   true,  {} },
+    { "hidden",             "createrawmnfinalbudget", &createrawmnfinalbudget,   true,  {"budgetname", "blockstart", "proposals", "feetxid"} },
 
 };
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -37,6 +37,8 @@ static const CRPCConvertParam vRPCConvertParams[] = {
     { "createrawtransaction", 0, "inputs" },
     { "createrawtransaction", 1, "outputs" },
     { "createrawtransaction", 2, "locktime" },
+    {"createrawmnfinalbudget", 1, "blockstart"},
+    {"createrawmnfinalbudget", 2, "proposals"},
     { "delegatestake", 1, "amount" },
     { "delegatestake", 3, "ext_owner" },
     { "delegatestake", 4, "include_delegated" },

--- a/src/test/budget_tests.cpp
+++ b/src/test/budget_tests.cpp
@@ -127,16 +127,40 @@ BOOST_FIXTURE_TEST_CASE(block_value, TestnetSetup)
     BOOST_CHECK_EQUAL(nBudgetAmtRet, 0);
 }
 
-void forceAddFakeProposal(const CScript& payee, const CAmount propAmt)
+
+/**
+ * 1) Create two proposals and two budget finalizations with a different proposal payment order:
+         BudA pays propA and propB, BudB pays propB and propA.
+   2) Vote both finalization budgets, adding more votes to budA (so it becomes the most voted one).
+ */
+void forceAddFakeProposals(const CTxOut& payee1, const CTxOut& payee2)
 {
     const CTxIn mnVin(GetRandHash(), 0);
     const uint256& propHash = GetRandHash(), finTxId = GetRandHash();
-    const CTxBudgetPayment txBudgetPayment(propHash, payee, propAmt);
-    CFinalizedBudget fin("main (test)", 144, {txBudgetPayment}, finTxId);
+    const CTxBudgetPayment txBudgetPayment(propHash, payee1.scriptPubKey, payee1.nValue);
+
+    const CTxIn mnVin2(GetRandHash(), 0);
+    const uint256& propHash2 = GetRandHash(), finTxId2 = GetRandHash();
+    const CTxBudgetPayment txBudgetPayment2(propHash2, payee2.scriptPubKey, payee2.nValue);
+
+    // Create first finalization
+    CFinalizedBudget fin("main (test)", 144, {txBudgetPayment, txBudgetPayment2}, finTxId);
     const CFinalizedBudgetVote fvote(mnVin, fin.GetHash());
+    const CFinalizedBudgetVote fvote1_a({GetRandHash(), 0}, fin.GetHash());
+    const CFinalizedBudgetVote fvote1_b({GetRandHash(), 0}, fin.GetHash());
     std::string strError;
     BOOST_CHECK(fin.AddOrUpdateVote(fvote, strError));
+    BOOST_CHECK(fin.AddOrUpdateVote(fvote1_a, strError));
+    BOOST_CHECK(fin.AddOrUpdateVote(fvote1_b, strError));
     g_budgetman.ForceAddFinalizedBudget(fin.GetHash(), fin.GetFeeTXHash(), fin);
+
+    // Create second finalization
+    CFinalizedBudget fin2("main2 (test)", 144, {txBudgetPayment2, txBudgetPayment}, finTxId2);
+    const CFinalizedBudgetVote fvote2(mnVin2, fin2.GetHash());
+    const CFinalizedBudgetVote fvote2_a({GetRandHash(), 0}, fin2.GetHash());
+    BOOST_CHECK(fin2.AddOrUpdateVote(fvote2, strError));
+    BOOST_CHECK(fin2.AddOrUpdateVote(fvote2_a, strError));
+    g_budgetman.ForceAddFinalizedBudget(fin2.GetHash(), fin2.GetFeeTXHash(), fin2);
 }
 
 BOOST_FIXTURE_TEST_CASE(budget_blocks_payee_test, TestChain100Setup)
@@ -144,28 +168,82 @@ BOOST_FIXTURE_TEST_CASE(budget_blocks_payee_test, TestChain100Setup)
     // Regtest superblock is every 144 blocks.
     for (int i=0; i<43; i++) CreateAndProcessBlock({}, coinbaseKey);
     enableMnSyncAndSuperblocksPayment();
+    g_budgetman.Clear();
     BOOST_CHECK_EQUAL(WITH_LOCK(cs_main, return chainActive.Height();), 143);
+    BOOST_ASSERT(g_budgetman.GetFinalizedBudgets().size() == 0);
 
     // Now we are at the superblock height, let's add a proposal to pay.
-    const CScript payee = GetScriptForDestination(CKeyID(uint160(ParseHex("816115944e077fe7c803cfa57f29b36bf87c1d35"))));
-    const CAmount propAmt = 100 * COIN;
-    forceAddFakeProposal(payee, propAmt);
+    const CScript payee1 = GetScriptForDestination(CKeyID(uint160(ParseHex("816115944e077fe7c803cfa57f29b36bf87c1d35"))));
+    const CAmount propAmt1 = 100 * COIN;
+    const CScript payee2 = GetScriptForDestination(CKeyID(uint160(ParseHex("8d5b4f83212214d6ef693e02e6d71969fddad976"))));
+    const CAmount propAmt2 = propAmt1;
+    forceAddFakeProposals({propAmt1, payee1}, {propAmt2, payee2});
 
     CBlock block = CreateBlock({}, coinbaseKey);
     // Check payee validity:
     CTxOut payeeOut = block.vtx[0]->vout[1];
-    BOOST_CHECK_EQUAL(payeeOut.nValue, propAmt);
-    BOOST_CHECK(payeeOut.scriptPubKey == payee);
+    BOOST_CHECK_EQUAL(payeeOut.nValue, propAmt1);
+    BOOST_CHECK(payeeOut.scriptPubKey == payee1);
+
+    // Good tx
+    CMutableTransaction goodMtx(*block.vtx[0]);
 
     // Modify payee
     CMutableTransaction mtx(*block.vtx[0]);
     mtx.vout[1].scriptPubKey = GetScriptForDestination(CKeyID(uint160(ParseHex("8c988f1a4a4de2161e0f50aac7f17e7f9555caa4"))));
     block.vtx[0] = MakeTransactionRef(mtx);
     std::shared_ptr<CBlock> pblock = FinalizeBlock(std::make_shared<CBlock>(block));
-    BOOST_CHECK(block.vtx[0]->vout[1].scriptPubKey != payee);
+    BOOST_CHECK(block.vtx[0]->vout[1].scriptPubKey != payee1);
 
     // Verify block rejection reason.
     ProcessBlockAndCheckRejectionReason(pblock, "bad-cb-payee", 143);
+
+    // Try to overmint, valid payee --> bad amount.
+    mtx = goodMtx; // reset
+    mtx.vout[1].nValue *= 2; // invalid amount
+    block.vtx[0] = MakeTransactionRef(mtx);
+    pblock = FinalizeBlock(std::make_shared<CBlock>(block));
+    BOOST_CHECK(block.vtx[0]->vout[1].scriptPubKey == payee1);
+    BOOST_CHECK(block.vtx[0]->vout[1].nValue == payeeOut.nValue * 2);
+    ProcessBlockAndCheckRejectionReason(pblock, "bad-blk-amount", 143);
+
+    // Try to send less to a valid payee --> bad amount.
+    mtx = goodMtx; // reset
+    mtx.vout[1].nValue /= 2;
+    block.vtx[0] = MakeTransactionRef(mtx);
+    pblock = FinalizeBlock(std::make_shared<CBlock>(block));
+    BOOST_CHECK(block.vtx[0]->vout[1].scriptPubKey == payee1);
+    BOOST_CHECK(block.vtx[0]->vout[1].nValue == payeeOut.nValue / 2);
+    ProcessBlockAndCheckRejectionReason(pblock, "bad-cb-payee", 143);
+
+    // Context, this has:
+    // 1) Two proposals and two budget finalizations with a different proposal payment order (read `forceAddFakeProposals()` description):
+    //      BudA pays propA and propB, BudB pays propB and propA.
+    // 2) Voted both budgets, adding more votes to budA (so it becomes the most voted one).
+    // 3) Now: in the superblock, pay to budB order (the less voted finalization) --> which will fail.
+
+    // Try to pay proposals in different order
+    mtx = goodMtx; // reset
+    std::vector<CFinalizedBudget*> vecFin = g_budgetman.GetFinalizedBudgets();
+    CFinalizedBudget* secondFin{nullptr};
+    for (auto fin : vecFin) {
+        if (!secondFin || fin->GetVoteCount() < secondFin->GetVoteCount()) {
+            secondFin = fin;
+        }
+    }
+    secondFin->GetPayeeAndAmount(144, mtx.vout[1].scriptPubKey, mtx.vout[1].nValue);
+    BOOST_CHECK(mtx.vout[1].scriptPubKey != goodMtx.vout[1].scriptPubKey);
+    BOOST_CHECK(mtx.vout[1].nValue == goodMtx.vout[1].nValue);
+    block.vtx[0] = MakeTransactionRef(mtx);
+    pblock = FinalizeBlock(std::make_shared<CBlock>(block));
+    ProcessBlockAndCheckRejectionReason(pblock, "bad-cb-payee", 143);
+
+    // Now create the good block
+    block.vtx[0] = MakeTransactionRef(goodMtx);
+    pblock = FinalizeBlock(std::make_shared<CBlock>(block));
+    CValidationState state;
+    ProcessNewBlock(state, pblock, nullptr);
+    BOOST_CHECK_EQUAL(WITH_LOCK(cs_main, return chainActive.Tip()->GetBlockHash();), pblock->GetHash());
 }
 
 BOOST_FIXTURE_TEST_CASE(budget_blocks_reorg_test, TestChain100Setup)
@@ -178,13 +256,15 @@ BOOST_FIXTURE_TEST_CASE(budget_blocks_reorg_test, TestChain100Setup)
     // Now we are at the superblock height, let's add a proposal to pay.
     const CScript payee = GetScriptForDestination(CKeyID(uint160(ParseHex("816115944e077fe7c803cfa57f29b36bf87c1d35"))));
     const CAmount propAmt = 100 * COIN;
-    forceAddFakeProposal(payee, propAmt);
+    const CScript payee2 = GetScriptForDestination(CKeyID(uint160(ParseHex("816115944e077fe7c803cfa57f29b36bf87c1d35"))));
+    const CAmount propAmt2 = propAmt * 2;
+    forceAddFakeProposals({propAmt, payee}, {propAmt2, payee2});
 
     // This will:
     // 1) Create a proposal to be paid at block 144 (first superblock).
     // 1) create blocksA and blockB at block 144 (paying for the proposal).
     // 2) Process and connect blockA.
-    // 3) Create blockC on top of BlockA and blockD on top of blockB.
+    // 3) Create blockC on top of BlockA and blockD on top of blockB. At height 145.
     // 4) Process and connect blockC.
     // 5) Now force the reorg:
     //    a) Process blockB and blockD.

--- a/src/test/test_pivx.cpp
+++ b/src/test/test_pivx.cpp
@@ -164,10 +164,18 @@ CBlock TestChainSetup::CreateAndProcessBlock(const std::vector<CMutableTransacti
     return CreateAndProcessBlock(txns, scriptPubKey);
 }
 
-CBlock TestChainSetup::CreateBlock(const std::vector<CMutableTransaction>& txns, const CScript& scriptPubKey, bool fNoMempoolTx)
+CBlock TestChainSetup::CreateBlock(const std::vector<CMutableTransaction>& txns,
+                                   const CScript& scriptPubKey,
+                                   bool fNoMempoolTx,
+                                   bool fTestBlockValidity)
 {
     std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler(
-            Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey, nullptr, false, nullptr, fNoMempoolTx);
+            Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey,
+                                                            nullptr,       // wallet
+                                                            false,   // fProofOfStake
+                                                            nullptr, // availableCoins
+                                                            fNoMempoolTx,
+                                                            fTestBlockValidity);
     std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>(pblocktemplate->block);
 
     // Add passed-in txns:
@@ -185,10 +193,11 @@ CBlock TestChainSetup::CreateBlock(const std::vector<CMutableTransaction>& txns,
     return *pblock;
 }
 
-CBlock TestChainSetup::CreateBlock(const std::vector<CMutableTransaction>& txns, const CKey& scriptKey)
+CBlock TestChainSetup::CreateBlock(const std::vector<CMutableTransaction>& txns, const CKey& scriptKey,
+                                   bool fTestBlockValidity)
 {
     CScript scriptPubKey = CScript() <<  ToByteVector(scriptKey.GetPubKey()) << OP_CHECKSIG;
-    return CreateBlock(txns, scriptPubKey);
+    return CreateBlock(txns, scriptPubKey, fTestBlockValidity);
 }
 
 std::shared_ptr<CBlock> FinalizeBlock(std::shared_ptr<CBlock> pblock)

--- a/src/test/test_pivx.h
+++ b/src/test/test_pivx.h
@@ -93,8 +93,11 @@ struct TestChainSetup : public TestingSetup
     // Include given transactions, and, if fNoMempoolTx=true, remove transactions coming from the mempool.
     CBlock CreateAndProcessBlock(const std::vector<CMutableTransaction>& txns, const CScript& scriptPubKey, bool fNoMempoolTx = true);
     CBlock CreateAndProcessBlock(const std::vector<CMutableTransaction>& txns, const CKey& scriptKey);
-    CBlock CreateBlock(const std::vector<CMutableTransaction>& txns, const CScript& scriptPubKey, bool fNoMempoolTx = true);
-    CBlock CreateBlock(const std::vector<CMutableTransaction>& txns, const CKey& scriptKey);
+    CBlock CreateBlock(const std::vector<CMutableTransaction>& txns,
+                       const CScript& scriptPubKey,
+                       bool fNoMempoolTx = true,
+                       bool fTestBlockValidity = true);
+    CBlock CreateBlock(const std::vector<CMutableTransaction>& txns, const CKey& scriptKey, bool fTestBlockValidity = true);
 
     std::vector<CTransaction> coinbaseTxns; // For convenience, coinbase transactions
     CKey coinbaseKey; // private/public key needed to spend coinbase transactions

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -151,6 +151,7 @@ TIERTWO_SCRIPTS = [
     'tiertwo_masternode_activation.py',         # ~ 352 sec
     'tiertwo_masternode_ping.py',               # ~ 293 sec
     'tiertwo_reorg_mempool.py',                 # ~ 97 sec
+    'tiertwo_governance_invalid_budget.py',
 ]
 
 SAPLING_SCRIPTS = [

--- a/test/functional/tiertwo_governance_invalid_budget.py
+++ b/test/functional/tiertwo_governance_invalid_budget.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The PIVX developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import PivxTestFramework
+from test_framework.util import (
+    assert_equal,
+    p2p_port,
+)
+
+import os
+import time
+
+class GovernanceInvalidBudgetTest(PivxTestFramework):
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        # 4 nodes:
+        # - 1 miner/mncontroller
+        # - 2 remote mns
+        # - 1 other node to stake a forked chain
+        self.num_nodes = 4
+        self.extra_args = [["-sporkkey=932HEevBSujW2ud7RfB1YF91AFygbBRQj3de3LyaCRqNzKKgWXi"],
+                           [],
+                           ["-listen", "-externalip=127.0.0.1"],
+                           ["-listen", "-externalip=127.0.0.1"],
+                           ]
+        self.enable_mocktime()
+
+        self.minerAPos = 0
+        self.minerBPos = 1
+        self.remoteOnePos = 1
+        self.remoteTwoPos = 2
+
+        self.masternodeOneAlias = "mnOne"
+        self.masternodeTwoAlias = "mntwo"
+
+        self.mnOnePrivkey = "9247iC59poZmqBYt9iDh9wDam6v9S1rW5XekjLGyPnDhrDkP4AK"
+        self.mnTwoPrivkey = "92Hkebp3RHdDidGZ7ARgS4orxJAGyFUPDXNqtsYsiwho1HGVRbF"
+
+    def run_test(self):
+        self.minerA = self.nodes[self.minerAPos]     # also controller of mn1 and mn2
+        self.minerB = self.nodes[self.minerBPos]
+        self.mn1 = self.nodes[self.remoteOnePos]
+        self.mn2 = self.nodes[self.remoteTwoPos]
+        self.setupContext()
+
+        # Create a proposal and vote on it
+        next_superblock = self.minerA.getnextsuperblock()
+        payee = self.minerA.getnewaddress()
+        self.log.info("Creating a proposal to be paid at block %d" % next_superblock)
+        proposalFeeTxId = self.minerA.preparebudget("test1", "https://test1.org", 2,
+                                               next_superblock, payee, 300)
+        self.stake_and_ping(self.minerAPos, 3, [self.mn1, self.mn2])
+        proposalHash = self.minerA.submitbudget("test1", "https://test1.org", 2,
+                                           next_superblock, payee, 300, proposalFeeTxId)
+        time.sleep(1)
+        self.stake_and_ping(self.minerAPos, 7, [self.mn1, self.mn2])
+        self.log.info("Vote for the proposal and check projection...")
+        self.minerA.mnbudgetvote("alias", proposalHash, "yes", self.masternodeOneAlias)
+        self.minerA.mnbudgetvote("alias", proposalHash, "yes", self.masternodeTwoAlias)
+        time.sleep(1)
+        self.stake_and_ping(self.minerAPos, 1, [self.mn1, self.mn2])
+        projection = self.minerB.getbudgetprojection()[0]
+        assert_equal(projection["Name"], "test1")
+        assert_equal(projection["Hash"], proposalHash)
+        assert_equal(projection["Yeas"], 2)
+
+        # Create invalid finalized budget and vote on it
+        self.log.info("Creating invalid budget finalization...")
+        self.stake_and_ping(self.minerAPos, 5, [self.mn1, self.mn2])
+
+        budgetname = "invalid finalization"
+        blockstart = self.minerA.getnextsuperblock()
+        proposals = []
+        badPropId = "aa0061d705de36385c37701e7632408bd9d2876626b1299a17f7dc818c0ad285"
+        badPropPayee = "8c988f1a4a4de2161e0f50aac7f17e7f9555caa4"
+        badPropAmount = 500
+        proposals.append({"proposalid": badPropId, "payee": badPropPayee, "amount": badPropAmount})
+        res = self.minerA.createrawmnfinalbudget(budgetname, blockstart, proposals)
+        assert(res["result"] == "tx_fee_sent")
+        feeBudgetId = res["id"]
+        time.sleep(1)
+        self.stake_and_ping(self.minerAPos, 4, [self.mn1, self.mn2])
+        res = self.minerA.createrawmnfinalbudget(budgetname, blockstart, proposals, feeBudgetId)
+        assert(res["result"] == "fin_budget_sent")
+        budgetFinHash = res["id"]
+        assert (budgetFinHash != "")
+        time.sleep(1)
+
+        self.log.info("Voting for invalid budget finalization...")
+        self.minerA.mnfinalbudget("vote-many", budgetFinHash)
+        self.stake_and_ping(self.minerAPos, 2, [self.mn1, self.mn2])
+        budFin = self.minerB.mnfinalbudget("show")
+        budget = budFin[next(iter(budFin))]
+        assert_equal(budget["VoteCount"], 2)
+
+        # Stake up until the block before the superblock.
+        skip_blocks = next_superblock - self.minerA.getblockcount() - 1
+        self.stake_and_ping(self.minerAPos, skip_blocks, [self.mn1, self.mn2])
+
+        # mine the superblock and check payment, it must not pay to the invalid finalization.
+        self.log.info("Checking superblock...")
+        self.stake_and_ping(self.nodes.index(self.minerA), 1, [])
+        assert_equal(self.minerA.getblockcount(), next_superblock)
+        coinstake = self.minerA.getrawtransaction(self.minerA.getblock(self.minerA.getbestblockhash())["tx"][1], True)
+        budget_payment_out = coinstake["vout"][-1]
+        assert(budget_payment_out["scriptPubKey"]["hex"] != badPropPayee)
+        assert(budget_payment_out["value"] != badPropAmount)
+
+        self.log.info("All good.")
+
+    def send_3_pings(self, mn_list):
+        self.advance_mocktime(30)
+        self.send_pings(mn_list)
+        self.stake_and_ping(self.minerAPos, 1, mn_list)
+        self.advance_mocktime(30)
+        self.send_pings(mn_list)
+        time.sleep(2)
+
+    def setupContext(self):
+        # First mine 250 PoW blocks (50 with minerB, 200 with minerA)
+        self.log.info("Generating 259 blocks...")
+        for _ in range(2):
+            for _ in range(25):
+                self.mocktime = self.generate_pow(self.minerBPos, self.mocktime)
+            self.sync_blocks()
+            for _ in range(100):
+                self.mocktime = self.generate_pow(self.minerAPos, self.mocktime)
+            self.sync_blocks()
+        # Then stake 9 blocks with minerA
+        self.stake_and_ping(self.minerAPos, 9, [])
+        for n in self.nodes:
+            assert_equal(n.getblockcount(), 259)
+
+        # Setup Masternodes
+        self.log.info("Masternodes setup...")
+        ownerdir = os.path.join(self.options.tmpdir, "node%d" % self.minerAPos, "regtest")
+        self.mnOneCollateral = self.setupMasternode(self.minerA, self.minerA, self.masternodeOneAlias,
+                                                    ownerdir, self.remoteOnePos, self.mnOnePrivkey)
+        self.mnTwoCollateral = self.setupMasternode(self.minerA, self.minerA, self.masternodeTwoAlias,
+                                                    ownerdir, self.remoteTwoPos, self.mnTwoPrivkey)
+
+        # Activate masternodes
+        self.log.info("Masternodes activation...")
+        self.stake_and_ping(self.minerAPos, 1, [])
+        time.sleep(3)
+        self.advance_mocktime(10)
+        remoteOnePort = p2p_port(self.remoteOnePos)
+        remoteTwoPort = p2p_port(self.remoteTwoPos)
+        self.mn1.initmasternode(self.mnOnePrivkey, "127.0.0.1:"+str(remoteOnePort))
+        self.mn2.initmasternode(self.mnTwoPrivkey, "127.0.0.1:"+str(remoteTwoPort))
+        self.stake_and_ping(self.minerAPos, 1, [])
+        self.wait_until_mnsync_finished()
+        self.controller_start_masternode(self.minerA, self.masternodeOneAlias)
+        self.controller_start_masternode(self.minerA, self.masternodeTwoAlias)
+        self.wait_until_mn_preenabled(self.mnOneCollateral.hash, 40)
+        self.wait_until_mn_preenabled(self.mnOneCollateral.hash, 40)
+        self.send_3_pings([self.mn1, self.mn2])
+        self.wait_until_mn_enabled(self.mnOneCollateral.hash, 120, [self.mn1, self.mn2])
+        self.wait_until_mn_enabled(self.mnOneCollateral.hash, 120, [self.mn1, self.mn2])
+
+        # activate sporks
+        self.log.info("Masternodes enabled. Activating sporks.")
+        self.activate_spork(self.minerAPos, "SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT")
+        self.activate_spork(self.minerAPos, "SPORK_9_MASTERNODE_BUDGET_ENFORCEMENT")
+        self.activate_spork(self.minerAPos, "SPORK_13_ENABLE_SUPERBLOCKS")
+
+
+if __name__ == '__main__':
+    GovernanceInvalidBudgetTest().main()


### PR DESCRIPTION
Built on top of #2427..
Expanded unit test coverage for the blockchain reorg during superblock range (parallel work of #2436), budget proposal payments distribution in different order and the creation of an invalid budget finalization.
