### PR TITLE
[GUI][Cleanup] Stop translating placeholder strings

### DIFF
--- a/src/qt/forms/askpassphrasedialog.ui
+++ b/src/qt/forms/askpassphrasedialog.ui
@@ -70,7 +70,7 @@
            <item alignment="Qt::AlignHCenter">
             <widget class="QLabel" name="labelTitle">
              <property name="text">
-              <string>TextLabel</string>
+              <string notr="true">N/A</string>
              </property>
              <property name="alignment">
               <set>Qt::AlignCenter</set>
@@ -148,7 +148,7 @@
              </size>
             </property>
             <property name="text">
-             <string>TextLabel</string>
+             <string notr="true">N/A</string>
             </property>
            </widget>
           </item>
@@ -204,7 +204,7 @@
         <item alignment="Qt::AlignHCenter">
          <widget class="QLabel" name="passLabel2">
           <property name="text">
-           <string>TextLabel</string>
+           <string notr="true">N/A</string>
           </property>
          </widget>
         </item>
@@ -261,7 +261,7 @@
         <item alignment="Qt::AlignHCenter">
          <widget class="QLabel" name="passLabel3">
           <property name="text">
-           <string>TextLabel</string>
+           <string notr="true">N/A</string>
           </property>
          </widget>
         </item>
@@ -351,7 +351,7 @@
            </size>
           </property>
           <property name="text">
-           <string>PushButton</string>
+           <string notr="true">N/A</string>
           </property>
          </widget>
         </item>

--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -144,7 +144,7 @@
            <item>
             <widget class="QLabel" name="labelCoinControlAmount">
              <property name="text">
-              <string>0.00 PIV</string>
+              <string notr="true">N/A</string>
              </property>
             </widget>
            </item>

--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -53,7 +53,7 @@
           <cursorShape>IBeamCursor</cursorShape>
          </property>
          <property name="text">
-          <string>N/A</string>
+          <string notr="true">N/A</string>
          </property>
          <property name="textFormat">
           <enum>Qt::PlainText</enum>
@@ -76,7 +76,7 @@
           <cursorShape>IBeamCursor</cursorShape>
          </property>
          <property name="text">
-          <string>N/A</string>
+          <string notr="true">N/A</string>
          </property>
          <property name="textFormat">
           <enum>Qt::PlainText</enum>
@@ -102,7 +102,7 @@
           <cursorShape>IBeamCursor</cursorShape>
          </property>
          <property name="text">
-          <string>N/A</string>
+          <string notr="true">N/A</string>
          </property>
          <property name="textFormat">
           <enum>Qt::PlainText</enum>
@@ -125,7 +125,7 @@
           <cursorShape>IBeamCursor</cursorShape>
          </property>
          <property name="text">
-          <string>N/A</string>
+          <string notr="true">N/A</string>
          </property>
          <property name="textFormat">
           <enum>Qt::PlainText</enum>
@@ -145,7 +145,7 @@
        <item row="5" column="1">
         <widget class="QLabel" name="dataDir">
          <property name="text">
-          <string>N/A</string>
+          <string notr="true">N/A</string>
          </property>
         </widget>
        </item>
@@ -175,7 +175,7 @@
           <cursorShape>IBeamCursor</cursorShape>
          </property>
          <property name="text">
-          <string>N/A</string>
+          <string notr="true">N/A</string>
          </property>
          <property name="textFormat">
           <enum>Qt::PlainText</enum>
@@ -198,7 +198,7 @@
           <cursorShape>IBeamCursor</cursorShape>
          </property>
          <property name="text">
-          <string>N/A</string>
+          <string notr="true">N/A</string>
          </property>
          <property name="textFormat">
           <enum>Qt::PlainText</enum>
@@ -221,7 +221,7 @@
           <cursorShape>IBeamCursor</cursorShape>
          </property>
          <property name="text">
-          <string>N/A</string>
+          <string notr="true">N/A</string>
          </property>
          <property name="textFormat">
           <enum>Qt::PlainText</enum>
@@ -257,7 +257,7 @@
           <cursorShape>IBeamCursor</cursorShape>
          </property>
          <property name="text">
-          <string>N/A</string>
+          <string notr="true">N/A</string>
          </property>
          <property name="textFormat">
           <enum>Qt::PlainText</enum>
@@ -280,7 +280,7 @@
           <cursorShape>IBeamCursor</cursorShape>
          </property>
          <property name="text">
-          <string>N/A</string>
+          <string notr="true">N/A</string>
          </property>
          <property name="textFormat">
           <enum>Qt::PlainText</enum>
@@ -300,7 +300,7 @@
        <item row="13" column="1">
         <widget class="QLabel" name="lastBlockHash">
          <property name="text">
-          <string>N/A</string>
+          <string notr="true">N/A</string>
          </property>
         </widget>
        </item>
@@ -816,7 +816,7 @@
              <cursorShape>IBeamCursor</cursorShape>
             </property>
             <property name="text">
-             <string>N/A</string>
+             <string notr="true">N/A</string>
             </property>
             <property name="textFormat">
              <enum>Qt::PlainText</enum>
@@ -839,7 +839,7 @@
              <cursorShape>IBeamCursor</cursorShape>
             </property>
             <property name="text">
-             <string>N/A</string>
+             <string notr="true">N/A</string>
             </property>
             <property name="textFormat">
              <enum>Qt::PlainText</enum>
@@ -862,7 +862,7 @@
              <cursorShape>IBeamCursor</cursorShape>
             </property>
             <property name="text">
-             <string>N/A</string>
+             <string notr="true">N/A</string>
             </property>
             <property name="textFormat">
              <enum>Qt::PlainText</enum>
@@ -885,7 +885,7 @@
              <cursorShape>IBeamCursor</cursorShape>
             </property>
             <property name="text">
-             <string>N/A</string>
+             <string notr="true">N/A</string>
             </property>
             <property name="textFormat">
              <enum>Qt::PlainText</enum>
@@ -908,7 +908,7 @@
              <cursorShape>IBeamCursor</cursorShape>
             </property>
             <property name="text">
-             <string>N/A</string>
+             <string notr="true">N/A</string>
             </property>
             <property name="textFormat">
              <enum>Qt::PlainText</enum>
@@ -931,7 +931,7 @@
              <cursorShape>IBeamCursor</cursorShape>
             </property>
             <property name="text">
-             <string>N/A</string>
+             <string notr="true">N/A</string>
             </property>
             <property name="textFormat">
              <enum>Qt::PlainText</enum>
@@ -954,7 +954,7 @@
              <cursorShape>IBeamCursor</cursorShape>
             </property>
             <property name="text">
-             <string>N/A</string>
+             <string notr="true">N/A</string>
             </property>
             <property name="textFormat">
              <enum>Qt::PlainText</enum>
@@ -977,7 +977,7 @@
              <cursorShape>IBeamCursor</cursorShape>
             </property>
             <property name="text">
-             <string>N/A</string>
+             <string notr="true">N/A</string>
             </property>
             <property name="textFormat">
              <enum>Qt::PlainText</enum>
@@ -1000,7 +1000,7 @@
              <cursorShape>IBeamCursor</cursorShape>
             </property>
             <property name="text">
-             <string>N/A</string>
+             <string notr="true">N/A</string>
             </property>
             <property name="textFormat">
              <enum>Qt::PlainText</enum>
@@ -1023,7 +1023,7 @@
              <cursorShape>IBeamCursor</cursorShape>
             </property>
             <property name="text">
