### PR TITLE
[wallet] fix segfault for P2CS inputs in CreateTransaction

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3153,7 +3153,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend,
 
                 // Fill vin
                 for (const std::pair<const CWalletTx*, unsigned int>& coin : setCoins) {
-                    if(coin.first->tx->vout[coin.second].scriptPubKey.IsPayToColdStaking()) {
+                    if(fStakeDelegationVoided && coin.first->tx->vout[coin.second].scriptPubKey.IsPayToColdStaking()) {
                         *fStakeDelegationVoided = true;
                     }
                     txNew.vin.emplace_back(coin.first->GetHash(), coin.second);


### PR DESCRIPTION
Do not try to access to `fStakeDelegationVoided` in `CWallet:: CreateTransaction` if it's not provided (nullptr).

The wallet crash can be triggered from every `CreateTransaction` call that does not provide the `fStakeDelegationVoided` pointer (The auto-combine dust flow, RPC functions like `sendtoaddress`, `legacy_sendmany`, `CreateBudgetFeeTX`, etc etc). Of course the wallet need to have delegated coins (be the owner of the P2CS outputs) and the wallet's utxo selection algorithm needs to select them for spending.

Will back port this fix to v5.2 as well.