### PR TITLE
[Validation] Synchronous update for CDeterministicMNManager::tipIndex

### DIFF
--- a/src/activemasternode.h
+++ b/src/activemasternode.h
@@ -56,8 +56,8 @@ public:
     virtual ~CActiveDeterministicMasternodeManager() = default;
     virtual void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload);
 
-    void Init();
-    void Reset(masternode_state_t _state);
+    void Init(const CBlockIndex* pindexTip);
+    void Reset(masternode_state_t _state, const CBlockIndex* pindexTip);
     // Sets the Deterministic Masternode Operator's private/public key
     OperationResult SetOperatorKey(const std::string& strMNOperatorPrivKey);
     // If the active masternode is ready, and the keyID matches with the registered one,

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -567,7 +567,7 @@ bool CDeterministicMNManager::UndoBlock(const CBlock& block, const CBlockIndex* 
     return true;
 }
 
-void CDeterministicMNManager::UpdatedBlockTip(const CBlockIndex* pindex)
+void CDeterministicMNManager::SetTipIndex(const CBlockIndex* pindex)
 {
     LOCK(cs);
     tipIndex = pindex;

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -569,7 +569,7 @@ public:
     bool ProcessBlock(const CBlock& block, const CBlockIndex* pindex, CValidationState& state, bool fJustCheck);
     bool UndoBlock(const CBlock& block, const CBlockIndex* pindex);
 
-    void UpdatedBlockTip(const CBlockIndex* pindex);
+    void SetTipIndex(const CBlockIndex* pindex);
 
     // the returned list will not contain the correct block hash (we can't know it yet as the coinbase TX is not updated yet)
     bool BuildNewListFromBlock(const CBlock& block, const CBlockIndex* pindexPrev, CValidationState& state, CDeterministicMNList& mnListRet, bool debugLogs);

--- a/src/evo/evonotificationinterface.cpp
+++ b/src/evo/evonotificationinterface.cpp
@@ -10,12 +10,12 @@
 void EvoNotificationInterface::InitializeCurrentBlockTip()
 {
     LOCK(cs_main);
-    UpdatedBlockTip(chainActive.Tip(), nullptr, IsInitialBlockDownload());
+    deterministicMNManager->UpdatedBlockTip(chainActive.Tip());
 }
 
 void EvoNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload)
 {
-    deterministicMNManager->UpdatedBlockTip(pindexNew);
+    // !TODO background thread updates
 }
 
 void EvoNotificationInterface::NotifyMasternodeListChanged(bool undo, const CDeterministicMNList& oldMNList, const CDeterministicMNListDiff& diff)

--- a/src/evo/evonotificationinterface.cpp
+++ b/src/evo/evonotificationinterface.cpp
@@ -10,7 +10,7 @@
 void EvoNotificationInterface::InitializeCurrentBlockTip()
 {
     LOCK(cs_main);
-    deterministicMNManager->UpdatedBlockTip(chainActive.Tip());
+    deterministicMNManager->SetTipIndex(chainActive.Tip());
 }
 
 void EvoNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1871,7 +1871,8 @@ bool AppInitMain()
             if (!res) { return UIError(res.getError()); }
             RegisterValidationInterface(activeMasternodeManager);
             // Init active masternode
