### PR TITLE
[Consensus] v5.3 network upgrade.

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -84,7 +84,9 @@ BITCOIN_TEST_SUITE = \
 if ENABLE_WALLET
 BITCOIN_TEST_SUITE += \
   wallet/test/wallet_test_fixture.cpp \
-  wallet/test/wallet_test_fixture.h
+  wallet/test/wallet_test_fixture.h \
+  wallet/test/pos_test_fixture.cpp \
+  wallet/test/pos_test_fixture.h
 endif
 
 # test_pivx binary #

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -175,7 +175,8 @@ SAPLING_TESTS +=\
   test/librust/sapling_rpc_wallet_tests.cpp \
   test/librust/sapling_wallet_tests.cpp \
   wallet/test/wallet_shielded_balances_tests.cpp \
-  wallet/test/wallet_sapling_transactions_validations_tests.cpp
+  wallet/test/wallet_sapling_transactions_validations_tests.cpp \
+  wallet/test/pos_validations_tests.cpp
 endif
 
 test_test_pivx_SOURCES = $(BITCOIN_TEST_SUITE) $(BITCOIN_TESTS) $(SAPLING_TESTS) $(JSON_TEST_FILES) $(RAW_TEST_FILES)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -201,6 +201,8 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_V4_0].nActivationHeight          = 2153200;
         consensus.vUpgrades[Consensus::UPGRADE_V5_0].nActivationHeight          = 2700500;
         consensus.vUpgrades[Consensus::UPGRADE_V5_2].nActivationHeight          = 2927000;
+        consensus.vUpgrades[Consensus::UPGRADE_V5_3].nActivationHeight =
+                Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
         consensus.vUpgrades[Consensus::UPGRADE_V6_0].nActivationHeight =
                 Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
 
@@ -340,6 +342,8 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_V4_0].nActivationHeight          = 201;
         consensus.vUpgrades[Consensus::UPGRADE_V5_0].nActivationHeight          = 201;
         consensus.vUpgrades[Consensus::UPGRADE_V5_2].nActivationHeight          = 262525;
+        consensus.vUpgrades[Consensus::UPGRADE_V5_3].nActivationHeight =
+                Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
         consensus.vUpgrades[Consensus::UPGRADE_V6_0].nActivationHeight =
                 Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
 
@@ -472,6 +476,7 @@ public:
                 Consensus::NetworkUpgrade::ALWAYS_ACTIVE;
         consensus.vUpgrades[Consensus::UPGRADE_V5_0].nActivationHeight          = 300;
         consensus.vUpgrades[Consensus::UPGRADE_V5_2].nActivationHeight          = 300;
