### PR TITLE
[Cleanup] Remove unused variables and private fields

### DIFF
--- a/src/bench/bls_dkg.cpp
+++ b/src/bench/bls_dkg.cpp
@@ -96,7 +96,6 @@ struct DKG
         // Benchmark.
         size_t memberIdx = 0;
         while (state.KeepRunning()) {
-            auto& m = members[memberIdx];
 
             ReceiveShares(memberIdx);
 

--- a/src/bench/walletprocessblock.cpp
+++ b/src/bench/walletprocessblock.cpp
@@ -164,7 +164,7 @@ static void WalletProcessBlockBench(benchmark::State& state)
             recipients.emplace_back(pwallet->GenerateNewSaplingZKey(), 100 * COIN, "", false);
             recipients.emplace_back(pwallet->GenerateNewSaplingZKey(), 240 * COIN, "", false);
 
-            SaplingOperation operation(params.GetConsensus(), nextBlockHeight, pwallet.get());
+            SaplingOperation operation(params.GetConsensus(), pwallet.get());
             auto operationResult = operation.setRecipients(recipients)
                     ->setSelectTransparentCoins(true)
                     ->setMinDepth(1)

--- a/src/evo/evonotificationinterface.h
+++ b/src/evo/evonotificationinterface.h
@@ -10,7 +10,6 @@
 class EvoNotificationInterface : public CValidationInterface
 {
 public:
-    explicit EvoNotificationInterface() {}
     virtual ~EvoNotificationInterface() = default;
 
     // a small helper to initialize current block height in sub-modules on startup

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -41,7 +41,6 @@ struct CompareScoreMN {
 // CMasternodeDB
 //
 
-static const int MASTERNODE_DB_VERSION = 1;
 static const int MASTERNODE_DB_VERSION_BIP155 = 2;
 
 CMasternodeDB::CMasternodeDB()

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -637,8 +637,7 @@ OperationResult WalletModel::PrepareShieldedTransaction(WalletModelTransaction* 
     if (!opResult) return opResult;
 
     // Create the operation
-    int nextBlockHeight = cachedNumBlocks + 1;
-    SaplingOperation operation(Params().GetConsensus(), nextBlockHeight, wallet);
+    SaplingOperation operation(Params().GetConsensus(), wallet);
     auto operationResult = operation.setRecipients(recipients)
              ->setTransparentKeyChange(modelTransaction->getPossibleKeyChange())
              ->setSelectTransparentCoins(fromTransparent)

--- a/src/sapling/sapling_operation.cpp
+++ b/src/sapling/sapling_operation.cpp
@@ -19,9 +19,9 @@ struct TxValues
     CAmount target{0};
 };
 
-SaplingOperation::SaplingOperation(const Consensus::Params& consensusParams, int nHeight, CWallet* _wallet) :
+SaplingOperation::SaplingOperation(const Consensus::Params& consensusParams, CWallet* _wallet) :
     wallet(_wallet),
-    txBuilder(consensusParams, nHeight, _wallet)
+    txBuilder(consensusParams, _wallet)
 {
     assert (wallet != nullptr);
 };

--- a/src/sapling/sapling_operation.h
+++ b/src/sapling/sapling_operation.h
@@ -82,7 +82,7 @@ public:
 
 class SaplingOperation {
 public:
-    explicit SaplingOperation(const Consensus::Params& consensusParams, int nHeight, CWallet* _wallet);
+    explicit SaplingOperation(const Consensus::Params& consensusParams, CWallet* _wallet);
     ~SaplingOperation();
 
     OperationResult build();

--- a/src/sapling/transaction_builder.cpp
+++ b/src/sapling/transaction_builder.cpp
@@ -131,10 +131,8 @@ std::string TransactionBuilderResult::GetError() {
 
 TransactionBuilder::TransactionBuilder(
     const Consensus::Params& _consensusParams,
-    int _nHeight,
     CKeyStore* _keystore) :
     consensusParams(_consensusParams),
-    nHeight(_nHeight),
     keystore(_keystore)
 {
     Clear();

--- a/src/sapling/transaction_builder.h
+++ b/src/sapling/transaction_builder.h
@@ -84,7 +84,6 @@ class TransactionBuilder
 {
 private:
     Consensus::Params consensusParams;
-    int nHeight;
     const CKeyStore* keystore;
     CMutableTransaction mtx;
     CAmount fee = -1;   // Verified in Build(). Must be set before.
@@ -99,7 +98,6 @@ private:
 public:
     TransactionBuilder(
         const Consensus::Params& consensusParams,
-        int nHeight,
         CKeyStore* keyStore = nullptr);
 
     void Clear();

--- a/src/support/allocators/mt_pooled_secure.h
+++ b/src/support/allocators/mt_pooled_secure.h
@@ -64,7 +64,6 @@ struct mt_pooled_secure_allocator : public std::allocator<T> {
 private:
     size_t get_bucket()
     {
-        auto tid = std::this_thread::get_id();
         size_t x = std::hash<std::thread::id>{}(std::this_thread::get_id());
         return x % pools.size();
     }

--- a/src/test/librust/sapling_rpc_wallet_tests.cpp
+++ b/src/test/librust/sapling_rpc_wallet_tests.cpp
@@ -350,7 +350,7 @@ BOOST_AUTO_TEST_CASE(saplingOperationTests)
     // there are no utxos to spend
     {
         std::vector<SendManyRecipient> recipients = { SendManyRecipient(zaddr1, COIN, "DEADBEEF", false) };
-        SaplingOperation operation(consensusParams, 1, &m_wallet);
+        SaplingOperation operation(consensusParams, &m_wallet);
         operation.setFromAddress(taddr1);
         auto res = operation.setRecipients(recipients)->buildAndSend(ret);
         BOOST_CHECK(!res);
@@ -360,7 +360,7 @@ BOOST_AUTO_TEST_CASE(saplingOperationTests)
     // minconf cannot be zero when sending from zaddr
     {
         std::vector<SendManyRecipient> recipients = { SendManyRecipient(zaddr1, COIN, "DEADBEEF", false) };
-        SaplingOperation operation(consensusParams, 1, &m_wallet);
+        SaplingOperation operation(consensusParams, &m_wallet);
         operation.setFromAddress(zaddr1);
         auto res = operation.setRecipients(recipients)->setMinDepth(0)->buildAndSend(ret);
         BOOST_CHECK(!res);
@@ -370,7 +370,7 @@ BOOST_AUTO_TEST_CASE(saplingOperationTests)
     // there are no unspent notes to spend
     {
         std::vector<SendManyRecipient> recipients = { SendManyRecipient(taddr1, COIN, false) };
-        SaplingOperation operation(consensusParams, 1, &m_wallet);
+        SaplingOperation operation(consensusParams, &m_wallet);
         operation.setFromAddress(zaddr1);
         auto res = operation.setRecipients(recipients)->buildAndSend(ret);
         BOOST_CHECK(!res);
@@ -428,8 +428,6 @@ BOOST_AUTO_TEST_CASE(rpc_shieldsendmany_taddr_to_sapling)
     auto zaddr1 = m_wallet.GenerateNewSaplingZKey();
 
     auto consensusParams = Params().GetConsensus();
-    retValue = CallRPC("getblockcount");
-    int nextBlockHeight = retValue.get_int() + 1;
 
     // Add a fake transaction to the wallet
     CMutableTransaction mtx;
@@ -457,7 +455,7 @@ BOOST_AUTO_TEST_CASE(rpc_shieldsendmany_taddr_to_sapling)
     BOOST_CHECK_MESSAGE(m_wallet.GetAvailableBalance() > 0, "tx not confirmed");
 
     std::vector<SendManyRecipient> recipients = { SendManyRecipient(zaddr1, 1 * COIN, "ABCD", false) };
-    SaplingOperation operation(consensusParams, nextBlockHeight, &m_wallet);
+    SaplingOperation operation(consensusParams, &m_wallet);
     operation.setFromAddress(taddr);
     BOOST_CHECK(operation.setRecipients(recipients)
                          ->setMinDepth(0)
@@ -465,7 +463,7 @@ BOOST_AUTO_TEST_CASE(rpc_shieldsendmany_taddr_to_sapling)
 
     // try from auto-selected transparent address
     std::vector<SendManyRecipient> recipients2 = { SendManyRecipient(zaddr1, 1 * COIN, "ABCD", false) };
-    SaplingOperation operation2(consensusParams, nextBlockHeight, &m_wallet);
+    SaplingOperation operation2(consensusParams, &m_wallet);
     BOOST_CHECK(operation2.setSelectTransparentCoins(true)
                           ->setRecipients(recipients2)
                           ->setMinDepth(0)

--- a/src/test/librust/sapling_wallet_tests.cpp
+++ b/src/test/librust/sapling_wallet_tests.cpp
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(SetSaplingNoteAddrsInCWalletTx) {
     BOOST_CHECK(nf != boost::none);
     uint256 nullifier = nf.get();
 
-    auto builder = TransactionBuilder(consensusParams, 1);
+    auto builder = TransactionBuilder(consensusParams);
     builder.AddSaplingSpend(expsk, note, anchor, witness);
     builder.AddSaplingOutput(fvk.ovk, pk, 40000000, {});
     builder.SetFee(10000000);
@@ -155,7 +155,7 @@ BOOST_AUTO_TEST_CASE(FindMySaplingNotes)
     auto testNote = GetTestSaplingNote(pa, 50000000);
 
     // Generate transaction
-    auto builder = TransactionBuilder(consensusParams, 1);
+    auto builder = TransactionBuilder(consensusParams);
     builder.AddSaplingSpend(expsk, testNote.note, testNote.tree.root(), testNote.tree.witness());
     builder.AddSaplingOutput(extfvk.fvk.ovk, pa, 25000000, {});
     builder.SetFee(10000000);
@@ -202,7 +202,7 @@ BOOST_AUTO_TEST_CASE(GetConflictedSaplingNotes)
     auto witness = saplingTree.witness();
 
     // Generate tx to create output note B
-    auto builder = TransactionBuilder(consensusParams, 1);
+    auto builder = TransactionBuilder(consensusParams);
     builder.AddSaplingSpend(expsk, note, anchor, witness);
     builder.AddSaplingOutput(extfvk.fvk.ovk, pk, 35000000, {});
     builder.SetFee(10000000);
@@ -257,14 +257,14 @@ BOOST_AUTO_TEST_CASE(GetConflictedSaplingNotes)
     anchor = saplingTree.root();
 
     // Create transaction to spend note B
-    auto builder2 = TransactionBuilder(consensusParams, 2);
+    auto builder2 = TransactionBuilder(consensusParams);
     builder2.SetFee(10000000);
     builder2.AddSaplingSpend(expsk, note2, anchor, spend_note_witness);
     builder2.AddSaplingOutput(extfvk.fvk.ovk, pk, 20000000, {});
     auto tx2 = builder2.Build().GetTxOrThrow();
 
     // Create conflicting transaction which also spends note B
-    auto builder3 = TransactionBuilder(consensusParams, 2);
+    auto builder3 = TransactionBuilder(consensusParams);
     builder3.SetFee(10000000);
     builder3.AddSaplingSpend(expsk, note2, anchor, spend_note_witness);
     builder3.AddSaplingOutput(extfvk.fvk.ovk, pk, 19999000, {});
@@ -312,7 +312,7 @@ BOOST_AUTO_TEST_CASE(SaplingNullifierIsSpent)
     auto testNote = GetTestSaplingNote(pa, 50000000);
 
     // Generate transaction
-    auto builder = TransactionBuilder(consensusParams, 1);
+    auto builder = TransactionBuilder(consensusParams);
     builder.AddSaplingSpend(expsk,  testNote.note, testNote.tree.root(), testNote.tree.witness());
     builder.AddSaplingOutput(extfvk.fvk.ovk, pa, 2500000, {});
     builder.SetFee(10000000);
@@ -371,7 +371,7 @@ BOOST_AUTO_TEST_CASE(NavigateFromSaplingNullifierToNote)
     auto testNote = GetTestSaplingNote(pa, 50000000);
 
     // Generate transaction
-    auto builder = TransactionBuilder(consensusParams, 1);
+    auto builder = TransactionBuilder(consensusParams);
     builder.AddSaplingSpend(expsk, testNote.note, testNote.tree.root(), testNote.tree.witness());
     builder.AddSaplingOutput(extfvk.fvk.ovk, pa, 25000000, {});
     builder.SetFee(10000000);
@@ -474,7 +474,7 @@ BOOST_AUTO_TEST_CASE(SpentSaplingNoteIsFromMe)
     auto witness = saplingTree.witness();
 
     // Generate transaction, which sends funds to note B
-    auto builder = TransactionBuilder(consensusParams, 1);
+    auto builder = TransactionBuilder(consensusParams);
     builder.AddSaplingSpend(expsk, note, anchor, witness);
     builder.AddSaplingOutput(extfvk.fvk.ovk, pk, 25000000, {});
     builder.SetFee(10000000);
@@ -547,7 +547,7 @@ BOOST_AUTO_TEST_CASE(SpentSaplingNoteIsFromMe)
     anchor = saplingTree.root();
 
     // Create transaction to spend note B
-    auto builder2 = TransactionBuilder(consensusParams, 2);
+    auto builder2 = TransactionBuilder(consensusParams);
     builder2.AddSaplingSpend(expsk, note2, anchor, spend_note_witness);
     builder2.AddSaplingOutput(extfvk.fvk.ovk, pk, 12500000, {});
     builder2.SetFee(10000000);
@@ -934,7 +934,7 @@ BOOST_AUTO_TEST_CASE(UpdatedSaplingNoteData)
     auto testNote = GetTestSaplingNote(pa, 50000000);
 
     // Generate transaction
-    auto builder = TransactionBuilder(consensusParams, 1);
+    auto builder = TransactionBuilder(consensusParams);
     builder.AddSaplingSpend(expsk, testNote.note, testNote.tree.root(), testNote.tree.witness());
     builder.AddSaplingOutput(extfvk.fvk.ovk, pa2, 25000000, {});
     builder.SetFee(10000000);
@@ -1045,7 +1045,7 @@ BOOST_AUTO_TEST_CASE(MarkAffectedSaplingTransactionsDirty)
 
     // Generate shielding tx from transparent to Sapling
     // 0.5 t-PIV in, 0.4 z-PIV out, 0.1 t-PIV fee
-    auto builder = TransactionBuilder(consensusParams, 1, &keystore);
+    auto builder = TransactionBuilder(consensusParams, &keystore);
     builder.AddTransparentInput(COutPoint(), scriptPubKey, 50000000);
     builder.AddSaplingOutput(extfvk.fvk.ovk, pk, 40000000, {});
     builder.SetFee(10000000);
@@ -1100,7 +1100,7 @@ BOOST_AUTO_TEST_CASE(MarkAffectedSaplingTransactionsDirty)
 
     // Create a Sapling-only transaction
     // 0.4 z-PIV in, 0.25 z-PIV out, 0.1 t-PIV fee, 0.05 z-PIV change
-    auto builder2 = TransactionBuilder(consensusParams, 2);
+    auto builder2 = TransactionBuilder(consensusParams);
     builder2.AddSaplingSpend(expsk, note, anchor, witness);
     builder2.AddSaplingOutput(extfvk.fvk.ovk, pk, 25000000, {});
     builder2.SetFee(10000000);
@@ -1156,7 +1156,7 @@ BOOST_AUTO_TEST_CASE(GetNotes)
         auto scriptPubKey = GetScriptForDestination(tsk.GetPubKey().GetID());
 
         // Generate shielding tx from transparent to Sapling (five 1 PIV notes)
-        auto builder = TransactionBuilder(consensusParams, 1, &keystore);
+        auto builder = TransactionBuilder(consensusParams, &keystore);
         builder.AddTransparentInput(COutPoint(), scriptPubKey, 510000000);
         for (int i=0; i<5; i++) builder.AddSaplingOutput(extfvk.fvk.ovk, pk, 100000000, {});
         builder.SetFee(10000000);

--- a/src/test/librust/transaction_builder_tests.cpp
+++ b/src/test/librust/transaction_builder_tests.cpp
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(TransparentToSapling)
 
     // Create a shielding transaction from transparent to Sapling
     // 0.5 t-PIV in, 0.4 shielded-PIV out, 0.1 t-PIV fee
-    auto builder = TransactionBuilder(consensusParams, 1, &keystore);
+    auto builder = TransactionBuilder(consensusParams, &keystore);
     builder.AddTransparentInput(COutPoint(uint256S("1234"), 0), scriptPubKey, 50000000);
     builder.AddSaplingOutput(fvk_from.ovk, pk, 40000000, {});
     builder.SetFee(10000000);
@@ -63,7 +63,7 @@ BOOST_AUTO_TEST_CASE(SaplingToSapling)
     // Create a Sapling-only transaction
     // --- 0.4 shielded-PIV in, 0.299 shielded-PIV out, 0.1 shielded-PIV fee, 0.001 shielded-PIV change (added to fee)
     auto testNote = GetTestSaplingNote(pa, 40000000);
-    auto builder = TransactionBuilder(consensusParams, 2);
+    auto builder = TransactionBuilder(consensusParams);
     builder.AddSaplingSpend(expsk, testNote.note, testNote.tree.root(), testNote.tree.witness());
     builder.SetFee(10000000);
 
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(SaplingToSapling)
 
     // --- Now try with 1 shielded-PIV in, 0.5 shielded-PIV out, 0.1 shielded-PIV fee, 0.4 shielded-PIV change
     auto testNote2 = GetTestSaplingNote(pa, 100000000);
-    auto builder2 = TransactionBuilder(consensusParams, 2);
+    auto builder2 = TransactionBuilder(consensusParams);
     builder2.AddSaplingSpend(expsk, testNote2.note, testNote2.tree.root(), testNote2.tree.witness());
     builder2.SetFee(10000000);
     builder2.AddSaplingOutput(fvk.ovk, pa, 50000000, {});
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(SaplingToSapling)
 
 BOOST_AUTO_TEST_CASE(ThrowsOnTransparentInputWithoutKeyStore)
 {
-    auto builder = TransactionBuilder(Params().GetConsensus(), 1);
+    auto builder = TransactionBuilder(Params().GetConsensus());
     BOOST_CHECK_THROW(builder.AddTransparentInput(COutPoint(), CScript(), 1), std::runtime_error);
 }
 
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE(RejectsInvalidTransparentOutput)
 {
     // Default CTxDestination type is an invalid address
     CTxDestination taddr;
-    auto builder = TransactionBuilder(Params().GetConsensus(), 1);
+    auto builder = TransactionBuilder(Params().GetConsensus());
     BOOST_CHECK_THROW(builder.AddTransparentOutput(taddr, 50), std::runtime_error);
 }
 
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(RejectsInvalidTransparentChangeAddress)
 {
     // Default CTxDestination type is an invalid address
     CTxDestination taddr;
-    auto builder = TransactionBuilder(Params().GetConsensus(), 1);
+    auto builder = TransactionBuilder(Params().GetConsensus());
     BOOST_CHECK_THROW(builder.SendChangeTo(taddr), std::runtime_error);
 }
 
@@ -145,14 +145,14 @@ BOOST_AUTO_TEST_CASE(FailsWithNegativeChange)
 
     // Fail if there is only a Sapling output
     // 0.5 shielded-PIV out, 0.1 t-PIV fee
-    auto builder = TransactionBuilder(consensusParams, 1);
+    auto builder = TransactionBuilder(consensusParams);
     builder.AddSaplingOutput(fvk.ovk, pa, 50000000, {});
     builder.SetFee(10000000);
     BOOST_CHECK_EQUAL("Change cannot be negative", builder.Build().GetError());
 
     // Fail if there is only a transparent output
     // 0.5 t-PIV out, 0.1 t-PIV fee
-    builder = TransactionBuilder(consensusParams, 1, &keystore);
+    builder = TransactionBuilder(consensusParams, &keystore);
     builder.AddTransparentOutput(taddr, 50000000);
     builder.SetFee(10000000);
     BOOST_CHECK_EQUAL("Change cannot be negative", builder.Build().GetError());
@@ -192,7 +192,7 @@ BOOST_AUTO_TEST_CASE(ChangeOutput)
 
     // No change address and no Sapling spends
     {
-        auto builder = TransactionBuilder(consensusParams, 1, &keystore);
+        auto builder = TransactionBuilder(consensusParams, &keystore);
         builder.SetFee(10000000);
         builder.AddTransparentInput(COutPoint(), scriptPubKey, 25000000);
         BOOST_CHECK_EQUAL("Could not determine change address", builder.Build().GetError());
@@ -200,7 +200,7 @@ BOOST_AUTO_TEST_CASE(ChangeOutput)
 
     // Change to the same address as the first Sapling spend
     {
-        auto builder = TransactionBuilder(consensusParams, 1, &keystore);
+        auto builder = TransactionBuilder(consensusParams, &keystore);
         builder.SetFee(10000000);
         builder.AddTransparentInput(COutPoint(), scriptPubKey, 25000000);
         builder.AddSaplingSpend(expsk, testNote.note, testNote.tree.root(), testNote.tree.witness());
@@ -215,7 +215,7 @@ BOOST_AUTO_TEST_CASE(ChangeOutput)
 
     // Change to a Sapling address
     {
-        auto builder = TransactionBuilder(consensusParams, 1, &keystore);
+        auto builder = TransactionBuilder(consensusParams, &keystore);
         builder.SetFee(10000000);
         builder.AddTransparentInput(COutPoint(), scriptPubKey, 25000000);
         builder.SendChangeTo(zChangeAddr, fvkOut.ovk);
@@ -230,7 +230,7 @@ BOOST_AUTO_TEST_CASE(ChangeOutput)
 
     // Change to a transparent address
     {
-        auto builder = TransactionBuilder(consensusParams, 1, &keystore);
+        auto builder = TransactionBuilder(consensusParams, &keystore);
         builder.SetFee(10000000);
         builder.AddTransparentInput(COutPoint(), scriptPubKey, 25000000);
         builder.SendChangeTo(taddr);
@@ -259,7 +259,7 @@ BOOST_AUTO_TEST_CASE(SetFee)
 
     // Configured fee (auto with SaplingOperation)
     {
-        auto builder = TransactionBuilder(consensusParams, 1);
+        auto builder = TransactionBuilder(consensusParams);
         builder.AddSaplingSpend(expsk, testNote.note, testNote.tree.root(), testNote.tree.witness());
         builder.AddSaplingOutput(fvk.ovk, pa, 3 * COIN, {});
 
@@ -283,7 +283,7 @@ BOOST_AUTO_TEST_CASE(CheckSaplingTxVersion)
     auto pk = sk.default_address();
 
     // Cannot add Sapling outputs to a non-Sapling transaction
-    auto builder = TransactionBuilder(consensusParams, 1);
+    auto builder = TransactionBuilder(consensusParams);
     builder.SetFee(10000000);
     try {
         builder.AddSaplingOutput(uint256(), pk, 12345, {});

--- a/src/test/librust/utiltest.cpp
+++ b/src/test/librust/utiltest.cpp
@@ -53,7 +53,7 @@ CWalletTx GetValidSaplingReceive(const Consensus::Params& consensusParams,
                                  std::vector<ShieldedDestination> vDest,
                                  const CWallet* pwalletIn)
 {
-    auto builder = TransactionBuilder(consensusParams, 1, &keyStoreFrom);
+    auto builder = TransactionBuilder(consensusParams, &keyStoreFrom);
     builder.SetFee(0);
 
     // From transparent inputs

--- a/src/test/test_pivx.cpp
+++ b/src/test/test_pivx.cpp
@@ -83,9 +83,10 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
         // our unit tests aren't testing multiple parts of the code at once.
         GetMainSignals().RegisterBackgroundSignalScheduler(scheduler);
 
-        // Register EvoNotificationInterface
         g_connman = std::make_unique<CConnman>(0x1337, 0x1337); // Deterministic randomness for tests.
         connman = g_connman.get();
+
+        // Register EvoNotificationInterface
         pEvoNotificationInterface = new EvoNotificationInterface();
         RegisterValidationInterface(pEvoNotificationInterface);
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1271,12 +1271,11 @@ static UniValue CreateColdStakeDelegation(CWallet* const pwallet, const UniValue
         // Delegate shield coins
         const Consensus::Params& consensus = Params().GetConsensus();
         // Check network status
-        int nextBlockHeight = chainActive.Height() + 1;
         if (sporkManager.IsSporkActive(SPORK_20_SAPLING_MAINTENANCE)) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "SHIELD in maintenance (SPORK 20)");
         }
         std::vector<SendManyRecipient> recipients = {SendManyRecipient(ownerKey, *stakeKey, nValue, fV6Enforced)};
-        SaplingOperation operation(consensus, nextBlockHeight, pwallet);
+        SaplingOperation operation(consensus, pwallet);
         OperationResult res = operation.setSelectShieldedCoins(true)
                                        ->setRecipients(recipients)
                                        ->build();
@@ -1647,8 +1646,7 @@ UniValue viewshieldtransaction(const JSONRPCRequest& request)
 static SaplingOperation CreateShieldedTransaction(CWallet* const pwallet, const JSONRPCRequest& request)
 {
     LOCK2(cs_main, pwallet->cs_wallet);
-    int nextBlockHeight = chainActive.Height() + 1;
-    SaplingOperation operation(Params().GetConsensus(), nextBlockHeight, pwallet);
+    SaplingOperation operation(Params().GetConsensus(), pwallet);
 
     // Param 0: source of funds. Can either be a valid address, sapling address,
     // or the string "from_transparent"|"from_trans_cold"|"from_shield"

--- a/src/wallet/test/wallet_sapling_transactions_validations_tests.cpp
+++ b/src/wallet/test/wallet_sapling_transactions_validations_tests.cpp
@@ -56,11 +56,10 @@ BOOST_FIXTURE_TEST_SUITE(wallet_sapling_transactions_validations_tests, TestSapl
 
 static SaplingOperation createOperationAndBuildTx(std::unique_ptr<CWallet>& pwallet,
                                                   std::vector<SendManyRecipient> recipients,
-                                                  int nextBlockHeight,
                                                   bool selectTransparentCoins)
 {
     // Create the operation
-    SaplingOperation operation(Params().GetConsensus(), nextBlockHeight, pwallet.get());
+    SaplingOperation operation(Params().GetConsensus(), pwallet.get());
     auto operationResult = operation.setRecipients(recipients)
             ->setSelectTransparentCoins(selectTransparentCoins)
             ->setSelectShieldedCoins(!selectTransparentCoins)
@@ -108,7 +107,7 @@ BOOST_AUTO_TEST_CASE(test_in_block_and_mempool_notes_double_spend)
     recipients.emplace_back(pa, CAmount(100 * COIN), "", false);
 
     // Create the operation and build the transaction
-    SaplingOperation operation = createOperationAndBuildTx(pwalletMain, recipients, tipHeight + 1, true);
+    SaplingOperation operation = createOperationAndBuildTx(pwalletMain, recipients, true);
     // broadcast the tx to the network
     std::string retHash;
     BOOST_ASSERT_MSG(operation.send(retHash), "error committing and broadcasting the transaction");
@@ -132,7 +131,7 @@ BOOST_AUTO_TEST_CASE(test_in_block_and_mempool_notes_double_spend)
     CTxDestination tDest2 = *res.getObjResult();
     std::vector<SendManyRecipient> recipients2;
     recipients2.emplace_back(tDest2, CAmount(90 * COIN), false);
-    SaplingOperation operation2 = createOperationAndBuildTx(pwalletMain, recipients2, tipHeight + 1, false);
+    SaplingOperation operation2 = createOperationAndBuildTx(pwalletMain, recipients2, false);
 
     // Create a second transaction that spends the same note with a different output now
     res = pwalletMain->getNewAddress("receiveInvalid");
@@ -140,7 +139,7 @@ BOOST_AUTO_TEST_CASE(test_in_block_and_mempool_notes_double_spend)
     CTxDestination tDest3 = *res.getObjResult();;
     std::vector<SendManyRecipient> recipients3;
     recipients3.emplace_back(tDest3, CAmount(5 * COIN), false);
-    SaplingOperation operation3 = createOperationAndBuildTx(pwalletMain, recipients3, tipHeight + 1, false);
+    SaplingOperation operation3 = createOperationAndBuildTx(pwalletMain, recipients3, false);
 
     // Now that both transactions were created, broadcast the first one
     std::string retTxHash2;

--- a/src/wallet/test/wallet_shielded_balances_tests.cpp
+++ b/src/wallet/test/wallet_shielded_balances_tests.cpp
@@ -162,7 +162,7 @@ BOOST_AUTO_TEST_CASE(GetShieldedSimpleCachedCreditAndDebit)
     CAmount firstDebitShieldedChange = firstDebit - fee;
 
     // Create the spending transaction
-    auto builder = TransactionBuilder(consensusParams, 1, &wallet);
+    auto builder = TransactionBuilder(consensusParams, &wallet);
     builder.SetFee(fee);
     builder.AddSaplingSpend(
             extskOut.expsk,
@@ -205,7 +205,7 @@ CWalletTx& buildTxAndLoadToWallet(CWallet& wallet, const libzcash::SaplingExtend
                                   const CAmount& destAmount, const Consensus::Params& consensus)
 {
     // Create the spending transaction
-    auto builder = TransactionBuilder(consensus, 1, &wallet);
+    auto builder = TransactionBuilder(consensus, &wallet);
     builder.SetFee(fee);
     builder.AddSaplingSpend(
             extskOut.expsk,


### PR DESCRIPTION
Simple cleanup of unused private field `TransactionBuilder::nHeight` and few local variables.