### PR TITLE
[TierTwo] Fix and improve several synchronization problems

### DIFF
--- a/src/budget/budgetmanager.cpp
+++ b/src/budget/budgetmanager.cpp
@@ -1360,7 +1360,7 @@ void CBudgetManager::Sync(CNode* pfrom, const uint256& nProp, bool fPartial)
     g_connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::SYNCSTATUSCOUNT, MASTERNODE_SYNC_BUDGET_FIN, nInvCount));
     LogPrint(BCLog::MNBUDGET, "%s: sent %d items\n", __func__, nInvCount);
 
-    {
+    if (!fPartial && nProp.IsNull()) { // Only for external full budget sync requests
         // Now that budget full sync request was handled, mark it as completed.
         // We are not going to answer full budget sync requests for an hour (BUDGET_SYNC_REQUEST_ACCEPTANCE_SECONDS).
         // The remote peer can still do single prop and mnv sync requests if needed.

--- a/src/budget/budgetmanager.cpp
+++ b/src/budget/budgetmanager.cpp
@@ -952,8 +952,8 @@ void CBudgetManager::NewBlock()
     // incremental sync with our peers
     if (masternodeSync.IsSynced()) {
         LogPrint(BCLog::MNBUDGET,"%s:  incremental sync started\n", __func__);
-        if (GetRandInt(1440) == 0) {
-            ClearSeen();
+        // Once every 7 days, try to relay the complete budget data
+        if (GetRandInt(Params().IsRegTestNet() ? 2 : 720) == 0) {
             ResetSync();
         }
 
@@ -1028,6 +1028,11 @@ void CBudgetManager::NewBlock()
     cleanOrphans(cs_votes, mapOrphanProposalVotes, mapSeenProposalVotes);
     // Clean orphan budget votes if no parent arrived after an hour.
     cleanOrphans(cs_finalizedvotes, mapOrphanFinalizedBudgetVotes, mapSeenFinalizedBudgetVotes);
+
+    // Once every 2 weeks (1/14 * 1/1440), clean the seen maps
+    if (masternodeSync.IsSynced() && GetRandInt(1440) == 0) {
+        ClearSeen();
+    }
 
     LogPrint(BCLog::MNBUDGET,"%s:  PASSED\n", __func__);
 }

--- a/src/budget/budgetmanager.h
+++ b/src/budget/budgetmanager.h
@@ -12,6 +12,8 @@
 
 class CValidationState;
 
+#define ORPHAN_VOTES_CACHE_LIMIT 10000
+
 //
 // Budget Manager : Contains all proposals for the budget
 //
@@ -31,9 +33,11 @@ protected:
     std::map<uint256, CFinalizedBudget> mapFinalizedBudgets;                // guarded by cs_budgets
 
     std::map<uint256, CBudgetVote> mapSeenProposalVotes;                    // guarded by cs_votes
-    std::map<uint256, std::vector<CBudgetVote>> mapOrphanProposalVotes;        // guarded by cs_votes
+    typedef std::pair<std::vector<CBudgetVote>, int64_t> PropVotesAndLastVoteReceivedTime;
+    std::map<uint256, PropVotesAndLastVoteReceivedTime> mapOrphanProposalVotes;        // guarded by cs_votes
     std::map<uint256, CFinalizedBudgetVote> mapSeenFinalizedBudgetVotes;    // guarded by cs_finalizedvotes
-    std::map<uint256, std::vector<CFinalizedBudgetVote>> mapOrphanFinalizedBudgetVotes;  // guarded by cs_finalizedvotes
+    typedef std::pair<std::vector<CFinalizedBudgetVote>, int64_t> BudVotesAndLastVoteReceivedTime;
+    std::map<uint256, BudVotesAndLastVoteReceivedTime> mapOrphanFinalizedBudgetVotes;  // guarded by cs_finalizedvotes
 
     // Memory Only. Updated in NewBlock (blocks arrive in order)
     std::atomic<int> nBestHeight;

--- a/src/budget/budgetmanager.h
+++ b/src/budget/budgetmanager.h
@@ -66,18 +66,15 @@ public:
 
     CBudgetManager() {}
 
-    void ClearSeen()
-    {
-        WITH_LOCK(cs_votes, mapSeenProposalVotes.clear(); );
-        WITH_LOCK(cs_finalizedvotes, mapSeenFinalizedBudgetVotes.clear(); );
-    }
-
     void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
 
     bool HaveProposal(const uint256& propHash) const { LOCK(cs_proposals); return mapProposals.count(propHash); }
     bool HaveSeenProposalVote(const uint256& voteHash) const { LOCK(cs_votes); return mapSeenProposalVotes.count(voteHash); }
     bool HaveFinalizedBudget(const uint256& budgetHash) const { LOCK(cs_budgets); return mapFinalizedBudgets.count(budgetHash); }
     bool HaveSeenFinalizedBudgetVote(const uint256& voteHash) const { LOCK(cs_finalizedvotes); return mapSeenFinalizedBudgetVotes.count(voteHash); }
+
+    // Clears and reloads seen votes in the maps, and clears orphan votes
+    void ReloadMapSeen();
 
     void AddSeenProposalVote(const CBudgetVote& vote);
     void AddSeenFinalizedBudgetVote(const CFinalizedBudgetVote& vote);

--- a/src/budget/budgetmanager.h
+++ b/src/budget/budgetmanager.h
@@ -98,7 +98,10 @@ public:
 
     void ResetSync() { SetSynced(false); }
     void MarkSynced() { SetSynced(true); }
-    void Sync(CNode* node, const uint256& nProp, bool fPartial = false);
+    // Respond to full budget sync requests and internally triggered partial budget items relay
+    void Sync(CNode* node, bool fPartial);
+    // Respond to single budget item requests (proposals / budget finalization)
+    void SyncSingleItem(CNode* pfrom, const uint256& nProp);
     void SetBestHeight(int height) { nBestHeight.store(height, std::memory_order_release); };
     int GetBestHeight() const { return nBestHeight.load(std::memory_order_acquire); }
 

--- a/src/budget/budgetmanager.h
+++ b/src/budget/budgetmanager.h
@@ -31,9 +31,9 @@ protected:
     std::map<uint256, CFinalizedBudget> mapFinalizedBudgets;                // guarded by cs_budgets
 
     std::map<uint256, CBudgetVote> mapSeenProposalVotes;                    // guarded by cs_votes
-    std::map<uint256, CBudgetVote> mapOrphanProposalVotes;                  // guarded by cs_votes
+    std::map<uint256, std::vector<CBudgetVote>> mapOrphanProposalVotes;        // guarded by cs_votes
     std::map<uint256, CFinalizedBudgetVote> mapSeenFinalizedBudgetVotes;    // guarded by cs_finalizedvotes
-    std::map<uint256, CFinalizedBudgetVote> mapOrphanFinalizedBudgetVotes;  // guarded by cs_finalizedvotes
+    std::map<uint256, std::vector<CFinalizedBudgetVote>> mapOrphanFinalizedBudgetVotes;  // guarded by cs_finalizedvotes
 
     // Memory Only. Updated in NewBlock (blocks arrive in order)
     std::atomic<int> nBestHeight;
@@ -140,7 +140,7 @@ public:
     uint256 SubmitFinalBudget();
 
     bool UpdateProposal(const CBudgetVote& vote, CNode* pfrom, std::string& strError);
-    bool UpdateFinalizedBudget(CFinalizedBudgetVote& vote, CNode* pfrom, std::string& strError);
+    bool UpdateFinalizedBudget(const CFinalizedBudgetVote& vote, CNode* pfrom, std::string& strError);
     TrxValidationStatus IsTransactionValid(const CTransaction& txNew, const uint256& nBlockHash, int nBlockHeight) const;
     std::string GetRequiredPaymentsString(int nBlockHeight);
     bool FillBlockPayee(CMutableTransaction& txCoinbase, CMutableTransaction& txCoinstake, const int nHeight, bool fProofOfStake) const;

--- a/src/budget/budgetproposal.cpp
+++ b/src/budget/budgetproposal.cpp
@@ -239,12 +239,6 @@ bool CBudgetProposal::AddOrUpdateVote(const CBudgetVote& vote, std::string& strE
         strAction = "Existing vote updated:";
     }
 
-    if (voteTime > GetTime() + (60 * 60)) {
-        strError = strprintf("new vote is too far ahead of current time - %s - nTime %lli - Max Time %lli\n", vote.GetHash().ToString(), voteTime, GetTime() + (60 * 60));
-        LogPrint(BCLog::MNBUDGET, "%s: %s\n", __func__, strError);
-        return false;
-    }
-
     mapVotes[mnId] = vote;
     LogPrint(BCLog::MNBUDGET, "%s: %s %s\n", __func__, strAction.c_str(), vote.GetHash().ToString().c_str());
 

--- a/src/budget/finalizedbudget.cpp
+++ b/src/budget/finalizedbudget.cpp
@@ -73,13 +73,6 @@ bool CFinalizedBudget::AddOrUpdateVote(const CFinalizedBudgetVote& vote, std::st
         strAction = "Existing vote updated:";
     }
 
-    if (voteTime > GetTime() + (60 * 60)) {
-        strError = strprintf("new vote is too far ahead of current time - %s - nTime %lli - Max Time %lli\n",
-                vote.GetHash().ToString(), voteTime, GetTime() + (60 * 60));
-        LogPrint(BCLog::MNBUDGET, "%s: %s\n", __func__, strError);
-        return false;
-    }
-
     mapVotes[mnId] = vote;
     LogPrint(BCLog::MNBUDGET, "%s: %s %s\n", __func__, strAction.c_str(), vote.GetHash().ToString().c_str());
     return true;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1819,7 +1819,7 @@ bool AppInitMain()
 
     //flag our cached items so we send them to our peers
     g_budgetman.ResetSync();
-    g_budgetman.ClearSeen();
+    g_budgetman.ReloadMapSeen();
 
     RegisterValidationInterface(&g_budgetman);
 

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -220,17 +220,12 @@ std::string CMasternodeSync::GetSyncStatus()
     return "";
 }
 
-void CMasternodeSync::ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv)
+void CMasternodeSync::ProcessSyncStatusMsg(int nItemID, int nCount)
 {
-    if (strCommand == NetMsgType::SYNCSTATUSCOUNT) { //Sync status count
-        int nItemID;
-        int nCount;
-        vRecv >> nItemID >> nCount;
+    if (RequestedMasternodeAssets >= MASTERNODE_SYNC_FINISHED) return;
 
-        if (RequestedMasternodeAssets >= MASTERNODE_SYNC_FINISHED) return;
-
-        //this means we will receive no further communication
-        switch (nItemID) {
+    //this means we will receive no further communication
+    switch (nItemID) {
         case (MASTERNODE_SYNC_LIST):
             if (nItemID != RequestedMasternodeAssets) return;
             sumMasternodeList += nCount;
@@ -251,10 +246,11 @@ void CMasternodeSync::ProcessMessage(CNode* pfrom, std::string& strCommand, CDat
             sumBudgetItemFin += nCount;
             countBudgetItemFin++;
             break;
-        }
-
-        LogPrint(BCLog::MASTERNODE, "CMasternodeSync:ProcessMessage - ssc - got inventory count %d %d\n", nItemID, nCount);
+        default:
+            break;
     }
+
+    LogPrint(BCLog::MASTERNODE, "CMasternodeSync:ProcessMessage - ssc - got inventory count %d %d\n", nItemID, nCount);
 }
 
 void CMasternodeSync::ClearFulfilledRequest()

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -402,6 +402,10 @@ bool CMasternodeSync::SyncWithNode(CNode* pnode, bool fLegacyMnObsolete)
 
         if (lastMasternodeWinner > 0 && lastMasternodeWinner < GetTime() - MASTERNODE_SYNC_TIMEOUT * 2 && RequestedMasternodeAttempt >= MASTERNODE_SYNC_THRESHOLD) { //hasn't received a new item in the last five seconds, so we'll move to the
             SwitchToNextAsset();
+            // in case we received a budget item while we were syncing the mnw, let's reset the last budget item received time.
+            // reason: if we received for example a single proposal +50 seconds ago, then once the budget sync starts (right after this call),
+            // it will look like the sync is finished, and will not wait to receive any budget data and declare the sync over.
+            lastBudgetItem = 0;
             return false;
         }
 
@@ -412,6 +416,11 @@ bool CMasternodeSync::SyncWithNode(CNode* pnode, bool fLegacyMnObsolete)
                 syncTimeout("MASTERNODE_SYNC_MNW");
             } else {
                 SwitchToNextAsset();
+                // Same as above (future: remove all of this duplicated code in v6.0.)
+                // in case we received a budget item while we were syncing the mnw, let's reset the last budget item received time.
+                // reason: if we received for example a single proposal +50 seconds ago, then once the budget sync starts (right after this call),
+                // it will look like the sync is finished, and will not wait to receive any budget data and declare the sync over.
+                lastBudgetItem = 0;
             }
             return false;
         }

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -346,127 +346,129 @@ bool CMasternodeSync::SyncWithNode(CNode* pnode, bool fLegacyMnObsolete)
         return false;
     }
 
