### PR TITLE
Solve filename and command line encoding issues on Windows

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -109,6 +109,7 @@ BITCOIN_TESTS =\
   test/evo_deterministicmns_tests.cpp \
   test/evo_specialtx_tests.cpp \
   test/flatfile_tests.cpp \
+  test/fs_tests.cpp \
   test/getarg_tests.cpp \
   test/hash_tests.cpp \
   test/key_tests.cpp \

--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -119,4 +119,106 @@ std::string get_filesystem_error_message(const fs::filesystem_error& e)
 #endif
 }
 
+#ifdef WIN32
+#ifdef __GLIBCXX__
+
+// reference: https://github.com/gcc-mirror/gcc/blob/gcc-7_3_0-release/libstdc%2B%2B-v3/include/std/fstream#L270
+
+static std::string openmodeToStr(std::ios_base::openmode mode)
+{
+    switch (mode & ~std::ios_base::ate) {
+    case std::ios_base::out:
+    case std::ios_base::out | std::ios_base::trunc:
+        return "w";
+    case std::ios_base::out | std::ios_base::app:
+    case std::ios_base::app:
+        return "a";
+    case std::ios_base::in:
+        return "r";
+    case std::ios_base::in | std::ios_base::out:
+        return "r+";
+    case std::ios_base::in | std::ios_base::out | std::ios_base::trunc:
+        return "w+";
+    case std::ios_base::in | std::ios_base::out | std::ios_base::app:
+    case std::ios_base::in | std::ios_base::app:
+        return "a+";
+    case std::ios_base::out | std::ios_base::binary:
+    case std::ios_base::out | std::ios_base::trunc | std::ios_base::binary:
+        return "wb";
+    case std::ios_base::out | std::ios_base::app | std::ios_base::binary:
+    case std::ios_base::app | std::ios_base::binary:
+        return "ab";
+    case std::ios_base::in | std::ios_base::binary:
+        return "rb";
+    case std::ios_base::in | std::ios_base::out | std::ios_base::binary:
+        return "r+b";
+    case std::ios_base::in | std::ios_base::out | std::ios_base::trunc | std::ios_base::binary:
+        return "w+b";
+    case std::ios_base::in | std::ios_base::out | std::ios_base::app | std::ios_base::binary:
+    case std::ios_base::in | std::ios_base::app | std::ios_base::binary:
+        return "a+b";
+    default:
+        return std::string();
+    }
+}
+
+void ifstream::open(const fs::path& p, std::ios_base::openmode mode)
+{
+    close();
+    m_file = fsbridge::fopen(p, openmodeToStr(mode).c_str());
+    if (m_file == nullptr) {
+        return;
+    }
+    m_filebuf = __gnu_cxx::stdio_filebuf<char>(m_file, mode);
+    rdbuf(&m_filebuf);
+    if (mode & std::ios_base::ate) {
+        seekg(0, std::ios_base::end);
+    }
+}
+
+void ifstream::close()
+{
+    if (m_file != nullptr) {
+        m_filebuf.close();
+        fclose(m_file);
+    }
+    m_file = nullptr;
+}
+
+void ofstream::open(const fs::path& p, std::ios_base::openmode mode)
+{
+    close();
+    m_file = fsbridge::fopen(p, openmodeToStr(mode).c_str());
+    if (m_file == nullptr) {
+        return;
+    }
+    m_filebuf = __gnu_cxx::stdio_filebuf<char>(m_file, mode);
+    rdbuf(&m_filebuf);
+    if (mode & std::ios_base::ate) {
+        seekp(0, std::ios_base::end);
+    }
+}
+
+void ofstream::close()
+{
+    if (m_file != nullptr) {
+        m_filebuf.close();
+        fclose(m_file);
+    }
+    m_file = nullptr;
+}
+#else // __GLIBCXX__
+
+static_assert(sizeof(*fs::path().BOOST_FILESYSTEM_C_STR) == sizeof(wchar_t),
+    "Warning: This build is using boost::filesystem ofstream and ifstream "
+    "implementations which will fail to open paths containing multibyte "
+    "characters. You should delete this static_assert to ignore this warning, "
+    "or switch to a different C++ standard library like the Microsoft C++ "
+    "Standard Library (where boost uses non-standard extensions to construct "
+    "stream objects with wide filenames), or the GNU libstdc++ library (where "
+    "a more complicated workaround has been implemented above).");
+
+#endif // __GLIBCXX__
+#endif // WIN32
+
 } // fsbridge

--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -103,4 +103,20 @@ bool FileLock::TryLock()
 }
 #endif
 
