### PR TITLE
[Backport] git-subtree-check.sh updated to latest upstream

### DIFF
--- a/test/lint/git-subtree-check.sh
+++ b/test/lint/git-subtree-check.sh
@@ -1,10 +1,44 @@
 #!/bin/sh
-# Copyright (c) 2015 The Bitcoin Core developers
+# Copyright (c) 2015-2020 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 export LC_ALL=C
-DIR="$1"
+
+check_remote=0
+while getopts "?hr" opt; do
+  case $opt in
+    '?' | h)
+      echo "Usage: $0 [-r] DIR [COMMIT]"
+      echo "       $0 -?"
+      echo ""
+      echo "Checks that a certain prefix is pure subtree, and optionally whether the"
+      echo "referenced commit is present in any fetched remote."
+      echo ""
+      echo "DIR is the prefix within the repository to check."
+      echo "COMMIT is the commit to check, if it is not provided, HEAD will be used."
+      echo ""
+      echo "-r      Check that subtree commit is present in repository."
+      echo "        To do this check, fetch the subtreed remote first. Example:"
+      echo ""
+      echo "            git fetch https://github.com/PIVX-Project/bls-signatures.git"
+      echo "            test/lint/git-subtree-check.sh -r src/chiabls"
+      exit 1
+    ;;
+    r)
+      check_remote=1
+    ;;
+  esac
+done
+shift $((OPTIND-1))
+
+if [ -z "$1" ]; then
+    echo "Need to provide a DIR, see $0 -?"
+    exit 1
+fi
+
+# Strip trailing / from directory path (in case it was added by autocomplete)
+DIR="${1%/}"
 COMMIT="$2"
 if [ -z "$COMMIT" ]; then
     COMMIT=HEAD
@@ -78,18 +112,20 @@ if [ "$tree_actual_tree" != "$tree_commit" ]; then
     exit 1
 fi
 
-# get the tree in the subtree commit referred to
-if [ "d$(git cat-file -t $rev 2>/dev/null)" != dcommit ]; then
-    echo "subtree commit $rev unavailable: cannot compare" >&2
-    exit
-fi
-tree_subtree=$(git show -s --format="%T" $rev)
-echo "$DIR in $COMMIT was last updated to upstream commit $rev (tree $tree_subtree)"
+if [ "$check_remote" != "0" ]; then
+    # get the tree in the subtree commit referred to
+    if [ "d$(git cat-file -t $rev 2>/dev/null)" != dcommit ]; then
+        echo "subtree commit $rev unavailable: cannot compare. Did you add and fetch the remote?" >&2
+        exit 1
+    fi
+    tree_subtree=$(git show -s --format="%T" $rev)
+    echo "$DIR in $COMMIT was last updated to upstream commit $rev (tree $tree_subtree)"
 
-# ... and compare the actual tree with it
-if [ "$tree_actual_tree" != "$tree_subtree" ]; then
-    echo "FAIL: subtree update commit differs from upstream tree!" >&2
-    exit 1
+    # ... and compare the actual tree with it
+    if [ "$tree_actual_tree" != "$tree_subtree" ]; then
+        echo "FAIL: subtree update commit differs from upstream tree!" >&2
+        exit 1
+    fi
 fi
 
 echo "GOOD"


### PR DESCRIPTION
Pulled latest `git-subtree-check.sh` changes from upstream. So it's easier to verify the new subtree that is being included in #2419.