### PR TITLE
[Refactor] Remove code duplication in sign/verify message rpc/gui

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -11,13 +11,13 @@
 #include "key_io.h"
 #include "sapling/key_io_sapling.h"
 #include "masternode-sync.h"
+#include "messagesigner.h"
 #include "net.h"
 #include "netbase.h"
 #include "rpc/server.h"
 #include "spork.h"
 #include "timedata.h"
 #include "util/system.h"
-#include "util/validation.h"
 #ifdef ENABLE_WALLET
 #include "wallet/rpcwallet.h"
 #include "wallet/wallet.h"
@@ -590,15 +590,8 @@ UniValue verifymessage(const JSONRPCRequest& request)
     if (fInvalid)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Malformed base64 encoding");
 
-    CHashWriter ss(SER_GETHASH, 0);
-    ss << strMessageMagic;
-    ss << strMessage;
-
-    CPubKey pubkey;
-    if (!pubkey.RecoverCompact(ss.GetHash(), vchSig))
-        return false;
-
-    return (pubkey.GetID() == *keyID);
+    std::string strError;
+    return CMessageSigner::VerifyMessage(*keyID, vchSig, strMessage, strError);
 }
 
 UniValue setmocktime(const JSONRPCRequest& request)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -15,6 +15,7 @@
 #include "httpserver.h"
 #include "key_io.h"
 #include "masternode-sync.h"
+#include "messagesigner.h"
 #include "net.h"
 #include "policy/feerate.h"
 #include "rpc/server.h"
@@ -23,7 +24,6 @@
 #include "spork.h"
 #include "timedata.h"
 #include "utilmoneystr.h"
-#include "util/validation.h"
 #include "wallet/wallet.h"
 #include "wallet/walletdb.h"
 #include "wallet/walletutil.h"
@@ -2019,13 +2019,10 @@ UniValue signmessage(const JSONRPCRequest& request)
     if (!pwallet->GetKey(*keyID, key))
         throw JSONRPCError(RPC_WALLET_ERROR, "Private key not available");
 
-    CHashWriter ss(SER_GETHASH, 0);
-    ss << strMessageMagic;
-    ss << strMessage;
-
     std::vector<unsigned char> vchSig;
-    if (!key.SignCompact(ss.GetHash(), vchSig))
+    if (!CMessageSigner::SignMessage(strMessage, vchSig, key)) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Sign failed");
+    }
 
     return EncodeBase64(vchSig);
 }


### PR DESCRIPTION
Simple refactoring commit to remove some code duplication. No functional changes.

note: 
currently this PR includes
- [x] #2548 

for easier rebase later: as here we replace the `util/validation.h` header include (introduced in #2548) with `messagesigner.h`, where `strMessageMagic` was accessed directly.