### PR TITLE
[Backport] Fix MN activation when the node received the mnb before initialize the MN

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -70,6 +70,13 @@ OperationResult initMasternode(const std::string& _strMasterNodePrivKey, const s
     activeMasternode.privKeyMasternode = key;
     activeMasternode.service = addrTest;
     fMasterNode = true;
+
+    if (masternodeSync.IsBlockchainSynced()) {
+        // Check if the masternode already exists in the list
+        CMasternode* pmn = mnodeman.Find(pubkey);
+        if (pmn) activeMasternode.EnableHotColdMasterNode(pmn->vin, pmn->addr);
+    }
+
     return OperationResult(true);
 }
 
@@ -92,11 +99,15 @@ void CActiveMasternode::ManageStatus()
     if (status == ACTIVE_MASTERNODE_SYNC_IN_PROCESS) status = ACTIVE_MASTERNODE_INITIAL;
 
     if (status == ACTIVE_MASTERNODE_INITIAL) {
-        CMasternode* pmn;
-        pmn = mnodeman.Find(pubKeyMasternode);
-        if (pmn != nullptr) {
-            if (pmn->IsEnabled() && pmn->protocolVersion == PROTOCOL_VERSION)
-                EnableHotColdMasterNode(pmn->vin, pmn->addr);
+        CMasternode* pmn = mnodeman.Find(pubKeyMasternode);
+        if (pmn) {
+            if (pmn->protocolVersion != PROTOCOL_VERSION) {
+                LogPrintf("%s: ERROR Trying to start a masternode running an old protocol version, "
+                          "the controller and masternode wallets need to be running the latest release version.\n", __func__);
+                return;
+            }
+            // Update vin and service
+            EnableHotColdMasterNode(pmn->vin, pmn->addr);
         }
     }
 

--- a/src/activemasternode.h
+++ b/src/activemasternode.h
@@ -43,7 +43,7 @@ public:
     CKey privKeyMasternode;
 
     // Initialized while registering Masternode
-    Optional<CTxIn> vin;
+    Optional<CTxIn> vin{nullopt};
     CService service;
 
     /// Manage status of main Masternode


### PR DESCRIPTION
Backports #2402 to the 5.2 branch for a subsequent minor version v5.2.1 / v5.2.0.1 release.