### PR TITLE
[wallet] Reopen CDBEnv after encryption instead of shutting down

### DIFF
--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -351,9 +351,9 @@ void AskPassphraseDialog::warningMessage()
     openStandardDialog(
             tr("Wallet encrypted"),
             "<qt>" +
-            tr("%1 will close now to finish the encryption process. "
+            tr("Your wallet is now encrypted. "
                "Remember that encrypting your wallet cannot fully protect "
-               "your PIVs from being stolen by malware infecting your computer.").arg(PACKAGE_NAME) +
+               "your PIVs from being stolen by malware infecting your computer.") +
             "<br><br><b>" +
             tr("IMPORTANT: Any previous backups you have made of your wallet file "
                "should be replaced with the newly generated, encrypted wallet file. "
@@ -362,7 +362,6 @@ void AskPassphraseDialog::warningMessage()
             "</b></qt>",
             tr("OK")
             );
-    QApplication::quit();
 }
 
 void AskPassphraseDialog::errorEncryptingWallet()

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -556,6 +556,7 @@ void BerkeleyBatch::Close()
         LOCK(cs_db);
         --env->mapFileUseCount[strFile];
     }
+    env->m_db_in_use.notify_all();
 }
 
 void BerkeleyEnvironment::CloseDb(const std::string& strFile)
@@ -570,6 +571,32 @@ void BerkeleyEnvironment::CloseDb(const std::string& strFile)
             mapDb[strFile] = NULL;
         }
     }
+}
+
+void BerkeleyEnvironment::ReloadDbEnv()
+{
+    // Make sure that no Db's are in use
+    AssertLockNotHeld(cs_db);
+    std::unique_lock<RecursiveMutex> lock(cs_db);
+    m_db_in_use.wait(lock, [this](){
+        for (auto& count : mapFileUseCount) {
+            if (count.second > 0) return false;
+        }
+        return true;
+    });
+
+    std::vector<std::string> filenames;
+    for (auto it : mapDb) {
+        filenames.push_back(it.first);
+    }
+    // Close the individual Db's
+    for (const std::string& filename : filenames) {
+        CloseDb(filename);
+    }
+    // Reset the environment
+    Flush(true); // This will flush and close the environment
+    Reset();
+    Open(true);
 }
 
 bool BerkeleyBatch::Rewrite(BerkeleyDatabase& database, const char* pszSkip)
@@ -801,5 +828,12 @@ void BerkeleyDatabase::Flush(bool shutdown)
             g_dbenvs.erase(env->Directory().string());
             env = nullptr;
         }
+    }
+}
+
+void BerkeleyDatabase::ReloadDbEnv()
+{
+    if (!IsDummy()) {
+        env->ReloadDbEnv();
     }
 }

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -803,9 +803,3 @@ void BerkeleyDatabase::Flush(bool shutdown)
         }
     }
 }
-
-void BerkeleyDatabase::CloseAndReset()
-{
-    env->Close();
-    env->Reset();
-}

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -173,6 +173,7 @@ bool BerkeleyEnvironment::Open(bool retry)
         S_IRUSR | S_IWUSR);
     if (ret != 0) {
         dbenv->close(0);
+        Reset();
         LogPrintf("BerkeleyEnvironment::Open: Error %d opening database environment: %s\n", ret, DbEnv::strerror(ret));
         if (retry) {
             // try moving the database env out of the way

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -697,7 +697,6 @@ void BerkeleyEnvironment::Flush(bool fShutdown)
                 if (!fMockDb) {
                     fs::remove_all(fs::path(strPath) / "database");
                 }
-                g_dbenvs.erase(strPath);
             }
         }
     }
@@ -797,7 +796,11 @@ void BerkeleyDatabase::Flush(bool shutdown)
 {
     if (!IsDummy()) {
         env->Flush(shutdown);
-        if (shutdown) env = nullptr;
+        if (shutdown) {
+            LOCK(cs_db);
+            g_dbenvs.erase(env->Directory().string());
+            env = nullptr;
+        }
     }
 }
 

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -143,10 +143,6 @@ public:
      */
     void Flush(bool shutdown);
 
