### PR TITLE
[Trivial] Update labelSubtitleAddress text in send widget ui

### DIFF
--- a/src/qt/pivx/forms/send.ui
+++ b/src/qt/pivx/forms/send.ui
@@ -255,7 +255,7 @@ padding-top:2px;
              <string notr="true">margin-left:8px;</string>
             </property>
             <property name="text">
-             <string>PIVX address or contact label</string>
+             <string>Recipient address</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Replaces #2238, which is abandoned. 
Closes #1637.