### PR TITLE
[BUG][GUI] Refine bytes/fee/"after fee" calculation in coin-control

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -550,9 +550,6 @@ TotalAmounts CoinControlDialog::getTotals() const
             t.nBytes += (GetCompactSize(nShieldIns) + GetCompactSize(nShieldOuts));
         }
 
-        // !TODO: ExtraPayload size for special txes. For now 1 byte for nullopt.
-        t.nBytes += 1;
-
         // nVersion, nType, nLockTime
         t.nBytes += 8;
 

--- a/src/sapling/sapling_operation.h
+++ b/src/sapling/sapling_operation.h
@@ -11,10 +11,6 @@
 #include "primitives/transaction.h"
 #include "wallet/wallet.h"
 
-// transaction.h comment: spending taddr output requires CTxIn >= 148 bytes and typical taddr txout is 34 bytes
-#define CTXIN_SPEND_DUST_SIZE   148
-#define CTXOUT_REGULAR_SIZE     34
-
 class CCoinControl;
 struct TxValues;
 

--- a/src/sapling/sapling_transaction.h
+++ b/src/sapling/sapling_transaction.h
@@ -17,7 +17,7 @@
 #include <boost/variant.hpp>
 
 // transaction.h comment: spending taddr output requires CTxIn >= 148 bytes and typical taddr txout is 34 bytes
-#define CTXIN_SPEND_DUST_SIZE   148
+#define CTXIN_SPEND_DUST_SIZE   149
 #define CTXOUT_REGULAR_SIZE     34
 
 // These constants are defined in the protocol § 7.1:


### PR DESCRIPTION
Should close #2156 

This bug is caused by the fact that a transparent input is *usally* 148 bytes (149 for p2cs spends), but can also be 149 sometimes (150 for p2cs spends), depending on the script length.
When a user copies "After fee" in coin-control, and sends it to a single recipient, this extra fee is typically (with few coins selected) offset by the lack of change output. But, when many inputs are selected in coin control, this becomes relevant.

Also:
- remove the duplicated definitions of `CTXIN_SPEND_DUST_SIZE` and `CTXOUT_REGULAR_SIZE` in `sapling_operation.h`
- remove the extra byte for the (nullopt) special payload, as that is not serialized for version=1 or type=0 transactions (and currently isn't possible to send special txes with the GUI).