### PR TITLE
[BugFix] Correct mnb ser/unser of BIP155 node addresses.

### DIFF
--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -25,7 +25,6 @@ extern CMasternodePayments masternodePayments;
 #define MNPAYMENTS_SIGNATURES_REQUIRED 6
 #define MNPAYMENTS_SIGNATURES_TOTAL 10
 
-void ProcessMessageMasternodePayments(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
 bool IsBlockPayeeValid(const CBlock& block, const CBlockIndex* pindexPrev);
 std::string GetRequiredPaymentsString(int nBlockHeight);
 bool IsBlockValueValid(int nHeight, CAmount& nExpectedValue, CAmount nMinted, CAmount& nBudgetAmt);

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -367,18 +367,6 @@ bool CMasternodeBroadcast::Sign(const CKey& key, const CPubKey& pubKey)
     return true;
 }
 
-bool CMasternodeBroadcast::Sign(const std::string strSignKey)
-{
-    CKey key;
-    CPubKey pubkey;
-
-    if (!CMessageSigner::GetKeysFromSecret(strSignKey, key, pubkey)) {
-        return error("%s : Invalid strSignKey", __func__);
-    }
-
-    return Sign(key, pubkey);
-}
-
 bool CMasternodeBroadcast::CheckSignature() const
 {
     std::string strError = "";

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -84,6 +84,7 @@ CMasternode::CMasternode() :
     nScanningErrorCount = 0;
     nLastScanningErrorBlockHeight = 0;
     mnPayeeScript.clear();
+    isBIP155Addr = false;
 }
 
 CMasternode::CMasternode(const CMasternode& other) :
@@ -100,6 +101,7 @@ CMasternode::CMasternode(const CMasternode& other) :
     nScanningErrorCount = other.nScanningErrorCount;
     nLastScanningErrorBlockHeight = other.nLastScanningErrorBlockHeight;
     mnPayeeScript = other.mnPayeeScript;
+    isBIP155Addr = other.isBIP155Addr;
 }
 
 CMasternode::CMasternode(const CDeterministicMNCPtr& dmn, int64_t registeredTime, const uint256& registeredHash) :
