### PR TITLE
[Test] Secondary chains acceptance test coverage

### DIFF
--- a/src/blockassembler.h
+++ b/src/blockassembler.h
@@ -167,7 +167,9 @@ public:
                                    bool fProofOfStake = false,
                                    std::vector<CStakeableOutput>* availableCoins = nullptr,
                                    bool fNoMempoolTx = false,
-                                   bool fTestValidity = true);
+                                   bool fTestValidity = true,
+                                   CBlockIndex* prevBlock = nullptr,
+                                   bool stopPoSOnNewBlock = true);
 
 private:
     // utility functions

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -422,7 +422,7 @@ public:
         consensus.nPoolMaxTransactions = 2;
         consensus.nProposalEstablishmentTime = 60 * 5;  // at least 5 min old to make it into a budget
         consensus.nStakeMinAge = 0;
-        consensus.nStakeMinDepth = 2;
+        consensus.nStakeMinDepth = 20;
         consensus.nTargetTimespan = 40 * 60;
         consensus.nTargetTimespanV2 = 30 * 60;
         consensus.nTargetSpacing = 1 * 60;

--- a/src/wallet/test/pos_validations_tests.cpp
+++ b/src/wallet/test/pos_validations_tests.cpp
@@ -5,12 +5,14 @@
 #include "wallet/test/pos_test_fixture.h"
 
 #include "blockassembler.h"
+#include "coincontrol.h"
 #include "util/blockstatecatcher.h"
 #include "blocksignature.h"
 #include "consensus/merkle.h"
 #include "primitives/block.h"
 #include "script/sign.h"
 #include "test/util/blocksutil.h"
+#include "util/blockstatecatcher.h"
 #include "wallet/wallet.h"
 
 #include <boost/test/unit_test.hpp>
@@ -86,6 +88,146 @@ BOOST_FIXTURE_TEST_CASE(coinstake_tests, TestPoSChainSetup)
     pblock = std::make_shared<CBlock>(pblocktemplate->block);
     ProcessNewBlock(pblock, nullptr);
     BOOST_CHECK_EQUAL(WITH_LOCK(cs_main, return chainActive.Tip()->GetBlockHash()), pblock->GetHash());
