### PR TITLE
Fix install-params.sh "popd: directory stack empty".

### DIFF
--- a/params/install-params.sh
+++ b/params/install-params.sh
@@ -133,7 +133,10 @@ EOF
     install_params "$SAPLING_SPEND_NAME" "$PARAMS_DIR/$SAPLING_SPEND_NAME" "8e48ffd23abb3a5fd9c5589204f32d9c31285a04b78096ba40a79b75677efc13"
     install_params "$SAPLING_OUTPUT_NAME" "$PARAMS_DIR/$SAPLING_OUTPUT_NAME" "2f0ebbcbb9bb0bcffe95a397e7eba89c29eb4dde6191c339db88570e3f3fb0e4"
 
-    popd
+    if [ -d ".git" ] || [ -f autogen.sh ]
+    then
+        popd
+    fi
 }
 
 main


### PR DESCRIPTION
Coming from #2457, cherry-picked from https://github.com/binance-chain/PIVX/commit/08281d4db421319baea23ee502db9032380ffeb2 , authored by @w20089527.

Thanks for the contribution 👌.

fixes #2457