### PR TITLE
[Cleanup] Remove and deglobalize system.h global variables.

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -235,15 +235,12 @@ OperationResult initMasternode(const std::string& _strMasterNodePrivKey, const s
         return errorOut("ERROR: Empty masternodeaddr");
     }
 
-    // Global params set
-    strMasterNodeAddr = _strMasterNodeAddr;
-
     // Address parsing.
     const CChainParams& params = Params();
     int nPort = 0;
     int nDefaultPort = params.GetDefaultPort();
     std::string strHost;
-    SplitHostPort(strMasterNodeAddr, nPort, strHost);
+    SplitHostPort(_strMasterNodeAddr, nPort, strHost);
 
     // Allow for the port number to be omitted here and just double check
     // that if a port is supplied, it matches the required default port.
@@ -254,7 +251,7 @@ OperationResult initMasternode(const std::string& _strMasterNodePrivKey, const s
     }
     CService addrTest(LookupNumeric(strHost.c_str(), nPort));
     if (!addrTest.IsValid()) {
-        return errorOut(strprintf(_("Invalid -masternodeaddr address: %s"), strMasterNodeAddr));
+        return errorOut(strprintf(_("Invalid -masternodeaddr address: %s"), _strMasterNodeAddr));
     }
 
     // Peer port needs to match the masternode public one for IPv4 and IPv6.

--- a/src/budget/budgetmanager.h
+++ b/src/budget/budgetmanager.h
@@ -53,6 +53,9 @@ public:
     mutable RecursiveMutex cs_finalizedvotes;
     mutable RecursiveMutex cs_votes;
 
+    // budget finalization
+    std::string strBudgetMode = "";
+
     CBudgetManager() {}
 
     void ClearSeen()

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1906,7 +1906,7 @@ bool AppInitMain()
     }
 
     //get the mode of budget voting for this masternode
-    strBudgetMode = gArgs.GetArg("-budgetvotemode", "auto");
+    g_budgetman.strBudgetMode = gArgs.GetArg("-budgetvotemode", "auto");
 
 #ifdef ENABLE_WALLET
     // !TODO: remove after complete transition to DMN
@@ -1940,7 +1940,7 @@ bool AppInitMain()
     }
 
     LogPrintf("fLiteMode %d\n", fLiteMode);
-    LogPrintf("Budget Mode %s\n", strBudgetMode.c_str());
+    LogPrintf("Budget Mode %s\n", g_budgetman.strBudgetMode.c_str());
 
     threadGroup.create_thread(std::bind(&ThreadCheckMasternodes));
 

--- a/src/pivxd.cpp
+++ b/src/pivxd.cpp
@@ -35,8 +35,6 @@
  * Use the buttons <code>Namespaces</code>, <code>Classes</code> or <code>Files</code> at the top of the page to start navigating the code.
  */
 
-static bool fDaemon;
-
 void WaitForShutdown()
 {
     while (!ShutdownRequested()) {
@@ -127,8 +125,7 @@ bool AppInit(int argc, char* argv[])
         }
 
 #ifndef WIN32
-        fDaemon = gArgs.GetBoolArg("-daemon", false);
-        if (fDaemon) {
+        if (gArgs.GetBoolArg("-daemon", false)) {
             fprintf(stdout, "PIVX server starting\n");
 
             // Daemonize

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -92,7 +92,6 @@ std::string strBudgetMode = "";
 
 ArgsManager gArgs;
 
-bool fDaemon = false;
 CTranslationInterface translationInterface;
 
 bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes)

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -86,7 +86,6 @@ const char * const PIVX_MASTERNODE_CONF_FILENAME = "masternode.conf";
 // PIVX only features
 // Masternode
 std::atomic<bool> fMasterNode{false};
-std::string strMasterNodeAddr = "";
 bool fLiteMode = false;
 // budget finalization
 std::string strBudgetMode = "";

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -87,8 +87,6 @@ const char * const PIVX_MASTERNODE_CONF_FILENAME = "masternode.conf";
 // Masternode
 std::atomic<bool> fMasterNode{false};
 bool fLiteMode = false;
-// budget finalization
-std::string strBudgetMode = "";
 
 ArgsManager gArgs;
 

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -55,7 +55,6 @@ extern const char * const DEFAULT_DEBUGLOGFILE;
 
 extern std::atomic<bool> fMasterNode;
 extern bool fLiteMode;
-extern std::string strBudgetMode;
 
 extern CTranslationInterface translationInterface;
 

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -55,7 +55,6 @@ extern const char * const DEFAULT_DEBUGLOGFILE;
 
 extern std::atomic<bool> fMasterNode;
 extern bool fLiteMode;
-extern std::string strMasterNodeAddr;
 extern std::string strBudgetMode;
 
 extern CTranslationInterface translationInterface;


### PR DESCRIPTION
Straightforward cleanup of global variables from `system.h` that are not needed to be global.