-             <string>N/A</string>
+             <string notr="true">N/A</string>
             </property>
             <property name="textFormat">
              <enum>Qt::PlainText</enum>
@@ -1046,7 +1046,7 @@
              <cursorShape>IBeamCursor</cursorShape>
             </property>
             <property name="text">
-             <string>N/A</string>
+             <string notr="true">N/A</string>
             </property>
             <property name="textFormat">
              <enum>Qt::PlainText</enum>
@@ -1069,7 +1069,7 @@
              <cursorShape>IBeamCursor</cursorShape>
             </property>
             <property name="text">
-             <string>N/A</string>
+             <string notr="true">N/A</string>
             </property>
             <property name="textFormat">
              <enum>Qt::PlainText</enum>
@@ -1092,7 +1092,7 @@
              <cursorShape>IBeamCursor</cursorShape>
             </property>
             <property name="text">
-             <string>N/A</string>
+             <string notr="true">N/A</string>
             </property>
             <property name="textFormat">
              <enum>Qt::PlainText</enum>
@@ -1115,7 +1115,7 @@
              <cursorShape>IBeamCursor</cursorShape>
             </property>
             <property name="text">
-             <string>N/A</string>
+             <string notr="true">N/A</string>
             </property>
             <property name="textFormat">
              <enum>Qt::PlainText</enum>
@@ -1138,7 +1138,7 @@
              <cursorShape>IBeamCursor</cursorShape>
             </property>
             <property name="text">
-             <string>N/A</string>
+             <string notr="true">N/A</string>
             </property>
             <property name="textFormat">
              <enum>Qt::PlainText</enum>
@@ -1164,7 +1164,7 @@
              <cursorShape>IBeamCursor</cursorShape>
             </property>
             <property name="text">
-             <string>N/A</string>
+             <string notr="true">N/A</string>
             </property>
             <property name="textFormat">
              <enum>Qt::PlainText</enum>
@@ -1187,7 +1187,7 @@
              <cursorShape>IBeamCursor</cursorShape>
             </property>
             <property name="text">
-             <string>N/A</string>
+             <string notr="true">N/A</string>
             </property>
             <property name="textFormat">
              <enum>Qt::PlainText</enum>
@@ -1265,7 +1265,7 @@
           <cursorShape>IBeamCursor</cursorShape>
          </property>
          <property name="text">
-          <string>N/A</string>
+          <string notr="true">N/A</string>
          </property>
          <property name="textFormat">
           <enum>Qt::PlainText</enum>
@@ -1484,7 +1484,7 @@
        <item row="10" column="2">
         <widget class="QLabel" name="label_repair_resync_command">
          <property name="text">
-          <string>-resync:</string>
+          <string notr="true">-resync:</string>
          </property>
         </widget>
        </item>

--- a/src/qt/locale/pivx_en.ts
+++ b/src/qt/locale/pivx_en.ts
@@ -4,12 +4,7 @@
 <context>
     <name>AddNewAddressDialog</name>
     <message>
-        <location filename="../pivx/forms/addnewaddressdialog.ui" line="+14"/>
-        <source>Dialog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+39"/>
+        <location filename="../pivx/forms/addnewaddressdialog.ui" line="+53"/>
         <source>New Address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -19,12 +14,7 @@
         <translation type="unfinished">Address</translation>
     </message>
     <message>
-        <location line="+19"/>
-        <source>PushButton</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+42"/>
+        <location line="+61"/>
         <source>CANCEL</source>
         <translation type="unfinished"></translation>
     </message>
@@ -37,12 +27,7 @@
 <context>
     <name>AddNewContactDialog</name>
     <message>
-        <location filename="../pivx/forms/addnewcontactdialog.ui" line="+14"/>
-        <source>Dialog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+240"/>
+        <location filename="../pivx/forms/addnewcontactdialog.ui" line="+254"/>
         <source>CANCEL</source>
         <translation type="unfinished"></translation>
     </message>
@@ -197,24 +182,6 @@
     </message>
 </context>
 <context>
-    <name>AddressLabelRow</name>
-    <message>
-        <location filename="../pivx/forms/addresslabelrow.ui" line="+20"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+39"/>
-        <source>Bob Allen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+23"/>
-        <source>DN6i46dytMPVhV1JMGZFuQBh7BZZ6nNLox</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>AddressTableModel</name>
     <message>
         <location filename="../addresstablemodel.cpp" line="+317"/>
@@ -245,12 +212,7 @@
 <context>
     <name>AddressesWidget</name>
     <message>
-        <location filename="../pivx/forms/addresseswidget.ui" line="+14"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+342"/>
+        <location filename="../pivx/forms/addresseswidget.ui" line="+356"/>
         <source>Contact name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -360,19 +322,6 @@ Are you sure?</source>
         <location filename="../forms/askpassphrasedialog.ui" line="+32"/>
         <source>Passphrase Dialog</source>
         <translation>Passphrase Dialog</translation>
-    </message>
-    <message>
-        <location line="+41"/>
-        <location line="+78"/>
-        <location line="+56"/>
-        <location line="+57"/>
-        <source>TextLabel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+90"/>
-        <source>PushButton</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../askpassphrasedialog.cpp" line="+90"/>
@@ -537,23 +486,12 @@ for staking</source>
 <context>
     <name>BalanceBubble</name>
     <message>
-        <location filename="../pivx/forms/balancebubble.ui" line="+26"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+49"/>
+        <location filename="../pivx/forms/balancebubble.ui" line="+75"/>
         <source>Transparent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+26"/>
-        <source>0.00 pivx</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-13"/>
+        <location line="+28"/>
         <source>Shielded</source>
         <translation type="unfinished"></translation>
     </message>
@@ -574,22 +512,12 @@ for staking</source>
 <context>
     <name>CSRow</name>
     <message>
-        <location filename="../pivx/forms/csrow.ui" line="+14"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+71"/>
+        <location filename="../pivx/forms/csrow.ui" line="+85"/>
         <source>Savings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <source>0,00 PIV</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+14"/>
+        <location line="+34"/>
         <source>address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -671,8 +599,7 @@ for staking</source>
         <translation>Amount</translation>
     </message>
     <message>
-        <location line="-393"/>
-        <location line="+124"/>
+        <location line="-269"/>
         <location line="+461"/>
         <source>0.00 PIV</source>
         <translation type="unfinished"></translation>
@@ -859,12 +786,7 @@ for staking</source>
 <context>
     <name>ColdStakingWidget</name>
     <message>
-        <location filename="../pivx/forms/coldstakingwidget.ui" line="+14"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+341"/>
+        <location filename="../pivx/forms/coldstakingwidget.ui" line="+355"/>
         <source>Owner address (optional, if empty a new address will be created)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1144,14 +1066,6 @@ address</source>
     </message>
 </context>
 <context>
-    <name>ContactDropdownRow</name>
-    <message>
-        <location filename="../pivx/forms/contactdropdownrow.ui" line="+20"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-</context>
-<context>
     <name>CreateProposalDialog</name>
     <message>
         <location filename="../pivx/forms/createproposaldialog.ui" line="+520"/>
@@ -1282,12 +1196,7 @@ address</source>
 <context>
     <name>DashboardWidget</name>
     <message>
-        <location filename="../pivx/forms/dashboardwidget.ui" line="+14"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+79"/>
+        <location filename="../pivx/forms/dashboardwidget.ui" line="+93"/>
         <source>Transactions</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1394,12 +1303,7 @@ It will start automatically as soon as the wallet has enough confirmations on an
 <context>
     <name>DefaultDialog</name>
     <message>
