### PR TITLE
[TierTwo] Long Living Masternode Quorums - Part 1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,8 @@ file(GLOB ZRUST_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/src/rust/include/*.h)
 file(GLOB SAPLING_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/src/sapling/*.h)
 file(GLOB IMMER_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/src/immer/*.h)
 file(GLOB EVO_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/src/evo/*.h)
+file(GLOB BLS_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/src/bls/*.h)
+file(GLOB LLMQ_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/src/llmq/*.h)
 
 source_group("BitcoinHeaders" FILES
         ${HEADERS}
@@ -184,6 +186,8 @@ source_group("BitcoinHeaders" FILES
         ${SAPLING_HEADERS}
         ${IMMER_HEADERS}
         ${EVO_HEADERS}
+        ${BLS_HEADERS}
+        ${LLMQ_HEADERS}
         ./src/support/cleanse.h
         ./src/support/events.h
         )
@@ -193,9 +197,6 @@ set(SERVER_SOURCES
         ./src/addrman.cpp
         ./src/bloom.cpp
         ./src/blocksignature.cpp
-        ./src/bls/bls_ies.cpp
-        ./src/bls/bls_worker.cpp
-        ./src/bls/bls_wrapper.cpp
         ./src/chain.cpp
         ./src/checkpoints.cpp
         ./src/consensus/tx_verify.cpp
@@ -367,6 +368,9 @@ set(COMMON_SOURCES
         ./src/activemasternode.cpp
         ./src/base58.cpp
         ./src/bip38.cpp
+        ./src/bls/bls_ies.cpp
+        ./src/bls/bls_worker.cpp
+        ./src/bls/bls_wrapper.cpp
         ./src/budget/budgetdb.cpp
         ./src/budget/budgetmanager.cpp
         ./src/budget/budgetproposal.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -389,6 +389,8 @@ set(COMMON_SOURCES
         ./src/evo/evodb.cpp
         ./src/evo/providertx.cpp
         ./src/evo/specialtx_validation.cpp
+        ./src/llmq/quorums_commitment.cpp
+        ./src/llmq/quorums_utils.cpp
         ./src/consensus/merkle.cpp
         ./src/consensus/zerocoin_verify.cpp
         ./src/primitives/block.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -389,7 +389,9 @@ set(COMMON_SOURCES
         ./src/evo/evodb.cpp
         ./src/evo/providertx.cpp
         ./src/evo/specialtx_validation.cpp
+        ./src/llmq/quorums_blockprocessor.cpp
         ./src/llmq/quorums_commitment.cpp
+        ./src/llmq/quorums_init.cpp
         ./src/llmq/quorums_utils.cpp
         ./src/consensus/merkle.cpp
         ./src/consensus/zerocoin_verify.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -187,7 +187,9 @@ BITCOIN_CORE_H = \
   evo/evonotificationinterface.h \
   evo/providertx.h \
   evo/specialtx_validation.h \
+  llmq/quorums_blockprocessor.h \
   llmq/quorums_commitment.h \
+  llmq/quorums_init.h \
   llmq/quorums_utils.h \
   addressbook.h \
   wallet/db.h \
@@ -349,7 +351,9 @@ libbitcoin_server_a_SOURCES = \
   evo/evonotificationinterface.cpp \
   evo/providertx.cpp \
   evo/specialtx_validation.cpp \
+  llmq/quorums_blockprocessor.cpp \
   llmq/quorums_commitment.cpp \
+  llmq/quorums_init.cpp \
   llmq/quorums_utils.cpp \
   httprpc.cpp \
   httpserver.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -187,6 +187,8 @@ BITCOIN_CORE_H = \
   evo/evonotificationinterface.h \
   evo/providertx.h \
   evo/specialtx_validation.h \
+  llmq/quorums_commitment.h \
+  llmq/quorums_utils.h \
   addressbook.h \
   wallet/db.h \
   flatfile.h \
@@ -347,6 +349,8 @@ libbitcoin_server_a_SOURCES = \
   evo/evonotificationinterface.cpp \
   evo/providertx.cpp \
   evo/specialtx_validation.cpp \
+  llmq/quorums_commitment.cpp \
+  llmq/quorums_utils.cpp \
   httprpc.cpp \
   httpserver.cpp \
   init.cpp \

--- a/src/blockassembler.cpp
+++ b/src/blockassembler.cpp
@@ -14,6 +14,7 @@
 #include "consensus/merkle.h"
 #include "consensus/upgrades.h"
 #include "consensus/validation.h"
+#include "llmq/quorums_blockprocessor.h"
 #include "masternode-payments.h"
 #include "policy/policy.h"
 #include "pow.h"
@@ -190,6 +191,22 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         return nullptr;
     }
 
+    // After v6 enforcement, add LLMQ commitments if needed
+    const Consensus::Params& consensus = Params().GetConsensus();
+    if (consensus.NetworkUpgradeActive(nHeight, Consensus::UPGRADE_V6_0)) {
+        LOCK(cs_main);
+        for (const auto& p : Params().GetConsensus().llmqs) {
+            CTransactionRef qcTx;
+            if (llmq::quorumBlockProcessor->GetMinableCommitmentTx(p.first, nHeight, qcTx)) {
+                pblock->vtx.emplace_back(qcTx);
+                pblocktemplate->vTxFees.emplace_back(0);
+                pblocktemplate->vTxSigOps.emplace_back(0);
+                nBlockSize += qcTx->GetTotalSize();
+                ++nBlockTx;
+            }
+        }
+    }
+
     if (!fNoMempoolTx) {
         // Add transactions from mempool
         LOCK2(cs_main,mempool.cs);
@@ -208,7 +225,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     nLastBlockSize = nBlockSize;
     LogPrintf("CreateNewBlock(): total size %u txs: %u fees: %ld sigops %d\n", nBlockSize, nBlockTx, nFees, nBlockSigOps);
 
-    const Consensus::Params& consensus = Params().GetConsensus();
+
     // Fill in header
     pblock->hashPrevBlock = pindexPrev->GetBlockHash();
     if (!fProofOfStake) UpdateTime(pblock, consensus, pindexPrev);

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -59,6 +59,84 @@ static CBlock CreateGenesisBlock(uint32_t nTime, uint32_t nNonce, uint32_t nBits
     return CreateGenesisBlock(pszTimestamp, genesisOutputScript, nTime, nNonce, nBits, nVersion, genesisReward);
 }
 
+// this one is for testing only
+static Consensus::LLMQParams llmq_test = {
+        .type = Consensus::LLMQ_TEST,
+        .name = "llmq_test",
+        .size = 3,
+        .minSize = 2,
+        .threshold = 2,
+
+        .dkgInterval = 60, // one DKG per hour
+        .dkgPhaseBlocks = 6,
+        .dkgMiningWindowStart = 30, // dkgPhaseBlocks * 5 = after finalization
+        .dkgMiningWindowEnd = 40,
+        .dkgBadVotesThreshold = 2,
+
+        .signingActiveQuorumCount = 2, // just a few ones to allow easier testing
+
+        .keepOldConnections = 3,
+        .recoveryMembers = 3,
+};
+
+static Consensus::LLMQParams llmq50_60 = {
+        .type = Consensus::LLMQ_50_60,
+        .name = "llmq_50_60",
+        .size = 50,
+        .minSize = 40,
+        .threshold = 30,
+
+        .dkgInterval = 60, // one DKG per hour
+        .dkgPhaseBlocks = 6,
+        .dkgMiningWindowStart = 30, // dkgPhaseBlocks * 5 = after finalization
+        .dkgMiningWindowEnd = 40,
+        .dkgBadVotesThreshold = 40,
+
+        .signingActiveQuorumCount = 24, // a full day worth of LLMQs
+
+        .keepOldConnections = 25,
+        .recoveryMembers = 25,
+};
+
+static Consensus::LLMQParams llmq400_60 = {
+        .type = Consensus::LLMQ_400_60,
+        .name = "llmq_400_60",
+        .size = 400,
+        .minSize = 300,
+        .threshold = 240,
+
+        .dkgInterval = 60 * 12, // one DKG every 12 hours
+        .dkgPhaseBlocks = 10,
+        .dkgMiningWindowStart = 50, // dkgPhaseBlocks * 5 = after finalization
+        .dkgMiningWindowEnd = 70,
+        .dkgBadVotesThreshold = 300,
+
+        .signingActiveQuorumCount = 4, // two days worth of LLMQs
+
+        .keepOldConnections = 5,
+        .recoveryMembers = 100,
+};
+
+// Used for deployment and min-proto-version signaling, so it needs a higher threshold
+static Consensus::LLMQParams llmq400_85 = {
+        .type = Consensus::LLMQ_400_85,
+        .name = "llmq_400_85",
+        .size = 400,
+        .minSize = 350,
+        .threshold = 340,
+
+        .dkgInterval = 60 * 24, // one DKG every 24 hours
+        .dkgPhaseBlocks = 10,
+        .dkgMiningWindowStart = 50, // dkgPhaseBlocks * 5 = after finalization
+        .dkgMiningWindowEnd = 70, // give it a larger mining window to make sure it is mined
+        .dkgBadVotesThreshold = 300,
+
+        .signingActiveQuorumCount = 4, // four days worth of LLMQs
+
+        .keepOldConnections = 5,
+        .recoveryMembers = 100,
+};
+
 /**
  * Main network
  */
@@ -255,6 +333,11 @@ public:
         bech32HRPs[SAPLING_INCOMING_VIEWING_KEY] = "pivks";
         bech32HRPs[SAPLING_EXTENDED_SPEND_KEY]   = "p-secret-spending-key-main";
         bech32HRPs[SAPLING_EXTENDED_FVK]         = "pxviews";
+
+        // long living quorum params
+        consensus.llmqs[Consensus::LLMQ_50_60] = llmq50_60;
+        consensus.llmqs[Consensus::LLMQ_400_60] = llmq400_60;
+        consensus.llmqs[Consensus::LLMQ_400_85] = llmq400_85;
     }
 
     const CCheckpointData& Checkpoints() const
@@ -382,6 +465,11 @@ public:
         bech32HRPs[SAPLING_INCOMING_VIEWING_KEY] = "pivktestsapling";
         bech32HRPs[SAPLING_EXTENDED_SPEND_KEY]   = "p-secret-spending-key-test";
         bech32HRPs[SAPLING_EXTENDED_FVK]         = "pxviewtestsapling";
+
+        // long living quorum params
+        consensus.llmqs[Consensus::LLMQ_50_60] = llmq50_60;
+        consensus.llmqs[Consensus::LLMQ_400_60] = llmq400_60;
+        consensus.llmqs[Consensus::LLMQ_400_85] = llmq400_85;
     }
 
     const CCheckpointData& Checkpoints() const
@@ -509,6 +597,9 @@ public:
         bech32HRPs[SAPLING_INCOMING_VIEWING_KEY] = "pivktestsapling";
         bech32HRPs[SAPLING_EXTENDED_SPEND_KEY]   = "p-secret-spending-key-test";
         bech32HRPs[SAPLING_EXTENDED_FVK]         = "pxviewtestsapling";
+
+        // long living quorum params
+        consensus.llmqs[Consensus::LLMQ_TEST] = llmq_test;
     }
 
     const CCheckpointData& Checkpoints() const

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -84,6 +84,82 @@ struct NetworkUpgrade {
     Optional<uint256> hashActivationBlock;
 };
 
