### PR TITLE
[RPC] Fully deprecate the autocombinerewards method

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -17,6 +17,13 @@ Notable Changes
 
 (Developers: add your notes here as part of your pull requests whenever possible)
 
+
+### Deprecated autocombinerewards RPC Command
+
+The `autocombinerewards` RPC command was soft-deprecated in v5.3.0 and replaced with explicit setter/getter commands `setautocombinethreshold`/`getautocombinethreshold`. PIVX Core, by default, will no longer accept the `autocombinerewards` command, returning a deprecation error, unless the `pivxd`/`pivx-qt` is started with the `-deprecatedrpc=autocombinerewards` option.
+
+This command will be fully removed in v6.0.0.
+
 *version* Change log
 ==============
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4455,6 +4455,13 @@ UniValue getstakesplitthreshold(const JSONRPCRequest& request)
 
 UniValue autocombinerewards(const JSONRPCRequest& request)
 {
+    if (!IsDeprecatedRPCEnabled("autocombinerewards")) {
+        if (request.fHelp) {
+            throw std::runtime_error("autocombinerewards (Deprecated, will be removed in v6.0. To use this command, start pivxd with -deprecatedrpc=autocombinerewards)");
+        }
+        throw JSONRPCError(RPC_METHOD_DEPRECATED, "autocombinerewards is deprecated and will be removed in v6.0. To use this command, start pivxd with -deprecatedrpc=autocombinerewards");
+    }
+
     CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
 
     if (!EnsureWalletIsAvailable(pwallet, request.fHelp))

--- a/test/functional/rpc_deprecated.py
+++ b/test/functional/rpc_deprecated.py
@@ -5,13 +5,14 @@
 """Test deprecation of RPC calls."""
 
 from test_framework.test_framework import PivxTestFramework
-# from test_framework.util import assert_raises_rpc_error
+from test_framework.util import assert_raises_rpc_error
+
 
 class DeprecatedRpcTest(PivxTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
         self.setup_clean_chain = True
-        self.extra_args = [[], []]
+        self.extra_args = [[], ["-deprecatedrpc=autocombinerewards"]]
 
     def run_test(self):
         # This test should be used to verify correct behaviour of deprecated
@@ -20,7 +21,13 @@ class DeprecatedRpcTest(PivxTestFramework):
         # self.log.info("Make sure that -deprecatedrpc=accounts allows it to take accounts")
         # assert_raises_rpc_error(-32, "listaccounts is deprecated", self.nodes[0].listaccounts)
         # self.nodes[1].listaccounts()
-        self.log.info("No test cases to run")  # remove this when adding any tests to this file
+
+        self.log.info("Test autocombinerewards deprecation")
+        # The autocombinerewards RPC method has been deprecated
+        assert_raises_rpc_error(-32, "autocombinerewards is deprecated", self.nodes[0].autocombinerewards, True, 500)
+        self.nodes[1].autocombinerewards(True, 500)
+
+        # self.log.info("No test cases to run")  # remove this when adding any tests to this file
 
 
 if __name__ == '__main__':

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -112,7 +112,7 @@ BASE_SCRIPTS= [
     'wallet_dump.py',                           # ~ 83 sec
     'rpc_net.py',                               # ~ 83 sec
     'rpc_bip38.py',                             # ~ 82 sec
-    #'rpc_deprecated.py',                        # ~ 80 sec (disabled for now, no deprecated RPC commands to test)
+    'rpc_deprecated.py',                        # ~ 80 sec
     'interface_bitcoin_cli.py',                 # ~ 80 sec
     'mempool_packages.py',                      # ~ 63 sec
 


### PR DESCRIPTION
This command was first marked soft-deprecated, and replaced with
explicit setter/getter commands, in v5.3.0.

This fully deprecates it by returning an error when calling, unless the
node is started with `-deprecatedrpc=autocombinerewards`. Revived the
`rpc_deprecated.py` functional test to cover this.