### PR TITLE
[Net][GUI][RPC] Add enable/disable network activity feature

### DIFF
--- a/src/guiinterface.h
+++ b/src/guiinterface.h
@@ -89,6 +89,9 @@ public:
     /** Number of network connections changed. */
     boost::signals2::signal<void(int newNumConnections)> NotifyNumConnectionsChanged;
 
+    /** Network activity state changed. */
+    boost::signals2::signal<void (bool networkActive)> NotifyNetworkActiveChanged;
+
     /** New, updated or cancelled alert. */
     boost::signals2::signal<void()> NotifyAlertChanged;
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1934,6 +1934,8 @@ void CConnman::SetNetworkActive(bool active)
     } else {
         fNetworkActive = true;
     }
+
+    if (clientInterface) clientInterface->NotifyNetworkActiveChanged(fNetworkActive);
 }
 
 CConnman::CConnman(uint64_t nSeed0In, uint64_t nSeed1In) : nSeed0(nSeed0In), nSeed1(nSeed1In)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1923,16 +1923,19 @@ void Discover()
 void CConnman::SetNetworkActive(bool active)
 {
     LogPrint(BCLog::NET, "SetNetworkActive: %s\n", active);
-    if (!active) {
-        fNetworkActive = false;
 
+    if (fNetworkActive == active) {
+        return;
+    }
+
+    fNetworkActive = active;
+
+    if (!fNetworkActive) {
         LOCK(cs_vNodes);
         // Close sockets to all nodes
         for(CNode* pnode : vNodes) {
             pnode->CloseSocketDisconnect();
         }
-    } else {
-        fNetworkActive = true;
     }
 
     if (clientInterface) clientInterface->NotifyNetworkActiveChanged(fNetworkActive);

--- a/src/net.h
+++ b/src/net.h
@@ -173,6 +173,7 @@ public:
     bool Start(CScheduler& scheduler, const Options& options);
     void Stop();
     void Interrupt();
+    bool GetNetworkActive() const { return fNetworkActive; };
     void SetNetworkActive(bool active);
     void OpenNetworkConnection(const CAddress& addrConnect, bool fCountFailure, CSemaphoreGrant* grantOutbound = nullptr, const char* strDest = nullptr, bool fOneShot = false, bool fFeeler = false, bool fAddnode = false);
     bool CheckIncomingNonce(uint64_t nonce);

--- a/src/net.h
+++ b/src/net.h
@@ -173,6 +173,7 @@ public:
     bool Start(CScheduler& scheduler, const Options& options);
     void Stop();
     void Interrupt();
+    void SetNetworkActive(bool active);
     void OpenNetworkConnection(const CAddress& addrConnect, bool fCountFailure, CSemaphoreGrant* grantOutbound = nullptr, const char* strDest = nullptr, bool fOneShot = false, bool fFeeler = false, bool fAddnode = false);
     bool CheckIncomingNonce(uint64_t nonce);
 
@@ -389,6 +390,7 @@ private:
     unsigned int nReceiveFloodSize{0};
 
     std::vector<ListenSocket> vhListenSocket;
+    std::atomic<bool> fNetworkActive{true};
     banmap_t setBanned;
     RecursiveMutex cs_setBanned;
     bool setBannedIsDirty{false};

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -78,6 +78,10 @@ public:
     bool inInitialBlockDownload() const;
     //! Return true if core is importing blocks
     enum BlockSource getBlockSource() const;
+    //! Return true if network activity in core is enabled
+    bool getNetworkActive() const;
+    //! Toggle network activity state in core
+    void setNetworkActive(bool active);
     //! Return warnings to be displayed in status bar
     QString getStatusBarWarnings() const;
 
@@ -111,6 +115,7 @@ private:
     // Listeners
     std::unique_ptr<interfaces::Handler> m_handler_show_progress;
     std::unique_ptr<interfaces::Handler> m_handler_notify_num_connections_changed;
+    std::unique_ptr<interfaces::Handler> m_handler_notify_net_activity_changed;
     std::unique_ptr<interfaces::Handler> m_handler_notify_alert_changed;
     std::unique_ptr<interfaces::Handler> m_handler_banned_list_changed;
     std::unique_ptr<interfaces::Handler> m_handler_notify_block_tip;
@@ -137,6 +142,7 @@ private:
 Q_SIGNALS:
     void numConnectionsChanged(int count);
     void numBlocksChanged(int count);
+    void networkActiveChanged(bool networkActive);
     void strMasternodesChanged(const QString& strMasternodes);
     void alertsChanged(const QString& warnings);
     void bytesChanged(quint64 totalBytesIn, quint64 totalBytesOut);
@@ -151,6 +157,7 @@ public Q_SLOTS:
     void updateTimer();
     void updateMnTimer();
     void updateNumConnections(int numConnections);
+    void updateNetworkActive(bool networkActive);
     void updateAlert();
     void updateBanlist();
 };

--- a/src/qt/pivx/settings/forms/settingswalletoptionswidget.ui
+++ b/src/qt/pivx/settings/forms/settingswalletoptionswidget.ui
@@ -250,6 +250,154 @@
             </item>
            </layout>
           </item>
+          <item>
+           <spacer name="horizontalSpacerNetwork">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Minimum</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item alignment="Qt::AlignRight">
+           <widget class="QWidget" name="containerNetworkActivity" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_5">
+             <property name="spacing">
+              <number>5</number>
+             </property>
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QGroupBox" name="groupBox_2">
+               <property name="styleSheet">
+                <string notr="true"/>
+               </property>
+               <property name="title">
+                <string/>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+               <layout class="QHBoxLayout" name="horizontalLayout_7">
+                <property name="spacing">
+                 <number>0</number>
+                </property>
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item alignment="Qt::AlignRight">
+                 <widget class="QPushButton" name="pushNetEnable">
+                  <property name="minimumSize">
+                   <size>
+                    <width>120</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>120</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="focusPolicy">
+                   <enum>Qt::NoFocus</enum>
+                  </property>
+                  <property name="text">
+                   <string>Enable</string>
+                  </property>
+                  <property name="checkable">
+                   <bool>true</bool>
+                  </property>
+                  <property name="autoExclusive">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item alignment="Qt::AlignLeft">
+                 <widget class="QPushButton" name="pushNetDisable">
+                  <property name="minimumSize">
+                   <size>
+                    <width>120</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>120</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="focusPolicy">
+                   <enum>Qt::NoFocus</enum>
+                  </property>
+                  <property name="text">
+                   <string>Disable</string>
+                  </property>
+                  <property name="checkable">
+                   <bool>true</bool>
+                  </property>
+                  <property name="checked">
+                   <bool>true</bool>
+                  </property>
+                  <property name="autoExclusive">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="labelNetActivity">
+               <property name="styleSheet">
+                <string notr="true"/>
+               </property>
+               <property name="text">
+                <string>Enable or disable network activity</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+               <property name="indent">
+                <number>0</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
          </layout>
         </item>
         <item>

--- a/src/qt/pivx/settings/settingsinformationwidget.cpp
+++ b/src/qt/pivx/settings/settingsinformationwidget.cpp
@@ -119,6 +119,7 @@ void SettingsInformationWidget::loadClientModel()
 
         setNumConnections(clientModel->getNumConnections());
         connect(clientModel, &ClientModel::numConnectionsChanged, this, &SettingsInformationWidget::setNumConnections);
+        connect(clientModel, &ClientModel::networkActiveChanged, this, &SettingsInformationWidget::networkActiveChanged);
 
         setNumBlocks(clientModel->getNumBlocks());
         connect(clientModel, &ClientModel::numBlocksChanged, this, &SettingsInformationWidget::setNumBlocks);
@@ -127,16 +128,34 @@ void SettingsInformationWidget::loadClientModel()
     }
 }
 
