### PR TITLE
[RPC] Do not register DMN-related RPC commands

### DIFF
--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -993,6 +993,11 @@ static const CRPCCommand commands[] =
 
 void RegisterEvoRPCCommands(CRPCTable &tableRPC)
 {
+    if (!Params().IsRegTestNet()) {
+        // Disabled before PIVX v6.0
+        return;
+    }
+
     for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++) {
         tableRPC.appendCommand(commands[vcidx].name, &commands[vcidx]);
     }


### PR DESCRIPTION
These commands cannot be used before v6.0 NU.
Their name (and category) is likely going to change (see issue #2385) before v6.0 release.
So, it is better to just disable them for now (for release 5.3).

I kept the registration on RegTest, so we can keep running the functional tests.