-        <location filename="../pivx/forms/defaultdialog.ui" line="+14"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+228"/>
+        <location filename="../pivx/forms/defaultdialog.ui" line="+242"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1475,14 +1379,6 @@ It will start automatically as soon as the wallet has enough confirmations on an
         <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>New key generation failed.</translation>
-    </message>
-</context>
-<context>
-    <name>ExpandableButton</name>
-    <message>
-        <location filename="../pivx/forms/expandablebutton.ui" line="+26"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
     </message>
 </context>
 <context>
@@ -1761,35 +1657,15 @@ Be part of the DAO.</source>
 <context>
     <name>LoadingDialog</name>
     <message>
-        <location filename="../pivx/forms/loadingdialog.ui" line="+14"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+69"/>
-        <source>TextLabel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+44"/>
+        <location filename="../pivx/forms/loadingdialog.ui" line="+127"/>
         <source>Loading</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+16"/>
-        <source>.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LockUnlock</name>
     <message>
-        <location filename="../pivx/forms/lockunlock.ui" line="+14"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+90"/>
+        <location filename="../pivx/forms/lockunlock.ui" line="+104"/>
         <source>Unlock Wallet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1807,11 +1683,6 @@ Be part of the DAO.</source>
 <context>
     <name>MNRow</name>
     <message>
-        <location filename="../pivx/forms/mnrow.ui" line="+14"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
         <location filename="../pivx/mnrow.cpp" line="+25"/>
         <source>Collateral tx not found</source>
         <translation type="unfinished"></translation>
@@ -1825,12 +1696,7 @@ Be part of the DAO.</source>
 <context>
     <name>MasterNodeWizardDialog</name>
     <message>
-        <location filename="../pivx/forms/masternodewizarddialog.ui" line="+14"/>
-        <source>Dialog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+182"/>
+        <location filename="../pivx/forms/masternodewizarddialog.ui" line="+196"/>
         <source>1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1998,12 +1864,7 @@ Be part of the DAO.</source>
 <context>
     <name>MasterNodesWidget</name>
     <message>
-        <location filename="../pivx/forms/masternodeswidget.ui" line="+14"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+281"/>
+        <location filename="../pivx/forms/masternodeswidget.ui" line="+295"/>
         <source>Start All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2199,12 +2060,7 @@ Are you sure?</source>
 <context>
     <name>MnInfoDialog</name>
     <message>
-        <location filename="../pivx/forms/mninfodialog.ui" line="+20"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+84"/>
+        <location filename="../pivx/forms/mninfodialog.ui" line="+104"/>
         <source>Masternode Information</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2334,22 +2190,9 @@ Are you sure?</source>
     </message>
 </context>
 <context>
-    <name>MyAddressRow</name>
-    <message>
-        <location filename="../pivx/forms/myaddressrow.ui" line="+14"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-</context>
-<context>
     <name>NavMenuWidget</name>
     <message>
-        <location filename="../pivx/forms/navmenuwidget.ui" line="+14"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+156"/>
+        <location filename="../pivx/forms/navmenuwidget.ui" line="+170"/>
         <source>HOME
 </source>
         <translation type="unfinished"></translation>
@@ -2396,11 +2239,6 @@ STAKING</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
-        <source>V 1.0.0</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../pivx/navmenuwidget.cpp" line="+23"/>
         <source>v%1</source>
         <translation type="unfinished"></translation>
@@ -2427,14 +2265,6 @@ STAKING</source>
         <location line="+13"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>OptionButton</name>
-    <message>
-        <location filename="../pivx/forms/optionbutton.ui" line="+14"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
     </message>
 </context>
 <context>
@@ -2578,12 +2408,12 @@ Address: %4
 <context>
     <name>ProposalCard</name>
     <message>
-        <location filename="../pivx/forms/proposalcard.ui" line="+343"/>
+        <location filename="../pivx/forms/proposalcard.ui" line="+355"/>
         <source>Vote</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pivx/proposalcard.cpp" line="+42"/>
+        <location filename="../pivx/proposalcard.cpp" line="+43"/>
         <source>Inactive proposal</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2676,7 +2506,12 @@ Address: %4
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+141"/>
+        <location line="+56"/>
+        <source>URL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+85"/>
         <source>Positive Votes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3043,40 +2878,7 @@ Address: %4
         <translation>Client name</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+20"/>
-        <location line="+30"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+20"/>
-        <location line="+516"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+78"/>
-        <source>N/A</source>
-        <translation>N/A</translation>
-    </message>
-    <message>
-        <location line="-1077"/>
+        <location line="+145"/>
         <source>Number of connections</source>
         <translation>Number of connections</translation>
     </message>
@@ -3353,12 +3155,7 @@ Address: %4
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
-        <source>-resync:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
+        <location line="+30"/>
         <source>Deletes all local blockchain folders so the wallet synchronizes from scratch.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3546,12 +3343,7 @@ Address: %4
 <context>
     <name>ReceiveDialog</name>
     <message>
-        <location filename="../pivx/forms/receivedialog.ui" line="+14"/>
-        <source>Dialog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+81"/>
+        <location filename="../pivx/forms/receivedialog.ui" line="+95"/>
         <source>My Address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3569,12 +3361,7 @@ Address: %4
 <context>
     <name>ReceiveWidget</name>
     <message>
-        <location filename="../pivx/forms/receivewidget.ui" line="+20"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+61"/>
+        <location filename="../pivx/forms/receivewidget.ui" line="+81"/>
         <source>Scan the QR code or copy the address to receive PIV</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3749,32 +3536,17 @@ try unlocking the wallet</source>
 <context>
     <name>RequestDialog</name>
     <message>
-        <location filename="../pivx/forms/requestdialog.ui" line="+14"/>
-        <source>Dialog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+242"/>
+        <location filename="../pivx/forms/requestdialog.ui" line="+256"/>
         <source>Amount</source>
         <translation type="unfinished">Amount</translation>
     </message>
     <message>
-        <location line="+74"/>
-        <source>PIV</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-117"/>
+        <location line="-43"/>
         <source>Instead of sharing only a PIVX address, you can create a payment request, bundling up more information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+332"/>
-        <source>D7VFR83SQbiezrW72hjcWJtcfip5krte2Z </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+53"/>
+        <location line="+385"/>
         <source>COPY ADDRESS</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3824,7 +3596,7 @@ try unlocking the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pivx/requestdialog.cpp" line="+27"/>
+        <location filename="../pivx/requestdialog.cpp" line="+28"/>
         <source>Creates an address to receive coin delegations and be able to stake them.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3862,12 +3634,7 @@ try unlocking the wallet</source>
 <context>
     <name>SendChangeAddressDialog</name>
     <message>
-        <location filename="../pivx/forms/sendchangeaddressdialog.ui" line="+14"/>
-        <source>Dialog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+238"/>
+        <location filename="../pivx/forms/sendchangeaddressdialog.ui" line="+252"/>
         <location filename="../pivx/sendchangeaddressdialog.cpp" line="+64"/>
         <source>CANCEL</source>
         <translation type="unfinished"></translation>
@@ -3906,27 +3673,12 @@ try unlocking the wallet</source>
 <context>
     <name>SendCustomFeeDialog</name>
     <message>
-        <location filename="../pivx/forms/sendcustomfeedialog.ui" line="+14"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+190"/>
+        <location filename="../pivx/forms/sendcustomfeedialog.ui" line="+204"/>
         <source>Recommended</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
