### PR TITLE
[Bug] Fix improper locking on Windows WSL1 environments

### DIFF
--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -8,7 +8,9 @@
 #ifndef WIN32
 #include <fcntl.h>
 #else
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <codecvt>
 #include <windows.h>
 #endif

--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -7,6 +7,9 @@
 
 #ifndef WIN32
 #include <fcntl.h>
+#include <string>
+#include <sys/file.h>
+#include <sys/utsname.h>
 #else
 #ifndef NOMINMAX
 #define NOMINMAX
@@ -49,20 +52,38 @@ FileLock::~FileLock()
     }
 }
 
+static bool IsWSL()
+{
+    struct utsname uname_data;
+    return uname(&uname_data) == 0 && std::string(uname_data.version).find("Microsoft") != std::string::npos;
+}
+
 bool FileLock::TryLock()
 {
     if (fd == -1) {
         return false;
     }
-    struct flock lock;
-    lock.l_type = F_WRLCK;
-    lock.l_whence = SEEK_SET;
-    lock.l_start = 0;
-    lock.l_len = 0;
-    if (fcntl(fd, F_SETLK, &lock) == -1) {
-        reason = GetErrorReason();
-        return false;
+
+    // Exclusive file locking is broken on WSL using fcntl (issue #18622)
+    // This workaround can be removed once the bug on WSL is fixed
+    static const bool is_wsl = IsWSL();
+    if (is_wsl) {
+        if (flock(fd, LOCK_EX | LOCK_NB) == -1) {
+            reason = GetErrorReason();
+            return false;
+        }
+    } else {
+        struct flock lock;
+        lock.l_type = F_WRLCK;
+        lock.l_whence = SEEK_SET;
+        lock.l_start = 0;
+        lock.l_len = 0;
+        if (fcntl(fd, F_SETLK, &lock) == -1) {
+            reason = GetErrorReason();
+            return false;
+        }
     }
+
     return true;
 }
 #else


### PR DESCRIPTION
Straight forward backport of https://github.com/bitcoin/bitcoin/pull/15782 and https://github.com/bitcoin/bitcoin/pull/18700 to address a bug in WSL1 environments that results in improper locking behavior; ie, a directory lock is not made exclusive as intended, thus resulting in multiple instances of the wallet/daemon being able to access the same datadir simultaneously instead of erroring out due to a locking conflict as intended.

This is specific to WSL1 environments, as WSL2 (not yet fully supported/documented), standard linux, and macOS environments behave as intended. 