### PR TITLE
[Util] Support serialization of std::vector<bool>

### DIFF
--- a/src/serialize.h
+++ b/src/serialize.h
@@ -681,6 +681,7 @@ template<typename Stream, unsigned int N, typename T> inline void Unserialize(St
  * vectors of unsigned char are a special case and are intended to be serialized as a single opaque blob.
  */
 template<typename Stream, typename T, typename A> void Serialize_impl(Stream& os, const std::vector<T, A>& v, const unsigned char&);
+template<typename Stream, typename T, typename A> void Serialize_impl(Stream& os, const std::vector<T, A>& v, const bool&);
 template<typename Stream, typename T, typename A, typename V> void Serialize_impl(Stream& os, const std::vector<T, A>& v, const V&);
 template<typename Stream, typename T, typename A> inline void Serialize(Stream& os, const std::vector<T, A>& v);
 template<typename Stream, typename T, typename A> void Unserialize_impl(Stream& is, std::vector<T, A>& v, const unsigned char&);
@@ -948,6 +949,18 @@ void Serialize_impl(Stream& os, const std::vector<T, A>& v, const unsigned char&
     WriteCompactSize(os, v.size());
     if (!v.empty())
         os.write((char*)v.data(), v.size() * sizeof(T));
+}
+
+template <typename Stream, typename T, typename A>
+void Serialize_impl(Stream& os, const std::vector<T, A>& v, const bool&)
+{
+    // A special case for std::vector<bool>, as dereferencing
+    // std::vector<bool>::const_iterator does not result in a const bool&
+    // due to std::vector's special casing for bool arguments.
+    WriteCompactSize(os, v.size());
+    for (bool elem : v) {
+        ::Serialize(os, elem);
+    }
 }
 
 template <typename Stream, typename T, typename A, typename V>

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -280,6 +280,14 @@ static bool isCanonicalException(const std::ios_base::failure& ex)
     return strcmp(expectedException.what(), ex.what()) == 0;
 }
 
+BOOST_AUTO_TEST_CASE(vector_bool)
+{
+    std::vector<uint8_t> vec1{1, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 0, 1, 0, 0, 1};
+    std::vector<bool> vec2{1, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 0, 1, 0, 0, 1};
+
+    BOOST_CHECK(vec1 == std::vector<uint8_t>(vec2.begin(), vec2.end()));
+    BOOST_CHECK(SerializeHash(vec1) == SerializeHash(vec2));
+}
 
 BOOST_AUTO_TEST_CASE(noncanonical)
 {


### PR DESCRIPTION
Backport of bitcoin#16730, fixing the following clang warning:

```
./serialize.h:631:44: warning: loop variable 'elem' is always a copy because the range of type 'const
      std::vector<bool, std::allocator<bool> >' does not return a reference [-Wrange-loop-analysis]
        for (const typename V::value_type& elem : v) {
                                           ^
./serialize.h:484:77: note: in instantiation of function template specialization
      'VectorFormatter<DefaultFormatter>::Ser<CHashWriter, std::vector<bool, std::allocator<bool> > >'
      requested here
    template<typename Stream> void Serialize(Stream &s) const { Formatter().Ser(s, m_object); }
                                                                            ^
./serialize.h:806:7: note: in instantiation of function template specialization
      'Wrapper<VectorFormatter<DefaultFormatter>, const std::vector<bool, std::allocator<bool> >
      &>::Serialize<CHashWriter>' requested here
    a.Serialize(os);
      ^
./serialize.h:956:5: note: in instantiation of function template specialization 'Serialize<CHashWriter,
      Wrapper<VectorFormatter<DefaultFormatter>, const std::vector<bool, std::allocator<bool> > &> >'
      requested here
    Serialize(os, Using<VectorFormatter<DefaultFormatter>>(v));
    ^
./serialize.h:962:5: note: in instantiation of function template specialization
      'Serialize_impl<CHashWriter, bool, std::allocator<bool>, bool>' requested here
    Serialize_impl(os, v, T());
    ^
./hash.h:247:11: note: in instantiation of function template specialization 'Serialize<CHashWriter, bool,
      std::allocator<bool> >' requested here
        ::Serialize(*this, obj);
          ^
./hash.h:292:8: note: in instantiation of function template specialization
      'CHashWriter::operator<<<std::vector<bool, std::allocator<bool> > >' requested here
    ss << obj;
       ^
init.cpp:1504:39: note: in instantiation of function template specialization
      'SerializeHash<std::vector<bool, std::allocator<bool> > >' requested here
        const uint256 asmap_version = SerializeHash(asmap);
```