-        <source>PIV/kilobyte</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-63"/>
-        <source>0.00 KB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-69"/>
+        <location line="-46"/>
         <source>Customize the transaction fee, depending on the fee value your transaction might be included faster in the blockchain</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3961,7 +3713,7 @@ try unlocking the wallet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+122"/>
+        <location line="+125"/>
         <source>Invalid custom fee amount</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3984,26 +3736,12 @@ try unlocking the wallet</source>
 <context>
     <name>SendMemoDialog</name>
     <message>
-        <location filename="../pivx/forms/sendmemodialog.ui" line="+14"/>
-        <source>Dialog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+137"/>
+        <location filename="../pivx/forms/sendmemodialog.ui" line="+151"/>
         <source>Private message only visible for the recipient(s)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+52"/>
-        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;.SF NS Text&apos;; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+65"/>
+        <location line="+117"/>
         <source>SAVE</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4021,12 +3759,7 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>SendMultiRow</name>
     <message>
-        <location filename="../pivx/forms/sendmultirow.ui" line="+26"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+118"/>
+        <location filename="../pivx/forms/sendmultirow.ui" line="+144"/>
         <source>Enter address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4323,12 +4056,7 @@ Do you want to continue?
 <context>
     <name>SettingsBackupWallet</name>
     <message>
-        <location filename="../pivx/settings/forms/settingsbackupwallet.ui" line="+14"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+147"/>
+        <location filename="../pivx/settings/forms/settingsbackupwallet.ui" line="+161"/>
         <source>Change Wallet Passphrase</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4390,12 +4118,7 @@ Remember to write it down and store it safely, otherwise you might lose access t
 <context>
     <name>SettingsBitToolWidget</name>
     <message>
-        <location filename="../pivx/settings/forms/settingsbittoolwidget.ui" line="+14"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+459"/>
+        <location filename="../pivx/settings/forms/settingsbittoolwidget.ui" line="+473"/>
         <source>Import Address</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4588,12 +4311,7 @@ Using this mechanism you can share your keys without middle-man risk, only need 
 <context>
     <name>SettingsConsoleWidget</name>
     <message>
-        <location filename="../pivx/settings/forms/settingsconsolewidget.ui" line="+14"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+46"/>
+        <location filename="../pivx/settings/forms/settingsconsolewidget.ui" line="+60"/>
         <source>Console</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4652,12 +4370,7 @@ Verify that you have installed a predetermined text editor.</source>
 <context>
     <name>SettingsDisplayOptionsWidget</name>
     <message>
-        <location filename="../pivx/settings/forms/settingsdisplayoptionswidget.ui" line="+14"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+194"/>
+        <location filename="../pivx/settings/forms/settingsdisplayoptionswidget.ui" line="+208"/>
         <source>Hide stake charts in the dashboard</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4726,12 +4439,7 @@ Verify that you have installed a predetermined text editor.</source>
 <context>
     <name>SettingsExportCSV</name>
     <message>
-        <location filename="../pivx/settings/forms/settingsexportcsv.ui" line="+14"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+41"/>
+        <location filename="../pivx/settings/forms/settingsexportcsv.ui" line="+55"/>
         <source>Export Accounting</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4742,44 +4450,31 @@ Verify that you have installed a predetermined text editor.</source>
     </message>
     <message>
         <location line="+35"/>
-        <source>Where</source>
+        <location filename="../pivx/settings/settingsexportcsv.cpp" line="+61"/>
+        <source>Export Transaction History</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+58"/>
         <location line="+115"/>
-        <location filename="../pivx/settings/settingsexportcsv.cpp" line="+70"/>
+        <location filename="../pivx/settings/settingsexportcsv.cpp" line="+8"/>
         <location line="+7"/>
         <source>Select folder...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="-48"/>
+        <location filename="../pivx/settings/settingsexportcsv.cpp" line="-15"/>
         <source>Export Address Book</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pivx/settings/settingsexportcsv.cpp" line="-16"/>
-        <source>Export CSV</source>
-        <translation type="unfinished"></translation>
+        <location filename="../pivx/settings/settingsexportcsv.cpp" line="+1"/>
+        <source>Comma separated file (*.csv)</source>
+        <translation type="unfinished">Comma separated file (*.csv)</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <source>Export Address List</source>
-        <translation type="unfinished">Export Address List</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>PIVX_tx_csv_export(*.csv)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+0"/>
-        <source>PIVX_addresses_csv_export(*.csv)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+23"/>
+        <location line="+22"/>
         <location line="+72"/>
         <source>Please select a folder to export the csv file first.</source>
         <translation type="unfinished"></translation>
@@ -4852,12 +4547,7 @@ There was an error trying to save the address list to %1. Please try again.</sou
 <context>
     <name>SettingsFaqWidget</name>
     <message>
-        <location filename="../pivx/settings/forms/settingsfaqwidget.ui" line="+14"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+152"/>
+        <location filename="../pivx/settings/forms/settingsfaqwidget.ui" line="+166"/>
         <source>1) What is PIVX?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4867,12 +4557,7 @@ There was an error trying to save the address list to %1. Please try again.</sou
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+148"/>
-        <source>https://PIVX.org/</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+135"/>
+        <location line="+283"/>
         <source>1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5110,12 +4795,7 @@ There was an error trying to save the address list to %1. Please try again.</sou
 <context>
     <name>SettingsInformationWidget</name>
     <message>
-        <location filename="../pivx/settings/forms/settingsinformationwidget.ui" line="+14"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+102"/>
+        <location filename="../pivx/settings/forms/settingsinformationwidget.ui" line="+116"/>
         <source>Network Monitor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5253,12 +4933,7 @@ There was an error trying to save the address list to %1. Please try again.</sou
 <context>
     <name>SettingsMainOptionsWidget</name>
     <message>
-        <location filename="../pivx/settings/forms/settingsmainoptionswidget.ui" line="+14"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+278"/>
+        <location filename="../pivx/settings/forms/settingsmainoptionswidget.ui" line="+292"/>
         <source>Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5339,12 +5014,7 @@ Are you sure?
 <context>
     <name>SettingsSignMessageWidgets</name>
     <message>
-        <location filename="../pivx/settings/forms/settingssignmessagewidgets.ui" line="+14"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+64"/>
+        <location filename="../pivx/settings/forms/settingssignmessagewidgets.ui" line="+78"/>
         <source>Sign/Verify Message</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5484,12 +5154,7 @@ Are you sure?
 <context>
     <name>SettingsWalletOptionsWidget</name>
     <message>
-        <location filename="../pivx/settings/forms/settingswalletoptionswidget.ui" line="+14"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+450"/>
+        <location filename="../pivx/settings/forms/settingswalletoptionswidget.ui" line="+464"/>
         <source>Reset to default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5593,12 +5258,7 @@ Are you sure?
 <context>
     <name>SettingsWalletRepairWidget</name>
     <message>
-        <location filename="../pivx/settings/forms/settingswalletrepairwidget.ui" line="+14"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+94"/>
+        <location filename="../pivx/settings/forms/settingswalletrepairwidget.ui" line="+108"/>
         <location filename="../pivx/settings/settingswalletrepairwidget.cpp" line="+22"/>
         <source>Wallet Repair</source>
         <translation type="unfinished"></translation>
@@ -5707,12 +5367,7 @@ Are you sure?
 <context>
     <name>SettingsWidget</name>
     <message>
