### PR TITLE
[RPC] Shield address setlabel/getaddressesbylabel

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -24,6 +24,15 @@ The `autocombinerewards` RPC command was soft-deprecated in v5.3.0 and replaced 
 
 This command will be fully removed in v6.0.0.
 
+### Shield address support for RPC label commands
+
+The `setlabel` RPC command now supports a shield address input argument to allow users to set labels for shield addresses. Additionally, the `getaddressesbylabel` RPC command will also now return shield addresses with a matching label.
+
+### Specify optional label for getnewshieldaddress
+
+The `getnewshieldaddress` RPC command now takes an optional argument `label (string)` to denote the desired label for the generated address.
+
+
 *version* Change log
 ==============
 

--- a/test/functional/wallet_labels.py
+++ b/test/functional/wallet_labels.py
@@ -120,6 +120,16 @@ class WalletlabelsTest(PivxTestFramework):
             label.verify(node)
             assert_raises_rpc_error(-11, "No addresses with label", node.getaddressesbylabel, "")
 
+        if not self.options.legacywallet:
+            # Check that setlabel can assign a label to a new unused shield address.
+            for label in labels:
+                shield_address = node.getnewshieldaddress()
+                node.setlabel(shield_address, label.name)
+                label.add_address(shield_address)
+                label.purpose[shield_address] = "shielded_receive"
+                label.verify(node)
+                assert_raises_rpc_error(-11, "No addresses with label", node.getaddressesbylabel, "")
+
         # Check that addmultisigaddress can assign labels.
         for label in labels:
             addresses = []


### PR DESCRIPTION
This adds shield address support to the `setlabel` and
`getaddressesbylabel` RPC commands. `setlabel` now accepts and validates
 shield address input argument, where `getaddressesbylabel` now returns
 shield addresses with a label matching the input argument.

Companion to #2600 that allows CLI users to set a label for shield addresses
after-the-fact, as well as see shield addresses with an assigned label in the
response of `getaddressesbylabel`

Also added relevant release notes for the changes in #2600.

Regression tests added as well to cover the `setlabel` command.