### PR TITLE
[scripted-diff] Rename wallet database classes

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -335,7 +335,7 @@ bool WalletModel::getWalletCustomFee(CAmount& nFeeRet)
 void WalletModel::setWalletCustomFee(bool fUseCustomFee, const CAmount nFee)
 {
     LOCK(wallet->cs_wallet);
-    CWalletDB db(wallet->GetDBHandle());
+    WalletBatch db(wallet->GetDBHandle());
     if (wallet->fUseCustomFee != fUseCustomFee) {
         wallet->fUseCustomFee = fUseCustomFee;
         db.WriteUseCustomFee(fUseCustomFee);

--- a/src/sapling/sapling_operation.cpp
+++ b/src/sapling/sapling_operation.cpp
@@ -409,7 +409,7 @@ static CacheCheckResult CheckCachedNote(CWallet* pwallet,
         if (sspkm->IsSaplingSpent(*(nd.nullifier))) {
             LogPrintf("Removed note %s as it appears to be already spent.\n", noteStr);
             prevTx.MarkDirty();
-            CWalletDB(pwallet->GetDBHandle(), "r+").WriteTx(prevTx);
+            WalletBatch(pwallet->GetDBHandle(), "r+").WriteTx(prevTx);
             pwallet->NotifyTransactionChanged(pwallet, t.op.hash, CT_UPDATED);
             return CacheCheckResult::SPENT;
         }

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -895,7 +895,7 @@ libzcash::SaplingPaymentAddress SaplingScriptPubKeyMan::GenerateNewSaplingZKey()
     } while (wallet->HaveSaplingSpendingKey(xsk.ToXFVK()));
 
     // Update the chain model in the database
-    if (!CWalletDB(wallet->GetDBHandle()).WriteHDChain(hdChain))
+    if (!WalletBatch(wallet->GetDBHandle()).WriteHDChain(hdChain))
         throw std::runtime_error(std::string(__func__) + ": Writing HD chain model failed");
 
     // Create new metadata
@@ -1001,7 +1001,7 @@ bool SaplingScriptPubKeyMan::AddSaplingZKey(
 
     if (!wallet->IsCrypted()) {
         auto ivk = sk.expsk.full_viewing_key().in_viewing_key();
-        return CWalletDB(wallet->GetDBHandle()).WriteSaplingZKey(ivk, sk, mapSaplingZKeyMetadata[ivk]);
+        return WalletBatch(wallet->GetDBHandle()).WriteSaplingZKey(ivk, sk, mapSaplingZKeyMetadata[ivk]);
     }
 
     return true;
@@ -1048,7 +1048,7 @@ bool SaplingScriptPubKeyMan::AddSaplingIncomingViewingKey(
     }
 
     if (!wallet->IsCrypted()) {
-        return CWalletDB(wallet->GetDBHandle()).WriteSaplingPaymentAddress(addr, ivk);
+        return WalletBatch(wallet->GetDBHandle()).WriteSaplingPaymentAddress(addr, ivk);
     }
 
     return true;
@@ -1083,12 +1083,12 @@ bool SaplingScriptPubKeyMan::AddCryptedSaplingSpendingKeyDB(const libzcash::Sapl
         return false;
     {
         LOCK(wallet->cs_wallet);
-        if (wallet->pwalletdbEncryption) {
-            return wallet->pwalletdbEncryption->WriteCryptedSaplingZKey(extfvk,
+        if (wallet->encrypted_batch) {
+            return wallet->encrypted_batch->WriteCryptedSaplingZKey(extfvk,
                                                                 vchCryptedSecret,
                                                                 mapSaplingZKeyMetadata[extfvk.fvk.in_viewing_key()]);
         } else {
-            return CWalletDB(wallet->GetDBHandle()).WriteCryptedSaplingZKey(extfvk,
+            return WalletBatch(wallet->GetDBHandle()).WriteCryptedSaplingZKey(extfvk,
                                                                     vchCryptedSecret,
                                                                     mapSaplingZKeyMetadata[extfvk.fvk.in_viewing_key()]);
         }
@@ -1175,7 +1175,7 @@ void SaplingScriptPubKeyMan::SetHDSeed(const CKeyID& keyID, bool force, bool mem
 
     // Update the commonOVK to recover t->shield notes
     commonOVK = getCommonOVKFromSeed();
-    if (!memonly && !CWalletDB(wallet->GetDBHandle()).WriteSaplingCommonOVK(*commonOVK)) {
+    if (!memonly && !WalletBatch(wallet->GetDBHandle()).WriteSaplingCommonOVK(*commonOVK)) {
         throw std::runtime_error(std::string(__func__) + ": writing sapling commonOVK failed");
     }
 }
@@ -1186,7 +1186,7 @@ void SaplingScriptPubKeyMan::SetHDChain(CHDChain& chain, bool memonly)
     if (chain.chainType != HDChain::ChainCounterType::Sapling)
         throw std::runtime_error(std::string(__func__) + ": trying to store an invalid chain type");
 
-    if (!memonly && !CWalletDB(wallet->GetDBHandle()).WriteHDChain(chain))
+    if (!memonly && !WalletBatch(wallet->GetDBHandle()).WriteHDChain(chain))
         throw std::runtime_error(std::string(__func__) + ": writing sapling chain failed");
 
     hdChain = chain;
@@ -1203,7 +1203,7 @@ uint256 SaplingScriptPubKeyMan::getCommonOVK()
 
     // Else, look for it in the database
     uint256 ovk;
-    if (CWalletDB(wallet->GetDBHandle()).ReadSaplingCommonOVK(ovk)) {
+    if (WalletBatch(wallet->GetDBHandle()).ReadSaplingCommonOVK(ovk)) {
         commonOVK = std::move(ovk);
         return *commonOVK;
     }
@@ -1212,7 +1212,7 @@ uint256 SaplingScriptPubKeyMan::getCommonOVK()
     // So we should always call this after unlocking the wallet during a spend
     // from a transparent address, or when changing/setting the HD seed.
     commonOVK = getCommonOVKFromSeed();
-    if (!CWalletDB(wallet->GetDBHandle()).WriteSaplingCommonOVK(*commonOVK)) {
+    if (!WalletBatch(wallet->GetDBHandle()).WriteSaplingCommonOVK(*commonOVK)) {
         throw std::runtime_error("Unable to write sapling Common OVK to database");
     }
     return *commonOVK;

--- a/src/test/librust/wallet_zkeys_tests.cpp
+++ b/src/test/librust/wallet_zkeys_tests.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_SUITE(wallet_zkeys_tests)
   * LoadSaplingZKeyMetadata()
   */
 BOOST_FIXTURE_TEST_CASE(StoreAndLoadSaplingZkeys, TestingSetup) {
-    CWallet wallet("dummy", CWalletDBWrapper::CreateDummy());
+    CWallet wallet("dummy", WalletDatabase::CreateDummy());
     LOCK(wallet.cs_wallet);
     // wallet should be empty
     std::set<libzcash::SaplingPaymentAddress> addrs;
@@ -129,12 +129,12 @@ BOOST_FIXTURE_TEST_CASE(StoreAndLoadSaplingZkeys, TestingSetup) {
 }
 
 /**
-  * This test covers methods on CWalletDB to load/save crypted sapling z keys.
+  * This test covers methods on WalletBatch to load/save crypted sapling z keys.
   */
 BOOST_FIXTURE_TEST_CASE(WriteCryptedSaplingZkeyDirectToDb, BasicTestingSetup) {
     fs::path path = fs::absolute("testWallet1", GetWalletDir());
     path.make_preferred();
-    std::unique_ptr<CWallet> testWallet = std::make_unique<CWallet>("testWallet1", CWalletDBWrapper::Create(path));
+    std::unique_ptr<CWallet> testWallet = std::make_unique<CWallet>("testWallet1", WalletDatabase::Create(path));
     bool fFirstRun;
     BOOST_CHECK_EQUAL(testWallet->LoadWallet(fFirstRun), DB_LOAD_OK);
     BOOST_CHECK(!testWallet->HasSaplingSPKM());
@@ -171,7 +171,7 @@ BOOST_FIXTURE_TEST_CASE(WriteCryptedSaplingZkeyDirectToDb, BasicTestingSetup) {
 
     // Create a new wallet from the existing wallet path
     fFirstRun = false;
-    std::unique_ptr<CWallet> wallet2 = std::make_unique<CWallet>("testWallet1", CWalletDBWrapper::Create(path));
+    std::unique_ptr<CWallet> wallet2 = std::make_unique<CWallet>("testWallet1", WalletDatabase::Create(path));
     BOOST_CHECK_EQUAL(DB_LOAD_OK, wallet2->LoadWallet(fFirstRun));
 
     // Confirm it's not the same as the other wallet

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -33,14 +33,14 @@ namespace {
 //! (https://docs.oracle.com/cd/E17275_01/html/programmer_reference/program_copy.html),
 //! so bitcoin should never create different databases with the same fileid, but
 //! this error can be triggered if users manually copy database files.
-void CheckUniqueFileid(const CDBEnv& env, const std::string& filename, Db& db)
+void CheckUniqueFileid(const BerkeleyEnvironment& env, const std::string& filename, Db& db)
 {
     if (env.IsMock()) return;
 
     u_int8_t fileid[DB_FILE_ID_LEN];
     int ret = db.get_mpf()->get_fileid(fileid);
     if (ret != 0) {
-        throw std::runtime_error(strprintf("CDB: Can't open database %s (get_fileid failed with %d)", filename, ret));
+        throw std::runtime_error(strprintf("BerkeleyBatch: Can't open database %s (get_fileid failed with %d)", filename, ret));
     }
 
     for (const auto& item : env.mapDb) {
@@ -49,7 +49,7 @@ void CheckUniqueFileid(const CDBEnv& env, const std::string& filename, Db& db)
             memcmp(fileid, item_fileid, sizeof(fileid)) == 0) {
             const char* item_filename = nullptr;
             item.second->get_dbname(&item_filename, nullptr);
-            throw std::runtime_error(strprintf("CDB: Can't open database %s (duplicates fileid %s from %s)", filename,
+            throw std::runtime_error(strprintf("BerkeleyBatch: Can't open database %s (duplicates fileid %s from %s)", filename,
                 HexStr(item_fileid),
                 item_filename ? item_filename : "(unknown database)"));
         }
@@ -57,10 +57,10 @@ void CheckUniqueFileid(const CDBEnv& env, const std::string& filename, Db& db)
 }
 
 RecursiveMutex cs_db;
-std::map<std::string, CDBEnv> g_dbenvs; //!< Map from directory name to open db environment.
+std::map<std::string, BerkeleyEnvironment> g_dbenvs; //!< Map from directory name to open db environment.
 } // namespace
 
-CDBEnv* GetWalletEnv(const fs::path& wallet_path, std::string& database_filename)
+BerkeleyEnvironment* GetWalletEnv(const fs::path& wallet_path, std::string& database_filename)
 {
     fs::path env_directory;
     if (fs::is_regular_file(wallet_path)) {
@@ -76,7 +76,7 @@ CDBEnv* GetWalletEnv(const fs::path& wallet_path, std::string& database_filename
         database_filename = "wallet.dat";
     }
     LOCK(cs_db);
-    // Note: An ununsed temporary CDBEnv object may be created inside the
+    // Note: An ununsed temporary BerkeleyEnvironment object may be created inside the
     // emplace function if the key already exists. This is a little inefficient,
     // but not a big concern since the map will be changed in the future to hold
     // pointers instead of objects, anyway.
@@ -84,10 +84,10 @@ CDBEnv* GetWalletEnv(const fs::path& wallet_path, std::string& database_filename
 }
 
 //
-// CDB
+// BerkeleyBatch
 //
 
-void CDBEnv::Close()
+void BerkeleyEnvironment::Close()
 {
     if (!fDbEnvInit)
         return;
@@ -111,24 +111,24 @@ void CDBEnv::Close()
         DbEnv((u_int32_t)0).remove(strPath.c_str(), 0);
 }
 
-void CDBEnv::Reset()
+void BerkeleyEnvironment::Reset()
 {
     dbenv.reset(new DbEnv(DB_CXX_NO_EXCEPTIONS));
     fDbEnvInit = false;
     fMockDb = false;
 }
 
-CDBEnv::CDBEnv(const fs::path& dir_path) : strPath(dir_path.string())
+BerkeleyEnvironment::BerkeleyEnvironment(const fs::path& dir_path) : strPath(dir_path.string())
 {
     Reset();
 }
 
-CDBEnv::~CDBEnv()
+BerkeleyEnvironment::~BerkeleyEnvironment()
 {
     Close();
 }
 
-bool CDBEnv::Open(bool retry)
+bool BerkeleyEnvironment::Open(bool retry)
 {
     if (fDbEnvInit)
         return true;
@@ -145,7 +145,7 @@ bool CDBEnv::Open(bool retry)
     fs::path pathLogDir = pathIn / "database";
     TryCreateDirectories(pathLogDir);
     fs::path pathErrorFile = pathIn / "db.log";
-    LogPrintf("CDBEnv::Open: LogDir=%s ErrorFile=%s\n", pathLogDir.string(), pathErrorFile.string());
+    LogPrintf("BerkeleyEnvironment::Open: LogDir=%s ErrorFile=%s\n", pathLogDir.string(), pathErrorFile.string());
 
     unsigned int nEnvFlags = 0;
     if (gArgs.GetBoolArg("-privdb", DEFAULT_WALLET_PRIVDB))
@@ -173,7 +173,7 @@ bool CDBEnv::Open(bool retry)
         S_IRUSR | S_IWUSR);
     if (ret != 0) {
         dbenv->close(0);
-        LogPrintf("CDBEnv::Open: Error %d opening database environment: %s\n", ret, DbEnv::strerror(ret));
+        LogPrintf("BerkeleyEnvironment::Open: Error %d opening database environment: %s\n", ret, DbEnv::strerror(ret));
         if (retry) {
             // try moving the database env out of the way
             fs::path pathDatabaseBak = pathIn / strprintf("database.%d.bak", GetTime());
@@ -198,14 +198,14 @@ bool CDBEnv::Open(bool retry)
     return true;
 }
 
-void CDBEnv::MakeMock()
+void BerkeleyEnvironment::MakeMock()
 {
     if (fDbEnvInit)
-        throw std::runtime_error("CDBEnv::MakeMock : Already initialized");
+        throw std::runtime_error("BerkeleyEnvironment::MakeMock : Already initialized");
 
     boost::this_thread::interruption_point();
 
-    LogPrint(BCLog::DB, "CDBEnv::MakeMock\n");
+    LogPrint(BCLog::DB, "BerkeleyEnvironment::MakeMock\n");
 
     dbenv->set_cachesize(1, 0, 1);
     dbenv->set_lg_bsize(10485760 * 4);
@@ -224,13 +224,13 @@ void CDBEnv::MakeMock()
             DB_PRIVATE,
         S_IRUSR | S_IWUSR);
     if (ret > 0)
-        throw std::runtime_error(strprintf("CDBEnv::MakeMock : Error %d opening database environment.", ret));
+        throw std::runtime_error(strprintf("BerkeleyEnvironment::MakeMock : Error %d opening database environment.", ret));
 
     fDbEnvInit = true;
     fMockDb = true;
 }
 
-CDBEnv::VerifyResult CDBEnv::Verify(const std::string& strFile, recoverFunc_type recoverFunc, std::string& out_backup_filename)
+BerkeleyEnvironment::VerifyResult BerkeleyEnvironment::Verify(const std::string& strFile, recoverFunc_type recoverFunc, std::string& out_backup_filename)
 {
     LOCK(cs_db);
     assert(mapFileUseCount.count(strFile) == 0);
@@ -247,10 +247,10 @@ CDBEnv::VerifyResult CDBEnv::Verify(const std::string& strFile, recoverFunc_type
     return (fRecovered ? RECOVER_OK : RECOVER_FAIL);
 }
 
-bool CDB::Recover(const fs::path& file_path, void *callbackDataIn, bool (*recoverKVcallback)(void* callbackData, CDataStream ssKey, CDataStream ssValue), std::string& newFilename)
+bool BerkeleyBatch::Recover(const fs::path& file_path, void *callbackDataIn, bool (*recoverKVcallback)(void* callbackData, CDataStream ssKey, CDataStream ssValue), std::string& newFilename)
 {
     std::string filename;
-    CDBEnv* env = GetWalletEnv(file_path, filename);
+    BerkeleyEnvironment* env = GetWalletEnv(file_path, filename);
 
     // Recovery procedure:
     // move wallet file to walletfilename.timestamp.bak
@@ -271,7 +271,7 @@ bool CDB::Recover(const fs::path& file_path, void *callbackDataIn, bool (*recove
         return false;
     }
 
-    std::vector<CDBEnv::KeyValPair> salvagedData;
+    std::vector<BerkeleyEnvironment::KeyValPair> salvagedData;
     bool fSuccess = env->Salvage(newFilename, true, salvagedData);
     if (salvagedData.empty())
     {
@@ -294,7 +294,7 @@ bool CDB::Recover(const fs::path& file_path, void *callbackDataIn, bool (*recove
     }
 
     DbTxn* ptxn = env->TxnBegin();
-    for (CDBEnv::KeyValPair& row : salvagedData)
+    for (BerkeleyEnvironment::KeyValPair& row : salvagedData)
     {
         if (recoverKVcallback)
         {
@@ -315,10 +315,10 @@ bool CDB::Recover(const fs::path& file_path, void *callbackDataIn, bool (*recove
     return fSuccess;
 }
 
-bool CDB::VerifyEnvironment(const fs::path& file_path, std::string& errorStr)
+bool BerkeleyBatch::VerifyEnvironment(const fs::path& file_path, std::string& errorStr)
 {
     std::string walletFile;
-    CDBEnv* env = GetWalletEnv(file_path, walletFile);
+    BerkeleyEnvironment* env = GetWalletEnv(file_path, walletFile);
     fs::path walletDir = env->Directory();
 
     LogPrintf("Using BerkeleyDB version %s\n", DbEnv::version(0, 0, 0));
@@ -337,17 +337,17 @@ bool CDB::VerifyEnvironment(const fs::path& file_path, std::string& errorStr)
     return true;
 }
 
-bool CDB::VerifyDatabaseFile(const fs::path& file_path, std::string& warningStr, std::string& errorStr, CDBEnv::recoverFunc_type recoverFunc)
+bool BerkeleyBatch::VerifyDatabaseFile(const fs::path& file_path, std::string& warningStr, std::string& errorStr, BerkeleyEnvironment::recoverFunc_type recoverFunc)
 {
     std::string walletFile;
-    CDBEnv* env = GetWalletEnv(file_path, walletFile);
+    BerkeleyEnvironment* env = GetWalletEnv(file_path, walletFile);
     fs::path walletDir = env->Directory();
 
     if (fs::exists(walletDir / walletFile))
     {
         std::string backup_filename;
-        CDBEnv::VerifyResult r = env->Verify(walletFile, recoverFunc, backup_filename);
-        if (r == CDBEnv::RECOVER_OK)
+        BerkeleyEnvironment::VerifyResult r = env->Verify(walletFile, recoverFunc, backup_filename);
+        if (r == BerkeleyEnvironment::RECOVER_OK)
         {
             warningStr = strprintf(_("Warning: Wallet file corrupt, data salvaged!"
                                      " Original %s saved as %s in %s; if"
@@ -355,7 +355,7 @@ bool CDB::VerifyDatabaseFile(const fs::path& file_path, std::string& warningStr,
                                      " restore from a backup."),
                                    walletFile, backup_filename, walletDir);
         }
-        if (r == CDBEnv::RECOVER_FAIL) {
+        if (r == BerkeleyEnvironment::RECOVER_FAIL) {
             errorStr = strprintf(_("%s corrupt, salvage failed"), walletFile);
             return false;
         }
@@ -369,7 +369,7 @@ static const char *HEADER_END = "HEADER=END";
 /* End of key/value data */
 static const char *DATA_END = "DATA=END";
 
-bool CDBEnv::Salvage(const std::string& strFile, bool fAggressive, std::vector<CDBEnv::KeyValPair>& vResult)
+bool BerkeleyEnvironment::Salvage(const std::string& strFile, bool fAggressive, std::vector<BerkeleyEnvironment::KeyValPair>& vResult)
 {
     LOCK(cs_db);
     assert(mapFileUseCount.count(strFile) == 0);
@@ -383,14 +383,14 @@ bool CDBEnv::Salvage(const std::string& strFile, bool fAggressive, std::vector<C
     Db db(dbenv.get(), 0);
     int result = db.verify(strFile.c_str(), nullptr, &strDump, flags);
     if (result == DB_VERIFY_BAD) {
-        LogPrintf("CDBEnv::Salvage : Database salvage found errors, all data may not be recoverable.\n");
+        LogPrintf("BerkeleyEnvironment::Salvage : Database salvage found errors, all data may not be recoverable.\n");
         if (!fAggressive) {
-            LogPrintf("CDBEnv::Salvage : Rerun with aggressive mode to ignore errors and continue.\n");
+            LogPrintf("BerkeleyEnvironment::Salvage : Rerun with aggressive mode to ignore errors and continue.\n");
             return false;
         }
     }
     if (result != 0 && result != DB_VERIFY_BAD) {
-        LogPrintf("CDBEnv::Salvage : Database salvage failed with result %d.\n", result);
+        LogPrintf("BerkeleyEnvironment::Salvage : Database salvage failed with result %d.\n", result);
         return false;
     }
 
@@ -414,7 +414,7 @@ bool CDBEnv::Salvage(const std::string& strFile, bool fAggressive, std::vector<C
                 break;
             getline(strDump, valueHex);
             if (valueHex == DATA_END) {
-                LogPrintf("CDBEnv::Salvage: WARNING: Number of keys in data does not match number of values.\n");
+                LogPrintf("BerkeleyEnvironment::Salvage: WARNING: Number of keys in data does not match number of values.\n");
                 break;
             }
             vResult.emplace_back(ParseHex(keyHex), ParseHex(valueHex));
@@ -422,7 +422,7 @@ bool CDBEnv::Salvage(const std::string& strFile, bool fAggressive, std::vector<C
     }
 
     if (keyHex != DATA_END) {
-        LogPrintf("CDBEnv::Salvage: WARNING: Unexpected end of file while reading salvage output.\n");
+        LogPrintf("BerkeleyEnvironment::Salvage: WARNING: Unexpected end of file while reading salvage output.\n");
         return false;
     }
 
@@ -430,7 +430,7 @@ bool CDBEnv::Salvage(const std::string& strFile, bool fAggressive, std::vector<C
 }
 
 
-void CDBEnv::CheckpointLSN(const std::string& strFile)
+void BerkeleyEnvironment::CheckpointLSN(const std::string& strFile)
 {
     dbenv->txn_checkpoint(0, 0, 0);
     if (fMockDb)
@@ -439,15 +439,15 @@ void CDBEnv::CheckpointLSN(const std::string& strFile)
 }
 
 
-CDB::CDB(CWalletDBWrapper& dbw, const char* pszMode, bool fFlushOnCloseIn) : pdb(nullptr), activeTxn(nullptr)
+BerkeleyBatch::BerkeleyBatch(BerkeleyDatabase& database, const char* pszMode, bool fFlushOnCloseIn) : pdb(nullptr), activeTxn(nullptr)
 {
     fReadOnly = (!strchr(pszMode, '+') && !strchr(pszMode, 'w'));
     fFlushOnClose = fFlushOnCloseIn;
-    env = dbw.env;
-    if (dbw.IsDummy()) {
+    env = database.env;
+    if (database.IsDummy()) {
         return;
     }
-    const std::string &strFilename = dbw.strFile;
+    const std::string &strFilename = database.strFile;
 
     bool fCreate = strchr(pszMode, 'c') != nullptr;
     unsigned int nFlags = DB_THREAD;
@@ -457,7 +457,7 @@ CDB::CDB(CWalletDBWrapper& dbw, const char* pszMode, bool fFlushOnCloseIn) : pdb
     {
         LOCK(cs_db);
         if (!env->Open(false /* retry */))
-            throw std::runtime_error("CDB: Failed to open database environment.");
+            throw std::runtime_error("BerkeleyBatch: Failed to open database environment.");
 
         pdb = env->mapDb[strFilename];
         if (pdb == nullptr) {
@@ -469,7 +469,7 @@ CDB::CDB(CWalletDBWrapper& dbw, const char* pszMode, bool fFlushOnCloseIn) : pdb
                 DbMpoolFile* mpf = pdb_temp->get_mpf();
                 ret = mpf->set_flags(DB_MPOOL_NOFILE, 1);
                 if (ret != 0) {
-                    throw std::runtime_error(strprintf("CDB: Failed to configure for no temp file backing for database %s", strFilename));
+                    throw std::runtime_error(strprintf("BerkeleyBatch: Failed to configure for no temp file backing for database %s", strFilename));
                 }
             }
 
@@ -481,7 +481,7 @@ CDB::CDB(CWalletDBWrapper& dbw, const char* pszMode, bool fFlushOnCloseIn) : pdb
                                  0);
 
             if (ret != 0) {
-                throw std::runtime_error(strprintf("CDB: Error %d, can't open database %s", ret, strFilename));
+                throw std::runtime_error(strprintf("BerkeleyBatch: Error %d, can't open database %s", ret, strFilename));
             }
 
             // Call CheckUniqueFileid on the containing BDB environment to
@@ -518,7 +518,7 @@ CDB::CDB(CWalletDBWrapper& dbw, const char* pszMode, bool fFlushOnCloseIn) : pdb
     }
 }
 
-void CDB::Flush()
+void BerkeleyBatch::Flush()
 {
     if (activeTxn)
         return;
@@ -531,12 +531,12 @@ void CDB::Flush()
     env->dbenv->txn_checkpoint(nMinutes ? gArgs.GetArg("-dblogsize", 100) * 1024 : 0, nMinutes, 0);
 }
 
-void CWalletDBWrapper::IncrementUpdateCounter()
+void BerkeleyDatabase::IncrementUpdateCounter()
 {
     ++nUpdateCounter;
 }
 
-void CDB::Close()
+void BerkeleyBatch::Close()
 {
     if (!pdb)
         return;
@@ -554,7 +554,7 @@ void CDB::Close()
     }
 }
 
-void CDBEnv::CloseDb(const std::string& strFile)
+void BerkeleyEnvironment::CloseDb(const std::string& strFile)
 {
     {
         LOCK(cs_db);
@@ -568,13 +568,13 @@ void CDBEnv::CloseDb(const std::string& strFile)
     }
 }
 
-bool CDB::Rewrite(CWalletDBWrapper& dbw, const char* pszSkip)
+bool BerkeleyBatch::Rewrite(BerkeleyDatabase& database, const char* pszSkip)
 {
-    if (dbw.IsDummy()) {
+    if (database.IsDummy()) {
         return true;
     }
-    CDBEnv *env = dbw.env;
-    const std::string& strFile = dbw.strFile;
+    BerkeleyEnvironment *env = database.env;
+    const std::string& strFile = database.strFile;
     while (true) {
         {
             LOCK(cs_db);
@@ -585,10 +585,10 @@ bool CDB::Rewrite(CWalletDBWrapper& dbw, const char* pszSkip)
                 env->mapFileUseCount.erase(strFile);
 
                 bool fSuccess = true;
-                LogPrintf("CDB::Rewrite : Rewriting %s...\n", strFile);
+                LogPrintf("BerkeleyBatch::Rewrite : Rewriting %s...\n", strFile);
                 std::string strFileRes = strFile + ".rewrite";
                 { // surround usage of db with extra {}
-                    CDB db(dbw, "r");
+                    BerkeleyBatch db(database, "r");
                     std::unique_ptr<Db> pdbCopy = std::make_unique<Db>(env->dbenv.get(), 0);
 
                     int ret = pdbCopy->open(NULL, // Txn pointer
@@ -598,7 +598,7 @@ bool CDB::Rewrite(CWalletDBWrapper& dbw, const char* pszSkip)
                         DB_CREATE,                // Flags
                         0);
                     if (ret > 0) {
-                        LogPrintf("CDB::Rewrite : Can't create database file %s\n", strFileRes);
+                        LogPrintf("BerkeleyBatch::Rewrite : Can't create database file %s\n", strFileRes);
                         fSuccess = false;
                     }
 
@@ -648,7 +648,7 @@ bool CDB::Rewrite(CWalletDBWrapper& dbw, const char* pszSkip)
                         fSuccess = false;
                 }
                 if (!fSuccess)
-                    LogPrintf("CDB::Rewrite : Failed to rewrite database file %s\n", strFileRes);
+                    LogPrintf("BerkeleyBatch::Rewrite : Failed to rewrite database file %s\n", strFileRes);
                 return fSuccess;
             }
         }
@@ -657,11 +657,11 @@ bool CDB::Rewrite(CWalletDBWrapper& dbw, const char* pszSkip)
 }
 
 
-void CDBEnv::Flush(bool fShutdown)
+void BerkeleyEnvironment::Flush(bool fShutdown)
 {
     int64_t nStart = GetTimeMillis();
     // Flush log data to the actual data file on all files that are not in use
-    LogPrint(BCLog::DB, "CDBEnv::Flush : Flush(%s)%s\n", fShutdown ? "true" : "false", fDbEnvInit ? "" : " database not started");
+    LogPrint(BCLog::DB, "BerkeleyEnvironment::Flush : Flush(%s)%s\n", fShutdown ? "true" : "false", fDbEnvInit ? "" : " database not started");
     if (!fDbEnvInit)
         return;
     {
@@ -670,21 +670,21 @@ void CDBEnv::Flush(bool fShutdown)
         while (mi != mapFileUseCount.end()) {
             std::string strFile = (*mi).first;
             int nRefCount = (*mi).second;
-            LogPrint(BCLog::DB, "CDBEnv::Flush : Flushing %s (refcount = %d)...\n", strFile, nRefCount);
+            LogPrint(BCLog::DB, "BerkeleyEnvironment::Flush : Flushing %s (refcount = %d)...\n", strFile, nRefCount);
             if (nRefCount == 0) {
                 // Move log data to the dat file
                 CloseDb(strFile);
-                LogPrint(BCLog::DB, "CDBEnv::Flush: %s checkpoint\n", strFile);
+                LogPrint(BCLog::DB, "BerkeleyEnvironment::Flush: %s checkpoint\n", strFile);
                 dbenv->txn_checkpoint(0, 0, 0);
-                LogPrint(BCLog::DB, "CDBEnv::Flush: %s detach\n", strFile);
+                LogPrint(BCLog::DB, "BerkeleyEnvironment::Flush: %s detach\n", strFile);
                 if (!fMockDb)
                     dbenv->lsn_reset(strFile.c_str(), 0);
-                LogPrint(BCLog::DB, "CDBEnv::Flush: %s closed\n", strFile);
+                LogPrint(BCLog::DB, "BerkeleyEnvironment::Flush: %s closed\n", strFile);
                 mapFileUseCount.erase(mi++);
             } else
                 mi++;
         }
-        LogPrint(BCLog::DB, "CDBEnv::Flush : Flush(%s)%s took %15dms\n", fShutdown ? "true" : "false", fDbEnvInit ? "" : " database not started", GetTimeMillis() - nStart);
+        LogPrint(BCLog::DB, "BerkeleyEnvironment::Flush : Flush(%s)%s took %15dms\n", fShutdown ? "true" : "false", fDbEnvInit ? "" : " database not started", GetTimeMillis() - nStart);
         if (fShutdown) {
             char** listp;
             if (mapFileUseCount.empty()) {
@@ -699,14 +699,14 @@ void CDBEnv::Flush(bool fShutdown)
     }
 }
 
-bool CDB::PeriodicFlush(CWalletDBWrapper& dbw)
+bool BerkeleyBatch::PeriodicFlush(BerkeleyDatabase& database)
 {
-    if (dbw.IsDummy()) {
+    if (database.IsDummy()) {
         return true;
     }
     bool ret = false;
-    CDBEnv *env = dbw.env;
-    const std::string& strFile = dbw.strFile;
+    BerkeleyEnvironment *env = database.env;
+    const std::string& strFile = database.strFile;
     TRY_LOCK(cs_db, lockDb);
     if (lockDb)
     {
@@ -739,12 +739,12 @@ bool CDB::PeriodicFlush(CWalletDBWrapper& dbw)
     return ret;
 }
 
-bool CWalletDBWrapper::Rewrite(const char* pszSkip)
+bool BerkeleyDatabase::Rewrite(const char* pszSkip)
 {
-    return CDB::Rewrite(*this, pszSkip);
+    return BerkeleyBatch::Rewrite(*this, pszSkip);
 }
 
-bool CWalletDBWrapper::Backup(const std::string& strDest)
+bool BerkeleyDatabase::Backup(const std::string& strDest)
 {
     if (IsDummy()) {
         return false;
@@ -789,7 +789,7 @@ bool CWalletDBWrapper::Backup(const std::string& strDest)
     }
 }
 
-void CWalletDBWrapper::Flush(bool shutdown)
+void BerkeleyDatabase::Flush(bool shutdown)
 {
     if (!IsDummy()) {
         env->Flush(shutdown);
@@ -797,7 +797,7 @@ void CWalletDBWrapper::Flush(bool shutdown)
     }
 }
 
-void CWalletDBWrapper::CloseAndReset()
+void BerkeleyDatabase::CloseAndReset()
 {
     env->Close();
     env->Reset();

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -24,7 +24,7 @@
 static const unsigned int DEFAULT_WALLET_DBLOGSIZE = 100;
 static const bool DEFAULT_WALLET_PRIVDB = true;
 
-class CDBEnv
+class BerkeleyEnvironment
 {
 private:
     bool fDbEnvInit;
@@ -38,8 +38,8 @@ public:
     std::map<std::string, int> mapFileUseCount;
     std::map<std::string, Db*> mapDb;
 
-    CDBEnv(const fs::path& env_directory);
-    ~CDBEnv();
+    BerkeleyEnvironment(const fs::path& env_directory);
+    ~BerkeleyEnvironment();
     void Reset();
 
     void MakeMock();
@@ -86,23 +86,23 @@ public:
     }
 };
 
-/** Get CDBEnv and database filename given a wallet path. */
-CDBEnv* GetWalletEnv(const fs::path& wallet_path, std::string& database_filename);
+/** Get BerkeleyEnvironment and database filename given a wallet path. */
+BerkeleyEnvironment* GetWalletEnv(const fs::path& wallet_path, std::string& database_filename);
 
 /** An instance of this class represents one database.
  * For BerkeleyDB this is just a (env, strFile) tuple.
  **/
-class CWalletDBWrapper
+class BerkeleyDatabase
 {
-    friend class CDB;
+    friend class BerkeleyBatch;
 public:
     /** Create dummy DB handle */
-    CWalletDBWrapper() : nLastSeen(0), nLastFlushed(0), nLastWalletUpdate(0), env(nullptr)
+    BerkeleyDatabase() : nLastSeen(0), nLastFlushed(0), nLastWalletUpdate(0), env(nullptr)
     {
     }
 
     /** Create DB handle to real database */
-    CWalletDBWrapper(const fs::path& wallet_path, bool mock = false) :
+    BerkeleyDatabase(const fs::path& wallet_path, bool mock = false) :
         nUpdateCounter(0), nLastSeen(0), nLastFlushed(0), nLastWalletUpdate(0)
     {
         env = GetWalletEnv(wallet_path, strFile);
@@ -114,21 +114,21 @@ public:
     }
 
     /** Return object for accessing database at specified path. */
-    static std::unique_ptr<CWalletDBWrapper> Create(const fs::path& path)
+    static std::unique_ptr<BerkeleyDatabase> Create(const fs::path& path)
     {
-        return std::make_unique<CWalletDBWrapper>(path);
+        return std::make_unique<BerkeleyDatabase>(path);
     }
 
     /** Return object for accessing dummy database with no read/write capabilities. */
-    static std::unique_ptr<CWalletDBWrapper> CreateDummy()
+    static std::unique_ptr<BerkeleyDatabase> CreateDummy()
     {
-        return std::make_unique<CWalletDBWrapper>();
+        return std::make_unique<BerkeleyDatabase>();
     }
 
     /** Return object for accessing temporary in-memory database. */
-    static std::unique_ptr<CWalletDBWrapper> CreateMock()
+    static std::unique_ptr<BerkeleyDatabase> CreateMock()
     {
-        return std::make_unique<CWalletDBWrapper>("", true /* mock */);
+        return std::make_unique<BerkeleyDatabase>("", true /* mock */);
     }
 
     /** Rewrite the entire database on disk, with the exception of key pszSkip if non-zero
@@ -156,7 +156,7 @@ public:
 
 private:
     /** BerkeleyDB specific */
-    CDBEnv *env;
+    BerkeleyEnvironment *env;
     std::string strFile;
 
     /** Return whether this database handle is a dummy for testing.
@@ -168,7 +168,7 @@ private:
 
 
 /** RAII class that provides access to a Berkeley database */
-class CDB
+class BerkeleyBatch
 {
 protected:
     Db* pdb;
@@ -176,14 +176,14 @@ protected:
     DbTxn* activeTxn;
     bool fReadOnly;
     bool fFlushOnClose;
-    CDBEnv *env;
+    BerkeleyEnvironment *env;
 
 public:
-    explicit CDB(CWalletDBWrapper& dbw, const char* pszMode = "r+", bool fFlushOnCloseIn=true);
-    ~CDB() { Close(); }
+    explicit BerkeleyBatch(BerkeleyDatabase& database, const char* pszMode = "r+", bool fFlushOnCloseIn=true);
+    ~BerkeleyBatch() { Close(); }
 
-    CDB(const CDB&) = delete;
-    CDB& operator=(const CDB&) = delete;
+    BerkeleyBatch(const BerkeleyBatch&) = delete;
+    BerkeleyBatch& operator=(const BerkeleyBatch&) = delete;
 
     void Flush();
     void Close();
@@ -191,11 +191,11 @@ public:
 
     /* flush the wallet passively (TRY_LOCK)
        ideal to be called periodically */
-    static bool PeriodicFlush(CWalletDBWrapper& dbw);
+    static bool PeriodicFlush(BerkeleyDatabase& database);
     /* verifies the database environment */
     static bool VerifyEnvironment(const fs::path& file_path, std::string& errorStr);
     /* verifies the database file */
-    static bool VerifyDatabaseFile(const fs::path& file_path, std::string& warningStr, std::string& errorStr, CDBEnv::recoverFunc_type recoverFunc);
+    static bool VerifyDatabaseFile(const fs::path& file_path, std::string& warningStr, std::string& errorStr, BerkeleyEnvironment::recoverFunc_type recoverFunc);
 
 public:
     template <typename K, typename T>
@@ -391,7 +391,7 @@ public:
         return Write(std::string("version"), nVersion);
     }
 
-    bool static Rewrite(CWalletDBWrapper& dbw, const char* pszSkip = NULL);
+    bool static Rewrite(BerkeleyDatabase& database, const char* pszSkip = NULL);
 };
 
 #endif // BITCOIN_DB_H

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -174,26 +174,26 @@ bool WalletVerify()
         }
 
         std::string strError;
-        if (!CWalletDB::VerifyEnvironment(wallet_path, strError)) {
+        if (!WalletBatch::VerifyEnvironment(wallet_path, strError)) {
             return UIError(strError);
         }
 
         if (gArgs.GetBoolArg("-salvagewallet", false)) {
             // Recover readable keypairs:
-            CWallet dummyWallet("dummy", CWalletDBWrapper::CreateDummy());
+            CWallet dummyWallet("dummy", WalletDatabase::CreateDummy());
             std::string backup_filename;
             // Even if we don't use this lock in this function, we want to preserve
             // lock order in LoadToWallet if query of chain state is needed to know
             // tx status. If lock can't be taken, tx confirmation status may be not
             // reliable.
             LOCK(cs_main);
-            if (!CWalletDB::Recover(wallet_path, (void *)&dummyWallet, CWalletDB::RecoverKeysOnlyFilter, backup_filename)) {
+            if (!WalletBatch::Recover(wallet_path, (void *)&dummyWallet, WalletBatch::RecoverKeysOnlyFilter, backup_filename)) {
                 return false;
             }
         }
 
         std::string strWarning;
-        bool dbV = CWalletDB::VerifyDatabaseFile(wallet_path, strWarning, strError);
+        bool dbV = WalletBatch::VerifyDatabaseFile(wallet_path, strWarning, strError);
         if (!strWarning.empty()) {
             UIWarning(strWarning);
         }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4475,7 +4475,7 @@ UniValue autocombinerewards(const JSONRPCRequest& request)
             "\nExamples:\n" +
             HelpExampleCli("autocombinerewards", "true 500") + HelpExampleRpc("autocombinerewards", "true 500"));
 
-    CWalletDB walletdb(pwallet->GetDBHandle());
+    WalletBatch batch(pwallet->GetDBHandle());
     CAmount nThreshold = 0;
 
     if (fEnable && request.params.size() > 1) {
@@ -4487,7 +4487,7 @@ UniValue autocombinerewards(const JSONRPCRequest& request)
     pwallet->fCombineDust = fEnable;
     pwallet->nAutoCombineThreshold = nThreshold;
 
-    if (!walletdb.WriteAutoCombineSettings(fEnable, nThreshold))
+    if (!batch.WriteAutoCombineSettings(fEnable, nThreshold))
         throw std::runtime_error("Changed settings in wallet but failed to save to database\n");
 
     return NullUniValue;
@@ -4535,7 +4535,7 @@ UniValue setautocombinethreshold(const JSONRPCRequest& request)
             throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("The threshold value cannot be less than %s", FormatMoney(COIN)));
     }
 
-    CWalletDB walletdb(pwallet->GetDBHandle());
+    WalletBatch batch(pwallet->GetDBHandle());
 
     {
         LOCK(pwallet->cs_wallet);
@@ -4545,7 +4545,7 @@ UniValue setautocombinethreshold(const JSONRPCRequest& request)
         UniValue result(UniValue::VOBJ);
         result.pushKV("enabled", fEnable);
         result.pushKV("threshold", ValueFromAmount(pwallet->nAutoCombineThreshold));
-        if (walletdb.WriteAutoCombineSettings(fEnable, nThreshold)) {
+        if (batch.WriteAutoCombineSettings(fEnable, nThreshold)) {
             result.pushKV("saved", "true");
         } else {
             result.pushKV("saved", "false");

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -82,7 +82,7 @@ bool ScriptPubKeyMan::CanGetAddresses(const uint8_t& type)
     return keypool_has_keys;
 }
 
-static int64_t GetOldestKeyTimeInPool(const std::set<int64_t>& setKeyPool, CWalletDB& batch) {
+static int64_t GetOldestKeyTimeInPool(const std::set<int64_t>& setKeyPool, WalletBatch& batch) {
     if (setKeyPool.empty()) {
         return GetTime();
     }
@@ -100,7 +100,7 @@ int64_t ScriptPubKeyMan::GetOldestKeyPoolTime()
 {
     LOCK(wallet->cs_KeyStore);
 
-    CWalletDB batch(wallet->GetDBHandle());
+    WalletBatch batch(wallet->GetDBHandle());
     // load oldest key from keypool, get time and return
     int64_t oldestKey = GetOldestKeyTimeInPool(setExternalKeyPool, batch);
     if (IsHDEnabled()) {
@@ -148,7 +148,7 @@ bool ScriptPubKeyMan::GetKeyFromPool(CPubKey& result, const uint8_t& changeType)
                 LogPrintf("%s: Wallet locked, cannot get address\n", __func__);
                 return false;
             }
-            CWalletDB batch(wallet->GetDBHandle());
+            WalletBatch batch(wallet->GetDBHandle());
             result = GenerateNewKey(batch, changeType);
             return true;
         }
@@ -188,7 +188,7 @@ bool ScriptPubKeyMan::ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool, 
             return false;
         }
 
-        CWalletDB batch(wallet->GetDBHandle());
+        WalletBatch batch(wallet->GetDBHandle());
 
         auto it = setKeyPool.begin();
         nIndex = *it;
@@ -225,7 +225,7 @@ bool ScriptPubKeyMan::ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool, 
 void ScriptPubKeyMan::KeepDestination(int64_t nIndex)
 {
     // Remove from key pool
-    CWalletDB batch(wallet->GetDBHandle());
+    WalletBatch batch(wallet->GetDBHandle());
     batch.ErasePool(nIndex);
     CPubKey pubkey;
     bool have_pk = wallet->GetPubKey(m_index_to_reserved_key.at(nIndex), pubkey);
@@ -267,7 +267,7 @@ void ScriptPubKeyMan::MarkReserveKeysAsUsed(int64_t keypool_id)
             (staking ? &setStakingKeyPool : &setExternalKeyPool) : &set_pre_split_keypool);
     auto it = setKeyPool->begin();
 
-    CWalletDB batch(wallet->GetDBHandle());
+    WalletBatch batch(wallet->GetDBHandle());
     while (it != std::end(*setKeyPool)) {
         const int64_t& index = *(it);
         if (index > keypool_id) break; // set*KeyPool is ordered
@@ -307,7 +307,7 @@ void ScriptPubKeyMan::MarkUnusedAddresses(const CScript& script)
 
 void ScriptPubKeyMan::MarkPreSplitKeys()
 {
-    CWalletDB batch(wallet->GetDBHandle());
+    WalletBatch batch(wallet->GetDBHandle());
     for (auto it = setExternalKeyPool.begin(); it != setExternalKeyPool.end();) {
         int64_t index = *it;
         CKeyPool keypool;
@@ -332,22 +332,22 @@ bool ScriptPubKeyMan::NewKeyPool()
     {
         LOCK(wallet->cs_wallet);
 
-        CWalletDB walletdb(wallet->GetDBHandle());
+        WalletBatch batch(wallet->GetDBHandle());
         // Internal
         for (const int64_t nIndex : setInternalKeyPool) {
-            walletdb.ErasePool(nIndex);
+            batch.ErasePool(nIndex);
         }
         setInternalKeyPool.clear();
 
         // External
         for (const int64_t nIndex : setExternalKeyPool) {
-            walletdb.ErasePool(nIndex);
+            batch.ErasePool(nIndex);
         }
         setExternalKeyPool.clear();
 
         // Staking
         for (const int64_t nIndex : setStakingKeyPool) {
-            walletdb.ErasePool(nIndex);
+            batch.ErasePool(nIndex);
         }
         setStakingKeyPool.clear();
 
@@ -393,7 +393,7 @@ bool ScriptPubKeyMan::TopUp(unsigned int kpSize)
             missingStaking = 0;
         }
 
-        CWalletDB batch(wallet->GetDBHandle());
+        WalletBatch batch(wallet->GetDBHandle());
         GeneratePool(batch, missingExternal, HDChain::ChangeType::EXTERNAL);
         GeneratePool(batch, missingInternal, HDChain::ChangeType::INTERNAL);
         GeneratePool(batch, missingStaking, HDChain::ChangeType::STAKING);
@@ -410,7 +410,7 @@ bool ScriptPubKeyMan::TopUp(unsigned int kpSize)
     return true;
 }
 
-void ScriptPubKeyMan::GeneratePool(CWalletDB& batch, int64_t targetSize, const uint8_t& type)
+void ScriptPubKeyMan::GeneratePool(WalletBatch& batch, int64_t targetSize, const uint8_t& type)
 {
     for (int64_t i = targetSize; i--;) {
         CPubKey pubkey(GenerateNewKey(batch, type));
@@ -418,7 +418,7 @@ void ScriptPubKeyMan::GeneratePool(CWalletDB& batch, int64_t targetSize, const u
     }
 }
 
-void ScriptPubKeyMan::AddKeypoolPubkeyWithDB(const CPubKey& pubkey, const uint8_t& type, CWalletDB &batch)
+void ScriptPubKeyMan::AddKeypoolPubkeyWithDB(const CPubKey& pubkey, const uint8_t& type, WalletBatch &batch)
 {
     LOCK(wallet->cs_wallet);
     assert(m_max_keypool_index < std::numeric_limits<int64_t>::max()); // How in the hell did you use so many keys?
@@ -442,7 +442,7 @@ void ScriptPubKeyMan::AddKeypoolPubkeyWithDB(const CPubKey& pubkey, const uint8_
 /**
  * Generate a new key and stores it in db.
  */
-CPubKey ScriptPubKeyMan::GenerateNewKey(CWalletDB &batch, const uint8_t& type)
+CPubKey ScriptPubKeyMan::GenerateNewKey(WalletBatch &batch, const uint8_t& type)
 {
     AssertLockHeld(wallet->cs_wallet);
     bool fCompressed = wallet->CanSupportFeature(FEATURE_COMPRPUBKEY); // default to compressed public keys if we want 0.6.0 wallets
@@ -477,7 +477,7 @@ CPubKey ScriptPubKeyMan::GenerateNewKey(CWalletDB &batch, const uint8_t& type)
     return pubkey;
 }
 
-void ScriptPubKeyMan::DeriveNewChildKey(CWalletDB &batch, CKeyMetadata& metadata, CKey& secret, const uint8_t& changeType)
+void ScriptPubKeyMan::DeriveNewChildKey(WalletBatch &batch, CKeyMetadata& metadata, CKey& secret, const uint8_t& changeType)
 {
     AssertLockHeld(wallet->cs_wallet);
     // Use BIP44 keypath scheme i.e. m / purpose' / coin_type' / account' / change / address_index
@@ -577,7 +577,7 @@ void ScriptPubKeyMan::UpdateTimeFirstKey(int64_t nCreateTime)
     }
 }
 
-bool ScriptPubKeyMan::AddKeyPubKeyWithDB(CWalletDB& batch, const CKey& secret, const CPubKey& pubkey)
+bool ScriptPubKeyMan::AddKeyPubKeyWithDB(WalletBatch& batch, const CKey& secret, const CPubKey& pubkey)
 {
     AssertLockHeld(wallet->cs_wallet);
 
@@ -682,7 +682,7 @@ void ScriptPubKeyMan::SetHDSeed(const CPubKey& seed, bool force, bool memOnly)
 void ScriptPubKeyMan::SetHDChain(CHDChain& chain, bool memonly)
 {
     LOCK(wallet->cs_wallet);
-    if (!memonly && !CWalletDB(wallet->GetDBHandle()).WriteHDChain(chain))
+    if (!memonly && !WalletBatch(wallet->GetDBHandle()).WriteHDChain(chain))
         throw std::runtime_error(std::string(__func__) + ": writing chain failed");
 
     hdChain = chain;

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -92,7 +92,7 @@ public:
     //! First wallet key time
     void UpdateTimeFirstKey(int64_t nCreateTime);
     //! Generate a new key
-    CPubKey GenerateNewKey(CWalletDB& batch, const uint8_t& type = HDChain::ChangeType::EXTERNAL);
+    CPubKey GenerateNewKey(WalletBatch& batch, const uint8_t& type = HDChain::ChangeType::EXTERNAL);
 
 
     //! Fetches a key from the keypool
@@ -130,7 +130,7 @@ private:
     CHDChain hdChain;
 
     /* TODO: This has not been implemented yet.. */
-    CWalletDB *encrypted_batch = nullptr;
+    WalletBatch *encrypted_batch = nullptr;
 
     // Key pool maps
     std::set<int64_t> setInternalKeyPool;
@@ -145,13 +145,13 @@ private:
     bool AddKeyPubKeyInner(const CKey& key, const CPubKey &pubkey);
 
     //! Adds a key to the store, and saves it to disk.
-    bool AddKeyPubKeyWithDB(CWalletDB &batch,const CKey& key, const CPubKey &pubkey);
+    bool AddKeyPubKeyWithDB(WalletBatch &batch,const CKey& key, const CPubKey &pubkey);
     /* Complete me */
-    void AddKeypoolPubkeyWithDB(const CPubKey& pubkey, const uint8_t& type, CWalletDB& batch);
-    void GeneratePool(CWalletDB& batch, int64_t targetSize, const uint8_t& type);
+    void AddKeypoolPubkeyWithDB(const CPubKey& pubkey, const uint8_t& type, WalletBatch& batch);
+    void GeneratePool(WalletBatch& batch, int64_t targetSize, const uint8_t& type);
 
     /* HD derive new child key (on internal or external chain) */
-    void DeriveNewChildKey(CWalletDB &batch, CKeyMetadata& metadata, CKey& secret, const uint8_t& type = HDChain::ChangeType::EXTERNAL);
+    void DeriveNewChildKey(WalletBatch &batch, CKeyMetadata& metadata, CKey& secret, const uint8_t& type = HDChain::ChangeType::EXTERNAL);
 
     /**
      * Marks all keys in the keypool up to and including reserve_key as used.

--- a/src/wallet/test/pos_test_fixture.cpp
+++ b/src/wallet/test/pos_test_fixture.cpp
@@ -12,7 +12,7 @@ TestPoSChainSetup::TestPoSChainSetup() : TestChainSetup(0)
     initZKSNARKS(); // init zk-snarks lib
 
     bool fFirstRun;
-    pwalletMain = std::make_unique<CWallet>("testWallet", CWalletDBWrapper::CreateMock());
+    pwalletMain = std::make_unique<CWallet>("testWallet", WalletDatabase::CreateMock());
     pwalletMain->LoadWallet(fFirstRun);
     RegisterValidationInterface(pwalletMain.get());
 

--- a/src/wallet/test/wallet_sapling_transactions_validations_tests.cpp
+++ b/src/wallet/test/wallet_sapling_transactions_validations_tests.cpp
@@ -24,7 +24,7 @@ struct TestSaplingChainSetup: public TestChain100Setup
         initZKSNARKS(); // init zk-snarks lib
 
         bool fFirstRun;
-        pwalletMain = std::make_unique<CWallet>("testWallet", CWalletDBWrapper::CreateMock());
+        pwalletMain = std::make_unique<CWallet>("testWallet", WalletDatabase::CreateMock());
         pwalletMain->LoadWallet(fFirstRun);
         RegisterValidationInterface(pwalletMain.get());
 

--- a/src/wallet/test/wallet_shielded_balances_tests.cpp
+++ b/src/wallet/test/wallet_shielded_balances_tests.cpp
@@ -49,7 +49,7 @@ CWalletTx& AddShieldedBalanceToWallet(CAmount inputAmount,
 {
 
     // Dummy wallet, used to generate the dummy transparent input key and sign it in the transaction builder
-    CWallet dummyWallet("dummy", CWalletDBWrapper::CreateDummy());
+    CWallet dummyWallet("dummy", WalletDatabase::CreateDummy());
     dummyWallet.SetMinVersion(FEATURE_SAPLING);
     dummyWallet.SetupSPKM(false, true);
     LOCK(dummyWallet.cs_wallet);

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -11,7 +11,7 @@
 #include "wallet/wallet.h"
 
 WalletTestingSetup::WalletTestingSetup(const std::string& chainName):
-        SaplingTestingSetup(chainName), m_wallet("mock", CWalletDBWrapper::CreateMock())
+        SaplingTestingSetup(chainName), m_wallet("mock", WalletDatabase::CreateMock())
 {
     bool fFirstRun;
     m_wallet.LoadWallet(fFirstRun);

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -36,7 +36,7 @@ typedef std::set<std::pair<const CWalletTx*,unsigned int> > CoinSet;
 
 BOOST_FIXTURE_TEST_SUITE(wallet_tests, WalletTestingSetup)
 
-static const CWallet testWallet("dummy", CWalletDBWrapper::CreateDummy());
+static const CWallet testWallet("dummy", WalletDatabase::CreateDummy());
 static std::vector<COutput> vCoins;
 
 static void add_coin(const CAmount& nValue, int nAge = 6*24, bool fIsFromMe = false, int nInput=0)
@@ -338,7 +338,7 @@ BOOST_FIXTURE_TEST_CASE(rescan, TestChain100Setup)
     // Verify ScanForWalletTransactions picks up transactions in both the old
     // and new block files.
     {
-        CWallet wallet("dummy", CWalletDBWrapper::CreateDummy());
+        CWallet wallet("dummy", WalletDatabase::CreateDummy());
         WITH_LOCK(wallet.cs_wallet, wallet.SetLastBlockProcessed(newTip); );
         AddKey(wallet, coinbaseKey);
         WalletRescanReserver reserver(&wallet);
@@ -355,7 +355,7 @@ BOOST_FIXTURE_TEST_CASE(rescan, TestChain100Setup)
     // Verify ScanForWalletTransactions only picks transactions in the new block
     // file.
     {
-        CWallet wallet("dummy", CWalletDBWrapper::CreateDummy());
+        CWallet wallet("dummy", WalletDatabase::CreateDummy());
         AddKey(wallet, coinbaseKey);
         WalletRescanReserver reserver(&wallet);
         reserver.reserve();
@@ -368,7 +368,7 @@ BOOST_FIXTURE_TEST_CASE(rescan, TestChain100Setup)
     // before the missing block, and success for a key whose creation time is
     // after.
     {
-        CWallet wallet("dummy", CWalletDBWrapper::CreateDummy());
+        CWallet wallet("dummy", WalletDatabase::CreateDummy());
         WITH_LOCK(wallet.cs_wallet, wallet.SetLastBlockProcessed(newTip); );
         vpwallets.insert(vpwallets.begin(), &wallet);
         UniValue keys;
@@ -419,7 +419,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
 
     // Import key into wallet and call dumpwallet to create backup file.
     {
-        CWallet wallet("dummy", CWalletDBWrapper::CreateDummy());
+        CWallet wallet("dummy", WalletDatabase::CreateDummy());
         {
             LOCK(wallet.cs_wallet);
             wallet.mapKeyMetadata[coinbaseKey.GetPubKey().GetID()].nCreateTime = KEY_TIME;
@@ -436,7 +436,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
     // Call importwallet RPC and verify all blocks with timestamps >= BLOCK_TIME
     // were scanned, and no prior blocks were scanned.
     {
-        CWallet wallet("dummy", CWalletDBWrapper::CreateDummy());
+        CWallet wallet("dummy", WalletDatabase::CreateDummy());
 
         JSONRPCRequest request;
         request.params.setArray();
@@ -568,7 +568,7 @@ BOOST_AUTO_TEST_CASE(cached_balances_tests)
     CAmount nCredit = 20 * COIN;
 
     // Setup wallet
-    CWallet wallet("testWallet1", CWalletDBWrapper::CreateMock());
+    CWallet wallet("testWallet1", WalletDatabase::CreateMock());
     bool fFirstRun;
     BOOST_CHECK_EQUAL(wallet.LoadWallet(fFirstRun), DB_LOAD_OK);
     LOCK2(cs_main, wallet.cs_wallet);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -599,7 +599,7 @@ private:
     std::string m_name;
 
     /** Internal database handle. */
-    std::unique_ptr<CWalletDBWrapper> dbw;
+    std::unique_ptr<WalletDatabase> database;
 
     /**
      * The following is used to keep track of how far behind the wallet is
@@ -710,7 +710,7 @@ public:
 
     bool fWalletUnlockStaking;
 
-    CWalletDB* pwalletdbEncryption;
+    WalletBatch* encrypted_batch;
 
     std::map<CKeyID, CKeyMetadata> mapKeyMetadata;
 
@@ -736,18 +736,18 @@ public:
     /** Get database handle used by this wallet. Ideally this function would
      * not be necessary.
      */
-    CWalletDBWrapper* GetDBHandlePtr() const { return dbw.get(); }
-    CWalletDBWrapper& GetDBHandle() const { return *dbw; }
+    WalletDatabase* GetDBHandlePtr() const { return database.get(); }
+    WalletDatabase& GetDBHandle() const { return *database; }
 
     /** Get a name for this wallet for logging/debugging purposes.
      */
     const std::string& GetName() const { return m_name; }
 
     /** Get the path to the wallet's db file */
-    fs::path GetPathToDBFile() { return dbw->GetPathToFile(); }
+    fs::path GetPathToDBFile() { return database->GetPathToFile(); }
 
     /** Construct wallet with specified name and database implementation. */
-    CWallet(std::string name, std::unique_ptr<CWalletDBWrapper> dbw_in);
+    CWallet(std::string name, std::unique_ptr<WalletDatabase> dbw_in);
     ~CWallet();
     void SetNull();
 
@@ -989,7 +989,7 @@ public:
      * Increment the next transaction order id
      * @return next transaction order id
      */
-    int64_t IncOrderPosNext(CWalletDB* pwalletdb = NULL);
+    int64_t IncOrderPosNext(WalletBatch* batch = NULL);
 
     void MarkDirty();
     bool AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose = true);
@@ -1121,7 +1121,7 @@ public:
     CAmount GetChange(const CTransactionRef& tx) const;
 
     void SetBestChain(const CBlockLocator& loc) override;
-    void SetBestChainInternal(CWalletDB& walletdb, const CBlockLocator& loc); // only public for testing purposes, must never be called directly in any other situation
+    void SetBestChainInternal(WalletBatch& batch, const CBlockLocator& loc); // only public for testing purposes, must never be called directly in any other situation
     // Force balance recomputation if any transaction got conflicted
     void MarkAffectedTransactionsDirty(const CTransaction& tx); // only public for testing purposes, must never be called directly in any other situation
 
@@ -1148,7 +1148,7 @@ public:
     unsigned int GetStakingKeyPoolSize();
 
     //! signify that a particular wallet feature is now used. this may change nWalletVersion and nWalletMaxVersion if those are lower
-    bool SetMinVersion(enum WalletFeature, CWalletDB* pwalletdbIn = NULL, bool fExplicit = false);
+    bool SetMinVersion(enum WalletFeature, WalletBatch* batch_in = NULL, bool fExplicit = false);
 
     //! change which version we're allowed to upgrade to (note that this does not immediately imply upgrading to that format)
     bool SetMaxVersion(int nVersion);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -179,7 +179,7 @@ bool WalletBatch::WriteSaplingCommonOVK(const uint256& ovk)
 
 bool WalletBatch::ReadSaplingCommonOVK(uint256& ovkRet)
 {
-    return batch.Read(std::string(DBKeys::SAP_COMMON_OVK), ovkRet);
+    return m_batch.Read(std::string(DBKeys::SAP_COMMON_OVK), ovkRet);
 }
 
 bool WalletBatch::WriteWitnessCacheSize(int64_t nWitnessCacheSize)
@@ -215,10 +215,10 @@ bool WalletBatch::WriteBestBlock(const CBlockLocator& locator)
 
 bool WalletBatch::ReadBestBlock(CBlockLocator& locator)
 {
-    if (batch.Read(std::string(DBKeys::BESTBLOCK), locator) && !locator.vHave.empty()) {
+    if (m_batch.Read(std::string(DBKeys::BESTBLOCK), locator) && !locator.vHave.empty()) {
         return true;
     }
-    return batch.Read(std::string(DBKeys::BESTBLOCK_NOMERKLE), locator);
+    return m_batch.Read(std::string(DBKeys::BESTBLOCK_NOMERKLE), locator);
 }
 
 bool WalletBatch::WriteOrderPosNext(int64_t nOrderPosNext)
@@ -251,7 +251,7 @@ bool WalletBatch::WriteAutoCombineSettings(bool fEnable, CAmount nCombineThresho
 
 bool WalletBatch::ReadPool(int64_t nPool, CKeyPool& keypool)
 {
-    return batch.Read(std::make_pair(std::string(DBKeys::POOL), nPool), keypool);
+    return m_batch.Read(std::make_pair(std::string(DBKeys::POOL), nPool), keypool);
 }
 
 bool WalletBatch::WritePool(int64_t nPool, const CKeyPool& keypool)
@@ -630,7 +630,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
     LOCK(pwallet->cs_wallet);
     try {
         int nMinVersion = 0;
-        if (batch.Read((std::string) DBKeys::MINVERSION, nMinVersion)) {
+        if (m_batch.Read((std::string) DBKeys::MINVERSION, nMinVersion)) {
             if (nMinVersion > CLIENT_VERSION) {
                 return DB_TOO_NEW;
             }
@@ -638,7 +638,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
         }
 
         // Get cursor
-        Dbc* pcursor = batch.GetCursor();
+        Dbc* pcursor = m_batch.GetCursor();
         if (!pcursor) {
             LogPrintf("Error getting wallet database cursor\n");
             return DB_CORRUPT;
@@ -648,7 +648,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
             // Read next record
             CDataStream ssKey(SER_DISK, CLIENT_VERSION);
             CDataStream ssValue(SER_DISK, CLIENT_VERSION);
-            int ret = batch.ReadAtCursor(pcursor, ssKey, ssValue);
+            int ret = m_batch.ReadAtCursor(pcursor, ssKey, ssValue);
             if (ret == DB_NOTFOUND) {
                 break;
             } else if (ret != 0) {
@@ -729,7 +729,7 @@ DBErrors WalletBatch::FindWalletTx(CWallet* pwallet, std::vector<uint256>& vTxHa
     try {
         LOCK(pwallet->cs_wallet);
         int nMinVersion = 0;
-        if (batch.Read((std::string) DBKeys::MINVERSION, nMinVersion)) {
+        if (m_batch.Read((std::string) DBKeys::MINVERSION, nMinVersion)) {
             if (nMinVersion > CLIENT_VERSION) {
                 return DB_TOO_NEW;
             }
@@ -737,7 +737,7 @@ DBErrors WalletBatch::FindWalletTx(CWallet* pwallet, std::vector<uint256>& vTxHa
         }
 
         // Get cursor
-        Dbc* pcursor = batch.GetCursor();
+        Dbc* pcursor = m_batch.GetCursor();
         if (!pcursor) {
             LogPrintf("Error getting wallet database cursor\n");
             return DB_CORRUPT;
@@ -747,7 +747,7 @@ DBErrors WalletBatch::FindWalletTx(CWallet* pwallet, std::vector<uint256>& vTxHa
             // Read next record
             CDataStream ssKey(SER_DISK, CLIENT_VERSION);
             CDataStream ssValue(SER_DISK, CLIENT_VERSION);
-            int ret = batch.ReadAtCursor(pcursor, ssKey, ssValue);
+            int ret = m_batch.ReadAtCursor(pcursor, ssKey, ssValue);
             if (ret == DB_NOTFOUND) {
                 break;
             } else if (ret != 0) {
@@ -957,25 +957,25 @@ bool WalletBatch::EraseDestData(const std::string& address, const std::string& k
 
 bool WalletBatch::TxnBegin()
 {
-    return batch.TxnBegin();
+    return m_batch.TxnBegin();
 }
 
 bool WalletBatch::TxnCommit()
 {
-    return batch.TxnCommit();
+    return m_batch.TxnCommit();
 }
 
 bool WalletBatch::TxnAbort()
 {
-    return batch.TxnAbort();
+    return m_batch.TxnAbort();
 }
 
 bool WalletBatch::ReadVersion(int& nVersion)
 {
-    return batch.ReadVersion(nVersion);
+    return m_batch.ReadVersion(nVersion);
 }
 
 bool WalletBatch::WriteVersion(int nVersion)
 {
-    return batch.WriteVersion(nVersion);
+    return m_batch.WriteVersion(nVersion);
 }

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -63,42 +63,42 @@ namespace DBKeys {
 
 
 //
-// CWalletDB
+// WalletBatch
 //
 
-bool CWalletDB::WriteName(const std::string& strAddress, const std::string& strName)
+bool WalletBatch::WriteName(const std::string& strAddress, const std::string& strName)
 {
     return WriteIC(std::make_pair(std::string(DBKeys::NAME), strAddress), strName);
 }
 
-bool CWalletDB::EraseName(const std::string& strAddress)
+bool WalletBatch::EraseName(const std::string& strAddress)
 {
     // This should only be used for sending addresses, never for receiving addresses,
     // receiving addresses must always have an address book entry if they're not change return.
     return EraseIC(std::make_pair(std::string(DBKeys::NAME), strAddress));
 }
 
-bool CWalletDB::WritePurpose(const std::string& strAddress, const std::string& strPurpose)
+bool WalletBatch::WritePurpose(const std::string& strAddress, const std::string& strPurpose)
 {
     return WriteIC(std::make_pair(std::string(DBKeys::PURPOSE), strAddress), strPurpose);
 }
 
-bool CWalletDB::ErasePurpose(const std::string& strPurpose)
+bool WalletBatch::ErasePurpose(const std::string& strPurpose)
 {
     return EraseIC(std::make_pair(std::string(DBKeys::PURPOSE), strPurpose));
 }
 
-bool CWalletDB::WriteTx(const CWalletTx& wtx)
+bool WalletBatch::WriteTx(const CWalletTx& wtx)
 {
     return WriteIC(std::make_pair(std::string(DBKeys::TX), wtx.GetHash()), wtx);
 }
 
-bool CWalletDB::EraseTx(uint256 hash)
+bool WalletBatch::EraseTx(uint256 hash)
 {
     return EraseIC(std::make_pair(std::string(DBKeys::TX), hash));
 }
 
-bool CWalletDB::WriteKey(const CPubKey& vchPubKey, const CPrivKey& vchPrivKey, const CKeyMetadata& keyMeta)
+bool WalletBatch::WriteKey(const CPubKey& vchPubKey, const CPrivKey& vchPrivKey, const CKeyMetadata& keyMeta)
 {
     if (!WriteIC(std::make_pair(std::string(DBKeys::KEYMETA), vchPubKey), keyMeta, false)) {
         return false;
@@ -113,7 +113,7 @@ bool CWalletDB::WriteKey(const CPubKey& vchPubKey, const CPrivKey& vchPrivKey, c
     return WriteIC(std::make_pair(std::string(DBKeys::KEY), vchPubKey), std::make_pair(vchPrivKey, Hash(vchKey.begin(), vchKey.end())), false);
 }
 
-bool CWalletDB::WriteCryptedKey(const CPubKey& vchPubKey,
+bool WalletBatch::WriteCryptedKey(const CPubKey& vchPubKey,
                                 const std::vector<unsigned char>& vchCryptedSecret,
                                 const CKeyMetadata& keyMeta)
 {
@@ -133,7 +133,7 @@ bool CWalletDB::WriteCryptedKey(const CPubKey& vchPubKey,
     return true;
 }
 
-bool CWalletDB::WriteSaplingZKey(const libzcash::SaplingIncomingViewingKey &ivk,
+bool WalletBatch::WriteSaplingZKey(const libzcash::SaplingIncomingViewingKey &ivk,
                                  const libzcash::SaplingExtendedSpendingKey &key,
                                  const CKeyMetadata &keyMeta)
 {
@@ -144,13 +144,13 @@ bool CWalletDB::WriteSaplingZKey(const libzcash::SaplingIncomingViewingKey &ivk,
     return WriteIC(std::make_pair(std::string(DBKeys::SAP_KEY), ivk), key, false);
 }
 
-bool CWalletDB::WriteSaplingPaymentAddress(const libzcash::SaplingPaymentAddress &addr,
+bool WalletBatch::WriteSaplingPaymentAddress(const libzcash::SaplingPaymentAddress &addr,
                                            const libzcash::SaplingIncomingViewingKey &ivk)
 {
     return WriteIC(std::make_pair(std::string(DBKeys::SAP_ADDR), addr), ivk, false);
 }
 
-bool CWalletDB::WriteCryptedSaplingZKey(const libzcash::SaplingExtendedFullViewingKey &extfvk,
+bool WalletBatch::WriteCryptedSaplingZKey(const libzcash::SaplingExtendedFullViewingKey &extfvk,
                                         const std::vector<unsigned char>& vchCryptedSecret,
                                         const CKeyMetadata &keyMeta)
 {
@@ -172,48 +172,48 @@ bool CWalletDB::WriteCryptedSaplingZKey(const libzcash::SaplingExtendedFullViewi
     return true;
 }
 
-bool CWalletDB::WriteSaplingCommonOVK(const uint256& ovk)
+bool WalletBatch::WriteSaplingCommonOVK(const uint256& ovk)
 {
     return WriteIC(std::string(DBKeys::SAP_COMMON_OVK), ovk);
 }
 
-bool CWalletDB::ReadSaplingCommonOVK(uint256& ovkRet)
+bool WalletBatch::ReadSaplingCommonOVK(uint256& ovkRet)
 {
     return batch.Read(std::string(DBKeys::SAP_COMMON_OVK), ovkRet);
 }
 
-bool CWalletDB::WriteWitnessCacheSize(int64_t nWitnessCacheSize)
+bool WalletBatch::WriteWitnessCacheSize(int64_t nWitnessCacheSize)
 {
     return WriteIC(std::string(DBKeys::SAP_WITNESS_CACHE_SIZE), nWitnessCacheSize);
 }
 
-bool CWalletDB::WriteMasterKey(unsigned int nID, const CMasterKey& kMasterKey)
+bool WalletBatch::WriteMasterKey(unsigned int nID, const CMasterKey& kMasterKey)
 {
     return WriteIC(std::make_pair(std::string(DBKeys::MASTER_KEY), nID), kMasterKey, true);
 }
 
-bool CWalletDB::WriteCScript(const uint160& hash, const CScript& redeemScript)
+bool WalletBatch::WriteCScript(const uint160& hash, const CScript& redeemScript)
 {
     return WriteIC(std::make_pair(std::string(DBKeys::CSCRIPT), hash), redeemScript, false);
 }
 
-bool CWalletDB::WriteWatchOnly(const CScript& dest)
+bool WalletBatch::WriteWatchOnly(const CScript& dest)
 {
     return WriteIC(std::make_pair(std::string(DBKeys::WATCHS), dest), '1');
 }
 
-bool CWalletDB::EraseWatchOnly(const CScript& dest)
+bool WalletBatch::EraseWatchOnly(const CScript& dest)
 {
     return EraseIC(std::make_pair(std::string(DBKeys::WATCHS), dest));
 }
 
-bool CWalletDB::WriteBestBlock(const CBlockLocator& locator)
+bool WalletBatch::WriteBestBlock(const CBlockLocator& locator)
 {
     WriteIC(std::string(DBKeys::BESTBLOCK), CBlockLocator()); // Write empty block locator so versions that require a merkle branch automatically rescan
     return WriteIC(std::string(DBKeys::BESTBLOCK_NOMERKLE), locator);
 }
 
-bool CWalletDB::ReadBestBlock(CBlockLocator& locator)
+bool WalletBatch::ReadBestBlock(CBlockLocator& locator)
 {
     if (batch.Read(std::string(DBKeys::BESTBLOCK), locator) && !locator.vHave.empty()) {
         return true;
@@ -221,27 +221,27 @@ bool CWalletDB::ReadBestBlock(CBlockLocator& locator)
     return batch.Read(std::string(DBKeys::BESTBLOCK_NOMERKLE), locator);
 }
 
-bool CWalletDB::WriteOrderPosNext(int64_t nOrderPosNext)
+bool WalletBatch::WriteOrderPosNext(int64_t nOrderPosNext)
 {
     return WriteIC(std::string(DBKeys::ORDERPOSNEXT), nOrderPosNext);
 }
 
-bool CWalletDB::WriteStakeSplitThreshold(const CAmount& nStakeSplitThreshold)
+bool WalletBatch::WriteStakeSplitThreshold(const CAmount& nStakeSplitThreshold)
 {
     return WriteIC(std::string(DBKeys::STAKE_SPLIT_THRESHOLD), nStakeSplitThreshold);
 }
 
-bool CWalletDB::WriteUseCustomFee(bool fUse)
+bool WalletBatch::WriteUseCustomFee(bool fUse)
 {
     return WriteIC(std::string(DBKeys::USE_CUSTOM_FEE), fUse);
 }
 
-bool CWalletDB::WriteCustomFeeValue(const CAmount& nFee)
+bool WalletBatch::WriteCustomFeeValue(const CAmount& nFee)
 {
     return WriteIC(std::string(DBKeys::CUSTOM_FEE_VALUE), nFee);
 }
 
-bool CWalletDB::WriteAutoCombineSettings(bool fEnable, CAmount nCombineThreshold)
+bool WalletBatch::WriteAutoCombineSettings(bool fEnable, CAmount nCombineThreshold)
 {
     std::pair<bool, CAmount> pSettings;
     pSettings.first = fEnable;
@@ -249,34 +249,34 @@ bool CWalletDB::WriteAutoCombineSettings(bool fEnable, CAmount nCombineThreshold
     return WriteIC(std::string(DBKeys::AUTOCOMBINE), pSettings, true);
 }
 
-bool CWalletDB::ReadPool(int64_t nPool, CKeyPool& keypool)
+bool WalletBatch::ReadPool(int64_t nPool, CKeyPool& keypool)
 {
     return batch.Read(std::make_pair(std::string(DBKeys::POOL), nPool), keypool);
 }
 
-bool CWalletDB::WritePool(int64_t nPool, const CKeyPool& keypool)
+bool WalletBatch::WritePool(int64_t nPool, const CKeyPool& keypool)
 {
     return WriteIC(std::make_pair(std::string(DBKeys::POOL), nPool), keypool);
 }
 
-bool CWalletDB::ErasePool(int64_t nPool)
+bool WalletBatch::ErasePool(int64_t nPool)
 {
     return EraseIC(std::make_pair(std::string(DBKeys::POOL), nPool));
 }
 
-bool CWalletDB::WriteMinVersion(int nVersion)
+bool WalletBatch::WriteMinVersion(int nVersion)
 {
     return WriteIC(std::string(DBKeys::MINVERSION), nVersion);
 }
 
-bool CWalletDB::WriteHDChain(const CHDChain& chain)
+bool WalletBatch::WriteHDChain(const CHDChain& chain)
 {
     std::string key = chain.chainType == HDChain::ChainCounterType::Sapling ?
                         DBKeys::SAP_HDCHAIN : DBKeys::HDCHAIN;
     return WriteIC(key, chain);
 }
 
-DBErrors CWalletDB::ReorderTransactions(CWallet* pwallet)
+DBErrors WalletBatch::ReorderTransactions(CWallet* pwallet)
 {
     LOCK(pwallet->cs_wallet);
     // Old wallets didn't have any defined order for transactions
@@ -614,14 +614,14 @@ bool ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue, CW
     return true;
 }
 
-bool CWalletDB::IsKeyType(const std::string& strType)
+bool WalletBatch::IsKeyType(const std::string& strType)
 {
     return (strType == DBKeys::KEY ||
             strType == DBKeys::MASTER_KEY || strType == DBKeys::CRYPTED_KEY ||
             strType == DBKeys::SAP_KEY || strType == DBKeys::SAP_KEY_CRIPTED);
 }
 
-DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
+DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
 {
     CWalletScanState wss;
     bool fNoncriticalErrors = false;
@@ -721,7 +721,7 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
     return result;
 }
 
-DBErrors CWalletDB::FindWalletTx(CWallet* pwallet, std::vector<uint256>& vTxHash, std::vector<CWalletTx>& vWtx)
+DBErrors WalletBatch::FindWalletTx(CWallet* pwallet, std::vector<uint256>& vTxHash, std::vector<CWalletTx>& vWtx)
 {
     bool fNoncriticalErrors = false;
     DBErrors result = DB_LOAD_OK;
@@ -781,7 +781,7 @@ DBErrors CWalletDB::FindWalletTx(CWallet* pwallet, std::vector<uint256>& vTxHash
     return result;
 }
 
-DBErrors CWalletDB::ZapWalletTx(CWallet* pwallet, std::vector<CWalletTx>& vWtx)
+DBErrors WalletBatch::ZapWalletTx(CWallet* pwallet, std::vector<CWalletTx>& vWtx)
 {
     // build list of wallet TXs
     std::vector<uint256> vTxHash;
@@ -809,7 +809,7 @@ void MaybeCompactWalletDB()
     }
 
     for (CWalletRef pwallet : vpwallets) {
-        CWalletDBWrapper& dbh = pwallet->GetDBHandle();
+        WalletDatabase& dbh = pwallet->GetDBHandle();
 
         unsigned int nUpdateCounter = dbh.nUpdateCounter;
         if (dbh.nLastSeen != nUpdateCounter) {
@@ -818,7 +818,7 @@ void MaybeCompactWalletDB()
         }
 
         if (dbh.nLastFlushed != nUpdateCounter && GetTime() - dbh.nLastWalletUpdate >= 2) {
-            if (CDB::PeriodicFlush(dbh)) {
+            if (BerkeleyBatch::PeriodicFlush(dbh)) {
                 dbh.nLastFlushed = nUpdateCounter;
             }
         }
@@ -900,19 +900,19 @@ bool AutoBackupWallet(CWallet& wallet, std::string& strBackupWarning, std::strin
 //
 // Try to (very carefully!) recover wallet file if there is a problem.
 //
-bool CWalletDB::Recover(const fs::path& wallet_path, void *callbackDataIn, bool (*recoverKVcallback)(void* callbackData, CDataStream ssKey, CDataStream ssValue), std::string& out_backup_filename)
+bool WalletBatch::Recover(const fs::path& wallet_path, void *callbackDataIn, bool (*recoverKVcallback)(void* callbackData, CDataStream ssKey, CDataStream ssValue), std::string& out_backup_filename)
 {
-    return CDB::Recover(wallet_path, callbackDataIn, recoverKVcallback, out_backup_filename);
+    return BerkeleyBatch::Recover(wallet_path, callbackDataIn, recoverKVcallback, out_backup_filename);
 }
 
-bool CWalletDB::Recover(const fs::path& wallet_path, std::string& out_backup_filename)
+bool WalletBatch::Recover(const fs::path& wallet_path, std::string& out_backup_filename)
 {
     // recover without a key filter callback
     // results in recovering all record types
-    return CWalletDB::Recover(wallet_path, nullptr, nullptr, out_backup_filename);
+    return WalletBatch::Recover(wallet_path, nullptr, nullptr, out_backup_filename);
 }
 
-bool CWalletDB::RecoverKeysOnlyFilter(void *callbackData, CDataStream ssKey, CDataStream ssValue)
+bool WalletBatch::RecoverKeysOnlyFilter(void *callbackData, CDataStream ssKey, CDataStream ssValue)
 {
     CWallet *dummyWallet = reinterpret_cast<CWallet*>(callbackData);
     CWalletScanState dummyWss;
@@ -928,54 +928,54 @@ bool CWalletDB::RecoverKeysOnlyFilter(void *callbackData, CDataStream ssKey, CDa
         return false;
     if (!fReadOK)
     {
-        LogPrintf("WARNING: CWalletDB::Recover skipping %s: %s\n", strType, strErr);
+        LogPrintf("WARNING: WalletBatch::Recover skipping %s: %s\n", strType, strErr);
         return false;
     }
 
     return true;
 }
 
-bool CWalletDB::VerifyEnvironment(const fs::path& wallet_path, std::string& errorStr)
+bool WalletBatch::VerifyEnvironment(const fs::path& wallet_path, std::string& errorStr)
 {
-    return CDB::VerifyEnvironment(wallet_path, errorStr);
+    return BerkeleyBatch::VerifyEnvironment(wallet_path, errorStr);
 }
 
-bool CWalletDB::VerifyDatabaseFile(const fs::path& wallet_path, std::string& warningStr, std::string& errorStr)
+bool WalletBatch::VerifyDatabaseFile(const fs::path& wallet_path, std::string& warningStr, std::string& errorStr)
 {
-    return CDB::VerifyDatabaseFile(wallet_path, warningStr, errorStr, CWalletDB::Recover);
+    return BerkeleyBatch::VerifyDatabaseFile(wallet_path, warningStr, errorStr, WalletBatch::Recover);
 }
 
-bool CWalletDB::WriteDestData(const std::string& address, const std::string& key, const std::string& value)
+bool WalletBatch::WriteDestData(const std::string& address, const std::string& key, const std::string& value)
 {
     return WriteIC(std::make_pair(std::string(DBKeys::DESTDATA), std::make_pair(address, key)), value);
 }
 
-bool CWalletDB::EraseDestData(const std::string& address, const std::string& key)
+bool WalletBatch::EraseDestData(const std::string& address, const std::string& key)
 {
     return EraseIC(std::make_pair(std::string(DBKeys::DESTDATA), std::make_pair(address, key)));
 }
 
-bool CWalletDB::TxnBegin()
+bool WalletBatch::TxnBegin()
 {
     return batch.TxnBegin();
 }
 
-bool CWalletDB::TxnCommit()
+bool WalletBatch::TxnCommit()
 {
     return batch.TxnCommit();
 }
 
-bool CWalletDB::TxnAbort()
+bool WalletBatch::TxnAbort()
 {
     return batch.TxnAbort();
 }
 
-bool CWalletDB::ReadVersion(int& nVersion)
+bool WalletBatch::ReadVersion(int& nVersion)
 {
     return batch.ReadVersion(nVersion);
 }
 
-bool CWalletDB::WriteVersion(int nVersion)
+bool WalletBatch::WriteVersion(int nVersion)
 {
     return batch.WriteVersion(nVersion);
 }

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -113,7 +113,7 @@ private:
     template <typename K, typename T>
     bool WriteIC(const K& key, const T& value, bool fOverwrite = true)
     {
-        if (!batch.Write(key, value, fOverwrite)) {
+        if (!m_batch.Write(key, value, fOverwrite)) {
             return false;
         }
         m_database.IncrementUpdateCounter();
@@ -123,7 +123,7 @@ private:
     template <typename K>
     bool EraseIC(const K& key)
     {
-        if (!batch.Erase(key)) {
+        if (!m_batch.Erase(key)) {
             return false;
         }
         m_database.IncrementUpdateCounter();
@@ -131,8 +131,8 @@ private:
     }
 
 public:
-    WalletBatch(WalletDatabase& database, const char* pszMode = "r+", bool _fFlushOnClose = true) :
-        batch(database, pszMode, _fFlushOnClose),
+    explicit WalletBatch(WalletDatabase& database, const char* pszMode = "r+", bool _fFlushOnClose = true) :
+        m_batch(database, pszMode, _fFlushOnClose),
         m_database(database)
     {
     }
@@ -227,7 +227,7 @@ public:
     //! Write wallet version
     bool WriteVersion(int nVersion);
 private:
-    BerkeleyBatch batch;
+    BerkeleyBatch m_batch;
     WalletDatabase& m_database;
 };
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -23,16 +23,13 @@
 /**
  * Overview of wallet database classes:
  *
- * - BerkeleyEnvironment is an environment in which the database exists (has no analog in dbwrapper.h)
- * - WalletDatabase represents a wallet database (similar to CDBWrapper in dbwrapper.h)
- * - BerkeleyBatch is a low-level database transaction (similar to CDBBatch in dbwrapper.h)
- * - WalletBatch is a modifier object for the wallet, and encapsulates a database
- *   transaction as well as methods to act on the database (no analog in
- *   dbwrapper.h)
+ * - WalletBatch is an abstract modifier object for the wallet database, and encapsulates a database
+ *   batch update as well as methods to act on the database. It should be agnostic to the database implementation.
  *
- * The latter two are named confusingly, in contrast to what the names BerkeleyBatch
- * and WalletBatch suggest they are transient transaction objects and don't
- * represent the database itself.
+ * The following classes are implementation specific:
+ * - BerkeleyEnvironment is an environment in which the database exists.
+ * - BerkeleyDatabase represents a wallet database.
+ * - BerkeleyBatch is a low-level database batch update.
  */
 
 static const bool DEFAULT_FLUSHWALLET = true;
@@ -106,7 +103,7 @@ public:
 };
 
 /** Access to the wallet database.
- * This should really be named CWalletDBBatch, as it represents a single transaction at the
+ * This represents a single transaction at the
  * database. It will be committed when the object goes out of scope.
  * Optionally (on by default) it will flush to disk as well.
  */

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -23,15 +23,15 @@
 /**
  * Overview of wallet database classes:
  *
- * - CDBEnv is an environment in which the database exists (has no analog in dbwrapper.h)
- * - CWalletDBWrapper represents a wallet database (similar to CDBWrapper in dbwrapper.h)
- * - CDB is a low-level database transaction (similar to CDBBatch in dbwrapper.h)
- * - CWalletDB is a modifier object for the wallet, and encapsulates a database
+ * - BerkeleyEnvironment is an environment in which the database exists (has no analog in dbwrapper.h)
+ * - WalletDatabase represents a wallet database (similar to CDBWrapper in dbwrapper.h)
+ * - BerkeleyBatch is a low-level database transaction (similar to CDBBatch in dbwrapper.h)
+ * - WalletBatch is a modifier object for the wallet, and encapsulates a database
  *   transaction as well as methods to act on the database (no analog in
  *   dbwrapper.h)
  *
- * The latter two are named confusingly, in contrast to what the names CDB
- * and CWalletDB suggest they are transient transaction objects and don't
+ * The latter two are named confusingly, in contrast to what the names BerkeleyBatch
+ * and WalletBatch suggest they are transient transaction objects and don't
  * represent the database itself.
  */
 
@@ -45,6 +45,9 @@ class CWallet;
 class CWalletTx;
 class uint160;
 class uint256;
+
+/** Backend-agnostic database type. */
+using WalletDatabase = BerkeleyDatabase;
 
 /** Error statuses for the wallet database */
 enum DBErrors {
@@ -107,7 +110,7 @@ public:
  * database. It will be committed when the object goes out of scope.
  * Optionally (on by default) it will flush to disk as well.
  */
-class CWalletDB
+class WalletBatch
 {
 private:
     template <typename K, typename T>
@@ -116,7 +119,7 @@ private:
         if (!batch.Write(key, value, fOverwrite)) {
             return false;
         }
-        m_dbw.IncrementUpdateCounter();
+        m_database.IncrementUpdateCounter();
         return true;
     }
 
@@ -126,18 +129,18 @@ private:
         if (!batch.Erase(key)) {
             return false;
         }
-        m_dbw.IncrementUpdateCounter();
+        m_database.IncrementUpdateCounter();
         return true;
     }
 
 public:
-    CWalletDB(CWalletDBWrapper& dbw, const char* pszMode = "r+", bool _fFlushOnClose = true) :
-        batch(dbw, pszMode, _fFlushOnClose),
-        m_dbw(dbw)
+    WalletBatch(WalletDatabase& database, const char* pszMode = "r+", bool _fFlushOnClose = true) :
+        batch(database, pszMode, _fFlushOnClose),
+        m_database(database)
     {
     }
-    CWalletDB(const CWalletDB&) = delete;
-    CWalletDB& operator=(const CWalletDB&) = delete;
+    WalletBatch(const WalletBatch&) = delete;
+    WalletBatch& operator=(const WalletBatch&) = delete;
 
     bool WriteName(const std::string& strAddress, const std::string& strName);
     bool EraseName(const std::string& strAddress);
@@ -227,8 +230,8 @@ public:
     //! Write wallet version
     bool WriteVersion(int nVersion);
 private:
-    CDB batch;
-    CWalletDBWrapper& m_dbw;
+    BerkeleyBatch batch;
+    WalletDatabase& m_database;
 };
 
 //! Called during init: Automatic backups

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -77,7 +77,7 @@ class MultiWalletTest(PivxTestFramework):
 
         # should not initialize if one wallet is a copy of another
         shutil.copyfile(wallet_dir('w8'), wallet_dir('w8_copy'))
-        exp_stderr = r"CDB: Can't open database w8_copy \(duplicates fileid \w+ from w8\)"
+        exp_stderr = r"BerkeleyBatch: Can't open database w8_copy \(duplicates fileid \w+ from w8\)"
         self.nodes[0].assert_start_raises_init_error(['-wallet=w8', '-wallet=w8_copy'], exp_stderr, match=ErrorMatch.PARTIAL_REGEX)
 
         # should not initialize if wallet file is a symlink

--- a/test/lint/commit-script-check.sh
+++ b/test/lint/commit-script-check.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright (c) 2017 The Bitcoin Core developers
+# Copyright (c) 2017-2020 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -11,32 +11,33 @@
 # The resulting script should exactly transform the previous commit into the current
 # one. Any remaining diff signals an error.
 
-if test "x$1" = "x"; then
+export LC_ALL=C
+if test -z $1; then
     echo "Usage: $0 <commit>..."
     exit 1
 fi
 
 RET=0
-PREV_BRANCH=`git name-rev --name-only HEAD`
-PREV_HEAD=`git rev-parse HEAD`
-for i in `git rev-list --reverse $1`; do
-    if git rev-list -n 1 --pretty="%s" $i | grep -q "^scripted-diff:"; then
-        git checkout --quiet $i^ || exit
-        SCRIPT="`git rev-list --format=%b -n1 $i | sed '/^-BEGIN VERIFY SCRIPT-$/,/^-END VERIFY SCRIPT-$/{//!b};d'`"
-        if test "x$SCRIPT" = "x"; then
-            echo "Error: missing script for: $i"
+PREV_BRANCH=$(git name-rev --name-only HEAD)
+PREV_HEAD=$(git rev-parse HEAD)
+for commit in $(git rev-list --reverse $1); do
+    if git rev-list -n 1 --pretty="%s" $commit | grep -q "^scripted-diff:"; then
+        git checkout --quiet $commit^ || exit
+        SCRIPT="$(git rev-list --format=%b -n1 $commit | sed '/^-BEGIN VERIFY SCRIPT-$/,/^-END VERIFY SCRIPT-$/{//!b};d')"
+        if test -z "$SCRIPT"; then
+            echo "Error: missing script for: $commit"
             echo "Failed"
             RET=1
         else
-            echo "Running script for: $i"
+            echo "Running script for: $commit"
             echo "$SCRIPT"
-            eval "$SCRIPT"
-            git --no-pager diff --exit-code $i && echo "OK" || (echo "Failed"; false) || RET=1
+            (eval "$SCRIPT")
+            git --no-pager diff --exit-code $commit && echo "OK" || (echo "Failed"; false) || RET=1
         fi
         git reset --quiet --hard HEAD
      else
-        if git rev-list "--format=%b" -n1 $i | grep -q '^-\(BEGIN\|END\)[ a-zA-Z]*-$'; then
-            echo "Error: script block marker but no scripted-diff in title"
+        if git rev-list "--format=%b" -n1 $commit | grep -q '^-\(BEGIN\|END\)[ a-zA-Z]*-$'; then
+            echo "Error: script block marker but no scripted-diff in title of commit $commit"
             echo "Failed"
             RET=1
         fi


### PR DESCRIPTION
Scripted diff to rename "some" wallet classes.

Backports #11851

Pushing it now because this is one of those annoying text-only rename backports that touch many files that we should try to avoid during the development/review period and only merge right after the release gets packed (aka now).