### PR TITLE
[TierTwo] Unify MNs info gathering into a single getMNsInfo() call

### DIFF
--- a/src/blockassembler.cpp
+++ b/src/blockassembler.cpp
@@ -39,17 +39,6 @@
 uint64_t nLastBlockTx = 0;
 uint64_t nLastBlockSize = 0;
 
-class ScoreCompare
-{
-public:
-    ScoreCompare() {}
-
-    bool operator()(const CTxMemPool::txiter a, const CTxMemPool::txiter b)
-    {
-        return CompareTxMemPoolEntryByScore()(*b,*a); // Convert to less than
-    }
-};
-
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)
 {
     int64_t nOldTime = pblock->nTime;

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -159,8 +159,22 @@ public:
     // Process GETMNLIST message, returning the banning score (if 0, no ban score increase is needed)
     int ProcessGetMNList(CNode* pfrom, CTxIn& vin);
 
-    /// Return the number of Masternodes older than (default) 8000 seconds
-    int stable_size() const;
+    struct MNsInfo {
+        // All the known MNs
+        int total;
+        // enabled MNs eligible for payments. Older than 8000 seconds.
+        int stableSize{0};
+        // MNs enabled.
+        int enabledSize{0};
+
+        // Networks
+        int ipv4{0};
+        int ipv6{0};
+        int onion{0};
+    };
+
+    // Return an overall status of the MNs list
+    CMasternodeMan::MNsInfo getMNsInfo() const;
 
     std::string ToString() const;
 

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -149,16 +149,6 @@ bool CTransaction::HasZerocoinMintOutputs() const
     return false;
 }
 
-bool CTransaction::HasZerocoinPublicSpendInputs() const
-{
-    // The wallet only allows publicSpend inputs in the same tx and not a combination between piv and zpiv
-    for(const CTxIn& txin : vin) {
-        if (txin.IsZerocoinPublicSpend())
-            return true;
-    }
-    return false;
-}
-
 bool CTransaction::IsCoinStake() const
 {
     if (vin.empty())
@@ -183,15 +173,15 @@ bool CTransaction::HasP2CSOutputs() const
 CAmount CTransaction::GetValueOut() const
 {
     CAmount nValueOut = 0;
-    for (std::vector<CTxOut>::const_iterator it(vout.begin()); it != vout.end(); ++it) {
+    for (const CTxOut& out : vout) {
         // PIVX: previously MoneyRange() was called here. This has been replaced with negative check and boundary wrap check.
-        if (it->nValue < 0)
+        if (out.nValue < 0)
             throw std::runtime_error("CTransaction::GetValueOut() : value out of range : less than 0");
 
-        if ((nValueOut + it->nValue) < nValueOut)
+        if (nValueOut + out.nValue < nValueOut)
             throw std::runtime_error("CTransaction::GetValueOut() : value out of range : wraps the int64_t boundary");
 
-        nValueOut += it->nValue;
+        nValueOut += out.nValue;
     }
 
     // Sapling
@@ -246,9 +236,9 @@ std::string CTransaction::ToString() const
         ss << ", extraPayload.size=" << extraPayload->size();
     }
     ss << ")\n";
-    for (unsigned int i = 0; i < vin.size(); i++)
-        ss << "    " << vin[i].ToString() << "\n";
-    for (unsigned int i = 0; i < vout.size(); i++)
-        ss << "    " << vout[i].ToString() << "\n";
+    for (const auto& in : vin)
+        ss << "    " << in.ToString() << "\n";
+    for (const auto& out : vout)
+        ss << "    " << out.ToString() << "\n";
     return ss.str();
 }

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -359,7 +359,6 @@ public:
     CAmount GetShieldedValueIn() const;
 
     bool HasZerocoinSpendInputs() const;
-    bool HasZerocoinPublicSpendInputs() const;
 
     bool HasZerocoinMintOutputs() const;
 

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -275,21 +275,19 @@ UniValue getmasternodecount (const JSONRPCRequest& request)
 
     UniValue obj(UniValue::VOBJ);
     int nCount = 0;
-    int ipv4 = 0, ipv6 = 0, onion = 0;
-
     const CBlockIndex* pChainTip = GetChainTip();
     if (!pChainTip) return "unknown";
 
     mnodeman.GetNextMasternodeInQueueForPayment(pChainTip->nHeight, true, nCount, pChainTip);
-    int total = mnodeman.CountNetworks(ipv4, ipv6, onion);
+    auto infoMNs = mnodeman.getMNsInfo();
 
-    obj.pushKV("total", total);
-    obj.pushKV("stable", mnodeman.stable_size());
-    obj.pushKV("enabled", mnodeman.CountEnabled());
+    obj.pushKV("total", infoMNs.total);
+    obj.pushKV("stable", infoMNs.stableSize);
+    obj.pushKV("enabled", infoMNs.enabledSize);
     obj.pushKV("inqueue", nCount);
-    obj.pushKV("ipv4", ipv4);
-    obj.pushKV("ipv6", ipv6);
-    obj.pushKV("onion", onion);
+    obj.pushKV("ipv4", infoMNs.ipv4);
+    obj.pushKV("ipv6", infoMNs.ipv6);
+    obj.pushKV("onion", infoMNs.onion);
 
     return obj;
 }


### PR DESCRIPTION
This simplifies the 'getmasternodecount' workflow that was walking through the 'mapMasternodes' 3 times locking the manager mutex when it can gather the information looping over it just once.

Plus, added a second commit cleaning the `HasZerocoinPublicSpendInputs` unused function and `ScoreCompare` unused class.