### PR TITLE
[Refactor] remove std::string DecodeBase58(const char*, int)

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -70,21 +70,6 @@ bool DecodeBase58(const char* psz, std::vector<unsigned char>& vch, int max_ret_
     return true;
 }
 
-std::string DecodeBase58(const char* psz, int max_ret_len)
-{
-    std::vector<unsigned char> vch;
-    DecodeBase58(psz, vch, max_ret_len);
-    std::stringstream ss;
-    ss << std::hex;
-
-    for (unsigned int i = 0; i < vch.size(); i++) {
-        unsigned char* c = &vch[i];
-        ss << std::setw(2) << std::setfill('0') << (int)c[0];
-    }
-
-    return ss.str();
-}
-
 std::string EncodeBase58(const unsigned char* pbegin, const unsigned char* pend)
 {
     // Skip & count leading zeroes.

--- a/src/base58.h
+++ b/src/base58.h
@@ -43,12 +43,6 @@ std::string EncodeBase58(const std::vector<unsigned char>& vch);
 NODISCARD bool DecodeBase58(const char* psz, std::vector<unsigned char>& vchRet, int max_ret_len);
 
 /**
- * Decode a base58-encoded string (psz) into a string.
- * psz cannot be NULL.
- */
-std::string DecodeBase58(const char* psz, int max_ret_len = std::numeric_limits<int>::max());
-
-/**
  * Decode a base58-encoded string (str) into a byte vector (vchRet).
  * return true if decoding is successful.
  */


### PR DESCRIPTION
Which is only used by bip38 code, and it's calling `bool DecodeBase58(const char*, std::vector<unsigned char>&, int)` ignoring its return value.
Replace with proper implementation, `bool Base58ToHex(const std::string&, std::string&)`, and make it static in bip38.cpp.