-    /** Close and reset.
-     */
-    void CloseAndReset();
-
     void IncrementUpdateCounter();
     std::atomic<unsigned int> nUpdateCounter;
     unsigned int nLastSeen;

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -37,6 +37,7 @@ public:
     std::unique_ptr<DbEnv> dbenv;
     std::map<std::string, int> mapFileUseCount;
     std::map<std::string, Db*> mapDb;
+    std::condition_variable_any m_db_in_use;
 
     BerkeleyEnvironment(const fs::path& env_directory);
     ~BerkeleyEnvironment();
@@ -75,6 +76,7 @@ public:
     void CheckpointLSN(const std::string& strFile);
 
     void CloseDb(const std::string& strFile);
+    void ReloadDbEnv();
 
     DbTxn* TxnBegin(int flags = DB_TXN_WRITE_NOSYNC)
     {
@@ -144,6 +146,9 @@ public:
     void Flush(bool shutdown);
 
     void IncrementUpdateCounter();
+
+    void ReloadDbEnv();
+
     std::atomic<unsigned int> nUpdateCounter;
     unsigned int nLastSeen;
     unsigned int nLastFlushed;

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -17,12 +17,18 @@
 #include <atomic>
 #include <map>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <db_cxx.h>
 
 static const unsigned int DEFAULT_WALLET_DBLOGSIZE = 100;
 static const bool DEFAULT_WALLET_PRIVDB = true;
+
+struct WalletDatabaseFileId {
+    u_int8_t value[DB_FILE_ID_LEN];
+    bool operator==(const WalletDatabaseFileId& rhs) const;
+};
 
 class BerkeleyEnvironment
 {
@@ -37,6 +43,7 @@ public:
     std::unique_ptr<DbEnv> dbenv;
     std::map<std::string, int> mapFileUseCount;
     std::map<std::string, Db*> mapDb;
+    std::unordered_map<std::string, WalletDatabaseFileId> m_fileids;
     std::condition_variable_any m_db_in_use;
 
     BerkeleyEnvironment(const fs::path& env_directory);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3630,7 +3630,6 @@ UniValue encryptwallet(const JSONRPCRequest& request)
             "will require the passphrase to be set prior the making these calls.\n"
             "Use the walletpassphrase call for this, and then walletlock call.\n"
             "If the wallet is already encrypted, use the walletpassphrasechange call.\n"
-            "Note that this will shutdown the server.\n"
 
             "\nArguments:\n"
             "1. \"passphrase\"    (string) The pass phrase to encrypt the wallet with. It must be at least 1 character, but should be long.\n"
@@ -3669,11 +3668,7 @@ UniValue encryptwallet(const JSONRPCRequest& request)
     if (!pwallet->EncryptWallet(strWalletPass))
         throw JSONRPCError(RPC_WALLET_ENCRYPTION_FAILED, "Error: Failed to encrypt the wallet.");
 
-    // BDB seems to have a bad habit of writing old data into
-    // slack space in .dat files; that is bad if the old data is
-    // unencrypted private keys. So:
-    StartShutdown();
-    return "wallet encrypted; pivx server stopping, restart to run with encrypted wallet. The keypool has been flushed, you need to make a new backup.";
+    return "wallet encrypted; The keypool has been flushed, you need to make a new backup.";
 }
 
 UniValue listunspent(const JSONRPCRequest& request)

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -10,8 +10,10 @@
 #include "wallet/rpcwallet.h"
 #include "wallet/wallet.h"
 
-WalletTestingSetup::WalletTestingSetup(const std::string& chainName):
-        SaplingTestingSetup(chainName), m_wallet("mock", WalletDatabase::CreateMock())
+WalletTestingSetupBase::WalletTestingSetupBase(const std::string& chainName,
+                                               const std::string& wallet_name,
+                                               std::unique_ptr<WalletDatabase> db) :
+        SaplingTestingSetup(chainName), m_wallet(wallet_name, std::move(db))
 {
     bool fFirstRun;
     m_wallet.LoadWallet(fFirstRun);
@@ -20,7 +22,10 @@ WalletTestingSetup::WalletTestingSetup(const std::string& chainName):
     RegisterWalletRPCCommands(tableRPC);
 }
 
-WalletTestingSetup::~WalletTestingSetup()
+WalletTestingSetupBase::~WalletTestingSetupBase()
 {
     UnregisterValidationInterface(&m_wallet);
 }
+
+WalletTestingSetup::WalletTestingSetup(const std::string& chainName) :
+        WalletTestingSetupBase(chainName, "mock", WalletDatabase::CreateMock()) {}

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -12,12 +12,18 @@
 
 /** Testing setup and teardown for wallet.
  */
-struct WalletTestingSetup : public SaplingTestingSetup
+struct WalletTestingSetupBase : public SaplingTestingSetup
+{
+    WalletTestingSetupBase(const std::string& chainName,
+                           const std::string& wallet_name,
+                           std::unique_ptr<WalletDatabase> db);
+    ~WalletTestingSetupBase();
+    CWallet m_wallet;
+};
+
+struct WalletTestingSetup : public WalletTestingSetupBase
 {
     WalletTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
-    ~WalletTestingSetup();
-
-    CWallet m_wallet;
 };
 
 struct WalletRegTestingSetup : public WalletTestingSetup

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -879,6 +879,12 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
         // Need to completely rewrite the wallet file; if we don't, bdb might keep
         // bits of the unencrypted private key in slack space in the database file.
         database->Rewrite();
+
+        // BDB seems to have a bad habit of writing old data into
+        // slack space in .dat files; that is bad if the old data is
+        // unencrypted private keys. So:
+        database->ReloadDbEnv();
+
     }
     NotifyStatusChanged(this);
 

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -10,7 +10,6 @@ from test_framework.util import (
     assert_raises_rpc_error,
     assert_greater_than,
     assert_greater_than_or_equal,
-    connect_nodes,
     count_bytes,
     find_vout_for_address,
     Decimal,
@@ -371,11 +370,7 @@ class RawTransactionsTest(PivxTestFramework):
     def test_locked_wallet(self):
         self.log.info("test locked wallet")
 
-        self.nodes[1].node_encrypt_wallet("test")
-        self.start_node(1)
-        connect_nodes(self.nodes[0], 1)
-        connect_nodes(self.nodes[1], 2)
-        self.sync_all()
+        self.nodes[1].encryptwallet("test")
 
         # Drain the keypool.
         self.nodes[1].getnewaddress()

--- a/test/functional/sapling_wallet_nullifiers.py
+++ b/test/functional/sapling_wallet_nullifiers.py
@@ -7,11 +7,7 @@
 from decimal import Decimal
 
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import assert_equal, assert_true, connect_nodes, get_coinstake_address
-
-def connect_nodes_bi(nodes, a, b):
-    connect_nodes(nodes[a], b)
-    connect_nodes(nodes[b], a)
+from test_framework.util import assert_equal, assert_true, get_coinstake_address
 
 class WalletNullifiersTest(PivxTestFramework):
 
@@ -45,14 +41,7 @@ class WalletNullifiersTest(PivxTestFramework):
         self.nodes[1].importsaplingkey(myzkey)
 
         # encrypt node 1 wallet and wait to terminate
-        self.nodes[1].node_encrypt_wallet("test")
-
-        # restart node 1
-        self.start_node(1, self.extra_args[1])
-        connect_nodes_bi(self.nodes, 0, 1)
-        connect_nodes_bi(self.nodes, 2, 1)
-        connect_nodes_bi(self.nodes, 3, 1)
-        self.sync_all()
+        self.nodes[1].encryptwallet("test")
 
         # send node 0  shield addr to note 2 zaddr
         recipients = []

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -277,14 +277,6 @@ class TestNode():
                 if re.search(re.escape(expected_msg), log, flags=re.MULTILINE) is None:
                     raise AssertionError('Expected message "{}" does not partially match log:\n\n{}\n\n'.format(expected_msg, print_log))
 
-    def node_encrypt_wallet(self, passphrase):
-        """"Encrypts the wallet.
-
-        This causes pivxd to shutdown, so this method takes
-        care of cleaning up resources."""
-        self.encryptwallet(passphrase)
-        self.wait_until_stopped()
-
     def add_p2p_connection(self, p2p_conn, *args, wait_for_verack=True, **kwargs):
         """Add a p2p connection to the node.
 

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -26,7 +26,6 @@ from test_framework.util import (
     assert_greater_than,
     assert_raises_rpc_error,
     bytes_to_hex_str,
-    connect_nodes,
     hex_str_to_bytes
 )
 
@@ -47,11 +46,9 @@ class BumpFeeTest(PivxTestFramework):
 
     def run_test(self):
         # Encrypt wallet for test_locked_wallet_fails test
-        self.nodes[1].node_encrypt_wallet(WALLET_PASSPHRASE)
-        self.start_node(1)
+        self.nodes[1].encryptwallet(WALLET_PASSPHRASE)
         self.nodes[1].walletpassphrase(WALLET_PASSPHRASE, WALLET_PASSPHRASE_TIMEOUT)
 
-        connect_nodes(self.nodes[0], 1)
         self.sync_all()
 
         peer_node, rbf_node = self.nodes

--- a/test/functional/wallet_dump.py
+++ b/test/functional/wallet_dump.py
@@ -107,8 +107,7 @@ class WalletDumpTest(PivxTestFramework):
         assert_equal(found_addr_rsv, 90 * 3)  # 90 keys external plus 100% internal keys plus 100% staking keys
 
         #encrypt wallet, restart, unlock and dump
-        self.nodes[0].node_encrypt_wallet('test')
-        self.start_node(0)
+        self.nodes[0].encryptwallet('test')
         self.nodes[0].walletpassphrase('test', 10)
         # Should be a no-op:
         self.nodes[0].keypoolrefill()

--- a/test/functional/wallet_encryption.py
+++ b/test/functional/wallet_encryption.py
@@ -31,8 +31,7 @@ class WalletEncryptionTest(PivxTestFramework):
         assert_equal(len(privkey), 52)
 
         # Encrypt the wallet
-        self.nodes[0].node_encrypt_wallet(passphrase)
-        self.start_node(0)
+        self.nodes[0].encryptwallet(passphrase)
 
         # Test that the wallet is encrypted
         assert_raises_rpc_error(-13, "Please enter the wallet passphrase with walletpassphrase first", self.nodes[0].dumpprivkey, address)

--- a/test/functional/wallet_keypool.py
+++ b/test/functional/wallet_keypool.py
@@ -21,9 +21,7 @@ class KeyPoolTest(PivxTestFramework):
         nodes[0].validateaddress(addr_before_encrypting)
 
         # Encrypt wallet and wait to terminate
-        nodes[0].node_encrypt_wallet('test')
-        # Restart node 0
-        self.start_node(0, self.extra_args[0])
+        nodes[0].encryptwallet('test')
         # Keep creating keys
         addr = nodes[0].getnewaddress()
         nodes[0].validateaddress(addr)


### PR DESCRIPTION
An improvement for the wallet UX: Stop requiring a wallet shutdown after the initial encryption. Now the process can safely continue running without any fear of leaking unencrypted keys.

PRs backported from upstream:

* #12493.
* #13161.
* #14320.