### PR TITLE
[Scripts] Ensure UTF8 encoding for ASCII file operations in python scripts

### DIFF
--- a/contrib/devtools/update-translations.py
+++ b/contrib/devtools/update-translations.py
@@ -238,7 +238,7 @@ def update_build_systems():
     filename_lang.sort(key=lambda x: x[0])
 
     # update qrc locales
-    with open('src/qt/pivx_locale.qrc', 'w') as f:
+    with open('src/qt/pivx_locale.qrc', 'w', encoding="utf8") as f:
         f.write('<!DOCTYPE RCC><RCC version="1.0">\n')
         f.write('    <qresource prefix="/translations">\n')
         for (filename, basename, lang) in filename_lang:
@@ -247,7 +247,7 @@ def update_build_systems():
         f.write('</RCC>\n')
 
     # update Makefile include
-    with open('src/Makefile.qt_locale.include', 'w') as f:
+    with open('src/Makefile.qt_locale.include', 'w', encoding="utf8") as f:
         f.write('QT_TS = \\\n')
         f.write(' \\\n'.join(f'  qt/locale/{filename}' for (filename, basename, lang) in filename_lang))
         f.write('\n') # make sure last line doesn't end with a backslash

--- a/contrib/gitian-build.py
+++ b/contrib/gitian-build.py
@@ -293,7 +293,7 @@ def main():
             args.is_fedora = True
         if os.path.isfile('/etc/centos-release'):
             args.is_centos = True
-        if os.path.isfile('/proc/version') and open('/proc/version', 'r').read().find('Microsoft'):
+        if os.path.isfile('/proc/version') and open('/proc/version', 'r', encoding="utf8").read().find('Microsoft'):
             args.is_wsl = True
 
     if args.kvm and args.docker:

--- a/contrib/linearize/linearize-data.py
+++ b/contrib/linearize/linearize-data.py
@@ -70,7 +70,7 @@ def get_blk_dt(blk_hdr):
 
 def get_block_hashes(settings):
 	blkindex = []
-	f = open(settings['hashlist'], "r")
+	f = open(settings['hashlist'], "r", encoding="utf8")
 	for line in f:
 		line = line.rstrip()
 		blkindex.append(line)
@@ -249,7 +249,7 @@ if __name__ == '__main__':
 		print("Usage: linearize-data.py CONFIG-FILE")
 		sys.exit(1)
 
-	f = open(sys.argv[1])
+	f = open(sys.argv[1], encoding="utf8")
 	for line in f:
 		# skip comment lines
 		m = re.search('^\s*#', line)

--- a/contrib/linearize/linearize-hashes.py
+++ b/contrib/linearize/linearize-hashes.py
@@ -79,7 +79,7 @@ if __name__ == '__main__':
 		print("Usage: linearize-hashes.py CONFIG-FILE")
 		sys.exit(1)
 
-	f = open(sys.argv[1])
+	f = open(sys.argv[1], encoding="utf8")
 	for line in f:
 		# skip comment lines
 		m = re.search('^\s*#', line)

--- a/share/qt/extract_strings_qt.py
+++ b/share/qt/extract_strings_qt.py
@@ -62,7 +62,7 @@ child = Popen([XGETTEXT,'--output=-','-n','--keyword=_'] + files, stdout=PIPE)
 
 messages = parse_po(out.decode('utf-8'))
 
