### PR TITLE
[GUI] Force argument insertion when switching languages

### DIFF
--- a/src/qt/pivx/welcomecontentwidget.cpp
+++ b/src/qt/pivx/welcomecontentwidget.cpp
@@ -209,6 +209,7 @@ void WelcomeContentWidget::checkLanguage()
         settings.sync();
         Q_EMIT onLanguageSelected();
         ui->retranslateUi(this);
+        ui->labelTitle2->setText(ui->labelTitle2->text().arg(PACKAGE_NAME));
     }
 }
 


### PR DESCRIPTION
On the Welcome screen, when users change the language, a call to Qt's
internal `retranslateUi()` is made. This, however does not take into
consideration any arguments in a source string, and instead treats them
as string literals (ie, `%1` is not considered an argument, but rather a
literal string)

Fix this by adding a supplemental call to `setText()` that DOES allow
for argument processing directly after the retranslation.

Fixes #2570