### PR TITLE
[Test] Fix evo_deterministicmns_tests fail for create a dup service addr

### DIFF
--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -175,11 +175,19 @@ static CMutableTransaction MalleateProTxPayout(const CMutableTransaction& tx)
     return tx2;
 }
 
+CService CreateUniqueAddr()
+{
+    CService ret;
+    auto dmnList = deterministicMNManager->GetListAtChainTip();
+    do { ret = LookupNumeric("1.1.1.1", InsecureRandRange(2000)); } while (dmnList.HasUniqueProperty(ret));
+    return ret;
+}
+
 static CMutableTransaction MalleateProUpServTx(const CMutableTransaction& tx)
 {
     ProUpServPL pl;
     GetTxPayload(tx, pl);
-    pl.addr = LookupNumeric("1.1.1.1", InsecureRandRange(2000));
+    pl.addr = CreateUniqueAddr();
     if (!pl.scriptOperatorPayout.empty()) {
         pl.scriptOperatorPayout = GenerateRandomAddress();
     }


### PR DESCRIPTION
Preventing the `MalleateProUpServTx` function for creating an already used addr by other DMN, triggering a different error instead of the expected `bad-protx-sig`.

Saw it failing once in GA, not very common for obvious reasons but it could still happen:
```
  Entering test module "Pivx Test Suite"
  test/evo_deterministicmns_tests.cpp(225): Entering test suite "deterministicmns_tests"
  test/evo_deterministicmns_tests.cpp(227): Entering test case "dip3_protx"
  test/evo_deterministicmns_tests.cpp(466): error: in "deterministicmns_tests/dip3_protx": check dummyState.GetRejectReason() == "bad-protx-sig" has failed [bad-protx-dup-addr != bad-protx-sig]
  test/evo_deterministicmns_tests.cpp(227): Leaving test case "dip3_protx"; testing time: 5607127us
```

Footnote: The `bad-protx-dup-addr` error is verified in another test case.