+void SettingsInformationWidget::updateNetworkState(int numConnections)
+{
+    bool netActivityState = clientModel->getNetworkActive();
+
+    QString connections;
+    if (!netActivityState && numConnections == 0) {
+        connections = tr("Network activity disabled");
+    } else {
+        connections = QString::number(numConnections) + " (";
+        connections += tr("In:") + " " + QString::number(clientModel->getNumConnections(CONNECTIONS_IN)) + " / ";
+        connections += tr("Out:") + " " + QString::number(clientModel->getNumConnections(CONNECTIONS_OUT)) + ")";
+        if(!netActivityState) {
+            connections += " " + tr("Network activity disabled");
+        }
+    }
+    ui->labelInfoConnections->setText(connections);
+}
+
 void SettingsInformationWidget::setNumConnections(int count)
 {
     if (!clientModel)
         return;
+    updateNetworkState(count);
+}
 
-    QString connections = QString::number(count) + " (";
-    connections += tr("In:") + " " + QString::number(clientModel->getNumConnections(CONNECTIONS_IN)) + " / ";
-    connections += tr("Out:") + " " + QString::number(clientModel->getNumConnections(CONNECTIONS_OUT)) + ")";
-
-    ui->labelInfoConnections->setText(connections);
+void SettingsInformationWidget::networkActiveChanged(bool active)
+{
+    updateNetworkState(clientModel->getNumConnections());
 }
 
 void SettingsInformationWidget::setNumBlocks(int count)

