### PR TITLE
[BUG][GUI] Fix P2CS grouping in coin control

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -780,7 +780,14 @@ void CoinControlDialog::updateView()
 
             // address
             itemWalletAddress->setText(COLUMN_ADDRESS, sWalletAddress);
-            itemWalletAddress->setToolTip(COLUMN_ADDRESS, sWalletAddress);
+            if (stakerAddress != nullopt) {
+                itemWalletAddress->setIcon(COLUMN_CONFIRMATIONS, QIcon("://ic-check-cold-staking-off"));
+                QString label = tr("Delegated to %1").arg(*stakerAddress);
+                itemWalletAddress->setToolTip(COLUMN_ADDRESS, label);
+                itemWalletAddress->setToolTip(COLUMN_CONFIRMATIONS, label);
+            } else {
+                itemWalletAddress->setToolTip(COLUMN_ADDRESS, sWalletAddress);
+            }
         }
 
         CAmount nSum = 0;

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -312,7 +312,8 @@ public:
         }
 
         bool operator<(const ListCoinsKey& key2) const {
-            return this->address < key2.address;
+            return this->address < key2.address ||
+                    (this->address == key2.address && this->stakerAddress < key2.stakerAddress);
         }
     };
 


### PR DESCRIPTION
**Problem**
Some coins in coin-control are marked as cold-utxos when they aren't.
Or vice-versa some delegated coin is not marked as it should.
More specifically, If a coin is sent to an address A, and another coin is delegated using A as owner, both coins will be listed under the same address (in treemode), and they will either be both marked as cold-utxos, or both marked as regular utxos (depending on which coin was added first to the map).

**Cause**
Bug in `ListCoinsKey::operator<`, which is not comparing the staker address.
Thus, in `CoinControlDialog::updateView`, coins sent to A (`{A, false, nullopt}`) and coins delegated with owner A and staker B (`{A, false, B}`) have the same key in `mapCoins`, therefore are added to the same list.

**Fix**
Complete `ListCoinsKey::operator<` so that it compares the staker address as well.
This way, coins sent to `{A, false, nullopt}` and coins delegated `{A, false, B}` are grouped separately.
Also, since the address label for the two groups is the same, add the cold-staking icon (in the empty confirmations column) and a tooltip for delegation groups.

Before (10-PIV delegation not marked as cold-utxo):
<img src="https://user-images.githubusercontent.com/18186894/126181221-f0288702-d82d-45cf-9020-c91ed1919d8d.png" width=700/>

After:
<img src="https://user-images.githubusercontent.com/18186894/126180923-934a2a46-e874-4cab-b164-1c1bb2366cf5.png" width=700/>

Thanks to @NoobieDev12 for reporting this bug.
