### PR TITLE
[TierTwo] Do not ask for single MN items if the node is in initial sync state

### DIFF
--- a/src/budget/budgetmanager.cpp
+++ b/src/budget/budgetmanager.cpp
@@ -1074,7 +1074,8 @@ bool CBudgetManager::ProcessProposalVote(CBudgetVote& vote, CNode* pfrom, CValid
     CMasternode* pmn = mnodeman.Find(voteVin.prevout);
     if (!pmn) {
         err = strprintf("unknown masternode - vin: %s", voteVin.prevout.ToString());
-        mnodeman.AskForMN(pfrom, voteVin);
+        // Ask for MN only if we finished syncing the MN list.
+        if (pfrom && masternodeSync.IsMasternodeListSynced()) mnodeman.AskForMN(pfrom, voteVin);
         return state.DoS(0, false, REJECT_INVALID, "bad-mvote", false, err);
     }
 
@@ -1085,8 +1086,6 @@ bool CBudgetManager::ProcessProposalVote(CBudgetVote& vote, CNode* pfrom, CValid
             err = strprintf("signature from masternode %s invalid", voteVin.prevout.ToString());
             return state.DoS(20, false, REJECT_INVALID, "bad-fbvote", false, err);
         }
-        // it could just be a non-synced masternode
-        mnodeman.AskForMN(pfrom, voteVin);
         return false;
     }
 
@@ -1175,7 +1174,8 @@ bool CBudgetManager::ProcessFinalizedBudgetVote(CFinalizedBudgetVote& vote, CNod
     CMasternode* pmn = mnodeman.Find(voteVin.prevout);
     if (!pmn) {
         err = strprintf("unknown masternode - vin: %s", voteVin.prevout.ToString());
-        mnodeman.AskForMN(pfrom, voteVin);
+        // Ask for MN only if we finished syncing the MN list.
+        if (pfrom && masternodeSync.IsMasternodeListSynced()) mnodeman.AskForMN(pfrom, voteVin);
         return state.DoS(0, false, REJECT_INVALID, "bad-fbvote", false, err);
     }
 
@@ -1186,8 +1186,6 @@ bool CBudgetManager::ProcessFinalizedBudgetVote(CFinalizedBudgetVote& vote, CNod
             err = strprintf("signature from masternode %s invalid", voteVin.prevout.ToString());
             return state.DoS(20, false, REJECT_INVALID, "bad-fbvote", false, err);
         }
-        // it could just be a non-synced masternode
-        mnodeman.AskForMN(pfrom, voteVin);
         return false;
     }
 

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -420,7 +420,7 @@ bool CMasternodeBroadcast::CheckAndUpdate(int& nDos)
     if (!CheckSignature()) {
         // For now (till v6.0), let's be "naive" and not fully ban nodes when the node is syncing
         // This could be a bad parsed BIP155 address that got stored on db on an old software version.
-        nDos = masternodeSync.IsSynced() ? 100 : 10;
+        nDos = masternodeSync.IsSynced() ? 100 : 5;
         return error("%s : Got bad Masternode address signature", __func__);
     }
 


### PR DESCRIPTION
Solving a last edge case race condition for the tier two initial sync process:
 if a `fbvote` or `fbs` message is received before or while we are synchronizing the MN list, there can be a race where the node will move to single items requests instead of requesting the full list (which is not what we want in the initial sync process as single items requests sync is a reactive approach while full list requests is a proactive one).

Plus, decreased the DoS score for a bad mnb signature during the initial synchronization process, so we don't end up banning pre v5.3.3 nodes too fast for an invalidly serialized mnb (this issue was solved in #2611 removing the mnb BIP155 flag, this is only an extra guard to give a bit more time to non-updated peers to upgrade while the network is upgrading).