### PR TITLE
[GUI] Correct proposal large title for being cut when the app window width isn't big enough

### DIFF
--- a/src/qt/pivx/forms/proposalcard.ui
+++ b/src/qt/pivx/forms/proposalcard.ui
@@ -76,6 +76,9 @@
       </property>
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <property name="spacing">
+         <number>0</number>
+        </property>
         <item>
          <widget class="QLabel" name="labelPropName">
           <property name="text">
@@ -104,8 +107,17 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="maximumSize">
+           <size>
+            <width>22</width>
+            <height>25</height>
+           </size>
+          </property>
           <property name="cursor">
            <cursorShape>PointingHandCursor</cursorShape>
+          </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
           </property>
           <property name="text">
            <string/>

--- a/src/qt/pivx/proposalcard.cpp
+++ b/src/qt/pivx/proposalcard.cpp
@@ -38,6 +38,7 @@ void ProposalCard::setProposal(const ProposalInfo& _proposalInfo)
 {
     proposalInfo = _proposalInfo;
     ui->labelPropName->setText(QString::fromStdString(proposalInfo.name));
+    ui->labelPropName->setToolTip(QString::fromStdString(proposalInfo.name));
     ui->labelPropAmount->setText(GUIUtil::formatBalance(proposalInfo.amount));
     ui->labelPropMonths->setText(proposalInfo.remainingPayments < 0 ? tr("Inactive proposal") :
             proposalInfo.remainingPayments == 0 ? tr("Last month in course") :


### PR DESCRIPTION
Found it while was testing #2626, a small bug that occurs when the app window width isn't big enough to automatically expand the three column grid proposal cards. So the last letter of proposals with large names are being cut.

For example, look at the proposal in the middle:

Before the fix:
<img width="1034" alt="Screen Shot 2021-11-04 at 6 44 15 PM" src="https://user-images.githubusercontent.com/5377650/140424886-366c12bc-4ce3-43c4-bcd6-89d35ec0f634.png">

After the fix:
<img width="944" alt="Screen Shot 2021-11-04 at 6 40 09 PM" src="https://user-images.githubusercontent.com/5377650/140424926-3e7965ae-1db6-4c3e-9f5c-d2adb3098b4b.png">

