### PR TITLE
[GUI] Remove extra jump line in mnb creation error message

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -304,7 +304,7 @@ bool CMasternodeBroadcast::Create(const std::string& strService,
     // Check if the MN has a ADDRv2 and reject it if the new NU wasn't enforced.
     if (!_service.IsAddrV1Compatible() &&
         !Params().GetConsensus().NetworkUpgradeActive(chainHeight, Consensus::UPGRADE_V5_3)) {
-        strErrorRet = "Cannot start MN with a v2 address before the v5.3 enforcement\n";
+        strErrorRet = "Cannot start MN with a v2 address before the v5.3 enforcement";
         return false;
     }
 

--- a/src/qt/pivx/masternodeswidget.cpp
+++ b/src/qt/pivx/masternodeswidget.cpp
@@ -18,7 +18,6 @@
 #include "masternode-sync.h"
 #include "masternodeconfig.h"
 #include "masternodeman.h"
-#include "wallet/wallet.h"
 #include "util/system.h"
 #include "qt/pivx/optionbutton.h"
 #include <fstream>
@@ -31,8 +30,6 @@
 class MNHolder : public FurListRow<QWidget*>
 {
 public:
-    MNHolder();
-
     explicit MNHolder(bool _isLightTheme) : FurListRow(), isLightTheme(_isLightTheme) {}
 
     MNRow* createHolder(int pos) override


### PR DESCRIPTION
Tiny bugfix that appeared walking through the wallet..

None of the mnb creation error strings contain a jump line because the returned string is used as command line output and in the GUI snackbar. None of them are expecting it, in the GUI, the snackbar notification text is being cut.