### PR TITLE
[Cleanup] Drop unneeded protocol version checks and constants

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -446,10 +446,8 @@ bool CMasternodeBroadcast::CheckAndUpdate(int& nDos, int nChainHeight)
     }
 
     std::string strError = "";
-    if (!CheckSignature())
-    {
-        // don't ban for old masternodes, their sigs could be broken because of the bug
-        nDos = protocolVersion < MIN_PEER_MNANNOUNCE ? 0 : 100;
+    if (!CheckSignature()) {
+        nDos = 100;
         return error("%s : Got bad Masternode address signature", __func__);
     }
 

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -623,7 +623,7 @@ bool CMasternodePing::CheckAndUpdate(int& nDos, int nChainHeight, bool fRequireA
         LogPrint(BCLog::MNPING,"%s: Masternode %s block hash %s is too old or has an invalid block hash\n",
                                         __func__, vin.prevout.hash.ToString(), blockHash.ToString());
         // don't ban peers relaying stale data before the active protocol enforcement
-        nDos = (ActiveProtocol() < MIN_PEER_CACHEDVERSION ? 0 : 33);
+        nDos = 33;
         return false;
     }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1312,7 +1312,7 @@ void CConnman::ThreadSocketHandler()
                 } else if (nTime - pnode->nLastSend > TIMEOUT_INTERVAL) {
                     LogPrintf("socket sending timeout: %is\n", nTime - pnode->nLastSend);
                     pnode->fDisconnect = true;
-                } else if (nTime - pnode->nLastRecv > (pnode->nVersion > BIP0031_VERSION ? TIMEOUT_INTERVAL : 90 * 60)) {
+                } else if (nTime - pnode->nLastRecv > TIMEOUT_INTERVAL) {
                     LogPrintf("socket receive timeout: %is\n", nTime - pnode->nLastRecv);
                     pnode->fDisconnect = true;
                 } else if (pnode->nPingNonceSent && pnode->nPingUsecStart + TIMEOUT_INTERVAL * 1000000 < GetTimeMicros()) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2119,11 +2119,6 @@ CConnman::~CConnman()
     Stop();
 }
 
