### PR TITLE
[Cleanup][Trivial] Remove unused SPORK_5

### DIFF
--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -15,7 +15,6 @@
 #define MAKE_SPORK_DEF(name, defaultValue) CSporkDef(name, defaultValue, #name)
 
 std::vector<CSporkDef> sporkDefs = {
-    MAKE_SPORK_DEF(SPORK_5_MAX_VALUE,                       1000),          // 1000 PIV
     MAKE_SPORK_DEF(SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT,  4070908800ULL), // OFF
     MAKE_SPORK_DEF(SPORK_9_MASTERNODE_BUDGET_ENFORCEMENT,   4070908800ULL), // OFF
     MAKE_SPORK_DEF(SPORK_13_ENABLE_SUPERBLOCKS,             4070908800ULL), // OFF

--- a/src/sporkid.h
+++ b/src/sporkid.h
@@ -14,7 +14,7 @@
 enum SporkId : int32_t {
     SPORK_2_SWIFTTX                             = 10001,      // Deprecated in v4.3.99
     SPORK_3_SWIFTTX_BLOCK_FILTERING             = 10002,      // Deprecated in v4.3.99
-    SPORK_5_MAX_VALUE                           = 10004,
+    SPORK_5_MAX_VALUE                           = 10004,      // Deprecated in v5.2.99
     SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT      = 10007,
     SPORK_9_MASTERNODE_BUDGET_ENFORCEMENT       = 10008,
     SPORK_13_ENABLE_SUPERBLOCKS                 = 10012,


### PR DESCRIPTION
As per title, spork5 is already unused, we can remove its definition.