### PR TITLE
[RPC][TierTwo][Bug] Initialize un-initialized MNsInfo member total

### DIFF
--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -161,7 +161,7 @@ public:
 
     struct MNsInfo {
         // All the known MNs
-        int total;
+        int total{0};
         // enabled MNs eligible for payments. Older than 8000 seconds.
         int stableSize{0};
         // MNs enabled.


### PR DESCRIPTION
Fixes a bug introduced in #2554 that leaves the `total` member of `MNsInfo` un-initialized by default, resulting in incorrect return results for the `getmasternodecount` RPC command.

Also added regression tests to exercise this command, slightly increasing code coverage