+        consensus.vUpgrades[Consensus::UPGRADE_V5_3].nActivationHeight          = 251;
         consensus.vUpgrades[Consensus::UPGRADE_V6_0].nActivationHeight =
                 Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -35,6 +35,7 @@ enum UpgradeIndex : uint32_t {
     UPGRADE_V4_0,
     UPGRADE_V5_0,
     UPGRADE_V5_2,
+    UPGRADE_V5_3,
     UPGRADE_V6_0,
     UPGRADE_TESTDUMMY,
     // NOTE: Also add new upgrades to NetworkUpgradeInfo in upgrades.cpp

--- a/src/consensus/upgrades.cpp
+++ b/src/consensus/upgrades.cpp
@@ -31,7 +31,7 @@ const struct NUInfo NetworkUpgradeInfo[Consensus::MAX_NETWORK_UPGRADES] = {
         },
         {
                 /*.strName =*/ "Zerocoin_v2",
-                /*.strInfo =*/ "new zerocoin serials and zPOS start",
+                /*.strInfo =*/ "New zerocoin serials and zPOS start",
         },
         {
                 /*.strName =*/ "BIP65",
@@ -39,15 +39,15 @@ const struct NUInfo NetworkUpgradeInfo[Consensus::MAX_NETWORK_UPGRADES] = {
         },
         {
                 /*.strName =*/ "Zerocoin_Public",
-                /*.strInfo =*/ "activation of zerocoin public spends (spend v3)",
+                /*.strInfo =*/ "Activation of zerocoin public spends (spend v3)",
         },
         {
                 /*.strName =*/ "PIVX_v3.4",
-                /*.strInfo =*/ "new 256-bit stake modifier - start block v6",
+                /*.strInfo =*/ "New 256-bit stake modifier - start block v6",
         },
         {
                 /*.strName =*/ "PIVX_v4.0",
-                /*.strInfo =*/ "new message sigs - start block v7 - time protocol - zc spend v4",
+                /*.strInfo =*/ "New message sigs - start block v7 - time protocol - zc spend v4",
         },
         {
                 /*.strName =*/ "v5_shield",
@@ -55,7 +55,11 @@ const struct NUInfo NetworkUpgradeInfo[Consensus::MAX_NETWORK_UPGRADES] = {
         },
         {
                 /*.strName =*/ "PIVX_v5.2",
-                /*.strInfo =*/ "new cold-staking rules",
+                /*.strInfo =*/ "New cold-staking rules",
+        },
+        {
+                /*.strName =*/ "PIVX_v5.3",
+                /*.strInfo =*/ "New staking rules",
         },
         {
                 /*.strName =*/ "v6_evo",

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -177,7 +177,7 @@ public:
     std::string GetStrMessage() const override;
     CTxIn GetVin() const { return vinMasternode; };
 
-    bool IsValid(CNode* pnode, std::string& strError);
+    bool IsValid(CNode* pnode, std::string& strError, int chainHeight);
     void Relay();
 
     void AddPayee(const CScript& payeeIn)

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -58,7 +58,7 @@ public:
     const CTxIn GetVin() const { return vin; };
     bool IsNull() const { return blockHash.IsNull() || vin.prevout.IsNull(); }
 
-    bool CheckAndUpdate(int& nDos, bool fRequireAvailable = true, bool fCheckSigTimeOnly = false);
+    bool CheckAndUpdate(int& nDos, int nChainHeight, bool fRequireAvailable = true, bool fCheckSigTimeOnly = false);
     void Relay();
 
     CMasternodePing& operator=(const CMasternodePing& other) = default;
@@ -156,7 +156,7 @@ public:
         Unserialize(s);
     }
 
-    bool UpdateFromNewBroadcast(CMasternodeBroadcast& mnb);
+    bool UpdateFromNewBroadcast(CMasternodeBroadcast& mnb, int chainHeight);
 
     CMasternode::state GetActiveState() const;
 
@@ -243,7 +243,7 @@ public:
     CMasternodeBroadcast(CService newAddr, CTxIn newVin, CPubKey newPubkey, CPubKey newPubkey2, int protocolVersionIn, const CMasternodePing& _lastPing);
     CMasternodeBroadcast(const CMasternode& mn);
 
-    bool CheckAndUpdate(int& nDoS);
+    bool CheckAndUpdate(int& nDoS, int nChainHeight);
     bool CheckInputsAndAdd(int chainHeight, int& nDos);
 
     uint256 GetHash() const;

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -713,7 +713,7 @@ int CMasternodeMan::ProcessMNBroadcast(CNode* pfrom, CMasternodeBroadcast& mnb)
     }
 
     int nDoS = 0;
-    if (!mnb.CheckAndUpdate(nDoS)) {
+    if (!mnb.CheckAndUpdate(nDoS, GetBestHeight())) {
         return nDoS;
     }
 
@@ -747,7 +747,7 @@ int CMasternodeMan::ProcessMNPing(CNode* pfrom, CMasternodePing& mnp)
     if (mapSeenMasternodePing.count(mnpHash)) return 0; //seen
 
     int nDoS = 0;
-    if (mnp.CheckAndUpdate(nDoS)) return 0;
+    if (mnp.CheckAndUpdate(nDoS, GetBestHeight())) return 0;
 
     if (nDoS > 0) {
         // if anything significant failed, mark that node
@@ -894,7 +894,7 @@ void CMasternodeMan::UpdateMasternodeList(CMasternodeBroadcast& mnb)
         CMasternode mn(mnb);
         Add(mn);
     } else {
-        pmn->UpdateFromNewBroadcast(mnb);
+        pmn->UpdateFromNewBroadcast(mnb, GetBestHeight());
     }
 }
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -176,6 +176,7 @@ set(BITCOIN_TESTS
         ${CMAKE_SOURCE_DIR}/src/wallet/test/crypto_tests.cpp
         ${CMAKE_SOURCE_DIR}/src/wallet/test/wallet_shielded_balances_tests.cpp
         ${CMAKE_SOURCE_DIR}/src/wallet/test/wallet_sapling_transactions_validations_tests.cpp
+        ${CMAKE_SOURCE_DIR}/src/wallet/test/pos_validations_tests.cpp
         )
 
 set(test_test_pivx_SOURCES ${BITCOIN_TEST_SUITE} ${BITCOIN_TESTS} ${JSON_TEST_FILES})

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -88,6 +88,8 @@ set(BITCOIN_TEST_SUITE
         ${CMAKE_CURRENT_SOURCE_DIR}/librust/sapling_test_fixture.cpp
         ${CMAKE_SOURCE_DIR}/src/wallet/test/wallet_test_fixture.h
         ${CMAKE_SOURCE_DIR}/src/wallet/test/wallet_test_fixture.cpp
+        ${CMAKE_SOURCE_DIR}/src/wallet/test/pos_test_fixture.h
+        ${CMAKE_SOURCE_DIR}/src/wallet/test/pos_test_fixture.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/librust/utiltest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/librust/utiltest.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/librust/json_test_vectors.h

--- a/src/test/budget_tests.cpp
+++ b/src/test/budget_tests.cpp
@@ -136,7 +136,7 @@ BOOST_FIXTURE_TEST_CASE(block_value_undermint, RegTestingSetup)
     CAmount nBudgetAmtRet = 0;
     // under-minting blocks are invalid after v6
     BOOST_CHECK(IsBlockValueValid(nHeight, nExpectedRet, -1, nBudgetAmtRet));
-    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_V6_0, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_V5_3, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
     BOOST_CHECK(!IsBlockValueValid(nHeight, nExpectedRet, -1, nBudgetAmtRet));
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2935,6 +2935,22 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
         }
     }
 
+    bool fActiveV5_3 = chainparams.GetConsensus().NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V5_3);
+    if (fActiveV5_3 && block.IsProofOfStake()) {
+        CTransactionRef csTx = block.vtx[1];
+        if (csTx->vin.size() > 1) {
+            return state.DoS(100, false, REJECT_INVALID, "bad-cs-multi-inputs", false,
+                             "invalid multi-inputs coinstake");
+        }
+
+        // Prevent multi-empty-outputs
+        for (int i=1; i<csTx->vout.size(); i++ ) {
+            if (csTx->vout[i].IsEmpty()) {
+                return state.DoS(100, false, REJECT_INVALID, "bad-txns-vout-empty");
+            }
+        }
+    }
+
     return true;
 }
 

