### PR TITLE
[BUG][RPC] Fix listmasternodes and getmasternodewinners

### DIFF
--- a/src/budget/budgetmanager.cpp
+++ b/src/budget/budgetmanager.cpp
@@ -899,10 +899,10 @@ bool CBudgetManager::AddAndRelayProposalVote(const CBudgetVote& vote, std::strin
 
 void CBudgetManager::UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload)
 {
-    NewBlock(pindexNew->nHeight);
+    NewBlock();
 }
 
-void CBudgetManager::NewBlock(int height)
+void CBudgetManager::NewBlock()
 {
     if (masternodeSync.RequestedMasternodeAssets <= MASTERNODE_SYNC_BUDGET) return;
 

--- a/src/budget/budgetmanager.cpp
+++ b/src/budget/budgetmanager.cpp
@@ -897,10 +897,13 @@ bool CBudgetManager::AddAndRelayProposalVote(const CBudgetVote& vote, std::strin
     return false;
 }
 
+void CBudgetManager::UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload)
+{
+    NewBlock(pindexNew->nHeight);
+}
+
 void CBudgetManager::NewBlock(int height)
 {
-    SetBestHeight(height);
-
     if (masternodeSync.RequestedMasternodeAssets <= MASTERNODE_SYNC_BUDGET) return;
 
     if (strBudgetMode == "suggest") { //suggest the budget we see

--- a/src/budget/budgetmanager.h
+++ b/src/budget/budgetmanager.h
@@ -98,7 +98,7 @@ public:
     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
     /// Process the message and returns the ban score (0 if no banning is needed)
     int ProcessMessageInner(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
-    void NewBlock(int height);
+    void NewBlock();
 
     int ProcessBudgetVoteSync(const uint256& nProp, CNode* pfrom);
     int ProcessProposal(CBudgetProposal& proposal);

--- a/src/budget/budgetmanager.h
+++ b/src/budget/budgetmanager.h
@@ -8,13 +8,14 @@
 
 #include "budget/budgetproposal.h"
 #include "budget/finalizedbudget.h"
+#include "validationinterface.h"
 
 class CValidationState;
 
 //
 // Budget Manager : Contains all proposals for the budget
 //
-class CBudgetManager
+class CBudgetManager : public CValidationInterface
 {
 protected:
     // map budget hash --> CollTx hash.
@@ -59,6 +60,8 @@ public:
         WITH_LOCK(cs_votes, mapSeenProposalVotes.clear(); );
         WITH_LOCK(cs_finalizedvotes, mapSeenFinalizedBudgetVotes.clear(); );
     }
+
+    void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
 
     bool HaveProposal(const uint256& propHash) const { LOCK(cs_proposals); return mapProposals.count(propHash); }
     bool HaveSeenProposalVote(const uint256& voteHash) const { LOCK(cs_votes); return mapSeenProposalVotes.count(voteHash); }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1845,10 +1845,14 @@ bool AppInitMain()
     g_budgetman.ResetSync();
     g_budgetman.ClearSeen();
 
+    RegisterValidationInterface(&g_budgetman);
+
     uiInterface.InitMessage(_("Loading masternode payment cache..."));
 
     CMasternodePaymentDB mnpayments;
     CMasternodePaymentDB::ReadResult readResult3 = mnpayments.Read(masternodePayments);
+
+    RegisterValidationInterface(&masternodePayments);
 
     if (readResult3 == CMasternodePaymentDB::FileError)
         LogPrintf("Missing masternode payment cache - mnpayments.dat, will try to recreate\n");

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -621,18 +621,18 @@ std::string CMasternodeBlockPayees::GetRequiredPaymentsString()
 {
     LOCK(cs_vecPayments);
 
-    std::string ret = "Unknown";
+    std::string ret = "";
 
     for (CMasternodePayee& payee : vecPayments) {
         CTxDestination address1;
         ExtractDestination(payee.scriptPubKey, address1);
-        if (ret != "Unknown") {
+        if (ret != "") {
             ret += ", ";
         }
-        ret = EncodeDestination(address1) + ":" + std::to_string(payee.nVotes);
+        ret += EncodeDestination(address1) + ":" + std::to_string(payee.nVotes);
     }
 
-    return ret;
+    return ret.empty() ? "Unknown" : ret;
 }
 
 std::string CMasternodePayments::GetRequiredPaymentsString(int nBlockHeight)

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -702,6 +702,13 @@ void CMasternodePayments::CleanPaymentList(int mnCount, int nHeight)
     }
 }
 
+void CMasternodePayments::UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload)
+{
+    if (masternodeSync.RequestedMasternodeAssets > MASTERNODE_SYNC_LIST) {
+        ProcessBlock(pindexNew->nHeight + 10);
+    }
+}
+
 void CMasternodePayments::ProcessBlock(int nBlockHeight)
 {
     // No more mnw messages after transition to DMN

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -8,6 +8,7 @@
 
 #include "key.h"
 #include "masternode.h"
+#include "validationinterface.h"
 
 
 extern RecursiveMutex cs_vecPayments;
@@ -203,7 +204,7 @@ public:
 // Keeps track of who should get paid for which blocks
 //
 
-class CMasternodePayments
+class CMasternodePayments : public CValidationInterface
 {
 private:
     int nLastBlockHeight;
@@ -224,6 +225,8 @@ public:
         mapMasternodeBlocks.clear();
         mapMasternodePayeeVotes.clear();
     }
+
+    void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
 
     bool AddWinningMasternode(CMasternodePaymentWinner& winner);
     void ProcessBlock(int nBlockHeight);

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -233,7 +233,7 @@ UniValue listmasternodes(const JSONRPCRequest& request)
         LookupHost(strHost.c_str(), node, false);
         std::string strNetwork = GetNetworkName(node.GetNetwork());
 
-        obj.pushKV("rank", (strStatus == "ENABLED" ? pos : 0));
+        obj.pushKV("rank", (strStatus == "ENABLED" ? pos : -1));
         obj.pushKV("type", "legacy");
         obj.pushKV("network", strNetwork);
         obj.pushKV("txhash", strTxHash);

--- a/test/functional/tiertwo_governance_sync_basic.py
+++ b/test/functional/tiertwo_governance_sync_basic.py
@@ -71,6 +71,7 @@ class MasternodeGovernanceBasicTest(PivxTier2TestFramework):
     def check_vote_existence(self, proposalName, mnCollateralHash, voteType, voteValid):
         for i in range(0, len(self.nodes)):
             node = self.nodes[i]
+            node.syncwithvalidationinterfacequeue()
             votesInfo = node.getbudgetvotes(proposalName)
             assert(len(votesInfo) > 0)
             found = False


### PR DESCRIPTION
Fix a couple RPC bugs related to masternode calls:
- rank for not-ENABLED masternodes in `listmasternods` should be `-1`
- `getmasternodewinners` not returning all payees (in case of multiple winners).

Also move the update of the cached height for the tiertwo managers to `ConnectTip` (and the block processing to the background thread).