+std::string get_filesystem_error_message(const fs::filesystem_error& e)
+{
+#ifndef WIN32
+    return e.what();
+#else
+    // Convert from Multi Byte to utf-16
+    std::string mb_string(e.what());
+    int size = MultiByteToWideChar(CP_ACP, 0, mb_string.c_str(), mb_string.size(), nullptr, 0);
+
+    std::wstring utf16_string(size, L'\0');
+    MultiByteToWideChar(CP_ACP, 0, mb_string.c_str(), mb_string.size(), &*utf16_string.begin(), size);
+    // Convert from utf-16 to utf-8
+    return std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t>().to_bytes(utf16_string);
+#endif
+}
+
 } // fsbridge

--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -16,7 +16,12 @@ namespace fsbridge {
 
 FILE *fopen(const fs::path& p, const char *mode)
 {
+#ifndef WIN32
     return ::fopen(p.string().c_str(), mode);
+#else
+    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>,wchar_t> utf8_cvt;
+    return ::_wfopen(p.wstring().c_str(), utf8_cvt.from_bytes(mode).c_str());
+#endif
 }
 
 

--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -8,6 +8,7 @@
 #ifndef WIN32
 #include <fcntl.h>
 #else
+#define NOMINMAX
 #include <codecvt>
 #include <windows.h>
 #endif
@@ -95,7 +96,7 @@ bool FileLock::TryLock()
         return false;
     }
     _OVERLAPPED overlapped = {0};
-    if (!LockFileEx(hFile, LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY, 0, 0, 0, &overlapped)) {
+    if (!LockFileEx(hFile, LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY, 0, std::numeric_limits<DWORD>::max(), std::numeric_limits<DWORD>::max(), &overlapped)) {
         reason = GetErrorReason();
         return false;
     }

--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -5,6 +5,13 @@
 
 #include "fs.h"
 
+#ifndef WIN32
+#include <fcntl.h>
+#else
+#include <codecvt>
+#include <windows.h>
+#endif
+
 namespace fsbridge {
 
 FILE *fopen(const fs::path& p, const char *mode)
@@ -12,5 +19,83 @@ FILE *fopen(const fs::path& p, const char *mode)
     return ::fopen(p.string().c_str(), mode);
 }
 
+
+#ifndef WIN32
+
+static std::string GetErrorReason() {
+    return std::strerror(errno);
+}
+
+FileLock::FileLock(const fs::path& file)
+{
+    fd = open(file.string().c_str(), O_RDWR);
+    if (fd == -1) {
+        reason = GetErrorReason();
+    }
+}
+
+FileLock::~FileLock()
+{
+    if (fd != -1) {
+        close(fd);
+    }
+}
+
+bool FileLock::TryLock()
+{
+    if (fd == -1) {
+        return false;
+    }
+    struct flock lock;
+    lock.l_type = F_WRLCK;
+    lock.l_whence = SEEK_SET;
+    lock.l_start = 0;
+    lock.l_len = 0;
+    if (fcntl(fd, F_SETLK, &lock) == -1) {
+        reason = GetErrorReason();
+        return false;
+    }
+    return true;
+}
+#else
+
+static std::string GetErrorReason() {
+    wchar_t* err;
+    FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        nullptr, GetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), reinterpret_cast<WCHAR*>(&err), 0, nullptr);
+    std::wstring err_str(err);
+    LocalFree(err);
+    return std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>>().to_bytes(err_str);
+}
+
+FileLock::FileLock(const fs::path& file)
+{
+    hFile = CreateFileW(file.wstring().c_str(),  GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+        nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (hFile == INVALID_HANDLE_VALUE) {
+        reason = GetErrorReason();
+    }
+}
+
+FileLock::~FileLock()
+{
+    if (hFile != INVALID_HANDLE_VALUE) {
+        CloseHandle(hFile);
+    }
+}
+
+bool FileLock::TryLock()
+{
+    if (hFile == INVALID_HANDLE_VALUE) {
+        return false;
+    }
+    _OVERLAPPED overlapped = {0};
+    if (!LockFileEx(hFile, LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY, 0, 0, 0, &overlapped)) {
+        reason = GetErrorReason();
+        return false;
+    }
+    return true;
+}
+#endif
 
 } // fsbridge

--- a/src/fs.h
+++ b/src/fs.h
@@ -39,6 +39,8 @@ namespace fsbridge {
         void* hFile = (void*)-1; // INVALID_HANDLE_VALUE
 #endif
     };
+
+    std::string get_filesystem_error_message(const fs::filesystem_error& e);
 };
 
 #endif // BITCOIN_FS_H

