### PR TITLE
[Validation] Restore pre-v5.3 guard for under-minting blocks rule

### DIFF
--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -224,7 +224,11 @@ bool IsBlockValueValid(int nHeight, CAmount& nExpectedValue, CAmount nMinted, CA
         }
     }
 
-    return nMinted >= 0 && nMinted <= nExpectedValue;
+    if (nMinted < 0 && consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V5_3)) {
+        return false;
+    }
+
+    return nMinted <= nExpectedValue;
 }
 
 bool IsBlockPayeeValid(const CBlock& block, const CBlockIndex* pindexPrev)
@@ -328,7 +332,6 @@ bool CMasternodePayments::GetLegacyMasternodeTxOut(int nHeight, std::vector<CTxO
     CScript payee;
     if (!GetBlockPayee(nHeight, payee)) {
         //no masternode detected
-        const Consensus::Params& consensus = Params().GetConsensus();
         const uint256& hash = mnodeman.GetHashAtHeight(nHeight - 1);
         MasternodeRef winningNode = mnodeman.GetCurrentMasterNode(hash);
         if (winningNode) {

--- a/src/test/budget_tests.cpp
+++ b/src/test/budget_tests.cpp
@@ -61,9 +61,6 @@ BOOST_FIXTURE_TEST_CASE(block_value, TestnetSetup)
     CAmount nExpectedRet = nBlockReward;
     CAmount nBudgetAmtRet = 0;
 
-    // under-minting
-    BOOST_CHECK(!IsBlockValueValid(nHeight, nExpectedRet, -1, nBudgetAmtRet));
-
     // regular block
     BOOST_CHECK(IsBlockValueValid(nHeight, nExpectedRet, 0, nBudgetAmtRet));
     BOOST_CHECK(IsBlockValueValid(nHeight, nExpectedRet, nBlockReward-1, nBudgetAmtRet));
@@ -130,6 +127,17 @@ BOOST_FIXTURE_TEST_CASE(block_value, TestnetSetup)
     BOOST_CHECK(!IsBlockValueValid(nHeight, nExpectedRet, nBlockReward+propAmt+1, nBudgetAmtRet));
     BOOST_CHECK_EQUAL(nExpectedRet, nBlockReward);
     BOOST_CHECK_EQUAL(nBudgetAmtRet, 0);
+}
+
+BOOST_FIXTURE_TEST_CASE(block_value_undermint, RegTestingSetup)
+{
+    int nHeight = 100;
+    CAmount nExpectedRet = GetBlockValue(nHeight);
+    CAmount nBudgetAmtRet = 0;
+    // under-minting blocks are invalid after v5.3
+    BOOST_CHECK(IsBlockValueValid(nHeight, nExpectedRet, -1, nBudgetAmtRet));
+    UpdateNetworkUpgradeParameters(Consensus::UPGRADE_V5_3, Consensus::NetworkUpgrade::ALWAYS_ACTIVE);
+    BOOST_CHECK(!IsBlockValueValid(nHeight, nExpectedRet, -1, nBudgetAmtRet));
 }
 
 /**


### PR DESCRIPTION
This was removed in #2549 but we need to restore it, as there are blocks in the past violating this rule.