### PR TITLE
[BUG] Consider also DMNs in CountEnabled and CountNetworks

### DIFF
--- a/src/budget/budgetmanager.cpp
+++ b/src/budget/budgetmanager.cpp
@@ -821,7 +821,7 @@ void CBudgetManager::RemoveStaleVotesOnProposal(CBudgetProposal* prop)
         auto mnList = deterministicMNManager->GetListAtChainTip();
         auto dmn = mnList.GetMNByCollateral(it->first);
         if (dmn) {
-            (*it).second.SetValid(mnList.IsMNValid(dmn));
+            (*it).second.SetValid(!dmn->IsPoSeBanned());
         } else {
             // -- Legacy System (!TODO: remove after enforcement) --
             CMasternode* pmn = mnodeman.Find(it->first);
@@ -845,7 +845,7 @@ void CBudgetManager::RemoveStaleVotesOnFinalBudget(CFinalizedBudget* fbud)
         auto mnList = deterministicMNManager->GetListAtChainTip();
         auto dmn = mnList.GetMNByCollateral(it->first);
         if (dmn) {
-            (*it).second.SetValid(mnList.IsMNValid(dmn));
+            (*it).second.SetValid(!dmn->IsPoSeBanned());
         } else {
             // -- Legacy System (!TODO: remove after enforcement) --
             CMasternode* pmn = mnodeman.Find(it->first);
@@ -1020,7 +1020,7 @@ bool CBudgetManager::ProcessProposalVote(CBudgetVote& vote, CNode* pfrom, CValid
 
         AddSeenProposalVote(vote);
 
-        if (!mnList.IsMNValid(dmn)) {
+        if (dmn->IsPoSeBanned()) {
             err = strprintf("masternode (%s) not valid or PoSe banned", mn_protx_id);
             return state.DoS(0, false, REJECT_INVALID, "bad-mvote", false, err);
         }
@@ -1116,7 +1116,7 @@ bool CBudgetManager::ProcessFinalizedBudgetVote(CFinalizedBudgetVote& vote, CNod
 
         AddSeenFinalizedBudgetVote(vote);
 
-        if (!mnList.IsMNValid(dmn)) {
+        if (dmn->IsPoSeBanned()) {
             err = strprintf("masternode (%s) not valid or PoSe banned", mn_protx_id);
             return state.DoS(0, false, REJECT_INVALID, "bad-fbvote", false, err);
         }

--- a/src/budget/budgetmanager.cpp
+++ b/src/budget/budgetmanager.cpp
@@ -619,7 +619,7 @@ bool CBudgetManager::GetFinalizedBudget(const uint256& nHash, CFinalizedBudget& 
 bool CBudgetManager::IsBudgetPaymentBlock(int nBlockHeight, int& nCountThreshold) const
 {
     int nHighestCount = GetHighestVoteCount(nBlockHeight);
-    int nCountEnabled = mnodeman.CountEnabled(ActiveProtocol());
+    int nCountEnabled = mnodeman.CountEnabled();
     int nFivePercent = nCountEnabled / 20;
     // threshold for highest finalized budgets (highest vote count - 10% of active masternodes)
     nCountThreshold = nHighestCount - (nCountEnabled / 10);
@@ -712,7 +712,7 @@ std::vector<CBudgetProposal> CBudgetManager::GetBudget()
     const int nBlocksPerCycle = Params().GetConsensus().nBudgetCycleBlocks;
     int nBlockStart = nHeight - nHeight % nBlocksPerCycle + nBlocksPerCycle;
     int nBlockEnd = nBlockStart + nBlocksPerCycle - 1;
-    int mnCount = mnodeman.CountEnabled(ActiveProtocol());
+    int mnCount = mnodeman.CountEnabled();
     CAmount nTotalBudget = GetTotalBudget(nBlockStart);
 
     for (CBudgetProposal* pbudgetProposal: vBudgetPorposalsSort) {
@@ -736,7 +736,7 @@ std::vector<CBudgetProposal> CBudgetManager::GetBudget()
         } else {
             LogPrint(BCLog::MNBUDGET,"%s:  -   Check 1 failed: valid=%d | %ld <= %ld | %ld >= %ld | Yeas=%d Nays=%d Count=%d | established=%d\n",
                     __func__, pbudgetProposal->IsValid(), pbudgetProposal->GetBlockStart(), nBlockStart, pbudgetProposal->GetBlockEnd(),
-                    nBlockEnd, pbudgetProposal->GetYeas(), pbudgetProposal->GetNays(), mnodeman.CountEnabled(ActiveProtocol()) / 10,
+                    nBlockEnd, pbudgetProposal->GetYeas(), pbudgetProposal->GetNays(), mnodeman.CountEnabled() / 10,
                     pbudgetProposal->IsEstablished());
         }
 

--- a/src/budget/budgetmanager.h
+++ b/src/budget/budgetmanager.h
@@ -137,6 +137,8 @@ public:
     // Only initialized masternodes: sign and submit votes on valid finalized budgets
     void VoteOnFinalizedBudgets();
 
+    int CountProposals() { LOCK(cs_proposals); return mapProposals.size(); }
+
     void CheckOrphanVotes();
     void Clear()
     {

--- a/src/budget/budgetproposal.cpp
+++ b/src/budget/budgetproposal.cpp
@@ -79,7 +79,7 @@ void CBudgetProposal::SyncVotes(CNode* pfrom, bool fPartial, int& nInvCount) con
 
 bool CBudgetProposal::IsHeavilyDownvoted(bool fNewRules)
 {
-    if (GetNays() - GetYeas() > (fNewRules ? 3 : 1) * mnodeman.CountEnabled(ActiveProtocol()) / 10) {
+    if (GetNays() - GetYeas() > (fNewRules ? 3 : 1) * mnodeman.CountEnabled() / 10) {
         strInvalid = "Heavily Downvoted";
         return true;
     }

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -105,36 +105,6 @@ void CDeterministicMN::ToJson(UniValue& obj) const
     obj.pushKV("dmnstate", stateObj);
 }
 
-bool CDeterministicMNList::IsMNValid(const uint256& proTxHash) const
-{
-    auto p = mnMap.find(proTxHash);
-    if (p == nullptr) {
-        return false;
-    }
-    return IsMNValid(*p);
-}
-
-bool CDeterministicMNList::IsMNPoSeBanned(const uint256& proTxHash) const
-{
-    auto p = mnMap.find(proTxHash);
-    if (p == nullptr) {
-        return false;
-    }
-    return IsMNPoSeBanned(*p);
-}
-
-bool CDeterministicMNList::IsMNValid(const CDeterministicMNCPtr& dmn) const
-{
-    return !IsMNPoSeBanned(dmn);
-}
-
-bool CDeterministicMNList::IsMNPoSeBanned(const CDeterministicMNCPtr& dmn) const
-{
-    assert(dmn);
-    const CDeterministicMNState& state = *dmn->pdmnState;
-    return state.nPoSeBanHeight != -1;
-}
-
 CDeterministicMNCPtr CDeterministicMNList::GetMN(const uint256& proTxHash) const
 {
     auto p = mnMap.find(proTxHash);
@@ -147,7 +117,7 @@ CDeterministicMNCPtr CDeterministicMNList::GetMN(const uint256& proTxHash) const
 CDeterministicMNCPtr CDeterministicMNList::GetValidMN(const uint256& proTxHash) const
 {
     auto dmn = GetMN(proTxHash);
-    if (dmn && !IsMNValid(dmn)) {
+    if (dmn && dmn->IsPoSeBanned()) {
         return nullptr;
     }
     return dmn;
@@ -171,7 +141,7 @@ CDeterministicMNCPtr CDeterministicMNList::GetMNByCollateral(const COutPoint& co
 CDeterministicMNCPtr CDeterministicMNList::GetValidMNByCollateral(const COutPoint& collateralOutpoint) const
 {
     auto dmn = GetMNByCollateral(collateralOutpoint);
-    if (dmn && !IsMNValid(dmn)) {
+    if (dmn && dmn->IsPoSeBanned()) {
         return nullptr;
     }
     return dmn;

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -213,6 +213,7 @@ public:
     }
 
     uint64_t GetInternalId() const;
+    bool IsPoSeBanned() const { return pdmnState->nPoSeBanHeight != -1; }
 
     std::string ToString() const;
     void ToJson(UniValue& obj) const;
@@ -321,7 +322,7 @@ public:
     {
         size_t count = 0;
         for (const auto& p : mnMap) {
-            if (IsMNValid(p.second)) {
+            if (!p.second->IsPoSeBanned()) {
                 count++;
             }
         }
@@ -332,7 +333,7 @@ public:
     void ForEachMN(bool onlyValid, Callback&& cb) const
     {
         for (const auto& p : mnMap) {
-            if (!onlyValid || IsMNValid(p.second)) {
+            if (!onlyValid || !p.second->IsPoSeBanned()) {
                 cb(p.second);
             }
         }
@@ -344,11 +345,6 @@ public:
     uint32_t GetTotalRegisteredCount() const { return nTotalRegisteredCount; }
     void SetHeight(int _height)                  { nHeight = _height; }
     void SetBlockHash(const uint256& _blockHash) { blockHash = _blockHash; }
-
-    bool IsMNValid(const uint256& proTxHash) const;
-    bool IsMNPoSeBanned(const uint256& proTxHash) const;
-    bool IsMNValid(const CDeterministicMNCPtr& dmn) const;
-    bool IsMNPoSeBanned(const CDeterministicMNCPtr& dmn) const;
 
     bool HasMN(const uint256& proTxHash) const
     {

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -277,7 +277,7 @@ void CMasternodeSync::Process()
         /*
             Resync if we lose all masternodes from sleep/wake or failure to sync originally
         */
-        if (mnodeman.CountEnabled() == 0 && !isRegTestNet) {
+        if (mnodeman.CountEnabled(true /* only_legacy */) == 0 && !isRegTestNet) {
             Reset();
         } else
             return;
@@ -401,7 +401,7 @@ bool CMasternodeSync::SyncWithNode(CNode* pnode, bool fLegacyMnObsolete)
             if (pnode->HasFulfilledRequest("mnwsync")) return true;
             pnode->FulfilledRequest("mnwsync");
 
-            int nMnCount = mnodeman.CountEnabled();
+            int nMnCount = mnodeman.CountEnabled(true /* only_legacy */);
             g_connman->PushMessage(pnode, msgMaker.Make(NetMsgType::GETMNWINNERS, nMnCount)); //sync payees
             RequestedMasternodeAttempt++;
             return false;

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -405,7 +405,7 @@ CMasternodeMan::MNsInfo CMasternodeMan::getMNsInfo() const
         mnList.ForEachMN(false, [&](const CDeterministicMNCPtr& dmn) {
             info.total++;
             CountNetwork(dmn->pdmnState->addr, info.ipv4, info.ipv6, info.onion);
-            if (mnList.IsMNValid(dmn)) {
+            if (!dmn->IsPoSeBanned()) {
                 info.enabledSize++;
                 info.stableSize++;
             }
@@ -722,7 +722,7 @@ std::vector<std::pair<int64_t, MasternodeRef>> CMasternodeMan::GetMasternodeRank
         auto mnList = deterministicMNManager->GetListAtChainTip();
         mnList.ForEachMN(false, [&](const CDeterministicMNCPtr& dmn) {
             const MasternodeRef mn = MakeMasternodeRefForDMN(dmn);
-            const uint32_t score = mnList.IsMNValid(dmn) ? mn->CalculateScore(hash).GetCompact(false) : 9999;
+            const uint32_t score = dmn->IsPoSeBanned() ? 9999 : mn->CalculateScore(hash).GetCompact(false);
 
             vecMasternodeScores.emplace_back(score, mn);
         });

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -400,10 +400,10 @@ CMasternodeMan::MNsInfo CMasternodeMan::getMNsInfo() const
     return info;
 }
 
-int CMasternodeMan::CountEnabled(int protocolVersion) const
+int CMasternodeMan::CountEnabled() const
 {
     int i = 0;
-    protocolVersion = protocolVersion == -1 ? ActiveProtocol() : protocolVersion;
+    int protocolVersion = ActiveProtocol();
 
     for (const auto& it : mapMasternodes) {
         const MasternodeRef& mn = it.second;

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -417,7 +417,7 @@ CMasternodeMan::MNsInfo CMasternodeMan::getMNsInfo() const
 
 int CMasternodeMan::CountEnabled(bool only_legacy) const
 {
-    int i = 0;
+    int count_enabled = 0;
     int protocolVersion = ActiveProtocol();
 
     {
@@ -425,15 +425,15 @@ int CMasternodeMan::CountEnabled(bool only_legacy) const
         for (const auto& it : mapMasternodes) {
             const MasternodeRef& mn = it.second;
             if (mn->protocolVersion < protocolVersion || !mn->IsEnabled()) continue;
-            i++;
+            count_enabled++;
         }
     }
 
     if (!only_legacy && deterministicMNManager->IsDIP3Enforced()) {
-        i += deterministicMNManager->GetListAtChainTip().GetValidMNsCount();
+        count_enabled += deterministicMNManager->GetListAtChainTip().GetValidMNsCount();
     }
 
-    return i;
+    return count_enabled;
 }
 
 void CMasternodeMan::DsegUpdate(CNode* pnode)

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -161,7 +161,7 @@ public:
 
     struct MNsInfo {
         // All the known MNs
-        int total;
+        int total{0};
         // enabled MNs eligible for payments. Older than 8000 seconds.
         int stableSize{0};
         // MNs enabled.

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -126,7 +126,7 @@ public:
     void SetBestHeight(int height) { nBestHeight.store(height, std::memory_order_release); };
     int GetBestHeight() const { return nBestHeight.load(std::memory_order_acquire); }
 
-    int CountEnabled(int protocolVersion = -1) const;
+    int CountEnabled() const;
 
     /// Count the number of nodes with a specific proto version for each network. Return the total.
     int CountNetworks(int& ipv4, int& ipv6, int& onion) const;

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -126,10 +126,7 @@ public:
     void SetBestHeight(int height) { nBestHeight.store(height, std::memory_order_release); };
     int GetBestHeight() const { return nBestHeight.load(std::memory_order_acquire); }
 
-    int CountEnabled() const;
-
-    /// Count the number of nodes with a specific proto version for each network. Return the total.
-    int CountNetworks(int& ipv4, int& ipv6, int& onion) const;
+    int CountEnabled(bool only_legacy = false) const;
 
     void DsegUpdate(CNode* pnode);
 

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -181,8 +181,8 @@ public:
     void UpdateMasternodeList(CMasternodeBroadcast& mnb);
 
     /// Get the time a masternode was last paid
-    int64_t GetLastPaid(const MasternodeRef& mn, const CBlockIndex* BlockReading) const;
-    int64_t SecondsSincePayment(const MasternodeRef& mn, const CBlockIndex* BlockReading) const;
+    int64_t GetLastPaid(const MasternodeRef& mn, int count_enabled, const CBlockIndex* BlockReading) const;
+    int64_t SecondsSincePayment(const MasternodeRef& mn, int count_enabled, const CBlockIndex* BlockReading) const;
 
     // Block hashes cycling vector management
     void CacheBlockHash(const CBlockIndex* pindex);

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -76,11 +76,13 @@ int ClientModel::getNumConnections(unsigned int flags) const
 
 QString ClientModel::getMasternodeCountString() const
 {
-    int ipv4 = 0, ipv6 = 0, onion = 0;
-    int total = mnodeman.CountNetworks(ipv4, ipv6, onion);
-    int nUnknown = total - ipv4 - ipv6 - onion;
-    if(nUnknown < 0) nUnknown = 0;
-    return tr("Total: %1 (IPv4: %2 / IPv6: %3 / Tor: %4 / Unknown: %5)").arg(QString::number(total)).arg(QString::number((int)ipv4)).arg(QString::number((int)ipv6)).arg(QString::number((int)onion)).arg(QString::number((int)nUnknown));
+    const auto& info = mnodeman.getMNsInfo();
+    int unknown = std::max(0, info.total - info.ipv4 - info.ipv6 - info.onion);
+    return tr("Total: %1 (IPv4: %2 / IPv6: %3 / Tor: %4 / Unknown: %5)").arg(QString::number(info.total))
+                                                                        .arg(QString::number(info.ipv4))
+                                                                        .arg(QString::number(info.ipv6))
+                                                                        .arg(QString::number(info.onion))
+                                                                        .arg(QString::number(unknown));
 }
 
 QString ClientModel::getMasternodesCount()

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -191,6 +191,7 @@ UniValue listmasternodes(const JSONRPCRequest& request)
     int nHeight = chainTip->nHeight;
     auto mnList = deterministicMNManager->GetListAtChainTip();
 
+    int count_enabled = mnodeman.CountEnabled();
     std::vector<std::pair<int64_t, MasternodeRef>> vMasternodeRanks = mnodeman.GetMasternodeRanks(nHeight);
     for (int pos=0; pos < (int) vMasternodeRanks.size(); pos++) {
         const auto& s = vMasternodeRanks[pos];
@@ -244,7 +245,7 @@ UniValue listmasternodes(const JSONRPCRequest& request)
         obj.pushKV("version", mn.protocolVersion);
         obj.pushKV("lastseen", (int64_t)mn.lastPing.sigTime);
         obj.pushKV("activetime", (int64_t)(mn.lastPing.sigTime - mn.sigTime));
-        obj.pushKV("lastpaid", (int64_t)mnodeman.GetLastPaid(s.second, chainTip));
+        obj.pushKV("lastpaid", (int64_t)mnodeman.GetLastPaid(s.second, count_enabled, chainTip));
 
         ret.push_back(obj);
     }

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -177,8 +177,7 @@ UniValue listmasternodes(const JSONRPCRequest& request)
         mnList.ForEachMN(false, [&](const CDeterministicMNCPtr& dmn) {
             UniValue obj(UniValue::VOBJ);
             dmn->ToJson(obj);
-            bool fEnabled = dmn->pdmnState->nPoSeBanHeight == -1;
-            if (filterMasternode(obj, strFilter, fEnabled)) {
+            if (filterMasternode(obj, strFilter, !dmn->IsPoSeBanned())) {
                 ret.push_back(obj);
             }
         });
@@ -204,7 +203,7 @@ UniValue listmasternodes(const JSONRPCRequest& request)
             if (dmn) {
                 UniValue obj(UniValue::VOBJ);
                 dmn->ToJson(obj);
-                bool fEnabled = dmn->pdmnState->nPoSeBanHeight == -1;
+                bool fEnabled = !dmn->IsPoSeBanned();
                 if (filterMasternode(obj, strFilter, fEnabled)) {
                     // Added for backward compatibility with legacy masternodes
                     obj.pushKV("type", "deterministic");

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -650,6 +650,7 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         // check that changing the operator key puts the MN in PoSe banned state
         BOOST_CHECK_MESSAGE(dmn->pdmnState->addr == CService(), "IP address not cleared after changing operator");
         BOOST_CHECK_MESSAGE(dmn->pdmnState->scriptOperatorPayout.empty(), "operator payee not empty after changing operator");
+        BOOST_CHECK(dmn->IsPoSeBanned());
         BOOST_CHECK_EQUAL(dmn->pdmnState->nPoSeBanHeight, nHeight);
 
         // revive the MN
@@ -663,6 +664,7 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         // check updated dmn state
         BOOST_CHECK_EQUAL(dmn->pdmnState->addr.GetPort(), 2000);
         BOOST_CHECK_EQUAL(dmn->pdmnState->nPoSeBanHeight, -1);
+        BOOST_CHECK(!dmn->IsPoSeBanned());
         BOOST_CHECK_EQUAL(dmn->pdmnState->nPoSeRevivedHeight, nHeight);
 
         // Mine 32 blocks, checking MN reward payments
@@ -780,6 +782,7 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         BOOST_CHECK_MESSAGE(dmn->pdmnState->addr == CService(), "mn IP address not removed");
         BOOST_CHECK_MESSAGE(dmn->pdmnState->scriptOperatorPayout.empty(), "mn operator payout not removed");
         BOOST_CHECK_EQUAL(dmn->pdmnState->nRevocationReason, reason);
+        BOOST_CHECK(dmn->IsPoSeBanned());
         BOOST_CHECK_EQUAL(dmn->pdmnState->nPoSeBanHeight, nHeight);
     }
 

--- a/test/functional/tiertwo_mn_compatibility.py
+++ b/test/functional/tiertwo_mn_compatibility.py
@@ -60,6 +60,12 @@ class MasternodeCompatibilityTest(PivxTier2TestFramework):
         assert_equal(status["dmnstate"]["PoSePenalty"], 0)
         assert_equal(status["status"], "Ready")
 
+    def check_mn_enabled_count(self, enabled, total):
+        for node in self.nodes:
+            node_count = node.getmasternodecount()
+            assert_equal(node_count['enabled'], enabled)
+            assert_equal(node_count['total'], total)
+
     """
     Checks the block at specified height
     Returns the address of the mn paid (in the coinbase), and the json coinstake tx
@@ -91,6 +97,9 @@ class MasternodeCompatibilityTest(PivxTier2TestFramework):
         self.mn_addresses = {}
         self.enable_mocktime()
         self.setup_3_masternodes_network()
+
+        # start with 3 masternodes (2 legacy + 1 DMN)
+        self.check_mn_enabled_count(3, 3)
 
         # add two more nodes to the network
         self.remoteDMN2 = self.nodes[self.remoteDMN2Pos]
@@ -124,6 +133,7 @@ class MasternodeCompatibilityTest(PivxTier2TestFramework):
         self.remoteDMN2.initmasternode(self.dmn2Privkey, "", True)
 
         # check list and status
+        self.check_mn_enabled_count(4, 4) # 2 legacy + 2 DMN
         txHashSet.add(self.proRegTx2)
         self.check_mn_list(self.miner, txHashSet)
         self.check_mns_status(self.remoteDMN2, self.proRegTx2)
@@ -156,6 +166,7 @@ class MasternodeCompatibilityTest(PivxTier2TestFramework):
 
         # The legacy masternode must no longer be in the list
         # and the DMN must have taken its place
+        self.check_mn_enabled_count(4, 4)  # 1 legacy + 3 DMN
         txHashSet.remove(self.mnOneCollateral.hash)
         txHashSet.add(self.proRegTx3)
         for node in self.nodes:
@@ -170,6 +181,7 @@ class MasternodeCompatibilityTest(PivxTier2TestFramework):
         self.send_3_pings()
 
         # the masternode list hasn't changed
+        self.check_mn_enabled_count(4, 4)
         for node in self.nodes:
             self.check_mn_list(node, txHashSet)
         self.log.info("Masternode list correctly unchanged in all nodes.")


### PR DESCRIPTION
Bug introduced in #2308.
We are considering the total masternode count, inclusive of deterministic masternodes, only in `GetNextMasternodeInQueueForPayment`, but not in other places.
Fix this by updating directly the function `CountEnabled`, using the legacy-only count exclusively for the masternode list sync.