### PR TITLE
scripted-diff: replace boost::optional with Optional<> wrapper

### DIFF
--- a/src/sapling/address.cpp
+++ b/src/sapling/address.cpp
@@ -1,9 +1,14 @@
+// Copyright (c) 2016-2020 The ZCash developers
+// Copyright (c) 2021 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
 #include "sapling/address.h"
+
+#include "hash.h"
 #include "sapling/noteencryption.h"
 #include "sapling/prf.h"
 #include "sapling/sapling_util.h"
-
-#include "hash.h"
 #include "streams.h"
 
 #include <librustzcash.h>

--- a/src/sapling/address.cpp
+++ b/src/sapling/address.cpp
@@ -65,20 +65,20 @@ SaplingSpendingKey SaplingSpendingKey::random() {
     }
 }
 
-boost::optional<SaplingPaymentAddress> SaplingIncomingViewingKey::address(diversifier_t d) const {
+Optional<SaplingPaymentAddress> SaplingIncomingViewingKey::address(diversifier_t d) const {
     uint256 pk_d;
     if (librustzcash_check_diversifier(d.data())) {
         librustzcash_ivk_to_pkd(this->begin(), d.data(), pk_d.begin());
         return SaplingPaymentAddress(d, pk_d);
     } else {
-        return boost::none;
+        return nullopt;
     }
 }
 
 SaplingPaymentAddress SaplingSpendingKey::default_address() const {
     // Iterates within default_diversifier to ensure a valid address is returned
     auto addrOpt = full_viewing_key().in_viewing_key().address(default_diversifier(*this));
-    assert(addrOpt != boost::none);
+    assert(addrOpt != nullopt);
     return addrOpt.value();
 }
 

--- a/src/sapling/address.h
+++ b/src/sapling/address.h
@@ -1,12 +1,17 @@
+// Copyright (c) 2016-2020 The ZCash developers
+// Copyright (c) 2021 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
 #ifndef ZC_ADDRESS_H_
 #define ZC_ADDRESS_H_
 
-#include "uint256.h"
-#include "serialize.h"
+#include "optional.h"
 #include "sapling/sapling.h"
+#include "serialize.h"
+#include "uint256.h"
 
 #include <array>
-#include "optional.h"
 #include <boost/variant.hpp>
 
 namespace libzcash {

--- a/src/sapling/address.h
+++ b/src/sapling/address.h
@@ -6,7 +6,7 @@
 #include "sapling/sapling.h"
 
 #include <array>
-#include <boost/optional.hpp>
+#include "optional.h"
 #include <boost/variant.hpp>
 
 namespace libzcash {
@@ -50,7 +50,7 @@ public:
     SaplingIncomingViewingKey(uint256 ivk) : uint256(ivk) { }
 
     // Can pass in diversifier for Sapling addr
-    boost::optional<SaplingPaymentAddress> address(diversifier_t d) const;
+    Optional<SaplingPaymentAddress> address(diversifier_t d) const;
 };
 
 class SaplingFullViewingKey {

--- a/src/sapling/incrementalmerkletree.cpp
+++ b/src/sapling/incrementalmerkletree.cpp
@@ -932,17 +932,17 @@ void IncrementalMerkleTree<Depth, Hash>::append(Hash obj) {
         right = obj;
     } else {
         // Combine the leaves and propagate it up the tree
-        boost::optional<Hash> combined = Hash::combine(*left, *right, 0);
+        Optional<Hash> combined = Hash::combine(*left, *right, 0);
 
         // Set the "left" leaf to the object and make the "right" leaf none
         left = obj;
-        right = boost::none;
+        right = nullopt;
 
         for (size_t i = 0; i < Depth; i++) {
             if (i < parents.size()) {
                 if (parents[i]) {
                     combined = Hash::combine(*parents[i], *combined, i+1);
-                    parents[i] = boost::none;
+                    parents[i] = nullopt;
                 } else {
                     parents[i] = *combined;
                     break;
@@ -1119,7 +1119,7 @@ void IncrementalWitness<Depth, Hash>::append(Hash obj) {
 
         if (cursor->is_complete(cursor_depth)) {
             filled.push_back(cursor->root(cursor_depth));
-            cursor = boost::none;
+            cursor = nullopt;
         }
     } else {
         cursor_depth = tree.next_depth(filled.size());

--- a/src/sapling/incrementalmerkletree.cpp
+++ b/src/sapling/incrementalmerkletree.cpp
@@ -1,5 +1,5 @@
-// Copyright (c) 2016-2018 The Zcash developers
-// Copyright (c) 2020 The PIVX developers
+// Copyright (c) 2016-2020 The ZCash developers
+// Copyright (c) 2021 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
@@ -7,6 +7,7 @@
 
 #include "crypto/sha256.h"
 #include "sapling/incrementalmerkletree.h"
+
 #include <librustzcash.h>
 
 namespace libzcash {

--- a/src/sapling/note.cpp
+++ b/src/sapling/note.cpp
@@ -22,7 +22,7 @@ SaplingNote::SaplingNote(const SaplingPaymentAddress& address, const uint64_t va
 }
 
 // Call librustzcash to compute the commitment
-boost::optional<uint256> SaplingNote::cmu() const
+Optional<uint256> SaplingNote::cmu() const
 {
     uint256 result;
     if (!librustzcash_sapling_compute_cm(
@@ -33,14 +33,14 @@ boost::optional<uint256> SaplingNote::cmu() const
             result.begin()
         ))
     {
-        return boost::none;
+        return nullopt;
     }
 
     return result;
 }
 
 // Call librustzcash to compute the nullifier
-boost::optional<uint256> SaplingNote::nullifier(const SaplingFullViewingKey& vk, const uint64_t position) const
+Optional<uint256> SaplingNote::nullifier(const SaplingFullViewingKey& vk, const uint64_t position) const
 {
     auto ak = vk.ak;
     auto nk = vk.nk;
@@ -57,7 +57,7 @@ boost::optional<uint256> SaplingNote::nullifier(const SaplingFullViewingKey& vk,
             result.begin()
     ))
     {
-        return boost::none;
+        return nullopt;
     }
 
     return result;
@@ -73,17 +73,17 @@ SaplingNotePlaintext::SaplingNotePlaintext(
 }
 
 
-boost::optional<SaplingNote> SaplingNotePlaintext::note(const SaplingIncomingViewingKey& ivk) const
+Optional<SaplingNote> SaplingNotePlaintext::note(const SaplingIncomingViewingKey& ivk) const
 {
     auto addr = ivk.address(d);
     if (addr) {
         return SaplingNote(d, addr.get().pk_d, value_, rcm);
     } else {
-        return boost::none;
+        return nullopt;
     }
 }
 
-boost::optional<SaplingOutgoingPlaintext> SaplingOutgoingPlaintext::decrypt(
+Optional<SaplingOutgoingPlaintext> SaplingOutgoingPlaintext::decrypt(
     const SaplingOutCiphertext& ciphertext,
     const uint256& ovk,
     const uint256& cv,
@@ -93,7 +93,7 @@ boost::optional<SaplingOutgoingPlaintext> SaplingOutgoingPlaintext::decrypt(
 {
     auto pt = AttemptSaplingOutDecryption(ciphertext, ovk, cv, cm, epk);
     if (!pt) {
-        return boost::none;
+        return nullopt;
     }
 
     // Deserialize from the plaintext
@@ -108,7 +108,7 @@ boost::optional<SaplingOutgoingPlaintext> SaplingOutgoingPlaintext::decrypt(
     return ret;
 }
 
-boost::optional<SaplingNotePlaintext> SaplingNotePlaintext::decrypt(
+Optional<SaplingNotePlaintext> SaplingNotePlaintext::decrypt(
     const SaplingEncCiphertext& ciphertext,
     const uint256& ivk,
     const uint256& epk,
@@ -117,7 +117,7 @@ boost::optional<SaplingNotePlaintext> SaplingNotePlaintext::decrypt(
 {
     auto pt = AttemptSaplingEncDecryption(ciphertext, ivk, epk);
     if (!pt) {
-        return boost::none;
+        return nullopt;
     }
 
     // Deserialize from the plaintext
@@ -131,7 +131,7 @@ boost::optional<SaplingNotePlaintext> SaplingNotePlaintext::decrypt(
 
     uint256 pk_d;
     if (!librustzcash_ivk_to_pkd(ivk.begin(), ret.d.data(), pk_d.begin())) {
-        return boost::none;
+        return nullopt;
     }
 
     uint256 cmu_expected;
@@ -143,17 +143,17 @@ boost::optional<SaplingNotePlaintext> SaplingNotePlaintext::decrypt(
         cmu_expected.begin()
     ))
     {
-        return boost::none;
+        return nullopt;
     }
 
     if (cmu_expected != cmu) {
-        return boost::none;
+        return nullopt;
     }
 
     return ret;
 }
 
-boost::optional<SaplingNotePlaintext> SaplingNotePlaintext::decrypt(
+Optional<SaplingNotePlaintext> SaplingNotePlaintext::decrypt(
     const SaplingEncCiphertext& ciphertext,
     const uint256& epk,
     const uint256& esk,
@@ -163,7 +163,7 @@ boost::optional<SaplingNotePlaintext> SaplingNotePlaintext::decrypt(
 {
     auto pt = AttemptSaplingEncDecryption(ciphertext, epk, esk, pk_d);
     if (!pt) {
-        return boost::none;
+        return nullopt;
     }
 
     // Deserialize from the plaintext
@@ -182,11 +182,11 @@ boost::optional<SaplingNotePlaintext> SaplingNotePlaintext::decrypt(
         cmu_expected.begin()
     ))
     {
-        return boost::none;
+        return nullopt;
     }
 
     if (cmu_expected != cmu) {
-        return boost::none;
+        return nullopt;
     }
 
     assert(ss.size() == 0);
@@ -194,12 +194,12 @@ boost::optional<SaplingNotePlaintext> SaplingNotePlaintext::decrypt(
     return ret;
 }
 
-boost::optional<SaplingNotePlaintextEncryptionResult> SaplingNotePlaintext::encrypt(const uint256& pk_d) const
+Optional<SaplingNotePlaintextEncryptionResult> SaplingNotePlaintext::encrypt(const uint256& pk_d) const
 {
     // Get the encryptor
     auto sne = SaplingNoteEncryption::FromDiversifier(d);
     if (!sne) {
-        return boost::none;
+        return nullopt;
     }
     auto enc = sne.get();
 
@@ -213,7 +213,7 @@ boost::optional<SaplingNotePlaintextEncryptionResult> SaplingNotePlaintext::encr
     // Encrypt the plaintext
     auto encciphertext = enc.encrypt_to_recipient(pk_d, pt);
     if (!encciphertext) {
-        return boost::none;
+        return nullopt;
     }
     return SaplingNotePlaintextEncryptionResult(encciphertext.get(), enc);
 }

--- a/src/sapling/note.cpp
+++ b/src/sapling/note.cpp
@@ -1,12 +1,16 @@
+// Copyright (c) 2016-2020 The ZCash developers
+// Copyright (c) 2021 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
 #include "sapling/note.h"
 
+#include "crypto/sha256.h"
+#include "random.h"
 #include "sapling/prf.h"
 #include "sapling/sapling_util.h"
-#include "crypto/sha256.h"
-
-#include "random.h"
-#include "version.h"
 #include "streams.h"
+#include "version.h"
 
 #include <librustzcash.h>
 

--- a/src/sapling/note.h
+++ b/src/sapling/note.h
@@ -1,13 +1,18 @@
+// Copyright (c) 2016-2020 The ZCash developers
+// Copyright (c) 2021 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
 #ifndef ZC_NOTE_H_
 #define ZC_NOTE_H_
 
+#include "optional.h"
 #include "sapling/address.h"
 #include "sapling/noteencryption.h"
 #include "sapling/sapling.h"
 #include "uint256.h"
 
 #include <array>
-#include "optional.h"
 
 namespace libzcash {
 

--- a/src/sapling/note.h
+++ b/src/sapling/note.h
@@ -7,7 +7,7 @@
 #include "uint256.h"
 
 #include <array>
-#include <boost/optional.hpp>
+#include "optional.h"
 
 namespace libzcash {
 
@@ -41,8 +41,8 @@ public:
     SaplingNote(const SaplingPaymentAddress& address, uint64_t value);
     virtual ~SaplingNote() {};
 
-    boost::optional<uint256> cmu() const;
-    boost::optional<uint256> nullifier(const SaplingFullViewingKey& vk, const uint64_t position) const;
+    Optional<uint256> cmu() const;
+    Optional<uint256> nullifier(const SaplingFullViewingKey& vk, const uint64_t position) const;
 };
 
 class BaseNotePlaintext {
@@ -72,14 +72,14 @@ public:
     SaplingNotePlaintext(const SaplingNote& note, const std::array<unsigned char, ZC_MEMO_SIZE>& memo);
     virtual ~SaplingNotePlaintext() {}
 
-    static boost::optional<SaplingNotePlaintext> decrypt(
+    static Optional<SaplingNotePlaintext> decrypt(
         const SaplingEncCiphertext& ciphertext,
         const uint256& ivk,
         const uint256& epk,
         const uint256& cmu
     );
 
-    static boost::optional<SaplingNotePlaintext> decrypt(
+    static Optional<SaplingNotePlaintext> decrypt(
         const SaplingEncCiphertext& ciphertext,
         const uint256& epk,
         const uint256& esk,
@@ -87,7 +87,7 @@ public:
         const uint256& cmu
     );
 
-    boost::optional<SaplingNote> note(const SaplingIncomingViewingKey& ivk) const;
+    Optional<SaplingNote> note(const SaplingIncomingViewingKey& ivk) const;
 
     SERIALIZE_METHODS(SaplingNotePlaintext, obj)
     {
@@ -104,7 +104,7 @@ public:
         READWRITE(obj.memo_);       // 512 bytes
     }
 
-    boost::optional<SaplingNotePlaintextEncryptionResult> encrypt(const uint256& pk_d) const;
+    Optional<SaplingNotePlaintextEncryptionResult> encrypt(const uint256& pk_d) const;
 };
 
 class SaplingOutgoingPlaintext
@@ -125,7 +125,7 @@ public:
         READWRITE(obj.esk);         // 8 bytes
     }
 
-    static boost::optional<SaplingOutgoingPlaintext> decrypt(
+    static Optional<SaplingOutgoingPlaintext> decrypt(
         const SaplingOutCiphertext& ciphertext,
         const uint256& ovk,
         const uint256& cv,

--- a/src/sapling/noteencryption.cpp
+++ b/src/sapling/noteencryption.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 The ZCash developers
-// Copyright (c) 2020 The PIVX developers
+// Copyright (c) 2021 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 #include "sapling/noteencryption.h"
 

--- a/src/sapling/noteencryption.cpp
+++ b/src/sapling/noteencryption.cpp
@@ -109,7 +109,7 @@ void KDF(unsigned char K[NOTEENCRYPTION_CIPHER_KEYSIZE],
 
 namespace libzcash {
 
-boost::optional<SaplingNoteEncryption> SaplingNoteEncryption::FromDiversifier(diversifier_t d) {
+Optional<SaplingNoteEncryption> SaplingNoteEncryption::FromDiversifier(diversifier_t d) {
     uint256 epk;
     uint256 esk;
 
@@ -118,13 +118,13 @@ boost::optional<SaplingNoteEncryption> SaplingNoteEncryption::FromDiversifier(di
 
     // Compute epk given the diversifier
     if (!librustzcash_sapling_ka_derivepublic(d.begin(), esk.begin(), epk.begin())) {
-        return boost::none;
+        return nullopt;
     }
 
     return SaplingNoteEncryption(epk, esk);
 }
 
-boost::optional<SaplingEncCiphertext> SaplingNoteEncryption::encrypt_to_recipient(
+Optional<SaplingEncCiphertext> SaplingNoteEncryption::encrypt_to_recipient(
     const uint256 &pk_d,
     const SaplingEncPlaintext &message
 )
@@ -136,7 +136,7 @@ boost::optional<SaplingEncCiphertext> SaplingNoteEncryption::encrypt_to_recipien
     uint256 dhsecret;
 
     if (!librustzcash_sapling_ka_agree(pk_d.begin(), esk.begin(), dhsecret.begin())) {
-        return boost::none;
+        return nullopt;
     }
 
     // Construct the symmetric key
@@ -160,7 +160,7 @@ boost::optional<SaplingEncCiphertext> SaplingNoteEncryption::encrypt_to_recipien
     return ciphertext;
 }
 
-boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption(
+Optional<SaplingEncPlaintext> AttemptSaplingEncDecryption(
     const SaplingEncCiphertext &ciphertext,
     const uint256 &ivk,
     const uint256 &epk
@@ -169,7 +169,7 @@ boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption(
     uint256 dhsecret;
 
     if (!librustzcash_sapling_ka_agree(epk.begin(), ivk.begin(), dhsecret.begin())) {
-        return boost::none;
+        return nullopt;
     }
 
     // Construct the symmetric key
@@ -189,13 +189,13 @@ boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption(
         0,
         cipher_nonce, K) != 0)
     {
-        return boost::none;
+        return nullopt;
     }
 
     return plaintext;
 }
 
-boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption (
+Optional<SaplingEncPlaintext> AttemptSaplingEncDecryption (
     const SaplingEncCiphertext &ciphertext,
     const uint256 &epk,
     const uint256 &esk,
@@ -205,7 +205,7 @@ boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption (
     uint256 dhsecret;
 
     if (!librustzcash_sapling_ka_agree(pk_d.begin(), esk.begin(), dhsecret.begin())) {
-        return boost::none;
+        return nullopt;
     }
 
     // Construct the symmetric key
@@ -225,7 +225,7 @@ boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption (
         0,
         cipher_nonce, K) != 0)
     {
-        return boost::none;
+        return nullopt;
     }
 
     return plaintext;
@@ -264,7 +264,7 @@ SaplingOutCiphertext SaplingNoteEncryption::encrypt_to_ourselves(
     return ciphertext;
 }
 
-boost::optional<SaplingOutPlaintext> AttemptSaplingOutDecryption(
+Optional<SaplingOutPlaintext> AttemptSaplingOutDecryption(
     const SaplingOutCiphertext &ciphertext,
     const uint256 &ovk,
     const uint256 &cv,
@@ -289,7 +289,7 @@ boost::optional<SaplingOutPlaintext> AttemptSaplingOutDecryption(
         0,
         cipher_nonce, K) != 0)
     {
-        return boost::none;
+        return nullopt;
     }
 
     return plaintext;

--- a/src/sapling/noteencryption.h
+++ b/src/sapling/noteencryption.h
@@ -16,7 +16,7 @@ https://github.com/zcash/zips/blob/master/protocol/protocol.pdf
 #include "sapling/sapling.h"
 
 #include <array>
-#include <boost/optional.hpp>
+#include "optional.h"
 
 namespace libzcash {
 
@@ -46,9 +46,9 @@ protected:
 
 public:
 
-    static boost::optional<SaplingNoteEncryption> FromDiversifier(diversifier_t d);
+    static Optional<SaplingNoteEncryption> FromDiversifier(diversifier_t d);
 
-    boost::optional<SaplingEncCiphertext> encrypt_to_recipient(
+    Optional<SaplingEncCiphertext> encrypt_to_recipient(
         const uint256 &pk_d,
         const SaplingEncPlaintext &message
     );
@@ -71,7 +71,7 @@ public:
 
 // Attempts to decrypt a Sapling note. This will not check that the contents
 // of the ciphertext are correct.
-boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption(
+Optional<SaplingEncPlaintext> AttemptSaplingEncDecryption(
     const SaplingEncCiphertext &ciphertext,
     const uint256 &ivk,
     const uint256 &epk
@@ -79,7 +79,7 @@ boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption(
 
 // Attempts to decrypt a Sapling note using outgoing plaintext.
 // This will not check that the contents of the ciphertext are correct.
-boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption (
+Optional<SaplingEncPlaintext> AttemptSaplingEncDecryption (
     const SaplingEncCiphertext &ciphertext,
     const uint256 &epk,
     const uint256 &esk,
@@ -88,7 +88,7 @@ boost::optional<SaplingEncPlaintext> AttemptSaplingEncDecryption (
 
 // Attempts to decrypt a Sapling note. This will not check that the contents
 // of the ciphertext are correct.
-boost::optional<SaplingOutPlaintext> AttemptSaplingOutDecryption(
+Optional<SaplingOutPlaintext> AttemptSaplingOutDecryption(
     const SaplingOutCiphertext &ciphertext,
     const uint256 &ovk,
     const uint256 &cv,

--- a/src/sapling/noteencryption.h
+++ b/src/sapling/noteencryption.h
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 The ZCash developers
-// Copyright (c) 2020 The PIVX developers
+// Copyright (c) 2021 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 /*
 See the Zcash protocol specification for more information.
@@ -11,12 +11,11 @@ https://github.com/zcash/zips/blob/master/protocol/protocol.pdf
 #ifndef ZC_NOTE_ENCRYPTION_H_
 #define ZC_NOTE_ENCRYPTION_H_
 
+#include "optional.h"
+#include "sapling/sapling.h"
 #include "uint256.h"
 
-#include "sapling/sapling.h"
-
 #include <array>
-#include "optional.h"
 
 namespace libzcash {
 

--- a/src/sapling/sapling_operation.cpp
+++ b/src/sapling/sapling_operation.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The PIVX developers
+// Copyright (c) 2021 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 

--- a/src/sapling/sapling_operation.cpp
+++ b/src/sapling/sapling_operation.cpp
@@ -512,7 +512,7 @@ OperationResult SaplingOperation::loadUnspentNotes(TxValues& txValues, uint256& 
 
     // Fetch Sapling anchor and witnesses
     uint256 anchor;
-    std::vector<boost::optional<SaplingWitness>> witnesses;
+    std::vector<Optional<SaplingWitness>> witnesses;
     wallet->GetSaplingScriptPubKeyMan()->GetSaplingNoteWitnesses(ops, witnesses, anchor);
 
     // Add Sapling spends

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -1,9 +1,10 @@
 // Copyright (c) 2016-2020 The ZCash developers
-// Copyright (c) 2020 The PIVX developers
+// Copyright (c) 2021 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 #include "sapling/saplingscriptpubkeyman.h"
+
 #include "chain.h" // for CBlockIndex
 #include "validation.h" // for ReadBlockFromDisk()
 

--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -67,7 +67,7 @@ void SaplingScriptPubKeyMan::UpdateSaplingNullifierNoteMapWithTx(CWalletTx& wtx)
             if (nd.nullifier) {
                 mapSaplingNullifiersToNotes.erase(item.second.nullifier.get());
             }
-            nd.nullifier = boost::none;
+            nd.nullifier = nullopt;
         } else {
             const libzcash::SaplingIncomingViewingKey& ivk = *(nd.ivk);
             uint64_t position = nd.witnesses.front().position();

--- a/src/sapling/zip32.cpp
+++ b/src/sapling/zip32.cpp
@@ -59,7 +59,7 @@ uint256 ovkForShieldingFromTaddr(HDSeed& seed) {
 
 namespace libzcash {
 
-boost::optional<SaplingExtendedFullViewingKey> SaplingExtendedFullViewingKey::Derive(uint32_t i) const
+Optional<SaplingExtendedFullViewingKey> SaplingExtendedFullViewingKey::Derive(uint32_t i) const
 {
     CDataStream ss_p(SER_NETWORK, PROTOCOL_VERSION);
     ss_p << *this;
@@ -76,11 +76,11 @@ boost::optional<SaplingExtendedFullViewingKey> SaplingExtendedFullViewingKey::De
         ss_i >> xfvk_i;
         return xfvk_i;
     } else {
-        return boost::none;
+        return nullopt;
     }
 }
 
-boost::optional<std::pair<diversifier_index_t, libzcash::SaplingPaymentAddress>>
+Optional<std::pair<diversifier_index_t, libzcash::SaplingPaymentAddress>>
     SaplingExtendedFullViewingKey::Address(diversifier_index_t j) const
 {
     CDataStream ss_xfvk(SER_NETWORK, PROTOCOL_VERSION);
@@ -98,7 +98,7 @@ boost::optional<std::pair<diversifier_index_t, libzcash::SaplingPaymentAddress>>
         ss_addr >> addr;
         return std::make_pair(j_ret, addr);
     } else {
-        return boost::none;
+        return nullopt;
     }
 }
 

--- a/src/sapling/zip32.cpp
+++ b/src/sapling/zip32.cpp
@@ -1,14 +1,15 @@
-// Copyright (c) 2018 The Zcash developers
+// Copyright (c) 2018-2020 The ZCash developers
+// Copyright (c) 2021 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 #include "sapling/zip32.h"
 
 #include "hash.h"
 #include "random.h"
+#include "sapling/prf.h"
 #include "streams.h"
 #include "version.h"
-#include "sapling/prf.h"
 
 #include <librustzcash.h>
 #include <sodium.h>

--- a/src/sapling/zip32.h
+++ b/src/sapling/zip32.h
@@ -12,7 +12,7 @@
 #include "support/allocators/zeroafterfree.h"
 #include "uint256.h"
 
-#include <boost/optional.hpp>
+#include "optional.h"
 
 const uint32_t ZIP32_HARDENED_KEY_LIMIT = 0x80000000;
 const size_t ZIP32_XFVK_SIZE = 169;
@@ -59,12 +59,12 @@ struct SaplingExtendedFullViewingKey {
 
     SERIALIZE_METHODS(SaplingExtendedFullViewingKey, obj) { READWRITE(obj.depth, obj.parentFVKTag, obj.childIndex, obj.chaincode, obj.fvk, obj.dk); }
 
-    boost::optional<SaplingExtendedFullViewingKey> Derive(uint32_t i) const;
+    Optional<SaplingExtendedFullViewingKey> Derive(uint32_t i) const;
 
     // Returns the first index starting from j that generates a valid
     // payment address, along with the corresponding address. Returns
     // an error if the diversifier space is exhausted.
-    boost::optional<std::pair<diversifier_index_t, libzcash::SaplingPaymentAddress>>
+    Optional<std::pair<diversifier_index_t, libzcash::SaplingPaymentAddress>>
         Address(diversifier_index_t j) const;
 
     libzcash::SaplingPaymentAddress DefaultAddress() const;

--- a/src/sapling/zip32.h
+++ b/src/sapling/zip32.h
@@ -1,18 +1,17 @@
-// Copyright (c) 2018 The Zcash developers
+// Copyright (c) 2018-2020 The ZCash developers
+// Copyright (c) 2021 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 #ifndef PIVX_ZIP32_H
 #define PIVX_ZIP32_H
 
-#include "uint256.h"
 #include "key.h"
+#include "optional.h"
 #include "sapling/address.h"
 #include "serialize.h"
 #include "support/allocators/zeroafterfree.h"
 #include "uint256.h"
-
-#include "optional.h"
 
 const uint32_t ZIP32_HARDENED_KEY_LIMIT = 0x80000000;
 const size_t ZIP32_XFVK_SIZE = 169;

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -64,8 +64,8 @@ extern CTranslationInterface translationInterface;
  */
 inline std::string _(const char* psz)
 {
-    // todo: this boost::optional is needed for now. Will get removed moving forward
-    boost::optional<std::string> rv = translationInterface.Translate(psz);
+    // todo: this Optional is needed for now. Will get removed moving forward
+    Optional<std::string> rv = translationInterface.Translate(psz);
     return rv ? (*rv) : psz;
 }
 

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -1,9 +1,9 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin developers
 // Copyright (c) 2014-2015 The Dash developers
-// Copyright (c) 2015-2020 The PIVX developers
+// Copyright (c) 2015-2021 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 /**
  * Server/client environment: argument handling, config file parsing,
@@ -19,6 +19,7 @@
 #include "fs.h"
 #include "logging.h"
 #include "compat.h"
+#include "optional.h"
 #include "sync.h"
 #include "tinyformat.h"
 #include "utiltime.h"

--- a/src/wallet/test/wallet_shielded_balances_tests.cpp
+++ b/src/wallet/test/wallet_shielded_balances_tests.cpp
@@ -98,7 +98,7 @@ SaplingSpendValues UpdateWalletInternalNotesData(CWalletTx& wtx, const SaplingOu
             wtx.tx->sapData->vShieldedOutput[sapPoint.n].ephemeralKey,
             wtx.tx->sapData->vShieldedOutput[sapPoint.n].cmu);
     assert(static_cast<bool>(maybe_pt));
-    boost::optional<libzcash::SaplingNotePlaintext> notePlainText = maybe_pt.get();
+    Optional<libzcash::SaplingNotePlaintext> notePlainText = maybe_pt.get();
     libzcash::SaplingNote note = notePlainText->note(ivk).get();
 
     // Append note to the tree
@@ -357,7 +357,7 @@ BOOST_AUTO_TEST_CASE(GetShieldedAvailableCredit)
 
     std::vector<SaplingOutPoint> ops = {saplingEntries[0].op};
     uint256 anchor;
-    std::vector<boost::optional<SaplingWitness>> witnesses;
+    std::vector<Optional<SaplingWitness>> witnesses;
     wallet.GetSaplingScriptPubKeyMan()->GetSaplingNoteWitnesses(ops, witnesses, anchor);
     SaplingSpendValues sapSpendValues{saplingEntries[0].note, anchor, *witnesses[0]};
 

--- a/src/wallet/test/wallet_shielded_balances_tests.cpp
+++ b/src/wallet/test/wallet_shielded_balances_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The PIVX developers
+// Copyright (c) 2021 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
@@ -14,7 +14,6 @@
 #include "wallet/wallet.h"
 
 #include <boost/filesystem.hpp>
-
 #include <boost/test/unit_test.hpp>
 
 CAmount fee = COIN; // Hardcoded fee


### PR DESCRIPTION
As per title: scripted commit (plus cleanup) to remove last remaining direct usages of `boost::optional`, mostly in the sapling files.