--- a/src/wallet/test/pos_test_fixture.cpp
+++ b/src/wallet/test/pos_test_fixture.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2021 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include "wallet/test/pos_test_fixture.h"
+#include "wallet/wallet.h"
+
+#include <boost/test/unit_test.hpp>
+
+TestPoSChainSetup::TestPoSChainSetup() : TestChainSetup(0)
+{
+    initZKSNARKS(); // init zk-snarks lib
+
+    bool fFirstRun;
+    pwalletMain = std::make_unique<CWallet>("testWallet", CWalletDBWrapper::CreateMock());
+    pwalletMain->LoadWallet(fFirstRun);
+    RegisterValidationInterface(pwalletMain.get());
+
+    {
+        LOCK(pwalletMain->cs_wallet);
+        pwalletMain->SetMinVersion(FEATURE_SAPLING);
+        gArgs.ForceSetArg("-keypool", "5");
+        pwalletMain->SetupSPKM(true);
+
+        // import coinbase key used to generate the 100-blocks chain
+        BOOST_CHECK(pwalletMain->AddKeyPubKey(coinbaseKey, coinbaseKey.GetPubKey()));
+    }
+
+    int posActivation = Params().GetConsensus().vUpgrades[Consensus::UPGRADE_POS].nActivationHeight - 1;
+    for (int i = 0; i < posActivation; i++) {
+        CBlock b = CreateAndProcessBlock({}, coinbaseKey);
+        coinbaseTxns.emplace_back(*b.vtx[0]);
+    }
+}
+
+TestPoSChainSetup::~TestPoSChainSetup()
+{
+    SyncWithValidationInterfaceQueue();
+    UnregisterValidationInterface(pwalletMain.get());
+}

--- a/src/wallet/test/pos_test_fixture.h
+++ b/src/wallet/test/pos_test_fixture.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#ifndef PIVX_POS_TEST_FIXTURE_H
+#define PIVX_POS_TEST_FIXTURE_H
+
+#include "test/test_pivx.h"
+
+class CWallet;
+
+/*
+ * A text fixture with a preloaded 250-blocks regtest chain running running on PoS
+ * and a wallet containing the key used for the coinbase outputs.
+ */
+struct TestPoSChainSetup: public TestChainSetup
+{
+    std::unique_ptr<CWallet> pwalletMain;
+
+    TestPoSChainSetup();
+    ~TestPoSChainSetup();
+};
+
+#endif // PIVX_POS_TEST_FIXTURE_H