--- a/src/fs.h
+++ b/src/fs.h
@@ -19,6 +19,26 @@ namespace fs = boost::filesystem;
 /** Bridge operations to C stdio */
 namespace fsbridge {
     FILE *fopen(const fs::path& p, const char *mode);
+
+    class FileLock
+    {
+    public:
+        FileLock() = delete;
+        FileLock(const FileLock&) = delete;
+        FileLock(FileLock&&) = delete;
+        explicit FileLock(const fs::path& file);
+        ~FileLock();
+        bool TryLock();
+        std::string GetReason() { return reason; }
+
+    private:
+        std::string reason;
+#ifndef WIN32
+        int fd = -1;
+#else
+        void* hFile = (void*)-1; // INVALID_HANDLE_VALUE
+#endif
+    };
 };
 
-#endif
+#endif // BITCOIN_FS_H

--- a/src/fs.h
+++ b/src/fs.h
@@ -8,6 +8,9 @@
 
 #include <stdio.h>
 #include <string>
+#if defined WIN32 && defined __GLIBCXX__
+#include <ext/stdio_filebuf.h>
+#endif
 
 #define BOOST_FILESYSTEM_NO_DEPRECATED
 #include <boost/filesystem.hpp>
@@ -41,6 +44,54 @@ namespace fsbridge {
     };
 
     std::string get_filesystem_error_message(const fs::filesystem_error& e);
