### PR TITLE
[Refactor] Clang-tidy and fix compiler error in HasReason class

### DIFF
--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -29,7 +29,7 @@
  * should be serialized in (unserialized from) v2 format (BIP155).
  * Make sure that this does not collide with any of the values in `version.h`
  */
-static const int ADDRV2_FORMAT = 0x20000000;
+static constexpr int ADDRV2_FORMAT = 0x20000000;
 
 /**
  * A network type.

--- a/src/test/test_pivx.h
+++ b/src/test/test_pivx.h
@@ -9,6 +9,8 @@
 #include "scheduler.h"
 #include "txdb.h"
 
+#include <stdexcept>
+
 #include <boost/thread.hpp>
 
 extern FastRandomContext insecure_rand_ctx;
@@ -144,17 +146,20 @@ struct TestMemPoolEntryHelper
 // define an implicit conversion here so that uint256 may be used directly in BOOST_CHECK_*
 std::ostream& operator<<(std::ostream& os, const uint256& num);
 
-// BOOST_CHECK_EXCEPTION predicates to check the specific validation error
-class HasReason {
+/**
+ * BOOST_CHECK_EXCEPTION predicates to check the specific validation error.
+ * Use as
+ * BOOST_CHECK_EXCEPTION(code that throws, exception type, HasReason("foo"));
+ */
+class HasReason
+{
 public:
-    HasReason(const std::string& reason) : m_reason(reason) {}
-    bool operator() (const std::runtime_error& e) const {
-        bool ret = std::string(e.what()).find(m_reason) != std::string::npos;
-        if (!ret) {
-            std::cout << "error: " << e.what() << std::endl;
-        }
-        return ret;
+    explicit HasReason(const std::string& reason) : m_reason(reason) {}
+    bool operator()(const std::exception& e) const
+    {
+        return std::string(e.what()).find(m_reason) != std::string::npos;
     };
+
 private:
     const std::string m_reason;
 };


### PR DESCRIPTION
Came across this compiler error when updating the [code coverage report](https://www.fuzzbawls.pw/pivx/regression-test-coverage/index.html). The server runs on CentOS 7 currently, which uses a fairly old (but still supported) version of gcc. Indeed, upstream also ran into this error (Ref: https://github.com/bitcoin/bitcoin/pull/20033)

Some older (but still supported) versions of gcc will throw an error
when trying to convert from `std::ios_base::failure` to `std::runtime_error`.
Use `std::exception` base type instead.

Also apply clang-format to the class and remove the `cout`.