### PR TITLE
[Tests] Replace usage of tostring() with tobytes()

### DIFF
--- a/test/functional/test_framework/netutil.py
+++ b/test/functional/test_framework/netutil.py
@@ -106,7 +106,7 @@ def all_interfaces():
             max_possible *= 2
         else:
             break
-    namestr = names.tostring()
+    namestr = names.tobytes()
     return [(namestr[i:i+16].split(b'\0', 1)[0],
              socket.inet_ntoa(namestr[i+20:i+24]))
             for i in range(0, outbytes, struct_size)]


### PR DESCRIPTION
Straight forward backport of https://github.com/bitcoin/bitcoin/pull/13963

> tostring() is deprecated as of python 3.7 and results in stderr output
> causing tests to fail