--- a/src/qt/pivx/settings/settingsinformationwidget.h
+++ b/src/qt/pivx/settings/settingsinformationwidget.h
@@ -28,6 +28,7 @@ public:
 
 private Q_SLOTS:
     void setNumConnections(int count);
+    void networkActiveChanged(bool active);
     void setNumBlocks(int count);
     void showEvent(QShowEvent* event) override;
     void hideEvent(QHideEvent* event) override;
@@ -39,6 +40,9 @@ public Q_SLOTS:
 private:
     Ui::SettingsInformationWidget *ui;
     RPCConsole *rpcConsole = nullptr;
+
+    // Update connections and network activity state.
+    void updateNetworkState(int numConnections);
 };
 
 #endif // SETTINGSINFORMATIONWIDGET_H

--- a/src/qt/pivx/settings/settingswalletoptionswidget.cpp
+++ b/src/qt/pivx/settings/settingswalletoptionswidget.cpp
@@ -32,6 +32,11 @@ SettingsWalletOptionsWidget::SettingsWalletOptionsWidget(PIVXGUI* _window, QWidg
     ui->spinBoxStakeSplitThreshold->setAttribute(Qt::WA_MacShowFocusRect, 0);
     setShadow(ui->spinBoxStakeSplitThreshold);
 
+    setCssProperty(ui->pushNetEnable, "btn-check-left");
+    ui->pushNetEnable->setChecked(true);
+    setCssProperty(ui->pushNetDisable, "btn-check-right");
+    setCssProperty(ui->labelNetActivity, "text-subtitle");
+
 #ifndef USE_UPNP
     ui->mapPortUpnp->setVisible(false);
 #endif
@@ -57,6 +62,8 @@ SettingsWalletOptionsWidget::SettingsWalletOptionsWidget(PIVXGUI* _window, QWidg
     setCssBtnSecondary(ui->pushButtonReset);
     setCssBtnSecondary(ui->pushButtonClean);
 
+    connect(ui->pushNetEnable, &QPushButton::clicked, [this](){setNetworkActivity(true);});
+    connect(ui->pushNetDisable,  &QPushButton::clicked, [this](){setNetworkActivity(false);});
     connect(ui->pushButtonSave, &QPushButton::clicked, [this] { Q_EMIT saveSettings(); });
     connect(ui->pushButtonReset, &QPushButton::clicked, this, &SettingsWalletOptionsWidget::onResetClicked);
     connect(ui->pushButtonClean, &QPushButton::clicked, [this] { Q_EMIT discardSettings(); });
@@ -88,6 +95,14 @@ void SettingsWalletOptionsWidget::loadWalletModel()
 {
     reloadWalletOptions();
     connect(walletModel, &WalletModel::notifySSTChanged, this, &SettingsWalletOptionsWidget::setSpinBoxStakeSplitThreshold);
+}
+
+void SettingsWalletOptionsWidget::loadClientModel()
+{
+    connect(clientModel, &ClientModel::networkActiveChanged, [this](bool isActive) {
+        ui->pushNetEnable->setChecked(isActive);
+        ui->pushNetDisable->setChecked(!isActive);
+    });
 }
 
 void SettingsWalletOptionsWidget::reloadWalletOptions()
@@ -130,6 +145,13 @@ void SettingsWalletOptionsWidget::discardWalletOnlyOptions()
 void SettingsWalletOptionsWidget::saveMapPortOptions()
 {
     clientModel->mapPort(ui->mapPortUpnp->isChecked(), ui->mapPortNatpmp->isChecked());
+}
+
+void SettingsWalletOptionsWidget::setNetworkActivity(bool active)
+{
+    if (clientModel->getNetworkActive() == active) return;
+    clientModel->setNetworkActive(active);
+    inform(active ? tr("Network activity enabled") : tr("Network activity disabled"));
 }
 
 SettingsWalletOptionsWidget::~SettingsWalletOptionsWidget(){

--- a/src/qt/pivx/settings/settingswalletoptionswidget.h
+++ b/src/qt/pivx/settings/settingswalletoptionswidget.h
@@ -38,10 +38,14 @@ private:
     Ui::SettingsWalletOptionsWidget *ui;
 
     void loadWalletModel() override;
+    void loadClientModel() override;
     void reloadWalletOptions();
 
     void setSpinBoxStakeSplitThreshold(double val);
     double getSpinBoxStakeSplitThreshold() const;
+
+    // Enable or disable the network activity
+    void setNetworkActivity(bool active);
 };
 
 #endif // SETTINGSWALLETOPTIONSWIDGET_H

--- a/src/qt/pivx/topbar.cpp
+++ b/src/qt/pivx/topbar.cpp
@@ -20,7 +20,6 @@
 #include "addresstablemodel.h"
 
 #include "masternode-sync.h"
-#include "wallet/wallet.h"
 
 #include <QPixmap>
 
@@ -421,6 +420,7 @@ void TopBar::loadClientModel()
 
         setNumBlocks(clientModel->getNumBlocks());
         connect(clientModel, &ClientModel::numBlocksChanged, this, &TopBar::setNumBlocks);
+        connect(clientModel, &ClientModel::networkActiveChanged, this, &TopBar::setNetworkActive);
 
         timerStakingIcon = new QTimer(ui->pushButtonStack);
         connect(timerStakingIcon, &QTimer::timeout, this, &TopBar::updateStakingStatus);
@@ -465,6 +465,18 @@ void TopBar::setNumConnections(int count)
     }
 
     ui->pushButtonConnection->setButtonText(tr("%n active connection(s)", "", count));
+}
+
+void TopBar::setNetworkActive(bool active)
+{
+    if (!active) {
+        ui->pushButtonSync->setButtonText(tr("Network activity disabled"));
+        ui->pushButtonSync->setButtonClassStyle("cssClass", "btn-check-sync-inactive", true);
+    } else {
+        if (!clientModel) return;
+        setNumBlocks(clientModel->getLastBlockProcessedHeight());
+        ui->pushButtonSync->setButtonClassStyle("cssClass", "btn-check-sync", true);
+    }
 }
 
 void TopBar::setNumBlocks(int count)

