### PR TITLE
[Refactor] Differentiate destinations from lookup keys and disallow automatic conversion between them

### DIFF
--- a/src/bip38.cpp
+++ b/src/bip38.cpp
@@ -287,7 +287,7 @@ bool BIP38_Decrypt(std::string strPassphrase, std::string strEncryptedKey, uint2
     CKey k;
     k.Set(privKey.begin(), privKey.end(), fCompressed);
     CPubKey pubkey = k.GetPubKey();
-    std::string address = EncodeDestination(pubkey.GetID());
+    std::string address = EncodeDestination(PKHash(pubkey));
 
     return strAddressHash == AddressToBip38Hash(address);
 }

--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -185,11 +185,11 @@ bool CBloomFilter::IsRelevantAndUpdate(const CTransaction& tx)
                 if ((nFlags & BLOOM_UPDATE_MASK) == BLOOM_UPDATE_ALL)
                     insert(COutPoint(hash, i));
                 else if ((nFlags & BLOOM_UPDATE_MASK) == BLOOM_UPDATE_P2PUBKEY_ONLY) {
-                    txnouttype type;
                     std::vector<std::vector<unsigned char> > vSolutions;
-                    if (Solver(txout.scriptPubKey, type, vSolutions) &&
-                        (type == TX_PUBKEY || type == TX_MULTISIG))
+                    txnouttype type = Solver(txout.scriptPubKey, vSolutions);
+                    if (type == TX_PUBKEY || type == TX_MULTISIG) {
                         insert(COutPoint(hash, i));
+                    }
                 }
                 break;
             }

--- a/src/budget/budgetutil.cpp
+++ b/src/budget/budgetutil.cpp
@@ -202,7 +202,7 @@ static mnKeyList getDMNVotingKeys(CWallet* const pwallet, const Optional<std::st
             } else if (filtered) {
                 resultsObj.push_back(packErrorRetStatus(*mnAliasFilter, strprintf(
                                         "Private key for voting address %s not known by this wallet",
-                                        EncodeDestination(dmn->pdmnState->keyIDVoting)))
+                                        EncodeDestination(PKHash(dmn->pdmnState->keyIDVoting))))
                                     );
                 failed++;
             }

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -19,6 +19,7 @@
 #include <boost/algorithm/string/split.hpp>
 
 #include <univalue.h>
+#include <string>
 
 CScript ParseScript(std::string s)
 {
@@ -32,10 +33,9 @@ CScript ParseScript(std::string s)
             if (op < OP_NOP && op != OP_RESERVED)
                 continue;
 
-            const char* name = GetOpName(static_cast<opcodetype>(op));
-            if (strcmp(name, "OP_UNKNOWN") == 0)
+            std::string strName = GetOpName(static_cast<opcodetype>(op));
+            if (strName == "OP_UNKNOWN")
                 continue;
-            std::string strName(name);
             mapOpNames[strName] = static_cast<opcodetype>(op);
             // Convenience: OP_ADD and just ADD are both recognized:
             boost::algorithm::replace_first(strName, "OP_", "");

--- a/src/destination_io.cpp
+++ b/src/destination_io.cpp
@@ -74,10 +74,10 @@ Destination& Destination::operator=(const Destination& from)
 }
 
 // Returns the key ID if Destination is a transparent "regular" destination
-const CKeyID* Destination::getKeyID()
+const PKHash* Destination::getKeyID()
 {
     const CTxDestination* regDest = Standard::GetTransparentDestination(dest);
-    return (regDest) ? boost::get<CKeyID>(regDest) : nullptr;
+    return (regDest) ? boost::get<PKHash>(regDest) : nullptr;
 }
 
 std::string Destination::ToString() const

--- a/src/destination_io.cpp
+++ b/src/destination_io.cpp
@@ -74,7 +74,7 @@ Destination& Destination::operator=(const Destination& from)
 }
 
 // Returns the key ID if Destination is a transparent "regular" destination
-const PKHash* Destination::getKeyID()
+const PKHash* Destination::getPkHash()
 {
     const CTxDestination* regDest = Standard::GetTransparentDestination(dest);
     return (regDest) ? boost::get<PKHash>(regDest) : nullptr;

--- a/src/destination_io.h
+++ b/src/destination_io.h
@@ -40,8 +40,8 @@ public:
     bool isP2CS{false};
 
     Destination& operator=(const Destination& from);
-    // Returns the key ID if Destination is a transparent "regular" destination
-    const CKeyID* getKeyID();
+    // Returns the key ID (pubkey hash) if Destination is a transparent "regular" destination
+    const PKHash* getKeyID();
     // Returns the encoded string address
     std::string ToString() const;
 };

--- a/src/destination_io.h
+++ b/src/destination_io.h
@@ -23,7 +23,7 @@ namespace Standard {
 
     // boost::get wrapper
     const libzcash::SaplingPaymentAddress* GetShieldedDestination(const CWDestination& dest);
-    const CTxDestination * GetTransparentDestination(const CWDestination& dest);
+    const CTxDestination* GetTransparentDestination(const CWDestination& dest);
 
 } // End Standard namespace
 
@@ -41,7 +41,7 @@ public:
 
     Destination& operator=(const Destination& from);
     // Returns the key ID (pubkey hash) if Destination is a transparent "regular" destination
-    const PKHash* getKeyID();
+    const PKHash* getPkHash();
     // Returns the encoded string address
     std::string ToString() const;
 };

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -39,7 +39,7 @@ std::string CDeterministicMNState::ToString() const
 
     return strprintf("CDeterministicMNState(nRegisteredHeight=%d, nLastPaidHeight=%d, nPoSePenalty=%d, nPoSeRevivedHeight=%d, nPoSeBanHeight=%d, nRevocationReason=%d, ownerAddress=%s, operatorPubKey=%s, votingAddress=%s, addr=%s, payoutAddress=%s, operatorPayoutAddress=%s)",
         nRegisteredHeight, nLastPaidHeight, nPoSePenalty, nPoSeRevivedHeight, nPoSeBanHeight, nRevocationReason,
-        EncodeDestination(keyIDOwner), pubKeyOperator.Get().ToString(), EncodeDestination(keyIDVoting), addr.ToStringIPPort(), payoutAddress, operatorPayoutAddress);
+        EncodeDestination(PKHash(keyIDOwner)), pubKeyOperator.Get().ToString(), EncodeDestination(PKHash(keyIDVoting)), addr.ToStringIPPort(), payoutAddress, operatorPayoutAddress);
 }
 
 void CDeterministicMNState::ToJson(UniValue& obj) const
@@ -53,9 +53,9 @@ void CDeterministicMNState::ToJson(UniValue& obj) const
     obj.pushKV("PoSeRevivedHeight", nPoSeRevivedHeight);
     obj.pushKV("PoSeBanHeight", nPoSeBanHeight);
     obj.pushKV("revocationReason", nRevocationReason);
-    obj.pushKV("ownerAddress", EncodeDestination(keyIDOwner));
+    obj.pushKV("ownerAddress", EncodeDestination(PKHash(keyIDOwner)));
     obj.pushKV("operatorPubKey", pubKeyOperator.Get().ToString());
-    obj.pushKV("votingAddress", EncodeDestination(keyIDVoting));
+    obj.pushKV("votingAddress", EncodeDestination(PKHash(keyIDVoting)));
 
     CTxDestination dest1;
     if (ExtractDestination(scriptPayout, dest1)) {
@@ -397,7 +397,7 @@ void CDeterministicMNList::AddMN(const CDeterministicMNCPtr& dmn, bool fBumpTota
         throw(std::runtime_error(strprintf("%s: can't add a masternode with a duplicate address %s", __func__, dmn->pdmnState->addr.ToStringIPPort())));
     }
     if (HasUniqueProperty(dmn->pdmnState->keyIDOwner) || HasUniqueProperty(dmn->pdmnState->pubKeyOperator)) {
-        throw(std::runtime_error(strprintf("%s: can't add a masternode with a duplicate key (%s or %s)", __func__, EncodeDestination(dmn->pdmnState->keyIDOwner), dmn->pdmnState->pubKeyOperator.Get().ToString())));
+        throw(std::runtime_error(strprintf("%s: can't add a masternode with a duplicate key (%s or %s)", __func__, EncodeDestination(PKHash(dmn->pdmnState->keyIDOwner)), dmn->pdmnState->pubKeyOperator.Get().ToString())));
     }
 
     mnMap = mnMap.set(dmn->proTxHash, dmn);

--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -192,7 +192,7 @@ bool CheckProRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValid
             return state.DoS(10, false, REJECT_INVALID, "bad-protx-collateral-pkh");
         }
         // collateral is not part of this ProRegTx, so we must verify ownership of the collateral
-        if (!CheckStringSig(pl, CKeyID(*keyForPayloadSig), state)) {
+        if (!CheckStringSig(pl, ToKeyID(*keyForPayloadSig), state)) {
             // pass the state returned by the function above
             return false;
         }

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -24,14 +24,14 @@ namespace
     public:
         DestinationEncoder(const CChainParams& params, const CChainParams::Base58Type _addrType = CChainParams::PUBKEY_ADDRESS) : m_params(params), m_addrType(_addrType) {}
 
-        std::string operator()(const CKeyID& id) const
+        std::string operator()(const PKHash& id) const
         {
             std::vector<unsigned char> data = m_params.Base58Prefix(m_addrType);
             data.insert(data.end(), id.begin(), id.end());
             return EncodeBase58Check(data);
         }
 
-        std::string operator()(const CScriptID& id) const
+        std::string operator()(const ScriptHash& id) const
         {
             std::vector<unsigned char> data = m_params.Base58Prefix(CChainParams::SCRIPT_ADDRESS);
             data.insert(data.end(), id.begin(), id.end());
@@ -52,21 +52,21 @@ namespace
             const std::vector<unsigned char>& pubkey_prefix = params.Base58Prefix(CChainParams::PUBKEY_ADDRESS);
             if (data.size() == hash.size() + pubkey_prefix.size() && std::equal(pubkey_prefix.begin(), pubkey_prefix.end(), data.begin())) {
                 std::copy(data.begin() + pubkey_prefix.size(), data.end(), hash.begin());
-                return CKeyID(hash);
+                return PKHash(hash);
             }
             // Public-key-hash-coldstaking-addresses have version 63 (or 73 testnet).
             const std::vector<unsigned char>& staking_prefix = params.Base58Prefix(CChainParams::STAKING_ADDRESS);
             if (data.size() == hash.size() + staking_prefix.size() && std::equal(staking_prefix.begin(), staking_prefix.end(), data.begin())) {
                 isStaking = true;
                 std::copy(data.begin() + staking_prefix.size(), data.end(), hash.begin());
-                return CKeyID(hash);
+                return PKHash(hash);
             }
             // Script-hash-addresses have version 13 (or 19 testnet).
             // The data vector contains RIPEMD160(SHA256(cscript)), where cscript is the serialized redemption script.
             const std::vector<unsigned char>& script_prefix = params.Base58Prefix(CChainParams::SCRIPT_ADDRESS);
             if (data.size() == hash.size() + script_prefix.size() && std::equal(script_prefix.begin(), script_prefix.end(), data.begin())) {
                 std::copy(data.begin() + script_prefix.size(), data.end(), hash.begin());
-                return CScriptID(hash);
+                return ScriptHash(hash);
             }
         }
         return CNoDestination();

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -292,7 +292,7 @@ bool CMasternodeBroadcast::Create(const CTxIn& txin,
     if (fImporting || fReindex) return false;
 
     LogPrint(BCLog::MASTERNODE, "CMasternodeBroadcast::Create -- pubKeyCollateralAddressNew = %s, pubKeyMasternodeNew.GetID() = %s\n",
-             EncodeDestination(pubKeyCollateralAddressNew.GetID()),
+             EncodeDestination(PKHash(pubKeyCollateralAddressNew)),
         pubKeyMasternodeNew.GetID().ToString());
 
     // Get block hash to ping (TODO: move outside of this function)
@@ -393,7 +393,7 @@ bool CMasternodeBroadcast::CheckAndUpdate(int& nDos)
     }
 
     CScript pubkeyScript;
-    pubkeyScript = GetScriptForDestination(pubKeyCollateralAddress.GetID());
+    pubkeyScript = GetScriptForDestination(PKHash(pubKeyCollateralAddress));
 
     if (pubkeyScript.size() != 25) {
         LogPrint(BCLog::MASTERNODE,"mnb - pubkey the wrong size\n");
@@ -402,7 +402,7 @@ bool CMasternodeBroadcast::CheckAndUpdate(int& nDos)
     }
 
     CScript pubkeyScript2;
-    pubkeyScript2 = GetScriptForDestination(pubKeyMasternode.GetID());
+    pubkeyScript2 = GetScriptForDestination(PKHash(pubKeyMasternode));
 
     if (pubkeyScript2.size() != 25) {
         LogPrint(BCLog::MASTERNODE,"mnb - pubkey2 the wrong size\n");

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -230,7 +230,7 @@ public:
      */
     CScript mnPayeeScript{};
     CScript GetPayeeScript() const {
-        return mnPayeeScript.empty() ? GetScriptForDestination(pubKeyCollateralAddress.GetID())
+        return mnPayeeScript.empty() ? GetScriptForDestination(PKHash(pubKeyCollateralAddress))
                                      : mnPayeeScript;
     }
 };

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -773,7 +773,7 @@ bool CMasternodeMan::CheckInputs(CMasternodeBroadcast& mnb, int nChainHeight, in
     }
 
     // Check collateral association with mnb pubkey
-    CScript payee = GetScriptForDestination(mnb.pubKeyCollateralAddress.GetID());
+    CScript payee = GetScriptForDestination(PKHash(mnb.pubKeyCollateralAddress.GetID()));
     if (collateralUtxo.out.scriptPubKey != payee) {
         LogPrint(BCLog::MASTERNODE,"mnb - collateral %s not associated with mnb pubkey\n", mnb.vin.prevout.ToString());
         nDoS = 33;

--- a/src/messagesigner.cpp
+++ b/src/messagesigner.cpp
@@ -95,7 +95,7 @@ bool CHashSigner::VerifyHash(const uint256& hash, const CKeyID& keyID, const std
 
     if(pubkeyFromSig.GetID() != keyID) {
         strErrorRet = strprintf("Keys don't match: pubkey=%s, pubkeyFromSig=%s, hash=%s, vchSig=%s",
-                EncodeDestination(keyID), EncodeDestination(pubkeyFromSig.GetID()),
+                                EncodeDestination(PKHash(keyID)), EncodeDestination(PKHash(pubkeyFromSig)),
                 hash.ToString(), EncodeBase64(vchSig));
         return false;
     }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -42,7 +42,7 @@ std::unique_ptr<CBlockTemplate> CreateNewBlockWithKey(std::unique_ptr<CReserveKe
 {
     CPubKey pubkey;
     if (!reservekey->GetReservedKey(pubkey)) return nullptr;
-    return CreateNewBlockWithScript(GetScriptForDestination(pubkey.GetID()), pwallet);
+    return CreateNewBlockWithScript(GetScriptForDestination(PKHash(pubkey)), pwallet);
 }
 
 std::unique_ptr<CBlockTemplate> CreateNewBlockWithScript(const CScript& coinbaseScript, CWallet* pwallet)

--- a/src/pivx-tx.cpp
+++ b/src/pivx-tx.cpp
@@ -266,7 +266,7 @@ static void MutateTxAddOutPubKey(CMutableTransaction& tx, const std::string& str
     }
     if (bScriptHash) {
         // Get the ID for the script, and then construct a P2SH destination for it.
-        scriptPubKey = GetScriptForDestination(CScriptID(scriptPubKey));
+        scriptPubKey = GetScriptForDestination(ScriptHash(scriptPubKey));
     }
 
     // construct TxOut, append to transaction output list
@@ -328,7 +328,7 @@ static void MutateTxAddOutMultiSig(CMutableTransaction& tx, const std::string& s
                         "redeemScript exceeds size limit: %d > %d", scriptPubKey.size(), MAX_SCRIPT_ELEMENT_SIZE));
         }
         // Get the ID for the script, and then construct a P2SH destination for it.
-        scriptPubKey = GetScriptForDestination(CScriptID(scriptPubKey));
+        scriptPubKey = GetScriptForDestination(ScriptHash(scriptPubKey));
     }
 
     // construct TxOut, append to transaction output list

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -78,11 +78,10 @@ CAmount GetShieldedDustThreshold(const CFeeRate& dustRelayFeeIn)
 bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType)
 {
     std::vector<valtype> vSolutions;
-    if (!Solver(scriptPubKey, whichType, vSolutions))
+    whichType = Solver(scriptPubKey, vSolutions);
+    if (whichType == TX_NONSTANDARD) {
         return false;
-
-    if (whichType == TX_MULTISIG)
-    {
+    } else if (whichType == TX_MULTISIG) {
         unsigned char m = vSolutions.front()[0];
         unsigned char n = vSolutions.back()[0];
         // Support up to x-of-3 multisig txns as standard
@@ -91,10 +90,11 @@ bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType)
         if (m < 1 || m > n)
             return false;
     } else if (whichType == TX_NULL_DATA &&
-               (!gArgs.GetBoolArg("-datacarrier", DEFAULT_ACCEPT_DATACARRIER) || scriptPubKey.size() > nMaxDatacarrierBytes))
+              (!gArgs.GetBoolArg("-datacarrier", DEFAULT_ACCEPT_DATACARRIER) || scriptPubKey.size() > nMaxDatacarrierBytes)) {
         return false;
+    }
 
