### PR TITLE
[wallet] Fix "null" backup file name.

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4371,7 +4371,8 @@ bool CWalletTx::AcceptToMemoryPool(CValidationState& state)
 
 std::string CWallet::GetUniqueWalletBackupName() const
 {
-    return strprintf("%s%s", (!m_name.empty() ? SanitizeString(m_name, SAFE_CHARS_FILENAME) : "null"), FormatISO8601DateTimeForBackup(GetTime()));
+    std::string name = !m_name.empty() ? SanitizeString(m_name, SAFE_CHARS_FILENAME) : "wallet_backup";
+    return strprintf("%s%s", name, FormatISO8601DateTimeForBackup(GetTime()));
 }
 
 CWallet::CWallet(std::string name, std::unique_ptr<WalletDatabase> database) : m_name(std::move(name)), database(std::move(database))

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -893,7 +893,7 @@ bool AutoBackupWallet(CWallet& wallet, std::string& strBackupWarning, std::strin
     }
 
     // Keep only 0 < nWalletBackups <= 10 backups, including the new one of course
-    folder_set_t folder_set = buildBackupsMapSortedByLastWrite(strWalletFile, backupsDir);
+    folder_set_t folder_set = buildBackupsMapSortedByLastWrite(backupFile.stem().string(), backupsDir);
     return cleanWalletBackups(folder_set, nWalletBackups, strBackupWarning);
 }
 


### PR DESCRIPTION
 New created wallets have no name set by default, thus why the `GetUniqueWalletBackupName` function returns "null", and the automatic backup process creates backup files with a name in the form of "null+date".

Changed the label to "wallet_backup" instead of "null" if the wallet has no name, plus fixed the rolling functionality that was not cleaning old files.