### PR TITLE
[TierTwo] Enforce MessageVersion::MESS_VER_HASH (mnb/mnp) with 5.3

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -417,6 +417,14 @@ bool CMasternodeBroadcast::CheckAndUpdate(int& nDos, int nChainHeight)
         return false;
     }
 
+    // reject old signature version after v5.3
+    if (nMessVersion != MessageVersion::MESS_VER_HASH &&
+        Params().GetConsensus().NetworkUpgradeActive(nChainHeight, Consensus::UPGRADE_V5_3)) {
+        LogPrint(BCLog::MASTERNODE, "mnb - rejecting old message version for mn %s\n", vin.prevout.hash.ToString());
+        nDos = 30;
+        return false;
+    }
+
     if (protocolVersion < ActiveProtocol()) {
         LogPrint(BCLog::MASTERNODE,"mnb - ignoring outdated Masternode %s protocol version %d\n", vin.prevout.hash.ToString(), protocolVersion);
         return false;
@@ -612,6 +620,14 @@ bool CMasternodePing::CheckAndUpdate(int& nDos, int nChainHeight, bool fRequireA
 
     if (sigTime <= GetAdjustedTime() - 60 * 60) {
         LogPrint(BCLog::MNPING,"%s: Signature rejected, too far into the past %s - %d %d \n", __func__, vin.prevout.hash.ToString(), sigTime, GetAdjustedTime());
+        nDos = 30;
+        return false;
+    }
+
+    // reject old signature version after v5.3
+    if (nMessVersion != MessageVersion::MESS_VER_HASH &&
+        Params().GetConsensus().NetworkUpgradeActive(nChainHeight, Consensus::UPGRADE_V5_3)) {
+        LogPrint(BCLog::MNPING, "mnp - rejecting old message version for mn %s\n", vin.prevout.hash.ToString());
         nDos = 30;
         return false;
     }

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -147,6 +147,7 @@ bool CMasternode::UpdateFromNewBroadcast(CMasternodeBroadcast& mnb, int chainHei
 {
     if (mnb.sigTime > sigTime) {
         // TODO: lock cs. Need to be careful as mnb.lastPing.CheckAndUpdate locks cs_main internally.
+        nMessVersion = mnb.nMessVersion;
         pubKeyMasternode = mnb.pubKeyMasternode;
         pubKeyCollateralAddress = mnb.pubKeyCollateralAddress;
         sigTime = mnb.sigTime;

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -232,6 +232,9 @@ int CMasternodeMan::CheckAndRemove(bool forceExpiredRemoval)
         return 0;
     }
 
+    // !TODO: can be removed after enforcement
+    bool reject_v0 = Params().GetConsensus().NetworkUpgradeActive(GetBestHeight(), Consensus::UPGRADE_V5_3);
+
     LOCK(cs);
 
     //remove inactive and outdated (or replaced by DMN)
@@ -242,7 +245,8 @@ int CMasternodeMan::CheckAndRemove(bool forceExpiredRemoval)
         if (activeState == CMasternode::MASTERNODE_REMOVE ||
             activeState == CMasternode::MASTERNODE_VIN_SPENT ||
             (forceExpiredRemoval && activeState == CMasternode::MASTERNODE_EXPIRED) ||
-            mn->protocolVersion < ActiveProtocol()) {
+            mn->protocolVersion < ActiveProtocol() ||
+            (reject_v0 && mn->nMessVersion != MessageVersion::MESS_VER_HASH)) {
             LogPrint(BCLog::MASTERNODE, "Removing inactive (legacy) Masternode %s\n", it->first.ToString());
             //erase all of the broadcasts we've seen from this vin
             // -- if we missed a few pings and the node was removed, this will allow is to get it back without them


### PR DESCRIPTION
After v5.3 NU enforcement reject mnb/mnp messages with `MESS_VER_STRMESS` nMessVersion, and clean up the maps.