-    return whichType != TX_NONSTANDARD;
+    return true;
 }
 
 bool IsStandardTx(const CTransactionRef& tx, int nBlockHeight, std::string& reason)
@@ -198,14 +198,10 @@ bool AreInputsStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
         const CTxOut& prev = mapInputs.AccessCoin(tx.vin[i].prevout).out;
 
         std::vector<std::vector<unsigned char> > vSolutions;
-        txnouttype whichType;
-        // get the scriptPubKey corresponding to this input:
-        const CScript& prevScript = prev.scriptPubKey;
-        if (!Solver(prevScript, whichType, vSolutions))
+        txnouttype whichType = Solver(prev.scriptPubKey, vSolutions);
+        if (whichType == TX_NONSTANDARD) {
             return false;
-
-        if (whichType == TX_SCRIPTHASH)
-        {
+        } else if (whichType == TX_SCRIPTHASH) {
             std::vector<std::vector<unsigned char> > stack;
             // convert the scriptSig into a stack, so we can inspect the redeemScript
             if (!EvalScript(stack, tx.vin[i].scriptSig, SCRIPT_VERIFY_NONE, BaseSignatureChecker(), tx.GetRequiredSigVersion()))

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -18,7 +18,6 @@
 
 #include <algorithm>
 
-#include <QDebug>
 #include <QFont>
 
 const QString AddressTableModel::Send = "S";
@@ -538,7 +537,7 @@ QString AddressTableModel::addRow(const QString& type, const QString& label, con
                 return QString();
             }
         }
-        strAddress = EncodeDestination(newKey.GetID());
+        strAddress = EncodeDestination(PKHash(newKey));
     } else {
         return QString();
     }

--- a/src/qt/pivx/settings/settingsbittoolwidget.cpp
+++ b/src/qt/pivx/settings/settingsbittoolwidget.cpp
@@ -163,7 +163,7 @@ void SettingsBitToolWidget::onEncryptKeyButtonENCClicked()
     }
 
     CKey key;
