### PR TITLE
[Snap] Fix nightly build's genbuild.sh patch

### DIFF
--- a/build-aux/snap/local/patches/X003-fix-use-snap-instead-of-dirty.patch
+++ b/build-aux/snap/local/patches/X003-fix-use-snap-instead-of-dirty.patch
@@ -1,25 +1,25 @@
-From ec230421e7107448ca9ac2421eb702924e12a879 Mon Sep 17 00:00:00 2001
-From: observerdev <dev@obsr.org>
-Date: Thu, 11 Apr 2019 00:12:00 +0200
-Subject: [PATCH] fix-use-snap-instead--of-dirty
+From 1110d61bd21b505fcea41bc3869c4dad1450b27e Mon Sep 17 00:00:00 2001
+From: Fuzzbawls <fuzzbawls@gmail.com>
+Date: Fri, 10 Sep 2021 01:46:16 -0700
+Subject: [Patch] Fix genbuild.sh for nightly snap builds
 
+Use "snap" suffix instead of "dirty"
 ---
  share/genbuild.sh | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/share/genbuild.sh b/share/genbuild.sh
-index 519cc6e..de56b8d 100755
+index 38c9ba176c..4088168c0b 100755
 --- a/share/genbuild.sh
 +++ b/share/genbuild.sh
-@@ -37,7 +37,7 @@ if [ "${BITCOIN_GENBUILD_NO_GIT}" != "1" -a -e "$(which git 2>/dev/null)" -a "$(
- 
+@@ -36,7 +36,7 @@ if [ "${BITCOIN_GENBUILD_NO_GIT}" != "1" -a -e "$(which git 2>/dev/null)" -a "$(
+
      # otherwise generate suffix from git, i.e. string like "59887e8-dirty"
      SUFFIX=$(git rev-parse --short HEAD)
 -    git diff-index --quiet HEAD -- || SUFFIX="$SUFFIX-dirty"
 +    git diff-index --quiet HEAD -- || SUFFIX="$SUFFIX-snap"
- 
-     # get a string like "2012-04-10 16:27:19 +0200"
-     LAST_COMMIT_DATE="$(git log -n 1 --format="%ci")"
--- 
-2.17.1
+ fi
 
+ if [ -n "$DESC" ]; then
+--
+2.17.1


### PR DESCRIPTION
#2525 introduced changes to the genbuild.sh script, which gets patched
during the nightly snap builds. This follows up #2525 to create a new,
compatible patch.