-        <location filename="../pivx/settings/forms/settingswidget.ui" line="+14"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+255"/>
+        <location filename="../pivx/settings/forms/settingswidget.ui" line="+269"/>
         <source>Wallet Data</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5876,27 +5531,9 @@ Are you sure?
     </message>
 </context>
 <context>
-    <name>SnackBar</name>
-    <message>
-        <location filename="../pivx/forms/snackbar.ui" line="+26"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+51"/>
-        <source>Contact Stored</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>Splash</name>
     <message>
-        <location filename="../pivx/forms/splash.ui" line="+26"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+143"/>
+        <location filename="../pivx/forms/splash.ui" line="+169"/>
         <source>Loading…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5912,12 +5549,7 @@ Are you sure?
 <context>
     <name>TooltipMenu</name>
     <message>
-        <location filename="../pivx/forms/tooltipmenu.ui" line="+26"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+60"/>
+        <location filename="../pivx/forms/tooltipmenu.ui" line="+86"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5940,12 +5572,7 @@ Are you sure?
 <context>
     <name>TopBar</name>
     <message>
-        <location filename="../pivx/forms/topbar.ui" line="+26"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+103"/>
+        <location filename="../pivx/forms/topbar.ui" line="+129"/>
         <source>transparent</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6464,12 +6091,7 @@ backup will be created.
 <context>
     <name>TxDetailDialog</name>
     <message>
-        <location filename="../pivx/forms/sendconfirmdialog.ui" line="+26"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+90"/>
+        <location filename="../pivx/forms/sendconfirmdialog.ui" line="+116"/>
         <location filename="../pivx/sendconfirmdialog.cpp" line="+75"/>
         <source>Transaction Details</source>
         <translation type="unfinished"></translation>
@@ -6492,17 +6114,7 @@ backup will be created.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+167"/>
-        <source>D7VFR83SQbie…BhjcWJtcfip5krte2Z </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+103"/>
-        <source>May 25, 2017</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-621"/>
+        <location line="-351"/>
         <source>ID</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6557,12 +6169,7 @@ backup will be created.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
-        <source>TextLabel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+51"/>
+        <location line="+151"/>
         <source>CANCEL</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6615,24 +6222,6 @@ backup will be created.
         <location line="+153"/>
         <source>Unknown</source>
         <translation type="unfinished">Unknown</translation>
-    </message>
-</context>
-<context>
-    <name>TxRow</name>
-    <message>
-        <location filename="../pivx/forms/txrow.ui" line="+20"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+142"/>
-        <source>+0.000585 PIV</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+10"/>
-        <source>-0.000585 PIV</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -7682,12 +7271,7 @@ Please run &apos;sapling-fetch-params&apos; or &apos;./util/fetch-params.sh&apos
 <context>
     <name>send</name>
     <message>
-        <location filename="../pivx/forms/send.ui" line="+14"/>
-        <source>Form</source>
-        <translation type="unfinished">Form</translation>
-    </message>
-    <message>
-        <location line="+60"/>
+        <location filename="../pivx/forms/send.ui" line="+74"/>
         <location line="+629"/>
         <source>Send</source>
         <translation type="unfinished"></translation>

--- a/src/qt/pivx/forms/addnewaddressdialog.ui
+++ b/src/qt/pivx/forms/addnewaddressdialog.ui
@@ -132,7 +132,7 @@
            </size>
           </property>
           <property name="text">
-           <string>PushButton</string>
+           <string notr="true">N/A</string>
           </property>
          </widget>
         </item>

--- a/src/qt/pivx/forms/addnewaddressdialog.ui
+++ b/src/qt/pivx/forms/addnewaddressdialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string notr="true">N/A</string>
   </property>
   <property name="styleSheet">
    <string notr="true"/>

--- a/src/qt/pivx/forms/addnewcontactdialog.ui
+++ b/src/qt/pivx/forms/addnewcontactdialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_4">
    <property name="spacing">

--- a/src/qt/pivx/forms/addresseswidget.ui
+++ b/src/qt/pivx/forms/addresseswidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="2,1">
    <property name="spacing">

--- a/src/qt/pivx/forms/addresslabelrow.ui
+++ b/src/qt/pivx/forms/addresslabelrow.ui
@@ -56,7 +56,7 @@
          <string notr="true"/>
         </property>
         <property name="text">
-         <string>Bob Allen</string>
+         <string notr="true">N/A</string>
         </property>
        </widget>
       </item>
@@ -79,7 +79,7 @@
          <string notr="true"/>
         </property>
         <property name="text">
-         <string>DN6i46dytMPVhV1JMGZFuQBh7BZZ6nNLox</string>
+         <string notr="true">N/A</string>
         </property>
        </widget>
       </item>

--- a/src/qt/pivx/forms/addresslabelrow.ui
+++ b/src/qt/pivx/forms/addresslabelrow.ui
@@ -17,7 +17,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/src/qt/pivx/forms/balancebubble.ui
+++ b/src/qt/pivx/forms/balancebubble.ui
@@ -23,7 +23,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <property name="styleSheet">
    <string notr="true">#BalanceBubble{

--- a/src/qt/pivx/forms/balancebubble.ui
+++ b/src/qt/pivx/forms/balancebubble.ui
@@ -87,7 +87,7 @@ background-color:transparent
          <string notr="true"/>
         </property>
         <property name="text">
-         <string>0.00 pivx</string>
+         <string notr="true">N/A</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
@@ -113,7 +113,7 @@ background-color:transparent
          <string notr="true"/>
         </property>
         <property name="text">
-         <string>0.00 pivx</string>
+         <string notr="true">N/A</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>

--- a/src/qt/pivx/forms/coldstakingwidget.ui
+++ b/src/qt/pivx/forms/coldstakingwidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout_1" stretch="2,1">
    <property name="spacing">

--- a/src/qt/pivx/forms/contactdropdownrow.ui
+++ b/src/qt/pivx/forms/contactdropdownrow.ui
@@ -67,7 +67,7 @@
            <string notr="true"/>
           </property>
           <property name="text">
-           <string notr="true">Bob Allen</string>
+           <string notr="true">N/A</string>
           </property>
          </widget>
         </item>
@@ -77,7 +77,7 @@
            <string notr="true"/>
           </property>
           <property name="text">
-           <string notr="true">DN6i46dytMPVhV1JMGZFuQBh7BZZ6nNLox</string>
+           <string notr="true">N/A</string>
           </property>
          </widget>
         </item>

--- a/src/qt/pivx/forms/contactdropdownrow.ui
+++ b/src/qt/pivx/forms/contactdropdownrow.ui
@@ -17,7 +17,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/src/qt/pivx/forms/createproposaldialog.ui
+++ b/src/qt/pivx/forms/createproposaldialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string notr="true">Dialog</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/src/qt/pivx/forms/csrow.ui
+++ b/src/qt/pivx/forms/csrow.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/src/qt/pivx/forms/csrow.ui
+++ b/src/qt/pivx/forms/csrow.ui
@@ -102,7 +102,7 @@
            <item>
             <widget class="QLabel" name="labelAmount">
              <property name="text">
-              <string>0,00 PIV</string>
+              <string notr="true">N/A</string>
              </property>
             </widget>
            </item>

--- a/src/qt/pivx/forms/dashboardwidget.ui
+++ b/src/qt/pivx/forms/dashboardwidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="3,2">
    <property name="spacing">

--- a/src/qt/pivx/forms/defaultdialog.ui
+++ b/src/qt/pivx/forms/defaultdialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <property name="spacing">