+
+    // GNU libstdc++ specific workaround for opening UTF-8 paths on Windows.
+    //
+    // On Windows, it is only possible to reliably access multibyte file paths through
+    // `wchar_t` APIs, not `char` APIs. But because the C++ standard doesn't
+    // require ifstream/ofstream `wchar_t` constructors, and the GNU library doesn't
+    // provide them (in contrast to the Microsoft C++ library, see
+    // https://stackoverflow.com/questions/821873/how-to-open-an-stdfstream-ofstream-or-ifstream-with-a-unicode-filename/822032#822032),
+    // Boost is forced to fall back to `char` constructors which may not work properly.
+    //
+    // Work around this issue by creating stream objects with `_wfopen` in
+    // combination with `__gnu_cxx::stdio_filebuf`. This workaround can be removed
+    // with an upgrade to C++17, where streams can be constructed directly from
+    // `std::filesystem::path` objects.
+
+#if defined WIN32 && defined __GLIBCXX__
+    class ifstream : public std::istream
+    {
+    public:
+        ifstream() = default;
+        explicit ifstream(const fs::path& p, std::ios_base::openmode mode = std::ios_base::in) { open(p, mode); }
+        ~ifstream() { close(); }
+        void open(const fs::path& p, std::ios_base::openmode mode = std::ios_base::in);
+        bool is_open() { return m_filebuf.is_open(); }
+        void close();
+
+    private:
+        __gnu_cxx::stdio_filebuf<char> m_filebuf;
+        FILE* m_file = nullptr;
+    };
+    class ofstream : public std::ostream
+    {
+    public:
+        ofstream() = default;
+        explicit ofstream(const fs::path& p, std::ios_base::openmode mode = std::ios_base::out) { open(p, mode); }
+        ~ofstream() { close(); }
+        void open(const fs::path& p, std::ios_base::openmode mode = std::ios_base::out);
+        bool is_open() { return m_filebuf.is_open(); }
+        void close();
+
+    private:
+        __gnu_cxx::stdio_filebuf<char> m_filebuf;
+        FILE* m_file = nullptr;
+    };
+#else  // !(WIN32 && __GLIBCXX__)
+    typedef fs::ifstream ifstream;
+    typedef fs::ofstream ofstream;
+#endif // WIN32 && __GLIBCXX__
 };
 
 #endif // BITCOIN_FS_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1190,6 +1190,9 @@ static bool LockDataDirectory(bool probeOnly)
 {
     // Make sure only a single PIVX process is using the data directory.
     fs::path datadir = GetDataDir();
+    if (!DirIsWritable(datadir)) {
+        return UIError(strprintf(_("Cannot write to data directory '%s'; check permissions."), datadir.string()));
+    }
     if (!LockDirectory(datadir, ".lock", probeOnly)) {
         return UIError(strprintf(_("Cannot obtain a lock on data directory %s. %s is probably already running."), datadir.string(), _(PACKAGE_NAME)));
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -75,12 +75,12 @@
 
 #ifndef WIN32
 #include <signal.h>
+#include <sys/stat.h>
 #endif
 
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/replace.hpp>
-#include <boost/interprocess/sync/file_lock.hpp>
 #include <boost/thread.hpp>
 
 #if ENABLE_ZMQ

--- a/src/logging.h
+++ b/src/logging.h
@@ -149,9 +149,9 @@ template<typename... Args> std::string FormatStringFromLogArgs(const char *fmt, 
         std::string _log_msg_; /* Unlikely name to avoid shadowing variables */     \
         try {                                                                       \
             _log_msg_ = tfm::format(__VA_ARGS__);                                   \
-        } catch (tinyformat::format_error &e) {                                     \
+        } catch (tinyformat::format_error &fmterr) {                                     \
             /* Original format string will have newline so don't add one here */    \
-            _log_msg_ = "Error \"" + std::string(e.what()) +                        \
+            _log_msg_ = "Error \"" + std::string(fmterr.what()) +                        \
                         "\" while formatting log message: " +                       \
                         FormatStringFromLogArgs(__VA_ARGS__);                       \
         }                                                                           \

--- a/src/masternodeconfig.cpp
+++ b/src/masternodeconfig.cpp
@@ -37,7 +37,7 @@ bool CMasternodeConfig::read(std::string& strErr)
     LOCK(cs_entries);
     int linenumber = 1;
     fs::path pathMasternodeConfigFile = GetMasternodeConfigFile();
-    fs::ifstream streamConfig(pathMasternodeConfigFile);
+    fsbridge::ifstream streamConfig(pathMasternodeConfigFile);
 
     if (!streamConfig.good()) {
         FILE* configFile = fsbridge::fopen(pathMasternodeConfigFile, "a");

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -18,6 +18,8 @@
 
 #ifndef WIN32
 #include <fcntl.h>
+#else
+#include <codecvt>
 #endif
 
 #if !defined(HAVE_MSG_NOSIGNAL) && !defined(MSG_NOSIGNAL)
@@ -703,12 +705,13 @@ bool LookupSubNet(const char* pszName, CSubNet& ret)
 #ifdef WIN32
 std::string NetworkErrorString(int err)
 {
-    char buf[256];
+    wchar_t buf[256];
     buf[0] = 0;
-    if (FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK,
-            NULL, err, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-            buf, sizeof(buf), NULL)) {
-        return strprintf("%s (%d)", buf, err);
+    if(FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK,
+            nullptr, err, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+            buf, ARRAYSIZE(buf), nullptr))
+    {
+        return strprintf("%s (%d)", std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>,wchar_t>().to_bytes(buf), err);
     } else {
         return strprintf("Unknown error (%d)", err);
     }

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -711,7 +711,8 @@ std::string NetworkErrorString(int err)
             nullptr, err, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
             buf, ARRAYSIZE(buf), nullptr))
     {
-        return strprintf("%s (%d)", std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>,wchar_t>().to_bytes(buf), err);
+        const auto& bufConvert = std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>,wchar_t>().to_bytes(buf);
+        return strprintf("%s (%d)", bufConvert, err);
     } else {
         return strprintf("Unknown error (%d)", err);
     }

--- a/src/pivx-cli.cpp
+++ b/src/pivx-cli.cpp
@@ -14,6 +14,7 @@
 #include "utilstrencodings.h"
 
 #include <stdio.h>
+#include <tuple>
 
 #include <event2/event.h>
 #include <event2/http.h>
@@ -324,6 +325,10 @@ int CommandLineRPC(int argc, char* argv[])
 
 int main(int argc, char* argv[])
 {
+#ifdef WIN32
+    util::WinCmdLineArgs winArgs;
+    std::tie(argc, argv) = winArgs.get();
+#endif
     SetupEnvironment();
     if (!SetupNetworking()) {
         fprintf(stderr, "Error: Initializing networking failed\n");

--- a/src/pivxd.cpp
+++ b/src/pivxd.cpp
@@ -170,6 +170,10 @@ bool AppInit(int argc, char* argv[])
 
 int main(int argc, char* argv[])
 {
+#ifdef WIN32
+    util::WinCmdLineArgs winArgs;
+    std::tie(argc, argv) = winArgs.get();
+#endif
     SetupEnvironment();
 
     // Connect pivxd signal handlers

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -535,7 +535,7 @@ fs::path static GetAutostartFilePath()
 
 bool GetStartOnSystemStartup()
 {
-    fs::ifstream optionFile(GetAutostartFilePath());
+    fsbridge::ifstream optionFile(GetAutostartFilePath());
     if (!optionFile.good())
         return false;
     // Scan through file for "Hidden=true":
@@ -564,7 +564,7 @@ bool SetStartOnSystemStartup(bool fAutoStart)
 
         fs::create_directories(GetAutostartDir());
 
-        fs::ofstream optionFile(GetAutostartFilePath(), std::ios_base::out | std::ios_base::trunc);
+        fsbridge::ofstream optionFile(GetAutostartFilePath(), std::ios_base::out | std::ios_base::trunc);
         if (!optionFile.good())
             return false;
         // Write a pivx.desktop file to the autostart directory:

--- a/src/qt/pivx.cpp
+++ b/src/qt/pivx.cpp
@@ -545,6 +545,10 @@ WId BitcoinApplication::getMainWinId() const
 #ifndef BITCOIN_QT_TEST
 int main(int argc, char* argv[])
 {
+#ifdef WIN32
+    util::WinCmdLineArgs winArgs;
+    std::tie(argc, argv) = winArgs.get();
+#endif
     SetupEnvironment();
 
     /// 1. Parse command-line options. These take precedence over anything else.

--- a/src/qt/pivx/masternodeswidget.cpp
+++ b/src/qt/pivx/masternodeswidget.cpp
@@ -383,7 +383,7 @@ void MasterNodesWidget::onDeleteMNClicked()
     fs::path pathBootstrap = GetDataDir() / strConfFile;
     if (fs::exists(pathBootstrap)) {
         fs::path pathMasternodeConfigFile = GetMasternodeConfigFile();
-        fs::ifstream streamConfig(pathMasternodeConfigFile);
+        fsbridge::ifstream streamConfig(pathMasternodeConfigFile);
 
         if (!streamConfig.good()) {
             inform(tr("Invalid masternode.conf file"));

--- a/src/qt/pivx/masternodewizarddialog.cpp
+++ b/src/qt/pivx/masternodewizarddialog.cpp
@@ -312,7 +312,7 @@ bool MasterNodeWizardDialog::createMN()
     }
 
     fs::path pathMasternodeConfigFile = GetMasternodeConfigFile();
-    fs::ifstream streamConfig(pathMasternodeConfigFile);
+    fsbridge::ifstream streamConfig(pathMasternodeConfigFile);
 
     if (!streamConfig.good()) {
         returnStr = tr("Invalid masternode.conf file");

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -14,9 +14,6 @@
 #include "utiltime.h"
 #include "version.h"
 
-#include <fstream>
-
-
 /**
  * JSON-RPC protocol.  PIVX speaks version 1.0 for maximum compatibility,
  * but uses JSON-RPC 1.1/2.0 standards for parts of the 1.0 standard that were
@@ -85,16 +82,16 @@ bool GenerateAuthCookie(std::string *cookie_out)
     /** the umask determines what permissions are used to create this file -
      * these are set to 077 in init.cpp unless overridden with -sysperms.
      */
-    std::ofstream file;
-    fs::path filepath = GetAuthCookieFile();
-    file.open(filepath.string().c_str());
+    fsbridge::ofstream file;
+    fs::path filepath_tmp = GetAuthCookieFile();
+    file.open(filepath_tmp);
     if (!file.is_open()) {
-        LogPrintf("Unable to open cookie authentication file %s for writing\n", filepath.string());
+        LogPrintf("Unable to open cookie authentication file %s for writing\n", filepath_tmp.string());
         return false;
     }
     file << cookie;
     file.close();
-    LogPrintf("Generated RPC authentication cookie %s\n", filepath.string());
+    LogPrintf("Generated RPC authentication cookie %s\n", filepath_tmp.string());
 
     if (cookie_out)
         *cookie_out = cookie;
@@ -103,10 +100,10 @@ bool GenerateAuthCookie(std::string *cookie_out)
 
 bool GetAuthCookie(std::string *cookie_out)
 {
-    std::ifstream file;
+    fsbridge::ifstream file;
     std::string cookie;
     fs::path filepath = GetAuthCookieFile();
-    file.open(filepath.string().c_str());
+    file.open(filepath);
     if (!file.is_open())
         return false;
     std::getline(file, cookie);

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -122,6 +122,6 @@ void DeleteAuthCookie()
     try {
         fs::remove(GetAuthCookieFile());
     } catch (const fs::filesystem_error& e) {
-        LogPrintf("%s: Unable to remove random auth cookie file: %s\n", __func__, e.what());
+        LogPrintf("%s: Unable to remove random auth cookie file: %s\n", __func__, fsbridge::get_filesystem_error_message(e));
     }
 }

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -127,6 +127,7 @@ set(BITCOIN_TESTS
         ${CMAKE_CURRENT_SOURCE_DIR}/evo_deterministicmns_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/evo_specialtx_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/flatfile_tests.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/fs_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/getarg_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/hash_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/key_tests.cpp

--- a/src/test/fs_tests.cpp
+++ b/src/test/fs_tests.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2011-2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+//
+#include "fs.h"
+#include "test/test_pivx.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(fs_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(fsbridge_fstream)
+{
+    fs::path tmpfolder = SetDataDir("fsbridge_fstream");
+    // tmpfile1 should be the same as tmpfile2
+    fs::path tmpfile1 = tmpfolder / "fs_tests_₿_🏃";
+    fs::path tmpfile2 = tmpfolder / L"fs_tests_₿_🏃";
+    {
+        fsbridge::ofstream file(tmpfile1);
+        file << "bitcoin";
+    }
+    {
+        fsbridge::ifstream file(tmpfile2);
+        std::string input_buffer;
+        file >> input_buffer;
+        BOOST_CHECK_EQUAL(input_buffer, "bitcoin");
+    }
+    {
+        fsbridge::ifstream file(tmpfile1, std::ios_base::in | std::ios_base::ate);
+        std::string input_buffer;
+        file >> input_buffer;
+        BOOST_CHECK_EQUAL(input_buffer, "");
+    }
+    {
+        fsbridge::ofstream file(tmpfile2, std::ios_base::out | std::ios_base::app);
+        file << "tests";
+    }
+    {
+        fsbridge::ifstream file(tmpfile1);
+        std::string input_buffer;
+        file >> input_buffer;
+        BOOST_CHECK_EQUAL(input_buffer, "bitcointests");
+    }
+    {
+        fsbridge::ofstream file(tmpfile2, std::ios_base::out | std::ios_base::trunc);
+        file << "bitcoin";
+    }
+    {
+        fsbridge::ifstream file(tmpfile1);
+        std::string input_buffer;
+        file >> input_buffer;
+        BOOST_CHECK_EQUAL(input_buffer, "bitcoin");
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1093,6 +1093,22 @@ BOOST_AUTO_TEST_CASE(test_LockDirectory)
     fs::remove_all(dirname);
 }
 
+BOOST_AUTO_TEST_CASE(test_DirIsWritable)
+{
+    // Should be able to write to the system tmp dir.
+    fs::path tmpdirname = fs::temp_directory_path();
+    BOOST_CHECK_EQUAL(DirIsWritable(tmpdirname), true);
+
+    // Should not be able to write to a non-existent dir.
+    tmpdirname = fs::temp_directory_path() / fs::unique_path();
+    BOOST_CHECK_EQUAL(DirIsWritable(tmpdirname), false);
+
+    fs::create_directory(tmpdirname);
+    // Should be able to write to it now.
+    BOOST_CHECK_EQUAL(DirIsWritable(tmpdirname), true);
+    fs::remove(tmpdirname);
+}
+
 namespace {
 
     struct Tracker

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -149,6 +149,19 @@ void ReleaseDirectoryLocks()
     dir_locks.clear();
 }
 
+bool DirIsWritable(const fs::path& directory)
+{
+    fs::path tmpFile = directory / fs::unique_path();
+
+    FILE* file = fsbridge::fopen(tmpFile, "a");
+    if (!file) return false;
+
+    fclose(file);
+    remove(tmpFile);
+
+    return true;
+}
+
 /**
  * Interpret a string argument as a boolean.
  *

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -66,6 +66,7 @@
 #include <codecvt>
 
 #include <io.h> /* for _commit */
+#include <shellapi.h>
 #include <shlobj.h>
 #endif
 
@@ -1066,6 +1067,10 @@ void SetupEnvironment()
     } catch (const std::runtime_error&) {
         setenv("LC_ALL", "C", 1);
     }
+#elif defined(WIN32)
+    // Set the default input/output charset is utf-8
+    SetConsoleCP(CP_UTF8);
+    SetConsoleOutputCP(CP_UTF8);
 #endif
     // The path locale is lazy initialized and to avoid deinitialization errors
     // in multithreading environments, it is set explicitly by the main thread.
@@ -1123,3 +1128,31 @@ int ScheduleBatchPriority(void)
     return 1;
 #endif
 }
+
+namespace util {
+#ifdef WIN32
+    WinCmdLineArgs::WinCmdLineArgs()
+{
+    wchar_t** wargv = CommandLineToArgvW(GetCommandLineW(), &argc);
+    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t> utf8_cvt;
+    argv = new char*[argc];
+    args.resize(argc);
+    for (int i = 0; i < argc; i++) {
+        args[i] = utf8_cvt.to_bytes(wargv[i]);
+        argv[i] = &*args[i].begin();
+    }
+    LocalFree(wargv);
+}
+
+WinCmdLineArgs::~WinCmdLineArgs()
+{
+    delete[] argv;
+}
+
+std::pair<int, char**> WinCmdLineArgs::get()
+{
+    return std::make_pair(argc, argv);
+}
+#endif
+} // namespace util
+

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -77,8 +77,6 @@
 #include <CoreFoundation/CoreFoundation.h>
 #endif
 
-#include <boost/interprocess/sync/file_lock.hpp>
-
 const char * const PIVX_CONF_FILENAME = "pivx.conf";
 const char * const PIVX_PID_FILENAME = "pivx.pid";
 const char * const PIVX_MASTERNODE_CONF_FILENAME = "masternode.conf";
@@ -110,7 +108,7 @@ bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes)
  * cleans them up and thus automatically unlocks them, or ReleaseDirectoryLocks
  * is called.
  */
-static std::map<std::string, std::unique_ptr<boost::interprocess::file_lock>> dir_locks;
+static std::map<std::string, std::unique_ptr<fsbridge::FileLock>> dir_locks;
 /** Mutex to protect dir_locks. */
 static std::mutex cs_dir_locks;
 
@@ -127,18 +125,13 @@ bool LockDirectory(const fs::path& directory, const std::string& lockfile_name, 
     // Create empty lock file if it doesn't exist.
     FILE* file = fsbridge::fopen(pathLockFile, "a");
     if (file) fclose(file);
-
-    try {
-        auto lock = std::make_unique<boost::interprocess::file_lock>(pathLockFile.string().c_str());
-        if (!lock->try_lock()) {
-            return false;
-        }
-        if (!probe_only) {
-            // Lock successful and we're not just probing, put it into the map
-            dir_locks.emplace(pathLockFile.string(), std::move(lock));
-        }
-    } catch (const boost::interprocess::interprocess_exception& e) {
-        return error("Error while attempting to lock directory %s: %s", directory.string(), e.what());
+    auto lock = std::make_unique<fsbridge::FileLock>(pathLockFile);
+    if (!lock->TryLock()) {
+        return error("Error while attempting to lock directory %s: %s", directory.string(), lock->GetReason());
+    }
+    if (!probe_only) {
+        // Lock successful and we're not just probing, put it into the map
+        dir_locks.emplace(pathLockFile.string(), std::move(lock));
     }
     return true;
 }

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -891,8 +891,8 @@ void CreatePidFile(const fs::path& path, pid_t pid)
 bool RenameOver(fs::path src, fs::path dest)
 {
 #ifdef WIN32
-    return MoveFileExA(src.string().c_str(), dest.string().c_str(),
-               MOVEFILE_REPLACE_EXISTING) != 0;
+    return MoveFileExW(src.wstring().c_str(), dest.wstring().c_str(),
+                       MOVEFILE_REPLACE_EXISTING) != 0;
 #else
     int rc = std::rename(src.string().c_str(), dest.string().c_str());
     return (rc == 0);

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -835,7 +835,7 @@ void ArgsManager::ReadConfigFile(const std::string& confPath)
         m_config_args.clear();
     }
 
-    fs::ifstream stream(GetConfigFile(confPath));
+    fsbridge::ifstream stream(GetConfigFile(confPath));
 
     // ok to not have a config file
     if (stream.good()) {

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -89,6 +89,7 @@ void AllocateFileRange(FILE* file, unsigned int offset, unsigned int length);
 bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes = 0);
 bool RenameOver(fs::path src, fs::path dest);
 bool LockDirectory(const fs::path& directory, const std::string& lockfile_name, bool probe_only=false);
+bool DirIsWritable(const fs::path& directory);
 
 /** Release all directory locks. This is used for unit testing only, at runtime
  * the global destructor will take care of the locks.

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -32,6 +32,7 @@
 #include <stdint.h>
 #include <string>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include <boost/signals2/signal.hpp>
@@ -300,5 +301,24 @@ fs::path AbsPathForConfigVal(const fs::path& path, bool net_specific = true);
  * sched_setchedule().
  */
 int ScheduleBatchPriority(void);
+
+namespace util {
+
+#ifdef WIN32
+class WinCmdLineArgs
+{
+public:
+    WinCmdLineArgs();
+    ~WinCmdLineArgs();
+    std::pair<int, char**> get();
+
+private:
+    int argc;
+    char** argv;
+    std::vector<std::string> args;
+};
+#endif
+
+} // namespace util
 
 #endif // BITCOIN_UTIL_SYSTEM_H

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -780,7 +780,7 @@ bool CWalletDBWrapper::Backup(const std::string& strDest)
                     LogPrintf("copied %s to %s\n", strFile, pathDest.string());
                     return true;
                 } catch (const fs::filesystem_error& e) {
-                    LogPrintf("error copying %s to %s - %s\n", strFile, pathDest.string(), e.what());
+                    LogPrintf("error copying %s to %s - %s\n", strFile, pathDest.string(), fsbridge::get_filesystem_error_message(e));
                     return false;
                 }
             }

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -19,7 +19,6 @@
 #include "wallet.h"
 #include "validation.h"
 
-#include <fstream>
 #include <secp256k1.h>
 #include <stdint.h>
 
@@ -350,10 +349,11 @@ UniValue importwallet(const JSONRPCRequest& request)
             "\nImport using the json rpc call\n" +
             HelpExampleRpc("importwallet", "\"test\""));
 
-    std::ifstream file;
-    file.open(request.params[0].get_str().c_str(), std::ios::in | std::ios::ate);
-    if (!file.is_open())
+    fsbridge::ifstream file;
+    file.open(request.params[0].get_str(), std::ios::in | std::ios::ate);
+    if (!file.is_open()) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot open wallet dump file");
+    }
 
     WalletRescanReserver reserver(pwallet);
     if (!reserver.reserve()) {
@@ -547,8 +547,8 @@ UniValue dumpwallet(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_PARAMETER, filepath.string() + " already exists. If you are sure this is what you want, move it out of the way first");
     }
 
-    std::ofstream file;
-    file.open(request.params[0].get_str().c_str());
+    fsbridge::ofstream file;
+    file.open(filepath);
     if (!file.is_open())
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot open wallet dump file");
 

--- a/test/functional/feature_filelock.py
+++ b/test/functional/feature_filelock.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Check that it's not possible to start a second pivxd instance using the same datadir or wallet."""
+import os
+
+from test_framework.test_framework import PivxTestFramework
+from test_framework.test_node import ErrorMatch
+
+class FilelockTest(PivxTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+
+    def setup_network(self):
+        self.add_nodes(self.num_nodes, extra_args=None)
+        self.nodes[0].start([])
+        self.nodes[0].wait_for_rpc_connection()
+
+    def is_wallet_compiled(self):
+        return True
+
+    def run_test(self):
+        datadir = os.path.join(self.nodes[0].datadir, 'regtest')
+        self.log.info("Using datadir {}".format(datadir))
+
+        self.log.info("Check that we can't start a second pivxd instance using the same datadir")
+        expected_msg = "Error: Cannot obtain a lock on data directory {}. PIVX Core is probably already running.".format(datadir)
+        self.nodes[1].assert_start_raises_init_error(extra_args=['-datadir={}'.format(self.nodes[0].datadir), '-noserver'], expected_msg=expected_msg)
+
+        if self.is_wallet_compiled():
+            wallet_dir = os.path.join(datadir, 'wallets')
+            self.log.info("Check that we can't start a second pivxd instance using the same wallet")
+            expected_msg = "Error: Error initializing wallet database environment"
+            self.nodes[1].assert_start_raises_init_error(extra_args=['-walletdir={}'.format(wallet_dir), '-noserver'], expected_msg=expected_msg, match=ErrorMatch.PARTIAL_REGEX)
+
+if __name__ == '__main__':
+    FilelockTest().main()

--- a/test/functional/feature_uacomment.py
+++ b/test/functional/feature_uacomment.py
@@ -30,7 +30,7 @@ class UacommentTest(PivxTestFramework):
         self.nodes[0].assert_start_raises_init_error(["-uacomment=" + 'a' * 256], expected, match=ErrorMatch.FULL_REGEX)
 
         self.log.info("test -uacomment unsafe characters")
-        for unsafe_char in ['/', ':', '(', ')']:
+        for unsafe_char in ['/', ':', '(', ')', '₿', '🏃']:
             expected = r"Error: User Agent comment \(" + re.escape(unsafe_char) + r"\) contains unsafe characters."
             self.nodes[0].assert_start_raises_init_error(["-uacomment=" + unsafe_char], expected, match=ErrorMatch.FULL_REGEX)
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -127,6 +127,7 @@ BASE_SCRIPTS= [
     'mining_v5_upgrade.py',                     # ~ 48 sec
     'p2p_mempool.py',                           # ~ 46 sec
     'rpc_named_arguments.py',                   # ~ 45 sec
+    'feature_filelock.py',
     'feature_help.py',                          # ~ 30 sec
 
     # Don't append tests at the end to avoid merge conflicts


### PR DESCRIPTION
As the software is currently using the ANSI encoding on Windows, the user's language settings could affect the proper functioning of the node/wallet, to the point of not be able to open some non-ASCII name files and directories.

This solves the Windows encoding issues, completing the entire #13869 work path (and some other required backports). Enabling for example users that use non-english characters in directories and file names to be accepted.

Backported PRs:
* #12422.
* #12630.
* #13862.
* #13866.
* #13877.
* #13878.
* #13883.
* #13884.
* #13886.
* #13888.
* #14192.
* #13734.
* #14426.

This is built on top of other two PRs that i have open #2423 and #2369.
Solves old issues #940 and #2163.


TODO:
* Backport `assert_start_raises_init_error` and `ErrorMatch` in TestNode` (https://github.com/bitcoin/bitcoin/pull/12718)