+}
+
+CTransaction CreateAndCommitTx(CWallet* pwalletMain, const CTxDestination& dest, CAmount destValue, CCoinControl* coinControl = nullptr)
+{
+    CTransactionRef txNew;
+    CReserveKey reservekey(pwalletMain);
+    CAmount nFeeRet = 0;
+    std::string strFailReason;
+    BOOST_ASSERT(pwalletMain->CreateTransaction(GetScriptForDestination(dest),
+                                   destValue,
+                                   txNew,
+                                   reservekey,
+                                   nFeeRet,
+                                   strFailReason,
+                                   coinControl));
+    pwalletMain->CommitTransaction(txNew, reservekey, nullptr);
+    return *txNew;
+}
+
+COutPoint GetOutpointWithAmount(const CTransaction& tx, CAmount outpointValue)
+{
+    for (int i=0; i<tx.vout.size(); i++) {
+        if (tx.vout[i].nValue == outpointValue) {
+            return COutPoint(tx.GetHash(), i);
+        }
+    }
+    BOOST_ASSERT_MSG(false, "error in test, no output in tx for value");
+    return {};
+}
+
+std::shared_ptr<CBlock> CreateBlockInternal(CWallet* pwalletMain, const std::vector<CMutableTransaction>& txns = {}, CBlockIndex* customPrevBlock = nullptr)
+{
+    std::vector<CStakeableOutput> availableCoins;
+    BOOST_CHECK(pwalletMain->StakeableCoins(&availableCoins));
+    std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler(
+            Params(), false).CreateNewBlock(CScript(),
+                                            pwalletMain,
+                                            true,
+                                            &availableCoins,
+                                            true,
+                                            false,
+                                            customPrevBlock,
+                                            false);
+    BOOST_ASSERT(pblocktemplate);
+    auto pblock = std::make_shared<CBlock>(pblocktemplate->block);
+    if (!txns.empty()) {
+        for (const auto& tx : txns) {
+            pblock->vtx.emplace_back(MakeTransactionRef(tx));
+        }
+        pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
+        assert(SignBlock(*pblock, *pwalletMain));
+    }
+    return pblock;
+}
+
+BOOST_FIXTURE_TEST_CASE(created_on_fork_tests, TestPoSChainSetup)
+{
+    // Let's create few more PoS blocks
+    for (int i=0; i<30; i++) {
+        std::shared_ptr<CBlock> pblock = CreateBlockInternal(pwalletMain.get());
+        BOOST_CHECK(ProcessNewBlock(pblock, nullptr));
+    }
+
+    // Chains diagram:
+    // A -- B -- C -- D -- E -- F
+    //           \
+    //             -- D1 -- E1 -- F1
+    //           \
+    //             -- D2 -- E2 -- F2
+
+    // Tests:
+    // 1) coins created in D1 and spent in E1
+    // 2) coins created and spent in E2, being double spent in F2.
+    // 3) coins created in D and spent in E'
+    // 4) coins create in D, spent in E and then double spent in E'
+
+    // Let's create block C with a valid c1tx
+    auto c1Tx = CreateAndCommitTx(pwalletMain.get(), *pwalletMain->getNewAddress("").getObjResult(), 249 * COIN);
+    WITH_LOCK(pwalletMain->cs_wallet, pwalletMain->LockCoin(GetOutpointWithAmount(c1Tx, 249 * COIN)));
+    std::shared_ptr<CBlock> pblockC = CreateBlockInternal(pwalletMain.get(), {c1Tx});
+    BOOST_CHECK(ProcessNewBlock(pblockC, nullptr));
+
+    // Create block D
+    std::shared_ptr<CBlock> pblockD = CreateBlockInternal(pwalletMain.get());
+
+    // Second forked block that connects a new tx
+    auto dest = pwalletMain->getNewAddress("").getObjResult();
+    auto d1Tx = CreateAndCommitTx(pwalletMain.get(), *dest, 200 * COIN);
+    std::shared_ptr<CBlock> pblockD1 = CreateBlockInternal(pwalletMain.get(), {d1Tx});
+
+    // Process blocks
+    ProcessNewBlock(pblockD, nullptr);
+    ProcessNewBlock(pblockD1, nullptr);
+    BOOST_CHECK(WITH_LOCK(cs_main, return chainActive.Tip()->GetBlockHash() ==  pblockD->GetHash()));
+
+    // Ensure that the coin does not exist in the main chain
+    const Coin& utxo = pcoinsTip->AccessCoin(COutPoint(d1Tx.GetHash(), 0));
+    BOOST_CHECK(utxo.out.IsNull());
+
+    // ### Check (1) -> coins created in D' and spent in E' ###
+
+    // Create tx spending the previously created tx on the forked chain
+    CCoinControl coinControl;
+    coinControl.fAllowOtherInputs = true;
+    coinControl.Select(COutPoint(d1Tx.GetHash(), 0), d1Tx.vout[0].nValue);
+    auto e1Tx = CreateAndCommitTx(pwalletMain.get(), *dest, d1Tx.vout[0].nValue, &coinControl);
+
+    CBlockIndex* pindexPrev = mapBlockIndex.at(pblockD1->GetHash());
+    std::shared_ptr<CBlock> pblockE1 = CreateBlockInternal(pwalletMain.get(), {e1Tx}, pindexPrev);
+    BOOST_CHECK(ProcessNewBlock(pblockE1, nullptr));
+
+    // ### Check (2) -> coins created and spent in E2, being double spent in F2 ###
+
+    // Create block E2 with E2_tx1 and E2_tx2. Where E2_tx2 is spending the outputs of E2_tx1
+    CCoinControl coinControlE2;
+    coinControlE2.Select(GetOutpointWithAmount(c1Tx, 249 * COIN), 249 * COIN);
+    auto E2_tx1 = CreateAndCommitTx(pwalletMain.get(), *dest, 200 * COIN, &coinControlE2);
+
+    coinControl.UnSelectAll();
+    coinControl.Select(GetOutpointWithAmount(E2_tx1, 200 * COIN), 200 * COIN);
+    coinControl.fAllowOtherInputs = false;
+    auto E2_tx2 = CreateAndCommitTx(pwalletMain.get(), *dest, 199 * COIN, &coinControl);
+
+    std::shared_ptr<CBlock> pblockE2 = CreateBlockInternal(pwalletMain.get(), {E2_tx1, E2_tx2}, pindexPrev);
+    BOOST_CHECK(ProcessNewBlock(pblockE2, nullptr));
+
+    // Create block with F2_tx1 spending E2_tx1 again.
+    auto F2_tx1 = CreateAndCommitTx(pwalletMain.get(), *dest, 199 * COIN, &coinControl);
+
+    pindexPrev = mapBlockIndex.at(pblockE2->GetHash());
+    std::shared_ptr<CBlock> pblock5Forked = CreateBlockInternal(pwalletMain.get(), {F2_tx1}, pindexPrev);
+    BlockStateCatcher stateCatcher(pblock5Forked->GetHash());
+    stateCatcher.registerEvent();
+    BOOST_CHECK(!ProcessNewBlock(pblock5Forked, nullptr));
+    BOOST_CHECK(stateCatcher.found);
+    CValidationState state = stateCatcher.state;
+    BOOST_CHECK(!stateCatcher.state.IsValid());
+    BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-txns-inputs-spent-fork-post-split");
+
+
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3289,6 +3289,11 @@ bool CWallet::CreateCoinStake(
         std::vector<CStakeableOutput>* availableCoins,
         bool stopOnNewBlock) const
 {
+    // shuffle coins
+    if (availableCoins && Params().IsRegTestNet()) {
+        Shuffle(availableCoins->begin(), availableCoins->end(), FastRandomContext());
+    }
+
     // Mark coin stake transaction
     txNew.vin.clear();
     txNew.vout.clear();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -683,6 +683,8 @@ public:
         assert(m_last_block_processed_height >= 0);
         return m_last_block_processed_height;
     };
+    /** Get last block processed height locking the wallet */
+    int GetLastBlockHeightLockWallet() const;
     /** Set last block processed height, currently only use in unit test */
     void SetLastBlockProcessed(const CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
     {
@@ -1080,7 +1082,8 @@ public:
                          unsigned int nBits,
                          CMutableTransaction& txNew,
                          int64_t& nTxNewTime,
-                         std::vector<CStakeableOutput>* availableCoins) const;
+                         std::vector<CStakeableOutput>* availableCoins,
+                         bool stopOnNewBlock = true) const;
     bool SignCoinStake(CMutableTransaction& txNew) const;
     void AutoCombineDust(CConnman* connman);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -662,6 +662,9 @@ private:
                                                      const bool fIncludeDelegated,
                                                      const bool fIncludeLocked) const;
 