--- a/src/qt/pivx/forms/defaultdialog.ui
+++ b/src/qt/pivx/forms/defaultdialog.ui
@@ -158,7 +158,7 @@
       <item>
        <widget class="QLabel" name="labelMessage">
         <property name="text">
-         <string notr="true">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</string>
+         <string notr="true">N/A</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>

--- a/src/qt/pivx/forms/expandablebutton.ui
+++ b/src/qt/pivx/forms/expandablebutton.ui
@@ -23,7 +23,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout" stretch="0">
    <property name="spacing">

--- a/src/qt/pivx/forms/governancewidget.ui
+++ b/src/qt/pivx/forms/governancewidget.ui
@@ -82,14 +82,14 @@
            <item>
             <widget class="QLabel" name="labelTitle">
              <property name="text">
-              <string notr="true">TextLabel</string>
+              <string notr="true">N/A</string>
              </property>
             </widget>
            </item>
            <item alignment="Qt::AlignTop">
             <widget class="QLabel" name="labelSubtitle1">
              <property name="text">
-              <string notr="true">TextLabel</string>
+              <string notr="true">N/A</string>
              </property>
             </widget>
            </item>
@@ -574,7 +574,7 @@
               <item>
                <widget class="QLabel" name="labelAvailableAmount">
                 <property name="text">
-                 <string notr="true">6,000 PIV</string>
+                 <string notr="true">N/A</string>
                 </property>
                </widget>
               </item>
@@ -660,7 +660,7 @@
               <item>
                <widget class="QLabel" name="labelAllocatedAmount">
                 <property name="text">
-                 <string notr="true">37,000 PIV</string>
+                 <string notr="true">N/A</string>
                 </property>
                </widget>
               </item>

--- a/src/qt/pivx/forms/governancewidget.ui
+++ b/src/qt/pivx/forms/governancewidget.ui
@@ -17,7 +17,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string notr="true">Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="2,1">
    <property name="spacing">

--- a/src/qt/pivx/forms/loadingdialog.ui
+++ b/src/qt/pivx/forms/loadingdialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/src/qt/pivx/forms/loadingdialog.ui
+++ b/src/qt/pivx/forms/loadingdialog.ui
@@ -80,7 +80,7 @@
             </size>
            </property>
            <property name="text">
-            <string>TextLabel</string>
+            <string notr="true">N/A</string>
            </property>
           </widget>
          </item>
@@ -140,7 +140,7 @@
                </size>
               </property>
               <property name="text">
-               <string>.</string>
+               <string notr="true">N/A</string>
               </property>
              </widget>
             </item>

--- a/src/qt/pivx/forms/lockunlock.ui
+++ b/src/qt/pivx/forms/lockunlock.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <property name="styleSheet">
    <string notr="true">margin:0px; padding:0px; border:none;</string>

--- a/src/qt/pivx/forms/masternodeswidget.ui
+++ b/src/qt/pivx/forms/masternodeswidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="2,1">
    <property name="spacing">

--- a/src/qt/pivx/forms/masternodewizarddialog.ui
+++ b/src/qt/pivx/forms/masternodewizarddialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_1">
    <property name="spacing">

--- a/src/qt/pivx/forms/mninfodialog.ui
+++ b/src/qt/pivx/forms/mninfodialog.ui
@@ -17,7 +17,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <property name="styleSheet">
    <string notr="true"/>

--- a/src/qt/pivx/forms/mninfodialog.ui
+++ b/src/qt/pivx/forms/mninfodialog.ui
@@ -271,7 +271,7 @@ background:transparent;
                    <item>
                     <widget class="QLabel" name="textId">
                      <property name="text">
-                      <string notr="true">492526e7fa3c810b35016...40a5df85ee227ab00b1156994</string>
+                      <string notr="true">N/A</string>
                      </property>
                     </widget>
                    </item>
@@ -350,7 +350,7 @@ background:transparent;
                    <item>
                     <widget class="QLabel" name="textAddress">
                      <property name="text">
-                      <string notr="true">127.0.0.2:43223</string>
+                      <string notr="true">N/A</string>
                      </property>
                     </widget>
                    </item>
@@ -395,7 +395,7 @@ background:transparent;
                    <item>
                     <widget class="QLabel" name="textAmount">
                      <property name="text">
-                      <string notr="true">492526e7fa3c810b35016...40a5df85ee227ab00b1156994</string>
+                      <string notr="true">N/A</string>
                      </property>
                     </widget>
                    </item>

--- a/src/qt/pivx/forms/mnrow.ui
+++ b/src/qt/pivx/forms/mnrow.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <property name="styleSheet">
    <string notr="true"/>

--- a/src/qt/pivx/forms/mnselectiondialog.ui
+++ b/src/qt/pivx/forms/mnselectiondialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string notr="true">Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <property name="spacing">

--- a/src/qt/pivx/forms/myaddressrow.ui
+++ b/src/qt/pivx/forms/myaddressrow.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/src/qt/pivx/forms/myaddressrow.ui
+++ b/src/qt/pivx/forms/myaddressrow.ui
@@ -54,7 +54,7 @@
      <item>
       <widget class="QLabel" name="labelDate">
        <property name="text">
-        <string notr="true">Date</string>
+        <string notr="true">N/A</string>
        </property>
       </widget>
      </item>
@@ -63,7 +63,7 @@
    <item>
     <widget class="QLabel" name="labelAddress">
      <property name="text">
-      <string notr="true">DN6i46dytMPVhV1JMGZFuQBh7BZZ6nNLox</string>
+      <string notr="true">N/A</string>
      </property>
     </widget>
    </item>

--- a/src/qt/pivx/forms/navmenuwidget.ui
+++ b/src/qt/pivx/forms/navmenuwidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <property name="styleSheet">
    <string notr="true">padding:0px;

--- a/src/qt/pivx/forms/navmenuwidget.ui
+++ b/src/qt/pivx/forms/navmenuwidget.ui
@@ -391,7 +391,7 @@ STAKING</string>
          </size>
         </property>
         <property name="text">
-         <string>V 1.0.0</string>
+         <string notr="true">N/A</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignBottom|Qt::AlignHCenter</set>

--- a/src/qt/pivx/forms/optionbutton.ui
+++ b/src/qt/pivx/forms/optionbutton.ui
@@ -112,7 +112,7 @@
           <item>
            <widget class="QLabel" name="labelTitleChange">
             <property name="text">
-             <string notr="true">TextLabel</string>
+             <string notr="true">N/A</string>
             </property>
            </widget>
           </item>
@@ -121,7 +121,7 @@
         <item>
          <widget class="QLabel" name="labelSubtitleChange">
           <property name="text">
-           <string notr="true">TextLabel</string>
+           <string notr="true">N/A</string>
           </property>
          </widget>
         </item>

--- a/src/qt/pivx/forms/optionbutton.ui
+++ b/src/qt/pivx/forms/optionbutton.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <property name="spacing">

--- a/src/qt/pivx/forms/proposalcard.ui
+++ b/src/qt/pivx/forms/proposalcard.ui
@@ -82,7 +82,7 @@
         <item>
          <widget class="QLabel" name="labelPropName">
           <property name="text">
-           <string notr="true">Proposal Name</string>
+           <string notr="true">N/A</string>
           </property>
          </widget>
         </item>
@@ -174,14 +174,14 @@
             <item alignment="Qt::AlignBottom">
              <widget class="QLabel" name="labelPropAmount">
               <property name="text">
