### PR TITLE
[Test] Fix wallet_encryption.py race condition.

### DIFF
--- a/test/functional/wallet_encryption.py
+++ b/test/functional/wallet_encryption.py
@@ -41,7 +41,7 @@ class WalletEncryptionTest(PivxTestFramework):
         assert_equal(privkey, self.nodes[0].dumpprivkey(address))
 
         # Check that the timeout is right
-        time.sleep(2)
+        time.sleep(3)
         assert_raises_rpc_error(-13, "Please enter the wallet passphrase with walletpassphrase first", self.nodes[0].dumpprivkey, address)
 
         # Test wrong passphrase


### PR DESCRIPTION
The wallet is being unlocked for 2 seconds, need to wait at least 3 seconds to be sure that it gets locked again. Then test the automatic lock status.

Failed in master's GA:
https://github.com/PIVX-Project/PIVX/runs/2883390877