### PR TITLE
 Span sources updates, up-to-date with current upstream.

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -500,6 +500,12 @@ class A
   - *Rationale*: Easier to understand what is happening, thus easier to spot mistakes, even for those
   that are not language lawyers
 
+- Use `Span` as function argument when it can operate on any range-like container.
+
+  - *Rationale*: Compared to `Foo(const vector<int>&)` this avoids the need for a (potentially expensive)
+    conversion to vector if the caller happens to have the input stored in another type of container.
+    However, be aware of the pitfalls documented in [span.h](../src/span.h).
+
 Strings and formatting
 ------------------------
 

--- a/src/attributes.h
+++ b/src/attributes.h
@@ -19,4 +19,14 @@
 #  endif
 #endif
 
+#if defined(__clang__)
+#  if __has_attribute(lifetimebound)
+#    define LIFETIMEBOUND [[clang::lifetimebound]]
+#  else
+#    define LIFETIMEBOUND
+#  endif
+#else
+#  define LIFETIMEBOUND
+#endif
+
 #endif // BITCOIN_ATTRIBUTES_H

--- a/src/messagesigner.cpp
+++ b/src/messagesigner.cpp
@@ -76,7 +76,7 @@ bool CHashSigner::VerifyHash(const uint256& hash, const CKeyID& keyID, const std
     if(pubkeyFromSig.GetID() != keyID) {
         strErrorRet = strprintf("Keys don't match: pubkey=%s, pubkeyFromSig=%s, hash=%s, vchSig=%s",
                 EncodeDestination(keyID), EncodeDestination(pubkeyFromSig.GetID()),
-                hash.ToString(), EncodeBase64(&vchSig[0], vchSig.size()));
+                hash.ToString(), EncodeBase64(vchSig));
         return false;
     }
 
@@ -131,6 +131,6 @@ bool CSignedMessage::CheckSignature(const CKeyID& keyID) const
 
 std::string CSignedMessage::GetSignatureBase64() const
 {
-    return EncodeBase64(&vchSig[0], vchSig.size());
+    return EncodeBase64(vchSig);
 }
 

--- a/src/qt/pivx/settings/settingssignmessagewidgets.cpp
+++ b/src/qt/pivx/settings/settingssignmessagewidgets.cpp
@@ -201,7 +201,7 @@ void SettingsSignMessageWidgets::onSignMessageButtonSMClicked()
     ui->statusLabel_SM->setStyleSheet("QLabel { color: green; }");
     ui->statusLabel_SM->setText(QString("<nobr>") + tr("Message signed.") + QString("</nobr>"));
 
-    ui->signatureOut_SM->setText(QString::fromStdString(EncodeBase64(&vchSig[0], vchSig.size())));
+    ui->signatureOut_SM->setText(QString::fromStdString(EncodeBase64(vchSig)));
 }
 
 void SettingsSignMessageWidgets::onVerifyMessage()

--- a/src/span.h
+++ b/src/span.h
@@ -7,6 +7,7 @@
 
 #include <type_traits>
 #include <cstddef>
+#include <algorithm>
 
 /** A Span is an object that can refer to a contiguous sequence of objects.
  *
@@ -21,9 +22,25 @@ class Span
 public:
     constexpr Span() noexcept : m_data(nullptr), m_size(0) {}
     constexpr Span(C* data, std::ptrdiff_t size) noexcept : m_data(data), m_size(size) {}
+    constexpr Span(C* data, C* end) noexcept : m_data(data), m_size(end - data) {}
 
     constexpr C* data() const noexcept { return m_data; }
+    constexpr C* begin() const noexcept { return m_data; }
+    constexpr C* end() const noexcept { return m_data + m_size; }
     constexpr std::ptrdiff_t size() const noexcept { return m_size; }
+    constexpr C& operator[](std::ptrdiff_t pos) const noexcept { return m_data[pos]; }
+
+    constexpr Span<C> subspan(std::ptrdiff_t offset) const noexcept { return Span<C>(m_data + offset, m_size - offset); }
+    constexpr Span<C> subspan(std::ptrdiff_t offset, std::ptrdiff_t count) const noexcept { return Span<C>(m_data + offset, count); }
+    constexpr Span<C> first(std::ptrdiff_t count) const noexcept { return Span<C>(m_data, count); }
+    constexpr Span<C> last(std::ptrdiff_t count) const noexcept { return Span<C>(m_data + m_size - count, count); }
+
+    friend constexpr bool operator==(const Span& a, const Span& b) noexcept { return a.size() == b.size() && std::equal(a.begin(), a.end(), b.begin()); }
+    friend constexpr bool operator!=(const Span& a, const Span& b) noexcept { return !(a == b); }
+    friend constexpr bool operator<(const Span& a, const Span& b) noexcept { return std::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end()); }
+    friend constexpr bool operator<=(const Span& a, const Span& b) noexcept { return !(b < a); }
+    friend constexpr bool operator>(const Span& a, const Span& b) noexcept { return (b < a); }
+    friend constexpr bool operator>=(const Span& a, const Span& b) noexcept { return !(a < b); }
 };
 
 /** Create a span to a container exposing data() and size().
@@ -34,6 +51,9 @@ public:
  *
  * std::span will have a constructor that implements this functionality directly.
  */