@@ -116,11 +118,13 @@ CMasternode::CMasternode(const CDeterministicMNCPtr& dmn, int64_t registeredTime
     nScanningErrorCount = 0;
     nLastScanningErrorBlockHeight = 0;
     mnPayeeScript = dmn->pdmnState->scriptPayout;
+    isBIP155Addr = !addr.IsAddrV1Compatible();
 }
 
 uint256 CMasternode::GetSignatureHash() const
 {
-    CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
+    int version = isBIP155Addr ? PROTOCOL_VERSION | ADDRV2_FORMAT : PROTOCOL_VERSION;
+    CHashWriter ss(SER_GETHASH, version);
     ss << nMessVersion;
     ss << addr;
     ss << sigTime;
@@ -153,6 +157,7 @@ bool CMasternode::UpdateFromNewBroadcast(CMasternodeBroadcast& mnb, int chainHei
         vchSig = mnb.vchSig;
         protocolVersion = mnb.protocolVersion;
         addr = mnb.addr;
+        isBIP155Addr = !mnb.addr.IsAddrV1Compatible();
         int nDoS = 0;
         if (mnb.lastPing.IsNull() || (!mnb.lastPing.IsNull() && mnb.lastPing.CheckAndUpdate(nDoS, chainHeight, false))) {
             lastPing = mnb.lastPing;
@@ -241,6 +246,7 @@ CMasternodeBroadcast::CMasternodeBroadcast(CService newAddr, CTxIn newVin, CPubK
     protocolVersion = protocolVersionIn;
     lastPing = _lastPing;
     sigTime = lastPing.sigTime;
+    isBIP155Addr = !addr.IsAddrV1Compatible();
 }
 
 CMasternodeBroadcast::CMasternodeBroadcast(const CMasternode& mn) :

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -102,6 +102,8 @@ public:
     int nScanningErrorCount;
     int nLastScanningErrorBlockHeight;
     CMasternodePing lastPing;
+    // Whether the MN addr is in BIP155 format. Required for the signature hash.
+    bool isBIP155Addr{false};
 
     explicit CMasternode();
     CMasternode(const CMasternode& other);
@@ -130,6 +132,7 @@ public:
         protocolVersion = other.protocolVersion;
         nScanningErrorCount = other.nScanningErrorCount;
         nLastScanningErrorBlockHeight = other.nLastScanningErrorBlockHeight;
+        isBIP155Addr = other.isBIP155Addr;
         return *this;
     }
 
@@ -150,6 +153,10 @@ public:
         READWRITE(obj.vin, obj.addr, obj.pubKeyCollateralAddress);
         READWRITE(obj.pubKeyMasternode, obj.vchSig, obj.sigTime, obj.protocolVersion);
         READWRITE(obj.lastPing, obj.nScanningErrorCount, obj.nLastScanningErrorBlockHeight);
+
+        if (obj.protocolVersion >= MIN_BIP155_PROTOCOL_VERSION) {
+            READWRITE(obj.isBIP155Addr);
+        }
     }
 
     template <typename Stream>

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -253,7 +253,6 @@ public:
 
     // special sign/verify
     bool Sign(const CKey& key, const CPubKey& pubKey);
-    bool Sign(const std::string strSignKey);
     bool CheckSignature() const;
 
     SERIALIZE_METHODS(CMasternodeBroadcast, obj)

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -40,6 +40,7 @@ struct CompareScoreMN {
 //
 
 static const int MASTERNODE_DB_VERSION = 1;
+static const int MASTERNODE_DB_VERSION_BIP155 = 2;
 
 CMasternodeDB::CMasternodeDB()
 {
@@ -50,12 +51,14 @@ CMasternodeDB::CMasternodeDB()
 bool CMasternodeDB::Write(const CMasternodeMan& mnodemanToSave)
 {
     int64_t nStart = GetTimeMillis();
+    const auto& params = Params();
 
     // serialize, checksum data up to that point, then append checksum
-    CDataStream ssMasternodes(SER_DISK, CLIENT_VERSION);
-    ssMasternodes << MASTERNODE_DB_VERSION;
+    // Always done in the latest format.
+    CDataStream ssMasternodes(SER_DISK, CLIENT_VERSION | ADDRV2_FORMAT);
+    ssMasternodes << MASTERNODE_DB_VERSION_BIP155;
     ssMasternodes << strMagicMessage;                   // masternode cache file specific magic message
-    ssMasternodes << Params().MessageStart(); // network specific magic number
+    ssMasternodes << params.MessageStart(); // network specific magic number
     ssMasternodes << mnodemanToSave;
     uint256 hash = Hash(ssMasternodes.begin(), ssMasternodes.end());
     ssMasternodes << hash;
@@ -112,7 +115,9 @@ CMasternodeDB::ReadResult CMasternodeDB::Read(CMasternodeMan& mnodemanToLoad)
     }
     filein.fclose();
 
-    CDataStream ssMasternodes(vchData, SER_DISK, CLIENT_VERSION);
+    const auto& params = Params();
+    // serialize, checksum data up to that point, then append checksum
+    CDataStream ssMasternodes(vchData, SER_DISK,  CLIENT_VERSION);
 
     // verify stored checksum matches input data
     uint256 hashTmp = Hash(ssMasternodes.begin(), ssMasternodes.end());
@@ -139,12 +144,18 @@ CMasternodeDB::ReadResult CMasternodeDB::Read(CMasternodeMan& mnodemanToLoad)
         ssMasternodes >> MakeSpan(pchMsgTmp);
 
         // ... verify the network matches ours
-        if (memcmp(pchMsgTmp.data(), Params().MessageStart(), pchMsgTmp.size()) != 0) {
+        if (memcmp(pchMsgTmp.data(), params.MessageStart(), pchMsgTmp.size()) != 0) {
             error("%s : Invalid network magic number", __func__);
             return IncorrectMagicNumber;
         }
-        // de-serialize data into CMasternodeMan object
-        ssMasternodes >> mnodemanToLoad;
+        // de-serialize data into CMasternodeMan object.
+        if (version == MASTERNODE_DB_VERSION_BIP155) {
+            OverrideStream<CDataStream> s(&ssMasternodes, ssMasternodes.GetType(), ssMasternodes.GetVersion() | ADDRV2_FORMAT);
+            s >> mnodemanToLoad;
+        } else {
+            // Old format
+            ssMasternodes >> mnodemanToLoad;
+        }
     } catch (const std::exception& e) {
         mnodemanToLoad.Clear();
         error("%s : Deserialize or I/O error - %s", __func__, e.what());
@@ -856,6 +867,24 @@ int CMasternodeMan::ProcessMessageInner(CNode* pfrom, std::string& strCommand, C
     if (strCommand == NetMsgType::MNBROADCAST) {
         CMasternodeBroadcast mnb;
         vRecv >> mnb;
+        return ProcessMNBroadcast(pfrom, mnb);
+
+    } else if (strCommand == NetMsgType::MNBROADCAST2) {
+        if (!Params().GetConsensus().NetworkUpgradeActive(GetBestHeight(), Consensus::UPGRADE_V5_3)) {
+            LogPrint(BCLog::MASTERNODE, "%s: mnb2 not enabled pre-V5.3 enforcement\n", __func__);
+            return 30;
+        }
+        CMasternodeBroadcast mnb;
+        OverrideStream<CDataStream> s(&vRecv, vRecv.GetType(), vRecv.GetVersion() | ADDRV2_FORMAT);
+        s >> mnb;
+        mnb.isBIP155Addr = !mnb.addr.IsAddrV1Compatible();
+
+        // For now, let's not process mnb2 with pre-BIP155 node addr format.
+        if (!mnb.isBIP155Addr) {
+            LogPrint(BCLog::MASTERNODE, "%s: mnb2 with pre-BIP155 node addr format rejected\n", __func__);
+            return 30;
+        }
+
         return ProcessMNBroadcast(pfrom, mnb);
 
     } else if (strCommand == NetMsgType::MNPING) {

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -42,6 +42,7 @@ const char* SENDHEADERS = "sendheaders";
 const char* SPORK = "spork";
 const char* GETSPORKS = "getsporks";
 const char* MNBROADCAST = "mnb";
+const char* MNBROADCAST2 = "mnb2"; // BIP155 support
 const char* MNPING = "mnp";
 const char* MNWINNER = "mnw";
 const char* GETMNWINNERS = "mnget";
@@ -99,7 +100,8 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::GETMNLIST,
     NetMsgType::BUDGETVOTESYNC,
     NetMsgType::GETSPORKS,
-    NetMsgType::SYNCSTATUSCOUNT
+    NetMsgType::SYNCSTATUSCOUNT,
+    NetMsgType::MNBROADCAST2
 };
 const static std::vector<std::string> allNetMessageTypesVec(allNetMessageTypes, allNetMessageTypes + ARRAYLEN(allNetMessageTypes));
 const static std::vector<std::string> tiertwoNetMessageTypesVec(std::find(allNetMessageTypesVec.begin(), allNetMessageTypesVec.end(), NetMsgType::SPORK), allNetMessageTypesVec.end());
@@ -195,7 +197,7 @@ std::string CInv::GetCommand() const
         case MSG_BUDGET_FINALIZED: return cmd.append(NetMsgType::FINALBUDGET);
         case MSG_BUDGET_FINALIZED_VOTE: return cmd.append(NetMsgType::FINALBUDGETVOTE);
         case MSG_MASTERNODE_QUORUM: return cmd.append("mnq"); // Unused
-        case MSG_MASTERNODE_ANNOUNCE: return cmd.append(NetMsgType::MNBROADCAST);
+        case MSG_MASTERNODE_ANNOUNCE: return cmd.append(NetMsgType::MNBROADCAST); // or MNBROADCAST2
         case MSG_MASTERNODE_PING: return cmd.append(NetMsgType::MNPING);
         case MSG_DSTX: return cmd.append("dstx"); // Deprecated
         default:

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -14,6 +14,7 @@
 
 #include "netaddress.h"
 #include "serialize.h"
+#include "streams.h"
 #include "uint256.h"
 #include "version.h"
 
@@ -309,29 +310,80 @@ class CAddress : public CService
 {
     static constexpr uint32_t TIME_INIT{100000000};
 
+    /** Historically, CAddress disk serialization stored the CLIENT_VERSION, optionally OR'ed with
+     *  the ADDRV2_FORMAT flag to indicate V2 serialization. The first field has since been
+     *  disentangled from client versioning, and now instead:
+     *  - The low bits (masked by DISK_VERSION_IGNORE_MASK) store the fixed value DISK_VERSION_INIT,
+     *    (in case any code exists that treats it as a client version) but are ignored on
+     *    deserialization.
+     *  - The high bits (masked by ~DISK_VERSION_IGNORE_MASK) store actual serialization information.
+     *    Only 0 or DISK_VERSION_ADDRV2 (equal to the historical ADDRV2_FORMAT) are valid now, and
+     *    any other value triggers a deserialization failure. Other values can be added later if
+     *    needed.
+     *
+     *  For disk deserialization, ADDRV2_FORMAT in the stream version signals that ADDRV2
+     *  deserialization is permitted, but the actual format is determined by the high bits in the
+     *  stored version field. For network serialization, the stream version having ADDRV2_FORMAT or
+     *  not determines the actual format used (as it has no embedded version number).
+     */
+    static constexpr uint32_t DISK_VERSION_INIT{220000};
+    static constexpr uint32_t DISK_VERSION_IGNORE_MASK{0b00000000'00000111'11111111'11111111};
+    /** The version number written in disk serialized addresses to indicate V2 serializations.
+     * It must be exactly 1<<29, as that is the value that historical versions used for this
+     * (they used their internal ADDRV2_FORMAT flag here). */
+    static constexpr uint32_t DISK_VERSION_ADDRV2{1 << 29};
+    static_assert((DISK_VERSION_INIT & ~DISK_VERSION_IGNORE_MASK) == 0, "DISK_VERSION_INIT must be covered by DISK_VERSION_IGNORE_MASK");
+    static_assert((DISK_VERSION_ADDRV2 & DISK_VERSION_IGNORE_MASK) == 0, "DISK_VERSION_ADDRV2 must not be covered by DISK_VERSION_IGNORE_MASK");
+
 public:
     CAddress() : CService{} {};
     CAddress(CService ipIn, ServiceFlags nServicesIn) : CService{ipIn}, nServices{nServicesIn} {};
-    CAddress(CService ipIn, ServiceFlags nServicesIn, uint32_t nTimeIn) : CService{ipIn}, nServices{nServicesIn}, nTime{nTimeIn} {};
+    CAddress(CService ipIn, ServiceFlags nServicesIn, uint32_t nTimeIn) : CService{ipIn}, nTime{nTimeIn}, nServices{nServicesIn} {};
 
     SERIALIZE_METHODS(CAddress, obj)
     {
-        SER_READ(obj, obj.nTime = TIME_INIT);
-        int nVersion = s.GetVersion();
+        // CAddress has a distinct network serialization and a disk serialization, but it should never
+        // be hashed (except through CHashWriter in addrdb.cpp, which sets SER_DISK), and it's
+        // ambiguous what that would mean. Make sure no code relying on that is introduced:
+        assert(!(s.GetType() & SER_GETHASH));
+        bool use_v2;
+        bool store_time;
         if (s.GetType() & SER_DISK) {
-            READWRITE(nVersion);
-        }
-        if ((s.GetType() & SER_DISK) ||
-            (nVersion != INIT_PROTO_VERSION && !(s.GetType() & SER_GETHASH))) {
+            // In the disk serialization format, the encoding (v1 or v2) is determined by a flag version
+            // that's part of the serialization itself. ADDRV2_FORMAT in the stream version only determines
+            // whether V2 is chosen/permitted at all.
+            uint32_t stored_format_version = DISK_VERSION_INIT;
+            if (s.GetVersion() & ADDRV2_FORMAT) stored_format_version |= DISK_VERSION_ADDRV2;
+            READWRITE(stored_format_version);
+            stored_format_version &= ~DISK_VERSION_IGNORE_MASK; // ignore low bits
+            if (stored_format_version == 0) {
+                use_v2 = false;
+            } else if (stored_format_version == DISK_VERSION_ADDRV2 && (s.GetVersion() & ADDRV2_FORMAT)) {
+                // Only support v2 deserialization if ADDRV2_FORMAT is set.
+                use_v2 = true;
+            } else {
+                throw std::ios_base::failure("Unsupported CAddress disk format version");
+            }
+            store_time = true;
+        } else {
+            // In the network serialization format, the encoding (v1 or v2) is determined directly by
+            // the value of ADDRV2_FORMAT in the stream version, as no explicitly encoded version
+            // exists in the stream.
+            assert(s.GetType() & SER_NETWORK);
+            use_v2 = s.GetVersion() & ADDRV2_FORMAT;
             // The only time we serialize a CAddress object without nTime is in
             // the initial VERSION messages which contain two CAddress records.
             // At that point, the serialization version is INIT_PROTO_VERSION.
             // After the version handshake, serialization version is >=
             // MIN_PEER_PROTO_VERSION and all ADDR messages are serialized with
             // nTime.
-            READWRITE(obj.nTime);
+            store_time = s.GetVersion() != INIT_PROTO_VERSION;
         }
-        if (nVersion & ADDRV2_FORMAT) {
+
+        SER_READ(obj, obj.nTime = TIME_INIT);
+        if (store_time) READWRITE(obj.nTime);
+        // nServices is serialized as CompactSize in V2; as uint64_t in V1.
+        if (use_v2) {
             uint64_t services_tmp;
             SER_WRITE(obj, services_tmp = obj.nServices);
             READWRITE(Using<CompactSizeFormatter<false>>(services_tmp));
@@ -339,12 +391,15 @@ public:
         } else {
             READWRITE(Using<CustomUintFormatter<8>>(obj.nServices));
         }
-        READWRITEAS(CService, obj);
+        // Invoke V1/V2 serializer for CService parent object.
+        OverrideStream<Stream> os(&s, s.GetType(), use_v2 ? ADDRV2_FORMAT : 0);
+        SerReadWriteMany(os, ser_action, ReadWriteAsHelper<CService>(obj));
     }
 
-    ServiceFlags nServices{NODE_NONE};
-    // disk and network only
+    //! Always included in serialization, except in the network format on INIT_PROTO_VERSION.
     uint32_t nTime{TIME_INIT};
+    //! Serialized as uint64_t in V1, and as CompactSize in V2.
+    ServiceFlags nServices{NODE_NONE};
 };
 
 /** getdata message types */

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -232,6 +232,11 @@ extern const char* GETSPORKS;
  */
 extern const char* MNBROADCAST;
 /**
+ * The mnbroadcast2 message is used to broadcast masternode startup data to connected peers
+ * Supporting BIP155 node addresses.
+ */
+extern const char* MNBROADCAST2;
+/**
  * The mnping message is used to ensure a masternode is still active
  */
 extern const char* MNPING;

--- a/src/version.h
+++ b/src/version.h
@@ -20,6 +20,9 @@ static const int INIT_PROTO_VERSION = 209;
 static const int MIN_PEER_PROTO_VERSION_BEFORE_ENFORCEMENT = 70922;
 static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT = 70923;
 
+//! Version where BIP155 was introduced
+static const int MIN_BIP155_PROTOCOL_VERSION = 70923;
+
 // Make sure that none of the values above collide with
 // `ADDRV2_FORMAT`.
 


### PR DESCRIPTION
Essentially the mnb node address is not being serialized/unserialized properly after the enforcement for the new BIP155 format (can be easily be seen adding a return value to `listmasternodes`. It will return an invalid addr for onion v3 established MNs).

The new ser/unser to the new format is not done automatically, was missing the `ADDRV2_FORMAT` version flag to the data stream.

So, after this PR, testnet nodes that are running the master branch will need to be refreshed.