### PR TITLE
[GUI] Add address search option in cold-staking widget

### DIFF
--- a/src/qt/pivx/coldstakingwidget.cpp
+++ b/src/qt/pivx/coldstakingwidget.cpp
@@ -168,6 +168,10 @@ ColdStakingWidget::ColdStakingWidget(PIVXGUI* parent) :
     ui->btnMyStakingAddresses->setChecked(true);
     ui->listViewStakingAddress->setVisible(false);
 
+    // My ColdStaking Addresses search filter
+    initCssEditLine(ui->lineEditFilter, true);
+    ui->lineEditFilter->setStyleSheet("font: 14px;");
+
     ui->btnMyStakingAddresses->setTitleClassAndText("btn-title-grey", tr("My Cold Staking Addresses"));
     ui->btnMyStakingAddresses->setSubTitleClassAndText("text-subtitle", tr("List your own cold staking addresses."));
     ui->btnMyStakingAddresses->layout()->setMargin(0);
@@ -197,6 +201,7 @@ ColdStakingWidget::ColdStakingWidget(PIVXGUI* parent) :
     connect(ui->listView, &QListView::clicked, this, &ColdStakingWidget::handleAddressClicked);
     connect(ui->listViewStakingAddress, &QListView::clicked, this, &ColdStakingWidget::handleMyColdAddressClicked);
     connect(ui->btnMyStakingAddresses, &OptionButton::clicked, this, &ColdStakingWidget::onMyStakingAddressesClicked);
+    connect(ui->lineEditFilter, &QLineEdit::textChanged, this, &ColdStakingWidget::filterChanged);
 
     coinControlDialog = new CoinControlDialog(nullptr, true);
 }
@@ -813,6 +818,11 @@ void ColdStakingWidget::onSortOrderChanged(int idx)
 {
     sortOrder = (Qt::SortOrder) ui->comboBoxSortOrder->itemData(idx).toInt();
     sortAddresses();
+}
+
+void ColdStakingWidget::filterChanged(const QString& str)
+{
+    this->addressesFilter->setFilterRegExp(str);
 }
 
 void ColdStakingWidget::sortAddresses()

--- a/src/qt/pivx/coldstakingwidget.h
+++ b/src/qt/pivx/coldstakingwidget.h
@@ -78,6 +78,7 @@ private Q_SLOTS:
     void onDelegationsRefreshed();
     void onSortChanged(int idx);
     void onSortOrderChanged(int idx);
+    void filterChanged(const QString& str);
 
 private:
     Ui::ColdStakingWidget *ui = nullptr;

--- a/src/qt/pivx/forms/coldstakingwidget.ui
+++ b/src/qt/pivx/forms/coldstakingwidget.ui
@@ -811,14 +811,45 @@ stake on your behalf, while you keep the keys securely offline.</string>
          <property name="bottomMargin">
           <number>5</number>
          </property>
+           <item>
+            <widget class="QLineEdit" name="lineEditFilter">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="contextMenuPolicy">
+              <enum>Qt::DefaultContextMenu</enum>
+             </property>
+             <property name="acceptDrops">
+              <bool>false</bool>
+             </property>
+             <property name="maxLength">
+              <number>40</number>
+             </property>
+             <property name="placeholderText">
+              <string>Filter</string>
+             </property>
+            </widget>
+           </item>
          <item>
           <spacer name="horizontalSpacer_6">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
+           <property name="sizeType">
+              <enum>QSizePolicy::Preferred</enum>
+           </property>
            <property name="sizeHint" stdset="0">
             <size>
-             <width>40</width>
+             <width>20</width>
              <height>20</height>
             </size>
            </property>
@@ -857,6 +888,9 @@ stake on your behalf, while you keep the keys securely offline.</string>
           </widget>
          </item>
         </layout>
+       <zorder>comboBoxSort</zorder>
+       <zorder>comboBoxSortOrder</zorder>
+       <zorder>lineEditFilter</zorder>
        </widget>
       </item>
       <item>

--- a/src/qt/pivx/receivewidget.cpp
+++ b/src/qt/pivx/receivewidget.cpp
@@ -111,7 +111,7 @@ ReceiveWidget::ReceiveWidget(PIVXGUI* parent) :
     connect(ui->listViewAddress, &QListView::clicked, this, &ReceiveWidget::handleAddressClicked);
     connect(ui->btnRequest, &OptionButton::clicked, this, &ReceiveWidget::onRequestClicked);
     connect(ui->btnMyAddresses, &OptionButton::clicked, this, &ReceiveWidget::onMyAddressesClicked);
-    connect(ui->lineEditFilter, &QLineEdit::textChanged, [this](){filterChanged(ui->lineEditFilter->text());});
+    connect(ui->lineEditFilter, &QLineEdit::textChanged, this, &ReceiveWidget::filterChanged);
 
     ui->pushLeft->setChecked(true);
     connect(ui->pushLeft, &QPushButton::clicked, [this](){onTransparentSelected(true);});


### PR DESCRIPTION
Same as the one introduced for the receive widget in #2353.
Closes #2499.