### PR TITLE
[Depends] Fix Qt builds for M1 apple builds

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -104,6 +104,9 @@ $(package)_config_opts_darwin += -device-option MAC_MIN_VERSION=$(OSX_MIN_VERSIO
 $(package)_config_opts_darwin += -device-option MAC_TARGET=$(host)
 endif
 
+# for macOS on Apple Silicon (ARM) see https://bugreports.qt.io/browse/QTBUG-85279
+$(package)_config_opts_aarch64_darwin += -device-option QMAKE_APPLE_DEVICE_ARCHS=arm64
+
 $(package)_config_opts_linux  = -qt-xkbcommon-x11
 $(package)_config_opts_linux += -qt-xcb
 $(package)_config_opts_linux += -no-xcb-xlib


### PR DESCRIPTION
Hard-set arm64 device arch for apple silicon (aarch64) builds in order
to ensure native binaries are all aarch64 compatible.

Note: At the moment, this only works for native depends builds on M1 CPUs as we're not yet at the point of supporting cross-compiling to aarch64-apple builds; Other builds are unaffected by this change.