### PR TITLE
[RPC][Net] Add getnodeaddresses RPC command

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -369,6 +369,30 @@ Low-level RPC changes
   now the empty string `""` instead of `"wallet.dat"`. If PIVX is started
   with any `-wallet=<path>` options, there is no change in behavior, and the
   name of any wallet is just its `<path>` string.
+  
+### New RPC Commands
+
+* `getnodeaddresses`
+    ```
+    getnodeaddresses ( count "network" )
+
+    Return known addresses which can potentially be used to find new nodes in the network
+
+    Arguments:
+    1. count      (numeric, optional) The maximum number of addresses to return. Specify 0 to return all known addresses.
+    2. "network"  (string, optional) Return only addresses of the specified network. Can be one of: ipv4, ipv6, onion.
+    Result:
+    [
+      {
+        "time": ttt,          (numeric) Timestamp in seconds since epoch (Jan 1 1970 GMT) when the node was last seen
+        "services": n,        (numeric) The services offered by the node
+        "address": "host",    (string) The address of the node
+        "port": n,            (numeric) The port number of the node
+        "network": "xxxx"     (string) The network (ipv4, ipv6, onion) the node connected through
+      }
+      ,...
+    ]
+    ```
 
 Database cache memory increased
 --------------------------------

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -481,11 +481,15 @@ int CAddrMan::Check_()
 }
 #endif
 