+template<typename A, int N>
+constexpr Span<A> MakeSpan(A (&a)[N]) { return Span<A>(a, N); }
+
 template<typename V>
 constexpr Span<typename std::remove_pointer<decltype(std::declval<V>().data())>::type> MakeSpan(V& v) { return Span<typename std::remove_pointer<decltype(std::declval<V>().data())>::type>(v.data(), v.size()); }
 

--- a/src/span.h
+++ b/src/span.h
@@ -25,6 +25,23 @@ public:
     constexpr Span(C* data, std::ptrdiff_t size) noexcept : m_data(data), m_size(size) {}
     constexpr Span(C* data, C* end) noexcept : m_data(data), m_size(end - data) {}
 
+    /** Implicit conversion of spans between compatible types.
+     *
+     *  Specifically, if a pointer to an array of type O can be implicitly converted to a pointer to an array of type
+     *  C, then permit implicit conversion of Span<O> to Span<C>. This matches the behavior of the corresponding
+     *  C++20 std::span constructor.
+     *
+     *  For example this means that a Span<T> can be converted into a Span<const T>.
+     */
+    template <typename O, typename std::enable_if<std::is_convertible<O (*)[], C (*)[]>::value, int>::type = 0>
+    constexpr Span(const Span<O>& other) noexcept : m_data(other.m_data), m_size(other.m_size) {}
+
+    /** Default copy constructor. */
+    constexpr Span(const Span&) noexcept = default;
+
+    /** Default assignment operator. */
+    Span& operator=(const Span& other) noexcept = default;
+
     constexpr C* data() const noexcept { return m_data; }
     constexpr C* begin() const noexcept { return m_data; }
     constexpr C* end() const noexcept { return m_data + m_size; }
@@ -44,6 +61,8 @@ public:
     friend constexpr bool operator<=(const Span& a, const Span& b) noexcept { return !(b < a); }
     friend constexpr bool operator>(const Span& a, const Span& b) noexcept { return (b < a); }
     friend constexpr bool operator>=(const Span& a, const Span& b) noexcept { return !(a < b); }
