### PR TITLE
[Build] fix GA boost test random seed number overflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -243,7 +243,7 @@ jobs:
       CCACHE_COMPRESS: 1
       PARAMS_DIR: ${{ github.workspace }}/.pivx-params
       WINEDEBUG: fixme-all
-      BOOST_TEST_RANDOM: 1${{ github.run_id }}
+      BOOST_TEST_RANDOM: 1 # random seed based on the current time
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
The random seed value, used in boost for shuffling the unit tests order, is interpreted as an unsigned int inside the boost test framework and the current value is overflowing the type range, thus why GA is failing in every PR and commit.

Solution: use the framework functionality to select a random seed based on the current time (can check it inside boost documentation [link](https://www.boost.org/doc/libs/1_76_0/libs/test/doc/html/boost_test/utf_reference/rt_param_reference/random.html)).