### PR TITLE
[Wallet] Sapling, restructure increment witnesses workflow

### DIFF
--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -31,7 +31,8 @@ bench_bench_pivx_SOURCES = \
   bench/perf.cpp \
   bench/perf.h \
   bench/prevector.cpp \
-  bench/util_time.cpp
+  bench/util_time.cpp \
+  bench/walletprocessblock.cpp
 
 nodist_bench_bench_pivx_SOURCES = $(GENERATED_BENCH_FILES)
 

--- a/src/bench/CMakeLists.txt
+++ b/src/bench/CMakeLists.txt
@@ -54,6 +54,7 @@ set(BITCOIN_BENCH_SUITE
         ${CMAKE_CURRENT_SOURCE_DIR}/perf.h
         ${CMAKE_CURRENT_SOURCE_DIR}/prevector.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/util_time.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/walletprocessblock.cpp
         )
 
 set(bench_bench_pivx_SOURCES ${BITCOIN_BENCH_SUITE} ${BITCOIN_TESTS})

--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -32,6 +32,7 @@ static void DeserializeAndCheckBlockTest(benchmark::State& state)
     stream.write(&a, 1); // Prevent compaction
 
     SelectParams(CBaseChainParams::MAIN);
+    const static auto verify_handle = std::make_unique<ECCVerifyHandle>();
 
     while (state.KeepRunning()) {
         CBlock block; // Note that CBlock caches its checked state, so we need to recreate it here

--- a/src/bench/walletprocessblock.cpp
+++ b/src/bench/walletprocessblock.cpp
@@ -1,0 +1,210 @@
+// Copyright (c) 2021 The PIVX Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include "bench.h"
+#include "blockassembler.h"
+#include "chainparams.h"
+#include "consensus/merkle.h"
+#include "evo/deterministicmns.h"
+#include "evo/evodb.h"
+#include "evo/evonotificationinterface.h"
+
+#include "sapling/sapling_operation.h"
+#include "scheduler.h"
+#include "script/sigcache.h"
+#include "sporkdb.h"
+#include "txdb.h"
+#include "validation.h"
+#include "wallet/wallet.h"
+
+#include <boost/thread.hpp>
+
+// Number of blocks that will be created to make noise on this benchmark
+const unsigned int CREATE_BLOCK = 500;
+// Number of transparent transactions that will be created to make noise on this benchmark.
+const unsigned int CREATE_TRANSACTIONS_PER_BLOCK = 20;
+
+static CMutableTransaction NewCoinbase(const int nHeight, const CScript& scriptPubKey)
+{
+    CMutableTransaction txCoinbase;
+    txCoinbase.vout.emplace_back();
+    txCoinbase.vout[0].SetEmpty();
+    txCoinbase.vout[0].scriptPubKey = scriptPubKey;
+    txCoinbase.vin.emplace_back();
+    txCoinbase.vin[0].scriptSig = CScript() << nHeight << OP_0;
+    txCoinbase.vout[0].nValue = GetBlockValue(nHeight);
+    return txCoinbase;
+}
+
+std::shared_ptr<CBlock> createAndProcessBlock(
+        const CChainParams& params,
+        const CScript& coinbaseScript,
+        const std::vector<CMutableTransaction>& txns,
+        CBlockIndex* prevpindex)
+{
+    int nextHeight = prevpindex ? prevpindex->nHeight + 1 : 0;
+    CMutableTransaction coinbaseTx = NewCoinbase(nextHeight, coinbaseScript);
+
+    CBlock block;
+    block.hashMerkleRoot = BlockMerkleRoot(block);
+    if (prevpindex) block.hashPrevBlock = prevpindex->GetBlockHash();
+    block.vtx.emplace_back(MakeTransactionRef(coinbaseTx));
+    for (const CMutableTransaction& tx : txns) {
+        block.vtx.emplace_back(MakeTransactionRef(tx));
+    }
+    block.hashFinalSaplingRoot = CalculateSaplingTreeRoot(&block, nextHeight, params);
+
+    const auto& blockHash = block.GetHash();
+    CBlockIndex* fakeIndex = new CBlockIndex{block};
+    fakeIndex->nHeight = nextHeight;
+    BlockMap::iterator mi = mapBlockIndex.emplace(blockHash, fakeIndex).first;
+    fakeIndex->phashBlock = &((*mi).first);
+    chainActive.SetTip(fakeIndex);
+    assert(chainActive.Contains(fakeIndex));
+    assert(nextHeight == chainActive.Height());
+
+    return std::make_shared<CBlock>(block);
+}
+
+CTransactionRef createNoisyTx(CWallet* pwallet, int numOfOutputs)
+{
+    CallResult<CTxDestination> ret = pwallet->getNewAddress("");
+    assert(ret);
+    const auto& dest = GetScriptForDestination(*ret.getObjResult());
+    std::vector<CRecipient> vecSend;
+    vecSend.reserve(numOfOutputs);
+    for (int i=0; i<numOfOutputs; i++) {
+        vecSend.emplace_back(dest, 5 * COIN, false);
+    }
+
+    CTransactionRef txRet;
+    CReserveKey reservedKey(pwallet);
+    CAmount nFeeRequired = 0;
+    int nChangePosInOut = -1;
+    std::string strFailReason;
+    bool fCreated = pwallet->CreateTransaction(vecSend,
+                                               txRet,
+                                               reservedKey,
+                                               nFeeRequired,
+                                               nChangePosInOut,
+                                               strFailReason);
+    assert(fCreated);
+    return txRet;
+}
+
+boost::thread_group threadGroup;
+CScheduler scheduler;
+EvoNotificationInterface* pEvoNotificationInterface;
+
+static void initBasics()
+{
+    initZKSNARKS();
+    CScheduler::Function serviceLoop = std::bind(&CScheduler::serviceQueue, &scheduler);
+    threadGroup.create_thread(std::bind(&TraceThread<CScheduler::Function>, "scheduler", serviceLoop));
+    GetMainSignals().RegisterBackgroundSignalScheduler(scheduler);
+
+    zerocoinDB.reset(new CZerocoinDB(0, true));
+    pSporkDB.reset(new CSporkDB(0, true));
+    pblocktree.reset(new CBlockTreeDB(1 << 20, true));
+    pcoinsdbview.reset(new CCoinsViewDB(1 << 23, true));
+    pcoinsTip.reset(new CCoinsViewCache(pcoinsdbview.get()));
+    evoDb.reset(new CEvoDB(1 << 20, true, true));
+    deterministicMNManager.reset(new CDeterministicMNManager(*evoDb));
+    pEvoNotificationInterface = new EvoNotificationInterface();
+    RegisterValidationInterface(pEvoNotificationInterface);
+}
+
+static void WalletProcessBlockBench(benchmark::State& state)
+{
+    const static auto verify_handle = std::make_unique<ECCVerifyHandle>();
+
+    SelectParams(CBaseChainParams::REGTEST);
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_POS, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_POS_V2, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_V5_0, 1);
+    const auto& params = Params();
+    initBasics();
+
+    std::unique_ptr<CWallet> pwallet = std::make_unique<CWallet>("default", WalletDatabase::CreateMock());
+    bool isInit;
+    pwallet->LoadWallet(isInit);
+    pwallet->SetupSPKM(true, true);
+    auto res = pwallet->getNewAddress("coinbase");
+    if (!res) throw std::runtime_error("Cannot create coinbase address");
+    const CScript& coinbaseScript = GetScriptForDestination(*res.getObjResult());
+
+    // Let's generate blocks first
+    int gen = CREATE_BLOCK;
+    for (int i=0; i<gen; i++) {
+        std::vector<CMutableTransaction> vtx;
+        if (i > 101) { // Generate extra transaction
+            vtx.emplace_back(*createNoisyTx(pwallet.get(), 15));
+            if (i > 106) {
+                for (int j=0; j<CREATE_TRANSACTIONS_PER_BLOCK; j++) {
+                    vtx.emplace_back(*createNoisyTx(pwallet.get(), 1));
+                }
+            }
+        }
+
+        std::shared_ptr<CBlock> pblock = createAndProcessBlock(params, coinbaseScript, vtx, chainActive.Tip());
+        pwallet->BlockConnected(pblock, mapBlockIndex[pblock->GetHash()]);
+    }
+    assert(WITH_LOCK(cs_main, return chainActive.Height();) == gen -1);
+    int nextBlockHeight = gen + 1;
+
+    // Now the wallet has balance to shield and the network is mature enough.
+    // let's generate 30 more blocks with 3 shielding transactions each.
+    std::vector<std::shared_ptr<CBlock>> blocks;
+    for (int i=0; i<30; i++) {
+        std::vector<CMutableTransaction> vtx;
+        for (int j=0; j<3; j++) {
+            std::vector<SendManyRecipient> recipients;
+            recipients.emplace_back(pwallet->GenerateNewSaplingZKey(), 2 * COIN, "", false);
+            recipients.emplace_back(pwallet->GenerateNewSaplingZKey(), 100 * COIN, "", false);
+            recipients.emplace_back(pwallet->GenerateNewSaplingZKey(), 240 * COIN, "", false);
+
+            SaplingOperation operation(params.GetConsensus(), nextBlockHeight, pwallet.get());
+            auto operationResult = operation.setRecipients(recipients)
+                    ->setSelectTransparentCoins(true)
+                    ->setMinDepth(1)
+                    ->build();
+
+            assert(operationResult);
+            vtx.emplace_back(operation.getFinalTx());
+        }
+
+        std::shared_ptr<CBlock> pblock = createAndProcessBlock(params,
+                                                               coinbaseScript,
+                                                               vtx,
+                                                               chainActive.Tip());
+        assert(WITH_LOCK(cs_main, return chainActive.Height();) == nextBlockHeight - 1);
+        blocks.emplace_back(pblock);
+        nextBlockHeight++;
+    }
+
+    // The wallet receiving the blocks..
+    while (state.KeepRunning()) {
+        for (const auto& pblock : blocks) {
+            pwallet->BlockConnected(pblock, mapBlockIndex[pblock->GetHash()]);
+        }
+    }
+
+    // Cleanup
+    ECC_Stop();
+    deterministicMNManager.reset();
+    evoDb.reset();
+    scheduler.stop();
+    threadGroup.interrupt_all();
+    threadGroup.join_all();
+    UnloadBlockIndex();
+    chainActive.SetTip(nullptr);
+    delete pEvoNotificationInterface;
+    pcoinsTip.reset();
+    pcoinsdbview.reset();
+    pblocktree.reset();
+    zerocoinDB.reset();
+    pSporkDB.reset();
+}
+
+BENCHMARK(WalletProcessBlockBench, 0);