+
+    template <typename O> friend class Span;
 };
 
 /** Create a span to a container exposing data() and size().

--- a/src/span.h
+++ b/src/span.h
@@ -18,11 +18,12 @@ template<typename C>
 class Span
 {
     C* m_data;
-    std::ptrdiff_t m_size;
+    std::size_t m_size;
 
 public:
     constexpr Span() noexcept : m_data(nullptr), m_size(0) {}
-    constexpr Span(C* data, std::ptrdiff_t size) noexcept : m_data(data), m_size(size) {}
+    constexpr Span(C* data, std::size_t size) noexcept : m_data(data), m_size(size) {}
+
     constexpr Span(C* data, C* end) noexcept : m_data(data), m_size(end - data) {}
 
     /** Implicit conversion of spans between compatible types.
@@ -47,13 +48,13 @@ public:
     constexpr C* end() const noexcept { return m_data + m_size; }
     constexpr C& front() const noexcept { return m_data[0]; }
     constexpr C& back() const noexcept { return m_data[m_size - 1]; }
-    constexpr std::ptrdiff_t size() const noexcept { return m_size; }
-    constexpr C& operator[](std::ptrdiff_t pos) const noexcept { return m_data[pos]; }
+    constexpr std::size_t size() const noexcept { return m_size; }
+    constexpr C& operator[](std::size_t pos) const noexcept { return m_data[pos]; }
 
-    constexpr Span<C> subspan(std::ptrdiff_t offset) const noexcept { return Span<C>(m_data + offset, m_size - offset); }
-    constexpr Span<C> subspan(std::ptrdiff_t offset, std::ptrdiff_t count) const noexcept { return Span<C>(m_data + offset, count); }
-    constexpr Span<C> first(std::ptrdiff_t count) const noexcept { return Span<C>(m_data, count); }
-    constexpr Span<C> last(std::ptrdiff_t count) const noexcept { return Span<C>(m_data + m_size - count, count); }
+    constexpr Span<C> subspan(std::size_t offset) const noexcept { return Span<C>(m_data + offset, m_size - offset); }
+    constexpr Span<C> subspan(std::size_t offset, std::size_t count) const noexcept { return Span<C>(m_data + offset, count); }
+    constexpr Span<C> first(std::size_t count) const noexcept { return Span<C>(m_data, count); }
+    constexpr Span<C> last(std::size_t count) const noexcept { return Span<C>(m_data + m_size - count, count); }
 
     friend constexpr bool operator==(const Span& a, const Span& b) noexcept { return a.size() == b.size() && std::equal(a.begin(), a.end(), b.begin()); }
     friend constexpr bool operator!=(const Span& a, const Span& b) noexcept { return !(a == b); }

--- a/src/span.h
+++ b/src/span.h
@@ -8,6 +8,7 @@
 #include <type_traits>
 #include <cstddef>
 #include <algorithm>
+#include <assert.h>
 
 /** A Span is an object that can refer to a contiguous sequence of objects.
  *
@@ -27,6 +28,8 @@ public:
     constexpr C* data() const noexcept { return m_data; }
     constexpr C* begin() const noexcept { return m_data; }
     constexpr C* end() const noexcept { return m_data + m_size; }
+    constexpr C& front() const noexcept { return m_data[0]; }
+    constexpr C& back() const noexcept { return m_data[m_size - 1]; }
     constexpr std::ptrdiff_t size() const noexcept { return m_size; }
     constexpr C& operator[](std::ptrdiff_t pos) const noexcept { return m_data[pos]; }
 
@@ -56,5 +59,16 @@ constexpr Span<A> MakeSpan(A (&a)[N]) { return Span<A>(a, N); }
 
 template<typename V>
 constexpr Span<typename std::remove_pointer<decltype(std::declval<V>().data())>::type> MakeSpan(V& v) { return Span<typename std::remove_pointer<decltype(std::declval<V>().data())>::type>(v.data(), v.size()); }
+
+/** Pop the last element off a span, and return a reference to that element. */
+template <typename T>
+T& SpanPopBack(Span<T>& span)
+{
+    size_t size = span.size();
+    assert(size > 0);
+    T& back = span[size - 1];
+    span = Span<T>(span.data(), size - 1);
+    return back;
+}
 
 #endif

--- a/src/span.h
+++ b/src/span.h
@@ -22,9 +22,22 @@ class Span
 
 public:
     constexpr Span() noexcept : m_data(nullptr), m_size(0) {}
-    constexpr Span(C* data, std::size_t size) noexcept : m_data(data), m_size(size) {}
 
-    constexpr Span(C* data, C* end) noexcept : m_data(data), m_size(end - data) {}
+    /** Construct a span from a begin pointer and a size.
+     *
+     * This implements a subset of the iterator-based std::span constructor in C++20,
+     * which is hard to implement without std::address_of.
+     */
+    template <typename T, typename std::enable_if<std::is_convertible<T (*)[], C (*)[]>::value, int>::type = 0>
+    constexpr Span(T* begin, std::size_t size) noexcept : m_data(begin), m_size(size) {}
+
+    /** Construct a span from a begin and end pointer.
+     *
+     * This implements a subset of the iterator-based std::span constructor in C++20,
+     * which is hard to implement without std::address_of.
+     */
+    template <typename T, typename std::enable_if<std::is_convertible<T (*)[], C (*)[]>::value, int>::type = 0>
+    constexpr Span(T* begin, T* end) noexcept : m_data(begin), m_size(end - begin) {}
 
     /** Implicit conversion of spans between compatible types.
      *

--- a/src/span.h
+++ b/src/span.h
@@ -84,6 +84,14 @@ class Span
     C* m_data;
     std::size_t m_size;
 
+    template <class T>
+    struct is_Span_int : public std::false_type {};
+    template <class T>
+    struct is_Span_int<Span<T>> : public std::true_type {};
+    template <class T>
+    struct is_Span : public is_Span_int<typename std::remove_cv<T>::type>{};
+
+
 public:
     constexpr Span() noexcept : m_data(nullptr), m_size(0) {}
 
@@ -134,8 +142,19 @@ public:
      * To prevent surprises, only Spans for constant value types are supported when passing in temporaries.
      * Note that this restriction does not exist when converting arrays or other Spans (see above).
      */
