### PR TITLE
GUI: bugfix, the command line interface is called "pivx-cli" not "pivx-core".

### DIFF
--- a/src/qt/pivx/settings/settingsfaqwidget.cpp
+++ b/src/qt/pivx/settings/settingsfaqwidget.cpp
@@ -104,7 +104,7 @@ SettingsFaqWidget::SettingsFaqWidget(PIVXGUI* parent, ClientModel* _model) :
                "package will be lit up and will state \"Staking Enabled\" to indicate "
                "it is staking. Using the command line interface (%1); the command %2 "
                "will confirm that staking is active.")
-                .arg("pivx-core", "<span style=\"font-style:italic\">getstakingstatus</span>")));
+                .arg("pivx-cli", "<span style=\"font-style:italic\">getstakingstatus</span>")));
     ui->labelContent_Stake->setText(stakeContent);
 
     QString supportContent = formatFAQContent(


### PR DESCRIPTION
Fixing a typo, the command line interface is "pivx-cli" not "pivx-core".