### PR TITLE
[budget] Do not count votes twice after calling GetBudgetWithHighestVoteCount.

### DIFF
--- a/src/budget/budgetmanager.h
+++ b/src/budget/budgetmanager.h
@@ -42,8 +42,13 @@ protected:
     // who's asked for the complete budget sync and the last time
     std::map<CNetAddr, int64_t> mAskedUsForBudgetSync; // guarded by cs_budgets and cs_proposals.
 
+    struct HighestFinBudget {
+        const CFinalizedBudget* m_budget_fin{nullptr};
+        int m_vote_count{0};
+    };
+
     // Returns a const pointer to the budget with highest vote count
-    const CFinalizedBudget* GetBudgetWithHighestVoteCount(int chainHeight) const;
+    HighestFinBudget GetBudgetWithHighestVoteCount(int chainHeight) const;
     int GetHighestVoteCount(int chainHeight) const;
     // Get the payee and amount for the budget with the highest vote count
     bool GetPayeeAndAmount(int chainHeight, CScript& payeeRet, CAmount& nAmountRet) const;

--- a/src/budget/budgetproposal.cpp
+++ b/src/budget/budgetproposal.cpp
@@ -4,8 +4,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "budget/budgetproposal.h"
-
-#include "masternodeman.h"
+#include "chainparams.h"
+#include "script/standard.h"
 
 CBudgetProposal::CBudgetProposal():
         nAllotted(0),
@@ -77,9 +77,9 @@ void CBudgetProposal::SyncVotes(CNode* pfrom, bool fPartial, int& nInvCount) con
     }
 }
 
-bool CBudgetProposal::IsHeavilyDownvoted(bool fNewRules)
+bool CBudgetProposal::IsHeavilyDownvoted(bool fNewRules, int mnCount)
 {
-    if (GetNays() - GetYeas() > (fNewRules ? 3 : 1) * mnodeman.CountEnabled() / 10) {
+    if (GetNays() - GetYeas() > (fNewRules ? 3 : 1) * mnCount / 10) {
         strInvalid = "Heavily Downvoted";
         return true;
     }
@@ -166,7 +166,7 @@ bool CBudgetProposal::updateExpired(int nCurrentHeight)
     return false;
 }
 
-bool CBudgetProposal::UpdateValid(int nCurrentHeight)
+bool CBudgetProposal::UpdateValid(int nCurrentHeight, int mnCount)
 {
     fValid = false;
 
@@ -175,7 +175,7 @@ bool CBudgetProposal::UpdateValid(int nCurrentHeight)
 
     // Never kill a proposal before the first superblock
     if (!fNewRules || nCurrentHeight > nBlockStart) {
-        if (IsHeavilyDownvoted(fNewRules)) return false;
+        if (IsHeavilyDownvoted(fNewRules, mnCount)) return false;
     }
 
     if (updateExpired(nCurrentHeight)) {

--- a/src/budget/budgetproposal.h
+++ b/src/budget/budgetproposal.h
@@ -33,7 +33,7 @@ private:
     std::string strInvalid;
 
     // Functions used inside UpdateValid()/IsWellFormed - setting strInvalid
-    bool IsHeavilyDownvoted(bool fNewRules);
+    bool IsHeavilyDownvoted(bool fNewRules, int mnCount);
     bool updateExpired(int nCurrentHeight);
     bool CheckStartEnd();
     bool CheckAmount(const CAmount& nTotalBudget);
@@ -64,7 +64,7 @@ public:
     void SyncVotes(CNode* pfrom, bool fPartial, int& nInvCount) const;
 
     // sets fValid and strInvalid, returns fValid
-    bool UpdateValid(int nHeight);
+    bool UpdateValid(int nHeight, int mnCount);
     // Static checks that should be done only once - sets strInvalid
     bool IsWellFormed(const CAmount& nTotalBudget);
     bool IsValid() const  { return fValid; }


### PR DESCRIPTION
The function is already counting the votes, just need to return the value.

Plus, removed `budgetproposal` dependency on `masternodeman`.