### PR TITLE
[GUI] Show disk space requirement per-network

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -17,7 +17,7 @@ Release Process
 ### Before every major release
 
 * Update hardcoded [seeds](/contrib/seeds/README.md), see [this pull request](https://github.com/bitcoin/bitcoin/pull/7415) for an example.
-* Update [`BLOCK_CHAIN_SIZE`](/src/qt/intro.cpp) to the current size plus some overhead.
+* Update [`BLOCK_CHAIN_SIZE` and `TESTNET_BLOCK_CHAIN_SIZE`](/src/qt/intro.cpp) to the current size plus some overhead for each respective network.
 * Update `src/chainparams.cpp` with statistics about the transaction count and rate.
 * On both the master branch and the new release branch:
   - update `CLIENT_VERSION_MINOR` in [`configure.ac`](../configure.ac)

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -21,9 +21,13 @@
 #include <QMessageBox>
 #include <QSettings>
 
-/* Minimum free space (in bytes) needed for data directory */
 static const uint64_t GB_BYTES = 1000000000LL;
-static const uint64_t BLOCK_CHAIN_SIZE = 1LL * GB_BYTES;
+/* Minimum free space (in GB) needed for mainnet data directory */
+static const uint64_t BLOCK_CHAIN_SIZE = 25;
+/* Minimum free space (in GB) needed for testnet data directory */
+static const uint64_t TESTNET_BLOCK_CHAIN_SIZE = 1;
+/* Total required space (in GB) depending on network */
+static uint64_t requiredSpace;
 
 /* Check free space asynchronously to prevent hanging the UI thread.
 
@@ -135,7 +139,7 @@ Intro::Intro(QWidget* parent) : QDialog(parent, Qt::WindowSystemMenuHint | Qt::W
 
     ui->welcomeLabel->setText(ui->welcomeLabel->text().arg(PACKAGE_NAME));
     ui->storageLabel->setText(ui->storageLabel->text().arg(PACKAGE_NAME));
-    ui->sizeWarningLabel->setText(ui->sizeWarningLabel->text().arg(PACKAGE_NAME).arg(BLOCK_CHAIN_SIZE / GB_BYTES));
+    ui->sizeWarningLabel->setText(ui->sizeWarningLabel->text().arg(PACKAGE_NAME).arg(requiredSpace));
     startThread();
 }
 
@@ -188,6 +192,13 @@ bool Intro::pickDataDirectory()
 
     if (!fs::exists(GUIUtil::qstringToBoostPath(dataDir)) || gArgs.GetBoolArg("-choosedatadir", DEFAULT_CHOOSE_DATADIR)) {
         // If current default data directory does not exist, let the user choose one
+        if (gArgs.GetBoolArg("-testnet", false)) {
+            requiredSpace = TESTNET_BLOCK_CHAIN_SIZE;
+        } else if (gArgs.GetBoolArg("-regtest", false)) {
+            requiredSpace = 0;
+        } else {
+            requiredSpace = BLOCK_CHAIN_SIZE;
+        }
         Intro intro;
         intro.setDataDirectory(dataDir);
         intro.setWindowIcon(QIcon(":icons/bitcoin"));
@@ -241,8 +252,8 @@ void Intro::setStatus(int status, const QString& message, quint64 bytesAvailable
         ui->freeSpace->setText("");
     } else {
         QString freeString = tr("%1 GB of free space available").arg(bytesAvailable / GB_BYTES);
-        if (bytesAvailable < BLOCK_CHAIN_SIZE) {
-            freeString += " " + tr("(of %1 GB needed)").arg(BLOCK_CHAIN_SIZE / GB_BYTES);
+        if (bytesAvailable < requiredSpace * GB_BYTES) {
+            freeString += " " + tr("(of %1 GB needed)").arg(requiredSpace);
             ui->freeSpace->setStyleSheet("QLabel { color: #800000 }");
         } else {
             ui->freeSpace->setStyleSheet("");


### PR DESCRIPTION
This introduces per-network required disk space into the intro UI in the
least intrusive way for now. Mainnet and Testnet have their own static
const variables, whereas Regtest is always set to "0"

This is intended as a temporary fix for #2618, with future intention on
moving these over to chainparams a la upstream and using a node IPC
interface layer, which we do not have yet.

Can be tested by passing `-choosedatadir` with a combination of `-testnet`,
`-regtest`, or standalone, and this has zero impact on translation strings.