### PR TITLE
[Trivial][Doc] Add missing codeblock triple backtick in relnotes file

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -478,6 +478,7 @@ The fee will be equally deducted from the amount of each selected address.
   [\"address\"          (string) Subtract fee from this address\n"
    ,...
   ]
+```
 
 For `fundrawtransaction` a new key (`subtractFeeFromOutputs`) is added to the `options` argument.
 It can be used to specify a list of output indexes.


### PR DESCRIPTION
Trivial. Codeblock in release notes file is not closed, messing up the rest of the markdown.