--- a/src/qt/pivx/topbar.h
+++ b/src/qt/pivx/topbar.h
@@ -49,6 +49,7 @@ public Q_SLOTS:
 
     void setNumConnections(int count);
     void setNumBlocks(int count);
+    void setNetworkActive(bool active);
     void setStakingStatusActive(bool fActive);
     void updateStakingStatus();
     void updateHDState(const bool upgraded, const QString& upgradeError);

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -176,13 +176,17 @@ void RPCConsole::setClientModel(ClientModel* model)
     ui->trafficGraph->setClientModel(model);
     if (model && clientModel->getPeerTableModel() && clientModel->getBanTableModel()) {
         // Keep up to date with client
-        setNumConnections(model->getNumConnections());
+        int num_connections = model->getNumConnections();
+        setNumConnections(num_connections);
         connect(model, &ClientModel::numConnectionsChanged, this, &RPCConsole::setNumConnections);
 
         setNumBlocks(model->getNumBlocks());
         connect(model, &ClientModel::numBlocksChanged, this, &RPCConsole::setNumBlocks);
 
         connect(model, &ClientModel::strMasternodesChanged, this, &RPCConsole::setMasternodeCount);
+
+        updateNetworkState(num_connections);
+        connect(model, &ClientModel::networkActiveChanged, this, &RPCConsole::setNetworkActive);
 
         updateTrafficStats(model->getTotalBytesRecv(), model->getTotalBytesSent());
         connect(model, &ClientModel::bytesChanged, this, &RPCConsole::updateTrafficStats);
@@ -436,16 +440,35 @@ void RPCConsole::message(int category, const QString& message, bool html)
     ui->messagesWidget->append(out);
 }
 
+void RPCConsole::updateNetworkState(int numConnections)
+{
+    bool netActivityState = clientModel->getNetworkActive();
+    QString connections;
+    if (!netActivityState && numConnections == 0) {
+        connections = tr("Network activity disabled");
+    } else {
+        connections = QString::number(numConnections) + " (";
+        connections += tr("In:") + " " + QString::number(clientModel->getNumConnections(CONNECTIONS_IN)) + " / ";
+        connections += tr("Out:") + " " + QString::number(clientModel->getNumConnections(CONNECTIONS_OUT)) + ")";
+        if(!netActivityState) {
+            connections += " " + tr("Network activity disabled");
+        }
+    }
+    ui->numberOfConnections->setText(connections);
+}
+
 void RPCConsole::setNumConnections(int count)
 {
     if (!clientModel)
         return;
 
-    QString connections = QString::number(count) + " (";
-    connections += tr("In:") + " " + QString::number(clientModel->getNumConnections(CONNECTIONS_IN)) + " / ";
-    connections += tr("Out:") + " " + QString::number(clientModel->getNumConnections(CONNECTIONS_OUT)) + ")";
+    updateNetworkState(count);
+}
 