-               <string notr="true">5,000 PIV</string>
+               <string notr="true">N/A</string>
               </property>
              </widget>
             </item>
             <item>
              <widget class="QLabel" name="labelPropMonths">
               <property name="text">
-               <string notr="true">2 months remaining</string>
+               <string notr="true">N/A</string>
               </property>
              </widget>
             </item>
@@ -207,7 +207,7 @@
             <string notr="true">margin-top:16;</string>
            </property>
            <property name="text">
-            <string notr="true">Passing</string>
+            <string notr="true">N/A</string>
            </property>
           </widget>
          </item>
@@ -289,7 +289,7 @@
                <string notr="true">color:#4D4D4D;</string>
               </property>
               <property name="text">
-               <string notr="true">24% No</string>
+               <string notr="true">N/A</string>
               </property>
              </widget>
             </item>
@@ -312,7 +312,7 @@
                <string notr="true">color:#5C4B7D;</string>
               </property>
               <property name="text">
-               <string notr="true">76% Yes</string>
+               <string notr="true">N/A</string>
               </property>
              </widget>
             </item>

--- a/src/qt/pivx/forms/proposalinfodialog.ui
+++ b/src/qt/pivx/forms/proposalinfodialog.ui
@@ -513,7 +513,7 @@ background:transparent;
                    <item row="1" column="3">
                     <widget class="QLabel" name="textStatus">
                      <property name="text">
-                      <string notr="true">Passing</string>
+                      <string notr="true">N/A</string>
                      </property>
                      <property name="alignment">
                       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -627,7 +627,7 @@ background:transparent;
                         </size>
                        </property>
                        <property name="text">
-                        <string notr="true">URL</string>
+                        <string>URL</string>
                        </property>
                       </widget>
                      </item>

--- a/src/qt/pivx/forms/proposalinfodialog.ui
+++ b/src/qt/pivx/forms/proposalinfodialog.ui
@@ -23,7 +23,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string notr="true">Proposal Information</string>
+   <string notr="true">N/A</string>
   </property>
   <property name="styleSheet">
    <string notr="true"/>

--- a/src/qt/pivx/forms/receivedialog.ui
+++ b/src/qt/pivx/forms/receivedialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string notr="true">N/A</string>
   </property>
   <property name="styleSheet">
    <string notr="true">background:white;</string>

--- a/src/qt/pivx/forms/receivewidget.ui
+++ b/src/qt/pivx/forms/receivewidget.ui
@@ -17,7 +17,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="2,1">
    <property name="spacing">

--- a/src/qt/pivx/forms/requestdialog.ui
+++ b/src/qt/pivx/forms/requestdialog.ui
@@ -542,7 +542,7 @@
           <item alignment="Qt::AlignHCenter">
            <widget class="QLabel" name="labelAddress">
             <property name="text">
-             <string>D7VFR83SQbiezrW72hjcWJtcfip5krte2Z </string>
+             <string notr="true">N/A </string>
             </property>
            </widget>
           </item>

--- a/src/qt/pivx/forms/requestdialog.ui
+++ b/src/qt/pivx/forms/requestdialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_5">
    <property name="spacing">

--- a/src/qt/pivx/forms/requestdialog.ui
+++ b/src/qt/pivx/forms/requestdialog.ui
@@ -327,7 +327,7 @@
                    <item>
                     <widget class="QLabel" name="comboBoxCoin">
                      <property name="text">
-                      <string>PIV</string>
+                      <string notr="true">N/A</string>
                      </property>
                      <property name="alignment">
                       <set>Qt::AlignCenter</set>

--- a/src/qt/pivx/forms/send.ui
+++ b/src/qt/pivx/forms/send.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="2,1">
    <property name="spacing">

--- a/src/qt/pivx/forms/sendchangeaddressdialog.ui
+++ b/src/qt/pivx/forms/sendchangeaddressdialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/src/qt/pivx/forms/sendconfirmdialog.ui
+++ b/src/qt/pivx/forms/sendconfirmdialog.ui
@@ -23,7 +23,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <property name="styleSheet">
    <string notr="true"/>

--- a/src/qt/pivx/forms/sendconfirmdialog.ui
+++ b/src/qt/pivx/forms/sendconfirmdialog.ui
@@ -799,7 +799,7 @@ background:transparent;
                    <item>
                     <widget class="QLabel" name="textChange">
                      <property name="text">
-                      <string>D7VFR83SQbie…BhjcWJtcfip5krte2Z </string>
+                      <string notr="true">N/A</string>
                      </property>
                     </widget>
                    </item>
@@ -902,7 +902,7 @@ background:transparent;
                    <item row="1" column="0">
                     <widget class="QLabel" name="textDate">
                      <property name="text">
-                      <string>May 25, 2017</string>
+                      <string notr="true">N/A</string>
                      </property>
                      <property name="alignment">
                       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -1060,7 +1060,7 @@ background:transparent;
                 <item>
                  <widget class="QLabel" name="labelWarning">
                   <property name="text">
-                   <string>TextLabel</string>
+                   <string notr="true">N/A</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignCenter</set>

--- a/src/qt/pivx/forms/sendcustomfeedialog.ui
+++ b/src/qt/pivx/forms/sendcustomfeedialog.ui
@@ -224,7 +224,7 @@
            <item alignment="Qt::AlignHCenter">
             <widget class="QLabel" name="labelFee">
              <property name="text">
-              <string>0.00 KB</string>
+              <string notr="true">N/A</string>
              </property>
             </widget>
            </item>

--- a/src/qt/pivx/forms/sendcustomfeedialog.ui
+++ b/src/qt/pivx/forms/sendcustomfeedialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <property name="spacing">

--- a/src/qt/pivx/forms/sendcustomfeedialog.ui
+++ b/src/qt/pivx/forms/sendcustomfeedialog.ui
@@ -287,7 +287,7 @@
            <item alignment="Qt::AlignHCenter">
             <widget class="QLabel" name="labelCustomFee">
              <property name="text">
-              <string>PIV/kilobyte</string>
+              <string notr="true">N/A</string>
              </property>
             </widget>
            </item>

--- a/src/qt/pivx/forms/sendmemodialog.ui
+++ b/src/qt/pivx/forms/sendmemodialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/src/qt/pivx/forms/sendmemodialog.ui
+++ b/src/qt/pivx/forms/sendmemodialog.ui
@@ -200,7 +200,7 @@
            <string notr="true"/>
           </property>
           <property name="html">
-           <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+           <string notr="true">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'.SF NS Text'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;

--- a/src/qt/pivx/forms/sendmultirow.ui
+++ b/src/qt/pivx/forms/sendmultirow.ui
@@ -23,7 +23,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <property name="spacing">

--- a/src/qt/pivx/forms/snackbar.ui
+++ b/src/qt/pivx/forms/snackbar.ui
@@ -74,7 +74,7 @@ font-size: 15px;
 color:white;</string>
         </property>
         <property name="text">
-         <string>Contact Stored</string>
+         <string notr="true">N/A</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>

--- a/src/qt/pivx/forms/snackbar.ui
+++ b/src/qt/pivx/forms/snackbar.ui
@@ -23,7 +23,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <property name="spacing">

--- a/src/qt/pivx/forms/splash.ui
+++ b/src/qt/pivx/forms/splash.ui
@@ -23,7 +23,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <property name="spacing">

--- a/src/qt/pivx/forms/tooltipmenu.ui
+++ b/src/qt/pivx/forms/tooltipmenu.ui
@@ -23,7 +23,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <property name="spacing">