-void CAddrMan::GetAddr_(std::vector<CAddress>& vAddr)
+void CAddrMan::GetAddr_(std::vector<CAddress>& vAddr, size_t max_addresses, size_t max_pct)
 {
-    unsigned int nNodes = ADDRMAN_GETADDR_MAX_PCT * vRandom.size() / 100;
-    if (nNodes > ADDRMAN_GETADDR_MAX)
-        nNodes = ADDRMAN_GETADDR_MAX;
+    size_t nNodes = vRandom.size();
+    if (max_pct != 0) {
+        nNodes = max_pct * nNodes / 100;
+    }
+    if (max_addresses != 0) {
+        nNodes = std::min(nNodes, max_addresses);
+    }
 
     // gather a list of random nodes, skipping those of low quality
     for (unsigned int n = 0; n < vRandom.size(); n++) {

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -494,6 +494,7 @@ void CAddrMan::GetAddr_(std::vector<CAddress>& vAddr, size_t max_addresses, size
     }
 
     // gather a list of random nodes, skipping those of low quality
+    const int64_t now{GetAdjustedTime()};
     for (unsigned int n = 0; n < vRandom.size(); n++) {
         if (vAddr.size() >= nNodes)
             break;
@@ -508,7 +509,7 @@ void CAddrMan::GetAddr_(std::vector<CAddress>& vAddr, size_t max_addresses, size
         if (network != nullopt && ai.GetNetClass() != network) continue;
 
         // Filter for quality
-        if (ai.IsTerrible()) continue;
+        if (ai.IsTerrible(now)) continue;
 
         vAddr.push_back(ai);
     }

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -7,8 +7,10 @@
 #include "addrman.h"
 
 #include "hash.h"
-#include "streams.h"
 #include "logging.h"
+#include "netaddress.h"
+#include "optional.h"
+#include "streams.h"
 #include "serialize.h"
 
 
@@ -481,7 +483,7 @@ int CAddrMan::Check_()
 }
 #endif
 
-void CAddrMan::GetAddr_(std::vector<CAddress>& vAddr, size_t max_addresses, size_t max_pct)
+void CAddrMan::GetAddr_(std::vector<CAddress>& vAddr, size_t max_addresses, size_t max_pct, Optional<Network> network)
 {
     size_t nNodes = vRandom.size();
     if (max_pct != 0) {
@@ -501,8 +503,14 @@ void CAddrMan::GetAddr_(std::vector<CAddress>& vAddr, size_t max_addresses, size
         assert(mapInfo.count(vRandom[n]) == 1);
 
         const CAddrInfo& ai = mapInfo[vRandom[n]];
-        if (!ai.IsTerrible())
-            vAddr.push_back(ai);
+
+        // Filter by network (optional)
+        if (network != nullopt && ai.GetNetClass() != network) continue;
+
+        // Filter for quality
+        if (ai.IsTerrible()) continue;
+
+        vAddr.push_back(ai);
     }
 }
 

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -159,12 +159,6 @@ public:
 //! how recent a successful connection should be before we allow an address to be evicted from tried
 #define ADDRMAN_REPLACEMENT_HOURS 4
 
-//! the maximum percentage of nodes to return in a getaddr call
-#define ADDRMAN_GETADDR_MAX_PCT 23
-
-//! the maximum number of nodes to return in a getaddr call
-#define ADDRMAN_GETADDR_MAX 2500
-
 //! Convenience
 #define ADDRMAN_TRIED_BUCKET_COUNT (1 << ADDRMAN_TRIED_BUCKET_COUNT_LOG2)
 #define ADDRMAN_NEW_BUCKET_COUNT (1 << ADDRMAN_NEW_BUCKET_COUNT_LOG2)
@@ -289,7 +283,7 @@ protected:
 #endif
 
     //! Select several addresses at once.
-    void GetAddr_(std::vector<CAddress>& vAddr) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void GetAddr_(std::vector<CAddress>& vAddr, size_t max_addresses, size_t max_pct) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     //! Mark an entry as currently-connected-to.
     void Connected_(const CService& addr, int64_t nTime) EXCLUSIVE_LOCKS_REQUIRED(cs);
@@ -703,13 +697,13 @@ public:
     }
 
     //! Return a bunch of addresses, selected at random.
-    std::vector<CAddress> GetAddr()
+    std::vector<CAddress> GetAddr(size_t max_addresses, size_t max_pct)
     {
         Check();
         std::vector<CAddress> vAddr;
         {
             LOCK(cs);
-            GetAddr_(vAddr);
+            GetAddr_(vAddr, max_addresses, max_pct);
         }
         Check();
         return vAddr;

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -13,6 +13,7 @@
 
 #include "clientversion.h"
 #include "netaddress.h"
+#include "optional.h"
 #include "protocol.h"
 #include "random.h"
 #include "sync.h"
@@ -282,8 +283,15 @@ protected:
     int Check_() EXCLUSIVE_LOCKS_REQUIRED(cs);
 #endif
 
-    //! Select several addresses at once.
-    void GetAddr_(std::vector<CAddress>& vAddr, size_t max_addresses, size_t max_pct) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    /**
+     * Return all or many randomly selected addresses, optionally by network.
+     *
+     * @param[out] vAddr         Vector of randomly selected addresses from vRandom.
+     * @param[in] max_addresses  Maximum number of addresses to return (0 = all).
+     * @param[in] max_pct        Maximum percentage of addresses to return (0 = all).
+     * @param[in] network        Select only addresses of this network (nullopt = all).
+     */
+    void GetAddr_(std::vector<CAddress>& vAddr, size_t max_addresses, size_t max_pct, Optional<Network> network = nullopt) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     //! Mark an entry as currently-connected-to.
     void Connected_(const CService& addr, int64_t nTime) EXCLUSIVE_LOCKS_REQUIRED(cs);

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -291,7 +291,7 @@ protected:
      * @param[in] max_pct        Maximum percentage of addresses to return (0 = all).
      * @param[in] network        Select only addresses of this network (nullopt = all).
      */
-    void GetAddr_(std::vector<CAddress>& vAddr, size_t max_addresses, size_t max_pct, Optional<Network> network = nullopt) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void GetAddr_(std::vector<CAddress>& vAddr, size_t max_addresses, size_t max_pct, Optional<Network> network) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     //! Mark an entry as currently-connected-to.
     void Connected_(const CService& addr, int64_t nTime) EXCLUSIVE_LOCKS_REQUIRED(cs);
@@ -704,14 +704,20 @@ public:
         return addrRet;
     }
 
-    //! Return a bunch of addresses, selected at random.
-    std::vector<CAddress> GetAddr(size_t max_addresses, size_t max_pct)
+    /**
+     * Return all or many randomly selected addresses, optionally by network.
+     *
+     * @param[in] max_addresses  Maximum number of addresses to return (0 = all).
+     * @param[in] max_pct        Maximum percentage of addresses to return (0 = all).
+     * @param[in] network        Select only addresses of this network (nullopt = all).
+     */
+    std::vector<CAddress> GetAddr(size_t max_addresses, size_t max_pct, Optional<Network> network)
     {
         Check();
         std::vector<CAddress> vAddr;
         {
             LOCK(cs);
-            GetAddr_(vAddr, max_addresses, max_pct);
+            GetAddr_(vAddr, max_addresses, max_pct, network);
         }
         Check();
         return vAddr;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -16,6 +16,7 @@
 #include "crypto/common.h"
 #include "crypto/sha256.h"
 #include "guiinterface.h"
+#include "netaddress.h"
 #include "netbase.h"
 #include "netmessagemaker.h"
 #include "optional.h"
@@ -2143,9 +2144,9 @@ bool CConnman::AddNewAddresses(const std::vector<CAddress>& vAddr, const CAddres
     return addrman.Add(vAddr, addrFrom, nTimePenalty);
 }
 
-std::vector<CAddress> CConnman::GetAddresses(size_t max_addresses, size_t max_pct)
+std::vector<CAddress> CConnman::GetAddresses(size_t max_addresses, size_t max_pct, Optional<Network> network)
 {
-    return addrman.GetAddr(max_addresses, max_pct, /* network */ nullopt);
+    return addrman.GetAddr(max_addresses, max_pct, network);
 }
 
 bool CConnman::AddNode(const std::string& strNode)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2142,9 +2142,9 @@ void CConnman::AddNewAddresses(const std::vector<CAddress>& vAddr, const CAddres
     addrman.Add(vAddr, addrFrom, nTimePenalty);
 }
 
-std::vector<CAddress> CConnman::GetAddresses()
+std::vector<CAddress> CConnman::GetAddresses(size_t max_addresses, size_t max_pct)
 {
-    return addrman.GetAddr();
+    return addrman.GetAddr(max_addresses, max_pct);
 }
 
 bool CConnman::AddNode(const std::string& strNode)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -18,6 +18,7 @@
 #include "guiinterface.h"
 #include "netbase.h"
 #include "netmessagemaker.h"
+#include "optional.h"
 #include "primitives/transaction.h"
 #include "scheduler.h"
 #include "validation.h"
@@ -2144,7 +2145,7 @@ bool CConnman::AddNewAddresses(const std::vector<CAddress>& vAddr, const CAddres
 
 std::vector<CAddress> CConnman::GetAddresses(size_t max_addresses, size_t max_pct)
 {
-    return addrman.GetAddr(max_addresses, max_pct);
+    return addrman.GetAddr(max_addresses, max_pct, /* network */ nullopt);
 }
 
 bool CConnman::AddNode(const std::string& strNode)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2137,9 +2137,9 @@ void CConnman::AddNewAddress(const CAddress& addr, const CAddress& addrFrom, int
     addrman.Add(addr, addrFrom, nTimePenalty);
 }
 
-void CConnman::AddNewAddresses(const std::vector<CAddress>& vAddr, const CAddress& addrFrom, int64_t nTimePenalty)
+bool CConnman::AddNewAddresses(const std::vector<CAddress>& vAddr, const CAddress& addrFrom, int64_t nTimePenalty)
 {
-    addrman.Add(vAddr, addrFrom, nTimePenalty);
+    return addrman.Add(vAddr, addrFrom, nTimePenalty);
 }
 
 std::vector<CAddress> CConnman::GetAddresses(size_t max_addresses, size_t max_pct)

--- a/src/net.h
+++ b/src/net.h
@@ -49,8 +49,8 @@ static const int FEELER_INTERVAL = 120;
 static const unsigned int MAX_INV_SZ = 50000;
 /** The maximum number of entries in a locator */
 static const unsigned int MAX_LOCATOR_SZ = 101;
-/** The maximum number of new addresses to accumulate before announcing. */
-static const unsigned int MAX_ADDR_TO_SEND = 1000;
+/** The maximum number of addresses from our addrman to return in response to a getaddr message. */
+static constexpr size_t MAX_ADDR_TO_SEND = 1000;
 /** Maximum length of incoming protocol messages (no message over 2 MiB is currently acceptable). */
 static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 2 * 1024 * 1024;
 /** Maximum length of strSubVer in `version` message */
@@ -217,7 +217,7 @@ public:
     void MarkAddressGood(const CAddress& addr);
     void AddNewAddress(const CAddress& addr, const CAddress& addrFrom, int64_t nTimePenalty = 0);
     void AddNewAddresses(const std::vector<CAddress>& vAddr, const CAddress& addrFrom, int64_t nTimePenalty = 0);
-    std::vector<CAddress> GetAddresses();
+    std::vector<CAddress> GetAddresses(size_t max_addresses, size_t max_pct);
 
     // Denial-of-service detection/prevention
     // The idea is to detect peers that are behaving

--- a/src/net.h
+++ b/src/net.h
@@ -216,7 +216,7 @@ public:
     void SetServices(const CService &addr, ServiceFlags nServices);
     void MarkAddressGood(const CAddress& addr);
     void AddNewAddress(const CAddress& addr, const CAddress& addrFrom, int64_t nTimePenalty = 0);
-    void AddNewAddresses(const std::vector<CAddress>& vAddr, const CAddress& addrFrom, int64_t nTimePenalty = 0);
+    bool AddNewAddresses(const std::vector<CAddress>& vAddr, const CAddress& addrFrom, int64_t nTimePenalty = 0);
     std::vector<CAddress> GetAddresses(size_t max_addresses, size_t max_pct);
 
     // Denial-of-service detection/prevention

--- a/src/net.h
+++ b/src/net.h
@@ -217,7 +217,14 @@ public:
     void MarkAddressGood(const CAddress& addr);
     void AddNewAddress(const CAddress& addr, const CAddress& addrFrom, int64_t nTimePenalty = 0);
     bool AddNewAddresses(const std::vector<CAddress>& vAddr, const CAddress& addrFrom, int64_t nTimePenalty = 0);
-    std::vector<CAddress> GetAddresses(size_t max_addresses, size_t max_pct);
+    /**
+     * Return all or many randomly selected addresses, optionally by network.
+     *
+     * @param[in] max_addresses  Maximum number of addresses to return (0 = all).
+     * @param[in] max_pct        Maximum percentage of addresses to return (0 = all).
+     * @param[in] network        Select only addresses of this network (nullopt = all).
+     */
+    std::vector<CAddress> GetAddresses(size_t max_addresses, size_t max_pct, Optional<Network> network);
 
     // Denial-of-service detection/prevention
     // The idea is to detect peers that are behaving

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1749,7 +1749,7 @@ bool static ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vR
     // getaddr message mitigates the attack.
     else if ((strCommand == NetMsgType::GETADDR) && (pfrom->fInbound)) {
         pfrom->vAddrToSend.clear();
-        std::vector<CAddress> vAddr = connman->GetAddresses(MAX_ADDR_TO_SEND, MAX_PCT_ADDR_TO_SEND);
+        std::vector<CAddress> vAddr = connman->GetAddresses(MAX_ADDR_TO_SEND, MAX_PCT_ADDR_TO_SEND, /* network */ nullopt);
         FastRandomContext insecure_rand;
         for (const CAddress& addr : vAddr)
             pfrom->PushAddress(addr, insecure_rand);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -24,6 +24,9 @@ int64_t nTimeBestReceived = 0;  // Used only to inform the wallet of when we las
 
 static const uint64_t RANDOMIZER_ID_ADDRESS_RELAY = 0x3cac0035b5866b90ULL; // SHA256("main address relay")[0:8]
 
+/** the maximum percentage of addresses from our addrman to return in response to a getaddr message. */
+static constexpr size_t MAX_PCT_ADDR_TO_SEND = 23;
+
 struct IteratorComparator
 {
     template<typename I>
@@ -1746,7 +1749,7 @@ bool static ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vR
     // getaddr message mitigates the attack.
     else if ((strCommand == NetMsgType::GETADDR) && (pfrom->fInbound)) {
         pfrom->vAddrToSend.clear();
-        std::vector<CAddress> vAddr = connman->GetAddresses();
+        std::vector<CAddress> vAddr = connman->GetAddresses(MAX_ADDR_TO_SEND, MAX_PCT_ADDR_TO_SEND);
         FastRandomContext insecure_rand;
         for (const CAddress& addr : vAddr)
             pfrom->PushAddress(addr, insecure_rand);

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -636,7 +636,7 @@ uint32_t CNetAddr::GetLinkedIPv4() const
     assert(false);
 }
 
-uint32_t CNetAddr::GetNetClass() const
+Network CNetAddr::GetNetClass() const
 {
     // Make sure that if we return NET_IPV6, then IsIPv6() is true. The callers expect that.
 

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -188,7 +188,7 @@ public:
     std::string ToStringIP() const;
     uint64_t GetHash() const;
     bool GetInAddr(struct in_addr* pipv4Addr) const;
-    uint32_t GetNetClass() const;
+    Network GetNetClass() const;
 
     //! For IPv4, mapped IPv4, SIIT translated IPv4, Teredo, 6to4 tunneled addresses, return the relevant IPv4 address as a uint32.
     uint32_t GetLinkedIPv4() const;

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -62,6 +62,7 @@ static const CRPCConvertParam vRPCConvertParams[] = {
     { "getshieldbalance", 2, "include_watchonly" },
     { "getnetworkhashps", 0, "nblocks" },
     { "getnetworkhashps", 1, "height" },
+    { "getnodeaddresses", 0, "count" },
     { "getrawmempool", 0, "verbose" },
     { "getrawtransaction", 1, "verbose" },
     { "getreceivedbyaddress", 1, "minconf" },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -28,6 +28,7 @@ public:
 static const CRPCConvertParam vRPCConvertParams[] = {
     { "addmultisigaddress", 0, "nrequired" },
     { "addmultisigaddress", 1, "keys" },
+    { "addpeeraddress", 1, "port" },
     { "autocombinerewards", 0, "enable" },
     { "autocombinerewards", 1, "threshold" },
     { "createmultisig", 0, "nrequired" },

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -10,6 +10,7 @@
 #include "net.h"
 #include "netbase.h"
 #include "net_processing.h"
+#include "optional.h"
 #include "protocol.h"
 #include "sync.h"
 #include "timedata.h"
@@ -594,7 +595,7 @@ static UniValue getnodeaddresses(const JSONRPCRequest& request)
     if (count < 0) throw JSONRPCError(RPC_INVALID_PARAMETER, "Address count out of range");
 
     // returns a shuffled list of CAddress
-    const std::vector<CAddress> vAddr{g_connman->GetAddresses(count, /* max_pct */ 0)};
+    const std::vector<CAddress> vAddr{g_connman->GetAddresses(count, /* max_pct */ 0, /* network */ nullopt)};
     UniValue ret(UniValue::VARR);
 
     for (const CAddress& addr : vAddr) {

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -567,8 +567,7 @@ static UniValue getnodeaddresses(const JSONRPCRequest& request)
             "\nReturn known addresses which can potentially be used to find new nodes in the network\n"
 
             "\nArguments:\n"
-            "1. \"count\"    (numeric, optional) How many addresses to return. Limited to the smaller of " + std::to_string(ADDRMAN_GETADDR_MAX) +
-            " or " + std::to_string(ADDRMAN_GETADDR_MAX_PCT) + "% of all known addresses. (default = 1)\n"
+            "1. \"count\"    (numeric, optional) The maximum number of addresses to return. Specify 0 to return all known addresses.\n"
 
             "\nResult:\n"
             "[\n"
@@ -593,18 +592,16 @@ static UniValue getnodeaddresses(const JSONRPCRequest& request)
     int count = 1;
     if (!request.params[0].isNull()) {
         count = request.params[0].get_int();
-        if (count <= 0) {
+        if (count < 0) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Address count out of range");
         }
     }
     // returns a shuffled list of CAddress
-    std::vector<CAddress> vAddr = g_connman->GetAddresses();
+    std::vector<CAddress> vAddr = g_connman->GetAddresses(count, /* max_pct */ 0);
     UniValue ret(UniValue::VARR);
 
-    int address_return_count = std::min<int>(count, vAddr.size());
-    for (int i = 0; i < address_return_count; ++i) {
+    for (const CAddress& addr : vAddr) {
         UniValue obj(UniValue::VOBJ);
-        const CAddress& addr = vAddr[i];
         obj.pushKV("time", (int)addr.nTime);
         obj.pushKV("services", (uint64_t)addr.nServices);
         obj.pushKV("address", addr.ToStringIP());

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -559,6 +559,61 @@ UniValue clearbanned(const JSONRPCRequest& request)
     return NullUniValue;
 }
 
+static UniValue getnodeaddresses(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() > 1) {
+        throw std::runtime_error(
+            "getnodeaddresses ( count )\n"
+            "\nReturn known addresses which can potentially be used to find new nodes in the network\n"
+
+            "\nArguments:\n"
+            "1. \"count\"    (numeric, optional) How many addresses to return. Limited to the smaller of " + std::to_string(ADDRMAN_GETADDR_MAX) +
+            " or " + std::to_string(ADDRMAN_GETADDR_MAX_PCT) + "% of all known addresses. (default = 1)\n"
+
+            "\nResult:\n"
+            "[\n"
+            "  {\n"
+            "    \"time\": ttt,                (numeric) Timestamp in seconds since epoch (Jan 1 1970 GMT) keeping track of when the node was last seen\n"
+            "    \"services\": n,              (numeric) The services offered\n"
+            "    \"address\": \"host\",        (string) The address of the node\n"
+            "    \"port\": n                   (numeric) The port of the node\n"
+            "  }\n"
+            "  ,...\n"
+            "]\n"
+
+            "\nExamples:\n"
+            + HelpExampleCli("getnodeaddresses", "8")
+            + HelpExampleRpc("getnodeaddresses", "8")
+        );
+    }
+    if (!g_connman) {
+        throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
+    }
+
+    int count = 1;
+    if (!request.params[0].isNull()) {
+        count = request.params[0].get_int();
+        if (count <= 0) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Address count out of range");
+        }
+    }
+    // returns a shuffled list of CAddress
+    std::vector<CAddress> vAddr = g_connman->GetAddresses();
+    UniValue ret(UniValue::VARR);
+
+    int address_return_count = std::min<int>(count, vAddr.size());
+    for (int i = 0; i < address_return_count; ++i) {
+        UniValue obj(UniValue::VOBJ);
+        const CAddress& addr = vAddr[i];
+        obj.pushKV("time", (int)addr.nTime);
+        obj.pushKV("services", (uint64_t)addr.nServices);
+        obj.pushKV("address", addr.ToStringIP());
+        obj.pushKV("port", addr.GetPort());
+        ret.push_back(obj);
+    }
+    return ret;
+}
+
 static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         okSafe argNames
   //  --------------------- ------------------------  -----------------------  ------ --------
@@ -569,6 +624,7 @@ static const CRPCCommand commands[] =
     { "network",            "getconnectioncount",     &getconnectioncount,     true,  {} },
     { "network",            "getnettotals",           &getnettotals,           true,  {} },
     { "network",            "getnetworkinfo",         &getnetworkinfo,         true,  {} },
+    { "network",            "getnodeaddresses",       &getnodeaddresses,       true,  {"count"} },
     { "network",            "getpeerinfo",            &getpeerinfo,            true,  {} },
     { "network",            "listbanned",             &listbanned,             true,  {} },
     { "network",            "ping",                   &ping,                   true,  {} },

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -385,7 +385,7 @@ BOOST_AUTO_TEST_CASE(addrman_getaddr)
     // Test: Sanity check, GetAddr should never return anything if addrman
     //  is empty.
     BOOST_CHECK(addrman.size() == 0);
-    std::vector<CAddress> vAddr1 = addrman.GetAddr();
+    std::vector<CAddress> vAddr1 = addrman.GetAddr(/* max_addresses */ 0, /* max_pct */0);
     BOOST_CHECK(vAddr1.size() == 0);
 
     CAddress addr1 = CAddress(ResolveService("250.250.2.1", 8333), NODE_NONE);
@@ -408,13 +408,15 @@ BOOST_AUTO_TEST_CASE(addrman_getaddr)
     addrman.Add(addr4, source2);
     addrman.Add(addr5, source1);
 
-    // GetAddr returns 23% of addresses, 23% of 5 is 1 rounded down.
-    BOOST_CHECK(addrman.GetAddr().size() == 1);
+    BOOST_CHECK_EQUAL(addrman.GetAddr(/* max_addresses */ 0, /* max_pct */ 0).size(), 5U);
+    // Net processing asks for 23% of addresses. 23% of 5 is 1 rounded down.
+    BOOST_CHECK_EQUAL(addrman.GetAddr(/* max_addresses */ 2500, /* max_pct */ 23).size(), 1U);
 
     // Test 24: Ensure GetAddr works with new and tried addresses.
     addrman.Good(CAddress(addr1, NODE_NONE));
     addrman.Good(CAddress(addr2, NODE_NONE));
-    BOOST_CHECK(addrman.GetAddr().size() == 1);
+    BOOST_CHECK_EQUAL(addrman.GetAddr(/* max_addresses */ 0, /* max_pct */ 0).size(), 5U);
+    BOOST_CHECK_EQUAL(addrman.GetAddr(/* max_addresses */ 2500, /* max_pct */ 23).size(), 1U);
 
     // Test 25: Ensure GetAddr still returns 23% when addrman has many addrs.
     for (unsigned int i = 1; i < (8 * 256); i++) {
@@ -430,7 +432,7 @@ BOOST_AUTO_TEST_CASE(addrman_getaddr)
         if (i % 8 == 0)
             addrman.Good(addr);
     }
-    std::vector<CAddress> vAddr = addrman.GetAddr();
+    std::vector<CAddress> vAddr = addrman.GetAddr(/* max_addresses */ 2500, /* max_pct */ 23);
 
     size_t percent23 = (addrman.size() * 23) / 100;
     BOOST_CHECK(vAddr.size() == percent23);

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -99,43 +99,54 @@ class NetTest(PivxTestFramework):
 
     def _test_getnodeaddresses(self):
         self.nodes[0].add_p2p_connection(P2PInterface())
+        services = NODE_NETWORK
 
-        # Add some addresses to the Address Manager over RPC. Due to the way
-        # bucket and bucket position are calculated, some of these addresses
-        # will collide.
+        # Add an IPv6 address to the address manager.
+        ipv6_addr = "1233:3432:2434:2343:3234:2345:6546:4534"
+        self.nodes[0].addpeeraddress(ipv6_addr, 51472)
+
+        # Add 10,000 IPv4 addresses to the address manager. Due to the way bucket
+        # and bucket positions are calculated, some of these addresses will collide.
         imported_addrs = []
         for i in range(10000):
             first_octet = i >> 8
             second_octet = i % 256
-            a = "{}.{}.1.1".format(first_octet, second_octet)  # IPv4
+            a = f"{first_octet}.{second_octet}.1.1"
             imported_addrs.append(a)
             self.nodes[0].addpeeraddress(a, 51472)
 
-        # Obtain addresses via rpc call and check they were ones sent in before.
-        #
-        # Maximum possible addresses in addrman is 10000, although actual
-        # number will usually be less due to bucket and bucket position
-        # collisions.
-        node_addresses = self.nodes[0].getnodeaddresses(0)
+        # Fetch the addresses via the RPC and test the results.
+        assert_equal(len(self.nodes[0].getnodeaddresses()), 1)  # default count is 1
+        assert_equal(len(self.nodes[0].getnodeaddresses(2)), 2)
+        assert_equal(len(self.nodes[0].getnodeaddresses(8, "ipv4")), 8)
+
+        # Maximum possible addresses in AddrMan is 10000. The actual number will
+        # usually be less due to bucket and bucket position collisions.
+        node_addresses = self.nodes[0].getnodeaddresses(0, "ipv4")
         assert_greater_than(len(node_addresses), 5000)
         assert_greater_than(10000, len(node_addresses))
         for a in node_addresses:
             assert_greater_than(a["time"], 1527811200)  # 1st June 2018
-            assert_equal(a["services"], NODE_NETWORK)
+            assert_equal(a["services"], services)
             assert a["address"] in imported_addrs
             assert_equal(a["port"], 51472)
             assert_equal(a["network"], "ipv4")
 
-        node_addresses = self.nodes[0].getnodeaddresses(1)
-        assert_equal(len(node_addresses), 1)
+        # Test the IPv6 address.
+        res = self.nodes[0].getnodeaddresses(0, "ipv6")
+        assert_equal(len(res), 1)
+        assert_equal(res[0]["address"], ipv6_addr)
+        assert_equal(res[0]["network"], "ipv6")
+        assert_equal(res[0]["port"], 51472)
+        assert_equal(res[0]["services"], services)
 
+        # Test for the absence of onion addresses.
+        for network in ["onion"]:
+            assert_equal(self.nodes[0].getnodeaddresses(0, network), [])
+
+        # Test invalid arguments.
         assert_raises_rpc_error(-8, "Address count out of range", self.nodes[0].getnodeaddresses, -1)
-
-        # addrman's size cannot be known reliably after insertion, as hash collisions may occur
-        # so only test that requesting a large number of addresses returns less than that
-        LARGE_REQUEST_COUNT = 10000
-        node_addresses = self.nodes[0].getnodeaddresses(LARGE_REQUEST_COUNT)
-        assert_greater_than(LARGE_REQUEST_COUNT, len(node_addresses))
+        assert_raises_rpc_error(-8, "Network not recognized: Foo", self.nodes[0].getnodeaddresses, 1, "Foo")
 
 if __name__ == '__main__':
     NetTest().main()

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -114,15 +114,23 @@ class NetTest(PivxTestFramework):
             msg.addrs.append(addr)
         self.nodes[0].p2p.send_and_ping(msg)
 
-        # obtain addresses via rpc call and check they were ones sent in before
-        REQUEST_COUNT = 10
-        node_addresses = self.nodes[0].getnodeaddresses(REQUEST_COUNT)
-        assert_equal(len(node_addresses), REQUEST_COUNT)
+        # Obtain addresses via rpc call and check they were ones sent in before.
+        #
+        # All addresses added above are in the same netgroup and so are assigned
+        # to the same bucket. Maximum possible addresses in addrman is therefore
+        # 64, although actual number will usually be slightly less due to
+        # BucketPosition collisions.
+        node_addresses = self.nodes[0].getnodeaddresses(0)
+        assert_greater_than(len(node_addresses), 50)
+        assert_greater_than(65, len(node_addresses))
         for a in node_addresses:
             assert_greater_than(a["time"], 1527811200)  # 1st June 2018
             assert_equal(a["services"], NODE_NETWORK)
             assert a["address"] in imported_addrs
             assert_equal(a["port"], 51472)
+
+        node_addresses = self.nodes[0].getnodeaddresses(1)
+        assert_equal(len(node_addresses), 1)
 
         assert_raises_rpc_error(-8, "Address count out of range", self.nodes[0].getnodeaddresses, -1)
 

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -107,7 +107,7 @@ class NetTest(PivxTestFramework):
         for i in range(10000):
             first_octet = i >> 8
             second_octet = i % 256
-            a = "{}.{}.1.1".format(first_octet, second_octet)
+            a = "{}.{}.1.1".format(first_octet, second_octet)  # IPv4
             imported_addrs.append(a)
             self.nodes[0].addpeeraddress(a, 51472)
 
@@ -124,6 +124,7 @@ class NetTest(PivxTestFramework):
             assert_equal(a["services"], NODE_NETWORK)
             assert a["address"] in imported_addrs
             assert_equal(a["port"], 51472)
+            assert_equal(a["network"], "ipv4")
 
         node_addresses = self.nodes[0].getnodeaddresses(1)
         assert_equal(len(node_addresses), 1)

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -7,7 +7,7 @@
 Tests correspond to code in rpc/net.cpp.
 """
 
-from test_framework.messages import CAddress, msg_addr, NODE_NETWORK
+from test_framework.messages import NODE_NETWORK
 from test_framework.mininode import P2PInterface
 from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
@@ -100,29 +100,25 @@ class NetTest(PivxTestFramework):
     def _test_getnodeaddresses(self):
         self.nodes[0].add_p2p_connection(P2PInterface())
 
-        # send some addresses to the node via the p2p message addr
-        msg = msg_addr()
+        # Add some addresses to the Address Manager over RPC. Due to the way
+        # bucket and bucket position are calculated, some of these addresses
+        # will collide.
         imported_addrs = []
-        for i in range(256):
-            a = "123.123.123.{}".format(i)
+        for i in range(10000):
+            first_octet = i >> 8
+            second_octet = i % 256
+            a = "{}.{}.1.1".format(first_octet, second_octet)
             imported_addrs.append(a)
-            addr = CAddress()
-            addr.time = 100000000
-            addr.nServices = NODE_NETWORK
-            addr.ip = a
-            addr.port = 51472
-            msg.addrs.append(addr)
-        self.nodes[0].p2p.send_and_ping(msg)
+            self.nodes[0].addpeeraddress(a, 51472)
 
         # Obtain addresses via rpc call and check they were ones sent in before.
         #
-        # All addresses added above are in the same netgroup and so are assigned
-        # to the same bucket. Maximum possible addresses in addrman is therefore
-        # 64, although actual number will usually be slightly less due to
-        # BucketPosition collisions.
+        # Maximum possible addresses in addrman is 10000, although actual
+        # number will usually be less due to bucket and bucket position
+        # collisions.
         node_addresses = self.nodes[0].getnodeaddresses(0)
-        assert_greater_than(len(node_addresses), 50)
-        assert_greater_than(65, len(node_addresses))
+        assert_greater_than(len(node_addresses), 5000)
+        assert_greater_than(10000, len(node_addresses))
         for a in node_addresses:
             assert_greater_than(a["time"], 1527811200)  # 1st June 2018
             assert_equal(a["services"], NODE_NETWORK)


### PR DESCRIPTION
Implement a new RPC command (`getnodeaddresses`) that provides RPC access to the node's addrman. It may be useful for PIVX wallets to broadcast their transactions over tor for improved privacy without using the centralized DNS seeds.

I've included upstream improvements to this feature here as well, and this RPC command was used to scrape the Tor v3 hardcoded seed nodes added in #2502

---------
Based on the following upstream PRs:
* https://github.com/bitcoin/bitcoin/pull/13152
* https://github.com/bitcoin/bitcoin/pull/19658
* https://github.com/bitcoin/bitcoin/pull/21594
* https://github.com/bitcoin/bitcoin/pull/21843