-    if (!walletModel->getKey(CKeyID(*pkHash), key)) {
+    if (!walletModel->getKey(ToKeyID(*pkHash), key)) {
         ui->statusLabel_ENC->setStyleSheet("QLabel { color: red; }");
         ui->statusLabel_ENC->setText(tr("Private key for the entered address is not available."));
         return;

--- a/src/qt/pivx/settings/settingssignmessagewidgets.cpp
+++ b/src/qt/pivx/settings/settingssignmessagewidgets.cpp
@@ -165,8 +165,8 @@ void SettingsSignMessageWidgets::onSignMessageButtonSMClicked()
         ui->statusLabel_SM->setText(tr("The entered address is invalid.") + QString(" ") + tr("Please check the address and try again."));
         return;
     }
-    const PKHash* keyID = boost::get<PKHash>(&addr);
-    if (!keyID) {
+    const PKHash* pkhash = boost::get<PKHash>(&addr);
+    if (!pkhash) {
         // TODO: change css..
         //ui->addressIn_SM->setValid(false);
         ui->statusLabel_SM->setStyleSheet("QLabel { color: red; }");
@@ -182,7 +182,7 @@ void SettingsSignMessageWidgets::onSignMessageButtonSMClicked()
     }
 
     CKey key;
-    if (!walletModel->getKey(CKeyID(*keyID), key)) {
+    if (!walletModel->getKey(ToKeyID(*pkhash), key)) {
         ui->statusLabel_SM->setStyleSheet("QLabel { color: red; }");
         ui->statusLabel_SM->setText(tr("Private key for the entered address is not available."));
         return;

--- a/src/qt/pivx/settings/settingssignmessagewidgets.cpp
+++ b/src/qt/pivx/settings/settingssignmessagewidgets.cpp
@@ -238,7 +238,7 @@ void SettingsSignMessageWidgets::onVerifyMessage()
     const std::string& message = ui->messageIn_SM->document()->toPlainText().toStdString();
 
     std::string err_log;
-    if (!CMessageSigner::VerifyMessage(CKeyID(*pkHash), vchSig, message, err_log)) {
+    if (!CMessageSigner::VerifyMessage(ToKeyID(*pkHash), vchSig, message, err_log)) {
         ui->statusLabel_SM->setStyleSheet("QLabel { color: red; }");
         ui->statusLabel_SM->setText(QString("<nobr>") + tr("Message verification failed.") + QString("</nobr>"));
         return;

--- a/src/qt/pivx/settings/settingssignmessagewidgets.cpp
+++ b/src/qt/pivx/settings/settingssignmessagewidgets.cpp
@@ -165,7 +165,7 @@ void SettingsSignMessageWidgets::onSignMessageButtonSMClicked()
         ui->statusLabel_SM->setText(tr("The entered address is invalid.") + QString(" ") + tr("Please check the address and try again."));
         return;
     }
-    const CKeyID* keyID = boost::get<CKeyID>(&addr);
+    const PKHash* keyID = boost::get<PKHash>(&addr);
     if (!keyID) {
         // TODO: change css..
         //ui->addressIn_SM->setValid(false);
@@ -182,7 +182,7 @@ void SettingsSignMessageWidgets::onSignMessageButtonSMClicked()
     }
 
     CKey key;
-    if (!walletModel->getKey(*keyID, key)) {
+    if (!walletModel->getKey(CKeyID(*keyID), key)) {
         ui->statusLabel_SM->setStyleSheet("QLabel { color: red; }");
         ui->statusLabel_SM->setText(tr("Private key for the entered address is not available."));
         return;
@@ -217,8 +217,8 @@ void SettingsSignMessageWidgets::onVerifyMessage()
         ui->statusLabel_SM->setText(tr("The entered address is invalid.") + QString(" ") + tr("Please check the address and try again."));
         return;
     }
-    const CKeyID* keyID = boost::get<CKeyID>(&addr);
-    if (!keyID) {
+    const PKHash* pkHash = boost::get<PKHash>(&addr);
+    if (!pkHash) {
         //ui->addressIn_SM->setValid(false);
         ui->statusLabel_SM->setStyleSheet("QLabel { color: red; }");
         ui->statusLabel_SM->setText(tr("The entered address does not refer to a key.") + QString(" ") + tr("Please check the address and try again."));
@@ -238,7 +238,7 @@ void SettingsSignMessageWidgets::onVerifyMessage()
     const std::string& message = ui->messageIn_SM->document()->toPlainText().toStdString();
 
     std::string err_log;
-    if (!CMessageSigner::VerifyMessage(*keyID, vchSig, message, err_log)) {
+    if (!CMessageSigner::VerifyMessage(CKeyID(*pkHash), vchSig, message, err_log)) {
         ui->statusLabel_SM->setStyleSheet("QLabel { color: red; }");
         ui->statusLabel_SM->setText(QString("<nobr>") + tr("Message verification failed.") + QString("</nobr>"));
         return;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -498,7 +498,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
                 }
 
                 const PKHash* stakerId = boost::get<PKHash>(&out);
-                const PKHash* ownerId = ownerAdd.getKeyID();
+                const PKHash* ownerId = ownerAdd.getPkHash();
                 if (!stakerId || !ownerId) {
                     return InvalidAddress;
                 }
@@ -997,12 +997,12 @@ bool WalletModel::updateAddressBookPurpose(const QString &addressStr, const std:
     if (isStaking)
         return error("Invalid PIVX address, cold staking address");
     PKHash pkhash;
-    if (!getKeyId(address, pkhash))
+    if (!getPkHash(address, pkhash))
         return false;
     return wallet->SetAddressBook(pkhash, getLabelForAddress(address), purpose);
 }
 
-bool WalletModel::getKeyId(const CTxDestination& address, PKHash& pkHashRet)
+bool WalletModel::getPkHash(const CTxDestination& address, PKHash& pkHashRet)
 {
     if (!IsValidDestination(address))
         return error("Invalid PIVX address");

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -503,8 +503,8 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
                     return InvalidAddress;
                 }
 
-                scriptPubKey = isV6Enforced() ? GetScriptForStakeDelegation(CKeyID(*stakerId), CKeyID(*ownerId))
-                        : GetScriptForStakeDelegationLOF(CKeyID(*stakerId), CKeyID(*ownerId));
+                scriptPubKey = isV6Enforced() ? GetScriptForStakeDelegation(ToKeyID(*stakerId), ToKeyID(*ownerId))
+                        : GetScriptForStakeDelegationLOF(ToKeyID(*stakerId), ToKeyID(*ownerId));
             } else {
                 // Regular P2PK or P2PKH
                 scriptPubKey = GetScriptForDestination(out);

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -293,7 +293,7 @@ public:
     bool updateAddressBookPurpose(const QString &addressStr, const std::string& purpose);
     std::string getLabelForAddress(const CTxDestination& address);
     QString getSaplingAddressString(const CWalletTx* wtx, const SaplingOutPoint& op) const;
-    bool getKeyId(const CTxDestination& address, CKeyID& keyID);
+    bool getKeyId(const CTxDestination& address, PKHash& pkHashRet);
     bool getKey(const CKeyID& keyID, CKey& key) const { return wallet->GetKey(keyID, key); }
     bool haveKey(const CKeyID& keyID) const { return wallet->HaveKey(keyID); }
     bool addKeys(const CKey& key, const CPubKey& pubkey, WalletRescanReserver& reserver);

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -293,7 +293,7 @@ public:
     bool updateAddressBookPurpose(const QString &addressStr, const std::string& purpose);
     std::string getLabelForAddress(const CTxDestination& address);
     QString getSaplingAddressString(const CWalletTx* wtx, const SaplingOutPoint& op) const;
-    bool getKeyId(const CTxDestination& address, PKHash& pkHashRet);
+    bool getPkHash(const CTxDestination& address, PKHash& pkHashRet);
     bool getKey(const CKeyID& keyID, CKey& key) const { return wallet->GetKey(keyID, key); }
     bool haveKey(const CKeyID& keyID) const { return wallet->HaveKey(keyID); }
     bool addKeys(const CKey& key, const CPubKey& pubkey, WalletRescanReserver& reserver);

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -223,7 +223,7 @@ UniValue listmasternodes(const JSONRPCRequest& request)
 
         if (strFilter != "" && strTxHash.find(strFilter) == std::string::npos &&
             mn.Status().find(strFilter) == std::string::npos &&
-            EncodeDestination(mn.pubKeyCollateralAddress.GetID()).find(strFilter) == std::string::npos) continue;
+            EncodeDestination(PKHash(mn.pubKeyCollateralAddress)).find(strFilter) == std::string::npos) continue;
 
         std::string strStatus = mn.Status();
         std::string strHost;
@@ -238,9 +238,9 @@ UniValue listmasternodes(const JSONRPCRequest& request)
         obj.pushKV("network", strNetwork);
         obj.pushKV("txhash", strTxHash);
         obj.pushKV("outidx", (uint64_t)oIdx);
-        obj.pushKV("pubkey", EncodeDestination(mn.pubKeyMasternode.GetID()));
+        obj.pushKV("pubkey", EncodeDestination(PKHash(mn.pubKeyMasternode)));
         obj.pushKV("status", strStatus);
-        obj.pushKV("addr", EncodeDestination(mn.pubKeyCollateralAddress.GetID()));
+        obj.pushKV("addr", EncodeDestination(PKHash(mn.pubKeyCollateralAddress)));
         obj.pushKV("version", mn.protocolVersion);
         obj.pushKV("lastseen", (int64_t)mn.lastPing.sigTime);
         obj.pushKV("activetime", (int64_t)(mn.lastPing.sigTime - mn.sigTime));
@@ -320,7 +320,7 @@ UniValue masternodecurrent(const JSONRPCRequest& request)
         UniValue obj(UniValue::VOBJ);
         obj.pushKV("protocol", (int64_t)winner->protocolVersion);
         obj.pushKV("txhash", winner->vin.prevout.hash.ToString());
-        obj.pushKV("pubkey", EncodeDestination(winner->pubKeyCollateralAddress.GetID()));
+        obj.pushKV("pubkey", EncodeDestination(PKHash(winner->pubKeyCollateralAddress)));
         obj.pushKV("lastseen", winner->lastPing.IsNull() ? winner->sigTime : (int64_t)winner->lastPing.sigTime);
         obj.pushKV("activeseconds", winner->lastPing.IsNull() ? 0 : (int64_t)(winner->lastPing.sigTime - winner->sigTime));
         return obj;
@@ -724,7 +724,7 @@ UniValue getmasternodestatus(const JSONRPCRequest& request)
         mnObj.pushKV("txhash", activeMasternode.vin->prevout.hash.ToString());
         mnObj.pushKV("outputidx", (uint64_t)activeMasternode.vin->prevout.n);
         mnObj.pushKV("netaddr", activeMasternode.service.ToString());
-        mnObj.pushKV("addr", EncodeDestination(pmn->pubKeyCollateralAddress.GetID()));
+        mnObj.pushKV("addr", EncodeDestination(PKHash(pmn->pubKeyCollateralAddress)));
         mnObj.pushKV("status", activeMasternode.GetStatus());
         mnObj.pushKV("message", activeMasternode.GetStatusMessage());
         return mnObj;
@@ -1041,8 +1041,8 @@ UniValue decodemasternodebroadcast(const JSONRPCRequest& request)
 
     resultObj.pushKV("vin", mnb.vin.prevout.ToString());
     resultObj.pushKV("addr", mnb.addr.ToString());
-    resultObj.pushKV("pubkeycollateral", EncodeDestination(mnb.pubKeyCollateralAddress.GetID()));
-    resultObj.pushKV("pubkeymasternode", EncodeDestination(mnb.pubKeyMasternode.GetID()));
+    resultObj.pushKV("pubkeycollateral", EncodeDestination(PKHash(mnb.pubKeyCollateralAddress)));
+    resultObj.pushKV("pubkeymasternode", EncodeDestination(PKHash(mnb.pubKeyMasternode)));
     resultObj.pushKV("vchsig", mnb.GetSignatureBase64());
     resultObj.pushKV("sigtime", mnb.sigTime);
     resultObj.pushKV("sigvalid", mnb.CheckSignature() ? "true" : "false");

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -126,7 +126,7 @@ UniValue generate(const JSONRPCRequest& request)
         reservekey = std::make_unique<CReserveKey>(pwallet);
         CPubKey pubkey;
         if (!reservekey->GetReservedKey(pubkey)) throw JSONRPCError(RPC_INTERNAL_ERROR, "Error: Cannot get key from keypool");
-        coinbaseScript = GetScriptForDestination(pubkey.GetID());
+        coinbaseScript = GetScriptForDestination(PKHash(pubkey));
     }
 
     // Create the blocks

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -237,7 +237,7 @@ public:
         UniValue obj(UniValue::VOBJ);
         CPubKey vchPubKey;
         obj.pushKV("isscript", false);
-        if (pwallet && pwallet->GetPubKey(CKeyID(pkHash), vchPubKey)) {
+        if (pwallet && pwallet->GetPubKey(ToKeyID(pkHash), vchPubKey)) {
             obj.pushKV("pubkey", HexStr(vchPubKey));
             obj.pushKV("iscompressed", vchPubKey.IsCompressed());
         }
@@ -473,7 +473,7 @@ CScript _createmultisig_redeemScript(CWallet * const pwallet, const UniValue& pa
                         strprintf("%s does not refer to a key", ks));
             }
             CPubKey vchPubKey;
-            if (!pwallet->GetPubKey(CKeyID(*pkHash), vchPubKey))
+            if (!pwallet->GetPubKey(ToKeyID(*pkHash), vchPubKey))
                 throw std::runtime_error(
                     strprintf("no full public key for address %s", ks));
             if (!vchPubKey.IsFullyValid())

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -248,7 +248,7 @@ public:
         UniValue obj(UniValue::VOBJ);
         obj.pushKV("isscript", true);
         CScript subscript;
-        if (pwallet && pwallet->GetCScript(scriptID, subscript)) {
+        if (pwallet && pwallet->GetCScript(CScriptID(scriptID), subscript)) {
             std::vector<CTxDestination> addresses;
             txnouttype whichType;
             int nRequired;

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -589,7 +589,7 @@ UniValue verifymessage(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Malformed base64 encoding");
 
     std::string strError;
-    return CMessageSigner::VerifyMessage(CKeyID(*pkHash), vchSig, strMessage, strError);
+    return CMessageSigner::VerifyMessage(ToKeyID(*pkHash), vchSig, strMessage, strError);
 }
 
 UniValue setmocktime(const JSONRPCRequest& request)

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -482,7 +482,7 @@ UniValue decodescript(const JSONRPCRequest& request)
     }
     ScriptPubKeyToUniv(script, r, false);
 
-    r.pushKV("p2sh", EncodeDestination(CScriptID(script)));
+    r.pushKV("p2sh", EncodeDestination(ScriptHash(script)));
     return r;
 }
 

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -183,7 +183,7 @@ static CKey ParsePrivKey(CWallet* pwallet, const std::string &strKeyOrAddress, b
         EnsureWalletIsUnlocked(pwallet);
         const PKHash* pkHash = boost::get<PKHash>(dest);
         assert (pkHash != nullptr);  // we just checked IsValidDestination
-        return GetKeyFromWallet(pwallet, CKeyID(*pkHash));
+        return GetKeyFromWallet(pwallet, ToKeyID(*pkHash));
 #else   // ENABLE_WALLET
         throw std::runtime_error("addresses not supported in no-wallet builds");
 #endif  // ENABLE_WALLET
@@ -213,7 +213,7 @@ static PKHash ParsePubKeyHashFromAddress(const std::string& strAddress)
 
 static CKeyID ParsePubKeyIDFromAddress(const std::string& strAddress)
 {
-    return CKeyID(ParsePubKeyHashFromAddress(strAddress));
+    return ToKeyID(ParsePubKeyHashFromAddress(strAddress));
 }
 
 static CBLSPublicKey ParseBLSPubKey(const std::string& hexKey)
@@ -513,7 +513,7 @@ static UniValue ProTxRegister(const JSONRPCRequest& request, bool fSignAndSend)
         throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("collateral type not supported: %s-%d", collateralHash.ToString(), collateralIndex));
     }
     CKey keyCollateral;
-    if (fSignAndSend && !pwallet->GetKey(CKeyID(*pkHash), keyCollateral)) {
+    if (fSignAndSend && !pwallet->GetKey(ToKeyID(*pkHash), keyCollateral)) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("collateral key not in wallet: %s", EncodeDestination(txDest)));
     }
 
@@ -670,7 +670,7 @@ static bool CheckWalletOwnsScript(CWallet* pwallet, const CScript& script)
     CTxDestination dest;
     if (ExtractDestination(script, dest)) {
         const PKHash* pkHash = boost::get<PKHash>(&dest);
-        if (pkHash && pwallet->HaveKey(CKeyID(*pkHash)))
+        if (pkHash && pwallet->HaveKey(ToKeyID(*pkHash)))
             return true;
         const ScriptHash* scriptHash = boost::get<ScriptHash>(&dest);
         if (scriptHash && pwallet->HaveCScript(CScriptID(*scriptHash)))

--- a/src/sapling/sapling_operation.cpp
+++ b/src/sapling/sapling_operation.cpp
@@ -195,7 +195,7 @@ OperationResult SaplingOperation::build()
             if (!tkeyChange->GetReservedKey(vchPubKey, true)) {
                 return errorOut("Could not generate a taddr to use as a change address");
             }
-            CTxDestination changeAddr = vchPubKey.GetID();
+            CTxDestination changeAddr = PKHash(vchPubKey);
             txBuilder.SendChangeTo(changeAddr);
         }
 

--- a/src/sapling/transaction_builder.cpp
+++ b/src/sapling/transaction_builder.cpp
@@ -208,7 +208,12 @@ void TransactionBuilder::AddTransparentOutput(const CTxOut& out)
 
 void TransactionBuilder::AddTransparentOutput(const CTxDestination& dest, CAmount value)
 {
-    AddTransparentOutput(CTxOut(value, GetScriptForDestination(dest)));
+    AddTransparentOutput(GetScriptForDestination(dest), value);
+}
+
+void TransactionBuilder::AddTransparentOutput(const CScript& script, CAmount value)
+{
+    AddTransparentOutput(CTxOut(value, script));
 }
 
 void TransactionBuilder::SetFee(CAmount _fee)

--- a/src/sapling/transaction_builder.cpp
+++ b/src/sapling/transaction_builder.cpp
@@ -199,9 +199,10 @@ void TransactionBuilder::AddTransparentInput(const COutPoint& utxo, const CScrip
 void TransactionBuilder::AddTransparentOutput(const CTxOut& out)
 {
     std::vector<std::vector<unsigned char> > vSolutions;
-    txnouttype whichType;
-    if (!Solver(out.scriptPubKey, whichType, vSolutions))
+    txnouttype whichType = Solver(out.scriptPubKey, vSolutions);
+    if (whichType == TX_NONSTANDARD) {
         throw std::runtime_error("Transaction builder: invalid script for transparent output");
+    }
     mtx.vout.push_back(out);
 }
 

--- a/src/sapling/transaction_builder.h
+++ b/src/sapling/transaction_builder.h
@@ -132,6 +132,7 @@ public:
 
     void AddTransparentOutput(const CTxOut& out);
     void AddTransparentOutput(const CTxDestination& dest, CAmount value);
+    void AddTransparentOutput(const CScript& script, CAmount value);
 
     void SendChangeTo(const libzcash::SaplingPaymentAddress& changeAddr, const uint256& ovk);
 

--- a/src/script/ismine.cpp
+++ b/src/script/ismine.cpp
@@ -74,14 +74,7 @@ isminetype IsMine(const CKeyStore& keystore, const CWDestination& dest)
 isminetype IsMine(const CKeyStore& keystore, const CScript& scriptPubKey)
 {
     std::vector<valtype> vSolutions;
-    txnouttype whichType;
-    if(!Solver(scriptPubKey, whichType, vSolutions)) {
-        if(keystore.HaveWatchOnly(scriptPubKey)) {
-            return ISMINE_WATCH_ONLY;
-        }
-
-        return ISMINE_NO;
-    }
+    txnouttype whichType = Solver(scriptPubKey, vSolutions);
 
     CKeyID keyID;
     switch (whichType) {

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -11,7 +11,9 @@
 #include <atomic>
 
 
-const char* GetOpName(opcodetype opcode)
+#include <string>
+
+std::string GetOpName(opcodetype opcode)
 {
     switch (opcode)
     {

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -190,7 +190,7 @@ enum opcodetype
     OP_INVALIDOPCODE = 0xff,
 };
 
-const char* GetOpName(opcodetype opcode);
+std::string GetOpName(opcodetype opcode);
 
 class scriptnum_error : public std::runtime_error
 {

--- a/src/script/script_error.cpp
+++ b/src/script/script_error.cpp
@@ -6,7 +6,9 @@
 
 #include "script_error.h"
 
-const char* ScriptErrorString(const ScriptError serror)
+#include <string>
+
+std::string ScriptErrorString(const ScriptError serror)
 {
     switch (serror)
     {

--- a/src/script/script_error.h
+++ b/src/script/script_error.h
@@ -7,6 +7,8 @@
 #ifndef BITCOIN_SCRIPT_SCRIPT_ERROR_H
 #define BITCOIN_SCRIPT_SCRIPT_ERROR_H
 
+#include <string>
+
 typedef enum ScriptError_t
 {
     SCRIPT_ERR_OK = 0,
@@ -59,6 +61,6 @@ typedef enum ScriptError_t
 
 #define SCRIPT_ERR_LAST SCRIPT_ERR_ERROR_COUNT
 
-const char* ScriptErrorString(const ScriptError error);
+std::string ScriptErrorString(const ScriptError error);
 
 #endif // BITCOIN_SCRIPT_SCRIPT_ERROR_H

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -74,8 +74,7 @@ static bool SignStep(const BaseSignatureCreator& creator, const CScript& scriptP
     ret.clear();
 
     std::vector<valtype> vSolutions;
-    if (!Solver(scriptPubKey, whichTypeRet, vSolutions))
-        return false;
+    whichTypeRet = Solver(scriptPubKey, vSolutions);
 
     CKeyID keyID;
     switch (whichTypeRet)
@@ -310,15 +309,13 @@ static Stacks CombineSignatures(const CScript& scriptPubKey, const BaseSignature
             return sigs2;
         else if (sigs2.script.empty() || sigs2.script.back().empty())
             return sigs1;
-        else
-        {
+        else {
             // Recur to combine:
             valtype spk = sigs1.script.back();
             CScript pubKey2(spk.begin(), spk.end());
 
-            txnouttype txType2;
             std::vector<std::vector<unsigned char> > vSolutions2;
-            Solver(pubKey2, txType2, vSolutions2);
+            txnouttype txType2 = Solver(pubKey2, vSolutions2);
             sigs1.script.pop_back();
             sigs2.script.pop_back();
             Stacks result = CombineSignatures(pubKey2, checker, txType2, vSolutions2, sigs1, sigs2, sigversion);
@@ -335,9 +332,8 @@ static Stacks CombineSignatures(const CScript& scriptPubKey, const BaseSignature
 SignatureData CombineSignatures(const CScript& scriptPubKey, const BaseSignatureChecker& checker,
                           const SignatureData& scriptSig1, const SignatureData& scriptSig2)
 {
-    txnouttype txType;
     std::vector<std::vector<unsigned char> > vSolutions;
-    Solver(scriptPubKey, txType, vSolutions);
+    txnouttype txType = Solver(scriptPubKey, vSolutions);
 
     return CombineSignatures(scriptPubKey, checker, txType, vSolutions, Stacks(scriptSig1, SIGVERSION_BASE), Stacks(scriptSig2, SIGVERSION_BASE), SIGVERSION_BASE).Output();
 }

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -97,7 +97,8 @@ static bool SignStep(const BaseSignatureCreator& creator, const CScript& scriptP
         }
         return true;
     case TX_SCRIPTHASH:
-        if (creator.KeyStore().GetCScript(uint160(vSolutions[0]), scriptRet)) {
+        h160 = uint160(vSolutions[0]);
+        if (creator.KeyStore().GetCScript(CScriptID{h160}, scriptRet)) {
             ret.emplace_back(scriptRet.begin(), scriptRet.end());
             return true;
         }

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -16,10 +16,13 @@ typedef std::vector<unsigned char> valtype;
 unsigned nMaxDatacarrierBytes = MAX_OP_RETURN_RELAY;
 
 CScriptID::CScriptID(const CScript& in) : uint160(Hash160(in.begin(), in.end())) {}
+CScriptID::CScriptID(const ScriptHash& in) : uint160(static_cast<uint160>(in)) {}
 
 ScriptHash::ScriptHash(const CScript& in) : uint160(Hash160(in.begin(), in.end())) {}
+ScriptHash::ScriptHash(const CScriptID& in) : uint160(static_cast<uint160>(in)) {}
 
 PKHash::PKHash(const CPubKey& pubkey) : uint160(pubkey.GetID()) {}
+PKHash::PKHash(const CKeyID& pubkey_id) : uint160(pubkey_id) {}
 
 CKeyID ToKeyID(const PKHash& key_hash)
 {

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -15,14 +15,14 @@ typedef std::vector<unsigned char> valtype;
 
 unsigned nMaxDatacarrierBytes = MAX_OP_RETURN_RELAY;
 
-CScriptID::CScriptID(const CScript& in) : uint160(Hash160(in.begin(), in.end())) {}
-CScriptID::CScriptID(const ScriptHash& in) : uint160(static_cast<uint160>(in)) {}
+CScriptID::CScriptID(const CScript& in) : BaseHash(Hash160(in.begin(), in.end())) {}
+CScriptID::CScriptID(const ScriptHash& in) : BaseHash(static_cast<uint160>(in)) {}
 
-ScriptHash::ScriptHash(const CScript& in) : uint160(Hash160(in.begin(), in.end())) {}
-ScriptHash::ScriptHash(const CScriptID& in) : uint160(static_cast<uint160>(in)) {}
+ScriptHash::ScriptHash(const CScript& in) : BaseHash(Hash160(in.begin(), in.end())) {}
+ScriptHash::ScriptHash(const CScriptID& in) : BaseHash(static_cast<uint160>(in)) {}
 
-PKHash::PKHash(const CPubKey& pubkey) : uint160(pubkey.GetID()) {}
-PKHash::PKHash(const CKeyID& pubkey_id) : uint160(pubkey_id) {}
+PKHash::PKHash(const CPubKey& pubkey) : BaseHash(pubkey.GetID()) {}
+PKHash::PKHash(const CKeyID& pubkey_id) : BaseHash(pubkey_id) {}
 
 CKeyID ToKeyID(const PKHash& key_hash)
 {

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -15,6 +15,10 @@ unsigned nMaxDatacarrierBytes = MAX_OP_RETURN_RELAY;
 
 CScriptID::CScriptID(const CScript& in) : uint160(Hash160(in.begin(), in.end())) {}
 
+ScriptHash::ScriptHash(const CScript& in) : uint160(Hash160(in.begin(), in.end())) {}
+
+PKHash::PKHash(const CPubKey& pubkey) : uint160(pubkey.GetID()) {}
+
 const char* GetTxnOutputType(txnouttype t)
 {
     switch (t)
@@ -154,17 +158,17 @@ bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet,
             return false;
         }
 
-        addressRet = pubKey.GetID();
+        addressRet = PKHash(pubKey);
         return true;
 
     } else if (whichType == TX_PUBKEYHASH) {
-        addressRet = CKeyID(uint160(vSolutions[0]));
+        addressRet = PKHash(uint160(vSolutions[0]));
         return true;
     } else if (whichType == TX_SCRIPTHASH) {
-        addressRet = CScriptID(uint160(vSolutions[0]));
+        addressRet = ScriptHash(uint160(vSolutions[0]));
         return true;
     } else if (whichType == TX_COLDSTAKE) {
-        addressRet = CKeyID(uint160(vSolutions[!fColdStake]));
+        addressRet = PKHash(uint160(vSolutions[!fColdStake]));
         return true;
     }
     // Multisig txns have more than one address...
@@ -192,7 +196,7 @@ bool ExtractDestinations(const CScript& scriptPubKey, txnouttype& typeRet, std::
             if (!pubKey.IsValid())
                 continue;
 
-            CTxDestination address = pubKey.GetID();
+            CTxDestination address = PKHash(pubKey);
             addressRet.push_back(address);
         }
 
@@ -204,8 +208,8 @@ bool ExtractDestinations(const CScript& scriptPubKey, txnouttype& typeRet, std::
         if (vSolutions.size() < 2)
             return false;
         nRequiredRet = 2;
-        addressRet.push_back(CKeyID(uint160(vSolutions[0])));
-        addressRet.push_back(CKeyID(uint160(vSolutions[1])));
+        addressRet.push_back(PKHash(uint160(vSolutions[0])));
+        addressRet.push_back(PKHash(uint160(vSolutions[1])));
         return true;
 
     } else
@@ -234,13 +238,13 @@ public:
         return false;
     }
 
-    bool operator()(const CKeyID &keyID) const {
+    bool operator()(const PKHash& keyID) const {
         script->clear();
         *script << OP_DUP << OP_HASH160 << ToByteVector(keyID) << OP_EQUALVERIFY << OP_CHECKSIG;
         return true;
     }
 
-    bool operator()(const CScriptID &scriptID) const {
+    bool operator()(const ScriptHash& scriptID) const {
         script->clear();
         *script << OP_HASH160 << ToByteVector(scriptID) << OP_EQUAL;
         return true;

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -9,6 +9,8 @@
 #include "pubkey.h"
 #include "script/script.h"
 
+#include <string>
+
 typedef std::vector<unsigned char> valtype;
 
 unsigned nMaxDatacarrierBytes = MAX_OP_RETURN_RELAY;
@@ -19,7 +21,7 @@ ScriptHash::ScriptHash(const CScript& in) : uint160(Hash160(in.begin(), in.end()
 
 PKHash::PKHash(const CPubKey& pubkey) : uint160(pubkey.GetID()) {}
 
-const char* GetTxnOutputType(txnouttype t)
+std::string GetTxnOutputType(txnouttype t)
 {
     switch (t)
     {
@@ -31,7 +33,7 @@ const char* GetTxnOutputType(txnouttype t)
     case TX_COLDSTAKE: return "coldstake";
     case TX_NULL_DATA: return "nulldata";
     }
-    return NULL;
+    assert(false);
 }
 
 static bool MatchPayToPubkey(const CScript& script, valtype& pubkey)

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -21,6 +21,11 @@ ScriptHash::ScriptHash(const CScript& in) : uint160(Hash160(in.begin(), in.end()
 
 PKHash::PKHash(const CPubKey& pubkey) : uint160(pubkey.GetID()) {}
 
+CKeyID ToKeyID(const PKHash& key_hash)
+{
+    return CKeyID{static_cast<uint160>(key_hash)};
+}
+
 std::string GetTxnOutputType(txnouttype t)
 {
     switch (t)

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -21,13 +21,74 @@ class CKeyID;
 class CScript;
 struct ScriptHash;
 
+template<typename HashType>
+class BaseHash
+{
+protected:
+    HashType m_hash;
+
+public:
+    BaseHash() : m_hash() {}
+    BaseHash(const HashType& in) : m_hash(in) {}
+
+    unsigned char* begin()
+    {
+        return m_hash.begin();
+    }
+
+    const unsigned char* begin() const
+    {
+        return m_hash.begin();
+    }
+
+    unsigned char* end()
+    {
+        return m_hash.end();
+    }
+
+    const unsigned char* end() const
+    {
+        return m_hash.end();
+    }
+
+    operator std::vector<unsigned char>() const
+    {
+        return std::vector<unsigned char>{m_hash.begin(), m_hash.end()};
+    }
+
+    std::string ToString() const
+    {
+        return m_hash.ToString();
+    }
+
+    bool operator==(const BaseHash<HashType>& other) const noexcept
+    {
+        return m_hash == other.m_hash;
+    }
+
+    bool operator!=(const BaseHash<HashType>& other) const noexcept
+    {
+        return !(m_hash == other.m_hash);
+    }
+
+    bool operator<(const BaseHash<HashType>& other) const noexcept
+    {
+        return m_hash < other.m_hash;
+    }
+
+    size_t size() const
+    {
+        return m_hash.size();
+    }
+};
+
 /** A reference to a CScript: the Hash160 of its serialization (see script.h) */
-class CScriptID : public uint160
+class CScriptID : public BaseHash<uint160>
 {
 public:
-    CScriptID() : uint160() {}
+    CScriptID() : BaseHash() {}
     explicit CScriptID(const CScript& in);
-    explicit CScriptID(const uint160& in) : uint160(in) {}
+    explicit CScriptID(const uint160& in) : BaseHash(in) {}
     explicit CScriptID(const ScriptHash& in);
 };
 
@@ -62,19 +123,23 @@ public:
     friend bool operator<(const CNoDestination &a, const CNoDestination &b) { return true; }
 };
 
-struct PKHash : public uint160
+struct PKHash : public BaseHash<uint160>
 {
-    PKHash() : uint160() {}
-    explicit PKHash(const uint160& hash) : uint160(hash) {}
+    PKHash() : BaseHash() {}
+    explicit PKHash(const uint160& hash) : BaseHash(hash) {}
     explicit PKHash(const CPubKey& pubkey);
     explicit PKHash(const CKeyID& pubkey_id);
 };
 CKeyID ToKeyID(const PKHash& key_hash);
 
-struct ScriptHash : public uint160
+struct ScriptHash : public BaseHash<uint160>
 {
-    ScriptHash() : uint160() {}
-    explicit ScriptHash(const uint160& hash) : uint160(hash) {}
+    ScriptHash() : BaseHash() {}
+    // These don't do what you'd expect.
+    // Use ScriptHash(GetScriptForDestination(...)) instead.
+    explicit ScriptHash(const PKHash& hash) = delete;
+
+    explicit ScriptHash(const uint160& hash) : BaseHash(hash) {}
     explicit ScriptHash(const CScript& script);
     explicit ScriptHash(const CScriptID& script);
 };

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -19,6 +19,7 @@ static const bool DEFAULT_ACCEPT_DATACARRIER = true;
 
 class CKeyID;
 class CScript;
+struct ScriptHash;
 
 /** A reference to a CScript: the Hash160 of its serialization (see script.h) */
 class CScriptID : public uint160
@@ -27,6 +28,7 @@ public:
     CScriptID() : uint160() {}
     explicit CScriptID(const CScript& in);
     explicit CScriptID(const uint160& in) : uint160(in) {}
+    explicit CScriptID(const ScriptHash& in);
 };
 
 static const unsigned int MAX_OP_RETURN_RELAY = 83;      //!< bytes (+1 for OP_RETURN, +2 for the pushdata opcodes)
@@ -65,6 +67,7 @@ struct PKHash : public uint160
     PKHash() : uint160() {}
     explicit PKHash(const uint160& hash) : uint160(hash) {}
     explicit PKHash(const CPubKey& pubkey);
+    explicit PKHash(const CKeyID& pubkey_id);
 };
 CKeyID ToKeyID(const PKHash& key_hash);
 
@@ -73,6 +76,7 @@ struct ScriptHash : public uint160
     ScriptHash() : uint160() {}
     explicit ScriptHash(const uint160& hash) : uint160(hash) {}
     explicit ScriptHash(const CScript& script);
+    explicit ScriptHash(const CScriptID& script);
 };
 
 /**

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -66,6 +66,7 @@ struct PKHash : public uint160
     explicit PKHash(const uint160& hash) : uint160(hash) {}
     explicit PKHash(const CPubKey& pubkey);
 };
+CKeyID ToKeyID(const PKHash& key_hash);
 
 struct ScriptHash : public uint160
 {

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -35,8 +35,7 @@ extern unsigned nMaxDatacarrierBytes;
 /**
  * Mandatory script verification flags that all new blocks must comply with for
  * them to be valid. (but old blocks may not comply with) Currently just P2SH,
- * but in the future other flags may be added, such as a soft-fork to enforce
- * strict DER encoding.
+ * but in the future other flags may be added.
  *
  * Failing one of these tests may trigger a DoS ban - see CheckInputs() for
  * details.

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -25,8 +25,8 @@ class CScriptID : public uint160
 {
 public:
     CScriptID() : uint160() {}
-    CScriptID(const CScript& in);
-    CScriptID(const uint160& in) : uint160(in) {}
+    explicit CScriptID(const CScript& in);
+    explicit CScriptID(const uint160& in) : uint160(in) {}
 };
 
 static const unsigned int MAX_OP_RETURN_RELAY = 83;      //!< bytes (+1 for OP_RETURN, +2 for the pushdata opcodes)
@@ -65,7 +65,6 @@ struct PKHash : public uint160
     PKHash() : uint160() {}
     explicit PKHash(const uint160& hash) : uint160(hash) {}
     explicit PKHash(const CPubKey& pubkey);
-    using uint160::uint160;
 };
 
 struct ScriptHash : public uint160
@@ -73,7 +72,6 @@ struct ScriptHash : public uint160
     ScriptHash() : uint160() {}
     explicit ScriptHash(const uint160& hash) : uint160(hash) {}
     explicit ScriptHash(const CScript& script);
-    using uint160::uint160;
 };
 
 /**

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -12,7 +12,8 @@
 
 #include <boost/variant.hpp>
 
-#include <stdint.h>
+#include <string>
+
 
 static const bool DEFAULT_ACCEPT_DATACARRIER = true;
 
@@ -88,7 +89,8 @@ typedef boost::variant<CNoDestination, PKHash, ScriptHash> CTxDestination;
 /** Check whether a CTxDestination is a CNoDestination. */
 bool IsValidDestination(const CTxDestination& dest);
 
-const char* GetTxnOutputType(txnouttype t);
+/** Get the name of a txnouttype as a C string, or nullptr if unknown. */
+std::string GetTxnOutputType(txnouttype t);
 
 /**
  * Parse a scriptPubKey and identify script type for standard scripts. If

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -60,14 +60,30 @@ public:
     friend bool operator<(const CNoDestination &a, const CNoDestination &b) { return true; }
 };
 
+struct PKHash : public uint160
+{
+    PKHash() : uint160() {}
+    explicit PKHash(const uint160& hash) : uint160(hash) {}
+    explicit PKHash(const CPubKey& pubkey);
+    using uint160::uint160;
+};
+
+struct ScriptHash : public uint160
+{
+    ScriptHash() : uint160() {}
+    explicit ScriptHash(const uint160& hash) : uint160(hash) {}
+    explicit ScriptHash(const CScript& script);
+    using uint160::uint160;
+};
+
 /**
  * A txout script template with a specific destination. It is either:
  *  * CNoDestination: no destination set
- *  * CKeyID: TX_PUBKEYHASH destination
- *  * CScriptID: TX_SCRIPTHASH destination
+ *  * PKHash: TX_PUBKEYHASH destination
+ *  * ScriptHash: TX_SCRIPTHASH destination
  *  A CTxDestination is the internal data type encoded in a PIVX address
  */
-typedef boost::variant<CNoDestination, CKeyID, CScriptID> CTxDestination;
+typedef boost::variant<CNoDestination, PKHash, ScriptHash> CTxDestination;
 
 /** Check whether a CTxDestination is a CNoDestination. */
 bool IsValidDestination(const CTxDestination& dest);

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -81,11 +81,10 @@ const char* GetTxnOutputType(txnouttype t);
  * script hash, for P2PKH it will contain the key hash, etc.
  *
  * @param[in]   scriptPubKey   Script to parse
- * @param[out]  typeRet        The script type
  * @param[out]  vSolutionsRet  Vector of parsed pubkeys and hashes
- * @return                     True if script matches standard template
+ * @return                     The script type. TX_NONSTANDARD represents a failed solve.
  */
-bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, std::vector<std::vector<unsigned char> >& vSolutionsRet);
+txnouttype Solver(const CScript& scriptPubKey, std::vector<std::vector<unsigned char>>& vSolutionsRet);
 
 /**
  * Parse a standard scriptPubKey for the destination address. Assigns result to

--- a/src/stakeinput.cpp
+++ b/src/stakeinput.cpp
@@ -82,11 +82,8 @@ CAmount CPivStake::GetValue() const
 bool CPivStake::CreateTxOuts(const CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) const
 {
     std::vector<valtype> vSolutions;
-    txnouttype whichType;
     CScript scriptPubKeyKernel = outputFrom.scriptPubKey;
-    if (!Solver(scriptPubKeyKernel, whichType, vSolutions))
-        return error("%s: failed to parse kernel", __func__);
-
+    txnouttype whichType = Solver(scriptPubKeyKernel, vSolutions);
     if (whichType != TX_PUBKEY && whichType != TX_PUBKEYHASH && whichType != TX_COLDSTAKE)
         return error("%s: type=%d (%s) not supported for scriptPubKeyKernel", __func__, whichType, GetTxnOutputType(whichType));
 

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -197,7 +197,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         tx.vin[0].scriptSig << OP_1;
         tx.vout.resize(1);
         tx.vout[0].nValue = 1*CENT;
-        tx.vout[0].scriptPubKey = GetScriptForDestination(key.GetPubKey().GetID());
+        tx.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key.GetPubKey()));
 
         AddOrphanTx(MakeTransactionRef(tx), i);
     }
@@ -213,7 +213,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         tx.vin[0].prevout.hash = txPrev->GetHash();
         tx.vout.resize(1);
         tx.vout[0].nValue = 1*CENT;
-        tx.vout[0].scriptPubKey = GetScriptForDestination(key.GetPubKey().GetID());
+        tx.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key.GetPubKey()));
         SignSignature(keystore, *txPrev, tx, 0, SIGHASH_ALL);
 
         AddOrphanTx(MakeTransactionRef(tx), i);
@@ -227,7 +227,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         CMutableTransaction tx;
         tx.vout.resize(1);
         tx.vout[0].nValue = 1*CENT;
-        tx.vout[0].scriptPubKey = GetScriptForDestination(key.GetPubKey().GetID());
+        tx.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key.GetPubKey()));
         tx.vin.resize(2777);
         for (unsigned int j = 0; j < tx.vin.size(); j++)
         {

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -116,12 +116,12 @@ public:
     bool operator()(const PKHash& id) const
     {
         uint160 exp_key(exp_payload);
-        return exp_key == id;
+        return PKHash(exp_key) == id;
     }
     bool operator()(const ScriptHash& id) const
     {
         uint160 exp_key(exp_payload);
-        return exp_key == id;
+        return ScriptHash(exp_key) == id;
     }
     bool operator()(const CNoDestination& no) const
     {

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -92,15 +92,15 @@ private:
     std::string exp_addrType;
 public:
     TestAddrTypeVisitor(const std::string &exp_addrType) : exp_addrType(exp_addrType) { }
-    bool operator()(const CKeyID &id) const
+    bool operator()(const PKHash& id) const
     {
         return (exp_addrType == "pubkey");
     }
-    bool operator()(const CScriptID &id) const
+    bool operator()(const ScriptHash& id) const
     {
         return (exp_addrType == "script");
     }
-    bool operator()(const CNoDestination &no) const
+    bool operator()(const CNoDestination& no) const
     {
         return (exp_addrType == "none");
     }
@@ -113,17 +113,17 @@ private:
     std::vector<unsigned char> exp_payload;
 public:
     TestPayloadVisitor(std::vector<unsigned char> &exp_payload) : exp_payload(exp_payload) { }
-    bool operator()(const CKeyID &id) const
+    bool operator()(const PKHash& id) const
     {
         uint160 exp_key(exp_payload);
         return exp_key == id;
     }
-    bool operator()(const CScriptID &id) const
+    bool operator()(const ScriptHash& id) const
     {
         uint160 exp_key(exp_payload);
         return exp_key == id;
     }
-    bool operator()(const CNoDestination &no) const
+    bool operator()(const CNoDestination& no) const
     {
         return exp_payload.size() == 0;
     }
@@ -171,7 +171,7 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_parse)
             // Must be valid public key
             destination = DecodeDestination(exp_base58string);
             BOOST_CHECK_MESSAGE(IsValidDestination(destination), "!IsValid:" + strTest);
-            BOOST_CHECK_MESSAGE((boost::get<CScriptID>(&destination) != nullptr) == (exp_addrType == "script"), "isScript mismatch" + strTest);
+            BOOST_CHECK_MESSAGE((boost::get<ScriptHash>(&destination) != nullptr) == (exp_addrType == "script"), "isScript mismatch" + strTest);
             BOOST_CHECK_MESSAGE(boost::apply_visitor(TestAddrTypeVisitor(exp_addrType), destination), "addrType mismatch" + strTest);
 
             // Public key must be invalid private key
@@ -218,11 +218,11 @@ BOOST_AUTO_TEST_CASE(base58_keys_valid_gen)
             CTxDestination dest;
             if(exp_addrType == "pubkey")
             {
-                dest = CKeyID(uint160(exp_payload));
+                dest = PKHash(uint160(exp_payload));
             }
             else if(exp_addrType == "script")
             {
-                dest = CScriptID(uint160(exp_payload));
+                dest = ScriptHash(uint160(exp_payload));
             }
             else if(exp_addrType == "none")
             {

--- a/src/test/budget_tests.cpp
+++ b/src/test/budget_tests.cpp
@@ -77,7 +77,7 @@ BOOST_FIXTURE_TEST_CASE(block_value, TestnetSetup)
     // superblock - create the finalized budget with a proposal, and vote on it
     nHeight = 144;
     const CTxIn mnVin(GetRandHash(), 0);
-    const CScript payee = GetScriptForDestination(CKeyID(uint160(ParseHex("816115944e077fe7c803cfa57f29b36bf87c1d35"))));
+    const CScript payee = GetScriptForDestination(PKHash(uint160(ParseHex("816115944e077fe7c803cfa57f29b36bf87c1d35"))));
     const CAmount propAmt = 100 * COIN;
     const uint256& propHash = GetRandHash(), finTxId = GetRandHash();
     const CTxBudgetPayment txBudgetPayment(propHash, payee, propAmt);
@@ -186,9 +186,9 @@ BOOST_FIXTURE_TEST_CASE(budget_blocks_payee_test, TestChain100Setup)
     BOOST_ASSERT(g_budgetman.GetFinalizedBudgets().size() == 0);
 
     // Now we are at the superblock height, let's add a proposal to pay.
-    const CScript payee1 = GetScriptForDestination(CKeyID(uint160(ParseHex("816115944e077fe7c803cfa57f29b36bf87c1d35"))));
+    const CScript payee1 = GetScriptForDestination(PKHash(uint160(ParseHex("816115944e077fe7c803cfa57f29b36bf87c1d35"))));
     const CAmount propAmt1 = 100 * COIN;
-    const CScript payee2 = GetScriptForDestination(CKeyID(uint160(ParseHex("8d5b4f83212214d6ef693e02e6d71969fddad976"))));
+    const CScript payee2 = GetScriptForDestination(PKHash(uint160(ParseHex("8d5b4f83212214d6ef693e02e6d71969fddad976"))));
     const CAmount propAmt2 = propAmt1;
     forceAddFakeProposals({propAmt1, payee1}, {propAmt2, payee2});
 
@@ -203,7 +203,7 @@ BOOST_FIXTURE_TEST_CASE(budget_blocks_payee_test, TestChain100Setup)
 
     // Modify payee
     CMutableTransaction mtx(*block.vtx[0]);
-    mtx.vout[1].scriptPubKey = GetScriptForDestination(CKeyID(uint160(ParseHex("8c988f1a4a4de2161e0f50aac7f17e7f9555caa4"))));
+    mtx.vout[1].scriptPubKey = GetScriptForDestination(PKHash(uint160(ParseHex("8c988f1a4a4de2161e0f50aac7f17e7f9555caa4"))));
     block.vtx[0] = MakeTransactionRef(mtx);
     std::shared_ptr<CBlock> pblock = FinalizeBlock(std::make_shared<CBlock>(block));
     BOOST_CHECK(block.vtx[0]->vout[1].scriptPubKey != payee1);
@@ -266,9 +266,9 @@ BOOST_FIXTURE_TEST_CASE(budget_blocks_reorg_test, TestChain100Setup)
     BOOST_CHECK_EQUAL(WITH_LOCK(cs_main, return chainActive.Height();), 143);
 
     // Now we are at the superblock height, let's add a proposal to pay.
-    const CScript payee = GetScriptForDestination(CKeyID(uint160(ParseHex("816115944e077fe7c803cfa57f29b36bf87c1d35"))));
+    const CScript payee = GetScriptForDestination(PKHash(uint160(ParseHex("816115944e077fe7c803cfa57f29b36bf87c1d35"))));
     const CAmount propAmt = 100 * COIN;
-    const CScript payee2 = GetScriptForDestination(CKeyID(uint160(ParseHex("816115944e077fe7c803cfa57f29b36bf87c1d35"))));
+    const CScript payee2 = GetScriptForDestination(PKHash(uint160(ParseHex("816115944e077fe7c803cfa57f29b36bf87c1d35"))));
     const CAmount propAmt2 = propAmt * 2;
     forceAddFakeProposals({propAmt, payee}, {propAmt2, payee2});
 
@@ -283,7 +283,7 @@ BOOST_FIXTURE_TEST_CASE(budget_blocks_reorg_test, TestChain100Setup)
     //    b) Create and process blockE on top of blockD.
     // 6) Verify that tip is at blockE.
 
-    CScript forkCoinbaseScript = GetScriptForDestination(CKeyID(uint160(ParseHex("8c988f1a4a4de2161e0f50aac7f17e7f9555caa4"))));
+    CScript forkCoinbaseScript = GetScriptForDestination(PKHash(uint160(ParseHex("8c988f1a4a4de2161e0f50aac7f17e7f9555caa4"))));
     CBlock blockA = CreateBlock({}, coinbaseKey, false);
     CBlock blockB = CreateBlock({}, forkCoinbaseScript, false);
     BOOST_CHECK(blockA.GetHash() != blockB.GetHash());
@@ -327,7 +327,7 @@ static CScript GetRandomP2PKH()
 {
     CKey key;
     key.MakeNewKey(false);
-    return GetScriptForDestination(key.GetPubKey().GetID());
+    return GetScriptForDestination(PKHash(key.GetPubKey()));
 }
 
 static CMutableTransaction NewCoinBase(int nHeight, CAmount cbaseAmt, const CScript& cbaseScript)

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -942,7 +942,7 @@ BOOST_AUTO_TEST_CASE(ccoins_serialization)
     Coin cc1;
     ss1 >> cc1;
     BOOST_CHECK_EQUAL(cc1.out.nValue, 60000000000ULL);
-    BOOST_CHECK_EQUAL(HexStr(cc1.out.scriptPubKey), HexStr(GetScriptForDestination(CKeyID(uint160(ParseHex("816115944e077fe7c803cfa57f29b36bf87c1d35"))))));
+    BOOST_CHECK_EQUAL(HexStr(cc1.out.scriptPubKey), HexStr(GetScriptForDestination(PKHash(uint160(ParseHex("816115944e077fe7c803cfa57f29b36bf87c1d35"))))));
 
     // Good example
     CDataStream ss2(ParseHex("8dcb7ebbd123008c988f1a4a4de2161e0f50aac7f17e7f9555caa4"), SER_DISK, CLIENT_VERSION);
@@ -951,7 +951,7 @@ BOOST_AUTO_TEST_CASE(ccoins_serialization)
     BOOST_CHECK_EQUAL(cc2.fCoinBase, true);
     BOOST_CHECK_EQUAL(cc2.nHeight, 59807);
     BOOST_CHECK_EQUAL(cc2.out.nValue, 110397);
-    BOOST_CHECK_EQUAL(HexStr(cc2.out.scriptPubKey), HexStr(GetScriptForDestination(CKeyID(uint160(ParseHex("8c988f1a4a4de2161e0f50aac7f17e7f9555caa4"))))));
+    BOOST_CHECK_EQUAL(HexStr(cc2.out.scriptPubKey), HexStr(GetScriptForDestination(PKHash(uint160(ParseHex("8c988f1a4a4de2161e0f50aac7f17e7f9555caa4"))))));
 
     // PIVX: Example with fCoinStake
     CDataStream ss2b(ParseHex("97b401808b63008c988f1a4a4de2161e0f50aac7f17e7f9555caa4"), SER_DISK, CLIENT_VERSION);
@@ -961,7 +961,7 @@ BOOST_AUTO_TEST_CASE(ccoins_serialization)
     BOOST_CHECK_EQUAL(cc2b.fCoinStake, true);
     BOOST_CHECK_EQUAL(cc2b.nHeight, 100000);
     BOOST_CHECK_EQUAL(cc2b.out.nValue, 2002 * COIN);
-    BOOST_CHECK_EQUAL(HexStr(cc2b.out.scriptPubKey), HexStr(GetScriptForDestination(CKeyID(uint160(ParseHex("8c988f1a4a4de2161e0f50aac7f17e7f9555caa4"))))));
+    BOOST_CHECK_EQUAL(HexStr(cc2b.out.scriptPubKey), HexStr(GetScriptForDestination(PKHash(uint160(ParseHex("8c988f1a4a4de2161e0f50aac7f17e7f9555caa4"))))));
 
     // Smallest possible example
     CDataStream ss3(ParseHex("000006"), SER_DISK, CLIENT_VERSION);

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -130,7 +130,7 @@ static CMutableTransaction CreateProRegTx(Optional<COutPoint> optCollateralOut, 
     tx.nVersion = CTransaction::TxVersion::SAPLING;
     tx.nType = CTransaction::TxType::PROREG;
     FundTransaction(tx, utxos, scriptPayout,
-                    GetScriptForDestination(coinbaseKey.GetPubKey().GetID()),
+                    GetScriptForDestination(PKHash(coinbaseKey.GetPubKey())),
                     (optCollateralOut ? 0 : Params().GetConsensus().nMNCollateralAmt));
 
     pl.inputsHash = CalcTxInputsHash(tx);
@@ -153,7 +153,7 @@ static CMutableTransaction CreateProUpServTx(SimpleUTXOMap& utxos, const uint256
     CMutableTransaction tx;
     tx.nVersion = CTransaction::TxVersion::SAPLING;
     tx.nType = CTransaction::TxType::PROUPSERV;
-    const CScript& s = GetScriptForDestination(coinbaseKey.GetPubKey().GetID());
+    const CScript& s = GetScriptForDestination(PKHash(coinbaseKey.GetPubKey()));
     FundTransaction(tx, utxos, s, s, 1 * COIN);
     pl.inputsHash = CalcTxInputsHash(tx);
     pl.sig = operatorKey.Sign(::SerializeHash(pl));
@@ -178,7 +178,7 @@ static CMutableTransaction CreateProUpRegTx(SimpleUTXOMap& utxos, const uint256&
     CMutableTransaction tx;
     tx.nVersion = CTransaction::TxVersion::SAPLING;
     tx.nType = CTransaction::TxType::PROUPREG;
-    const CScript& s = GetScriptForDestination(coinbaseKey.GetPubKey().GetID());
+    const CScript& s = GetScriptForDestination(PKHash(coinbaseKey.GetPubKey()));
     FundTransaction(tx, utxos, s, s, 1 * COIN);
     pl.inputsHash = CalcTxInputsHash(tx);
     BOOST_ASSERT(CHashSigner::SignHash(::SerializeHash(pl), ownerKey, pl.vchSig));
@@ -200,7 +200,7 @@ static CMutableTransaction CreateProUpRevTx(SimpleUTXOMap& utxos, const uint256&
     CMutableTransaction tx;
     tx.nVersion = CTransaction::TxVersion::SAPLING;
     tx.nType = CTransaction::TxType::PROUPREV;
-    const CScript& s = GetScriptForDestination(coinbaseKey.GetPubKey().GetID());
+    const CScript& s = GetScriptForDestination(PKHash(coinbaseKey.GetPubKey()));
     FundTransaction(tx, utxos, s, s, 1 * COIN);
     pl.inputsHash = CalcTxInputsHash(tx);
     pl.sig = operatorKey.Sign(::SerializeHash(pl));
@@ -215,7 +215,7 @@ static CScript GenerateRandomAddress()
 {
     CKey key;
     key.MakeNewKey(false);
-    return GetScriptForDestination(key.GetPubKey().GetID());
+    return GetScriptForDestination(PKHash(key.GetPubKey()));
 }
 
 template<typename ProPL>
@@ -507,7 +507,7 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
     }
     invalidCoinbaseTx.vout.emplace_back(
             CTxOut(GetBlockValue(nHeight + 1) - GetMasternodePayment(),
-                   GetScriptForDestination(coinbaseKey.GetPubKey().GetID())));
+                   GetScriptForDestination(PKHash(coinbaseKey.GetPubKey()))));
     pblock->vtx[0] = MakeTransactionRef(invalidCoinbaseTx);
     pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
     ProcessNewBlock(pblock, nullptr);

--- a/src/test/evo_specialtx_tests.cpp
+++ b/src/test/evo_specialtx_tests.cpp
@@ -34,7 +34,7 @@ static CBLSPublicKey GetRandomBLSKey()
 
 static CScript GetRandomScript()
 {
-    return GetScriptForDestination(GetRandomKeyID());
+    return GetScriptForDestination(PKHash(GetRandomKeyID()));
 }
 
 static ProRegPL GetRandomProRegPayload()

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -8,7 +8,6 @@
 #include "base58.h"
 #include "key_io.h"
 #include "uint256.h"
-#include "util/system.h"
 #include "utilstrencodings.h"
 #include "test_pivx.h"
 
@@ -71,10 +70,10 @@ BOOST_AUTO_TEST_CASE(key_test1)
     BOOST_CHECK(!key2C.VerifyPubKey(pubkey2));
     BOOST_CHECK(key2C.VerifyPubKey(pubkey2C));
 
-    BOOST_CHECK(DecodeDestination(addr1)  == CTxDestination(pubkey1.GetID()));
-    BOOST_CHECK(DecodeDestination(addr2)  == CTxDestination(pubkey2.GetID()));
-    BOOST_CHECK(DecodeDestination(addr1C) == CTxDestination(pubkey1C.GetID()));
-    BOOST_CHECK(DecodeDestination(addr2C) == CTxDestination(pubkey2C.GetID()));
+    BOOST_CHECK(DecodeDestination(addr1)  == CTxDestination(PKHash(pubkey1)));
+    BOOST_CHECK(DecodeDestination(addr2)  == CTxDestination(PKHash(pubkey2)));
+    BOOST_CHECK(DecodeDestination(addr1C) == CTxDestination(PKHash(pubkey1C)));
+    BOOST_CHECK(DecodeDestination(addr2C) == CTxDestination(PKHash(pubkey2C)));
 
     for (int n=0; n<16; n++)
     {

--- a/src/test/librust/sapling_wallet_tests.cpp
+++ b/src/test/librust/sapling_wallet_tests.cpp
@@ -1041,7 +1041,7 @@ BOOST_AUTO_TEST_CASE(MarkAffectedSaplingTransactionsDirty)
     // Set up transparent address
     CBasicKeyStore keystore;
     CKey tsk = AddTestCKeyToKeyStore(keystore);
-    auto scriptPubKey = GetScriptForDestination(tsk.GetPubKey().GetID());
+    auto scriptPubKey = GetScriptForDestination(PKHash(tsk.GetPubKey()));
 
     // Generate shielding tx from transparent to Sapling
     // 0.5 t-PIV in, 0.4 z-PIV out, 0.1 t-PIV fee
@@ -1153,7 +1153,7 @@ BOOST_AUTO_TEST_CASE(GetNotes)
         // Set up transparent address
         CBasicKeyStore keystore;
         CKey tsk = AddTestCKeyToKeyStore(keystore);
-        auto scriptPubKey = GetScriptForDestination(tsk.GetPubKey().GetID());
+        auto scriptPubKey = GetScriptForDestination(PKHash(tsk.GetPubKey()));
 
         // Generate shielding tx from transparent to Sapling (five 1 PIV notes)
         auto builder = TransactionBuilder(consensusParams, &keystore);

--- a/src/test/librust/transaction_builder_tests.cpp
+++ b/src/test/librust/transaction_builder_tests.cpp
@@ -21,7 +21,7 @@ BOOST_AUTO_TEST_CASE(TransparentToSapling)
 
     CBasicKeyStore keystore;
     CKey tsk = AddTestCKeyToKeyStore(keystore);
-    auto scriptPubKey = GetScriptForDestination(tsk.GetPubKey().GetID());
+    auto scriptPubKey = GetScriptForDestination(PKHash(tsk.GetPubKey()));
 
     auto sk_from = libzcash::SaplingSpendingKey::random();
     auto fvk_from = sk_from.full_viewing_key();
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(FailsWithNegativeChange)
     // Set up dummy transparent address
     CBasicKeyStore keystore;
     CKey tsk = AddTestCKeyToKeyStore(keystore);
-    auto tkeyid = tsk.GetPubKey().GetID();
+    auto tkeyid = PKHash(tsk.GetPubKey());
     auto scriptPubKey = GetScriptForDestination(tkeyid);
     CTxDestination taddr = tkeyid;
 
@@ -186,7 +186,7 @@ BOOST_AUTO_TEST_CASE(ChangeOutput)
     // Set up dummy transparent address
     CBasicKeyStore keystore;
     CKey tsk = AddTestCKeyToKeyStore(keystore);
-    auto tkeyid = tsk.GetPubKey().GetID();
+    auto tkeyid = PKHash(tsk.GetPubKey());
     auto scriptPubKey = GetScriptForDestination(tkeyid);
     CTxDestination taddr = tkeyid;
 

--- a/src/test/librust/utiltest.cpp
+++ b/src/test/librust/utiltest.cpp
@@ -82,7 +82,7 @@ CWalletTx GetValidSaplingReceive(const Consensus::Params& consensusParams,
                                  const CWallet* pwalletIn) {
     // From taddr
     CKey tsk = AddTestCKeyToWallet(keyStoreFrom, genNewKey);
-    auto scriptPubKey = GetScriptForDestination(tsk.GetPubKey().GetID());
+    auto scriptPubKey = GetScriptForDestination(PKHash(tsk.GetPubKey()));
 
     // Two equal dummy inputs to by-pass the coinbase check.
     TransparentInput dummyInput{COutPoint(), scriptPubKey, inputAmount / 2};
@@ -111,5 +111,5 @@ CWalletTx GetValidSaplingReceive(const Consensus::Params& consensusParams,
 
 CScript CreateDummyDestinationScript() {
     CKey key = CreateCkey(true);
-    return GetScriptForDestination(key.GetPubKey().GetID());
+    return GetScriptForDestination(PKHash(key.GetPubKey()));
 }

--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -28,7 +28,7 @@ CScript GetScriptForType(CPubKey pubKey, BlockSignatureType type)
         case P2PK:
             return CScript() << pubKey << OP_CHECKSIG;
         default:
-            return GetScriptForDestination(pubKey.GetID());
+            return GetScriptForDestination(PKHash(pubKey));
     }
 }
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -302,7 +302,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.vin[0].scriptSig = CScript() << OP_1;
     tx.vout[0].nValue = 4900000000LL;
     script = CScript() << OP_0;
-    tx.vout[0].scriptPubKey = GetScriptForDestination(CScriptID(script));
+    tx.vout[0].scriptPubKey = GetScriptForDestination(ScriptHash(script));
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Fee(10000000L).Time(GetTime()).SpendsCoinbaseOrCoinstake(true).FromTx(tx));
     tx.vin[0].prevout.hash = hash;

--- a/src/test/mnpayments_tests.cpp
+++ b/src/test/mnpayments_tests.cpp
@@ -86,7 +86,7 @@ std::vector<FakeMasternode> buildMNList(const uint256& tipHash, uint64_t tipTime
         CKey mnKey;
         mnKey.MakeNewKey(true);
         const CPubKey& mnPubKey = mnKey.GetPubKey();
-        const CScript& mnPayeeScript = GetScriptForDestination(mnPubKey.GetID());
+        const CScript& mnPayeeScript = GetScriptForDestination(PKHash(mnPubKey.GetID()));
         // Fake collateral out and key for now
         COutPoint mnCollateral(GetRandHash(), 0);
         const CPubKey& collateralPubKey = mnPubKey;
@@ -212,8 +212,8 @@ BOOST_FIXTURE_TEST_CASE(mnwinner_test, TestChain100Setup)
 
     // Now let's push two valid winner payments and make every MN in the top ten vote for them (having more votes in mnwinnerA than in mnwinnerB).
     mnRank = mnodeman.GetMasternodeRanks(nextBlockHeight - 100);
-    CScript firstRankedPayee = GetScriptForDestination(mnRank[0].second->pubKeyCollateralAddress.GetID());
-    CScript secondRankedPayee = GetScriptForDestination(mnRank[1].second->pubKeyCollateralAddress.GetID());
+    CScript firstRankedPayee = GetScriptForDestination(PKHash(mnRank[0].second->pubKeyCollateralAddress.GetID()));
+    CScript secondRankedPayee = GetScriptForDestination(PKHash(mnRank[1].second->pubKeyCollateralAddress.GetID()));
 
     // Let's vote with the first 6 nodes for MN ranked 1
     // And with the last 4 nodes for MN ranked 2
@@ -263,7 +263,7 @@ BOOST_FIXTURE_TEST_CASE(mnwinner_test, TestChain100Setup)
     // Generate 125 blocks paying to different MNs to load the payments cache.
     for (int i = 0; i < 125; i++) {
         mnRank = mnodeman.GetMasternodeRanks(nextBlockHeight - 100);
-        payeeScript = GetScriptForDestination(mnRank[0].second->pubKeyCollateralAddress.GetID());
+        payeeScript = GetScriptForDestination(PKHash(mnRank[0].second->pubKeyCollateralAddress.GetID()));
         for (int j=0; j<7; j++) { // votes
             auto voterMn = findMNData(mnList, mnRank[j].second);
             CMasternode* pVoterMN = mnodeman.Find(voterMn.mn.vin.prevout);
@@ -288,7 +288,7 @@ BOOST_FIXTURE_TEST_CASE(mnwinner_test, TestChain100Setup)
     // 1) Schedule payment and vote for it with the first 6 MNs.
     mnRank = mnodeman.GetMasternodeRanks(nextBlockHeight - 100);
     MasternodeRef mnToPay = mnRank[0].second;
-    payeeScript = GetScriptForDestination(mnToPay->pubKeyCollateralAddress.GetID());
+    payeeScript = GetScriptForDestination(PKHash(mnToPay->pubKeyCollateralAddress.GetID()));
     for (int i=0; i<6; i++) {
         auto voterMn = findMNData(mnList, mnRank[i].second);
         CMasternode* pVoterMN = mnodeman.Find(voterMn.mn.vin.prevout);

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -205,10 +205,9 @@ BOOST_AUTO_TEST_CASE(multisig_Solver1)
 
     {
         std::vector<valtype> solutions;
-        txnouttype whichType;
         CScript s;
         s << ToByteVector(key[0].GetPubKey()) << OP_CHECKSIG;
-        BOOST_CHECK(Solver(s, whichType, solutions));
+        BOOST_CHECK(Solver(s, solutions) != TX_NONSTANDARD);
         BOOST_CHECK(solutions.size() == 1);
         CTxDestination addr;
         BOOST_CHECK(ExtractDestination(s, addr));
@@ -218,10 +217,9 @@ BOOST_AUTO_TEST_CASE(multisig_Solver1)
     }
     {
         std::vector<valtype> solutions;
-        txnouttype whichType;
         CScript s;
         s << OP_DUP << OP_HASH160 << ToByteVector(key[0].GetPubKey().GetID()) << OP_EQUALVERIFY << OP_CHECKSIG;
-        BOOST_CHECK(Solver(s, whichType, solutions));
+        BOOST_CHECK(Solver(s, solutions) != TX_NONSTANDARD);
         BOOST_CHECK(solutions.size() == 1);
         CTxDestination addr;
         BOOST_CHECK(ExtractDestination(s, addr));
@@ -231,10 +229,9 @@ BOOST_AUTO_TEST_CASE(multisig_Solver1)
     }
     {
         std::vector<valtype> solutions;
-        txnouttype whichType;
         CScript s;
         s << OP_2 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << OP_2 << OP_CHECKMULTISIG;
-        BOOST_CHECK(Solver(s, whichType, solutions));
+        BOOST_CHECK(Solver(s, solutions) != TX_NONSTANDARD);
         BOOST_CHECK_EQUAL(solutions.size(), 4U);
         CTxDestination addr;
         BOOST_CHECK(!ExtractDestination(s, addr));
@@ -244,10 +241,10 @@ BOOST_AUTO_TEST_CASE(multisig_Solver1)
     }
     {
         std::vector<valtype> solutions;
-        txnouttype whichType;
         CScript s;
         s << OP_1 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << OP_2 << OP_CHECKMULTISIG;
-        BOOST_CHECK(Solver(s, whichType, solutions));
+        txnouttype whichType = Solver(s, solutions);
+        BOOST_CHECK(whichType != TX_NONSTANDARD);
         BOOST_CHECK_EQUAL(solutions.size(), 4U);
         std::vector<CTxDestination> addrs;
         int nRequired;
@@ -261,10 +258,9 @@ BOOST_AUTO_TEST_CASE(multisig_Solver1)
     }
     {
         std::vector<valtype> solutions;
-        txnouttype whichType;
         CScript s;
         s << OP_2 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << ToByteVector(key[2].GetPubKey()) << OP_3 << OP_CHECKMULTISIG;
-        BOOST_CHECK(Solver(s, whichType, solutions));
+        BOOST_CHECK(Solver(s, solutions) != TX_NONSTANDARD);
         BOOST_CHECK(solutions.size() == 5);
     }
 }

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(multisig_Solver1)
     {
         key[i].MakeNewKey(true);
         keystore.AddKey(key[i]);
-        keyaddr[i] = key[i].GetPubKey().GetID();
+        keyaddr[i] = PKHash(key[i].GetPubKey());
     }
     partialkeystore.AddKey(key[0]);
 

--- a/src/test/script_P2CS_tests.cpp
+++ b/src/test/script_P2CS_tests.cpp
@@ -13,7 +13,7 @@ BOOST_FIXTURE_TEST_SUITE(script_P2CS_tests, WalletTestingSetup)
 
 void CheckValidKeyId(const CTxDestination& dest, const CKeyID& expectedKey)
 {
-    const CKeyID* keyid = boost::get<CKeyID>(&dest);
+    const PKHash* keyid = boost::get<PKHash>(&dest);
     if (keyid) {
         BOOST_CHECK(keyid);
         BOOST_CHECK(*keyid == expectedKey);
@@ -68,7 +68,7 @@ static CScript GetDummyP2CS(const CKeyID& dummyKeyID)
     return GetScriptForStakeDelegation(dummyKeyID, dummyKeyID);
 }
 
-static CScript GetDummyP2PKH(const CKeyID& dummyKeyID)
+static CScript GetDummyP2PKH(const PKHash& dummyKeyID)
 {
     return GetScriptForDestination(dummyKeyID);
 }
@@ -149,7 +149,8 @@ BOOST_AUTO_TEST_CASE(coldstake_lof_script)
 
     const CKey& dummyKey = KeyIO::DecodeSecret("YNdsth3BsW53DYmCiR12SofWSAt2utXQUSGoin3PekVQCMbzfS7E");
     const CKeyID& dummyKeyID = dummyKey.GetPubKey().GetID();
-    const CScript& dummyP2PKH = GetDummyP2PKH(dummyKeyID);
+    const PKHash dummyKeyHash(dummyKey.GetPubKey());
+    const CScript& dummyP2PKH = GetDummyP2PKH(dummyKeyHash);
 
     // Add a masternode out
     tx.vout.emplace_back(3 * COIN, dummyP2PKH);
@@ -225,7 +226,8 @@ BOOST_AUTO_TEST_CASE(coldstake_script)
 
     const CKey& dummyKey = KeyIO::DecodeSecret("YNdsth3BsW53DYmCiR12SofWSAt2utXQUSGoin3PekVQCMbzfS7E");
     const CKeyID& dummyKeyID = dummyKey.GetPubKey().GetID();
-    const CScript& dummyP2PKH = GetDummyP2PKH(dummyKeyID);
+    const PKHash dummyKeyHash(dummyKey.GetPubKey());
+    const CScript& dummyP2PKH = GetDummyP2PKH(dummyKeyHash);
 
     // Add a dummy P2PKH out at the end
     tx.vout.emplace_back(3 * COIN, dummyP2PKH);

--- a/src/test/script_P2SH_tests.cpp
+++ b/src/test/script_P2SH_tests.cpp
@@ -70,14 +70,14 @@ BOOST_AUTO_TEST_CASE(sign)
     // different keys, straight/P2SH, pubkey/pubkeyhash
     CScript standardScripts[4];
     standardScripts[0] << ToByteVector(key[0].GetPubKey()) << OP_CHECKSIG;
-    standardScripts[1] = GetScriptForDestination(key[1].GetPubKey().GetID());
+    standardScripts[1] = GetScriptForDestination(PKHash(key[1].GetPubKey()));
     standardScripts[2] << ToByteVector(key[1].GetPubKey()) << OP_CHECKSIG;
-    standardScripts[3] = GetScriptForDestination(key[2].GetPubKey().GetID());
+    standardScripts[3] = GetScriptForDestination(PKHash(key[2].GetPubKey()));
     CScript evalScripts[4];
     for (int i = 0; i < 4; i++)
     {
         keystore.AddCScript(standardScripts[i]);
-        evalScripts[i] = GetScriptForDestination(CScriptID(standardScripts[i]));
+        evalScripts[i] = GetScriptForDestination(ScriptHash(standardScripts[i]));
     }
 
     CMutableTransaction txFrom;  // Funding transaction:
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(norecurse)
     CScript invalidAsScript;
     invalidAsScript << OP_INVALIDOPCODE << OP_INVALIDOPCODE;
 
-    CScript p2sh = GetScriptForDestination(CScriptID(invalidAsScript));
+    CScript p2sh = GetScriptForDestination(ScriptHash(invalidAsScript));
 
     CScript scriptSig;
     scriptSig << Serialize(invalidAsScript);
@@ -143,7 +143,7 @@ BOOST_AUTO_TEST_CASE(norecurse)
 
     // Try to recur, and verification should succeed because
     // the inner HASH160 <> EQUAL should only check the hash:
-    CScript p2sh2 = GetScriptForDestination(CScriptID(p2sh));
+    CScript p2sh2 = GetScriptForDestination(ScriptHash(p2sh));
     CScript scriptSig2;
     scriptSig2 << Serialize(invalidAsScript) << Serialize(p2sh);
 
@@ -166,7 +166,7 @@ BOOST_AUTO_TEST_CASE(set)
     }
 
     CScript inner[4];
-    inner[0] = GetScriptForDestination(key[0].GetPubKey().GetID());
+    inner[0] = GetScriptForDestination(PKHash(key[0].GetPubKey()));
     inner[1] = GetScriptForMultisig(2, std::vector<CPubKey>(keys.begin(), keys.begin()+2));
     inner[2] = GetScriptForMultisig(1, std::vector<CPubKey>(keys.begin(), keys.begin()+2));
     inner[3] = GetScriptForMultisig(2, std::vector<CPubKey>(keys.begin(), keys.begin()+3));
@@ -174,7 +174,7 @@ BOOST_AUTO_TEST_CASE(set)
     CScript outer[4];
     for (int i = 0; i < 4; i++)
     {
-        outer[i] = GetScriptForDestination(CScriptID(inner[i]));
+        outer[i] = GetScriptForDestination(ScriptHash(inner[i]));
         keystore.AddCScript(inner[i]);
     }
 
@@ -246,7 +246,7 @@ BOOST_AUTO_TEST_CASE(switchover)
     CScript scriptSig;
     scriptSig << Serialize(notValid);
 
-    CScript fund = GetScriptForDestination(CScriptID(notValid));
+    CScript fund = GetScriptForDestination(ScriptHash(notValid));
 
 
     // Validation should succeed under old rules (hash is correct):
@@ -277,11 +277,11 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     txFrom.vout.resize(7);
 
     // First three are standard:
-    CScript pay1 = GetScriptForDestination(key[0].GetPubKey().GetID());
+    CScript pay1 = GetScriptForDestination(PKHash(key[0].GetPubKey()));
     keystore.AddCScript(pay1);
     CScript pay1of3 = GetScriptForMultisig(1, keys);
 
-    txFrom.vout[0].scriptPubKey = GetScriptForDestination(CScriptID(pay1)); // P2SH (OP_CHECKSIG)
+    txFrom.vout[0].scriptPubKey = GetScriptForDestination(ScriptHash(pay1)); // P2SH (OP_CHECKSIG)
     txFrom.vout[0].nValue = 1000;
     txFrom.vout[1].scriptPubKey = pay1; // ordinary OP_CHECKSIG
     txFrom.vout[1].nValue = 2000;
@@ -296,7 +296,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     oneAndTwo << OP_2 << ToByteVector(key[3].GetPubKey()) << ToByteVector(key[4].GetPubKey()) << ToByteVector(key[5].GetPubKey());
     oneAndTwo << OP_3 << OP_CHECKMULTISIG;
     keystore.AddCScript(oneAndTwo);
-    txFrom.vout[3].scriptPubKey = GetScriptForDestination(CScriptID(oneAndTwo));
+    txFrom.vout[3].scriptPubKey = GetScriptForDestination(ScriptHash(oneAndTwo));
     txFrom.vout[3].nValue = 4000;
 
     // vout[4] is max sigops:
@@ -305,24 +305,24 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
         fifteenSigops << ToByteVector(key[i%3].GetPubKey());
     fifteenSigops << OP_15 << OP_CHECKMULTISIG;
     keystore.AddCScript(fifteenSigops);
-    txFrom.vout[4].scriptPubKey = GetScriptForDestination(CScriptID(fifteenSigops));
+    txFrom.vout[4].scriptPubKey = GetScriptForDestination(ScriptHash(fifteenSigops));
     txFrom.vout[4].nValue = 5000;
 
     // vout[5/6] are non-standard because they exceed MAX_P2SH_SIGOPS
     CScript sixteenSigops; sixteenSigops << OP_16 << OP_CHECKMULTISIG;
     keystore.AddCScript(sixteenSigops);
-    txFrom.vout[5].scriptPubKey = GetScriptForDestination(CScriptID(fifteenSigops));
+    txFrom.vout[5].scriptPubKey = GetScriptForDestination(ScriptHash(fifteenSigops));
     txFrom.vout[5].nValue = 5000;
     CScript twentySigops; twentySigops << OP_CHECKMULTISIG;
     keystore.AddCScript(twentySigops);
-    txFrom.vout[6].scriptPubKey = GetScriptForDestination(CScriptID(twentySigops));
+    txFrom.vout[6].scriptPubKey = GetScriptForDestination(ScriptHash(twentySigops));
     txFrom.vout[6].nValue = 6000;
 
     AddCoins(coins, txFrom, 0);
 
     CMutableTransaction txTo;
     txTo.vout.resize(1);
-    txTo.vout[0].scriptPubKey = GetScriptForDestination(key[1].GetPubKey().GetID());
+    txTo.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key[1].GetPubKey()));
 
     txTo.vin.resize(5);
     for (int i = 0; i < 5; i++)
@@ -345,7 +345,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
 
     CMutableTransaction txToNonStd1;
     txToNonStd1.vout.resize(1);
-    txToNonStd1.vout[0].scriptPubKey = GetScriptForDestination(key[1].GetPubKey().GetID());
+    txToNonStd1.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key[1].GetPubKey()));
     txToNonStd1.vout[0].nValue = 1000;
     txToNonStd1.vin.resize(1);
     txToNonStd1.vin[0].prevout.n = 5;
@@ -357,7 +357,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
 
     CMutableTransaction txToNonStd2;
     txToNonStd2.vout.resize(1);
-    txToNonStd2.vout[0].scriptPubKey = GetScriptForDestination(key[1].GetPubKey().GetID());
+    txToNonStd2.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key[1].GetPubKey()));
     txToNonStd2.vout[0].nValue = 1000;
     txToNonStd2.vin.resize(1);
     txToNonStd2.vin[0].prevout.n = 6;

--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -24,32 +24,28 @@ BOOST_AUTO_TEST_CASE(script_standard_Solver_success)
     }
 
     CScript s;
-    txnouttype whichType;
     std::vector<std::vector<unsigned char> > solutions;
 
     // TX_PUBKEY
     s.clear();
     s << ToByteVector(pubkeys[0]) << OP_CHECKSIG;
-    BOOST_CHECK(Solver(s, whichType, solutions));
-    BOOST_CHECK_EQUAL(whichType, TX_PUBKEY);
-    BOOST_CHECK_EQUAL(solutions.size(), 1);
+    BOOST_CHECK_EQUAL(Solver(s, solutions), TX_PUBKEY);
+    BOOST_CHECK_EQUAL(solutions.size(), 1U);
     BOOST_CHECK(solutions[0] == ToByteVector(pubkeys[0]));
 
     // TX_PUBKEYHASH
     s.clear();
     s << OP_DUP << OP_HASH160 << ToByteVector(pubkeys[0].GetID()) << OP_EQUALVERIFY << OP_CHECKSIG;
-    BOOST_CHECK(Solver(s, whichType, solutions));
-    BOOST_CHECK_EQUAL(whichType, TX_PUBKEYHASH);
-    BOOST_CHECK_EQUAL(solutions.size(), 1);
+    BOOST_CHECK_EQUAL(Solver(s, solutions), TX_PUBKEYHASH);
+    BOOST_CHECK_EQUAL(solutions.size(), 1U);
     BOOST_CHECK(solutions[0] == ToByteVector(pubkeys[0].GetID()));
 
     // TX_SCRIPTHASH
     CScript redeemScript(s); // initialize with leftover P2PKH script
     s.clear();
     s << OP_HASH160 << ToByteVector(CScriptID(redeemScript)) << OP_EQUAL;
-    BOOST_CHECK(Solver(s, whichType, solutions));
-    BOOST_CHECK_EQUAL(whichType, TX_SCRIPTHASH);
-    BOOST_CHECK_EQUAL(solutions.size(), 1);
+    BOOST_CHECK_EQUAL(Solver(s, solutions), TX_SCRIPTHASH);
+    BOOST_CHECK_EQUAL(solutions.size(), 1U);
     BOOST_CHECK(solutions[0] == ToByteVector(CScriptID(redeemScript)));
 
     // TX_MULTISIG
@@ -58,9 +54,8 @@ BOOST_AUTO_TEST_CASE(script_standard_Solver_success)
         ToByteVector(pubkeys[0]) <<
         ToByteVector(pubkeys[1]) <<
         OP_2 << OP_CHECKMULTISIG;
-    BOOST_CHECK(Solver(s, whichType, solutions));
-    BOOST_CHECK_EQUAL(whichType, TX_MULTISIG);
-    BOOST_CHECK_EQUAL(solutions.size(), 4);
+    BOOST_CHECK_EQUAL(Solver(s, solutions), TX_MULTISIG);
+    BOOST_CHECK_EQUAL(solutions.size(), 4U);
     BOOST_CHECK(solutions[0] == std::vector<unsigned char>({1}));
     BOOST_CHECK(solutions[1] == ToByteVector(pubkeys[0]));
     BOOST_CHECK(solutions[2] == ToByteVector(pubkeys[1]));
@@ -72,9 +67,8 @@ BOOST_AUTO_TEST_CASE(script_standard_Solver_success)
         ToByteVector(pubkeys[1]) <<
         ToByteVector(pubkeys[2]) <<
         OP_3 << OP_CHECKMULTISIG;
-    BOOST_CHECK(Solver(s, whichType, solutions));
-    BOOST_CHECK_EQUAL(whichType, TX_MULTISIG);
-    BOOST_CHECK_EQUAL(solutions.size(), 5);
+    BOOST_CHECK_EQUAL(Solver(s, solutions), TX_MULTISIG);
+    BOOST_CHECK_EQUAL(solutions.size(), 5U);
     BOOST_CHECK(solutions[0] == std::vector<unsigned char>({2}));
     BOOST_CHECK(solutions[1] == ToByteVector(pubkeys[0]));
     BOOST_CHECK(solutions[2] == ToByteVector(pubkeys[1]));
@@ -87,15 +81,13 @@ BOOST_AUTO_TEST_CASE(script_standard_Solver_success)
         std::vector<unsigned char>({0}) <<
         std::vector<unsigned char>({75}) <<
         std::vector<unsigned char>({255});
-    BOOST_CHECK(Solver(s, whichType, solutions));
-    BOOST_CHECK_EQUAL(whichType, TX_NULL_DATA);
-    BOOST_CHECK_EQUAL(solutions.size(), 0);
+    BOOST_CHECK_EQUAL(Solver(s, solutions), TX_NULL_DATA);
+    BOOST_CHECK_EQUAL(solutions.size(), 0U);
 
     // TX_NONSTANDARD
     s.clear();
     s << OP_9 << OP_ADD << OP_11 << OP_EQUAL;
-    BOOST_CHECK(!Solver(s, whichType, solutions));
-    BOOST_CHECK_EQUAL(whichType, TX_NONSTANDARD);
+    BOOST_CHECK_EQUAL(Solver(s, solutions), TX_NONSTANDARD);
 }
 
 BOOST_AUTO_TEST_CASE(script_standard_Solver_failure)
@@ -106,53 +98,52 @@ BOOST_AUTO_TEST_CASE(script_standard_Solver_failure)
     pubkey = key.GetPubKey();
 
     CScript s;
-    txnouttype whichType;
     std::vector<std::vector<unsigned char> > solutions;
 
     // TX_PUBKEY with incorrectly sized pubkey
     s.clear();
     s << std::vector<unsigned char>(30, 0x01) << OP_CHECKSIG;
-    BOOST_CHECK(!Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(Solver(s, solutions), TX_NONSTANDARD);
 
     // TX_PUBKEYHASH with incorrectly sized key hash
     s.clear();
     s << OP_DUP << OP_HASH160 << ToByteVector(pubkey) << OP_EQUALVERIFY << OP_CHECKSIG;
-    BOOST_CHECK(!Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(Solver(s, solutions), TX_NONSTANDARD);
 
     // TX_SCRIPTHASH with incorrectly sized script hash
     s.clear();
     s << OP_HASH160 << std::vector<unsigned char>(21, 0x01) << OP_EQUAL;
-    BOOST_CHECK(!Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(Solver(s, solutions), TX_NONSTANDARD);
 
     // TX_MULTISIG 0/2
     s.clear();
     s << OP_0 << ToByteVector(pubkey) << OP_1 << OP_CHECKMULTISIG;
-    BOOST_CHECK(!Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(Solver(s, solutions), TX_NONSTANDARD);
 
     // TX_MULTISIG 2/1
     s.clear();
     s << OP_2 << ToByteVector(pubkey) << OP_1 << OP_CHECKMULTISIG;
-    BOOST_CHECK(!Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(Solver(s, solutions), TX_NONSTANDARD);
 
     // TX_MULTISIG n = 2 with 1 pubkey
     s.clear();
     s << OP_1 << ToByteVector(pubkey) << OP_2 << OP_CHECKMULTISIG;
-    BOOST_CHECK(!Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(Solver(s, solutions), TX_NONSTANDARD);
 
     // TX_MULTISIG n = 1 with 0 pubkeys
     s.clear();
     s << OP_1 << OP_1 << OP_CHECKMULTISIG;
-    BOOST_CHECK(!Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(Solver(s, solutions), TX_NONSTANDARD);
 
     // TX_NULL_DATA with other opcodes
     s.clear();
     s << OP_RETURN << std::vector<unsigned char>({75}) << OP_ADD;
-    BOOST_CHECK(!Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(Solver(s, solutions), TX_NONSTANDARD);
 
     // TX_WITNESS with incorrect program size
     s.clear();
     s << OP_0 << std::vector<unsigned char>(19, 0x01);
-    BOOST_CHECK(!Solver(s, whichType, solutions));
+    BOOST_CHECK_EQUAL(Solver(s, solutions), TX_NONSTANDARD);
 }
 
 BOOST_AUTO_TEST_CASE(script_standard_ExtractDestination)

--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -160,23 +160,23 @@ BOOST_AUTO_TEST_CASE(script_standard_ExtractDestination)
     s.clear();
     s << ToByteVector(pubkey) << OP_CHECKSIG;
     BOOST_CHECK(ExtractDestination(s, address));
-    BOOST_CHECK(boost::get<CKeyID>(&address) &&
-                *boost::get<CKeyID>(&address) == pubkey.GetID());
+    BOOST_CHECK(boost::get<PKHash>(&address) &&
+                *boost::get<PKHash>(&address) == PKHash(pubkey));
 
     // TX_PUBKEYHASH
     s.clear();
     s << OP_DUP << OP_HASH160 << ToByteVector(pubkey.GetID()) << OP_EQUALVERIFY << OP_CHECKSIG;
     BOOST_CHECK(ExtractDestination(s, address));
-    BOOST_CHECK(boost::get<CKeyID>(&address) &&
-                *boost::get<CKeyID>(&address) == pubkey.GetID());
+    BOOST_CHECK(boost::get<PKHash>(&address) &&
+                *boost::get<PKHash>(&address) == PKHash(pubkey));
 
     // TX_SCRIPTHASH
     CScript redeemScript(s); // initialize with leftover P2PKH script
     s.clear();
     s << OP_HASH160 << ToByteVector(CScriptID(redeemScript)) << OP_EQUAL;
     BOOST_CHECK(ExtractDestination(s, address));
-    BOOST_CHECK(boost::get<CScriptID>(&address) &&
-                *boost::get<CScriptID>(&address) == CScriptID(redeemScript));
+    BOOST_CHECK(boost::get<ScriptHash>(&address) &&
+                *boost::get<ScriptHash>(&address) == ScriptHash(redeemScript));
 
     // TX_MULTISIG
     s.clear();
@@ -210,8 +210,8 @@ BOOST_AUTO_TEST_CASE(script_standard_ExtractDestinations)
     BOOST_CHECK_EQUAL(whichType, TX_PUBKEY);
     BOOST_CHECK_EQUAL(addresses.size(), 1);
     BOOST_CHECK_EQUAL(nRequired, 1);
-    BOOST_CHECK(boost::get<CKeyID>(&addresses[0]) &&
-                *boost::get<CKeyID>(&addresses[0]) == pubkeys[0].GetID());
+    BOOST_CHECK(boost::get<PKHash>(&addresses[0]) &&
+                *boost::get<PKHash>(&addresses[0]) == PKHash(pubkeys[0]));
 
     // TX_PUBKEYHASH
     s.clear();
@@ -220,8 +220,8 @@ BOOST_AUTO_TEST_CASE(script_standard_ExtractDestinations)
     BOOST_CHECK_EQUAL(whichType, TX_PUBKEYHASH);
     BOOST_CHECK_EQUAL(addresses.size(), 1);
     BOOST_CHECK_EQUAL(nRequired, 1);
-    BOOST_CHECK(boost::get<CKeyID>(&addresses[0]) &&
-                *boost::get<CKeyID>(&addresses[0]) == pubkeys[0].GetID());
+    BOOST_CHECK(boost::get<PKHash>(&addresses[0]) &&
+                *boost::get<PKHash>(&addresses[0]) == PKHash(pubkeys[0]));
 
     // TX_SCRIPTHASH
     CScript redeemScript(s); // initialize with leftover P2PKH script
@@ -231,8 +231,8 @@ BOOST_AUTO_TEST_CASE(script_standard_ExtractDestinations)
     BOOST_CHECK_EQUAL(whichType, TX_SCRIPTHASH);
     BOOST_CHECK_EQUAL(addresses.size(), 1);
     BOOST_CHECK_EQUAL(nRequired, 1);
-    BOOST_CHECK(boost::get<CScriptID>(&addresses[0]) &&
-                *boost::get<CScriptID>(&addresses[0]) == CScriptID(redeemScript));
+    BOOST_CHECK(boost::get<ScriptHash>(&addresses[0]) &&
+                *boost::get<ScriptHash>(&addresses[0]) == ScriptHash(redeemScript));
 
     // TX_MULTISIG
     s.clear();
@@ -244,10 +244,10 @@ BOOST_AUTO_TEST_CASE(script_standard_ExtractDestinations)
     BOOST_CHECK_EQUAL(whichType, TX_MULTISIG);
     BOOST_CHECK_EQUAL(addresses.size(), 2);
     BOOST_CHECK_EQUAL(nRequired, 2);
-    BOOST_CHECK(boost::get<CKeyID>(&addresses[0]) &&
-                *boost::get<CKeyID>(&addresses[0]) == pubkeys[0].GetID());
-    BOOST_CHECK(boost::get<CKeyID>(&addresses[1]) &&
-                *boost::get<CKeyID>(&addresses[1]) == pubkeys[1].GetID());
+    BOOST_CHECK(boost::get<PKHash>(&addresses[0]) &&
+                *boost::get<PKHash>(&addresses[0]) == PKHash(pubkeys[0]));
+    BOOST_CHECK(boost::get<PKHash>(&addresses[1]) &&
+                *boost::get<PKHash>(&addresses[1]) == PKHash(pubkeys[1]));
 
     // TX_NULL_DATA
     s.clear();
@@ -269,14 +269,14 @@ BOOST_AUTO_TEST_CASE(script_standard_GetScriptFor_)
     // CKeyID
     expected.clear();
     expected << OP_DUP << OP_HASH160 << ToByteVector(pubkeys[0].GetID()) << OP_EQUALVERIFY << OP_CHECKSIG;
-    result = GetScriptForDestination(pubkeys[0].GetID());
+    result = GetScriptForDestination(PKHash(pubkeys[0]));
     BOOST_CHECK(result == expected);
 
     // CScriptID
     CScript redeemScript(result);
     expected.clear();
     expected << OP_HASH160 << ToByteVector(CScriptID(redeemScript)) << OP_EQUAL;
-    result = GetScriptForDestination(CScriptID(redeemScript));
+    result = GetScriptForDestination(ScriptHash(redeemScript));
     BOOST_CHECK(result == expected);
 
     // CNoDestination

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -85,7 +85,7 @@ static ScriptErrorDesc script_errors[]={
     {SCRIPT_ERR_DISCOURAGE_UPGRADABLE_NOPS, "DISCOURAGE_UPGRADABLE_NOPS"}
 };
 
-const char *FormatScriptError(ScriptError_t err)
+static std::string FormatScriptError(ScriptError_t err)
 {
     for (unsigned int i=0; i<ARRAYLEN(script_errors); ++i)
         if (script_errors[i].err == err)
@@ -147,7 +147,7 @@ void DoTest(const CScript& scriptPubKey, const CScript& scriptSig, int flags, co
     static const CAmount amountZero = 0;
     BOOST_CHECK_MESSAGE(VerifyScript(scriptSig, scriptPubKey, flags,
             MutableTransactionSignatureChecker(&tx, 0, amountZero), tx.GetRequiredSigVersion(), &err) == expect, message);
-    BOOST_CHECK_MESSAGE(err == scriptError, std::string(FormatScriptError(err)) + " where " + std::string(FormatScriptError((ScriptError_t)scriptError)) + " expected: " + message);
+    BOOST_CHECK_MESSAGE(err == scriptError, FormatScriptError(err) + " where " + FormatScriptError((ScriptError_t)scriptError) + " expected: " + message);
 #if defined(HAVE_CONSENSUS_LIB)
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
     stream << tx2;

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -892,7 +892,7 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
         keystore.AddKey(key);
     }
 
-    CMutableTransaction txFrom = BuildCreditingTransaction(GetScriptForDestination(keys[0].GetPubKey().GetID()));
+    CMutableTransaction txFrom = BuildCreditingTransaction(GetScriptForDestination(PKHash(keys[0].GetPubKey())));
     CMutableTransaction txTo = BuildSpendingTransaction(CScript(), txFrom);
     CScript& scriptPubKey = txFrom.vout[0].scriptPubKey;
     CScript& scriptSig = txTo.vin[0].scriptSig;
@@ -916,7 +916,7 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
     // P2SH, single-signature case:
     CScript pkSingle; pkSingle << ToByteVector(keys[0].GetPubKey()) << OP_CHECKSIG;
     keystore.AddCScript(pkSingle);
-    scriptPubKey = GetScriptForDestination(CScriptID(pkSingle));
+    scriptPubKey = GetScriptForDestination(ScriptHash(pkSingle));
     SignSignature(keystore, txFrom, txTo, 0, SIGHASH_ALL);
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), SignatureData(scriptSig), empty);
     BOOST_CHECK(combined.scriptSig == scriptSig);

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(GetSigOpCount)
     BOOST_CHECK_EQUAL(s1.GetSigOpCount(true), 3U);
     BOOST_CHECK_EQUAL(s1.GetSigOpCount(false), 21U);
 
-    CScript p2sh = GetScriptForDestination(CScriptID(s1));
+    CScript p2sh = GetScriptForDestination(ScriptHash(s1));
     CScript scriptSig;
     scriptSig << OP_0 << Serialize(s1);
     BOOST_CHECK_EQUAL(p2sh.GetSigOpCount(scriptSig), 3U);
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(GetSigOpCount)
     BOOST_CHECK_EQUAL(s2.GetSigOpCount(true), 3U);
     BOOST_CHECK_EQUAL(s2.GetSigOpCount(false), 20U);
 
-    p2sh = GetScriptForDestination(CScriptID(s2));
+    p2sh = GetScriptForDestination(ScriptHash(s2));
     BOOST_CHECK_EQUAL(p2sh.GetSigOpCount(true), 0U);
     BOOST_CHECK_EQUAL(p2sh.GetSigOpCount(false), 0U);
     CScript scriptSig2;

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -283,9 +283,9 @@ SetupDummyInputs(CBasicKeyStore& keystoreRet, CCoinsViewCache& coinsRet)
 
     dummyTransactions[1].vout.resize(2);
     dummyTransactions[1].vout[0].nValue = 21*CENT;
-    dummyTransactions[1].vout[0].scriptPubKey = GetScriptForDestination(key[2].GetPubKey().GetID());
+    dummyTransactions[1].vout[0].scriptPubKey = GetScriptForDestination(PKHash(key[2].GetPubKey()));
     dummyTransactions[1].vout[1].nValue = 22*CENT;
-    dummyTransactions[1].vout[1].scriptPubKey = GetScriptForDestination(key[3].GetPubKey().GetID());
+    dummyTransactions[1].vout[1].scriptPubKey = GetScriptForDestination(PKHash(key[3].GetPubKey()));
     AddCoins(coinsRet, dummyTransactions[1], 0);
 
     return dummyTransactions;
@@ -325,7 +325,7 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction) {
     key.MakeNewKey(false);
     CBasicKeyStore keystore;
     keystore.AddKeyPubKey(key, key.GetPubKey());
-    CKeyID hash = key.GetPubKey().GetID();
+    PKHash hash(key.GetPubKey());
     CScript scriptPubKey = GetScriptForDestination(hash);
 
     std::vector<int> sigHashes;
@@ -412,7 +412,7 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.vout[0].nValue = 90*CENT;
     CKey key;
     key.MakeNewKey(true);
-    t.vout[0].scriptPubKey = GetScriptForDestination(key.GetPubKey().GetID());
+    t.vout[0].scriptPubKey = GetScriptForDestination(PKHash(key.GetPubKey()));
 
     std::string reason;
     BOOST_CHECK(IsStandardTx(t, 0, reason));

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -487,7 +487,7 @@ UniValue dumpprivkey(const JSONRPCRequest& request)
     if (!pkHash)
         throw JSONRPCError(RPC_TYPE_ERROR, "Address does not refer to a key");
     CKey vchSecret;
-    if (!pwallet->GetKey(CKeyID(*pkHash), vchSecret))
+    if (!pwallet->GetKey(ToKeyID(*pkHash), vchSecret))
         throw JSONRPCError(RPC_WALLET_ERROR, "Private key for address " + strAddress + " is not known");
     return KeyIO::EncodeSecret(vchSecret);
 }
@@ -1146,11 +1146,11 @@ UniValue bip38encrypt(const JSONRPCRequest& request)
     CTxDestination address = DecodeDestination(strAddress);
     if (!IsValidDestination(address))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid PIVX address");
-    const PKHash* keyID = boost::get<PKHash>(&address);
-    if (!keyID)
+    const PKHash* pkhash = boost::get<PKHash>(&address);
+    if (!pkhash)
         throw JSONRPCError(RPC_TYPE_ERROR, "Address does not refer to a key");
     CKey vchSecret;
-    if (!pwallet->GetKey(CKeyID(*keyID), vchSecret))
+    if (!pwallet->GetKey(ToKeyID(*pkhash), vchSecret))
         throw JSONRPCError(RPC_WALLET_ERROR, "Private key for address " + strAddress + " is not known");
 
     uint256 privKey = vchSecret.GetPrivKey_256();

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -18,7 +18,6 @@
 #include "wallet.h"
 #include "validation.h"
 
-#include <secp256k1.h>
 #include <stdint.h>
 
 #include <boost/algorithm/string.hpp>
@@ -187,7 +186,7 @@ static void ImportScript(CWallet* const pwallet, const CScript& script, const st
         throw JSONRPCError(RPC_WALLET_ERROR, "Error adding address to wallet");
 
     if (isRedeemScript) {
-        if (!pwallet->HaveCScript(script) && !pwallet->AddCScript(script))
+        if (!pwallet->HaveCScript(CScriptID(script)) && !pwallet->AddCScript(script))
             throw JSONRPCError(RPC_WALLET_ERROR, "Error adding p2sh redeemScript to wallet");
         ImportAddress(pwallet, ScriptHash(script), strLabel,  "receive");
     }
@@ -736,7 +735,7 @@ static UniValue processImport(CWallet* const pwallet, const UniValue& data, cons
                 throw JSONRPCError(RPC_WALLET_ERROR, "Error adding address to wallet");
             }
 
-            if (!pwallet->HaveCScript(redeemScript) && !pwallet->AddCScript(redeemScript)) {
+            if (!pwallet->HaveCScript(CScriptID(redeemScript)) && !pwallet->AddCScript(redeemScript)) {
                 throw JSONRPCError(RPC_WALLET_ERROR, "Error adding p2sh redeemScript to wallet");
             }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1205,7 +1205,7 @@ static UniValue CreateColdStakeDelegation(CWallet* const pwallet, const UniValue
     PKHash* stakerPkHash = boost::get<PKHash>(&stakeAddr);
     if (!stakerPkHash)
         throw JSONRPCError(RPC_WALLET_ERROR, "Unable to get stake pubkey hash from stakingaddress");
-    CKeyID stakeKey(*stakerPkHash);
+    CKeyID stakeKey(ToKeyID(*stakerPkHash));
 
     // Get Amount
     CAmount nValue = AmountFromValue(params[1]);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -223,7 +223,7 @@ UniValue getaddressinfo(const JSONRPCRequest& request)
         // transparent destination
         const PKHash* pkHash = boost::get<PKHash>(pTransDest);
         if (pkHash) {
-            auto it = pwallet->mapKeyMetadata.find(CKeyID(*pkHash));
+            auto it = pwallet->mapKeyMetadata.find(ToKeyID(*pkHash));
             if(it != pwallet->mapKeyMetadata.end()) {
                 meta = &it->second;
             }
@@ -1234,7 +1234,7 @@ static UniValue CreateColdStakeDelegation(CWallet* const pwallet, const UniValue
         CTxDestination dest = DecodeDestination(params[2].get_str(), isStaking);
         if (!IsValidDestination(dest) || isStaking)
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid PIVX spending address");
-        ownerKey = CKeyID(*boost::get<PKHash>(&dest));
+        ownerKey = ToKeyID(*boost::get<PKHash>(&dest));
         // Check that the owner address belongs to this wallet, or fForceExternalAddr is true
         bool fForceExternalAddr = params.size() > 3 && !params[3].isNull() ? params[3].get_bool() : false;
         if (!fForceExternalAddr && !pwallet->HaveKey(ownerKey)) {
@@ -1250,7 +1250,7 @@ static UniValue CreateColdStakeDelegation(CWallet* const pwallet, const UniValue
         CTxDestination ownerAddr = GetNewAddressFromLabel(pwallet, "delegated", NullUniValue);
         PKHash* pOwnerKey = boost::get<PKHash>(&ownerAddr);
         assert(pOwnerKey);
-        ownerKey = CKeyID(*pOwnerKey);
+        ownerKey = ToKeyID(*pOwnerKey);
         ownerAddressStr = EncodeDestination(ownerAddr);
     }
 
@@ -2022,12 +2022,12 @@ UniValue signmessage(const JSONRPCRequest& request)
     if (!IsValidDestination(dest))
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid address");
 
-    const PKHash* keyID = boost::get<PKHash>(&dest);
-    if (!keyID)
+    const PKHash* pkhash = boost::get<PKHash>(&dest);
+    if (!pkhash)
         throw JSONRPCError(RPC_TYPE_ERROR, "Address does not refer to key");
 
     CKey key;
-    if (!pwallet->GetKey(CKeyID(*keyID), key))
+    if (!pwallet->GetKey(ToKeyID(*pkhash), key))
         throw JSONRPCError(RPC_WALLET_ERROR, "Private key not available");
 
     std::vector<unsigned char> vchSig;

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -275,10 +275,11 @@ void ScriptPubKeyMan::MarkReserveKeysAsUsed(int64_t keypool_id)
         CKeyPool keypool;
         if (batch.ReadPool(index, keypool)) {
             const CKeyID& keyid = keypool.vchPubKey.GetID();
+            PKHash pkHash(keypool.vchPubKey);
             m_pool_key_to_index.erase(keyid);
             // add missing receive addresses to the AddressBook
-            if (!internal && !wallet->HasAddressBook(keyid)) {
-                wallet->SetAddressBook(keyid, "", staking ? AddressBook::AddressBookPurpose::COLD_STAKING
+            if (!internal && !wallet->HasAddressBook(pkHash)) {
+                wallet->SetAddressBook(pkHash, "", staking ? AddressBook::AddressBookPurpose::COLD_STAKING
                                                           : AddressBook::AddressBookPurpose::RECEIVE);
             }
         }

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -630,7 +630,7 @@ BOOST_AUTO_TEST_CASE(cached_balances_tests)
     std::vector<CTxIn> vinDebit = {CTxIn(COutPoint(wtxCredit.GetHash(), 0))};
     CKey key;
     key.MakeNewKey(true);
-    std::vector<CTxOut> voutDebit = {CTxOut(nDebit, GetScriptForDestination(key.GetPubKey().GetID()))};
+    std::vector<CTxOut> voutDebit = {CTxOut(nDebit, GetScriptForDestination(PKHash(key.GetPubKey())))};
     CWalletTx& wtxDebit = BuildAndLoadTxToWallet(vinDebit, voutDebit, wallet);
 
     // Validates (3)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -234,7 +234,7 @@ int64_t CWallet::GetKeyCreationTime(const CTxDestination& address)
     const PKHash* pkhash = boost::get<PKHash>(&address);
     if (pkhash) {
         CPubKey keyRet;
-        if (GetPubKey(CKeyID(*pkhash), keyRet)) {
+        if (GetPubKey(ToKeyID(*pkhash), keyRet)) {
             return GetKeyCreationTime(keyRet);
         }
     }
@@ -786,13 +786,13 @@ bool CWallet::GetVinAndKeysFromOutput(COutput out, CTxIn& txinRet, CPubKey& pubK
     CTxDestination address1;
     ExtractDestination(pubScript, address1, fColdStake);
 
-    const PKHash* keyID = boost::get<PKHash>(&address1);
-    if (!keyID) {
+    const PKHash* pkhash = boost::get<PKHash>(&address1);
+    if (!pkhash) {
         LogPrintf("CWallet::GetVinAndKeysFromOutput -- Address does not refer to a key\n");
         return false;
     }
 
-    if (!GetKey(CKeyID(*keyID), keyRet)) {
+    if (!GetKey(ToKeyID(*pkhash), keyRet)) {
         LogPrintf("CWallet::GetVinAndKeysFromOutput -- Private key for address is not known\n");
         return false;
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -95,17 +95,20 @@ public:
         }
     }
 
-    void operator()(const CKeyID& keyId)
+    void operator()(const PKHash& pkHash)
     {
-        if (keystore.HaveKey(keyId))
-            vKeys.push_back(keyId);
+        CKeyID keyId(pkHash);
+        if (keystore.HaveKey(keyId)) {
+            vKeys.emplace_back(keyId);
+        }
     }
 
-    void operator()(const CScriptID& scriptId)
+    void operator()(const ScriptHash& scriptHash)
     {
         CScript script;
-        if (keystore.GetCScript(scriptId, script))
+        if (keystore.GetCScript(CScriptID(scriptHash), script)) {
             Process(script);
+        }
     }
 
     void operator()(const CNoDestination& none) {}

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -97,7 +97,7 @@ public:
 
     void operator()(const PKHash& pkHash)
     {
-        CKeyID keyId(pkHash);
+        CKeyID keyId{ToKeyID(pkHash)};
         if (keystore.HaveKey(keyId)) {
             vKeys.emplace_back(keyId);
         }


### PR DESCRIPTION
Built of top of #2494. Following up work.

Focused mainly on differentiate the destination elements, hash types (public key hash and script hash), from the wallet lookup keys (`CScriptID` and `CKeyID`). Creating dedicated types: `CScriptID->ScriptHash` and `CKeyID->PKHash`. And disallow the error prone automatic conversion between them.

Adapting:
* #13429
* #15452
* #17938
* #19004
* #19073

This is the last PR before i'm able to port the hash.h interface simplification using Spans, which will fix a good number of compiler warnings.