### PR TITLE
[BUG][TierTwo] Clear fulfilled requests when mnsync fails

### DIFF
--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -185,11 +185,13 @@ int CMasternodeSync::GetNextAsset(int currentAsset)
 
 void CMasternodeSync::SwitchToNextAsset()
 {
+    if (RequestedMasternodeAssets == MASTERNODE_SYNC_INITIAL ||
+            RequestedMasternodeAssets == MASTERNODE_SYNC_FAILED) {
+        ClearFulfilledRequest();
+    }
     const int nextAsset = GetNextAsset(RequestedMasternodeAssets);
     if (nextAsset == MASTERNODE_SYNC_FINISHED) {
         LogPrintf("%s - Sync has finished\n", __func__);
-    } else if (nextAsset == MASTERNODE_SYNC_FAILED) {
-        ClearFulfilledRequest();
     }
     RequestedMasternodeAssets = nextAsset;
     RequestedMasternodeAttempt = 0;


### PR DESCRIPTION
the current asset should be checked, not the "next" one.
Introduced in 8b10fc22c292604bdbb8cc8e7a757eed4120d431