### PR TITLE
[GUI][BUG] Console: allow empty arguments

### DIFF
--- a/src/qt/rpcexecutor.cpp
+++ b/src/qt/rpcexecutor.cpp
@@ -112,6 +112,7 @@ bool RPCExecutor::ExecuteCommandLine(std::string& strResult, const std::string& 
     enum CmdParseState
     {
         STATE_EATING_SPACES,
+        STATE_EATING_SPACES_IN_ARG,
         STATE_ARGUMENT,
         STATE_SINGLEQUOTED,
         STATE_DOUBLEQUOTED,
@@ -195,6 +196,7 @@ bool RPCExecutor::ExecuteCommandLine(std::string& strResult, const std::string& 
                     break;
             }
             case STATE_ARGUMENT: // In or after argument
+            case STATE_EATING_SPACES_IN_ARG:
             case STATE_EATING_SPACES: // Handle runs of whitespace
                 switch(ch)
             {
@@ -206,13 +208,12 @@ bool RPCExecutor::ExecuteCommandLine(std::string& strResult, const std::string& 
                     {
                         if (ch == '(' && stack.size() && stack.back().size() > 0)
                             stack.push_back(std::vector<std::string>());
-                        if (curarg.size())
-                        {
-                            // don't allow commands after executed commands on baselevel
-                            if (!stack.size())
-                                throw std::runtime_error("Invalid Syntax");
-                            stack.back().push_back(curarg);
-                        }
+
+                        // don't allow commands after executed commands on baselevel
+                        if (!stack.size())
+                            throw std::runtime_error("Invalid Syntax");
+
+                        stack.back().push_back(curarg);
                         curarg.clear();
                         state = STATE_EATING_SPACES;
                     }
@@ -238,13 +239,12 @@ bool RPCExecutor::ExecuteCommandLine(std::string& strResult, const std::string& 
                     }
                     break;
                 case ' ': case ',': case '\t':
-                    if(state == STATE_ARGUMENT) // Space ends argument
+                    if(state == STATE_ARGUMENT || (state == STATE_EATING_SPACES_IN_ARG && ch == ',')) // Space ends argument
                     {
-                        if (curarg.size())
-                            stack.back().push_back(curarg);
+                        stack.back().push_back(curarg);
                         curarg.clear();
                     }
-                    state = STATE_EATING_SPACES;
+                    state = (ch == ',' ? STATE_EATING_SPACES_IN_ARG : STATE_EATING_SPACES);
                     break;
                 default: curarg += ch; state = STATE_ARGUMENT;
             }


### PR DESCRIPTION
#2372 broke the support for empty arguments `""` (which is required as first argument of `sendmany`).
Backport the fix from bitcoin#9329

Thanks to @NoobieDev12 for reporting this bug.