--- a/src/wallet/test/pos_validations_tests.cpp
+++ b/src/wallet/test/pos_validations_tests.cpp
@@ -1,0 +1,91 @@
+// Copyright (c) 2020 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include "wallet/test/pos_test_fixture.h"
+
+#include "blockassembler.h"
+#include "util/blockstatecatcher.h"
+#include "blocksignature.h"
+#include "consensus/merkle.h"
+#include "primitives/block.h"
+#include "script/sign.h"
+#include "test/util/blocksutil.h"
+#include "wallet/wallet.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(pos_validations_tests)
+
+void reSignTx(CMutableTransaction& mtx,
+              const std::vector<CTxOut>& txPrevOutputs,
+              CWallet* wallet)
+{
+    CTransaction txNewConst(mtx);
+    for (int index=0; index < (int) txPrevOutputs.size(); index++) {
+        const CTxOut& prevOut = txPrevOutputs.at(index);
+        SignatureData sigdata;
+        BOOST_ASSERT(ProduceSignature(
+                TransactionSignatureCreator(wallet, &txNewConst, index, prevOut.nValue, SIGHASH_ALL),
+                prevOut.scriptPubKey,
+                sigdata,
+                txNewConst.GetRequiredSigVersion(),
+                true));
+        UpdateTransaction(mtx, index, sigdata);
+    }
+}
+
+BOOST_FIXTURE_TEST_CASE(coinstake_tests, TestPoSChainSetup)
+{
+    // Verify that we are at block 251
+    BOOST_CHECK_EQUAL(WITH_LOCK(cs_main, return chainActive.Tip()->nHeight), 250);
+    SyncWithValidationInterfaceQueue();
+
+    // Let's create the block
+    std::vector<CStakeableOutput> availableCoins;
+    BOOST_CHECK(pwalletMain->StakeableCoins(&availableCoins));
+    std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler(
+            Params(), false).CreateNewBlock(CScript(),
+                                            pwalletMain.get(),
+                                            true,
+                                            &availableCoins,
+                                            true);
+    std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>(pblocktemplate->block);
+    BOOST_CHECK(pblock->IsProofOfStake());
+
+    // Add a second input to a coinstake
+    CMutableTransaction mtx(*pblock->vtx[1]);
+    const CStakeableOutput& in2 = availableCoins.back();
+    availableCoins.pop_back();
+    CTxIn vin2(in2.tx->GetHash(), in2.i);
+    mtx.vin.emplace_back(vin2);
+
+    CTxOut prevOutput1 = pwalletMain->GetWalletTx(mtx.vin[0].prevout.hash)->tx->vout[mtx.vin[0].prevout.n];
+    std::vector<CTxOut> txPrevOutputs{prevOutput1, in2.tx->tx->vout[in2.i]};
+
+    reSignTx(mtx, txPrevOutputs, pwalletMain.get());
+    pblock->vtx[1] = MakeTransactionRef(mtx);
+    pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
+    BOOST_CHECK(SignBlock(*pblock, *pwalletMain));
+    ProcessBlockAndCheckRejectionReason(pblock, "bad-cs-multi-inputs", 250);
+
+    // Check multi-empty-outputs now
+    pblock = std::make_shared<CBlock>(pblocktemplate->block);
+    mtx = CMutableTransaction(*pblock->vtx[1]);
+    for (int i = 0; i < 999; ++i) {
+        mtx.vout.emplace_back();
+        mtx.vout.back().SetEmpty();
+    }
+    reSignTx(mtx, {prevOutput1}, pwalletMain.get());
+    pblock->vtx[1] = MakeTransactionRef(mtx);
+    pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
+    BOOST_CHECK(SignBlock(*pblock, *pwalletMain));
+    ProcessBlockAndCheckRejectionReason(pblock, "bad-txns-vout-empty", 250);
+
+    // Now connect the proper block
+    pblock = std::make_shared<CBlock>(pblocktemplate->block);
+    ProcessNewBlock(pblock, nullptr);
+    BOOST_CHECK_EQUAL(WITH_LOCK(cs_main, return chainActive.Tip()->GetBlockHash()), pblock->GetHash());
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Grouped the consensus changes for the coming v5.3 upgrade.

There is no enforcement height defined to not set it until everything is ready but.. we aren't far from be able to enforce it on testnet and start testing the release deeply, only have to merge #2411 and can be done.