### PR TITLE
[Gitian][Bug] Ignore changes to relic_conf.h.in

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -140,6 +140,7 @@ script: |
   export PATH=${WRAP_DIR}:${PATH}
 
   # Create the release tarball using (arbitrarily) the first host
+  git update-index --assume-unchanged src/chiabls/contrib/relic/include/relic_conf.h.in
   ./autogen.sh
   CONFIG_SITE=${BASEPREFIX}/`echo "${HOSTS}" | awk '{print $1;}'`/share/config.site ./configure --prefix=/
   make dist

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -103,6 +103,7 @@ script: |
   export PATH=${WRAP_DIR}:${PATH}
 
   # Create the release tarball using (arbitrarily) the first host
+  git update-index --assume-unchanged src/chiabls/contrib/relic/include/relic_conf.h.in
   ./autogen.sh
   CONFIG_SITE=${BASEPREFIX}/`echo "${HOSTS}" | awk '{print $1;}'`/share/config.site ./configure --prefix=/
   make dist

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -110,6 +110,7 @@ script: |
   export PATH=${WRAP_DIR}:${PATH}
 
   # Create the release tarball using (arbitrarily) the first host
+  git update-index --assume-unchanged src/chiabls/contrib/relic/include/relic_conf.h.in
   ./autogen.sh
   CONFIG_SITE=${BASEPREFIX}/`echo "${HOSTS}" | awk '{print $1;}'`/share/config.site ./configure --prefix=/
   make dist


### PR DESCRIPTION
This file gets overwritten during the autotools build process, but we don't actually want to track changes to it in our repo.

Currently, gitian builds will see that this file has changes, and thus mark the build as "dirty". This PR tells gitian builds to ignore any changes to the file via `update-index --assume-unchanged` so that release versions are no longer marked as "dirty".