### PR TITLE
[RPC][BUG] fix missing minimum depth set for legacy transactions.

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2346,7 +2346,10 @@ static UniValue legacy_sendmany(CWallet* const pwallet, const UniValue& sendTo, 
                                                nullptr,     // coinControl
                                                true,        // sign
                                                0,           // nFeePay
-                                               fIncludeDelegated);
+                                               fIncludeDelegated,
+                                               nullptr, // fStakeDelegationVoided
+                                               0, // default extra size
+                                               nMinDepth);
     if (!fCreated)
         throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, strFailReason);
     const CWallet::CommitResult& res = pwallet->CommitTransaction(txNew, keyChange, g_connman.get());

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3006,7 +3006,8 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend,
     CAmount nFeePay,
     bool fIncludeDelegated,
     bool* fStakeDelegationVoided,
-    int nExtraSize)
+    int nExtraSize,
+    int nMinDepth)
 {
     CAmount nValue = 0;
     int nChangePosRequest = nChangePosInOut;
@@ -3031,6 +3032,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend,
     CWallet::AvailableCoinsFilter coinFilter;
     coinFilter.fOnlySpendable = true;
     coinFilter.fIncludeDelegated = fIncludeDelegated;
+    coinFilter.minDepth = nMinDepth;
 
     {
         std::set<std::pair<const CWalletTx*,unsigned int> > setCoins;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1054,7 +1054,8 @@ public:
         CAmount nFeePay = 0,
         bool fIncludeDelegated = false,
         bool* fStakeDelegationVoided = nullptr,
-        int nExtraSize = 0);
+        int nExtraSize = 0,
+        int nMinDepth = 0);
 
     bool CreateTransaction(CScript scriptPubKey, const CAmount& nValue, CTransactionRef& tx, CReserveKey& reservekey, CAmount& nFeeRet, std::string& strFailReason, const CCoinControl* coinControl = NULL, CAmount nFeePay = 0, bool fIncludeDelegated = false);
 


### PR DESCRIPTION
Bug introduced when the coins filter class was created, the create transaction process has no way of customizing the minimum depth value, affecting the RPC `sendmany` command that is not setting the user's provided argument.

This bug can cause transaction creation errors such us the `"too many unconfirmed ancestors"` on third party services that are making a good number of txs on a short lapse of time as the mempool ancestors limit can be exceeded, blocking every subsequent `sendmany` call until the txs are confirmed.