### PR TITLE
[BugFix] fix app always triggering the tutorial dialog if no manual '-wallet' arg is provided.

### DIFF
--- a/src/qt/pivx.cpp
+++ b/src/qt/pivx.cpp
@@ -686,6 +686,7 @@ int main(int argc, char* argv[])
     // Check if at least one wallet exists, otherwise prompt tutorial
     bool createTutorial{true};
     const fs::path wallet_dir = GetWalletDir();
+    gArgs.SoftSetArg("-wallet", "");
     for (const std::string& wallet_name : gArgs.GetArgs("-wallet")) {
         auto opRes = VerifyWalletPath(wallet_name);
         if (!opRes) throw std::runtime_error(opRes.getError());

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -472,7 +472,7 @@ bool ArgsManager::GetBoolArg(const std::string& strArg, bool fDefault) const
 bool ArgsManager::SoftSetArg(const std::string& strArg, const std::string& strValue)
 {
     LOCK(cs_args);
-    if (IsArgSet(strArg)) return false;;
+    if (IsArgSet(strArg)) return false;
     ForceSetArg(strArg, strValue);
     return true;
 }


### PR DESCRIPTION
As the intro dialog check is executed before calling the 'WalletParameterInteraction()' function in the GUI, the '-wallet' arg soft set is not being performed, skipping the for-loop wallet path check. Always launching the tutorial dialog even when there is an already existent wallet.