-    if (pnode->nVersion >= ActiveProtocol()) {
-        if (RequestedMasternodeAssets == MASTERNODE_SYNC_LIST) {
-            if (fLegacyMnObsolete) {
-                SwitchToNextAsset();
-                return false;
-            }
+    if (pnode->nVersion < ActiveProtocol()) {
+        return true; // move to next peer
+    }
 
-            LogPrint(BCLog::MASTERNODE, "CMasternodeSync::Process() - lastMasternodeList %lld (GetTime() - MASTERNODE_SYNC_TIMEOUT) %lld\n", lastMasternodeList, GetTime() - MASTERNODE_SYNC_TIMEOUT);
-            if (lastMasternodeList > 0 && lastMasternodeList < GetTime() - MASTERNODE_SYNC_TIMEOUT * 8 && RequestedMasternodeAttempt >= MASTERNODE_SYNC_THRESHOLD) {
-                // hasn't received a new item in the last 40 seconds AND has sent at least a minimum of MASTERNODE_SYNC_THRESHOLD GETMNLIST requests,
-                // so we'll move to the next asset.
-                SwitchToNextAsset();
-                return false;
-            }
-
-            // timeout
-            if (lastMasternodeList == 0 &&
-                (RequestedMasternodeAttempt >= MASTERNODE_SYNC_THRESHOLD * 3 || GetTime() - nAssetSyncStarted > MASTERNODE_SYNC_TIMEOUT * 5)) {
-                if (sporkManager.IsSporkActive(SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT)) {
-                    syncTimeout("MASTERNODE_SYNC_LIST");
-                } else {
-                    SwitchToNextAsset();
-                }
-                return false;
-            }
-
-            // Don't request mnlist initial sync to more than 8 randomly ordered peers in this round
-            if (RequestedMasternodeAttempt >= MASTERNODE_SYNC_THRESHOLD * 4) return false;
-
-            // Request mnb sync if we haven't requested it yet.
-            if (pnode->HasFulfilledRequest("mnsync")) return true;
-
-            // Try to request MN list sync.
-            if (!mnodeman.RequestMnList(pnode)) {
-                return true; // Failed, try next peer.
-            }
-
-            // Mark sync requested.
-            pnode->FulfilledRequest("mnsync");
-            // Increase the sync attempt count
-            RequestedMasternodeAttempt++;
-
-            return false; // sleep 1 second before do another request round.
+    if (RequestedMasternodeAssets == MASTERNODE_SYNC_LIST) {
+        if (fLegacyMnObsolete) {
+            SwitchToNextAsset();
+            return false;
         }
 
-        if (RequestedMasternodeAssets == MASTERNODE_SYNC_MNW) {
-            if (fLegacyMnObsolete) {
-                SwitchToNextAsset();
-                return false;
-            }
-
-            if (lastMasternodeWinner > 0 && lastMasternodeWinner < GetTime() - MASTERNODE_SYNC_TIMEOUT * 2 && RequestedMasternodeAttempt >= MASTERNODE_SYNC_THRESHOLD) { //hasn't received a new item in the last five seconds, so we'll move to the
-                SwitchToNextAsset();
-                return false;
-            }
-
-            // timeout
-            if (lastMasternodeWinner == 0 &&
-                (RequestedMasternodeAttempt >= MASTERNODE_SYNC_THRESHOLD * 3 || GetTime() - nAssetSyncStarted > MASTERNODE_SYNC_TIMEOUT * 5)) {
-                if (sporkManager.IsSporkActive(SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT)) {
-                    syncTimeout("MASTERNODE_SYNC_MNW");
-                } else {
-                    SwitchToNextAsset();
-                }
-                return false;
-            }
-
-            // Don't request mnw initial sync to more than 6 randomly ordered peers in this round.
-            if (RequestedMasternodeAttempt >= MASTERNODE_SYNC_THRESHOLD * 3) return false;
-
-            // Request mnw sync if we haven't requested it yet.
-            if (pnode->HasFulfilledRequest("mnwsync")) return true;
-
-            // Mark sync requested.
-            pnode->FulfilledRequest("mnwsync");
-
-            // Sync mn winners
-            int nMnCount = mnodeman.CountEnabled(true /* only_legacy */);
-            g_connman->PushMessage(pnode, msgMaker.Make(NetMsgType::GETMNWINNERS, nMnCount));
-            RequestedMasternodeAttempt++;
-
-            return false; // sleep 1 second before do another request round.
+        LogPrint(BCLog::MASTERNODE, "CMasternodeSync::Process() - lastMasternodeList %lld (GetTime() - MASTERNODE_SYNC_TIMEOUT) %lld\n", lastMasternodeList, GetTime() - MASTERNODE_SYNC_TIMEOUT);
+        if (lastMasternodeList > 0 && lastMasternodeList < GetTime() - MASTERNODE_SYNC_TIMEOUT * 8 && RequestedMasternodeAttempt >= MASTERNODE_SYNC_THRESHOLD) {
+            // hasn't received a new item in the last 40 seconds AND has sent at least a minimum of MASTERNODE_SYNC_THRESHOLD GETMNLIST requests,
+            // so we'll move to the next asset.
+            SwitchToNextAsset();
+            return false;
         }
 
-        if (RequestedMasternodeAssets == MASTERNODE_SYNC_BUDGET) {
-            // We'll start rejecting votes if we accidentally get set as synced too soon
-            if (lastBudgetItem > 0 && lastBudgetItem < GetTime() - MASTERNODE_SYNC_TIMEOUT * 10 && RequestedMasternodeAttempt >= MASTERNODE_SYNC_THRESHOLD) {
-                // Hasn't received a new item in the last fifty seconds and more than MASTERNODE_SYNC_THRESHOLD requests were sent,
-                // so we'll move to the next asset
+        // timeout
+        if (lastMasternodeList == 0 &&
+            (RequestedMasternodeAttempt >= MASTERNODE_SYNC_THRESHOLD * 3 || GetTime() - nAssetSyncStarted > MASTERNODE_SYNC_TIMEOUT * 5)) {
+            if (sporkManager.IsSporkActive(SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT)) {
+                syncTimeout("MASTERNODE_SYNC_LIST");
+            } else {
                 SwitchToNextAsset();
-
-                // Try to activate our masternode if possible
-                activeMasternode.ManageStatus();
-                return false;
             }
-
-            // timeout
-            if (lastBudgetItem == 0 &&
-                (RequestedMasternodeAttempt >= MASTERNODE_SYNC_THRESHOLD * 3 || GetTime() - nAssetSyncStarted > MASTERNODE_SYNC_TIMEOUT * 5)) {
-                // maybe there is no budgets at all, so just finish syncing
-                SwitchToNextAsset();
-                activeMasternode.ManageStatus();
-                return false;
-            }
-
-            // Don't request budget initial sync to more than 6 randomly ordered peers in this round.
-            if (RequestedMasternodeAttempt >= MASTERNODE_SYNC_THRESHOLD * 3) return false;
-
-            // Request bud sync if we haven't requested it yet.
-            if (pnode->HasFulfilledRequest("busync")) return true;
-
-            // Mark sync requested.
-            pnode->FulfilledRequest("busync");
-
-            // Sync proposals, finalizations and votes
-            uint256 n;
-            g_connman->PushMessage(pnode, msgMaker.Make(NetMsgType::BUDGETVOTESYNC, n));
-            RequestedMasternodeAttempt++;
-
-            return false; // sleep 1 second before do another request round.
+            return false;
         }
+
+        // Don't request mnlist initial sync to more than 8 randomly ordered peers in this round
+        if (RequestedMasternodeAttempt >= MASTERNODE_SYNC_THRESHOLD * 4) return false;
+
+        // Request mnb sync if we haven't requested it yet.
+        if (pnode->HasFulfilledRequest("mnsync")) return true;
+
+        // Try to request MN list sync.
+        if (!mnodeman.RequestMnList(pnode)) {
+            return true; // Failed, try next peer.
+        }
+
+        // Mark sync requested.
+        pnode->FulfilledRequest("mnsync");
+        // Increase the sync attempt count
+        RequestedMasternodeAttempt++;
+
+        return false; // sleep 1 second before do another request round.
+    }
+
+    if (RequestedMasternodeAssets == MASTERNODE_SYNC_MNW) {
+        if (fLegacyMnObsolete) {
+            SwitchToNextAsset();
+            return false;
+        }
+
+        if (lastMasternodeWinner > 0 && lastMasternodeWinner < GetTime() - MASTERNODE_SYNC_TIMEOUT * 2 && RequestedMasternodeAttempt >= MASTERNODE_SYNC_THRESHOLD) { //hasn't received a new item in the last five seconds, so we'll move to the
+            SwitchToNextAsset();
+            return false;
+        }
+
+        // timeout
+        if (lastMasternodeWinner == 0 &&
+            (RequestedMasternodeAttempt >= MASTERNODE_SYNC_THRESHOLD * 3 || GetTime() - nAssetSyncStarted > MASTERNODE_SYNC_TIMEOUT * 5)) {
+            if (sporkManager.IsSporkActive(SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT)) {
+                syncTimeout("MASTERNODE_SYNC_MNW");
+            } else {
+                SwitchToNextAsset();
+            }
+            return false;
+        }
+
+        // Don't request mnw initial sync to more than 6 randomly ordered peers in this round.
+        if (RequestedMasternodeAttempt >= MASTERNODE_SYNC_THRESHOLD * 3) return false;
+
+        // Request mnw sync if we haven't requested it yet.
+        if (pnode->HasFulfilledRequest("mnwsync")) return true;
+
+        // Mark sync requested.
+        pnode->FulfilledRequest("mnwsync");
+
+        // Sync mn winners
+        int nMnCount = mnodeman.CountEnabled(true /* only_legacy */);
+        g_connman->PushMessage(pnode, msgMaker.Make(NetMsgType::GETMNWINNERS, nMnCount));
+        RequestedMasternodeAttempt++;
+
+        return false; // sleep 1 second before do another request round.
+    }
+
+    if (RequestedMasternodeAssets == MASTERNODE_SYNC_BUDGET) {
+        // We'll start rejecting votes if we accidentally get set as synced too soon
+        if (lastBudgetItem > 0 && lastBudgetItem < GetTime() - MASTERNODE_SYNC_TIMEOUT * 10 && RequestedMasternodeAttempt >= MASTERNODE_SYNC_THRESHOLD) {
+            // Hasn't received a new item in the last fifty seconds and more than MASTERNODE_SYNC_THRESHOLD requests were sent,
+            // so we'll move to the next asset
+            SwitchToNextAsset();
+
+            // Try to activate our masternode if possible
+            activeMasternode.ManageStatus();
+            return false;
+        }
+
+        // timeout
+        if (lastBudgetItem == 0 &&
+            (RequestedMasternodeAttempt >= MASTERNODE_SYNC_THRESHOLD * 3 || GetTime() - nAssetSyncStarted > MASTERNODE_SYNC_TIMEOUT * 5)) {
+            // maybe there is no budgets at all, so just finish syncing
+            SwitchToNextAsset();
+            activeMasternode.ManageStatus();
+            return false;
+        }
+
+        // Don't request budget initial sync to more than 6 randomly ordered peers in this round.
+        if (RequestedMasternodeAttempt >= MASTERNODE_SYNC_THRESHOLD * 3) return false;
+
+        // Request bud sync if we haven't requested it yet.
+        if (pnode->HasFulfilledRequest("busync")) return true;
+
+        // Mark sync requested.
+        pnode->FulfilledRequest("busync");
+
+        // Sync proposals, finalizations and votes
+        uint256 n;
+        g_connman->PushMessage(pnode, msgMaker.Make(NetMsgType::BUDGETVOTESYNC, n));
+        RequestedMasternodeAttempt++;
+
+        return false; // sleep 1 second before do another request round.
     }
 
     return true;

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -411,7 +411,7 @@ bool CMasternodeSync::SyncWithNode(CNode* pnode, bool fLegacyMnObsolete)
 
         // timeout
         if (lastMasternodeWinner == 0 &&
-            (RequestedMasternodeAttempt >= MASTERNODE_SYNC_THRESHOLD * 3 || GetTime() - nAssetSyncStarted > MASTERNODE_SYNC_TIMEOUT * 5)) {
+            (RequestedMasternodeAttempt >= MASTERNODE_SYNC_THRESHOLD * 2 || GetTime() - nAssetSyncStarted > MASTERNODE_SYNC_TIMEOUT * 5)) {
             if (sporkManager.IsSporkActive(SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT)) {
                 syncTimeout("MASTERNODE_SYNC_MNW");
             } else {
@@ -425,8 +425,8 @@ bool CMasternodeSync::SyncWithNode(CNode* pnode, bool fLegacyMnObsolete)
             return false;
         }
 
-        // Don't request mnw initial sync to more than 6 randomly ordered peers in this round.
-        if (RequestedMasternodeAttempt >= MASTERNODE_SYNC_THRESHOLD * 3) return false;
+        // Don't request mnw initial sync to more than 4 randomly ordered peers in this round.
+        if (RequestedMasternodeAttempt >= MASTERNODE_SYNC_THRESHOLD * 2) return false;
 
         // Request mnw sync if we haven't requested it yet.
         if (pnode->HasFulfilledRequest("mnwsync")) return true;

--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -337,11 +337,18 @@ bool CMasternodeSync::SyncWithNode(CNode* pnode, bool fLegacyMnObsolete)
 
     //set to synced
     if (RequestedMasternodeAssets == MASTERNODE_SYNC_SPORKS) {
+
+        // Sync sporks from at least 2 peers
+        if (RequestedMasternodeAttempt >= MASTERNODE_SYNC_THRESHOLD) {
+            SwitchToNextAsset();
+            return false;
+        }
+
+        // Request sporks sync if we haven't requested it yet.
         if (pnode->HasFulfilledRequest("getspork")) return true;
         pnode->FulfilledRequest("getspork");
 
-        g_connman->PushMessage(pnode, msgMaker.Make(NetMsgType::GETSPORKS)); //get current network sporks
-        if (RequestedMasternodeAttempt >= 2) SwitchToNextAsset();
+        g_connman->PushMessage(pnode, msgMaker.Make(NetMsgType::GETSPORKS));
         RequestedMasternodeAttempt++;
         return false;
     }

--- a/src/masternode-sync.h
+++ b/src/masternode-sync.h
@@ -79,7 +79,7 @@ public:
     void AddedBudgetItem(const uint256& hash);
     void SwitchToNextAsset();
     std::string GetSyncStatus();
-    void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
+    void ProcessSyncStatusMsg(int nItemID, int itemCount);
     bool IsBudgetFinEmpty();
     bool IsBudgetPropEmpty();
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1924,7 +1924,6 @@ bool static ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vR
                 g_budgetman.ProcessMessage(pfrom, strCommand, vRecv);
                 masternodePayments.ProcessMessageMasternodePayments(pfrom, strCommand, vRecv);
                 sporkManager.ProcessSpork(pfrom, strCommand, vRecv);
-                masternodeSync.ProcessMessage(pfrom, strCommand, vRecv);
             }
         } else {
             // Ignore unknown commands for extensibility

--- a/src/tiertwo_networksync.cpp
+++ b/src/tiertwo_networksync.cpp
@@ -93,6 +93,9 @@ bool CMasternodeSync::MessageDispatcher(CNode* pfrom, std::string& strCommand, C
         int nCount;
         vRecv >> nItemID >> nCount;
 
+        // Update stats
+        ProcessSyncStatusMsg(nItemID, nCount);
+
         // this means we will receive no further communication on the first sync
         switch (nItemID) {
             case MASTERNODE_SYNC_LIST: {

--- a/test/functional/tiertwo_governance_sync_basic.py
+++ b/test/functional/tiertwo_governance_sync_basic.py
@@ -20,7 +20,7 @@ from test_framework.util import (
     assert_true,
     connect_nodes,
     get_datadir_path,
-    satoshi_round,
+    satoshi_round
 )
 import shutil
 import os
@@ -235,10 +235,24 @@ class MasternodeGovernanceBasicTest(PivxTier2TestFramework):
         self.check_vote_existence(firstProposal.name, self.mnOneCollateral.hash, "YES", True)
         self.log.info("all good, MN1 vote accepted everywhere!")
 
+        # before broadcast the second vote, let's drop the budget data of ownerOne.
+        # so the node is forced to send a single proposal sync when the, now orphan, proposal vote is received.
+        self.log.info("Testing single proposal re-sync based on an orphan vote, dropping budget data...")
+        self.ownerOne.cleanbudget(try_sync=False)
+        assert_equal(self.ownerOne.getbudgetprojection(), []) # empty
+        assert_equal(self.ownerOne.getbudgetinfo(), [])
+
         # now let's vote for the proposal with the second MN
         self.log.info("Voting with MN2...")
         voteResult = self.ownerTwo.mnbudgetvote("alias", firstProposal.proposalHash, "yes", self.masternodeTwoAlias, True)
         assert_equal(voteResult["detail"][0]["result"], "success")
+
+        # check orphan vote proposal re-sync
+        self.log.info("checking orphan vote based proposal re-sync...")
+        time.sleep(5) # wait a bit before check it
+        self.check_proposal_existence(firstProposal.name, firstProposal.proposalHash)
+        self.check_vote_existence(firstProposal.name, self.mnOneCollateral.hash, "YES", True)
+        self.log.info("all good, orphan vote based proposal re-sync succeeded")
 
         # check that the vote was accepted everywhere
         self.stake(1, [self.remoteOne, self.remoteTwo])
@@ -288,22 +302,38 @@ class MasternodeGovernanceBasicTest(PivxTier2TestFramework):
         self.check_budget_finalization_sync(0, "OK")
 
         self.log.info("budget finalization synced!, now voting for the budget finalization..")
+        # Connecting owner to all the other nodes.
+        self.connect_to_all(self.ownerOnePos)
 
         voteResult = self.ownerOne.mnfinalbudget("vote-many", budgetFinHash, True)
         assert_equal(voteResult["detail"][0]["result"], "success")
+        time.sleep(2) # wait a bit
+        self.stake(2, [self.remoteOne, self.remoteTwo])
+        self.check_budget_finalization_sync(1, "OK")
         self.log.info("Remote One voted successfully.")
+
+        # before broadcast the second finalization vote, let's drop the budget data of remoteOne.
+        # so the node is forced to send a single fin sync when the, now orphan, vote is received.
+        self.log.info("Testing single fin re-sync based on an orphan vote, dropping budget data...")
+        self.remoteOne.cleanbudget(try_sync=False)
+        assert_equal(self.remoteOne.getbudgetprojection(), []) # empty
+        assert_equal(self.remoteOne.getbudgetinfo(), [])
+
+        # vote for finalization with MN2 and the DMN
         voteResult = self.ownerTwo.mnfinalbudget("vote-many", budgetFinHash, True)
         assert_equal(voteResult["detail"][0]["result"], "success")
         self.log.info("Remote Two voted successfully.")
         voteResult = self.remoteDMN1.mnfinalbudget("vote", budgetFinHash)
         assert_equal(voteResult["detail"][0]["result"], "success")
         self.log.info("DMN voted successfully.")
+        time.sleep(2) # wait a bit
         self.stake(2, [self.remoteOne, self.remoteTwo])
 
         self.log.info("checking finalization votes..")
         self.check_budget_finalization_sync(3, "OK")
+        self.log.info("orphan vote based finalization re-sync succeeded")
 
-        self.stake(8, [self.remoteOne, self.remoteTwo])
+        self.stake(6, [self.remoteOne, self.remoteTwo])
         addrInfo = self.miner.listreceivedbyaddress(0, False, False, firstProposal.paymentAddr)
         assert_equal(addrInfo[0]["amount"], firstProposal.amountPerCycle)
 
@@ -341,9 +371,7 @@ class MasternodeGovernanceBasicTest(PivxTier2TestFramework):
         self.log.info("restarting node..")
         self.start_node(self.ownerTwoPos)
         self.ownerTwo.setmocktime(self.mocktime)
-        for i in range(self.num_nodes):
-            if i is not self.ownerTwoPos:
-                self.connect_nodes_bi(self.nodes, self.ownerTwoPos, i)
+        self.connect_to_all(self.ownerTwoPos)
         self.stake(2, [self.remoteOne, self.remoteTwo])
 
         self.log.info("syncing node..")


### PR DESCRIPTION
A never ending story, more improvements and corrections for the tier two initial synchronization.

This time, the following points are tackled:

1) Fix a bad workflow that causes the budget data initial synchronization to be skipped.
if we received for example a proposal +50 seconds ago, while we are synchronizing another asset, then once the budget sync starts, it will look like the sync is finished when it's not. Not waiting to receive any budget data, declaring the sync completed.

2) Decrease `mnw` sync threshold to 4 peers to "minimize" the insane amount of network flood and initial tier two sync delay.
MNW initial sync is mostly for historical reasons, getting +20k items per peer (+120k items total for the previous threshold of 6) is a high amount of duplicated data relayed over the wire. 80k is still very high but.. it's something that we have to live with until v6.0 (which removes entirely the need of `mnw` messages..).

3) Fix extra sync attempt for the mnlist asset badly incremented in the sporks sync flow.

4) Connect the not-connected `ProcessSyncStatusMsg` (ex `masternodesync.ProcessMessage()`). Thus why the tier two sync stats counters are always in 0, this function was being skipped.

5) The node, after triggering the internal budget data relay process (relaying budget data to every known peer), is invalidly blocking every remote peer, for an hour, for follow-up budget sync requests.

6) The orphans votes maps are linking a single prop/bud parent hash to a single vote, discarding the previous stored item every time that a new orphan arrives. Blocking any follow-up reception of the orphan votes that were discarded, prohibiting its connection.  (edge case scenario: splitting risk)

7) Added test coverage for:
   1) Single proposal sync based on an orphan proposal vote reception.
   2) Single budget finalization sync based on an orphan finalization vote reception.
   3) Orphan proposal votes and orphan budget fin votes connection when parent is received. 

8) Removed unneeded extra items network sync roundtrip: No need to trigger an inv-based sync when the peer sent us a single proposal sync request. And stop walking through the budgets and proposals maps, locking their mutexes, on every single peer unique proposal/bud_fin item request. 

9) Generalized the budget full sync items relay process.

Let's aim to include this work on the coming v5.4.0.