+enum LLMQType : uint8_t
+{
+    LLMQ_NONE = 0xff,
+
+    LLMQ_50_60 = 1, // 50 members, 30 (60%) threshold, one per hour
+    LLMQ_400_60 = 2, // 400 members, 240 (60%) threshold, one every 12 hours
+    LLMQ_400_85 = 3, // 400 members, 340 (85%) threshold, one every 24 hours
+
+    // for testing only
+    LLMQ_TEST = 100, // 3 members, 2 (66%) threshold, one per hour. Params might differ when -llmqtestparams is used
+};
+
+// Configures a LLMQ and its DKG
+// See https://github.com/dashpay/dips/blob/master/dip-0006.md for more details
+struct LLMQParams {
+    LLMQType type;
+
+    // not consensus critical, only used in logging, RPC and UI
+    std::string name;
+
+    // the size of the quorum, e.g. 50 or 400
+    int size;
+
+    // The minimum number of valid members after the DKK. If less members are determined valid, no commitment can be
+    // created. Should be higher then the threshold to allow some room for failing nodes, otherwise quorum might end up
+    // not being able to ever created a recovered signature if more nodes fail after the DKG
+    int minSize;
+
+    // The threshold required to recover a final signature. Should be at least 50%+1 of the quorum size. This value
+    // also controls the size of the public key verification vector and has a large influence on the performance of
+    // recovery. It also influences the amount of minimum messages that need to be exchanged for a single signing session.
+    // This value has the most influence on the security of the quorum. The number of total malicious masternodes
+    // required to negatively influence signing sessions highly correlates to the threshold percentage.
+    int threshold;
+
+    // The interval in number blocks for DKGs and the creation of LLMQs. If set to 60 for example, a DKG will start
+    // every 60 blocks, which is approximately once every hour.
+    int dkgInterval;
+
+    // The number of blocks per phase in a DKG session. There are 6 phases plus the mining phase that need to be processed
+    // per DKG. Set this value to a number of blocks so that each phase has enough time to propagate all required
+    // messages to all members before the next phase starts. If blocks are produced too fast, whole DKG sessions will
+    // fail.
+    int dkgPhaseBlocks;
+
+    // The starting block inside the DKG interval for when mining of commitments starts. The value is inclusive.
+    // Starting from this block, the inclusion of (possibly null) commitments is enforced until the first non-null
+    // commitment is mined. The chosen value should be at least 5 * dkgPhaseBlocks so that it starts right after the
+    // finalization phase.
+    int dkgMiningWindowStart;
+
+    // The ending block inside the DKG interval for when mining of commitments ends. The value is inclusive.
+    // Choose a value so that miners have enough time to receive the commitment and mine it. Also take into consideration
+    // that miners might omit real commitments and revert to always including null commitments. The mining window should
+    // be large enough so that other miners have a chance to produce a block containing a non-null commitment. The window
+    // should at the same time not be too large so that not too much space is wasted with null commitments in case a DKG
+    // session failed.
+    int dkgMiningWindowEnd;
+
+    // In the complaint phase, members will vote on other members being bad (missing valid contribution). If at least
+    // dkgBadVotesThreshold have voted for another member to be bad, it will considered to be bad by all other members
+    // as well. This serves as a protection against late-comers who send their contribution on the bring of
+    // phase-transition, which would otherwise result in inconsistent views of the valid members set
+    int dkgBadVotesThreshold;
+
+    // Number of quorums to consider "active" for signing sessions
+    int signingActiveQuorumCount;
+
+    // Used for inter-quorum communication. This is the number of quorums for which we should keep old connections. This
+    // should be at least one more then the active quorums set.
+    int keepOldConnections;
+
+    // How many members should we try to send all sigShares to before we give up.
+    int recoveryMembers;
+};
+
 /**
  * Parameters that influence chain consensus.
  */
@@ -190,6 +266,9 @@ struct Params {
      * heights).
      */
     bool NetworkUpgradeActive(int nHeight, Consensus::UpgradeIndex idx) const;
+
+    // LLMQ
+    std::map<LLMQType, LLMQParams> llmqs;
 };
 } // namespace Consensus
 

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -54,11 +54,13 @@ unsigned int GetP2SHSigOpCount(const CTransaction& tx, const CCoinsViewCache& in
 bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fColdStakingActive)
 {
     // Basic checks that don't depend on any context
-    // Transactions containing empty `vin` must have non-empty `vShieldedSpend`.
-    if (tx.vin.empty() && (tx.sapData && tx.sapData->vShieldedSpend.empty()))
+    // Transactions containing empty `vin` must have non-empty `vShieldedSpend`,
+    // or they must be quorum commitments (only one per-type allowed in a block)
+    if (tx.vin.empty() && (tx.sapData && tx.sapData->vShieldedSpend.empty()) && !tx.IsQuorumCommitmentTx())
         return state.DoS(10, false, REJECT_INVALID, "bad-txns-vin-empty");
-    // Transactions containing empty `vout` must have non-empty `vShieldedOutput`.
-    if (tx.vout.empty() && (tx.sapData && tx.sapData->vShieldedOutput.empty()))
+    // Transactions containing empty `vout` must have non-empty `vShieldedOutput`,
+    // or they must be quorum commitments (only one per-type allowed in a block)
+    if (tx.vout.empty() && (tx.sapData && tx.sapData->vShieldedOutput.empty()) && !tx.IsQuorumCommitmentTx())
         return state.DoS(10, false, REJECT_INVALID, "bad-txns-vout-empty");
 
     // Version check

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -11,6 +11,7 @@
 #include "dbwrapper.h"
 #include "evo/evodb.h"
 #include "evo/providertx.h"
+#include "llmq/quorums_commitment.h"
 #include "saltedhasher.h"
 #include "sync.h"
 
@@ -573,6 +574,7 @@ public:
 
     // the returned list will not contain the correct block hash (we can't know it yet as the coinbase TX is not updated yet)
     bool BuildNewListFromBlock(const CBlock& block, const CBlockIndex* pindexPrev, CValidationState& state, CDeterministicMNList& mnListRet, bool debugLogs);
+    void HandleQuorumCommitment(llmq::CFinalCommitment& qc, const CBlockIndex* pindexQuorum, CDeterministicMNList& mnList, bool debugLogs);
     void DecreasePoSePenalties(CDeterministicMNList& mnList);
 
     // to return a valid list, it must have been built first, so never call it with a block not-yet connected (e.g. from CheckBlock).

--- a/src/evo/specialtx_validation.cpp
+++ b/src/evo/specialtx_validation.cpp
@@ -12,6 +12,7 @@
 #include "consensus/validation.h"
 #include "evo/deterministicmns.h"
 #include "evo/providertx.h"
+#include "llmq/quorums_commitment.h"
 #include "messagesigner.h"
 #include "primitives/transaction.h"
 #include "primitives/block.h"
@@ -488,6 +489,10 @@ bool CheckSpecialTxNoContext(const CTransaction& tx, CValidationState& state)
             // provider-update-revoke
             return CheckProUpRevTx(tx, nullptr, state);
         }
+        case CTransaction::TxType::LLMQCOMM: {
+            // quorum commitment
+            return llmq::CheckLLMQCommitment(tx, nullptr, state);
+        }
     }
 
     return state.DoS(10, error("%s: special tx %s with invalid type %d", __func__, tx.GetHash().ToString(), tx.nType),
@@ -531,6 +536,10 @@ bool CheckSpecialTx(const CTransaction& tx, const CBlockIndex* pindexPrev, const
         case CTransaction::TxType::PROUPREV: {
             // provider-update-revoke
             return CheckProUpRevTx(tx, pindexPrev, state);
+        }
+        case CTransaction::TxType::LLMQCOMM: {
+            // quorum commitment
+            return llmq::CheckLLMQCommitment(tx, pindexPrev, state);
         }
     }
 

--- a/src/evo/specialtx_validation.cpp
+++ b/src/evo/specialtx_validation.cpp
@@ -12,6 +12,7 @@
 #include "consensus/validation.h"
 #include "evo/deterministicmns.h"
 #include "evo/providertx.h"
+#include "llmq/quorums_blockprocessor.h"
 #include "llmq/quorums_commitment.h"
 #include "messagesigner.h"
 #include "primitives/transaction.h"
@@ -557,12 +558,16 @@ bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, co
         }
     }
 
+    if (!llmq::quorumBlockProcessor->ProcessBlock(block, pindex, state, fJustCheck)) {
+        // pass the state returned by the function above
+        return false;
+    }
+
     if (!deterministicMNManager->ProcessBlock(block, pindex, state, fJustCheck)) {
         // pass the state returned by the function above
         return false;
     }
 
-    // !TODO: ProcessBlock llmq quorum block processor
     return true;
 }
 
@@ -571,7 +576,9 @@ bool UndoSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex)
     if (!deterministicMNManager->UndoBlock(block, pindex)) {
         return false;
     }
-    // !TODO: UndoBlock llmq quorum block processor
+    if (!llmq::quorumBlockProcessor->UndoBlock(block, pindex)) {
+        return false;
+    }
     return true;
 }
 

--- a/src/llmq/quorums_blockprocessor.cpp
+++ b/src/llmq/quorums_blockprocessor.cpp
@@ -98,7 +98,7 @@ void CQuorumBlockProcessor::ProcessMessage(CNode* pfrom, CDataStream& vRecv)
         return;
     }
 