-    ui->numberOfConnections->setText(connections);
+void RPCConsole::setNetworkActive(bool networkActive)
+{
+    if (!clientModel) return;
+    updateNetworkState(clientModel->getNumConnections());
 }
 
 void RPCConsole::setNumBlocks(int count)
@@ -835,4 +858,3 @@ void RPCConsole::showOrHideBanTableIfRequired()
     ui->banlistWidget->setVisible(visible);
     ui->banHeading->setVisible(visible);
 }
-

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -81,6 +81,8 @@ public Q_SLOTS:
     void message(int category, const QString &message, bool html);
     /** Set number of connections shown in the UI */
     void setNumConnections(int count);
+    /** Set network state shown in the UI */
+    void setNetworkActive(bool networkActive);
     /** Set number of blocks shown in the UI */
     void setNumBlocks(int count);
     /** Set number of masternodes shown in the UI */
@@ -150,6 +152,9 @@ private:
     QMenu *peersTableContextMenu;
     QMenu *banTableContextMenu;
     RPCTimerInterface *rpcTimerInterface;
+
+    /** Update UI with latest network info from model. */
+    void updateNetworkState(int num_connections);
 };
 
 #endif // BITCOIN_QT_RPCCONSOLE_H

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -142,6 +142,7 @@ static const CRPCConvertParam vRPCConvertParams[] = {
     { "sendtoaddress", 4, "subtract_fee" },
     { "setautocombinethreshold", 0, "enable" },
     { "setautocombinethreshold", 1, "threshold" },
+    { "setnetworkactive", 0, "active"},
     { "setban", 2, "bantime" },
     { "setban", 3, "absolute" },
     { "setgenerate", 0, "generate" },

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -125,8 +125,9 @@ UniValue getinfo(const JSONRPCRequest& request)
 #endif
     obj.pushKV("blocks", (int)chainActive.Height());
     obj.pushKV("timeoffset", GetTimeOffset());
-    if(g_connman)
+    if(g_connman) {
         obj.pushKV("connections", (int)g_connman->GetNodeCount(CConnman::CONNECTIONS_ALL));
+    }
     obj.pushKV("proxy", (proxy.IsValid() ? proxy.proxy.ToStringIPPort() : std::string()));
     obj.pushKV("difficulty", (double)GetDifficulty());
     obj.pushKV("testnet", Params().IsTestnet());

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -6,7 +6,6 @@
 #include "rpc/server.h"
 #include "rpc/client.h"
 
-#include "key_io.h"
 #include "netbase.h"
 #include "util/system.h"
 
@@ -93,6 +92,28 @@ BOOST_AUTO_TEST_CASE(rpc_rawparams)
     BOOST_CHECK_THROW(CallRPC("sendrawtransaction null"), std::runtime_error);
     BOOST_CHECK_THROW(CallRPC("sendrawtransaction DEADBEEF"), std::runtime_error);
     BOOST_CHECK_THROW(CallRPC(std::string("sendrawtransaction ")+rawtx+" extra"), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(rpc_togglenetwork)
+{
+    UniValue r;
+
+    r = CallRPC("getnetworkinfo");
+    bool netState = find_value(r.get_obj(), "networkactive").get_bool();
+    BOOST_CHECK_EQUAL(netState, true);
+
+    BOOST_CHECK_NO_THROW(CallRPC("setnetworkactive false"));
+    r = CallRPC("getnetworkinfo");
+    int numConnection = find_value(r.get_obj(), "connections").get_int();
+    BOOST_CHECK_EQUAL(numConnection, 0);
+
+    netState = find_value(r.get_obj(), "networkactive").get_bool();
+    BOOST_CHECK_EQUAL(netState, false);
+
+    BOOST_CHECK_NO_THROW(CallRPC("setnetworkactive true"));
+    r = CallRPC("getnetworkinfo");
+    netState = find_value(r.get_obj(), "networkactive").get_bool();
+    BOOST_CHECK_EQUAL(netState, true);
 }
 
 BOOST_AUTO_TEST_CASE(rpc_rawsign)


### PR DESCRIPTION
Allowing the user/test to stop and restart the network activity.

Pretty useful for some manual isolation test cases.

When the network activity is disabled the client will close all connections, stop accepting inbound connections, and stop opening new outbound connections, until the network activity is reenabled.

Quick demo video:

https://user-images.githubusercontent.com/5377650/137732464-02624285-2e62-483d-bf79-6df9cb0162f1.mp4

TODO:
Add release-notes for the new RPC command and the GUI control.