### PR TITLE
[Network] Add mainnet DNS seeder from furszy.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -232,6 +232,7 @@ public:
         // Note that of those with the service bits flag, most only support a subset of possible options
         vSeeds.emplace_back("pivx.seed.fuzzbawls.pw", true);     // Primary DNS Seeder from Fuzzbawls
         vSeeds.emplace_back("pivx.seed2.fuzzbawls.pw", true);    // Secondary DNS Seeder from Fuzzbawls
+        vSeeds.emplace_back("pivx-seed.furszy.net", true);     // Primary DNS Seeder from furszy
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1, 30);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1, 13);


### PR DESCRIPTION
Added a new DNS seeder, it's already crawling the network and exposing a list of reliable nodes to be used as entry point.
Check it calling to `nslookup pivx-seed.furszy.net`.

As every other sipa's based seeder, it's only supporting v1 addresses. A good future goal will be to add v2 addresses support as well.