-f = open(OUT_CPP, 'w')
+f = open(OUT_CPP, 'w', encoding="utf8")
 f.write("""
 
 #include <QtGlobal>

--- a/test/functional/combine_logs.py
+++ b/test/functional/combine_logs.py
@@ -113,7 +113,7 @@ def get_log_events(source, logfile):
     Log events may be split over multiple lines. We use the timestamp
     regex match as the marker for a new log event."""
     try:
-        with open(logfile, 'r') as infile:
+        with open(logfile, 'r', encoding="utf8") as infile:
             event = ''
             timestamp = ''
             for line in infile:

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -527,7 +527,7 @@ class PivxTestFramework():
                 if i == 0:
                     # Add .incomplete flagfile
                     # (removed at the end during clean_cache_subdir)
-                    open(os.path.join(datadir, ".incomplete"), 'a').close()
+                    open(os.path.join(datadir, ".incomplete"), 'a', encoding="utf8").close()
                 args = [os.getenv("BITCOIND", "pivxd"), "-spendzeroconfchange=1", "-server", "-keypool=1",
                         "-datadir=" + datadir, "-discover=0"]
                 self.nodes.append(
@@ -1147,7 +1147,7 @@ class PivxTestFramework():
                                                  collateralTxId,
                                                  collateralTxId_n)
         destPath = os.path.join(mnOwnerDirPath, "masternode.conf")
-        with open(destPath, "a+") as file_object:
+        with open(destPath, "a+", encoding="utf8") as file_object:
             file_object.write("\n")
             file_object.write(confData)
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -335,7 +335,7 @@ def get_auth_cookie(datadir):
                     assert password is None  # Ensure that there is only one rpcpassword line
                     password = line.split("=")[1].strip("\n")
     if os.path.isfile(os.path.join(datadir, "regtest", ".cookie")):
-        with open(os.path.join(datadir, "regtest", ".cookie"), 'r') as f:
+        with open(os.path.join(datadir, "regtest", ".cookie"), 'r', encoding="utf8") as f:
             userpass = f.read()
             split_userpass = userpass.split(':')
             user = split_userpass[0]

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -688,7 +688,7 @@ class RPCCoverage():
         if not os.path.isfile(coverage_ref_filename):
             raise RuntimeError("No coverage reference found")
 
-        with open(coverage_ref_filename, 'r') as f:
+        with open(coverage_ref_filename, 'r', encoding="utf8") as f:
             all_cmds.update([i.strip() for i in f.readlines()])
 
         for root, dirs, files in os.walk(self.dir):
@@ -697,7 +697,7 @@ class RPCCoverage():
                     coverage_filenames.add(os.path.join(root, filename))
 
         for filename in coverage_filenames:
-            with open(filename, 'r') as f:
+            with open(filename, 'r', encoding="utf8") as f:
                 covered_cmds.update([i.strip() for i in f.readlines()])
 
         return all_cmds - covered_cmds

--- a/test/functional/tiertwo_masternode_ping.py
+++ b/test/functional/tiertwo_masternode_ping.py
@@ -67,7 +67,7 @@ class MasternodePingTest(PivxTestFramework):
         confData = masternodeAlias + " 127.0.0.1:" + str(p2p_port(2)) + " " + \
                    str(mnPrivkey) +  " " + str(collateralTxId) + " " + str(vout)
         destPath = os.path.join(self.options.tmpdir, "node1", "regtest", "masternode.conf")
-        with open(destPath, "a+") as file_object:
+        with open(destPath, "a+", encoding="utf8") as file_object:
             file_object.write("\n")
             file_object.write(confData)
 

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -88,7 +88,7 @@ class MultiWalletTest(PivxTestFramework):
         self.nodes[0].assert_start_raises_init_error(['-walletdir=bad'], 'Error: Specified -walletdir "bad" does not exist')
         # should not initialize if the specified walletdir is not a directory
         not_a_dir = wallet_dir('notadir')
-        open(not_a_dir, 'a').close()
+        open(not_a_dir, 'a', encoding="utf8").close()
         self.nodes[0].assert_start_raises_init_error(['-walletdir=' + not_a_dir], 'Error: Specified -walletdir "' + not_a_dir + '" is not a directory')
 
         self.log.info("Do not allow -zapwallettxes with multiwallet")

--- a/test/lint/check-doc.py
+++ b/test/lint/check-doc.py
@@ -25,8 +25,8 @@ REGEX_DOC = re.compile(r'HelpMessageOpt\(\"(\-[^\"=]+?)(?:=|\")')
 SET_DOC_OPTIONAL = set(['-rpcssl', '-benchmark', '-h', '-help', '-socks', '-tor', '-debugnet', '-whitelistalwaysrelay', '-prematurewitness', '-walletprematurewitness', '-promiscuousmempoolflags', '-blockminsize', '-checklevel', '-liquidityprovider', '-anonymizepivxamount', '-dbcrashratio'])
 
 def main():
-    used = check_output(CMD_GREP_ARGS, shell=True, universal_newlines=True)
-    docd = check_output(CMD_GREP_DOCS, shell=True, universal_newlines=True)
+    used = check_output(CMD_GREP_ARGS, shell=True, universal_newlines=True, encoding="utf8")
+    docd = check_output(CMD_GREP_DOCS, shell=True, universal_newlines=True, encoding="utf8")
 
     args_used = set(re.findall(re.compile(REGEX_ARG), used))
     args_docd = set(re.findall(re.compile(REGEX_DOC), docd)).union(SET_DOC_OPTIONAL)

--- a/test/lint/lint-python-utf8-encoding.sh
+++ b/test/lint/lint-python-utf8-encoding.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018-2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Make sure we explicitly open all text files using UTF-8 (or ASCII) encoding to
+# avoid potential issues on the BSDs where the locale is not always set.
+
+export LC_ALL=C
+EXIT_CODE=0
+OUTPUT=$(git grep " open(" -- "*.py" ":(exclude)src/crc32c/" | grep -vE "encoding=.(ascii|utf8|utf-8)." | grep -vE "open\([^,]*, ['\"][^'\"]*b[^'\"]*['\"]")
+if [[ ${OUTPUT} != "" ]]; then
+    echo "Python's open(...) seems to be used to open text files without explicitly"
+    echo "specifying encoding=\"utf8\":"
+    echo
+    echo "${OUTPUT}"
+    EXIT_CODE=1
+fi
+OUTPUT=$(git grep "check_output(" -- "*.py" ":(exclude)src/crc32c/"| grep "universal_newlines=True" | grep -vE "encoding=.(ascii|utf8|utf-8).")
+if [[ ${OUTPUT} != "" ]]; then
+    echo "Python's check_output(...) seems to be used to get program outputs without explicitly"
+    echo "specifying encoding=\"utf8\":"
+    echo
+    echo "${OUTPUT}"
+    EXIT_CODE=1
+fi
+exit ${EXIT_CODE}

--- a/test/lint/lint-whitespace.sh
+++ b/test/lint/lint-whitespace.sh
@@ -40,14 +40,14 @@ if [ -z "${COMMIT_RANGE}" ]; then
 fi
 
 showdiff() {
-  if ! git diff -U0 "${COMMIT_RANGE}" -- "." ":(exclude)depends/patches/" ":(exclude)src/chiabls" ":(exclude)src/leveldb/" ":(exclude)src/secp256k1/" ":(exclude)src/univalue/" ":(exclude)doc/release-notes.md" ":(exclude)doc/release-notes/" ":(exclude)build-aux/snap/local/patches/"; then
+  if ! git diff -U0 "${COMMIT_RANGE}" -- "." ":(exclude)depends/patches/" ":(exclude)src/chiabls" ":(exclude)src/leveldb/" ":(exclude)src/secp256k1/" ":(exclude)src/univalue/" ":(exclude)doc/release-notes.md" ":(exclude)doc/release-notes/" ":(exclude)build-aux/snap/local/patches/" ":(exclude)contrib/linearize/"; then
     echo "Failed to get a diff"
     exit 1
   fi
 }
 
 showcodediff() {
-  if ! git diff -U0 "${COMMIT_RANGE}" -- *.cpp *.h *.md *.py *.sh ":(exclude)src/chiabls" ":(exclude)src/leveldb/" ":(exclude)src/secp256k1/" ":(exclude)src/univalue/" ":(exclude)doc/release-notes.md" ":(exclude)doc/release-notes/" ":(exclude)build-aux/snap/local/patches/"; then
+  if ! git diff -U0 "${COMMIT_RANGE}" -- *.cpp *.h *.md *.py *.sh ":(exclude)src/chiabls" ":(exclude)src/leveldb/" ":(exclude)src/secp256k1/" ":(exclude)src/univalue/" ":(exclude)doc/release-notes.md" ":(exclude)doc/release-notes/" ":(exclude)build-aux/snap/local/patches/" ":(exclude)contrib/linearize/"; then
     echo "Failed to get a diff"
     exit 1
   fi

--- a/test/lint/logprint-scanner.py
+++ b/test/lint/logprint-scanner.py
@@ -29,7 +29,7 @@ def countRelevantCommas(line):
     return numRelevantCommas
 
 if __name__ == "__main__":
-    out = check_output("git rev-parse --show-toplevel", shell=True, universal_newlines=True)
+    out = check_output("git rev-parse --show-toplevel", shell=True, universal_newlines=True, encoding="utf8")
     srcDir = out.rstrip() + "/src/"
 
     filelist = [os.path.join(dp, f) for dp, dn, filenames in os.walk(srcDir) for f in filenames if os.path.splitext(f)[1] == '.cpp' or os.path.splitext(f)[1] == '.h' ]


### PR DESCRIPTION
Unspecified encoding can lead to inconsistent behavior or results across platforms when dealing with ascii files.

This resolves such issues and adds a CI lint script to also ensure no regressions occur in the future.

---------

Note: the 3rd commit is included to explicitly exclude the unused and outdated linearize scripts from the whitespace linter, as both of them use tabs instead of spaces, and have not been updated to use python3. Alternatively, we can remove the linearize scripts entirely (as they are currently not used) now, and update/re-add them later if or when their use is needed.