### PR TITLE
[GUI] [BUG] set locked label invisible for shield notes.

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -478,6 +478,7 @@ void CoinControlDialog::updateLabelLocked()
         } else
             ui->labelLocked->setVisible(false);
     } else {
+        ui->labelLocked->setVisible(false);
         // TODO: implement locked notes functionality inside the wallet..
     }
 }


### PR DESCRIPTION
We don't support shield locked notes functionality yet. As we are reusing the same coin control dialog, once we open the dialog for shield notes, the locked coins label can still be, invalidly, showing the previous label value for regular utxo.