### PR TITLE
[Build] bench build, raw generated file improvement and fixes.

### DIFF
--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -15,6 +15,8 @@ bench_bench_pivx_SOURCES = \
   bench/base58.cpp \
   bench/checkblock.cpp \
   bench/checkqueue.cpp \
+  bench/data.h \
+  bench/data.cpp \
   bench/chacha20.cpp \
   bench/crypto_hash.cpp \
   bench/lockedpool.cpp \
@@ -55,7 +57,7 @@ CLEAN_BITCOIN_BENCH = bench/*.gcda bench/*.gcno $(GENERATED_TEST_FILES)
 
 CLEANFILES += $(CLEAN_BITCOIN_BENCH)
 
-bench/checkblock.cpp: bench/data/block2680960.raw.h
+bench/data.cpp: bench/data/block2680960.raw.h
 
 bitcoin_bench: $(BENCH_BINARY)
 

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -1,13 +1,18 @@
+# Copyright (c) 2015-2021 The Bitcoin Core developers
+# Copyright (c) 2020-2021 The PIVX Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 bin_PROGRAMS += bench/bench_pivx
 BENCH_SRCDIR = bench
 BENCH_BINARY = bench/bench_pivx$(EXEEXT)
 
-RAW_TEST_FILES = \
+RAW_BENCH_FILES = \
   bench/data/block2680960.raw
-
-GENERATED_TEST_FILES = $(RAW_TEST_FILES:.raw=.raw.h)
+GENERATED_BENCH_FILES = $(RAW_BENCH_FILES:.raw=.raw.h)
 
 bench_bench_pivx_SOURCES = \
+  $(RAW_BENCH_FILES) \
   bench/bench_pivx.cpp \
   bench/bench.cpp \
   bench/bench.h \
@@ -25,7 +30,7 @@ bench_bench_pivx_SOURCES = \
   bench/prevector.cpp \
   bench/util_time.cpp
 
-nodist_bench_bench_pivx_SOURCES = $(GENERATED_TEST_FILES)
+nodist_bench_bench_pivx_SOURCES = $(GENERATED_BENCH_FILES)
 
 bench_bench_pivx_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(EVENT_CFLAGS) $(EVENT_PTHREADS_CFLAGS) -I$(builddir)/bench/
 bench_bench_pivx_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
@@ -52,8 +57,7 @@ endif
 bench_bench_pivx_LDADD += $(LIBBITCOIN_CONSENSUS) $(BOOST_LIBS) $(BDB_LIBS) $(MINIUPNPC_LIBS) $(NATPMP_LIBS) $(EVENT_PTHREADS_LIBS) $(EVENT_LIBS)
 bench_bench_pivx_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 
-# !TODO: .raw.h generated test files are not removed with make clean
-CLEAN_BITCOIN_BENCH = bench/*.gcda bench/*.gcno $(GENERATED_TEST_FILES)
+CLEAN_BITCOIN_BENCH = bench/*.gcda bench/*.gcno $(GENERATED_BENCH_FILES)
 
 CLEANFILES += $(CLEAN_BITCOIN_BENCH)
 

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -68,7 +68,7 @@ bitcoin_bench_clean : FORCE
 %.raw.h: %.raw
 	@$(MKDIR_P) $(@D)
 	@{ \
-	 echo "static unsigned const char $(*F)[] = {" && \
+	 echo "static unsigned const char $(*F)_raw[] = {" && \
 	 $(HEXDUMP) -v -e '8/1 "0x%02x, "' -e '"\n"' $< | $(SED) -e 's/0x  ,//g' && \
 	 echo "};"; \
 	} > "$@.new" && mv -f "$@.new" "$@"

--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -2,13 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "bench.h"
+#include "bench/bench.h"
+#include "bench/data.h"
 
 #include "validation.h"
-
-namespace block_bench {
-#include "bench/data/block2680960.raw.h"
-}
 
 // These are the two major time-sinks which happen after we have fully received
 // a block off the wire, but before we can relay the block on to peers using
@@ -16,25 +13,22 @@ namespace block_bench {
 
 static void DeserializeBlockTest(benchmark::State& state)
 {
-    CDataStream stream((const char*)block_bench::block2680960,
-            (const char*)&block_bench::block2680960[sizeof(block_bench::block2680960)],
-            SER_NETWORK, PROTOCOL_VERSION);
-    char a;
+    CDataStream stream(benchmark::data::block2680960, SER_NETWORK, PROTOCOL_VERSION);
+    char a = '\0';
     stream.write(&a, 1); // Prevent compaction
 
     while (state.KeepRunning()) {
         CBlock block;
         stream >> block;
-        assert(stream.Rewind(sizeof(block_bench::block2680960)));
+        bool rewound = stream.Rewind(benchmark::data::block2680960.size());
+        assert(rewound);
     }
 }
 
 static void DeserializeAndCheckBlockTest(benchmark::State& state)
 {
-    CDataStream stream((const char*)block_bench::block2680960,
-            (const char*)&block_bench::block2680960[sizeof(block_bench::block2680960)],
-            SER_NETWORK, PROTOCOL_VERSION);
-    char a;
+    CDataStream stream(benchmark::data::block2680960, SER_NETWORK, PROTOCOL_VERSION);
+    char a = '\0';
     stream.write(&a, 1); // Prevent compaction
 
     SelectParams(CBaseChainParams::MAIN);
@@ -42,7 +36,8 @@ static void DeserializeAndCheckBlockTest(benchmark::State& state)
     while (state.KeepRunning()) {
         CBlock block; // Note that CBlock caches its checked state, so we need to recreate it here
         stream >> block;
-        assert(stream.Rewind(sizeof(block_bench::block2680960)));
+        bool rewound = stream.Rewind(benchmark::data::block2680960.size());
+        assert(rewound);
 
         CValidationState state;
         assert(CheckBlock(block, state));

--- a/src/bench/data.cpp
+++ b/src/bench/data.cpp
@@ -1,0 +1,14 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/data.h>
+
+namespace benchmark {
+namespace data {
+
+#include <bench/data/block2680960.raw.h>
+const std::vector<uint8_t> block2680960{block2680960_raw, block2680960_raw + sizeof(block2680960_raw) / sizeof(block2680960_raw[0])};
+
+} // namespace data
+} // namespace benchmark

--- a/src/bench/data.h
+++ b/src/bench/data.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_BENCH_DATA_H
+#define BITCOIN_BENCH_DATA_H
+
+#include <cstdint>
+#include <vector>
+
+namespace benchmark {
+namespace data {
+
+extern const std::vector<uint8_t> block2680960;
+
+} // namespace data
+} // namespace benchmark
+
+#endif // BITCOIN_BENCH_DATA_H


### PR DESCRIPTION
Small decoupled from #2411.

Fixing issues with the raw generated files in the benchmarking framework.
1) Specify correct raw data name.
2) Backports #16299.
3) Make clean now removes the file/s.