### PR TITLE
[GUI] Don't show UTXO locking options for shield notes

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -828,6 +828,12 @@ void CoinControlDialog::updateView()
     // sort view
     sortView(sortColumn, sortOrder);
     ui->treeWidget->setEnabled(true);
+
+    // TODO: Remove this once note locking is functional
+    // Hide or show locking button and context menu items
+    lockAction->setVisible(fSelectTransparent);
+    unlockAction->setVisible(fSelectTransparent);
+    ui->pushButtonToggleLock->setVisible(fSelectTransparent);
 }
 
 void CoinControlDialog::refreshDialog()


### PR DESCRIPTION
Note locking is not yet implemented, as such there is no reason to show
any of the locking related actions in the coin control dialog.