### PR TITLE
[WIP][bugFix] Wrong use of `ASSERT_WITH_MSG` in validation_block_tests and missing validation state set.

### DIFF
--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -143,9 +143,9 @@ BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
                 if (block->vtx.size() == 1) {
                     bool processed = ProcessNewBlock(state, block, nullptr);
                     // Future to do: "prevblk-not-found" here is the only valid reason to not check processed flag.
-                    if (state.GetRejectReason() == "duplicate" ||
-                        state.GetRejectReason() == "prevblk-not-found" ||
-                        state.GetRejectReason() == "bad-prevblk") continue;
+                    std::string reason = state.GetRejectReason();
+                    if (reason == "duplicate" || reason == "prevblk-not-found" ||
+                        reason == "bad-prevblk" || reason == "blk-out-of-order") continue;
                     ASSERT_WITH_MSG(processed,  ("Error: " + state.GetRejectReason()).c_str());
                 }
             }

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -146,7 +146,7 @@ BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
                     if (state.GetRejectReason() == "duplicate" ||
                         state.GetRejectReason() == "prevblk-not-found" ||
                         state.GetRejectReason() == "bad-prevblk") continue;
-                    ASSERT_WITH_MSG(!processed,  ("Error: " + state.GetRejectReason()).c_str());
+                    ASSERT_WITH_MSG(processed,  ("Error: " + state.GetRejectReason()).c_str());
                 }
             }
         });

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2813,10 +2813,10 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
     int nHeight = 0;
     if (pindexPrev != nullptr && block.hashPrevBlock != UINT256_ZERO) {
         if (pindexPrev->GetBlockHash() != block.hashPrevBlock) {
-            //out of order
+            // out of order
             auto mi = mapBlockIndex.find(block.hashPrevBlock);
-            if (mi == mapBlockIndex.end()) {
-                return false;
+            if (mi == mapBlockIndex.end()) { // future: Move contextual check outside of CheckBlock (Accept/ConnectBlock).
+                return state.Error("blk-out-of-order");
             }
             pindexPrev = mi->second;
         }


### PR DESCRIPTION
Reasons why we are having GA failures in `validation_block_tests`:
1) The `ASSERT_WITH_MSG ` is defined as `ASSERT_WITH_MSG(validCondition, errorCauseStr)` and not `ASSERT_WITH_MSG(invalidCondition, errorCauseStr)`. 
2) `CheckBlock` is receiving blocks out of order and failing without setting the proper validation state.
Future: Move tip contextual checks in `CheckBlock` to Accept/ConnectBlock. 