### PR TITLE
[Refactoring] remove circular dependency primitives/transaction <-> script/standard

### DIFF
--- a/src/blocksignature.cpp
+++ b/src/blocksignature.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2020 The PIVX developers
+// Copyright (c) 2017-2021 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -6,6 +6,23 @@
 
 #include "script/standard.h"
 #include "zpivchain.h"
+
+static bool GetKeyIDFromUTXO(const CTxOut& utxo, CKeyID& keyIDRet)
+{
+    std::vector<valtype> vSolutions;
+    txnouttype whichType;
+    if (utxo.scriptPubKey.empty() || !Solver(utxo.scriptPubKey, whichType, vSolutions))
+        return false;
+    if (whichType == TX_PUBKEY) {
+        keyIDRet = CPubKey(vSolutions[0]).GetID();
+        return true;
+    }
+    if (whichType == TX_PUBKEYHASH || whichType == TX_COLDSTAKE) {
+        keyIDRet = CKeyID(uint160(vSolutions[0]));
+        return true;
+    }
+    return false;
+}
 
 bool SignBlockWithKey(CBlock& block, const CKey& key)
 {
@@ -21,7 +38,7 @@ bool SignBlock(CBlock& block, const CKeyStore& keystore)
     if (block.IsProofOfWork()) {
         bool fFoundID = false;
         for (const CTxOut& txout : block.vtx[0]->vout) {
-            if (!txout.GetKeyIDFromUTXO(keyID))
+            if (!GetKeyIDFromUTXO(txout, keyID))
                 continue;
             fFoundID = true;
             break;
@@ -29,7 +46,7 @@ bool SignBlock(CBlock& block, const CKeyStore& keystore)
         if (!fFoundID)
             return error("%s: failed to find key for PoW", __func__);
     } else {
-        if (!block.vtx[1]->vout[1].GetKeyIDFromUTXO(keyID))
+        if (!GetKeyIDFromUTXO(block.vtx[1]->vout[1], keyID))
             return error("%s: failed to find key for PoS", __func__);
     }
 

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -1,13 +1,12 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin developers
-// Copyright (c) 2015-2020 The PIVX developers
+// Copyright (c) 2015-2021 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 #include "primitives/transaction.h"
 
 #include "hash.h"
-#include "script/standard.h"
 #include "tinyformat.h"
 #include "utilstrencodings.h"
 
@@ -79,23 +78,6 @@ CTxOut::CTxOut(const CAmount& nValueIn, CScript scriptPubKeyIn)
 uint256 CTxOut::GetHash() const
 {
     return SerializeHash(*this);
-}
-
-bool CTxOut::GetKeyIDFromUTXO(CKeyID& keyIDRet) const
-{
-    std::vector<valtype> vSolutions;
-    txnouttype whichType;
-    if (scriptPubKey.empty() || !Solver(scriptPubKey, whichType, vSolutions))
-        return false;
-    if (whichType == TX_PUBKEY) {
-        keyIDRet = CPubKey(vSolutions[0]).GetID();
-        return true;
-    }
-    if (whichType == TX_PUBKEYHASH || whichType == TX_COLDSTAKE) {
-        keyIDRet = CKeyID(uint160(vSolutions[0]));
-        return true;
-    }
-    return false;
 }
 
 bool CTxOut::IsZerocoinMint() const

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin developers
-// Copyright (c) 2015-2020 The PIVX developers
+// Copyright (c) 2015-2021 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
@@ -172,7 +172,6 @@ public:
     }
 
     uint256 GetHash() const;
-    bool GetKeyIDFromUTXO(CKeyID& keyIDRet) const;
 
     bool IsZerocoinMint() const;
 

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -71,7 +71,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "kernel -> stakeinput -> wallet/wallet -> kernel"
     "legacy/validation_zerocoin_legacy -> wallet/wallet -> validation -> legacy/validation_zerocoin_legacy"
     "masternode-sync -> masternodeman -> net_processing -> masternode-sync"
-    "primitives/transaction -> script/standard -> script/interpreter -> primitives/transaction"
     "qt/askpassphrasedialog -> qt/pivx/pivxgui -> qt/pivx/topbar -> qt/askpassphrasedialog"
     "qt/pivx/coldstakingwidget -> qt/pivx/tooltipmenu -> qt/pivx/pivxgui -> qt/pivx/coldstakingwidget"
     "qt/pivx/masternodeswidget -> qt/pivx/tooltipmenu -> qt/pivx/pivxgui -> qt/pivx/masternodeswidget"


### PR DESCRIPTION
by moving `GetKeyIDFromUTXO` out of `CTxOut`, making it a static function of `blocksignature.cpp`, which is the only place using it.

based on top of:
- [x] #2641 