+    /** Return the selected known outputs */
+    std::vector<COutput> GetOutputsFromCoinControl(const CCoinControl* coinControl);
+
     //! Destination --> label/purpose mapping.
     std::map<CWDestination, AddressBook::CAddressBookData> mapAddressBook;
 

--- a/test/functional/mining_pos_coldStaking.py
+++ b/test/functional/mining_pos_coldStaking.py
@@ -223,7 +223,8 @@ class PIVX_ColdStakingTest(PivxTestFramework):
         assert_raises_rpc_error(-26, "mandatory-script-verify-flag-failed (Script failed an OP_CHECKCOLDSTAKEVERIFY operation",
                                 self.spendUTXOwithNode, u, 1)
         self.log.info("Good. Cold staker was NOT able to spend (failed OP_CHECKCOLDSTAKEVERIFY)")
-        self.mocktime = self.generate_pos(2, self.mocktime)
+        for _ in range(20): # Staking min depth
+            self.mocktime = self.generate_pos(2, self.mocktime)
         self.sync_blocks()
 
         # 9) check that the staker can use the coins to stake a block with internal miner.


### PR DESCRIPTION
```
Chains diagram:

A -- B -- C -- D -- E -- F -- G -- H
           \
             -- D1 -- E1 -- F1
           \
             -- D2 -- E2 -- F2
           \
             -- D3 -- E3 -- F3 -- G3 -- H3 
           \
             -- D4 -- E4 -- F4
```


Coverage added on this work:
1) coins created in D1 and spent in E1. --> expected result: pass.
2) coins created in E, being spent in D4 --> expected result: reject.
3) coins created and spent in E2, being double spent in F2. --> expected result: reject.
4) coins created in D and spent in E3. --> expected result: reject.
5) coins create in D, spent in F and then double spent in F3. --> expected result: reject.
6) coins created in G and G3, being spent in H and H3 --> expected result: pass.
