### PR TITLE
[GUI][BUG] remove duplicated coll. confirmation check in MNModel::data

### DIFF
--- a/src/qt/pivx/mnmodel.cpp
+++ b/src/qt/pivx/mnmodel.cpp
@@ -106,12 +106,7 @@ QVariant MNModel::data(const QModelIndex &index, int role) const
                 return "Not available";
             }
             case WAS_COLLATERAL_ACCEPTED:{
-                if (!isAvailable) return false;
-                std::string txHash = rec->vin.prevout.hash.GetHex();
-                if (!collateralTxAccepted.value(txHash) && walletModel) {
-                    return walletModel->getWalletTxDepth(rec->vin.prevout.hash) > 0;
-                }
-                return true;
+                return isAvailable && collateralTxAccepted.value(rec->vin.prevout.hash.GetHex());
             }
         }
     }


### PR DESCRIPTION
Follow up to the discussion in #2529.
If walletModel is null, then `MNModel::data` returns true at `WAS_COLLATERAL_ACCEPTED`.
Fix the bug removing the duplicated check (`getWalletTxDepth > MasternodeCollateralMinConf()` is already checked every 30 seconds in `MNModel::updateMNList`).