--- a/src/evo/evonotificationinterface.h
+++ b/src/evo/evonotificationinterface.h
@@ -10,7 +10,7 @@
 class EvoNotificationInterface : public CValidationInterface
 {
 public:
-    explicit EvoNotificationInterface(CConnman& connmanIn): connman(connmanIn) {}
+    explicit EvoNotificationInterface() {}
     virtual ~EvoNotificationInterface() = default;
 
     // a small helper to initialize current block height in sub-modules on startup
@@ -20,9 +20,6 @@ protected:
     // CValidationInterface
     void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
     void NotifyMasternodeListChanged(bool undo, const CDeterministicMNList& oldMNList, const CDeterministicMNListDiff& diff) override;
-
-private:
-    CConnman& connman;
 };
 
 #endif // EVONOTIFICATIONINTERFACE_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1529,7 +1529,7 @@ bool AppInitMain()
     }
 #endif
 
-    pEvoNotificationInterface = new EvoNotificationInterface(connman);
+    pEvoNotificationInterface = new EvoNotificationInterface();
     RegisterValidationInterface(pEvoNotificationInterface);
 
     // ********************************************************* Step 7: load block chain

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -137,53 +137,49 @@ void CopyPreviousWitnesses(NoteDataMap& noteDataMap, int indexHeight, int64_t nW
     }
 }
 
