### PR TITLE
[Consensus] Establish v5.3 NU enforcement height for mainnet

### DIFF
--- a/src/blockassembler.cpp
+++ b/src/blockassembler.cpp
@@ -536,7 +536,7 @@ void IncrementExtraNonce(std::shared_ptr<CBlock>& pblock, int nHeight, unsigned 
 int32_t ComputeBlockVersion(const Consensus::Params& consensus, int nHeight)
 {
     if (NetworkUpgradeActive(nHeight, consensus, Consensus::UPGRADE_V5_0)) {
-        return CBlockHeader::CURRENT_VERSION;       // v10 (since 5.1.99)
+        return CBlockHeader::CURRENT_VERSION;       // v11 (since 5.2.99)
     } else if (consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V4_0)) {
         return 7;
     } else if (consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V3_4)) {

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -201,8 +201,7 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_V4_0].nActivationHeight          = 2153200;
         consensus.vUpgrades[Consensus::UPGRADE_V5_0].nActivationHeight          = 2700500;
         consensus.vUpgrades[Consensus::UPGRADE_V5_2].nActivationHeight          = 2927000;
-        consensus.vUpgrades[Consensus::UPGRADE_V5_3].nActivationHeight =
-                Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
+        consensus.vUpgrades[Consensus::UPGRADE_V5_3].nActivationHeight          = 3014000;
         consensus.vUpgrades[Consensus::UPGRADE_V6_0].nActivationHeight =
                 Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
 

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -23,7 +23,7 @@ class CBlockHeader
 {
 public:
     // header
-    static const int32_t CURRENT_VERSION=10;    // since v5.1.99
+    static const int32_t CURRENT_VERSION=11;    // since v5.2.99
     int32_t nVersion;
     uint256 hashPrevBlock;
     uint256 hashMerkleRoot;

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -35,9 +35,9 @@ MY_RELAY = 1 # from version 70001 onwards, fRelay should be appended to version 
 
 MAX_INV_SZ = 50000
 MAX_BLOCK_BASE_SIZE = 2000000
-CURRENT_BLK_VERSION = 10
+CURRENT_BLK_VERSION = 11
 
-COIN = 100000000 # 1 btc in satoshis
+COIN = 100000000 # 1 PIV in satoshis
 
 NODE_NETWORK = (1 << 0)
 # NODE_GETUTXO = (1 << 1)


### PR DESCRIPTION
Set the v5.3 network upgrade enforcement height for mainnet and bump the block version number to "notify" nodes about the update.

```
v5.3 enforcement at block `3,014,000` --> around 9/10 Sept.
```

Some dates that have in mind, we can pack the release candidate this weekend Aug 21/22th, and moving forward, pack the final release at Aug 27/28th, leaving a ~14 days window till the HF enforcement. Then celebrate and enjoy the network improvements with a good beer/coke.