### PR TITLE
[Test] Add test case for node with a full "ask for" inv set.

### DIFF
--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -262,7 +262,7 @@ int CMasternodeMan::CheckAndRemove(bool forceExpiredRemoval)
             //    sending a brand new mnb
             std::map<uint256, CMasternodeBroadcast>::iterator it3 = mapSeenMasternodeBroadcast.begin();
             while (it3 != mapSeenMasternodeBroadcast.end()) {
-                if (it3->second.vin == it->second->vin) {
+                if (it3->second.vin.prevout == it->first) {
                     masternodeSync.mapSeenSyncMNB.erase((*it3).first);
                     it3 = mapSeenMasternodeBroadcast.erase(it3);
                 } else {
@@ -277,6 +277,16 @@ int CMasternodeMan::CheckAndRemove(bool forceExpiredRemoval)
                     it2 = mWeAskedForMasternodeListEntry.erase(it2);
                 } else {
                     ++it2;
+                }
+            }
+
+            // clean MN pings right away.
+            auto itPing = mapSeenMasternodePing.begin();
+            while (itPing != mapSeenMasternodePing.end()) {
+                if (itPing->second.GetVin().prevout == it->first) {
+                    itPing = mapSeenMasternodePing.erase(itPing);
+                } else {
+                    ++itPing;
                 }
             }
 

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -12,10 +12,13 @@ from test_framework.mininode import (
     P2PDataStore,
     P2PInterface,
 )
+from test_framework.messages import CTxIn, COutPoint, msg_mnping
 from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
+    assert_equal,
     hex_str_to_bytes,
 )
+from random import getrandbits
 
 MSG_LIMIT = 2 * 1024 * 1024  # 2MB, per MAX_PROTOCOL_MESSAGE_LENGTH
 VALID_DATA_LIMIT = MSG_LIMIT - 5  # Account for the 5-byte length prefix
@@ -39,6 +42,19 @@ class SenderOfAddrV2(P2PInterface):
     def wait_for_sendaddrv2(self):
         self.wait_until(lambda: 'sendaddrv2' in self.last_message)
 
+class InvReceiver(P2PInterface):
+
+    def __init__(self):
+        super().__init__()
+        self.vec_mnp = {}
+        self.getdata_count = 0
+
+    def on_getdata(self, message):
+        for inv in message.inv:
+            if inv.type == 15: # MNPING
+                self.send_message(self.vec_mnp[inv.hash])
+                self.getdata_count+=1
+
 class InvalidMessagesTest(PivxTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
@@ -55,6 +71,7 @@ class InvalidMessagesTest(PivxTestFramework):
         self.test_addrv2_unrecognized_network()
         self.test_large_inv()
         self.test_resource_exhaustion()
+        self.test_fill_askfor()
 
     def test_magic_bytes(self):
         conn = self.nodes[0].add_p2p_connection(P2PDataStore())
@@ -185,6 +202,33 @@ class InvalidMessagesTest(PivxTestFramework):
         with self.nodes[0].assert_debug_log(['Misbehaving', 'peer=9 (20 -> 40): message getdata size() = 50001']):
             msg = messages.msg_getdata([messages.CInv(1, 1)] * 50001)
             conn.send_and_ping(msg)
+        self.nodes[0].disconnect_p2ps()
+
+    def test_fill_askfor(self):
+        self.nodes[0].generate(1) # IBD
+        conn = self.nodes[0].add_p2p_connection(InvReceiver())
+        invs = []
+        blockhash = int(self.nodes[0].getbestblockhash(), 16)
+        for _ in range(50000):
+            mnp = msg_mnping(CTxIn(COutPoint(getrandbits(256))), blockhash, int(time.time()))
+            conn.vec_mnp[mnp.get_hash()] = mnp
+            invs.append(messages.CInv(15, mnp.get_hash()))
+        assert_equal(len(conn.vec_mnp), 50000)
+        assert_equal(len(invs), 50000)
+        msg = messages.msg_inv(invs)
+        conn.send_message(msg)
+
+        time.sleep(20) # wait a bit
+        assert_equal(conn.getdata_count, 50000)
+
+        # Prior #2611 the node was blocking any follow-up request.
+        mnp = msg_mnping(CTxIn(COutPoint(getrandbits(256))), getrandbits(256), int(time.time()))
+        conn.vec_mnp[mnp.get_hash()] = mnp
+        msg = messages.msg_inv([messages.CInv(15, mnp.get_hash())])
+        conn.send_and_ping(msg)
+        time.sleep(3)
+
+        assert_equal(conn.getdata_count, 50001)
         self.nodes[0].disconnect_p2ps()
 
     def test_resource_exhaustion(self):

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -289,13 +289,9 @@ class CInv:
         11: "MSG_BUDGET_FINALIZED",
         12: "MSG_BUDGET_FINALIZED_VOTE",
         13: "MSG_MASTERNODE_QUORUM",
-        14: "MSG_MASTERNODE_QUORUM",
         15: "MSG_MASTERNODE_ANNOUNCE",
         16: "MSG_MASTERNODE_PING",
-        17: "MSG_DSTX",
-        18: "MSG_PUBCOINS",
-        19: "MSG_GENWIT",
-        20: "MSG_ACC_VALUE"
+        17: "MSG_DSTX"
     }
 
     def __init__(self, t=0, h=0):

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1149,6 +1149,41 @@ class msg_getblocks:
         return "msg_getblocks(locator=%s hashstop=%064x)" \
             % (repr(self.locator), self.hashstop)
 
+class msg_mnping:
+    command = b"mnp"
+
+    def __init__(self, _vin, _blockhash, _sigtime):
+        self.vin = _vin
+        self.blockhash = _blockhash
+        self.sigtime = _sigtime
+        self.vch_sig = b""
+        self.mess_version = 1
+        self.cached_hash = b""
+
+    def deserialize(self, f):
+        self.vin.deserialize(f)
+        self.blockhash = deser_uint256(f)
+        self.sigtime = struct.unpack("<q", f.read(8))[0]
+        self.vch_sig = deser_string(f)
+        self.mess_version = struct.unpack("<i", f.read(4))[0]
+
+    def serialize(self):
+        r = b""
+        r += self.vin.serialize()
+        r += ser_uint256(self.blockhash)
+        r += struct.pack("<q", self.sigtime)
+        r += ser_string(self.vch_sig)
+        r += struct.pack("<I", self.mess_version)
+        return r
+
+    def get_hash(self):
+        if self.cached_hash == b"":
+            self.cached_hash = uint256_from_str(hash256(self.serialize()))
+        return self.cached_hash
+
+    def __repr__(self):
+        return "msg_mnping(vin=%s blockhash=%064x)" \
+               % (repr(self.vin), self.blockhash)
 
 class msg_tx:
     command = b"tx"


### PR DESCRIPTION
Follow-up work to #2611. 
Adding a regression test case for one of the issues solved in #2611:

As none of the mnp inv requests were being removed from the waiting for response inv set and map when the item arrives.
The set was growing non-stop for the entire node life cycle up to the point where no subsequent inv msg were accepted anymore.

After v6.0, as the mnp message will be removed, the test can be moved to be based on quorum inv msgs.