### PR TITLE
[GUI] Fix not visible contacts list for shield/CS addrs

### DIFF
--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -298,8 +298,9 @@ public:
     int sizeSend() { return sendNum; }
     int sizeRecv() { return recvNum; }
     int sizeDell() { return dellNum; }
-    int SizeColdSend() { return coldSendNum; }
+    int sizeColdSend() { return coldSendNum; }
     int sizeShieldedSend() { return shieldedSendNum; }
+    int sizeSendAll() { return sizeSend() + sizeColdSend() + sizeShieldedSend(); }
 
     AddressTableEntry* index(int idx)
     {
@@ -338,8 +339,9 @@ int AddressTableModel::columnCount(const QModelIndex& parent) const
 int AddressTableModel::sizeSend() const { return priv->sizeSend(); }
 int AddressTableModel::sizeRecv() const { return priv->sizeRecv(); }
 int AddressTableModel::sizeDell() const { return priv->sizeDell(); }
-int AddressTableModel::sizeColdSend() const { return priv->SizeColdSend(); }
+int AddressTableModel::sizeColdSend() const { return priv->sizeColdSend(); }
 int AddressTableModel::sizeShieldedSend() const { return priv->sizeShieldedSend(); }
+int AddressTableModel::sizeSendAll() const { return priv->sizeSendAll(); }
 
 QVariant AddressTableModel::data(const QModelIndex& index, int role) const
 {

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -65,6 +65,7 @@ public:
     int sizeDell() const;
     int sizeColdSend() const;
     int sizeShieldedSend() const;
+    int sizeSendAll() const;
     void notifyChange(const QModelIndex &index);
     QVariant data(const QModelIndex& index, int role) const;
     bool setData(const QModelIndex& index, const QVariant& value, int role);

--- a/src/qt/pivx/addresseswidget.cpp
+++ b/src/qt/pivx/addresseswidget.cpp
@@ -4,8 +4,8 @@
 
 #include "qt/pivx/addresseswidget.h"
 #include "qt/pivx/forms/ui_addresseswidget.h"
+#include "qt/pivx/addressfilterproxymodel.h"
 #include "qt/pivx/addresslabelrow.h"
-#include "qt/pivx/addnewaddressdialog.h"
 #include "qt/pivx/tooltipmenu.h"
 
 #include "qt/pivx/addnewcontactdialog.h"
@@ -23,11 +23,10 @@
 class ContactsHolder : public FurListRow<QWidget*>
 {
 public:
-    ContactsHolder();
-
     explicit ContactsHolder(bool _isLightTheme) : FurListRow(), isLightTheme(_isLightTheme){}
 
-    AddressLabelRow* createHolder(int pos) override{
+    AddressLabelRow* createHolder(int pos) override
+    {
         if (!cachedRow) cachedRow = new AddressLabelRow();
         cachedRow->init(isLightTheme, false);
         return cachedRow;
@@ -35,7 +34,7 @@ public:
 
     void init(QWidget* holder,const QModelIndex &index, bool isHovered, bool isSelected) const override
     {
-        AddressLabelRow* row = static_cast<AddressLabelRow*>(holder);
+        AddressLabelRow* row = dynamic_cast<AddressLabelRow*>(holder);
 
         row->updateState(isLightTheme, isHovered, isSelected);
 
@@ -133,15 +132,15 @@ AddressesWidget::AddressesWidget(PIVXGUI* parent) :
     connect(ui->btnAddContact, &OptionButton::clicked, this, &AddressesWidget::onAddContactShowHideClicked);
 }
 
-void AddressesWidget::handleAddressClicked(const QModelIndex &index)
+void AddressesWidget::handleAddressClicked(const QModelIndex& _index)
 {
-    ui->listAddresses->setCurrentIndex(index);
-    QRect rect = ui->listAddresses->visualRect(index);
+    ui->listAddresses->setCurrentIndex(_index);
+    QRect rect = ui->listAddresses->visualRect(_index);
     QPoint pos = rect.topRight();
     pos.setX(pos.x() - (DECORATION_SIZE * 2));
     pos.setY(pos.y() + (DECORATION_SIZE));
 
-    QModelIndex rIndex = filter->mapToSource(index);
+    QModelIndex rIndex = filter->mapToSource(_index);
 
     if (!this->menu) {
         this->menu = new TooltipMenu(window, this);
@@ -152,7 +151,7 @@ void AddressesWidget::handleAddressClicked(const QModelIndex &index)
     } else {
         this->menu->hide();
     }
-    this->index = rIndex;
+    index = rIndex;
     menu->move(pos);
     menu->show();
 }
@@ -250,8 +249,9 @@ void AddressesWidget::onEditClicked()
 void AddressesWidget::onDeleteClicked()
 {
     if (walletModel) {
-        if (ask(tr("Delete Contact"), tr("You are just about to remove the contact:\n\n%1\n\nAre you sure?").arg(index.data(Qt::DisplayRole).toString().toUtf8().constData()))
-        ) {
+        if (ask(tr("Delete Contact"),
+                tr("You are just about to remove the contact:\n\n%1\n\nAre you sure?")
+                .arg(index.data(Qt::DisplayRole).toString().toUtf8().constData()))) {
             if (this->walletModel->getAddressTableModel()->removeRows(index.row(), 1, index)) {
                 updateListView();
                 inform(tr("Contact Deleted"));
@@ -299,7 +299,7 @@ void AddressesWidget::sortAddresses()
 
 void AddressesWidget::changeTheme(bool isLightTheme, QString& theme)
 {
-    static_cast<ContactsHolder*>(this->delegate->getRowFactory())->isLightTheme = isLightTheme;
+    dynamic_cast<ContactsHolder*>(this->delegate->getRowFactory())->isLightTheme = isLightTheme;
 }
 
 AddressesWidget::~AddressesWidget()

--- a/src/qt/pivx/addresseswidget.cpp
+++ b/src/qt/pivx/addresseswidget.cpp
@@ -175,7 +175,7 @@ void AddressesWidget::loadWalletModel()
 
 void AddressesWidget::updateListView()
 {
-    bool empty = addressTablemodel->sizeSend() == 0;
+    bool empty = addressTablemodel->sizeSendAll() == 0;
     ui->emptyContainer->setVisible(empty);
     ui->listAddresses->setVisible(!empty);
 }

--- a/src/qt/pivx/addresseswidget.h
+++ b/src/qt/pivx/addresseswidget.h
@@ -7,13 +7,11 @@
 
 #include "qt/pivx/pwidget.h"
 #include "addresstablemodel.h"
-#include "qt/pivx/tooltipmenu.h"
 #include "furabstractlistitemdelegate.h"
-#include "qt/pivx/addressfilterproxymodel.h"
 
 #include <QWidget>
 
-class AddressViewDelegate;
+class AddressFilterProxyModel;
 class TooltipMenu;
 class PIVXGUI;
 class WalletModel;
@@ -35,7 +33,6 @@ public:
     ~AddressesWidget();
 
     void loadWalletModel() override;
-    void onNewContactClicked();
 
 private Q_SLOTS:
     void handleAddressClicked(const QModelIndex &index);
@@ -55,7 +52,6 @@ private:
     AddressTableModel* addressTablemodel = nullptr;
     AddressFilterProxyModel *filter = nullptr;
 
-    bool isOnMyAddresses = true;
     TooltipMenu* menu = nullptr;
 
     // Cached index

--- a/src/qt/pivx/addressfilterproxymodel.cpp
+++ b/src/qt/pivx/addressfilterproxymodel.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "qt/pivx/addressfilterproxymodel.h"
-#include <iostream>
+#include "qt/addresstablemodel.h"
 
 bool AddressFilterProxyModel::filterAcceptsRow(int row, const QModelIndex& parent) const
 {

--- a/src/qt/pivx/addressfilterproxymodel.h
+++ b/src/qt/pivx/addressfilterproxymodel.h
@@ -6,8 +6,6 @@
 #define PIVX_CORE_NEW_GUI_ADDRESSFILTERPROXYMODEL_H
 
 #include <QSortFilterProxyModel>
-#include "addresstablemodel.h"
-
 
 class AddressFilterProxyModel final : public QSortFilterProxyModel
 {

--- a/src/qt/pivx/addresslabelrow.cpp
+++ b/src/qt/pivx/addresslabelrow.cpp
@@ -19,7 +19,7 @@ void AddressLabelRow::init(bool isLightTheme, bool isHover)
     updateState(isLightTheme, isHover, false);
 }
 
-void AddressLabelRow::updateView(QString address, QString label)
+void AddressLabelRow::updateView(const QString& address, const QString& label)
 {
     ui->lblAddress->setText(address);
     ui->lblLabel->setText(label);

--- a/src/qt/pivx/addresslabelrow.h
+++ b/src/qt/pivx/addresslabelrow.h
@@ -22,7 +22,7 @@ public:
     void init(bool isLightTheme, bool isHover);
 
     void updateState(bool isLightTheme, bool isHovered, bool isSelected);
-    void updateView(QString address, QString label);
+    void updateView(const QString& address, const QString& label);
 protected:
     virtual void enterEvent(QEvent *);
     virtual void leaveEvent(QEvent *);

--- a/src/qt/pivx/myaddressrow.cpp
+++ b/src/qt/pivx/myaddressrow.cpp
@@ -15,7 +15,7 @@ MyAddressRow::MyAddressRow(QWidget *parent) :
     ui->labelDate->setProperty("cssClass", "text-list-caption");
 }
 
-void MyAddressRow::updateView(QString address, QString label, QString date){
+void MyAddressRow::updateView(const QString& address, const QString& label, const QString& date){
     ui->labelName->setText(label);
     ui->labelAddress->setText(address);
     if (date.isEmpty()){

--- a/src/qt/pivx/myaddressrow.h
+++ b/src/qt/pivx/myaddressrow.h
@@ -19,7 +19,7 @@ public:
     explicit MyAddressRow(QWidget *parent = nullptr);
     ~MyAddressRow();
 
-    void updateView(QString address, QString label, QString date);
+    void updateView(const QString& address, const QString& label, const QString& date);
 
 private:
     Ui::MyAddressRow *ui;

--- a/src/qt/pivx/receivedialog.cpp
+++ b/src/qt/pivx/receivedialog.cpp
@@ -5,8 +5,9 @@
 #include "qt/pivx/receivedialog.h"
 #include "qt/pivx/forms/ui_receivedialog.h"
 #include "qt/pivx/qtutils.h"
-#include "walletmodel.h"
-#include <QFile>
+#include "qt/walletmodel.h"
+
+#include <QPixmap>
 
 ReceiveDialog::ReceiveDialog(QWidget *parent) :
     FocusedDialog(parent),
@@ -45,7 +46,7 @@ ReceiveDialog::ReceiveDialog(QWidget *parent) :
     connect(ui->btnSave, &QPushButton::clicked, this, &ReceiveDialog::onCopy);
 }
 
-void ReceiveDialog::updateQr(QString address)
+void ReceiveDialog::updateQr(const QString& address)
 {
     if (!info) info = new SendCoinsRecipient();
     info->address = address;
@@ -55,8 +56,7 @@ void ReceiveDialog::updateQr(QString address)
     QString error;
     QPixmap pixmap = encodeToQr(uri, error);
     if (!pixmap.isNull()) {
-        qrImage = &pixmap;
-        ui->labelQrImg->setPixmap(qrImage->scaled(ui->labelQrImg->width(), ui->labelQrImg->height()));
+        ui->labelQrImg->setPixmap(pixmap.scaled(ui->labelQrImg->width(), ui->labelQrImg->height()));
     } else {
         ui->labelQrImg->setText(!error.isEmpty() ? error : "Error encoding address");
     }

--- a/src/qt/pivx/receivedialog.h
+++ b/src/qt/pivx/receivedialog.h
@@ -6,7 +6,6 @@
 #define RECEIVEDIALOG_H
 
 #include "qt/pivx/focuseddialog.h"
-#include <QPixmap>
 
 class SendCoinsRecipient;
 
@@ -22,13 +21,12 @@ public:
     explicit ReceiveDialog(QWidget *parent = nullptr);
     ~ReceiveDialog();
 
-    void updateQr(QString address);
+    void updateQr(const QString& address);
 
 private Q_SLOTS:
     void onCopy();
 private:
     Ui::ReceiveDialog *ui{nullptr};
-    QPixmap *qrImage{nullptr};
     SendCoinsRecipient *info{nullptr};
 };
 

--- a/src/qt/pivx/receivewidget.cpp
+++ b/src/qt/pivx/receivewidget.cpp
@@ -8,7 +8,6 @@
 #include "qt/pivx/addnewcontactdialog.h"
 #include "qt/pivx/qtutils.h"
 #include "qt/pivx/myaddressrow.h"
-#include "qt/pivx/furlistrow.h"
 #include "qt/pivx/addressholder.h"
 #include "walletmodel.h"
 #include "guiutil.h"
@@ -145,11 +144,10 @@ void ReceiveWidget::refreshView(const QModelIndex& tl, const QModelIndex& br)
     return refreshView(index.data(Qt::DisplayRole).toString());
 }
 
-void ReceiveWidget::refreshView(QString refreshAddress)
+void ReceiveWidget::refreshView(const QString& refreshAddress)
 {
     try {
-        QString latestAddress = (refreshAddress.isEmpty()) ? this->addressTableModel->getAddressToShow(shieldedMode) : refreshAddress;
-
+        const QString& latestAddress = (refreshAddress.isEmpty()) ? addressTableModel->getAddressToShow(shieldedMode) : refreshAddress;
         if (latestAddress.isEmpty()) {
             // Check for generation errors
             ui->labelQrImg->setText(tr("No available address\ntry unlocking the wallet"));
@@ -189,7 +187,7 @@ void ReceiveWidget::updateLabel()
     }
 }
 
-void ReceiveWidget::updateQr(QString& address)
+void ReceiveWidget::updateQr(const QString& address)
 {
     info->address = address;
     QString uri = GUIUtil::formatBitcoinURI(*info);
@@ -199,8 +197,7 @@ void ReceiveWidget::updateQr(QString& address)
     QColor qrColor("#382d4d");
     QPixmap pixmap = encodeToQr(uri, error, qrColor);
     if (!pixmap.isNull()) {
-        qrImage = &pixmap;
-        ui->labelQrImg->setPixmap(qrImage->scaled(ui->labelQrImg->width(), ui->labelQrImg->height()));
+        ui->labelQrImg->setPixmap(pixmap.scaled(ui->labelQrImg->width(), ui->labelQrImg->height()));
     } else {
         ui->labelQrImg->setText(!error.isEmpty() ? error : "Error encoding address");
     }
@@ -236,6 +233,7 @@ void ReceiveWidget::onLabelClicked()
                 inform(tr("Error storing address label"));
             }
         }
+        dialog->deleteLater();
         isShowingDialog = false;
     }
 }

--- a/src/qt/pivx/receivewidget.h
+++ b/src/qt/pivx/receivewidget.h
@@ -45,7 +45,7 @@ private Q_SLOTS:
     void onLabelClicked();
     void onCopyClicked();
     void refreshView(const QModelIndex& tl, const QModelIndex& br);
-    void refreshView(QString refreshAddress = QString());
+    void refreshView(const QString& refreshAddress = QString());
     void handleAddressClicked(const QModelIndex &index);
     void onSortChanged(int idx);
     void onSortOrderChanged(int idx);
@@ -62,14 +62,12 @@ private:
 
     // Cached last address
     SendCoinsRecipient *info{nullptr};
-    // Cached qr
-    QPixmap *qrImage{nullptr};
 
     // Cached sort type and order
     AddressTableModel::ColumnIndex sortType = AddressTableModel::Label;
     Qt::SortOrder sortOrder = Qt::AscendingOrder;
 
-    void updateQr(QString& address);
+    void updateQr(const QString& address);
     void updateLabel();
     void showAddressGenerationDialog(bool isPaymentRequest);
     void sortAddresses();

--- a/src/qt/pivx/requestdialog.cpp
+++ b/src/qt/pivx/requestdialog.cpp
@@ -162,21 +162,20 @@ void RequestDialog::showEvent(QShowEvent *event)
     if (ui->lineEditAmount) ui->lineEditAmount->setFocus();
 }
 
-void RequestDialog::updateQr(QString str)
+void RequestDialog::updateQr(const QString& str)
 {
     QString uri = GUIUtil::formatBitcoinURI(*info);
     ui->labelQrImg->setText("");
     QString error;
     QPixmap pixmap = encodeToQr(uri, error);
     if (!pixmap.isNull()) {
-        qrImage = &pixmap;
-        ui->labelQrImg->setPixmap(qrImage->scaled(ui->labelQrImg->width(), ui->labelQrImg->height()));
+        ui->labelQrImg->setPixmap(pixmap.scaled(ui->labelQrImg->width(), ui->labelQrImg->height()));
     } else {
         ui->labelQrImg->setText(!error.isEmpty() ? error : "Error encoding address");
     }
 }
 
-void RequestDialog::inform(QString text)
+void RequestDialog::inform(const QString& text)
 {
     if (!snackBar)
         snackBar = new SnackBar(nullptr, this);

--- a/src/qt/pivx/requestdialog.h
+++ b/src/qt/pivx/requestdialog.h
@@ -45,10 +45,8 @@ private:
     // Cached last address
     SendCoinsRecipient *info{nullptr};
 
-    QPixmap *qrImage{nullptr};
-
-    void updateQr(QString str);
-    void inform(QString text);
+    void updateQr(const QString& str);
+    void inform(const QString& text);
 };
 
 #endif // REQUESTDIALOG_H


### PR DESCRIPTION
As the addresses widget only takes into account the transparent addr contacts size in the list visibility update, the view is not presented if the wallet only has shield and/or cold staking addr contacts stored.

The first commit is the bug fix, the others are purely code cleanups that made while was digging over the bug cause.