### PR TITLE
[Refactor] Make HexStr take a span

### DIFF
--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -40,13 +40,14 @@ std::string FormatScript(const CScript& script)
                 }
             }
             if (vch.size() > 0) {
-                ret += strprintf("0x%x 0x%x ", HexStr(it2, it - vch.size()), HexStr(it - vch.size(), it));
+                ret += strprintf("0x%x 0x%x ", HexStr(std::vector<uint8_t>(it2, it - vch.size())),
+                                 HexStr(std::vector<uint8_t>(it - vch.size(), it)));
             } else {
-                ret += strprintf("0x%x", HexStr(it2, it));
+                ret += strprintf("0x%x ", HexStr(std::vector<uint8_t>(it2, it)));
             }
             continue;
         }
-        ret += strprintf("0x%x ", HexStr(it2, script.end()));
+        ret += strprintf("0x%x ", HexStr(std::vector<uint8_t>(it2, script.end())));
         break;
     }
     return ret.substr(0, ret.size() - 1);
@@ -116,7 +117,7 @@ std::string EncodeHexTx(const CTransaction& tx)
 {
     CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
     ssTx << tx;
-    return HexStr(ssTx.begin(), ssTx.end());
+    return HexStr(ssTx);
 }
 
 void ScriptPubKeyToUniv(const CScript& scriptPubKey,
@@ -129,7 +130,7 @@ void ScriptPubKeyToUniv(const CScript& scriptPubKey,
 
     out.pushKV("asm", ScriptToAsmStr(scriptPubKey));
     if (fIncludeHex)
-        out.pushKV("hex", HexStr(scriptPubKey.begin(), scriptPubKey.end()));
+        out.pushKV("hex", HexStr(scriptPubKey));
 
     if (!ExtractDestinations(scriptPubKey, type, addresses, nRequired)) {
         if (!scriptPubKey.empty() && scriptPubKey.IsZerocoinMint()) {
@@ -174,13 +175,13 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry)
     for (const CTxIn& txin : tx.vin) {
         UniValue in(UniValue::VOBJ);
         if (tx.IsCoinBase())
-            in.pushKV("coinbase", HexStr(txin.scriptSig.begin(), txin.scriptSig.end()));
+            in.pushKV("coinbase", HexStr(txin.scriptSig));
         else {
             in.pushKV("txid", txin.prevout.hash.GetHex());
             in.pushKV("vout", (int64_t)txin.prevout.n);
             UniValue o(UniValue::VOBJ);
             o.pushKV("asm", ScriptToAsmStr(txin.scriptSig, true));
-            o.pushKV("hex", HexStr(txin.scriptSig.begin(), txin.scriptSig.end()));
+            o.pushKV("hex", HexStr(txin.scriptSig));
             in.pushKV("scriptSig", o);
         }
         in.pushKV("sequence", (int64_t)txin.nSequence);

--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -214,7 +214,7 @@ std::string ProRegPL::MakeSignString() const
 {
     std::ostringstream ss;
 
-    ss << HexStr(scriptPayout.begin(), scriptPayout.end()) << "|";
+    ss << HexStr(scriptPayout) << "|";
     ss << strprintf("%d", nOperatorReward) << "|";
     ss << EncodeDestination(keyIDOwner) << "|";
     ss << EncodeDestination(keyIDVoting) << "|";

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1959,8 +1959,8 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
     {
         LogPrint(BCLog::NET, "%s(%s, %u bytes): CHECKSUM ERROR expected %s was %s\n", __func__,
            SanitizeString(strCommand), nMessageSize,
-           HexStr(hash.begin(), hash.begin()+CMessageHeader::CHECKSUM_SIZE),
-           HexStr(hdr.pchChecksum, hdr.pchChecksum+CMessageHeader::CHECKSUM_SIZE));
+           HexStr(Span<uint8_t>(hash.begin(), hash.begin() + CMessageHeader::CHECKSUM_SIZE)),
+           HexStr(hdr.pchChecksum));
         return fMoreWork;
     }
 

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -155,7 +155,7 @@ static bool rest_headers(HTTPRequest* req,
     }
 
     case RF_HEX: {
-        std::string strHex = HexStr(ssHeader.begin(), ssHeader.end()) + "\n";
+        std::string strHex = HexStr(ssHeader) + "\n";
         req->WriteHeader("Content-Type", "text/plain");
         req->WriteReply(HTTP_OK, strHex);
         return true;
@@ -217,7 +217,7 @@ static bool rest_block(HTTPRequest* req,
     }
 
     case RF_HEX: {
-        std::string strHex = HexStr(ssBlock.begin(), ssBlock.end()) + "\n";
+        std::string strHex = HexStr(ssBlock) + "\n";
         req->WriteHeader("Content-Type", "text/plain");
         req->WriteReply(HTTP_OK, strHex);
         return true;
@@ -346,7 +346,7 @@ static bool rest_tx(HTTPRequest* req, const std::string& strURIPart)
     }
 
     case RF_HEX: {
-        std::string strHex = HexStr(ssTx.begin(), ssTx.end()) + "\n";
+        std::string strHex = HexStr(ssTx) + "\n";
         req->WriteHeader("Content-Type", "text/plain");
         req->WriteReply(HTTP_OK, strHex);
         return true;
@@ -507,7 +507,7 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
     case RF_HEX: {
         CDataStream ssGetUTXOResponse(SER_NETWORK, PROTOCOL_VERSION);
         ssGetUTXOResponse << chainActive.Height() << chainActive.Tip()->GetBlockHash() << bitmap << outs;
-        std::string strHex = HexStr(ssGetUTXOResponse.begin(), ssGetUTXOResponse.end()) + "\n";
+        std::string strHex = HexStr(ssGetUTXOResponse) + "\n";
 
         req->WriteHeader("Content-Type", "text/plain");
         req->WriteReply(HTTP_OK, strHex);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -584,7 +584,7 @@ UniValue getblock(const JSONRPCRequest& request)
     if (!fVerbose) {
         CDataStream ssBlock(SER_NETWORK, PROTOCOL_VERSION);
         ssBlock << block;
-        std::string strHex = HexStr(ssBlock.begin(), ssBlock.end());
+        std::string strHex = HexStr(ssBlock);
         return strHex;
     }
 
@@ -642,7 +642,7 @@ UniValue getblockheader(const JSONRPCRequest& request)
     if (!fVerbose) {
         CDataStream ssBlock(SER_NETWORK, PROTOCOL_VERSION);
         ssBlock << pblockindex->GetBlockHeader();
-        std::string strHex = HexStr(ssBlock.begin(), ssBlock.end());
+        std::string strHex = HexStr(ssBlock);
         return strHex;
     }
 

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -377,7 +377,7 @@ void SerializeMNB(UniValue& statusObjRet, const CMasternodeBroadcast& mnb, const
         successful++;
         CDataStream ssMnb(SER_NETWORK, PROTOCOL_VERSION);
         ssMnb << mnb;
-        statusObjRet.pushKV("hex", HexStr(ssMnb.begin(), ssMnb.end()));
+        statusObjRet.pushKV("hex", HexStr(ssMnb));
     } else {
         failed++;
     }

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -690,7 +690,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     }
 
     UniValue aux(UniValue::VOBJ);
-    aux.pushKV("flags", HexStr(COINBASE_FLAGS.begin(), COINBASE_FLAGS.end()));
+    aux.pushKV("flags", HexStr(COINBASE_FLAGS));
 
     arith_uint256& hashTarget = arith_uint256().SetCompact(pblock->nBits);
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -254,7 +254,7 @@ public:
             int nRequired;
             ExtractDestinations(subscript, whichType, addresses, nRequired);
             obj.pushKV("script", GetTxnOutputType(whichType));
-            obj.pushKV("hex", HexStr(subscript.begin(), subscript.end()));
+            obj.pushKV("hex", HexStr(subscript));
             UniValue a(UniValue::VARR);
             for (const CTxDestination& addr : addresses)
                 a.push_back(EncodeDestination(addr));
@@ -354,7 +354,7 @@ public:
     UniValue operator()(const CTxDestination &dest) const {
         UniValue ret(UniValue::VOBJ);
         CScript scriptPubKey = GetScriptForDestination(dest);
-        ret.pushKV("scriptPubKey", HexStr(scriptPubKey.begin(), scriptPubKey.end()));
+        ret.pushKV("scriptPubKey", HexStr(scriptPubKey));
 
 #ifdef ENABLE_WALLET
         isminetype mine = pwallet ? IsMine(*pwallet, dest) : ISMINE_NO;
@@ -538,7 +538,7 @@ UniValue createmultisig(const JSONRPCRequest& request)
 
     UniValue result(UniValue::VOBJ);
     result.pushKV("address", EncodeDestination(innerID));
-    result.pushKV("redeemScript", HexStr(inner.begin(), inner.end()));
+    result.pushKV("redeemScript", HexStr(inner));
 
     return result;
 }

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -12,7 +12,6 @@
 #include "util/system.h"
 #include "utilstrencodings.h"
 #include "utiltime.h"
-#include "version.h"
 
 #include <fstream>
 
@@ -80,7 +79,7 @@ bool GenerateAuthCookie(std::string *cookie_out)
     const size_t COOKIE_SIZE = 32;
     unsigned char rand_pwd[COOKIE_SIZE];
     GetRandBytes(rand_pwd, COOKIE_SIZE);
-    std::string cookie = COOKIEAUTH_USER + ":" + HexStr(rand_pwd, rand_pwd+COOKIE_SIZE);
+    std::string cookie = COOKIEAUTH_USER + ":" + HexStr(rand_pwd);
 
     /** the umask determines what permissions are used to create this file -
      * these are set to 077 in init.cpp unless overridden with -sysperms.

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -493,7 +493,7 @@ static void TxInErrorToJSON(const CTxIn& txin, UniValue& vErrorsRet, const std::
     UniValue entry(UniValue::VOBJ);
     entry.pushKV("txid", txin.prevout.hash.ToString());
     entry.pushKV("vout", (uint64_t)txin.prevout.n);
-    entry.pushKV("scriptSig", HexStr(txin.scriptSig.begin(), txin.scriptSig.end()));
+    entry.pushKV("scriptSig", HexStr(txin.scriptSig));
     entry.pushKV("sequence", (uint64_t)txin.nSequence);
     entry.pushKV("error", strMessage);
     vErrorsRet.push_back(entry);

--- a/src/sapling/sapling_core_write.cpp
+++ b/src/sapling/sapling_core_write.cpp
@@ -16,8 +16,8 @@ static UniValue TxShieldedSpendsToJSON(const CTransaction& tx) {
             obj.pushKV("anchor", spendDesc.anchor.GetHex());
             obj.pushKV("nullifier", spendDesc.nullifier.GetHex());
             obj.pushKV("rk", spendDesc.rk.GetHex());
-            obj.pushKV("proof", HexStr(spendDesc.zkproof.begin(), spendDesc.zkproof.end()));
-            obj.pushKV("spendAuthSig", HexStr(spendDesc.spendAuthSig.begin(), spendDesc.spendAuthSig.end()));
+            obj.pushKV("proof", HexStr(spendDesc.zkproof));
+            obj.pushKV("spendAuthSig", HexStr(spendDesc.spendAuthSig));
             vdesc.push_back(obj);
         }
     }
@@ -32,9 +32,9 @@ static UniValue TxShieldedOutputsToJSON(const CTransaction& tx) {
             obj.pushKV("cv", outputDesc.cv.GetHex());
             obj.pushKV("cmu", outputDesc.cmu.GetHex());
             obj.pushKV("ephemeralKey", outputDesc.ephemeralKey.GetHex());
-            obj.pushKV("encCiphertext", HexStr(outputDesc.encCiphertext.begin(), outputDesc.encCiphertext.end()));
-            obj.pushKV("outCiphertext", HexStr(outputDesc.outCiphertext.begin(), outputDesc.outCiphertext.end()));
-            obj.pushKV("proof", HexStr(outputDesc.zkproof.begin(), outputDesc.zkproof.end()));
+            obj.pushKV("encCiphertext", HexStr(outputDesc.encCiphertext));
+            obj.pushKV("outCiphertext", HexStr(outputDesc.outCiphertext));
+            obj.pushKV("proof", HexStr(outputDesc.zkproof));
             vdesc.push_back(obj);
         }
     }
@@ -50,7 +50,7 @@ void TxSaplingToJSON(const CTransaction& tx, UniValue& entry) {
         UniValue voutputdesc = TxShieldedOutputsToJSON(tx);
         entry.pushKV("vShieldOutput", voutputdesc);
         if (tx.sapData->hasBindingSig()) {
-            entry.pushKV("bindingSig", HexStr(tx.sapData->bindingSig.begin(), tx.sapData->bindingSig.end()));
+            entry.pushKV("bindingSig", HexStr(tx.sapData->bindingSig));
         }
     }
 }

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -617,7 +617,7 @@ Optional<std::string> SaplingScriptPubKeyMan::GetOutPointMemo(const CWalletTx& t
         if (IsValidUTF8(memoStr)) return memoStr;
     }
     // non UTF-8 memo. Return as hex encoded raw memo.
-    return HexStr(memo.begin(), end.base());
+    return HexStr(std::vector<unsigned char>(memo.begin(), end.base()));
 }
 
 Optional<std::pair<

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -985,7 +985,7 @@ BOOST_AUTO_TEST_CASE(ccoins_serialization)
     CDataStream tmp(SER_DISK, CLIENT_VERSION);
     uint64_t x = 3000000000ULL;
     tmp << VARINT(x);
-    BOOST_CHECK_EQUAL(HexStr(tmp.begin(), tmp.end()), "8a95c0bb00");
+    BOOST_CHECK_EQUAL(HexStr(tmp), "8a95c0bb00");
     CDataStream ss5(ParseHex("00008a95c0bb00"), SER_DISK, CLIENT_VERSION);
     try {
         Coin cc5;

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -174,7 +174,7 @@ BOOST_AUTO_TEST_CASE(sighash_test)
         CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
         ss << txTo;
         std::cout << "\t[\"" ;
-        std::cout << HexStr(ss.begin(), ss.end()) << "\", \"";
+        std::cout << HexStr(ss) << "\", \"";
         std::cout << HexStr(scriptCode) << "\", ";
         std::cout << nIn << ", ";
         std::cout << nHashType << ", \"";

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -71,47 +71,24 @@ BOOST_AUTO_TEST_CASE(util_ParseHex)
 BOOST_AUTO_TEST_CASE(util_HexStr)
 {
     BOOST_CHECK_EQUAL(
-        HexStr(ParseHex_expected, ParseHex_expected + sizeof(ParseHex_expected)),
-        "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f");
+            HexStr(ParseHex_expected),
+            "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f");
 
     BOOST_CHECK_EQUAL(
-        HexStr(ParseHex_expected + sizeof(ParseHex_expected),
-               ParseHex_expected + sizeof(ParseHex_expected)),
-        "");
+            HexStr(Span<const unsigned char>(
+                    ParseHex_expected + sizeof(ParseHex_expected),
+                    ParseHex_expected + sizeof(ParseHex_expected))),
+            "");
 
     BOOST_CHECK_EQUAL(
-        HexStr(ParseHex_expected, ParseHex_expected),
-        "");
+            HexStr(Span<const unsigned char>(ParseHex_expected, ParseHex_expected)),
+            "");
 
     std::vector<unsigned char> ParseHex_vec(ParseHex_expected, ParseHex_expected + 5);
 
     BOOST_CHECK_EQUAL(
-        HexStr(ParseHex_vec.rbegin(), ParseHex_vec.rend()),
-        "b0fd8a6704"
-    );
-
-    BOOST_CHECK_EQUAL(
-        HexStr(std::reverse_iterator<const uint8_t *>(ParseHex_expected),
-               std::reverse_iterator<const uint8_t *>(ParseHex_expected)),
-        ""
-    );
-
-    BOOST_CHECK_EQUAL(
-        HexStr(std::reverse_iterator<const uint8_t *>(ParseHex_expected + 1),
-               std::reverse_iterator<const uint8_t *>(ParseHex_expected)),
-        "04"
-    );
-
-    BOOST_CHECK_EQUAL(
-        HexStr(std::reverse_iterator<const uint8_t *>(ParseHex_expected + 5),
-               std::reverse_iterator<const uint8_t *>(ParseHex_expected)),
-        "b0fd8a6704"
-    );
-
-    BOOST_CHECK_EQUAL(
-        HexStr(std::reverse_iterator<const uint8_t *>(ParseHex_expected + 65),
-               std::reverse_iterator<const uint8_t *>(ParseHex_expected)),
-        "5f1df16b2b704c8a578d0bbaf74d385cde12c11ee50455f3c438ef4c3fbcf649b6de611feae06279a60939e028a8d65c10b73071a6f16719274855feb0fd8a6704"
+            HexStr(ParseHex_vec),
+            "04678afdb0"
     );
 }
 

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -6,7 +6,6 @@
 #include "util/system.h"
 
 #include "clientversion.h"
-#include "primitives/transaction.h"
 #include "sync.h"
 #include "utilstrencodings.h"
 #include "util/string.h"
@@ -76,18 +75,44 @@ BOOST_AUTO_TEST_CASE(util_HexStr)
         "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f");
 
     BOOST_CHECK_EQUAL(
-        HexStr(ParseHex_expected, ParseHex_expected + 5, true),
-        "04 67 8a fd b0");
+        HexStr(ParseHex_expected + sizeof(ParseHex_expected),
+               ParseHex_expected + sizeof(ParseHex_expected)),
+        "");
 
     BOOST_CHECK_EQUAL(
-        HexStr(ParseHex_expected, ParseHex_expected, true),
+        HexStr(ParseHex_expected, ParseHex_expected),
         "");
 
     std::vector<unsigned char> ParseHex_vec(ParseHex_expected, ParseHex_expected + 5);
 
     BOOST_CHECK_EQUAL(
-        HexStr(ParseHex_vec, true),
-        "04 67 8a fd b0");
+        HexStr(ParseHex_vec.rbegin(), ParseHex_vec.rend()),
+        "b0fd8a6704"
+    );
+
+    BOOST_CHECK_EQUAL(
+        HexStr(std::reverse_iterator<const uint8_t *>(ParseHex_expected),
+               std::reverse_iterator<const uint8_t *>(ParseHex_expected)),
+        ""
+    );
+
+    BOOST_CHECK_EQUAL(
+        HexStr(std::reverse_iterator<const uint8_t *>(ParseHex_expected + 1),
+               std::reverse_iterator<const uint8_t *>(ParseHex_expected)),
+        "04"
+    );
+
+    BOOST_CHECK_EQUAL(
+        HexStr(std::reverse_iterator<const uint8_t *>(ParseHex_expected + 5),
+               std::reverse_iterator<const uint8_t *>(ParseHex_expected)),
+        "b0fd8a6704"
+    );
+
+    BOOST_CHECK_EQUAL(
+        HexStr(std::reverse_iterator<const uint8_t *>(ParseHex_expected + 65),
+               std::reverse_iterator<const uint8_t *>(ParseHex_expected)),
+        "5f1df16b2b704c8a578d0bbaf74d385cde12c11ee50455f3c438ef4c3fbcf649b6de611feae06279a60939e028a8d65c10b73071a6f16719274855feb0fd8a6704"
+    );
 }
 
 BOOST_AUTO_TEST_CASE(util_Join)

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -8,7 +8,6 @@
 
 #include "utilstrencodings.h"
 
-#include <stdio.h>
 #include <string.h>
 
 template <unsigned int BITS>
@@ -21,7 +20,11 @@ base_blob<BITS>::base_blob(const std::vector<unsigned char>& vch)
 template <unsigned int BITS>
 std::string base_blob<BITS>::GetHex() const
 {
-    return HexStr(std::reverse_iterator<const uint8_t*>(m_data + sizeof(m_data)), std::reverse_iterator<const uint8_t*>(m_data));
+    uint8_t m_data_rev[WIDTH];
+    for (int i = 0; i < WIDTH; ++i) {
+        m_data_rev[i] = m_data[WIDTH - 1 - i];
+    }
+    return HexStr(m_data_rev);
 }
 
 template <unsigned int BITS>

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -528,6 +528,19 @@ std::string Capitalize(std::string str)
     return str;
 }
 
+std::string HexStr(const Span<const uint8_t> s)
+{
+    std::string rv;
+    static constexpr char hexmap[16] = { '0', '1', '2', '3', '4', '5', '6', '7',
+                                         '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+    rv.reserve(s.size() * 2);
+    for (uint8_t v: s) {
+        rv.push_back(hexmap[v >> 4]);
+        rv.push_back(hexmap[v & 15]);
+    }
+    return rv;
+}
+
 // Based on http://www.zedwood.com/article/cpp-is-valid-utf8-string-function
 bool IsValidUTF8(const std::string& str)
 {

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -13,6 +13,7 @@
 #include "support/allocators/secure.h"
 #include "span.h"
 #include <algorithm>
+#include <iterator>
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -107,33 +108,30 @@ T FindFirstNonZero(T itbegin, T itend)
 }
 
 template <typename T>
-std::string HexStr(const T itbegin, const T itend, bool fSpaces = false)
+std::string HexStr(const T itbegin, const T itend)
 {
     std::string rv;
     static const char hexmap[16] = {'0', '1', '2', '3', '4', '5', '6', '7',
         '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
-    rv.reserve((itend - itbegin) * 3);
+    rv.reserve(std::distance(itbegin, itend) * 2);
     for (T it = itbegin; it < itend; ++it) {
         unsigned char val = (unsigned char)(*it);
-        if (fSpaces && it != itbegin)
-            rv.push_back(' ');
         rv.push_back(hexmap[val >> 4]);
         rv.push_back(hexmap[val & 15]);
     }
-
     return rv;
 }
 
 template <typename T>
-inline std::string HexStr(const T& vch, bool fSpaces = false)
+inline std::string HexStr(const T& vch)
 {
-    return HexStr(vch.begin(), vch.end(), fSpaces);
+    return HexStr(vch.begin(), vch.end());
 }
 
 template <typename T>
-inline std::string HexStrTrimmed(const T& vch, bool fSpaces = false)
+inline std::string HexStrTrimmed(const T& vch)
 {
-    return HexStr(vch.begin(), FindFirstNonZero(vch.rbegin(), vch.rend()).base(), fSpaces);
+    return HexStr(vch.begin(), FindFirstNonZero(vch.rbegin(), vch.rend()).base());
 }
 
 /** Reverse the endianess of a string */

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -12,6 +12,7 @@
 
 #include "support/allocators/secure.h"
 #include "span.h"
+
 #include <algorithm>
 #include <iterator>
 #include <stdint.h>
@@ -107,32 +108,11 @@ T FindFirstNonZero(T itbegin, T itend)
     return std::find_if(itbegin, itend, [](unsigned char v) { return v != 0; });
 }
 
-template <typename T>
-std::string HexStr(const T itbegin, const T itend)
-{
-    std::string rv;
-    static const char hexmap[16] = {'0', '1', '2', '3', '4', '5', '6', '7',
-        '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
-    rv.reserve(std::distance(itbegin, itend) * 2);
-    for (T it = itbegin; it < itend; ++it) {
-        unsigned char val = (unsigned char)(*it);
-        rv.push_back(hexmap[val >> 4]);
-        rv.push_back(hexmap[val & 15]);
-    }
-    return rv;
-}
-
-template <typename T>
-inline std::string HexStr(const T& vch)
-{
-    return HexStr(vch.begin(), vch.end());
-}
-
-template <typename T>
-inline std::string HexStrTrimmed(const T& vch)
-{
-    return HexStr(vch.begin(), FindFirstNonZero(vch.rbegin(), vch.rend()).base());
-}
+/**
+ * Convert a span of bytes to a lower-case hexadecimal string.
+ */
+std::string HexStr(const Span<const uint8_t> s);
+inline std::string HexStr(const Span<const char> s) { return HexStr(MakeUCharSpan(s)); }
 
 /** Reverse the endianess of a string */
 inline std::string ReverseEndianString(std::string in)

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -50,7 +50,7 @@ void CheckUniqueFileid(const CDBEnv& env, const std::string& filename, Db& db)
             const char* item_filename = nullptr;
             item.second->get_dbname(&item_filename, nullptr);
             throw std::runtime_error(strprintf("CDB: Can't open database %s (duplicates fileid %s from %s)", filename,
-                HexStr(std::begin(item_fileid), std::end(item_fileid)),
+                HexStr(item_fileid),
                 item_filename ? item_filename : "(unknown database)"));
         }
     }

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -48,7 +48,7 @@ std::string static EncodeDumpString(const std::string& str)
     std::stringstream ret;
     for (unsigned char c : str) {
         if (c <= 32 || c >= 128 || c == '%') {
-            ret << '%' << HexStr(&c, &c + 1);
+            ret << '%' << HexStr(Span<const unsigned char>(&c, 1));
         } else {
             ret << c;
         }

--- a/src/wallet/test/crypto_tests.cpp
+++ b/src/wallet/test/crypto_tests.cpp
@@ -25,10 +25,10 @@ static void TestPassphraseSingle(const std::vector<unsigned char>& vchSalt, cons
 
     if(!correctKey.empty())
         BOOST_CHECK_MESSAGE(memcmp(crypt.vchKey.data(), correctKey.data(), crypt.vchKey.size()) == 0,
-                HexStr(crypt.vchKey.begin(), crypt.vchKey.end()) + std::string(" != ") + HexStr(correctKey.begin(), correctKey.end()));
+                HexStr(crypt.vchKey) + std::string(" != ") + HexStr(correctKey));
     if(!correctIV.empty())
         BOOST_CHECK_MESSAGE(memcmp(crypt.vchIV.data(), correctIV.data(), crypt.vchIV.size()) == 0,
-                HexStr(crypt.vchIV.begin(), crypt.vchIV.end()) + std::string(" != ") + HexStr(correctIV.begin(), correctIV.end()));
+                HexStr(crypt.vchIV) + std::string(" != ") + HexStr(correctIV));
 
 }
 


### PR DESCRIPTION
Follow up to #2470. Only the last two commits are from this work.

Make `HexStr` take a span of bytes, instead of an awkward pair of templated iterators. Simplifying most of the uses.

Adaptation of #19660 and #15573. 