### PR TITLE
[Refactor] Remove finalized budgets earlier

### DIFF
--- a/src/budget/finalizedbudget.cpp
+++ b/src/budget/finalizedbudget.cpp
@@ -200,7 +200,7 @@ bool CFinalizedBudget::CheckStartEnd()
     }
 
     // The following 2 checks check the same (basically if vecBudgetPayments.size() > 100)
-    if (GetBlockEnd() - nBlockStart > 100) {
+    if (GetBlockEnd() - nBlockStart + 1 > 100) {
         strInvalid = "Invalid BlockEnd";
         return false;
     }

--- a/src/budget/finalizedbudget.cpp
+++ b/src/budget/finalizedbudget.cpp
@@ -200,11 +200,11 @@ bool CFinalizedBudget::CheckStartEnd()
     }
 
     // The following 2 checks check the same (basically if vecBudgetPayments.size() > 100)
-    if (GetBlockEnd() - nBlockStart + 1 > 100) {
+    if (GetBlockEnd() - nBlockStart + 1 > MAX_PROPOSALS_PER_CYCLE) {
         strInvalid = "Invalid BlockEnd";
         return false;
     }
-    if ((int)vecBudgetPayments.size() > 100) {
+    if ((int)vecBudgetPayments.size() > MAX_PROPOSALS_PER_CYCLE) {
         strInvalid = "Invalid budget payments count (too many)";
         return false;
     }

--- a/src/budget/finalizedbudget.cpp
+++ b/src/budget/finalizedbudget.cpp
@@ -235,12 +235,10 @@ bool CFinalizedBudget::CheckName()
 
 bool CFinalizedBudget::updateExpired(int nCurrentHeight)
 {
-    // Remove budgets after their last payment block
+    // Remove finalized budgets 2 * MAX_PROPOSALS_PER_CYCLE blocks after their end
     const int nBlockEnd = GetBlockEnd();
-    const int nBlocksPerCycle = Params().GetConsensus().nBudgetCycleBlocks;
-    const int nLastSuperBlock = nCurrentHeight - nCurrentHeight % nBlocksPerCycle;
-    if (nBlockEnd < nLastSuperBlock) {
-        strInvalid = strprintf("(ends at block %ld) too old and obsolete", nBlockEnd);
+    if (nCurrentHeight >= nBlockEnd + 2 * MAX_PROPOSALS_PER_CYCLE) {
+        strInvalid = strprintf("(ends at block %ld) too old and obsolete (current %ld)", nBlockEnd, nCurrentHeight);
         return true;
     }
 

--- a/src/budget/finalizedbudget.h
+++ b/src/budget/finalizedbudget.h
@@ -51,6 +51,8 @@ protected:
     std::string strProposals;
 
 public:
+    static constexpr unsigned int MAX_PROPOSALS_PER_CYCLE = 100;
+
     // Set in CBudgetManager::AddFinalizedBudget via CheckCollateral
     int64_t nTime;
 


### PR DESCRIPTION
Currently we keep (and relay) finalized budgets for a whole cycle after the superblock.
These finalization messages (and relative votes) might be rejected (they might include expired proposals at that point) by new peers, syncing after the budget payments are over.
There is no need to keep and sync finalized budgets for a whole cycle of 43200 blocks.
This PR sets the expiration to 200 blocks after the last budget payment.