--- a/src/qt/pivx/forms/topbar.ui
+++ b/src/qt/pivx/forms/topbar.ui
@@ -23,7 +23,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_10" stretch="0">
    <property name="spacing">

--- a/src/qt/pivx/forms/txrow.ui
+++ b/src/qt/pivx/forms/txrow.ui
@@ -159,7 +159,7 @@
                <string notr="true"/>
               </property>
               <property name="text">
-               <string>+0.000585 PIV</string>
+               <string notr="true">N/A</string>
               </property>
              </widget>
             </item>
@@ -169,7 +169,7 @@
                <string notr="true"/>
               </property>
               <property name="text">
-               <string>-0.000585 PIV</string>
+               <string notr="true">N/A</string>
               </property>
              </widget>
             </item>

--- a/src/qt/pivx/forms/txrow.ui
+++ b/src/qt/pivx/forms/txrow.ui
@@ -17,7 +17,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
    <property name="spacing">

--- a/src/qt/pivx/forms/welcomecontentwidget.ui
+++ b/src/qt/pivx/forms/welcomecontentwidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string></string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/src/qt/pivx/requestdialog.cpp
+++ b/src/qt/pivx/requestdialog.cpp
@@ -65,6 +65,7 @@ RequestDialog::RequestDialog(QWidget *parent) :
 void RequestDialog::setWalletModel(WalletModel *model)
 {
     this->walletModel = model;
+    ui->comboBoxCoin->setText(BitcoinUnits::name(this->walletModel->getOptionsModel()->getDisplayUnit()));
 }
 
 void RequestDialog::setPaymentRequest(bool isPaymentRequest)
@@ -111,7 +112,7 @@ void RequestDialog::accept()
         CallResult<Destination> r;
         if (this->isPaymentRequest) {
             r = walletModel->getNewAddress(label);
-            title = tr("Request for ") + BitcoinUnits::format(displayUnit, info->amount, false, BitcoinUnits::separatorAlways) + " " + QString(CURRENCY_UNIT.c_str());
+            title = tr("Request for ") + BitcoinUnits::format(displayUnit, info->amount, false, BitcoinUnits::separatorAlways) + " " + BitcoinUnits::name(displayUnit);
         } else {
             r = walletModel->getNewStakingAddress(label);
             title = tr("Cold Staking Address Generated");

--- a/src/qt/pivx/sendcustomfeedialog.cpp
+++ b/src/qt/pivx/sendcustomfeedialog.cpp
@@ -63,6 +63,9 @@ void SendCustomFeeDialog::showEvent(QShowEvent* event)
 {
     FocusedDialog::showEvent(event);
     updateFee();
+
+    ui->labelCustomFee->setText(BitcoinUnits::name(walletModel->getOptionsModel()->getDisplayUnit()) + "/kB");
+
     if (walletModel->hasWalletCustomFee()) {
         ui->checkBoxCustom->setChecked(true);
         onCustomChecked();

--- a/src/qt/pivx/settings/forms/settingsbackupwallet.ui
+++ b/src/qt/pivx/settings/forms/settingsbackupwallet.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/src/qt/pivx/settings/forms/settingsbittoolwidget.ui
+++ b/src/qt/pivx/settings/forms/settingsbittoolwidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/src/qt/pivx/settings/forms/settingsconsolewidget.ui
+++ b/src/qt/pivx/settings/forms/settingsconsolewidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/src/qt/pivx/settings/forms/settingsdisplayoptionswidget.ui
+++ b/src/qt/pivx/settings/forms/settingsdisplayoptionswidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/src/qt/pivx/settings/forms/settingsexportcsv.ui
+++ b/src/qt/pivx/settings/forms/settingsexportcsv.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/src/qt/pivx/settings/forms/settingsexportcsv.ui
+++ b/src/qt/pivx/settings/forms/settingsexportcsv.ui
@@ -94,7 +94,7 @@
            <item>
             <widget class="QLabel" name="labelSubtitleLocation">
              <property name="text">
-              <string>Where</string>
+              <string>Export Transaction History</string>
              </property>
             </widget>
            </item>

--- a/src/qt/pivx/settings/forms/settingsfaqwidget.ui
+++ b/src/qt/pivx/settings/forms/settingsfaqwidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout" stretch="0">
    <property name="spacing">

--- a/src/qt/pivx/settings/forms/settingsfaqwidget.ui
+++ b/src/qt/pivx/settings/forms/settingsfaqwidget.ui
@@ -342,7 +342,7 @@
                   <enum>Qt::NoFocus</enum>
                  </property>
                  <property name="text">
-                  <string>https://PIVX.org/</string>
+                  <string notr="true">https://www.PIVX.org</string>
                  </property>
                 </widget>
                </item>

--- a/src/qt/pivx/settings/forms/settingsinformationwidget.ui
+++ b/src/qt/pivx/settings/forms/settingsinformationwidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/src/qt/pivx/settings/forms/settingsmainoptionswidget.ui
+++ b/src/qt/pivx/settings/forms/settingsmainoptionswidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/src/qt/pivx/settings/forms/settingssignmessagewidgets.ui
+++ b/src/qt/pivx/settings/forms/settingssignmessagewidgets.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/src/qt/pivx/settings/forms/settingswalletoptionswidget.ui
+++ b/src/qt/pivx/settings/forms/settingswalletoptionswidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">

--- a/src/qt/pivx/settings/forms/settingswalletrepairwidget.ui
+++ b/src/qt/pivx/settings/forms/settingswalletrepairwidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <property name="spacing">

--- a/src/qt/pivx/settings/forms/settingswidget.ui
+++ b/src/qt/pivx/settings/forms/settingswidget.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string notr="true">N/A</string>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,2">
    <property name="spacing">

--- a/src/qt/pivx/settings/settingsexportcsv.cpp
+++ b/src/qt/pivx/settings/settingsexportcsv.cpp
@@ -58,9 +58,8 @@ SettingsExportCSV::SettingsExportCSV(PIVXGUI* _window, QWidget *parent) :
 void SettingsExportCSV::selectFileOutput(const bool isTxExport)
 {
     QString filename = GUIUtil::getSaveFileName(this,
-                                        isTxExport ? tr("Export CSV") : tr("Export Address List"), QString(),
-                                        isTxExport ? tr("PIVX_tx_csv_export(*.csv)") : tr("PIVX_addresses_csv_export(*.csv)"),
-                                        nullptr);
+                                        isTxExport ? tr("Export Transaction History") : tr("Export Address Book"), QString(),
+                                        tr("Comma separated file (*.csv)"), nullptr);
 
     if (isTxExport) {
         if (!filename.isEmpty()) {


### PR DESCRIPTION
Stop passing placeholder strings that will never be shown in the GUI to Transifex. This includes many unused `WindowTitle` instances, as well as dynamic strings that are always set programmatically.

Additionally, we can simplify the fee-per-kb text by not passing a string literal, and instead use a dynamic string that doesn't need translating. The same goes for the payment request UI, where we can simply insert the current network's acronym (`PIV` or `tPIV`, for example) instead of a static string that doesn't need translation.

Lastly, the export UI had some strings that were either too vague, or multiple strings that described the same thing.

-------

Net difference in number of strings is 3 new and 75 removed.

As we base the inclusion of a translation language into the wallet client on it's translation completion percentage; getting rid of these placeholder strings, as well as unifying multiple strings to describe the same thing, will ultimately improve the translation process and make it easier for a language to reach the 80% translation threshold for inclusion.