### PR TITLE
[RPC][Doc] Fix RPC/cli example in setautocombinethreshold help

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4519,7 +4519,7 @@ UniValue setautocombinethreshold(const JSONRPCRequest& request)
             "}\n"
 
             "\nExamples:\n" +
-            HelpExampleCli("setautocombinethreshold", "500.12") + HelpExampleRpc("setautocombinethreshold", "500.12"));
+            HelpExampleCli("setautocombinethreshold", "true 500.12") + HelpExampleRpc("setautocombinethreshold", "true, 500.12"));
 
     RPCTypeCheck(request.params, {UniValue::VBOOL, UniValue::VNUM});
 


### PR DESCRIPTION
Missing first argument (bolean, required, "enable").