### PR TITLE
[BUG][Tests] Delay POS activation in feature_blockhashcache test

### DIFF
--- a/test/functional/feature_blockhashcache.py
+++ b/test/functional/feature_blockhashcache.py
@@ -17,6 +17,8 @@ class BlockHashCacheTest(PivxTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True
+        # This test can go up to block 400 (2 * CACHE_SIZE). Delay POS activation
+        self.extra_args = [['-nuparams=PoS:401', '-nuparams=PIVX_v3.4:402']]
 
     def log_title(self):
         title = "*** Starting %s ***" % self.__class__.__name__


### PR DESCRIPTION
Simple fix to prevent test failures such as in [this GA job](https://github.com/PIVX-Project/PIVX/pull/2480/checks?check_run_id=3162468067).