-            activeMasternodeManager->Init();
+            const CBlockIndex* pindexTip = WITH_LOCK(cs_main, return chainActive.Tip(); );
+            activeMasternodeManager->Init(pindexTip);
         } else {
             // Check enforcement
             if (deterministicMNManager->LegacyMNObsolete()) {

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -83,7 +83,8 @@ UniValue initmasternode(const JSONRPCRequest& request)
         }
         auto res = activeMasternodeManager->SetOperatorKey(_strMasterNodePrivKey);
         if (!res) throw std::runtime_error(res.getError());
-        activeMasternodeManager->Init();
+        const CBlockIndex* pindexTip = WITH_LOCK(cs_main, return chainActive.Tip(); );
+        activeMasternodeManager->Init(pindexTip);
         if (activeMasternodeManager->GetState() == CActiveDeterministicMasternodeManager::MASTERNODE_ERROR) {
             throw std::runtime_error(activeMasternodeManager->GetStatus());
         }

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -624,7 +624,7 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
     // ProUpReg: change voting key, operator key and payout address
     {
         const uint256& proTx = dmnHashes[InsecureRandRange(dmnHashes.size())];            // pick one at random
-        const CBLSSecretKey& new_operatorKey = GetRandomBLSKey();
+        CBLSSecretKey new_operatorKey = GetRandomBLSKey();
         const CKey& new_votingKey = GetRandomKey();
         const CScript& new_payee = GenerateRandomAddress();
         // try first with wrong owner key
@@ -652,7 +652,7 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         BOOST_CHECK_MESSAGE(dmn->pdmnState->keyIDVoting == new_votingKey.GetPubKey().GetID(), "mn voting key not changed");
         BOOST_CHECK_MESSAGE(dmn->pdmnState->scriptPayout == new_payee, "mn script payout not changed");
 
-        operatorKeys.at(proTx) = new_operatorKey;
+        operatorKeys[proTx] = std::move(new_operatorKey);
 
         // check that changing the operator key puts the MN in PoSe banned state
         BOOST_CHECK_MESSAGE(dmn->pdmnState->addr == CService(), "IP address not cleared after changing operator");

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -342,7 +342,6 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         CreateAndProcessBlock({tx}, coinbaseKey);
         chainTip = chainActive.Tip();
         BOOST_CHECK_EQUAL(chainTip->nHeight, nHeight + 1);
-        SyncWithValidationInterfaceQueue();
         BOOST_CHECK(deterministicMNManager->GetListAtChainTip().HasMN(txid));
 
         // Add change to the utxos map
@@ -361,8 +360,12 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
     // Mine 20 blocks, checking MN reward payments
     std::map<uint256, int> mapPayments;
     for (size_t i = 0; i < 20; i++) {
-        SyncWithValidationInterfaceQueue();
-        auto dmnExpectedPayee = deterministicMNManager->GetListAtChainTip().GetMNPayee();
+        auto mnList = deterministicMNManager->GetListAtChainTip();
+        BOOST_CHECK_EQUAL(mnList.GetValidMNsCount(), 6);
+        BOOST_CHECK_EQUAL(mnList.GetHeight(), nHeight);
+
+        // get next payee
+        auto dmnExpectedPayee = mnList.GetMNPayee();
         CBlock block = CreateAndProcessBlock({}, coinbaseKey);
         chainTip = chainActive.Tip();
         BOOST_ASSERT(!block.vtx.empty());
@@ -465,7 +468,6 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         CreateAndProcessBlock(txns, coinbaseKey);
         chainTip = chainActive.Tip();
         BOOST_CHECK_EQUAL(chainTip->nHeight, nHeight + 1);
-        SyncWithValidationInterfaceQueue();
         auto mnList = deterministicMNManager->GetListAtChainTip();
         for (size_t j = 0; j < 3; j++) {
             BOOST_CHECK(mnList.HasMN(txns[j].GetHash()));
@@ -477,10 +479,10 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
     // Mine 30 blocks, checking MN reward payments
     mapPayments.clear();
     for (size_t i = 0; i < 30; i++) {
-        auto dmnExpectedPayee = deterministicMNManager->GetListAtChainTip().GetMNPayee();
+        auto mnList = deterministicMNManager->GetListAtChainTip();
+        auto dmnExpectedPayee = mnList.GetMNPayee();
         CBlock block = CreateAndProcessBlock({}, coinbaseKey);
         chainTip = chainActive.Tip();
-        SyncWithValidationInterfaceQueue();
         BOOST_ASSERT(!block.vtx.empty());
         BOOST_CHECK(IsMNPayeeInBlock(block, dmnExpectedPayee->pdmnState->scriptPayout));
         mapPayments[dmnExpectedPayee->proTxHash]++;
@@ -533,7 +535,6 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         chainTip = chainActive.Tip();
         BOOST_CHECK_EQUAL(chainTip->nHeight, nHeight + 1);
 
-        SyncWithValidationInterfaceQueue();
         auto dmn = deterministicMNManager->GetListAtChainTip().GetMN(proTx);
         BOOST_ASSERT(dmn != nullptr);
         BOOST_CHECK_EQUAL(dmn->pdmnState->addr.GetPort(), 1000);
@@ -576,7 +577,6 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         CreateAndProcessBlock({tx}, coinbaseKey);
         chainTip = chainActive.Tip();
         BOOST_CHECK_EQUAL(chainTip->nHeight, ++nHeight);
-        SyncWithValidationInterfaceQueue();
         auto mnList = deterministicMNManager->GetListAtChainTip();
         BOOST_CHECK(mnList.HasMN(txid));
         auto dmn = mnList.GetMN(txid);
@@ -589,7 +589,6 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         CreateAndProcessBlock({tx2}, coinbaseKey);
         chainTip = chainActive.Tip();
         BOOST_CHECK_EQUAL(chainTip->nHeight, ++nHeight);
-        SyncWithValidationInterfaceQueue();
         dmn = deterministicMNManager->GetListAtChainTip().GetMN(txid);
         BOOST_ASSERT(dmn != nullptr);
         BOOST_CHECK(dmn->pdmnState->scriptOperatorPayout == operatorPayee);
@@ -647,7 +646,6 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         chainTip = chainActive.Tip();
         BOOST_CHECK_EQUAL(chainTip->nHeight, ++nHeight);
 
-        SyncWithValidationInterfaceQueue();
         auto dmn = deterministicMNManager->GetListAtChainTip().GetMN(proTx);
         BOOST_ASSERT(dmn != nullptr);
         BOOST_CHECK_MESSAGE(dmn->pdmnState->pubKeyOperator.Get() == new_operatorKey.GetPublicKey(), "mn operator key not changed");
@@ -667,7 +665,6 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         CreateAndProcessBlock({tx3}, coinbaseKey);
         chainTip = chainActive.Tip();
         BOOST_CHECK_EQUAL(chainTip->nHeight, ++nHeight);
-        SyncWithValidationInterfaceQueue();
         dmn = deterministicMNManager->GetListAtChainTip().GetMN(proTx);
 
         // check updated dmn state
@@ -679,7 +676,6 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         // Mine 32 blocks, checking MN reward payments
         mapPayments.clear();
         for (size_t i = 0; i < 32; i++) {
-            SyncWithValidationInterfaceQueue();
             auto dmnExpectedPayee = deterministicMNManager->GetListAtChainTip().GetMNPayee();
             CBlock block = CreateAndProcessBlock({}, coinbaseKey);
             chainTip = chainActive.Tip();
@@ -786,7 +782,6 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         chainTip = chainActive.Tip();
         BOOST_CHECK_EQUAL(chainTip->nHeight, ++nHeight);
 
-        SyncWithValidationInterfaceQueue();
         auto dmn = deterministicMNManager->GetListAtChainTip().GetMN(proTx);
         BOOST_ASSERT(dmn != nullptr);
         BOOST_CHECK_MESSAGE(!dmn->pdmnState->pubKeyOperator.Get().IsValid(), "mn operator key not removed");

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1931,7 +1931,9 @@ bool static DisconnectTip(CValidationState& state, const CChainParams& chainpara
             disconnectpool->removeEntry(it);
         }
     }
+
     // Update MN manager cache
+    deterministicMNManager->UpdatedBlockTip(pindexDelete->pprev);
     // replace the cached hash of pindexDelete with the hash of the block
     // at depth CACHED_BLOCK_HASHES if it exists, or empty hash otherwise.
     if ((unsigned) pindexDelete->nHeight >= CACHED_BLOCK_HASHES) {
@@ -2075,6 +2077,7 @@ bool static ConnectTip(CValidationState& state, CBlockIndex* pindexNew, const st
     // Update MN manager cache
     mnodeman.CacheBlockHash(pindexNew);
     mnodeman.CheckSpentCollaterals(blockConnecting.vtx);
+    deterministicMNManager->UpdatedBlockTip(pindexNew);
 
     int64_t nTime6 = GetTimeMicros();
     nTimePostConnect += nTime6 - nTime5;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1933,7 +1933,7 @@ bool static DisconnectTip(CValidationState& state, const CChainParams& chainpara
     }
 
     // Update MN manager cache
-    deterministicMNManager->UpdatedBlockTip(pindexDelete->pprev);
+    deterministicMNManager->SetTipIndex(pindexDelete->pprev);
     // replace the cached hash of pindexDelete with the hash of the block
     // at depth CACHED_BLOCK_HASHES if it exists, or empty hash otherwise.
     if ((unsigned) pindexDelete->nHeight >= CACHED_BLOCK_HASHES) {
@@ -2077,7 +2077,7 @@ bool static ConnectTip(CValidationState& state, CBlockIndex* pindexNew, const st
     // Update MN manager cache
     mnodeman.CacheBlockHash(pindexNew);
     mnodeman.CheckSpentCollaterals(blockConnecting.vtx);
-    deterministicMNManager->UpdatedBlockTip(pindexNew);
+    deterministicMNManager->SetTipIndex(pindexNew);
 
     int64_t nTime6 = GetTimeMicros();
     nTimePostConnect += nTime6 - nTime5;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1932,15 +1932,6 @@ bool static DisconnectTip(CValidationState& state, const CChainParams& chainpara
         }
     }
 
-    // Update MN manager cache
-    deterministicMNManager->SetTipIndex(pindexDelete->pprev);
-    // replace the cached hash of pindexDelete with the hash of the block
-    // at depth CACHED_BLOCK_HASHES if it exists, or empty hash otherwise.
-    if ((unsigned) pindexDelete->nHeight >= CACHED_BLOCK_HASHES) {
-        mnodeman.CacheBlockHash(chainActive[pindexDelete->nHeight - CACHED_BLOCK_HASHES]);
-    } else {
-        mnodeman.UncacheBlockHash(pindexDelete);
-    }
     // Evict from mempool if the anchor changes
     if (saplingAnchorBeforeDisconnect != saplingAnchorAfterDisconnect) {
         // The anchor may not change between block disconnects,
@@ -1952,6 +1943,16 @@ bool static DisconnectTip(CValidationState& state, const CChainParams& chainpara
     // Let wallets know transactions went from 1-confirmed to
     // 0-confirmed or conflicted:
     GetMainSignals().BlockDisconnected(pblock, pindexDelete->GetBlockHash(), pindexDelete->nHeight, pindexDelete->GetBlockTime());
+
+    // Update MN manager cache
+    deterministicMNManager->SetTipIndex(pindexDelete->pprev);
+    // replace the cached hash of pindexDelete with the hash of the block
+    // at depth CACHED_BLOCK_HASHES if it exists, or empty hash otherwise.
+    if ((unsigned) pindexDelete->nHeight >= CACHED_BLOCK_HASHES) {
+        mnodeman.CacheBlockHash(chainActive[pindexDelete->nHeight - CACHED_BLOCK_HASHES]);
+    } else {
+        mnodeman.UncacheBlockHash(pindexDelete);
+    }
 
     return true;
 }

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -83,7 +83,7 @@ protected:
      *
      * Called on a background thread.
      */
-    virtual void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) {}
+    virtual void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload) {}
     /**
      * Notifies listeners of a transaction having been added to mempool.
      *


### PR DESCRIPTION
As this has direct consensus implications, it cannot be updated in the background thread (in fact, the tests must pass without having to resort to `SyncWithValidationInterfaceQueue`).

The manager's tip must be updated on the caller's thread and, on the other hand, what is being called by `UpdatedBlockTip` (on the background), such as `CActiveDeterministicMasternodeManager::Init` or `CActiveDeterministicMasternodeManager::Reset`, shouldn't rely on the manager's tip, but use `pindexNew` instead.