-    template <typename V, typename std::enable_if<(std::is_const<C>::value || std::is_lvalue_reference<V>::value) && std::is_convertible<typename std::remove_pointer<decltype(std::declval<V&>().data())>::type (*)[], C (*)[]>::value && std::is_convertible<decltype(std::declval<V&>().size()), std::size_t>::value, int>::type = 0>
-    constexpr Span(V&& v) noexcept : m_data(v.data()), m_size(v.size()) {}
+    template <typename V>
+    constexpr Span(V& other,
+        typename std::enable_if<!is_Span<V>::value &&
+                                std::is_convertible<typename std::remove_pointer<decltype(std::declval<V&>().data())>::type (*)[], C (*)[]>::value &&
+                                std::is_convertible<decltype(std::declval<V&>().size()), std::size_t>::value, std::nullptr_t>::type = nullptr)
+        : m_data(other.data()), m_size(other.size()){}
+
+    template <typename V>
+    constexpr Span(const V& other,
+        typename std::enable_if<!is_Span<V>::value &&
+                                std::is_convertible<typename std::remove_pointer<decltype(std::declval<const V&>().data())>::type (*)[], C (*)[]>::value &&
+                                std::is_convertible<decltype(std::declval<const V&>().size()), std::size_t>::value, std::nullptr_t>::type = nullptr)
+        : m_data(other.data()), m_size(other.size()){}
 
     constexpr C* data() const noexcept { return m_data; }
     constexpr C* begin() const noexcept { return m_data; }

--- a/src/span.h
+++ b/src/span.h
@@ -18,6 +18,16 @@
 #define ASSERT_IF_DEBUG(x)
 #endif
 
+#if defined(__clang__)
+#if __has_attribute(lifetimebound)
+#define SPAN_ATTR_LIFETIMEBOUND [[clang::lifetimebound]]
+#else
+#define SPAN_ATTR_LIFETIMEBOUND
+#endif
+#else
+#define SPAN_ATTR_LIFETIMEBOUND
+#endif
+
 /** A Span is an object that can refer to a contiguous sequence of objects.
  *
  * It implements a subset of C++20's std::span.
@@ -143,14 +153,14 @@ public:
      * Note that this restriction does not exist when converting arrays or other Spans (see above).
      */
     template <typename V>