-template<typename NoteDataMap>
-void AppendNoteCommitment(NoteDataMap& noteDataMap, int indexHeight, int64_t nWitnessCacheSize, const uint256& note_commitment)
+void AppendNoteCommitment(SaplingNoteData* nd, int indexHeight, int64_t nWitnessCacheSize, const uint256& note_commitment)
 {
-    for (auto& item : noteDataMap) {
-        auto* nd = &(item.second);
-        // skip externally sent notes
-        if (!nd->IsMyNote()) continue;
-        if (nd->witnessHeight < indexHeight && nd->witnesses.size() > 0) {
-            // Check the validity of the cache
-            // See comment in CopyPreviousWitnesses about validity.
-            assert(nWitnessCacheSize >= (int64_t) nd->witnesses.size());
-            nd->witnesses.front().append(note_commitment);
-        }
+    // skip externally sent notes
+    if (!nd->IsMyNote()) return;
+    // No empty witnesses can reach here. Before any append, the note must be already witnessed.
+    if (nd->witnessHeight < indexHeight && nd->witnesses.size() > 0) {
+        // Check the validity of the cache
+        // See comment in CopyPreviousWitnesses about validity.
+        assert(nWitnessCacheSize >= (int64_t) nd->witnesses.size());
+        nd->witnesses.front().append(note_commitment);
     }
 }
 
-template<typename OutPoint, typename NoteData, typename Witness>
-void WitnessNoteIfMine(std::map<OutPoint, NoteData>& noteDataMap, int indexHeight, int64_t nWitnessCacheSize, const OutPoint& key, const Witness& witness)
+template<typename Witness>
+void WitnessNoteIfMine(SaplingNoteData* nd,
+                       int indexHeight,
+                       int64_t nWitnessCacheSize,
+                       const Witness& witness)
 {
-    auto ndIt = noteDataMap.find(key);
-    if (ndIt != noteDataMap.end()) {
-        auto* nd = &ndIt->second;
-        // skip externally sent and already witnessed notes
-        if (!nd->IsMyNote() || nd->witnessHeight >= indexHeight) return;
-        if (nd->witnesses.size() > 0) {
-            // We think this can happen because we write out the
-            // witness cache state after every block increment or
-            // decrement, but the block index itself is written in
-            // batches. So if the node crashes in between these two
-            // operations, it is possible for IncrementNoteWitnesses
-            // to be called again on previously-cached blocks. This
-            // doesn't affect existing cached notes because of the
-            // NoteData::witnessHeight checks. See #1378 for details.
-            LogPrintf("Inconsistent witness cache state found for %s\n- Cache size: %d\n- Top (height %d): %s\n- New (height %d): %s\n",
-                      key.ToString(), nd->witnesses.size(),
-                      nd->witnessHeight,
-                      nd->witnesses.front().root().GetHex(),
-                      indexHeight,
-                      witness.root().GetHex());
-            nd->witnesses.clear();
-        }
-        nd->witnesses.push_front(witness);
-        // Set height to one less than pindex so it gets incremented
-        nd->witnessHeight = indexHeight - 1;
-        // Check the validity of the cache
-        assert(nWitnessCacheSize >= (int64_t) nd->witnesses.size());
+    assert(nd);
+    // skip externally sent and already witnessed notes
+    if (!nd->IsMyNote() || nd->witnessHeight >= indexHeight) return;
+    if (!nd->witnesses.empty()) {
+        // We think this can happen because we write out the
+        // witness cache state after every block increment or
+        // decrement, but the block index itself is written in
+        // batches. So if the node crashes in between these two
+        // operations, it is possible for IncrementNoteWitnesses
+        // to be called again on previously-cached blocks. This
+        // doesn't affect existing cached notes because of the
+        // NoteData::witnessHeight checks. See #1378 for details.
+        LogPrintf("Inconsistent witness cache state found\n- Cache size: %d\n- Top (height %d): %s\n- New (height %d): %s\n",
+                  nd->witnesses.size(), nd->witnessHeight,
+                  nd->witnesses.front().root().GetHex(),
+                  indexHeight,
+                  witness.root().GetHex());
+        nd->witnesses.clear();
     }
+    nd->witnesses.push_front(witness);
+    // Set height to one less than pindex so it gets incremented
+    nd->witnessHeight = indexHeight - 1;
+    // Check the validity of the cache
+    assert(nWitnessCacheSize >= (int64_t) nd->witnesses.size());
 }
 
 template<typename NoteDataMap>
@@ -203,48 +199,82 @@ void UpdateWitnessHeights(NoteDataMap& noteDataMap, int indexHeight, int64_t nWi
 }
 
 void SaplingScriptPubKeyMan::IncrementNoteWitnesses(const CBlockIndex* pindex,
-                                     const CBlock* pblock,
-                                     SaplingMerkleTree& saplingTree)
+                                                    const CBlock* pblock,
+                                                    SaplingMerkleTree& saplingTreeRes)
 {
     LOCK(wallet->cs_wallet);
     int chainHeight = pindex->nHeight;
-    for (std::pair<const uint256, CWalletTx>& wtxItem : wallet->mapWallet) {
-        ::CopyPreviousWitnesses(wtxItem.second.mapSaplingNoteData, chainHeight, nWitnessCacheSize);
-    }
 
+    // Set the update cache flag.
+    int64_t prevWitCacheSize = nWitnessCacheSize;
     if (nWitnessCacheSize < WITNESS_CACHE_SIZE) {
         nWitnessCacheSize += 1;
         nWitnessCacheNeedsUpdate = true;
     }
 
+    // 1) Loop over the block txs and gather the note commitments ordered.
+    // If the wtx is from this wallet, witness it and append the following block note commitments on top.
+    std::vector<uint256> noteCommitments;
+    std::vector<std::pair<CWalletTx*, SaplingNoteData*>> inBlockArrivingNotes;
     for (const auto& tx : pblock->vtx) {
         if (!tx->IsShieldedTx()) continue;
 
-        const uint256& hash = tx->GetHash();
-        bool txIsOurs = wallet->mapWallet.count(hash);
+        const auto& hash = tx->GetHash();
+        auto it = wallet->mapWallet.find(hash);
+        bool txIsOurs = it != wallet->mapWallet.end();
 
-        // Sapling
         for (uint32_t i = 0; i < tx->sapData->vShieldedOutput.size(); i++) {
-            const uint256& note_commitment = tx->sapData->vShieldedOutput[i].cmu;
-            saplingTree.append(note_commitment);
+            const auto& cmu = tx->sapData->vShieldedOutput[i].cmu;
+            noteCommitments.emplace_back(cmu);
 
-            // Increment existing witnesses
-            for (std::pair<const uint256, CWalletTx>& wtxItem : wallet->mapWallet) {
-                ::AppendNoteCommitment(wtxItem.second.mapSaplingNoteData, chainHeight, nWitnessCacheSize, note_commitment);
+            // Append note commitment to the in-block wallet's notes.
+            // This is processed here because we already looked for the wtx on
+            // the WitnessNoteIfMine call and only need to append the follow-up block notes,
+            // not every block note (check below).
+            for (auto& item : inBlockArrivingNotes) {
+                ::AppendNoteCommitment(item.second, chainHeight, nWitnessCacheSize, cmu);
             }
 
-            // If this is our note, witness it
+            // If tx is from this wallet, try to witness the note for the first time (if exists).
+            // And add it to the in-block arriving txs.
+            saplingTreeRes.append(cmu);
             if (txIsOurs) {
-                SaplingOutPoint outPoint {hash, i};
-                ::WitnessNoteIfMine(wallet->mapWallet.at(hash).mapSaplingNoteData, chainHeight, nWitnessCacheSize, outPoint, saplingTree.witness());
+                CWalletTx* wtx = &it->second;
+                auto ndIt = wtx->mapSaplingNoteData.find({hash, i});
+                if (ndIt != wtx->mapSaplingNoteData.end()) {
+                    SaplingNoteData* nd = &ndIt->second;
+                    ::WitnessNoteIfMine(nd, chainHeight, nWitnessCacheSize, saplingTreeRes.witness());
+                    inBlockArrivingNotes.emplace_back(std::make_pair(wtx, nd));
+                }
             }
         }
-
     }
 
-    // Update witness heights
-    for (std::pair<const uint256, CWalletTx>& wtxItem : wallet->mapWallet) {
-        ::UpdateWitnessHeights(wtxItem.second.mapSaplingNoteData, chainHeight, nWitnessCacheSize);
+    // 2) Mark already sync wtx, so we don't process them again.
+    for (auto& item : inBlockArrivingNotes) {
+        ::UpdateWitnessHeights(item.first->mapSaplingNoteData, chainHeight, nWitnessCacheSize);
+    }
+
+    // 3) Loop over the shield txs in the wallet's map (excluding the wtx arriving in this block) and for each tx:
+    //    a) Copy the previous witness.
+    //    b) Append all new notes commitments
+    //    c) Update witness last processed height
+    for (auto& it : wallet->mapWallet) {
+        CWalletTx& wtx = it.second;
+        if (!wtx.mapSaplingNoteData.empty()) {
+            // Create copy of the previous witness (verifying pre-arriving block witness cache size)
+            ::CopyPreviousWitnesses(wtx.mapSaplingNoteData, chainHeight, prevWitCacheSize);
+
+            // Append new notes commitments.
+            for (auto& noteComm : noteCommitments) {
+                for (auto& item : wtx.mapSaplingNoteData) {
+                    AppendNoteCommitment(&(item.second), chainHeight, nWitnessCacheSize, noteComm);
+                }
+            }
+
+            // Set last processed height.
+            ::UpdateWitnessHeights(wtx.mapSaplingNoteData, chainHeight, nWitnessCacheSize);
+        }
     }
 
     // For performance reasons, we write out the witness cache in

--- a/src/test/test_pivx.cpp
+++ b/src/test/test_pivx.cpp
@@ -86,7 +86,7 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
         // Register EvoNotificationInterface
         g_connman = std::make_unique<CConnman>(0x1337, 0x1337); // Deterministic randomness for tests.
         connman = g_connman.get();
-        pEvoNotificationInterface = new EvoNotificationInterface(*connman);
+        pEvoNotificationInterface = new EvoNotificationInterface();
         RegisterValidationInterface(pEvoNotificationInterface);
 
         // Ideally we'd move all the RPC tests to the functional testing framework


### PR DESCRIPTION
This work aims to improve the structure and performance of the wallet's Sapling increment witnesses flow.

The process is essentially walking through the entire wallet's txs map a minimum of 2 times, if there is no shield tx in the arriving block, and adds one more for each shield tx inside the block. Which affects mainly to wallets with a large number of transactions as the wallet is locked while this operation is being executed.

So, straight to the point, the current increment witness workflow is:
```
1) for-each tx in wallet : call CopyPreviousWitnesses.
2) for-each tx in block:
   a) for-each note in tx:
      a1) for-each tx in wallet : call AppendNoteCommitment.
      a2) if note is mine : call WitnessNoteIfMine.
3) for-each tx in wallet : call UpdateWitnessHeights.
```

And, have re-structured it into:
```
1) for-each tx in block : gather note commitments in vecComm.
2) for-each shield tx in wallet:
  a) copy the previous witness.
  b) for-each note commitment in vecComm:
      b1) append notes commitment.
      b2) witness note if ours.
  c) Update witness last processed height.
```

Finishing with only one loop over the wallet's txs map in the entire increment witnesses workflow.

PD: The benchmark that did is still a bit raw..
