### PR TITLE
[TierTwo][BugFix] Fix peer banning for not synced tiertwo + GetMNList and inv performance improvements.

### DIFF
--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -793,23 +793,39 @@ int CMasternodeMan::ProcessMNPing(CNode* pfrom, CMasternodePing& mnp)
 
 int CMasternodeMan::ProcessGetMNList(CNode* pfrom, CTxIn& vin)
 {
-    if (vin.IsNull()) { //only should ask for this once
-        //local network
-        bool isLocal = (pfrom->addr.IsRFC1918() || pfrom->addr.IsLocal());
+    // Single MN request
+    if (!vin.IsNull()) {
+        CMasternode* mn = Find(vin.prevout);
+        if (!mn || !mn->IsEnabled()) return 0; // Nothing to return.
 
-        if (!isLocal && Params().NetworkIDString() == CBaseChainParams::MAIN) {
-            std::map<CNetAddr, int64_t>::iterator i = mAskedUsForMasternodeList.find(pfrom->addr);
-            if (i != mAskedUsForMasternodeList.end()) {
-                int64_t t = (*i).second;
-                if (GetTime() < t) {
-                    LogPrintf("CMasternodeMan::ProcessMessage() : dseg - peer already asked me for the list\n");
-                    return 34;
-                }
+        // Broadcast the MN.
+        CMasternodeBroadcast mnb = CMasternodeBroadcast(*mn);
+        const uint256& hash = mnb.GetHash();
+        pfrom->PushInventory(CInv(MSG_MASTERNODE_ANNOUNCE, hash));
+
+        // Add to mapSeenMasternodeBroadcast in case that isn't there for some reason.
+        if (!mapSeenMasternodeBroadcast.count(hash)) mapSeenMasternodeBroadcast.emplace(hash, mnb);
+
+        LogPrint(BCLog::MASTERNODE, "dseg - Sent 1 Masternode entry to peer %i\n", pfrom->GetId());
+        return 0;
+    }
+
+    // Only should ask for this once
+    // local network
+    bool isLocal = (pfrom->addr.IsRFC1918() || pfrom->addr.IsLocal());
+
+    if (!isLocal && Params().NetworkIDString() == CBaseChainParams::MAIN) {
+        std::map<CNetAddr, int64_t>::iterator i = mAskedUsForMasternodeList.find(pfrom->addr);
+        if (i != mAskedUsForMasternodeList.end()) {
+            int64_t t = (*i).second;
+            if (GetTime() < t) {
+                LogPrintf("CMasternodeMan::ProcessMessage() : dseg - peer already asked me for the list\n");
+                return 34;
             }
-            int64_t askAgain = GetTime() + MASTERNODES_DSEG_SECONDS;
-            mAskedUsForMasternodeList[pfrom->addr] = askAgain;
         }
-    } //else, asking for a specific node which is ok
+        int64_t askAgain = GetTime() + MASTERNODES_DSEG_SECONDS;
+        mAskedUsForMasternodeList[pfrom->addr] = askAgain;
+    }
 
     int nInvCount = 0;
     {
@@ -820,27 +836,24 @@ int CMasternodeMan::ProcessGetMNList(CNode* pfrom, CTxIn& vin)
 
             if (mn->IsEnabled()) {
                 LogPrint(BCLog::MASTERNODE, "dseg - Sending Masternode entry - %s \n", mn->vin.prevout.hash.ToString());
-                if (vin.IsNull() || vin == mn->vin) {
-                    CMasternodeBroadcast mnb = CMasternodeBroadcast(*mn);
-                    uint256 hash = mnb.GetHash();
-                    pfrom->PushInventory(CInv(MSG_MASTERNODE_ANNOUNCE, hash));
-                    nInvCount++;
 
-                    if (!mapSeenMasternodeBroadcast.count(hash)) mapSeenMasternodeBroadcast.emplace(hash, mnb);
+                CMasternodeBroadcast mnb = CMasternodeBroadcast(*mn);
+                uint256 hash = mnb.GetHash();
+                pfrom->PushInventory(CInv(MSG_MASTERNODE_ANNOUNCE, hash));
+                nInvCount++;
 
-                    if (vin == mn->vin) {
-                        LogPrint(BCLog::MASTERNODE, "dseg - Sent 1 Masternode entry to peer %i\n", pfrom->GetId());
-                        return 0;
-                    }
+                if (!mapSeenMasternodeBroadcast.count(hash)) mapSeenMasternodeBroadcast.emplace(hash, mnb);
+
+                if (vin == mn->vin) {
+                    LogPrint(BCLog::MASTERNODE, "dseg - Sent 1 Masternode entry to peer %i\n", pfrom->GetId());
+                    return 0;
                 }
             }
         }
     }
 
-    if (vin.IsNull()) {
-        g_connman->PushMessage(pfrom, CNetMsgMaker(pfrom->GetSendVersion()).Make(NetMsgType::SYNCSTATUSCOUNT, MASTERNODE_SYNC_LIST, nInvCount));
-        LogPrint(BCLog::MASTERNODE, "dseg - Sent %d Masternode entries to peer %i\n", nInvCount, pfrom->GetId());
-    }
+    g_connman->PushMessage(pfrom, CNetMsgMaker(pfrom->GetSendVersion()).Make(NetMsgType::SYNCSTATUSCOUNT, MASTERNODE_SYNC_LIST, nInvCount));
+    LogPrint(BCLog::MASTERNODE, "dseg - Sent %d Masternode entries to peer %i\n", nInvCount, pfrom->GetId());
 
     // All good
     return 0;

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -83,6 +83,9 @@ private:
     int ProcessMNPing(CNode* pfrom, CMasternodePing& mnp);
     int ProcessMessageInner(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
 
+    // Relay a MN
+    void BroadcastInvMN(CMasternode* mn, CNode* pfrom);
+
 public:
     // Keep track of all broadcasts I've seen
     std::map<uint256, CMasternodeBroadcast> mapSeenMasternodeBroadcast;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2171,7 +2171,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto, std::atomic<bool>& interruptM
         std::vector<CInv> vInvWait;
         {
             LOCK(pto->cs_inventory);
-            vInv.reserve(std::max<size_t>(pto->vInventoryBlockToSend.size(), INVENTORY_BROADCAST_MAX));
+            vInv.reserve(std::max<size_t>(pto->vInventoryBlockToSend.size() + pto->vInventoryTierTwoToSend.size(), INVENTORY_BROADCAST_MAX));
 
             // Add blocks
             for (const uint256& hash : pto->vInventoryBlockToSend) {


### PR DESCRIPTION
Dug over the recurrent "mnw - invalid signature" error during the initial MNs list synchronization, made a large performance improvements to the `GetMNList` process and solved a bug in the inventory vector size calculation.

1) Most of the "mnw - invalid signature" errors,  during the initial tier two synchronization, are due a not synced MNs list, not because the signature is invalid (the two statement are logging the same error string).
As the tier two initial sync use to not relay the complete MNs list at once (it slowly syncs up while the node receives different messages such as `mnwinner` and `mnvote`), we have to request the missing MN without increasing the misbehaving score as this can/will ban a good peers invalidly.  Single MN requests to a certain peer are guarded to be done only every 10 min.

2) The inventory messages broadcast is not contemplating the tier two inv vector in the reserve call, reallocating the vector on-demand to cover the new size on every tier two inv append.

3) Improved the `GetMNList` msg processing that was walking through **all** of the MNs every single time, don't care if the peer is requesting a single MN..