-    constexpr Span(V& other,
+    constexpr Span(V& other SPAN_ATTR_LIFETIMEBOUND,
         typename std::enable_if<!is_Span<V>::value &&
                                 std::is_convertible<typename std::remove_pointer<decltype(std::declval<V&>().data())>::type (*)[], C (*)[]>::value &&
                                 std::is_convertible<decltype(std::declval<V&>().size()), std::size_t>::value, std::nullptr_t>::type = nullptr)
         : m_data(other.data()), m_size(other.size()){}
 
     template <typename V>
-    constexpr Span(const V& other,
+    constexpr Span(const V& other SPAN_ATTR_LIFETIMEBOUND,
         typename std::enable_if<!is_Span<V>::value &&
                                 std::is_convertible<typename std::remove_pointer<decltype(std::declval<const V&>().data())>::type (*)[], C (*)[]>::value &&
                                 std::is_convertible<decltype(std::declval<const V&>().size()), std::size_t>::value, std::nullptr_t>::type = nullptr)
@@ -210,9 +220,9 @@ public:
 /** MakeSpan for arrays: */
 template <typename A, int N> Span<A> constexpr MakeSpan(A (&a)[N]) { return Span<A>(a, N); }
 /** MakeSpan for temporaries / rvalue references, only supporting const output. */
-template <typename V> constexpr auto MakeSpan(V&& v) -> typename std::enable_if<!std::is_lvalue_reference<V>::value, Span<const typename std::remove_pointer<decltype(v.data())>::type>>::type { return std::forward<V>(v); }
+template <typename V> constexpr auto MakeSpan(V&& v SPAN_ATTR_LIFETIMEBOUND) -> typename std::enable_if<!std::is_lvalue_reference<V>::value, Span<const typename std::remove_pointer<decltype(v.data())>::type>>::type { return std::forward<V>(v); }
 /** MakeSpan for (lvalue) references, supporting mutable output. */
-template <typename V> constexpr auto MakeSpan(V& v) -> Span<typename std::remove_pointer<decltype(v.data())>::type> { return v; }
+template <typename V> constexpr auto MakeSpan(V& v SPAN_ATTR_LIFETIMEBOUND) -> Span<typename std::remove_pointer<decltype(v.data())>::type> { return v; }
 
 /** Pop the last element off a span, and return a reference to that element. */
 template <typename T>

--- a/src/span.h
+++ b/src/span.h
@@ -235,4 +235,16 @@ T& SpanPopBack(Span<T>& span)
     return back;
 }
 
+// Helper functions to safely cast to unsigned char pointers.
+inline unsigned char* UCharCast(char* c) { return (unsigned char*)c; }
+inline unsigned char* UCharCast(unsigned char* c) { return c; }
+inline const unsigned char* UCharCast(const char* c) { return (unsigned char*)c; }
+inline const unsigned char* UCharCast(const unsigned char* c) { return c; }
+
+// Helper function to safely convert a Span to a Span<[const] unsigned char>.
+template <typename T> constexpr auto UCharSpanCast(Span<T> s) -> Span<typename std::remove_pointer<decltype(UCharCast(s.data()))>::type> { return {UCharCast(s.data()), s.size()}; }
+
+/** Like MakeSpan, but for (const) unsigned char member types only. Only works for (un)signed char containers. */
+template <typename V> constexpr auto MakeUCharSpan(V&& v) -> decltype(UCharSpanCast(MakeSpan(std::forward<V>(v)))) { return UCharSpanCast(MakeSpan(std::forward<V>(v))); }
+
 #endif

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -57,6 +57,9 @@ public:
     void SetHex(const std::string& str);
     std::string ToString() const;
 
+    const unsigned char* data() const { return m_data; }
+    unsigned char* data() { return m_data; }
+
     unsigned char* begin()
     {
         return &m_data[0];

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -123,20 +123,20 @@ std::vector<unsigned char> ParseHex(const std::string& str)
     return ParseHex(str.c_str());
 }
 
-std::string EncodeBase64(const unsigned char* pch, size_t len)
+std::string EncodeBase64(Span<const unsigned char> input)
 {
     static const char *pbase64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
     std::string str;
-    str.reserve(((len + 2) / 3) * 4);
-    ConvertBits<8, 6, true>([&](int v) { str += pbase64[v]; }, pch, pch + len);
+    str.reserve(((input.size() + 2) / 3) * 4);
+    ConvertBits<8, 6, true>([&](int v) { str += pbase64[v]; }, input.begin(), input.end());
     while (str.size() % 4) str += '=';
     return str;
 }
 
 std::string EncodeBase64(const std::string& str)
 {
-    return EncodeBase64((const unsigned char*)str.c_str(), str.size());
+    return EncodeBase64(MakeUCharSpan(str));
 }
 
 std::vector<unsigned char> DecodeBase64(const char* p, bool* pfInvalid)

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -11,6 +11,7 @@
 #define BITCOIN_UTILSTRENCODINGS_H
 
 #include "support/allocators/secure.h"
+#include "span.h"
 #include <algorithm>
 #include <stdint.h>
 #include <string>
@@ -54,7 +55,7 @@ signed char HexDigit(char c);
 bool IsHex(const std::string& str);
 std::vector<unsigned char> DecodeBase64(const char* p, bool* pfInvalid = NULL);
 std::string DecodeBase64(const std::string& str);
-std::string EncodeBase64(const unsigned char* pch, size_t len);
+std::string EncodeBase64(Span<const unsigned char> input);
 std::string EncodeBase64(const std::string& str);
 std::vector<unsigned char> DecodeBase32(const char* p, bool* pfInvalid = NULL);
 std::string DecodeBase32(const std::string& str);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2023,7 +2023,7 @@ UniValue signmessage(const JSONRPCRequest& request)
     if (!key.SignCompact(ss.GetHash(), vchSig))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Sign failed");
 
-    return EncodeBase64(&vchSig[0], vchSig.size());
+    return EncodeBase64(vchSig);
 }
 
 UniValue getreceivedbyaddress(const JSONRPCRequest& request)


### PR DESCRIPTION
Another decouple from #2411.
Purely focused on updating the Span sources to be up-to-date with current upstream.

Following PRs/commits were back ported:

* #13697 (only 29943a904a11607787d28b1f4288f500bd076dde)
* 2b0fcff7f26d59fed4bcafd1602325122a206c67 (only span changes).
* #18591 (only 0fbde488b24f62b4bbbde216647941dcac65c81a).
* #18468 (without 2676aeadfa0e43dcaaccc4720623cdfe0beed528).
* #19367.
* #19387.
* #19326 (only 56782504 and e63dcc3a here). 
* #19687 (only e2aa1a585a83971639572cd2c84565ec360deac9 here, 2bc20719 is inside #2411 and require net related commits that are introduced down the commits line there).

Extra side note:
Some of the current serialization compiler warnings in master will be fixed with this, other ones are coming down 2411 commits line as they need other previous PRs.