-size_t CConnman::GetAddressCount() const
-{
-    return addrman.size();
-}
-
 void CConnman::SetServices(const CService &addr, ServiceFlags nServices)
 {
     addrman.SetServices(addr, nServices);

--- a/src/net.h
+++ b/src/net.h
@@ -212,7 +212,6 @@ public:
     CNode* ConnectNode(CAddress addrConnect);
 
     // Addrman functions
-    size_t GetAddressCount() const;
     void SetServices(const CService &addr, ServiceFlags nServices);
     void MarkAddressGood(const CAddress& addr);
     void AddNewAddress(const CAddress& addr, const CAddress& addrFrom, int64_t nTimePenalty = 0);

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -289,8 +289,6 @@ enum ServiceFlags : uint64_t {
     NODE_NETWORK = (1 << 0),
 
     // NODE_BLOOM means the node is capable and willing to handle bloom-filtered connections.
-    // Bitcoin Core nodes used to support this by default, without advertising this bit,
-    // but no longer do as of protocol version 70011 (= NO_BLOOM_VERSION)
     NODE_BLOOM = (1 << 2),
 
     // NODE_BLOOM_WITHOUT_MN means the node has the same features as NODE_BLOOM with the only difference

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -322,7 +322,13 @@ public:
             READWRITE(nVersion);
         }
         if ((s.GetType() & SER_DISK) ||
-            (nVersion >= CADDR_TIME_VERSION && !(s.GetType() & SER_GETHASH))) {
+            (nVersion != INIT_PROTO_VERSION && !(s.GetType() & SER_GETHASH))) {
+            // The only time we serialize a CAddress object without nTime is in
+            // the initial VERSION messages which contain two CAddress records.
+            // At that point, the serialization version is INIT_PROTO_VERSION.
+            // After the version handshake, serialization version is >=
+            // MIN_PEER_PROTO_VERSION and all ADDR messages are serialized with
+            // nTime.
             READWRITE(obj.nTime);
         }
         if (nVersion & ADDRV2_FORMAT) {

--- a/src/version.h
+++ b/src/version.h
@@ -20,9 +20,6 @@ static const int INIT_PROTO_VERSION = 209;
 static const int MIN_PEER_PROTO_VERSION_BEFORE_ENFORCEMENT = 70922;
 static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT = 70923;
 
-//! peers with version older than this, could relay invalid (stale) mn pings
-static const int MIN_PEER_CACHEDVERSION = 70921;
-
 //! masternodes older than this proto version use old strMessage format for mnannounce
 static const int MIN_PEER_MNANNOUNCE = 70913;
 

--- a/src/version.h
+++ b/src/version.h
@@ -20,9 +20,6 @@ static const int INIT_PROTO_VERSION = 209;
 static const int MIN_PEER_PROTO_VERSION_BEFORE_ENFORCEMENT = 70922;
 static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT = 70923;
 
-//! masternodes older than this proto version use old strMessage format for mnannounce
-static const int MIN_PEER_MNANNOUNCE = 70913;
-
 //! nTime field added to CAddress, starting with this version;
 //! if possible, avoid requesting addresses nodes older than this
 static const int CADDR_TIME_VERSION = 31402;

--- a/src/version.h
+++ b/src/version.h
@@ -20,9 +20,6 @@ static const int INIT_PROTO_VERSION = 209;
 static const int MIN_PEER_PROTO_VERSION_BEFORE_ENFORCEMENT = 70922;
 static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT = 70923;
 
-//! BIP 0031, pong message, is enabled for all versions AFTER this one
-static const int BIP0031_VERSION = 60000;
-
 // Make sure that none of the values above collide with
 // `ADDRV2_FORMAT`.
 

--- a/src/version.h
+++ b/src/version.h
@@ -20,10 +20,6 @@ static const int INIT_PROTO_VERSION = 209;
 static const int MIN_PEER_PROTO_VERSION_BEFORE_ENFORCEMENT = 70922;
 static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT = 70923;
 
-//! nTime field added to CAddress, starting with this version;
-//! if possible, avoid requesting addresses nodes older than this
-static const int CADDR_TIME_VERSION = 31402;
-
 //! BIP 0031, pong message, is enabled for all versions AFTER this one
 static const int BIP0031_VERSION = 60000;
 

--- a/src/version.h
+++ b/src/version.h
@@ -16,9 +16,6 @@ static const int PROTOCOL_VERSION = 70923;
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
 
-//! In this version, 'getheaders' was introduced.
-static const int GETHEADERS_VERSION = 70077;
-
 //! disconnect from peers older than this proto version
 static const int MIN_PEER_PROTO_VERSION_BEFORE_ENFORCEMENT = 70922;
 static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT = 70923;
@@ -35,13 +32,6 @@ static const int CADDR_TIME_VERSION = 31402;
 
 //! BIP 0031, pong message, is enabled for all versions AFTER this one
 static const int BIP0031_VERSION = 60000;
-
-//! "mempool" command, enhanced "getdata" behavior starts with this version
-static const int MEMPOOL_GD_VERSION = 60002;
-
-//! "filter*" commands are disabled without NODE_BLOOM after and including this version
-static const int NO_BLOOM_VERSION = 70005;
-
 
 // Make sure that none of the values above collide with
 // `ADDRV2_FORMAT`.


### PR DESCRIPTION
After the version handshake the protocol version must be >= `MIN_PEER_PROTO_VERSION_BEFORE_ENFORCEMENT` (or `MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT`, depending on the sporks value).

Therefore we can drop all constants below `70922`.
Most of them are already unused. For the others we can just remove the checks `if (pnode->nVersion > x)`.