-    if (!qc.Verify(pquorumIndex, true)) {
+    if (!qc.Verify(pquorumIndex)) {
         SetMisbehaving(pfrom, 100, "invalid commtiment for quorum", qc.quorumHash.ToString());
         return;
     }

--- a/src/llmq/quorums_blockprocessor.cpp
+++ b/src/llmq/quorums_blockprocessor.cpp
@@ -94,7 +94,7 @@ void CQuorumBlockProcessor::ProcessMessage(CNode* pfrom, CDataStream& vRecv)
         if (it != minableCommitmentsByQuorum.end()) {
             auto jt = minableCommitments.find(it->second);
             if (jt != minableCommitments.end()) {
-                if (jt->second.CountSigners() <= qc.CountSigners()) {
+                if (jt->second.CountSigners() > qc.CountSigners()) {
                     return;
                 }
             }

--- a/src/llmq/quorums_blockprocessor.cpp
+++ b/src/llmq/quorums_blockprocessor.cpp
@@ -175,7 +175,7 @@ bool CQuorumBlockProcessor::GetCommitmentsFromBlock(const CBlock& block, const C
     ret.clear();
 
     for (const auto& tx : block.vtx) {
-        if (tx->nType != CTransaction::TxType::LLMQCOMM) {
+        if (!tx->IsQuorumCommitmentTx()) {
             continue;
         }
         LLMQCommPL pl;

--- a/src/llmq/quorums_blockprocessor.cpp
+++ b/src/llmq/quorums_blockprocessor.cpp
@@ -33,9 +33,8 @@ template<typename... Args>
 static void SetMisbehaving(CNode* pfrom, int nDos, const char* fmt, const Args&... args)
 {
     LOCK(cs_main);
-    // !TODO: Add log category for LLMQ stuff
     try {
-        LogPrintf("Invalid QFCOMMITMENT message from peer=%d (reason: %s)\n",
+        LogPrint(BCLog::LLMQ, "Invalid QFCOMMITMENT message from peer=%d (reason: %s)\n",
                 pfrom->GetId(), tfm::format(fmt, args...));
     } catch (tinyformat::format_error &e) {
         LogPrintf("Error (%s) while formatting message %s\n", std::string(e.what()), fmt);

--- a/src/llmq/quorums_blockprocessor.cpp
+++ b/src/llmq/quorums_blockprocessor.cpp
@@ -1,0 +1,426 @@
+// Copyright (c) 2018-2021 The Dash Core developers
+// Copyright (c) 2021 The PIVX developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "llmq/quorums_blockprocessor.h"
+
+#include "chain.h"
+#include "chainparams.h"
+#include "consensus/validation.h"
+#include "llmq/quorums_utils.h"
+#include "evo/evodb.h"
+#include "net.h"
+#include "net_processing.h"
+#include "primitives/block.h"
+#include "validation.h"
+
+namespace llmq
+{
+std::unique_ptr<CQuorumBlockProcessor> quorumBlockProcessor{nullptr};
+
+static const std::string DB_MINED_COMMITMENT = "q_mc";
+static const std::string DB_MINED_COMMITMENT_BY_INVERSED_HEIGHT = "q_mcih";
+
+CQuorumBlockProcessor::CQuorumBlockProcessor(CEvoDB &_evoDb) :
+    evoDb(_evoDb)
+{
+    // TODO: add unordered lru cache
+    //utils::InitQuorumsCache(mapHasMinedCommitmentCache);
+}
+
+void CQuorumBlockProcessor::ProcessMessage(CNode* pfrom, CDataStream& vRecv)
+{
+    // !TODO
+}
+
+bool CQuorumBlockProcessor::ProcessBlock(const CBlock& block, const CBlockIndex* pindex, CValidationState& state, bool fJustCheck)
+{
+    LOCK(cs_main);
+    const auto& consensus = Params().GetConsensus();
+
+    bool fDIP3Active = consensus.NetworkUpgradeActive(pindex->nHeight, Consensus::UPGRADE_V6_0);
+    if (!fDIP3Active) {
+        return true;
+    }
+
+    std::map<Consensus::LLMQType, CFinalCommitment> qcs;
+    if (!GetCommitmentsFromBlock(block, pindex, qcs, state)) {
+        return false;
+    }
+
+    // The following checks make sure that there is always a (possibly null) commitment while in the mining phase
+    // until the first non-null commitment has been mined. After the non-null commitment, no other commitments are
+    // allowed, including null commitments.
+    // Note: must only check quorums that were enabled at the _previous_ block height to match mining logic
+    for (const auto& llmq : consensus.llmqs) {
+        // skip these checks when replaying blocks after the crash
+        if (WITH_LOCK(cs_main, return chainActive.Tip(); ) == nullptr) {
+            break;
+        }
+
+        // does the currently processed block contain a (possibly null) commitment for the current session?
+        Consensus::LLMQType type = llmq.first;
+        bool hasCommitmentInNewBlock = qcs.count(type) != 0;
+        bool isCommitmentRequired = IsCommitmentRequired(type, pindex->nHeight);
+
+        if (hasCommitmentInNewBlock && !isCommitmentRequired) {
+            // If we're either not in the mining phase or a non-null commitment was mined already, reject the block
+            return state.DoS(100, false, REJECT_INVALID, "bad-qc-not-allowed");
+        }
+
+        if (!hasCommitmentInNewBlock && isCommitmentRequired) {
+            // If no non-null commitment was mined for the mining phase yet and the new block does not include
+            // a (possibly null) commitment, the block should be rejected.
+            return state.DoS(100, false, REJECT_INVALID, "bad-qc-missing");
+        }
+    }
+
+    const uint256& blockHash = block.GetHash();
+
+    for (const auto& p : qcs) {
+        const auto& qc = p.second;
+        if (!ProcessCommitment(pindex->nHeight, blockHash, qc, state, fJustCheck)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+// We store a mapping from minedHeight->quorumHeight in the DB
+// minedHeight is inversed so that entries are traversable in reversed order
+static std::tuple<std::string, uint8_t, uint32_t> BuildInversedHeightKey(Consensus::LLMQType llmqType, int nMinedHeight)
+{
+    // nMinedHeight must be converted to big endian to make it comparable when serialized
+    return std::make_tuple(DB_MINED_COMMITMENT_BY_INVERSED_HEIGHT, static_cast<uint8_t>(llmqType), htobe32(std::numeric_limits<uint32_t>::max() - nMinedHeight));
+}
+
+bool CQuorumBlockProcessor::ProcessCommitment(int nHeight, const uint256& blockHash, const CFinalCommitment& qc, CValidationState& state, bool fJustCheck)
+{
+    // skip `bad-qc-block` checks below when replaying blocks after a crash
+    const uint256& quorumHash = WITH_LOCK(cs_main, return chainActive.Tip(); ) != nullptr
+                              ? GetQuorumBlockHash((Consensus::LLMQType)qc.llmqType, nHeight)
+                              : qc.quorumHash;
+
+    if (quorumHash.IsNull()) {
+        return state.DoS(100, false, REJECT_INVALID, "bad-qc-null-quorumhash");
+    }
+    if (quorumHash != qc.quorumHash) {
+        return state.DoS(100, false, REJECT_INVALID, "bad-qc-block");
+    }
+
+    // index of quorumHash already checked
+    const CBlockIndex* quorumIndex = mapBlockIndex.at(quorumHash);
+
+    // Verify signatures
+    if (!qc.Verify(quorumIndex, true)) {
+        return state.DoS(100, false, REJECT_INVALID, "bad-qc-invalid");
+    }
+
+    if (fJustCheck || qc.IsNull()) {
+        return true;
+    }
+
+    const auto& params = Params().GetConsensus().llmqs.at((Consensus::LLMQType)qc.llmqType);
+
+    // Store commitment in DB
+    auto cacheKey = std::make_pair(static_cast<uint8_t>(params.type), quorumHash);
+    evoDb.Write(std::make_pair(DB_MINED_COMMITMENT, cacheKey), std::make_pair(qc, blockHash));
+    evoDb.Write(BuildInversedHeightKey(params.type, nHeight), quorumIndex->nHeight);
+
+    {
+        LOCK(minableCommitmentsCs);
+        //mapHasMinedCommitmentCache[qc.llmqType].erase(qc.quorumHash);
+        minableCommitmentsByQuorum.erase(cacheKey);
+        minableCommitments.erase(::SerializeHash(qc));
+    }
+
+    LogPrintf("%s: processed commitment from block. type=%d, quorumHash=%s, signers=%s, validMembers=%d, quorumPublicKey=%s\n", __func__,
+              qc.llmqType, quorumHash.ToString(), qc.CountSigners(), qc.CountValidMembers(), ""/*qc.quorumPublicKey.ToString()*/);
+
+    return true;
+}
+
+bool CQuorumBlockProcessor::UndoBlock(const CBlock& block, const CBlockIndex* pindex)
+{
+    std::map<Consensus::LLMQType, CFinalCommitment> qcs;
+    CValidationState dummy;
+    if (!GetCommitmentsFromBlock(block, pindex, qcs, dummy)) {
+        return false;
+    }
+
+    for (const auto& p : qcs) {
+        const auto& qc = p.second;
+        if (qc.IsNull()) {
+            continue;
+        }
+
+        evoDb.Erase(std::make_pair(DB_MINED_COMMITMENT, std::make_pair(static_cast<uint8_t>(qc.llmqType), qc.quorumHash)));
+        evoDb.Erase(BuildInversedHeightKey((Consensus::LLMQType)qc.llmqType, pindex->nHeight));
+        {
+            LOCK(minableCommitmentsCs);
+            //mapHasMinedCommitmentCache[qc.llmqType].erase(qc.quorumHash);
+        }
+
+        // if a reorg happened, we should allow to mine this commitment later
+        AddMinableCommitment(qc);
+    }
+
+    return true;
+}
+
+bool CQuorumBlockProcessor::GetCommitmentsFromBlock(const CBlock& block, const CBlockIndex* pindex, std::map<Consensus::LLMQType, CFinalCommitment>& ret, CValidationState& state)
+{
+    ret.clear();
+
+    for (const auto& tx : block.vtx) {
+        if (tx->nType != CTransaction::TxType::LLMQCOMM) {
+            continue;
+        }
+        LLMQCommPL pl;
+        if (!GetTxPayload(*tx, pl)) {
+            // should not happen as it was verified before processing the block
+            return state.DoS(100, false, REJECT_INVALID, "bad-qc-payload");
+        }
+
+        // only allow one commitment per type and per block
+        if (ret.count((Consensus::LLMQType)pl.commitment.llmqType)) {
+            return state.DoS(100, false, REJECT_INVALID, "bad-qc-dup");
+        }
+
+        ret.emplace((Consensus::LLMQType)pl.commitment.llmqType, std::move(pl.commitment));
+    }
+
+    return true;
+}
+
+bool CQuorumBlockProcessor::IsMiningPhase(Consensus::LLMQType llmqType, int nHeight)
+{
+    const auto& params = Params().GetConsensus().llmqs.at(llmqType);
+    int phaseIndex = nHeight % params.dkgInterval;
+    return phaseIndex >= params.dkgMiningWindowStart && phaseIndex <= params.dkgMiningWindowEnd;
+}
+
+bool CQuorumBlockProcessor::IsCommitmentRequired(Consensus::LLMQType llmqType, int nHeight)
+{
+    const uint256& quorumHash = GetQuorumBlockHash(llmqType, nHeight);
+
+    // perform extra check for quorumHash.IsNull as the quorum hash is unknown for the first block of a session
+    // this is because the currently processed block's hash will be the quorumHash of this session
+    bool isMiningPhase = !quorumHash.IsNull() && IsMiningPhase(llmqType, nHeight);
+
+    // did we already mine a non-null commitment for this session?
+    bool hasMinedCommitment = !quorumHash.IsNull() && HasMinedCommitment(llmqType, quorumHash);
+
+    return isMiningPhase && !hasMinedCommitment;
+}
+
+// This method returns UINT256_ZERO on the first block of the DKG interval (because the block hash is not known yet)
+uint256 CQuorumBlockProcessor::GetQuorumBlockHash(Consensus::LLMQType llmqType, int nHeight)
+{
+    auto& params = Params().GetConsensus().llmqs.at(llmqType);
+    int quorumStartHeight = nHeight - (nHeight % params.dkgInterval);
+
+    LOCK(cs_main);
+    if (quorumStartHeight > chainActive.Height()) {
+        return UINT256_ZERO;
+    }
+    return chainActive[quorumStartHeight]->GetBlockHash();
+}
+
+bool CQuorumBlockProcessor::HasMinedCommitment(Consensus::LLMQType llmqType, const uint256& quorumHash)
+{
+    bool fExists;
+    /*
+    {
+        LOCK(minableCommitmentsCs);
+        if (mapHasMinedCommitmentCache[llmqType].get(quorumHash, fExists)) {
+            return fExists;
+        }
+    }
+    */
+
+    fExists = evoDb.Exists(std::make_pair(DB_MINED_COMMITMENT, std::make_pair(static_cast<uint8_t>(llmqType), quorumHash)));
+
+    /*
+    LOCK(minableCommitmentsCs);
+    mapHasMinedCommitmentCache[llmqType].insert(quorumHash, fExists);
+    */
+
+    return fExists;
+}
+
+bool CQuorumBlockProcessor::GetMinedCommitment(Consensus::LLMQType llmqType, const uint256& quorumHash, CFinalCommitment& retQc, uint256& retMinedBlockHash)
+{
+    auto key = std::make_pair(DB_MINED_COMMITMENT, std::make_pair(static_cast<uint8_t>(llmqType), quorumHash));
+    std::pair<CFinalCommitment, uint256> p;
+    if (!evoDb.Read(key, p)) {
+        return false;
+    }
+    retQc = std::move(p.first);
+    retMinedBlockHash = p.second;
+    return true;
+}
+
+// The returned quorums are in reversed order, so the most recent one is at index 0
+std::vector<const CBlockIndex*> CQuorumBlockProcessor::GetMinedCommitmentsUntilBlock(Consensus::LLMQType llmqType, const CBlockIndex* pindex, size_t maxCount)
+{
+    LOCK(evoDb.cs);
+
+    auto dbIt = evoDb.GetCurTransaction().NewIteratorUniquePtr();
+
+    auto firstKey = BuildInversedHeightKey(llmqType, pindex->nHeight);
+    auto lastKey = BuildInversedHeightKey(llmqType, 0);
+
+    dbIt->Seek(firstKey);
+
+    std::vector<const CBlockIndex*> ret;
+    ret.reserve(maxCount);
+
+    while (dbIt->Valid() && ret.size() < maxCount) {
+        decltype(firstKey) curKey;
+        int quorumHeight;
+        if (!dbIt->GetKey(curKey) || curKey >= lastKey) {
+            break;
+        }
+        if (std::get<0>(curKey) != DB_MINED_COMMITMENT_BY_INVERSED_HEIGHT || std::get<1>(curKey) != static_cast<uint8_t>(llmqType)) {
+            break;
+        }
+
+        uint32_t nMinedHeight = std::numeric_limits<uint32_t>::max() - be32toh(std::get<2>(curKey));
+        if (nMinedHeight > (uint32_t) pindex->nHeight) {
+            break;
+        }
+
+        if (!dbIt->GetValue(quorumHeight)) {
+            break;
+        }
+
+        auto quorumIndex = pindex->GetAncestor(quorumHeight);
+        assert(quorumIndex);
+        ret.emplace_back(quorumIndex);
+
+        dbIt->Next();
+    }
+
+    return ret;
+}
+
+// The returned quorums are in reversed order, so the most recent one is at index 0
+std::map<Consensus::LLMQType, std::vector<const CBlockIndex*>> CQuorumBlockProcessor::GetMinedAndActiveCommitmentsUntilBlock(const CBlockIndex* pindex)
+{
+    std::map<Consensus::LLMQType, std::vector<const CBlockIndex*>> ret;
+
+    for (const auto& p : Params().GetConsensus().llmqs) {
+        auto& v = ret[p.second.type];
+        v.reserve(p.second.signingActiveQuorumCount);
+        auto commitments = GetMinedCommitmentsUntilBlock(p.second.type, pindex, p.second.signingActiveQuorumCount);
+        for (auto& c : commitments) {
+            v.emplace_back(c);
+        }
+    }
+
+    return ret;
+}
+
+bool CQuorumBlockProcessor::HasMinableCommitment(const uint256& hash)
+{
+    LOCK(minableCommitmentsCs);
+    return minableCommitments.count(hash) != 0;
+}
+
+void CQuorumBlockProcessor::AddMinableCommitment(const CFinalCommitment& fqc)
+{
+    bool relay = false;
+    uint256 commitmentHash = ::SerializeHash(fqc);
+
+    {
+        LOCK(minableCommitmentsCs);
+
+        auto k = std::make_pair(fqc.llmqType, fqc.quorumHash);
+        auto ins = minableCommitmentsByQuorum.emplace(k, commitmentHash);
+        if (ins.second) {
+            minableCommitments.emplace(commitmentHash, fqc);
+            relay = true;
+        } else {
+            auto& oldFqc = minableCommitments.at(ins.first->second);
+            if (fqc.CountSigners() > oldFqc.CountSigners()) {
+                // new commitment has more signers, so override the known one
+                ins.first->second = commitmentHash;
+                minableCommitments.erase(ins.first->second);
+                minableCommitments.emplace(commitmentHash, fqc);
+                relay = true;
+            }
+        }
+    }
+
+    // We only relay the new commitment if it's new or better then the old one (!TODO)
+    /*
+    if (relay) {
+        CInv inv(MSG_QUORUM_FINAL_COMMITMENT, commitmentHash);
+        g_connman->RelayInv(inv);
+    }
+    */
+}
+
+bool CQuorumBlockProcessor::GetMinableCommitmentByHash(const uint256& commitmentHash, llmq::CFinalCommitment& ret)
+{
+    LOCK(minableCommitmentsCs);
+    auto it = minableCommitments.find(commitmentHash);
+    if (it == minableCommitments.end()) {
+        return false;
+    }
+    ret = it->second;
+    return true;
+}
+
+// Will return false if no commitment should be mined
+// Will return true and a null commitment if no minable commitment is known and none was mined yet
+bool CQuorumBlockProcessor::GetMinableCommitment(Consensus::LLMQType llmqType, int nHeight, CFinalCommitment& ret)
+{
+    if (!IsCommitmentRequired(llmqType, nHeight)) {
+        // no commitment required
+        return false;
+    }
+
+    uint256 quorumHash = GetQuorumBlockHash(llmqType, nHeight);
+    if (quorumHash.IsNull()) {
+        return false;
+    }
+
+    LOCK(minableCommitmentsCs);
+
+    auto k = std::make_pair(static_cast<uint8_t>(llmqType), quorumHash);
+    auto it = minableCommitmentsByQuorum.find(k);
+    if (it == minableCommitmentsByQuorum.end()) {
+        // null commitment required
+        ret = CFinalCommitment(Params().GetConsensus().llmqs.at(llmqType), quorumHash);
+        return true;
+    }
+
+    ret = minableCommitments.at(it->second);
+
+    return true;
+}
+
+bool CQuorumBlockProcessor::GetMinableCommitmentTx(Consensus::LLMQType llmqType, int nHeight, CTransactionRef& ret)
+{
+    LLMQCommPL pl;
+    if (!GetMinableCommitment(llmqType, nHeight, pl.commitment)) {
+        return false;
+    }
+
+    pl.nHeight = nHeight;
+
+    CMutableTransaction tx;
+    tx.nVersion = CTransaction::TxVersion::SAPLING;
+    tx.nType = CTransaction::TxType::LLMQCOMM;
+    SetTxPayload(tx, pl);
+
+    ret = MakeTransactionRef(tx);
+
+    return true;
+}
+
+} // namespace llmq

--- a/src/llmq/quorums_blockprocessor.cpp
+++ b/src/llmq/quorums_blockprocessor.cpp
@@ -187,13 +187,8 @@ bool CQuorumBlockProcessor::ProcessCommitment(int nHeight, const uint256& blockH
         return state.DoS(100, false, REJECT_INVALID, "bad-qc-block");
     }
 
-    // index of quorumHash already checked
+    // index of quorumHash (and commitment signature) already checked
     const CBlockIndex* quorumIndex = mapBlockIndex.at(quorumHash);
-
-    // Verify signatures
-    if (!qc.Verify(quorumIndex, true)) {
-        return state.DoS(100, false, REJECT_INVALID, "bad-qc-invalid");
-    }
 
     if (fJustCheck || qc.IsNull()) {
         return true;

--- a/src/llmq/quorums_blockprocessor.h
+++ b/src/llmq/quorums_blockprocessor.h
@@ -1,0 +1,72 @@
+// Copyright (c) 2018-2021 The Dash Core developers
+// Copyright (c) 2021 The PIVX developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef PIVX_LLMQ_BLOCKPROCESSOR_H
+#define PIVX_LLMQ_BLOCKPROCESSOR_H
+
+#include "consensus/params.h"
+#include "llmq/quorums_commitment.h"
+#include "primitives/transaction.h"
+#include "sync.h"
+#include "uint256.h"
+
+#include <map>
+
+class CBlock;
+class CBlockIndex;
+class CConnman;
+class CDataStream;
+class CEvoDB;
+class CNode;
+class CValidationState;
+
+namespace llmq
+{
+
+class CQuorumBlockProcessor
+{
+private:
+    CEvoDB& evoDb;
+
+    // TODO cleanup
+    mutable RecursiveMutex minableCommitmentsCs;
+    // <llmqType, quorumHash> --> commitment hash
+    std::map<std::pair<uint8_t, uint256>, uint256> minableCommitmentsByQuorum;
+    // commitment hash --> final commitment
+    std::map<uint256, CFinalCommitment> minableCommitments;
+
+public:
+    explicit CQuorumBlockProcessor(CEvoDB& _evoDb);
+
+    void ProcessMessage(CNode* pfrom, CDataStream& vRecv);
+
+    bool ProcessBlock(const CBlock& block, const CBlockIndex* pindex, CValidationState& state, bool fJustCheck);
+    bool UndoBlock(const CBlock& block, const CBlockIndex* pindex);
+
+    void AddMinableCommitment(const CFinalCommitment& fqc);
+    bool HasMinableCommitment(const uint256& hash);
+    bool GetMinableCommitmentByHash(const uint256& commitmentHash, CFinalCommitment& ret);
+    bool GetMinableCommitment(Consensus::LLMQType llmqType, int nHeight, CFinalCommitment& ret);
+    bool GetMinableCommitmentTx(Consensus::LLMQType llmqType, int nHeight, CTransactionRef& ret);
+
+    bool HasMinedCommitment(Consensus::LLMQType llmqType, const uint256& quorumHash);
+    bool GetMinedCommitment(Consensus::LLMQType llmqType, const uint256& quorumHash, CFinalCommitment& ret, uint256& retMinedBlockHash);
+
+    std::vector<const CBlockIndex*> GetMinedCommitmentsUntilBlock(Consensus::LLMQType llmqType, const CBlockIndex* pindex, size_t maxCount);
+    std::map<Consensus::LLMQType, std::vector<const CBlockIndex*>> GetMinedAndActiveCommitmentsUntilBlock(const CBlockIndex* pindex);
+
+private:
+    static bool GetCommitmentsFromBlock(const CBlock& block, const CBlockIndex* pindex, std::map<Consensus::LLMQType, CFinalCommitment>& ret, CValidationState& state);
+    bool ProcessCommitment(int nHeight, const uint256& blockHash, const CFinalCommitment& qc, CValidationState& state, bool fJustCheck);
+    static bool IsMiningPhase(Consensus::LLMQType llmqType, int nHeight);
+    bool IsCommitmentRequired(Consensus::LLMQType llmqType, int nHeight);
+    static uint256 GetQuorumBlockHash(Consensus::LLMQType llmqType, int nHeight);
+};
+
+extern std::unique_ptr<CQuorumBlockProcessor> quorumBlockProcessor;
+
+} // namespace llmq
+
+#endif // PIVX_LLMQ_BLOCKPROCESSOR_H

--- a/src/llmq/quorums_blockprocessor.h
+++ b/src/llmq/quorums_blockprocessor.h
@@ -45,8 +45,9 @@ public:
     bool ProcessBlock(const CBlock& block, const CBlockIndex* pindex, CValidationState& state, bool fJustCheck);
     bool UndoBlock(const CBlock& block, const CBlockIndex* pindex);
 
-    void AddMinableCommitment(const CFinalCommitment& fqc);
+    void AddAndRelayMinableCommitment(const CFinalCommitment& fqc);
     bool HasMinableCommitment(const uint256& hash);
+    bool HasBetterMinableCommitment(const CFinalCommitment& qc);
     bool GetMinableCommitmentByHash(const uint256& commitmentHash, CFinalCommitment& ret);
     bool GetMinableCommitment(Consensus::LLMQType llmqType, int nHeight, CFinalCommitment& ret);
     bool GetMinableCommitmentTx(Consensus::LLMQType llmqType, int nHeight, CTransactionRef& ret);

--- a/src/llmq/quorums_blockprocessor.h
+++ b/src/llmq/quorums_blockprocessor.h
@@ -40,7 +40,7 @@ private:
 public:
     explicit CQuorumBlockProcessor(CEvoDB& _evoDb);
 
-    void ProcessMessage(CNode* pfrom, CDataStream& vRecv);
+    void ProcessMessage(CNode* pfrom, CDataStream& vRecv, int& retMisbehavingScore);
 
     bool ProcessBlock(const CBlock& block, const CBlockIndex* pindex, CValidationState& state, bool fJustCheck);
     bool UndoBlock(const CBlock& block, const CBlockIndex* pindex);

--- a/src/llmq/quorums_blockprocessor.h
+++ b/src/llmq/quorums_blockprocessor.h
@@ -45,7 +45,7 @@ public:
     bool ProcessBlock(const CBlock& block, const CBlockIndex* pindex, CValidationState& state, bool fJustCheck);
     bool UndoBlock(const CBlock& block, const CBlockIndex* pindex);
 
-    void AddAndRelayMinableCommitment(const CFinalCommitment& fqc);
+    void AddAndRelayMinableCommitment(const CFinalCommitment& fqc, uint256* cached_fqc_hash = nullptr);
     bool HasMinableCommitment(const uint256& hash);
     bool HasBetterMinableCommitment(const CFinalCommitment& qc);
     bool GetMinableCommitmentByHash(const uint256& commitmentHash, CFinalCommitment& ret);

--- a/src/llmq/quorums_commitment.cpp
+++ b/src/llmq/quorums_commitment.cpp
@@ -151,5 +151,57 @@ bool CFinalCommitment::VerifySizes(const Consensus::LLMQParams& params) const
     return true;
 }
 
+void LLMQCommPL::ToJson(UniValue& obj) const
+{
+    obj.setObject();
+    obj.pushKV("version", (int)nVersion);
+    obj.pushKV("height", (int)nHeight);
+
+    UniValue qcObj;
+    commitment.ToJson(qcObj);
+    obj.pushKV("commitment", qcObj);
+}
+
+bool CheckLLMQCommitment(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state)
+{
+    LLMQCommPL pl;
+    if (!GetTxPayload(tx, pl)) {
+        return state.DoS(100, false, REJECT_INVALID, "bad-qc-payload");
+    }
+
+    if (pl.nVersion == 0 || pl.nVersion > LLMQCommPL::CURRENT_VERSION) {
+        return state.DoS(100, false, REJECT_INVALID, "bad-qc-version");
+    }
+
+    if (!Params().GetConsensus().llmqs.count((Consensus::LLMQType)pl.commitment.llmqType)) {
+        return state.DoS(100, false, REJECT_INVALID, "bad-qc-type");
+    }
+    const auto& params = Params().GetConsensus().llmqs.at((Consensus::LLMQType)pl.commitment.llmqType);
+
+    if (!pl.commitment.VerifySizes(params)) {
+        return state.DoS(100, false, REJECT_INVALID, "bad-qc-invalid-sizes");
+    }
+
+    if (pindexPrev) {
+        if (pl.nHeight != (uint32_t)pindexPrev->nHeight + 1) {
+            return state.DoS(100, false, REJECT_INVALID, "bad-qc-height");
+        }
+
+        if (!mapBlockIndex.count(pl.commitment.quorumHash)) {
+            return state.DoS(100, false, REJECT_INVALID, "bad-qc-quorum-hash");
+        }
+        const CBlockIndex* pindexQuorum = mapBlockIndex.at(pl.commitment.quorumHash);
+        if (pindexQuorum != pindexPrev->GetAncestor(pindexQuorum->nHeight)) {
+            // not part of active chain
+            return state.DoS(100, false, REJECT_INVALID, "bad-qc-quorum-hash");
+        }
+
+        if (!pl.commitment.Verify(pindexQuorum, false)) {
+            return state.DoS(100, false, REJECT_INVALID, "bad-qc-invalid");
+        }
+    }
+
+    return true;
+}
 
 } // namespace llmq

--- a/src/llmq/quorums_commitment.cpp
+++ b/src/llmq/quorums_commitment.cpp
@@ -58,7 +58,7 @@ template<typename... Args>
 static bool errorFinalCommitment(const char* fmt, const Args&... args)
 {
     try {
-        LogPrintf("Invalid Final Commitment -- %s\n", tfm::format(fmt, args...));
+        LogPrint(BCLog::LLMQ, "Invalid Final Commitment -- %s\n", tfm::format(fmt, args...));
     } catch (tinyformat::format_error &e) {
         LogPrintf("Error (%s) while formatting message %s\n", std::string(e.what()), fmt);
     }

--- a/src/llmq/quorums_commitment.cpp
+++ b/src/llmq/quorums_commitment.cpp
@@ -1,0 +1,155 @@
+// Copyright (c) 2018-2019 The Dash Core developers
+// Copyright (c) 2021 The PIVX developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "llmq/quorums_commitment.h"
+
+#include "chainparams.h"
+#include "llmq/quorums_utils.h"
+#include "logging.h"
+#include "validation.h"
+
+
+namespace llmq
+{
+
+CFinalCommitment::CFinalCommitment(const Consensus::LLMQParams& params, const uint256& _quorumHash) :
+        llmqType(params.type),
+        quorumHash(_quorumHash),
+        signers(params.size),
+        validMembers(params.size)
+{
+}
+
+bool CFinalCommitment::IsNull() const
+{
+    if (CountSigners() > 0 || CountValidMembers() > 0) {
+        return false;
+    }
+
+    if (quorumPublicKey.IsValid() ||
+        !quorumVvecHash.IsNull() ||
+        membersSig.IsValid() ||
+        quorumSig.IsValid()) {
+        return false;
+    }
+
+    return true;
+}
+
+void CFinalCommitment::ToJson(UniValue& obj) const
+{
+    obj.setObject();
+    obj.pushKV("version", (int)nVersion);
+    obj.pushKV("llmqType", (int)llmqType);
+    obj.pushKV("quorumHash", quorumHash.ToString());
+    obj.pushKV("signersCount", CountSigners());
+    obj.pushKV("signers", utils::ToHexStr(signers));
+    obj.pushKV("validMembersCount", CountValidMembers());
+    obj.pushKV("validMembers", utils::ToHexStr(validMembers));
+    obj.pushKV("quorumPublicKey", quorumPublicKey.ToString());
+    obj.pushKV("quorumVvecHash", quorumVvecHash.ToString());
+    obj.pushKV("quorumSig", quorumSig.ToString());
+    obj.pushKV("membersSig", membersSig.ToString());
+}
+
+template<typename... Args>
+static bool errorFinalCommitment(const char* fmt, const Args&... args)
+{
+    try {
+        LogPrintf("Invalid Final Commitment -- %s\n", tfm::format(fmt, args...));
+    } catch (tinyformat::format_error &e) {
+        LogPrintf("Error (%s) while formatting message %s\n", std::string(e.what()), fmt);
+    }
+    return false;
+}
+
+bool CFinalCommitment::Verify(const CBlockIndex* pQuorumIndex, bool checkSigs) const
+{
+    if (nVersion == 0 || nVersion > CURRENT_VERSION) {
+        return errorFinalCommitment("version (%d)", nVersion);
+    }
+
+    if (!Params().GetConsensus().llmqs.count((Consensus::LLMQType)llmqType)) {
+        return errorFinalCommitment("type (%d)", llmqType);
+    }
+    const auto& params = Params().GetConsensus().llmqs.at((Consensus::LLMQType)llmqType);
+
+    if (!VerifySizes(params)) {
+        return errorFinalCommitment("sizes");
+    }
+
+    if (IsNull()) {
+        return true;
+    }
+
+    int count_validmembers = CountValidMembers();
+    if (count_validmembers < params.minSize) {
+        return errorFinalCommitment("valid members count (%d < %d)", count_validmembers, params.minSize);
+    }
+    int count_signers = CountSigners();
+    if (count_signers < params.minSize) {
+        return errorFinalCommitment("signers count (%d < %d)", count_signers, params.minSize);
+    }
+
+    if (!quorumPublicKey.IsValid()) {
+        return errorFinalCommitment("public key");
+    }
+    if (quorumVvecHash.IsNull()) {
+        return errorFinalCommitment("quorumVvecHash");
+    }
+    if (!membersSig.IsValid()) {
+        return errorFinalCommitment("membersSig");
+    }
+    if (!quorumSig.IsValid()) {
+        return errorFinalCommitment("quorumSig");
+    }
+
+    auto members = utils::GetAllQuorumMembers(params.type, pQuorumIndex);
+    for (size_t i = members.size(); i < params.size; i++) {
+        if (validMembers[i]) {
+            return errorFinalCommitment("validMembers bitset (bit %d should not be set)", i);
+        }
+        if (signers[i]) {
+            return errorFinalCommitment("signers bitset (bit %d should not be set)", i);
+        }
+    }
+
+    // sigs are only checked when the block is processed
+    if (checkSigs) {
+        uint256 commitmentHash = utils::BuildCommitmentHash(params.type, quorumHash, validMembers, quorumPublicKey, quorumVvecHash);
+
+        std::vector<CBLSPublicKey> memberPubKeys;
+        for (size_t i = 0; i < members.size(); i++) {
+            if (!signers[i]) {
+                continue;
+            }
+            memberPubKeys.emplace_back(members[i]->pdmnState->pubKeyOperator.Get());
+        }
+
+        if (!membersSig.VerifySecureAggregated(memberPubKeys, commitmentHash)) {
+            return errorFinalCommitment("aggregated members signature");
+        }
+
+        if (!quorumSig.VerifyInsecure(quorumPublicKey, commitmentHash)) {
+            return errorFinalCommitment("invalid quorum signature");
+        }
+    }
+
+    return true;
+}
+
+bool CFinalCommitment::VerifySizes(const Consensus::LLMQParams& params) const
+{
+    if ((int)signers.size() != params.size) {
+        return errorFinalCommitment("signers size (%d != %d)", signers.size(), params.size);
+    }
+    if ((int)validMembers.size() != params.size) {
+        return errorFinalCommitment("validMembers size (%d != %d)", validMembers.size(), params.size);
+    }
+    return true;
+}
+
+
+} // namespace llmq

--- a/src/llmq/quorums_commitment.cpp
+++ b/src/llmq/quorums_commitment.cpp
@@ -196,7 +196,7 @@ bool CheckLLMQCommitment(const CTransaction& tx, const CBlockIndex* pindexPrev, 
             return state.DoS(100, false, REJECT_INVALID, "bad-qc-quorum-hash");
         }
 
-        if (!pl.commitment.Verify(pindexQuorum, false)) {
+        if (!pl.commitment.Verify(pindexQuorum, true)) {
             return state.DoS(100, false, REJECT_INVALID, "bad-qc-invalid");
         }
     }

--- a/src/llmq/quorums_commitment.h
+++ b/src/llmq/quorums_commitment.h
@@ -48,7 +48,7 @@ public:
     bool IsNull() const;
     void ToJson(UniValue& obj) const;
 
-    bool Verify(const CBlockIndex* pQuorumIndex, bool checkSigs) const;
+    bool Verify(const CBlockIndex* pQuorumIndex) const;
     bool VerifySizes(const Consensus::LLMQParams& params) const;
 
     SERIALIZE_METHODS(CFinalCommitment, obj)

--- a/src/llmq/quorums_commitment.h
+++ b/src/llmq/quorums_commitment.h
@@ -1,0 +1,72 @@
+// Copyright (c) 2018-2019 The Dash Core developers
+// Copyright (c) 2021 The PIVX developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef PIVX_QUORUMS_COMMITMENT_H
+#define PIVX_QUORUMS_COMMITMENT_H
+
+#include "bls/bls_wrapper.h"
+#include "consensus/params.h"
+#include "evo/deterministicmns.h"
+
+#include <univalue.h>
+
+namespace llmq
+{
+
+// This message is an aggregation of all received premature commitments and only valid if
+// enough (>=threshold) premature commitments were aggregated
+// This is mined on-chain as part of LLMQCOMM payload.
+class CFinalCommitment
+{
+public:
+    static const uint16_t CURRENT_VERSION = 1;
+
+    uint16_t nVersion{CURRENT_VERSION};
+    uint8_t llmqType{Consensus::LLMQ_NONE};
+    uint256 quorumHash;
+    std::vector<bool> signers;
+    std::vector<bool> validMembers;
+
+    CBLSPublicKey quorumPublicKey;
+    uint256 quorumVvecHash;
+
+    CBLSSignature quorumSig; // recovered threshold sig of blockHash+validMembers+pubKeyHash+vvecHash
+    CBLSSignature membersSig; // aggregated member sig of blockHash+validMembers+pubKeyHash+vvecHash
+
+public:
+    CFinalCommitment() = default;
+    CFinalCommitment(const Consensus::LLMQParams& params, const uint256& _quorumHash);
+
+    int CountSigners() const { return (int)std::count(signers.begin(), signers.end(), true); }
+    int CountValidMembers() const { return (int)std::count(validMembers.begin(), validMembers.end(), true); }
+
+    bool IsNull() const;
+    void ToJson(UniValue& obj) const;
+
+    bool Verify(const CBlockIndex* pQuorumIndex, bool checkSigs) const;
+    bool VerifySizes(const Consensus::LLMQParams& params) const;
+
+    /* !TODO: fix with new serialization
+    ADD_SERIALIZE_METHODS
+
+    template<typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action)
+    {
+        READWRITE(nVersion);
+        READWRITE(llmqType);
+        READWRITE(quorumHash);
+        READWRITE(DYNBITSET(signers));
+        READWRITE(DYNBITSET(validMembers));
+        READWRITE(quorumPublicKey);
+        READWRITE(quorumVvecHash);
+        READWRITE(quorumSig);
+        READWRITE(membersSig);
+    }
+    */
+};
+
+} // namespace llmq
+
+#endif // PIVX_QUORUMS_COMMITMENT_H

--- a/src/llmq/quorums_commitment.h
+++ b/src/llmq/quorums_commitment.h
@@ -48,23 +48,18 @@ public:
     bool Verify(const CBlockIndex* pQuorumIndex, bool checkSigs) const;
     bool VerifySizes(const Consensus::LLMQParams& params) const;
 
-    /* !TODO: fix with new serialization
-    ADD_SERIALIZE_METHODS
-
-    template<typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(CFinalCommitment, obj)
     {
-        READWRITE(nVersion);
-        READWRITE(llmqType);
-        READWRITE(quorumHash);
-        READWRITE(DYNBITSET(signers));
-        READWRITE(DYNBITSET(validMembers));
-        READWRITE(quorumPublicKey);
-        READWRITE(quorumVvecHash);
-        READWRITE(quorumSig);
-        READWRITE(membersSig);
+        READWRITE(obj.nVersion);
+        READWRITE(obj.llmqType);
+        READWRITE(obj.quorumHash);
+        READWRITE(DYNBITSET(obj.signers));
+        READWRITE(DYNBITSET(obj.validMembers));
+        READWRITE(obj.quorumPublicKey);
+        READWRITE(obj.quorumVvecHash);
+        READWRITE(obj.quorumSig);
+        READWRITE(obj.membersSig);
     }
-    */
 };
 
 } // namespace llmq

--- a/src/llmq/quorums_commitment.h
+++ b/src/llmq/quorums_commitment.h
@@ -8,9 +8,12 @@
 
 #include "bls/bls_wrapper.h"
 #include "consensus/params.h"
-#include "evo/deterministicmns.h"
 
 #include <univalue.h>
+
+class CBlockIndex;
+class CValidationState;
+class CTransaction;
 
 namespace llmq
 {

--- a/src/llmq/quorums_commitment.h
+++ b/src/llmq/quorums_commitment.h
@@ -62,6 +62,29 @@ public:
     }
 };
 
+class LLMQCommPL
+{
+public:
+    static const uint16_t CURRENT_VERSION = 1;
+
+public:
+    uint16_t nVersion{CURRENT_VERSION};
+    uint32_t nHeight{(uint32_t)-1};
+    CFinalCommitment commitment;
+
+public:
+    SERIALIZE_METHODS(LLMQCommPL, obj)
+    {
+        READWRITE(obj.nVersion);
+        READWRITE(obj.nHeight);
+        READWRITE(obj.commitment);
+    }
+
+    void ToJson(UniValue& obj) const;
+};
+
+bool CheckLLMQCommitment(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state);
+
 } // namespace llmq
 
 #endif // PIVX_QUORUMS_COMMITMENT_H

--- a/src/llmq/quorums_init.cpp
+++ b/src/llmq/quorums_init.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2018-2021 The Dash Core developers
+// Copyright (c) 2021 The PIVX developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "llmq/quorums_init.h"
+
+#include "bls/bls_worker.h"
+#include "llmq/quorums_blockprocessor.h"
+#include "llmq/quorums_commitment.h"
+
+
+namespace llmq
+{
+
+CBLSWorker* blsWorker;
+
+void InitLLMQSystem(CEvoDB& evoDb)
+{
+    blsWorker = new CBLSWorker();
+    quorumBlockProcessor.reset(new CQuorumBlockProcessor(evoDb));
+    /* !TODO
+    quorumDKGSessionManager.reset(new CDKGSessionManager(evoDb, *blsWorker));
+    */
+}
+
+void DestroyLLMQSystem()
+{
+    quorumBlockProcessor.reset();
+    //quorumDKGSessionManager.reset();
+    delete blsWorker;
+    blsWorker = nullptr;
+}
+
+void StartLLMQSystem()
+{
+    if (blsWorker) {
+        blsWorker->Start();
+    }
+}
+
+void StopLLMQSystem()
+{
+    if (blsWorker) {
+        blsWorker->Stop();
+    }
+}
+
+} // namespace llmq

--- a/src/llmq/quorums_init.h
+++ b/src/llmq/quorums_init.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2018-2021 The Dash Core developers
+// Copyright (c) 2021 The PIVX developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef PIVX_LLMQ_INIT_H
+#define PIVX_LLMQ_INIT_H
+
+class CDBWrapper;
+class CEvoDB;
+
+namespace llmq
+{
+
+// Init/destroy LLMQ globals
+void InitLLMQSystem(CEvoDB& evoDb);
+void DestroyLLMQSystem();
+
+// Manage scheduled tasks, threads, listeners etc.
+void StartLLMQSystem();
+void StopLLMQSystem();
+
+} // namespace llmq
+
+#endif // PIVX_LLMQ_INIT_H

--- a/src/llmq/quorums_utils.cpp
+++ b/src/llmq/quorums_utils.cpp
@@ -1,0 +1,59 @@
+// Copyright (c) 2018-2019 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "llmq/quorums_utils.h"
+
+#include "bls/bls_wrapper.h"
+#include "chainparams.h"
+#include "random.h"
+#include "spork.h"
+#include "validation.h"
+
+namespace llmq
+{
+
+namespace utils
+{
+
+std::vector<CDeterministicMNCPtr> GetAllQuorumMembers(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum)
+{
+    auto& params = Params().GetConsensus().llmqs.at(llmqType);
+    auto allMns = deterministicMNManager->GetListForBlock(pindexQuorum);
+    auto modifier = ::SerializeHash(std::make_pair(static_cast<uint8_t>(llmqType), pindexQuorum->GetBlockHash()));
+    return allMns.CalculateQuorum(params.size, modifier);
+}
+
+uint256 BuildCommitmentHash(Consensus::LLMQType llmqType, const uint256& blockHash, const std::vector<bool>& validMembers, const CBLSPublicKey& pubKey, const uint256& vvecHash)
+{
+    CHashWriter hw(SER_NETWORK, 0);
+    hw << static_cast<uint8_t>(llmqType);
+    hw << blockHash;
+    hw << DYNBITSET(validMembers);
+    hw << pubKey;
+    hw << vvecHash;
+    return hw.GetHash();
+}
+
+uint256 BuildSignHash(Consensus::LLMQType llmqType, const uint256& quorumHash, const uint256& id, const uint256& msgHash)
+{
+    CHashWriter h(SER_GETHASH, 0);
+    h << static_cast<uint8_t>(llmqType);
+    h << quorumHash;
+    h << id;
+    h << msgHash;
+    return h.GetHash();
+}
+
+std::string ToHexStr(const std::vector<bool>& vBits)
+{
+    std::vector<uint8_t> vBytes((vBits.size() + 7) / 8);
+    for (size_t i = 0; i < vBits.size(); i++) {
+        vBytes[i / 8] |= vBits[i] << (i % 8);
+    }
+    return HexStr(vBytes);
+}
+
+} // namespace llmq::utils
+
+} // namespace llmq

--- a/src/llmq/quorums_utils.h
+++ b/src/llmq/quorums_utils.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2018-2019 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef PIVX_QUORUMS_UTILS_H
+#define PIVX_QUORUMS_UTILS_H
+
+#include "consensus/params.h"
+#include "evo/deterministicmns.h"
+#include "net.h"
+
+#include <vector>
+
+class CBLSPublicKey;
+
+namespace llmq
+{
+
+namespace utils
+{
+
+std::vector<CDeterministicMNCPtr> GetAllQuorumMembers(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum);
+
+uint256 BuildCommitmentHash(Consensus::LLMQType llmqType, const uint256& blockHash, const std::vector<bool>& validMembers, const CBLSPublicKey& pubKey, const uint256& vvecHash);
+uint256 BuildSignHash(Consensus::LLMQType llmqType, const uint256& quorumHash, const uint256& id, const uint256& msgHash);
+
+// works for sig shares and recovered sigs
+template<typename T>
+uint256 BuildSignHash(const T& s)
+{
+   return BuildSignHash((Consensus::LLMQType)s.llmqType, s.quorumHash, s.id, s.msgHash);
+}
+
+std::string ToHexStr(const std::vector<bool>& vBits);
+
+} // namespace llmq::utils
+
+} // namespace llmq
+
+#endif // PIVX_QUORUMS_UTILS_H

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -127,6 +127,7 @@ const CLogCategoryDesc LogCategories[] = {
         {BCLog::SAPLING,        "sapling"},
         {BCLog::SPORKS,         "sporks"},
         {BCLog::VALIDATION,     "validation"},
+        {BCLog::LLMQ,           "llmq"},
         {BCLog::ALL,            "1"},
         {BCLog::ALL,            "all"},
 };

--- a/src/logging.h
+++ b/src/logging.h
@@ -66,6 +66,7 @@ namespace BCLog {
         SAPLING     = (1 << 26),
         SPORKS      = (1 << 27),
         VALIDATION  = (1 << 28),
+        LLMQ        = (1 << 29),
         ALL         = ~(uint32_t)0,
     };
 

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -256,6 +256,7 @@ public:
         PROUPSERV = 2,
         PROUPREG = 3,
         PROUPREV = 4,
+        LLMQCOMM = 5,
     };
 
     static const int16_t CURRENT_VERSION = TxVersion::LEGACY;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -337,6 +337,11 @@ public:
         return IsSpecialTx() && nType == TxType::PROREG;
     }
 
+    bool IsQuorumCommitmentTx() const
+    {
+        return IsSpecialTx() && nType == TxType::LLMQCOMM;
+    }
+
     // Ensure that special and sapling fields are signed
     SigVersion GetRequiredSigVersion() const
     {

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -53,6 +53,7 @@ const char* FINALBUDGET = "fbs";
 const char* FINALBUDGETVOTE = "fbvote";
 const char* SYNCSTATUSCOUNT = "ssc";
 const char* GETMNLIST = "dseg";
+const char* QFCOMMITMENT = "qfcommit";
 }; // namespace NetMsgType
 
 /** All known message types. Keep this in the same order as the list of
@@ -101,7 +102,8 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::BUDGETVOTESYNC,
     NetMsgType::GETSPORKS,
     NetMsgType::SYNCSTATUSCOUNT,
-    NetMsgType::MNBROADCAST2
+    NetMsgType::MNBROADCAST2,
+    NetMsgType::QFCOMMITMENT
 };
 const static std::vector<std::string> allNetMessageTypesVec(allNetMessageTypes, allNetMessageTypes + ARRAYLEN(allNetMessageTypes));
 const static std::vector<std::string> tiertwoNetMessageTypesVec(std::find(allNetMessageTypesVec.begin(), allNetMessageTypesVec.end(), NetMsgType::SPORK), allNetMessageTypesVec.end());
@@ -200,6 +202,7 @@ std::string CInv::GetCommand() const
         case MSG_MASTERNODE_ANNOUNCE: return cmd.append(NetMsgType::MNBROADCAST); // or MNBROADCAST2
         case MSG_MASTERNODE_PING: return cmd.append(NetMsgType::MNPING);
         case MSG_DSTX: return cmd.append("dstx"); // Deprecated
+        case MSG_QUORUM_FINAL_COMMITMENT: return cmd.append(NetMsgType::QFCOMMITMENT);
         default:
             throw std::out_of_range(strprintf("%s: type=%d unknown type", __func__, type));
     }

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -274,6 +274,10 @@ extern const char* FINALBUDGETVOTE;
  * The syncstatuscount message is used to track the layer 2 syncing process
  */
 extern const char* SYNCSTATUSCOUNT;
+/**
+ * The qfcommit message is used to propagate LLMQ final commitments
+ */
+extern const char* QFCOMMITMENT;
 }; // namespace NetMsgType
 
 /* Get a vector of all valid message types (see above) */
@@ -425,8 +429,9 @@ enum GetDataMsg
     MSG_MASTERNODE_QUORUM,
     MSG_MASTERNODE_ANNOUNCE,
     MSG_MASTERNODE_PING,
-    MSG_DSTX,
-    MSG_TYPE_MAX = MSG_DSTX
+    MSG_DSTX,               // Deprecated
+    MSG_QUORUM_FINAL_COMMITMENT,
+    MSG_TYPE_MAX = MSG_QUORUM_FINAL_COMMITMENT
 };
 
 /** inv message data */

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -842,6 +842,12 @@ template<typename Stream, typename K, typename T> void Serialize(Stream& os, con
 template<typename Stream, typename K, typename T> void Unserialize(Stream& is, std::pair<K, T>& item);
 
 /**
+ * tuple
+ */
+template<typename Stream, typename... Elements> void Serialize(Stream& os, const std::tuple<Elements...>& item);
+template<typename Stream, typename... Elements> void Unserialize(Stream& is, std::tuple<Elements...>& item);
+
+/**
  * map
  */
 template<typename Stream, typename K, typename T, typename Pred, typename A> void Serialize(Stream& os, const std::map<K, T, Pred, A>& m);
@@ -1092,6 +1098,54 @@ void Unserialize(Stream& is, std::pair<K, T>& item)
 {
     Unserialize(is, item.first);
     Unserialize(is, item.second);
+}
+
+/**
+ * tuple
+ */
+template<typename Stream, int index, typename... Ts>
+struct SerializeTuple {
+    void operator() (Stream&s, std::tuple<Ts...>& t) {
+        SerializeTuple<Stream, index - 1, Ts...>{}(s, t);
+        s << std::get<index>(t);
+    }
+};
+
+template<typename Stream, typename... Ts>
+struct SerializeTuple<Stream, 0, Ts...> {
+    void operator() (Stream&s, std::tuple<Ts...>& t) {
+        s << std::get<0>(t);
+    }
+};
+
+template<typename Stream, int index, typename... Ts>
+struct DeserializeTuple {
+    void operator() (Stream&s, std::tuple<Ts...>& t) {
+        DeserializeTuple<Stream, index - 1, Ts...>{}(s, t);
+        s >> std::get<index>(t);
+    }
+};
+
+template<typename Stream, typename... Ts>
+struct DeserializeTuple<Stream, 0, Ts...> {
+    void operator() (Stream&s, std::tuple<Ts...>& t) {
+        s >> std::get<0>(t);
+    }
+};
+
+
+template<typename Stream, typename... Elements>
+void Serialize(Stream& os, const std::tuple<Elements...>& item)
+{
+    const auto size = std::tuple_size<std::tuple<Elements...>>::value;
+    SerializeTuple<Stream, size - 1, Elements...>{}(os, const_cast<std::tuple<Elements...>&>(item));
+}
+
+template<typename Stream, typename... Elements>
+void Unserialize(Stream& is, std::tuple<Elements...>& item)
+{
+    const auto size = std::tuple_size<std::tuple<Elements...>>::value;
+    DeserializeTuple<Stream, size - 1, Elements...>{}(is, item);
 }
 
 

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -1035,12 +1035,12 @@ BOOST_FIXTURE_TEST_CASE(dkg_pose, TestChain400Setup)
     // create final commitment
     llmq::CFinalCommitment qfc = CreateFinalCommitment(pkeys, skeys, quorumHash);
     BOOST_CHECK(!qfc.IsNull());
-    BOOST_CHECK(qfc.Verify(quorumIndex, true));
+    BOOST_CHECK(qfc.Verify(quorumIndex));
     // verify that it fails against different members
     do {
         quorumIndex = quorumIndex->pprev;
     } while(llmq::utils::GetAllQuorumMembers(Consensus::LLMQ_TEST, quorumIndex) == members);
-    BOOST_CHECK(!qfc.Verify(quorumIndex, true));
+    BOOST_CHECK(!qfc.Verify(quorumIndex));
 
     // receive final commitment message
     CNode dummyNode(id++, NODE_NETWORK, 0, INVALID_SOCKET, CAddress(ip(0xa0b0c001), NODE_NONE), 0, 0, "", true);
@@ -1100,7 +1100,7 @@ BOOST_FIXTURE_TEST_CASE(dkg_pose, TestChain400Setup)
     std::vector<CBLSSecretKey> skeys2(skeys.begin(), skeys.end()-1);
     llmq::CFinalCommitment qfc2 = CreateFinalCommitment(pkeys2, skeys2, quorumHash);
     BOOST_CHECK(!qfc2.IsNull());
-    BOOST_CHECK(qfc2.Verify(quorumIndex, true));
+    BOOST_CHECK(qfc2.Verify(quorumIndex));
     {
         CDataStream vRecv(SER_NETWORK, PROTOCOL_VERSION);
         vRecv << qfc2;
@@ -1112,7 +1112,7 @@ BOOST_FIXTURE_TEST_CASE(dkg_pose, TestChain400Setup)
     // Now receive another commitment for the same quorum hash, but with all 3 signatures
     qfc = CreateFinalCommitment(pkeys, skeys, quorumHash);
     BOOST_CHECK(!qfc.IsNull());
-    BOOST_CHECK(qfc.Verify(quorumIndex, true));
+    BOOST_CHECK(qfc.Verify(quorumIndex));
     {
         CDataStream vRecv(SER_NETWORK, PROTOCOL_VERSION);
         vRecv << qfc;

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -1119,16 +1119,9 @@ BOOST_FIXTURE_TEST_CASE(dkg_pose, TestChain400Setup)
         llmq::quorumBlockProcessor->ProcessMessage(&dummyNode, vRecv);
     }
     BOOST_CHECK(qfc.CountSigners() > qfc2.CountSigners());
-    // final commitment received, accepted, and replaced the previous one (with less memebers) ?
-    /*
-    TODO: this test is currently failing.
-    It has been introduced with the specific purpose of triggering this bug in Dash code:
-    when processing final quorum commitments we should skip the message if we have a better one locally,
-    but instead we skip the message if we have a commitment to the same hash but with LESS signatures.
-    The next commit fixes it.
 
+    // final commitment received, accepted, and replaced the previous one (with less memebers)
     BOOST_CHECK(llmq::quorumBlockProcessor->HasMinableCommitment(::SerializeHash(qfc)));
-    */
 
     UpdateNetworkUpgradeParameters(Consensus::UPGRADE_V6_0, Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT);
 }

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -961,6 +961,15 @@ CService ip(uint32_t i)
     return CService(CNetAddr(s), Params().GetDefaultPort());
 }
 
+static void ProcessQuorum(llmq::CQuorumBlockProcessor* processor, const llmq::CFinalCommitment& qfc, CNode* node)
+{
+    CDataStream vRecv(SER_NETWORK, PROTOCOL_VERSION);
+    vRecv << qfc;
+    int banScore{0};
+    processor->ProcessMessage(node, vRecv, banScore);
+    BOOST_CHECK_EQUAL(banScore, 0);
+}
+
 static NodeId id = 0;
 
 BOOST_FIXTURE_TEST_CASE(dkg_pose, TestChain400Setup)
@@ -1044,11 +1053,7 @@ BOOST_FIXTURE_TEST_CASE(dkg_pose, TestChain400Setup)
 
     // receive final commitment message
     CNode dummyNode(id++, NODE_NETWORK, 0, INVALID_SOCKET, CAddress(ip(0xa0b0c001), NODE_NONE), 0, 0, "", true);
-    {
-        CDataStream vRecv(SER_NETWORK, PROTOCOL_VERSION);
-        vRecv << qfc;
-        llmq::quorumBlockProcessor->ProcessMessage(&dummyNode, vRecv);
-    }
+    ProcessQuorum(llmq::quorumBlockProcessor.get(), qfc, &dummyNode);
     BOOST_CHECK(llmq::quorumBlockProcessor->HasMinableCommitment(::SerializeHash(qfc)));
 
     // mine final commitment (at block 450)
@@ -1101,11 +1106,7 @@ BOOST_FIXTURE_TEST_CASE(dkg_pose, TestChain400Setup)
     llmq::CFinalCommitment qfc2 = CreateFinalCommitment(pkeys2, skeys2, quorumHash);
     BOOST_CHECK(!qfc2.IsNull());
     BOOST_CHECK(qfc2.Verify(quorumIndex));
-    {
-        CDataStream vRecv(SER_NETWORK, PROTOCOL_VERSION);
-        vRecv << qfc2;
-        llmq::quorumBlockProcessor->ProcessMessage(&dummyNode, vRecv);
-    }
+    ProcessQuorum(llmq::quorumBlockProcessor.get(), qfc2, &dummyNode);
     // final commitment received and accepted
     BOOST_CHECK(llmq::quorumBlockProcessor->HasMinableCommitment(::SerializeHash(qfc2)));
 
@@ -1113,11 +1114,7 @@ BOOST_FIXTURE_TEST_CASE(dkg_pose, TestChain400Setup)
     qfc = CreateFinalCommitment(pkeys, skeys, quorumHash);
     BOOST_CHECK(!qfc.IsNull());
     BOOST_CHECK(qfc.Verify(quorumIndex));
-    {
-        CDataStream vRecv(SER_NETWORK, PROTOCOL_VERSION);
-        vRecv << qfc;
-        llmq::quorumBlockProcessor->ProcessMessage(&dummyNode, vRecv);
-    }
+    ProcessQuorum(llmq::quorumBlockProcessor.get(), qfc, &dummyNode);
     BOOST_CHECK(qfc.CountSigners() > qfc2.CountSigners());
 
     // final commitment received, accepted, and replaced the previous one (with less memebers)

--- a/src/test/evo_specialtx_tests.cpp
+++ b/src/test/evo_specialtx_tests.cpp
@@ -7,6 +7,7 @@
 #include "consensus/validation.h"
 #include "evo/providertx.h"
 #include "evo/specialtx_validation.h"
+#include "llmq/quorums_commitment.h"
 #include "messagesigner.h"
 #include "netbase.h"
 #include "primitives/transaction.h"
@@ -87,6 +88,44 @@ static ProUpRevPL GetRandomProUpRevPayload()
     pl.inputsHash = GetRandHash();
     pl.sig.SetByteVector(InsecureRandBytes(BLS_CURVE_SIG_SIZE));
     return pl;
+}
+
+llmq::CFinalCommitment GetRandomLLMQCommitment()
+{
+    llmq::CFinalCommitment fc;
+    fc.nVersion = InsecureRand16();
+    fc.llmqType = InsecureRandBits(8);
+    fc.quorumHash = GetRandHash();
+    int vecsize = InsecureRandRange(500);
+    for (int i = 0; i < vecsize; i++) {
+        fc.signers.emplace_back((bool)InsecureRandBits(1));
+        fc.validMembers.emplace_back((bool)InsecureRandBits(1));
+    }
+    fc.quorumPublicKey.SetByteVector(InsecureRandBytes(BLS_CURVE_PUBKEY_SIZE));
+    fc.quorumVvecHash = GetRandHash();
+    fc.quorumSig.SetByteVector(InsecureRandBytes(BLS_CURVE_SIG_SIZE));
+    fc.membersSig.SetByteVector(InsecureRandBytes(BLS_CURVE_SIG_SIZE));
+    return fc;
+}
+
+static llmq::LLMQCommPL GetRandomLLMQCommPayload()
+{
+    llmq::LLMQCommPL pl;
+    pl.nHeight = InsecureRand32();
+    pl.commitment = GetRandomLLMQCommitment();
+    return pl;
+}
+
+static bool EqualCommitments(const llmq::CFinalCommitment& a, const llmq::CFinalCommitment& b)
+{
+    return a.nVersion == b.nVersion &&
+           a.llmqType == b.llmqType &&
+           a.quorumHash == b.quorumHash &&
+           a.signers == b.signers &&
+           a.quorumPublicKey == b.quorumPublicKey &&
+           a.quorumVvecHash == b.quorumVvecHash &&
+           a.quorumSig == b.quorumSig &&
+           a.membersSig == b.membersSig;
 }
 
 BOOST_AUTO_TEST_CASE(protx_validation_test)
@@ -222,6 +261,18 @@ BOOST_AUTO_TEST_CASE(proreg_checkstringsig_test)
     BOOST_CHECK(!CMessageSigner::VerifyMessage(keyID, pl.vchSig, pl.MakeSignString(), strError));
     pl.scriptPayout = GetRandomScript();
     BOOST_CHECK(!CMessageSigner::VerifyMessage(keyID, pl.vchSig, pl.MakeSignString(), strError));
+}
+
+BOOST_AUTO_TEST_CASE(llmqcomm_setpayload_test)
+{
+    const llmq::LLMQCommPL& pl = GetRandomLLMQCommPayload();
+
+    CMutableTransaction mtx;
+    SetTxPayload(mtx, pl);
+    llmq::LLMQCommPL pl2;
+    BOOST_CHECK(GetTxPayload(mtx, pl2));
+    BOOST_CHECK(pl.nHeight == pl2.nHeight);
+    BOOST_CHECK(EqualCommitments(pl.commitment, pl2.commitment));
 }
 
 

--- a/src/test/test_pivx.cpp
+++ b/src/test/test_pivx.cpp
@@ -14,6 +14,7 @@
 #include "evo/deterministicmns.h"
 #include "evo/evodb.h"
 #include "evo/evonotificationinterface.h"
+#include "llmq/quorums_init.h"
 #include "miner.h"
 #include "net_processing.h"
 #include "rpc/server.h"
@@ -99,6 +100,7 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
         pblocktree.reset(new CBlockTreeDB(1 << 20, true));
         pcoinsdbview.reset(new CCoinsViewDB(1 << 23, true));
         pcoinsTip.reset(new CCoinsViewCache(pcoinsdbview.get()));
+        llmq::InitLLMQSystem(*evoDb);
         if (!LoadGenesisBlock()) {
             throw std::runtime_error("Error initializing block database");
         }
@@ -130,6 +132,7 @@ TestingSetup::~TestingSetup()
         pblocktree.reset();
         zerocoinDB.reset();
         pSporkDB.reset();
+        llmq::DestroyLLMQSystem();
 }
 
 // Test chain only available on regtest

--- a/src/tiertwo_networksync.cpp
+++ b/src/tiertwo_networksync.cpp
@@ -4,6 +4,7 @@
 
 #include "masternode-sync.h"
 
+#include "llmq/quorums_blockprocessor.h"
 #include "masternodeman.h"          // for mnodeman
 #include "netmessagemaker.h"
 #include "net_processing.h"         // for Misbehaving
@@ -43,6 +44,11 @@ bool CMasternodeSync::MessageDispatcher(CNode* pfrom, std::string& strCommand, C
     if (strCommand == NetMsgType::GETSPORKS) {
         // send sporks
         sporkManager.ProcessGetSporks(pfrom, strCommand, vRecv);
+        return true;
+    }
+
+    if (strCommand == NetMsgType::QFCOMMITMENT) {
+        llmq::quorumBlockProcessor->ProcessMessage(pfrom, vRecv);
         return true;
     }
 

--- a/src/tiertwo_networksync.cpp
+++ b/src/tiertwo_networksync.cpp
@@ -48,6 +48,8 @@ bool CMasternodeSync::MessageDispatcher(CNode* pfrom, std::string& strCommand, C
     }
 
     if (strCommand == NetMsgType::QFCOMMITMENT) {
+        // Only process qfc if v6.0.0 is enforced.
+        if (!deterministicMNManager->IsDIP3Enforced()) return true; // nothing to do.
         llmq::quorumBlockProcessor->ProcessMessage(pfrom, vRecv);
         return true;
     }

--- a/src/tiertwo_networksync.cpp
+++ b/src/tiertwo_networksync.cpp
@@ -50,7 +50,11 @@ bool CMasternodeSync::MessageDispatcher(CNode* pfrom, std::string& strCommand, C
     if (strCommand == NetMsgType::QFCOMMITMENT) {
         // Only process qfc if v6.0.0 is enforced.
         if (!deterministicMNManager->IsDIP3Enforced()) return true; // nothing to do.
-        llmq::quorumBlockProcessor->ProcessMessage(pfrom, vRecv);
+        int retMisbehavingScore{0};
+        llmq::quorumBlockProcessor->ProcessMessage(pfrom, vRecv, retMisbehavingScore);
+        if (retMisbehavingScore > 0) {
+            WITH_LOCK(cs_main, Misbehaving(pfrom->GetId(), retMisbehavingScore));
+        }
         return true;
     }
 

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -51,13 +51,13 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "consensus/zerocoin_verify -> spork -> validation -> consensus/zerocoin_verify"
     "evo/deterministicmns -> masternode -> masternode-sync -> evo/deterministicmns"
     "evo/deterministicmns -> masternode -> wallet/wallet -> evo/deterministicmns"
+    "evo/specialtx_validation -> llmq/quorums_commitment -> validation -> evo/specialtx_validation"
     "kernel -> stakeinput -> wallet/wallet -> kernel"
     "legacy/validation_zerocoin_legacy -> wallet/wallet -> validation -> legacy/validation_zerocoin_legacy"
     "qt/askpassphrasedialog -> qt/pivx/pivxgui -> qt/pivx/topbar -> qt/askpassphrasedialog"
     "qt/pivx/coldstakingwidget -> qt/pivx/tooltipmenu -> qt/pivx/pivxgui -> qt/pivx/coldstakingwidget"
     "qt/pivx/masternodeswidget -> qt/pivx/tooltipmenu -> qt/pivx/pivxgui -> qt/pivx/masternodeswidget"
     "qt/pivx/pivxgui -> qt/pivx/send -> qt/pivx/tooltipmenu -> qt/pivx/pivxgui"
-    "chain -> legacy/stakemodifier -> validation -> evo/specialtx_validation -> chain"
     "chain -> legacy/stakemodifier -> validation -> validationinterface -> chain"
     "chain -> legacy/stakemodifier -> stakeinput -> txdb -> chain"
     "chain -> legacy/stakemodifier -> validation -> checkpoints -> chain"
@@ -66,7 +66,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "chain -> legacy/stakemodifier -> validation -> zpivchain -> chain"
     "consensus/tx_verify -> consensus/zerocoin_verify -> spork -> validation -> consensus/tx_verify"
     "evo/deterministicmns -> masternodeman -> validation -> validationinterface -> evo/deterministicmns"
-    "evo/deterministicmns -> masternodeman -> validation -> evo/specialtx_validation -> evo/deterministicmns"
 )
 
 EXIT_CODE=0

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -18,6 +18,8 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "consensus/params -> consensus/upgrades -> consensus/params"
     "crypter -> wallet/wallet -> crypter"
     "evo/deterministicmns -> masternodeman -> evo/deterministicmns"
+    "evo/deterministicmns -> llmq/quorums_utils -> evo/deterministicmns"
+    "llmq/quorums_blockprocessor -> net_processing -> llmq/quorums_blockprocessor"
     "kernel -> validation -> kernel"
     "masternode -> masternode-sync -> masternode"
     "masternode -> masternodeman -> masternode"
@@ -65,7 +67,7 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "chain -> legacy/stakemodifier -> validation -> pow -> chain"
     "chain -> legacy/stakemodifier -> validation -> zpivchain -> chain"
     "consensus/tx_verify -> consensus/zerocoin_verify -> spork -> validation -> consensus/tx_verify"
-    "evo/deterministicmns -> masternodeman -> validation -> validationinterface -> evo/deterministicmns"
+    "evo/deterministicmns -> llmq/quorums_commitment -> validation -> validationinterface -> evo/deterministicmns"
 )
 
 EXIT_CODE=0

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -19,7 +19,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "crypter -> wallet/wallet -> crypter"
     "evo/deterministicmns -> masternodeman -> evo/deterministicmns"
     "evo/deterministicmns -> llmq/quorums_utils -> evo/deterministicmns"
-    "llmq/quorums_blockprocessor -> net_processing -> llmq/quorums_blockprocessor"
     "kernel -> validation -> kernel"
     "masternode -> masternode-sync -> masternode"
     "masternode -> masternodeman -> masternode"

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -51,7 +51,7 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "consensus/zerocoin_verify -> spork -> validation -> consensus/zerocoin_verify"
     "evo/deterministicmns -> masternode -> masternode-sync -> evo/deterministicmns"
     "evo/deterministicmns -> masternode -> wallet/wallet -> evo/deterministicmns"
-    "evo/specialtx_validation -> llmq/quorums_commitment -> validation -> evo/specialtx_validation"
+    "evo/specialtx_validation -> llmq/quorums_blockprocessor -> validation -> evo/specialtx_validation"
     "kernel -> stakeinput -> wallet/wallet -> kernel"
     "legacy/validation_zerocoin_legacy -> wallet/wallet -> validation -> legacy/validation_zerocoin_legacy"
     "qt/askpassphrasedialog -> qt/pivx/pivxgui -> qt/pivx/topbar -> qt/askpassphrasedialog"


### PR DESCRIPTION
This PR lays the groundwork for the implementation of [DIP6](https://github.com/dashpay/dips/blob/master/dip-0006.md).
Here we introduce the concept of "quorum final commitment", which is the result of a DKG round.
This object is serialized and relayed to the network via a new message, `qfcommit`. Then, it is mined on chain as payload of a new type of special transaction, `LLMQComm` tx (which is the last phase of the DKG protocol).

With this, it is possible to implement (and test) the masternode proof-of-service, based on the DKG participation.

Intra-quorum communication and signing sessions will be part of future pull requests.