### PR TITLE
[Build] Sanitize governance UIs item naming

### DIFF
--- a/src/qt/pivx/forms/governancewidget.ui
+++ b/src/qt/pivx/forms/governancewidget.ui
@@ -19,7 +19,7 @@
   <property name="windowTitle">
    <string notr="true">N/A</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="2,1">
+  <layout class="QHBoxLayout" name="horizontalLayout_1" stretch="2,1">
    <property name="spacing">
     <number>0</number>
    </property>
@@ -37,7 +37,7 @@
    </property>
    <item>
     <widget class="QWidget" name="left" native="true">
-     <layout class="QVBoxLayout" name="verticalLayout_3" stretch="0,0,1,0">
+     <layout class="QVBoxLayout" name="verticalLayout_1" stretch="0,0,1,0">
       <property name="leftMargin">
        <number>0</number>
       </property>
@@ -58,7 +58,7 @@
           <height>60</height>
          </size>
         </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
          <property name="spacing">
           <number>0</number>
          </property>
@@ -75,7 +75,7 @@
           <number>0</number>
          </property>
          <item>
-          <layout class="QVBoxLayout" name="verticalLayout_8">
+          <layout class="QVBoxLayout" name="verticalLayout_2">
            <property name="spacing">
             <number>5</number>
            </property>
@@ -116,7 +116,7 @@
              <height>0</height>
             </size>
            </property>
-           <layout class="QHBoxLayout" name="horizontalLayout_4">
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
             <property name="leftMargin">
              <number>0</number>
             </property>
@@ -144,7 +144,7 @@
              <height>0</height>
             </size>
            </property>
-           <layout class="QHBoxLayout" name="horizontalLayout_5">
+           <layout class="QHBoxLayout" name="horizontalLayout_4">
             <property name="leftMargin">
              <number>0</number>
             </property>
@@ -199,7 +199,7 @@
          </property>
          <item>
           <widget class="QWidget" name="containerWarning" native="true">
-           <layout class="QVBoxLayout" name="verticalLayout_21">
+           <layout class="QVBoxLayout" name="verticalLayout_4">
             <property name="spacing">
              <number>6</number>
             </property>
@@ -226,7 +226,7 @@
               <property name="frameShadow">
                <enum>QFrame::Raised</enum>
               </property>
-              <layout class="QHBoxLayout" name="horizontalLayout11" stretch="0,2">
+              <layout class="QHBoxLayout" name="horizontalLayout_5" stretch="0,2">
                <property name="spacing">
                 <number>3</number>
                </property>
@@ -288,7 +288,7 @@
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout_2">
+        <layout class="QVBoxLayout" name="verticalLayout_5">
          <property name="spacing">
           <number>0</number>
          </property>
@@ -356,7 +356,7 @@
         <property name="frameShadow">
          <enum>QFrame::Raised</enum>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout_7" stretch="8">
+        <layout class="QVBoxLayout" name="verticalLayout_6" stretch="8">
          <property name="spacing">
           <number>0</number>
          </property>
@@ -386,7 +386,7 @@
            <property name="frameShadow">
             <enum>QFrame::Raised</enum>
            </property>
-           <layout class="QVBoxLayout" name="verticalLayout">
+           <layout class="QVBoxLayout" name="verticalLayout_7">
             <property name="spacing">
              <number>12</number>
             </property>
@@ -451,7 +451,7 @@
    </item>
    <item>
     <widget class="QWidget" name="right" native="true">
-     <layout class="QVBoxLayout" name="verticalLayout_5">
+     <layout class="QVBoxLayout" name="verticalLayout_8">
       <property name="leftMargin">
        <number>0</number>
       </property>
@@ -465,7 +465,7 @@
        <number>0</number>
       </property>
       <item>
-       <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0">
+       <layout class="QVBoxLayout" name="verticalLayout_9" stretch="0,0,0">
         <property name="spacing">
          <number>6</number>
         </property>
@@ -480,7 +480,7 @@
          </widget>
         </item>
         <item>
-         <spacer name="verticalSpacer_4">
+         <spacer name="verticalSpacer_1">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>
@@ -503,7 +503,7 @@
             <height>200</height>
            </size>
           </property>
-          <layout class="QVBoxLayout" name="verticalLayout_6">
+          <layout class="QVBoxLayout" name="verticalLayout_10">
            <property name="leftMargin">
             <number>0</number>
            </property>
@@ -548,7 +548,7 @@
            </item>
            <item>
             <widget class="QWidget" name="widget" native="true">
-             <layout class="QVBoxLayout" name="verticalLayout_10">
+             <layout class="QVBoxLayout" name="verticalLayout_11">
               <property name="spacing">
                <number>3</number>
               </property>
@@ -617,7 +617,7 @@
             </widget>
            </item>
            <item>
-            <spacer name="verticalSpacer_7">
+            <spacer name="verticalSpacer_4">
              <property name="orientation">
               <enum>Qt::Vertical</enum>
              </property>
@@ -634,7 +634,7 @@
            </item>
            <item>
             <widget class="QWidget" name="widget_2" native="true">
-             <layout class="QVBoxLayout" name="verticalLayout_9">
+             <layout class="QVBoxLayout" name="verticalLayout_12">
               <property name="spacing">
                <number>3</number>
               </property>
@@ -665,7 +665,7 @@
                </widget>
               </item>
               <item>
-               <spacer name="verticalSpacer_6">
+               <spacer name="verticalSpacer_5">
                 <property name="orientation">
                  <enum>Qt::Vertical</enum>
                 </property>
@@ -703,7 +703,7 @@
             </widget>
            </item>
            <item>
-            <spacer name="verticalSpacer_8">
+            <spacer name="verticalSpacer_6">
              <property name="orientation">
               <enum>Qt::Vertical</enum>
              </property>
@@ -717,7 +717,7 @@
            </item>
            <item>
             <widget class="QWidget" name="containerSuperblockInfo" native="true">
-             <layout class="QHBoxLayout" name="horizontalLayout">
+             <layout class="QHBoxLayout" name="horizontalLayout_6">
               <property name="spacing">
                <number>4</number>
               </property>

--- a/src/qt/pivx/forms/proposalcard.ui
+++ b/src/qt/pivx/forms/proposalcard.ui
@@ -28,7 +28,7 @@
     <height>200</height>
    </size>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QVBoxLayout" name="verticalLayout_1">
    <property name="spacing">
     <number>0</number>
    </property>
@@ -61,7 +61,7 @@
      <property name="styleSheet">
       <string notr="true"/>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3" stretch="4,4,2,4">
+     <layout class="QVBoxLayout" name="verticalLayout_2" stretch="4,4,2,4">
       <property name="leftMargin">
        <number>12</number>
       </property>
@@ -75,7 +75,7 @@
        <number>12</number>
       </property>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <layout class="QHBoxLayout" name="horizontalLayout_1">
         <property name="spacing">
          <number>0</number>
         </property>
@@ -87,7 +87,7 @@
          </widget>
         </item>
         <item>
-         <spacer name="horizontalSpacer_4">
+         <spacer name="horizontalSpacer_1">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -128,7 +128,7 @@
       </item>
       <item>
        <widget class="QWidget" name="widget" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
          <property name="spacing">
           <number>0</number>
          </property>
@@ -152,7 +152,7 @@
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
-           <layout class="QVBoxLayout" name="verticalLayout">
+           <layout class="QVBoxLayout" name="verticalLayout_3">
             <property name="spacing">
              <number>5</number>
             </property>
@@ -189,7 +189,7 @@
           </widget>
          </item>
          <item>
-          <spacer name="horizontalSpacer">
+          <spacer name="horizontalSpacer_2">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
@@ -273,7 +273,7 @@
              <height>0</height>
             </size>
            </property>
-           <layout class="QHBoxLayout" name="horizontalLayout_4">
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
             <property name="spacing">
              <number>0</number>
             </property>
@@ -294,7 +294,7 @@
              </widget>
             </item>
             <item>
-             <spacer name="horizontalSpacer_5">
+             <spacer name="horizontalSpacer_3">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
@@ -323,9 +323,9 @@
        </widget>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
         <item>
-         <spacer name="horizontalSpacer_2">
+         <spacer name="horizontalSpacer_4">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -357,7 +357,7 @@
          </widget>
         </item>
         <item>
-         <spacer name="horizontalSpacer_3">
+         <spacer name="horizontalSpacer_5">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>

--- a/src/qt/pivx/forms/proposalinfodialog.ui
+++ b/src/qt/pivx/forms/proposalinfodialog.ui
@@ -28,7 +28,7 @@
   <property name="styleSheet">
    <string notr="true"/>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_3">
+  <layout class="QVBoxLayout" name="verticalLayout_1">
    <property name="spacing">
     <number>0</number>
    </property>
@@ -61,7 +61,7 @@
      <property name="frameShadow">
       <enum>QFrame::Raised</enum>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
+     <layout class="QVBoxLayout" name="verticalLayout_2">
       <property name="leftMargin">
        <number>0</number>
       </property>
@@ -69,7 +69,7 @@
        <number>0</number>
       </property>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <layout class="QHBoxLayout" name="horizontalLayout_1">
         <property name="spacing">
          <number>0</number>
         </property>
@@ -184,7 +184,7 @@
           <height>450</height>
          </size>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout_4">
+        <layout class="QVBoxLayout" name="verticalLayout_3">
          <property name="leftMargin">
           <number>0</number>
          </property>
@@ -230,7 +230,7 @@ background:transparent;
 background:transparent;
 }</string>
             </property>
-            <layout class="QVBoxLayout" name="verticalLayout_7">
+            <layout class="QVBoxLayout" name="verticalLayout_4">
              <property name="spacing">
               <number>0</number>
              </property>
@@ -251,7 +251,7 @@ background:transparent;
              </property>
              <item>
               <widget class="QWidget" name="content" native="true">
-               <layout class="QVBoxLayout" name="verticalLayout_2">
+               <layout class="QVBoxLayout" name="verticalLayout_5">
                 <property name="leftMargin">
                  <number>16</number>
                 </property>
@@ -263,7 +263,7 @@ background:transparent;
                 </property>
                 <item>
                  <widget class="QWidget" name="contentID" native="true">
-                  <layout class="QHBoxLayout" name="horizontalLayout_12" stretch="0,0">
+                  <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0">
                    <property name="leftMargin">
                     <number>0</number>
                    </property>
@@ -343,7 +343,7 @@ background:transparent;
                 </item>
                 <item>
                  <widget class="QWidget" name="contentName" native="true">
-                  <layout class="QHBoxLayout" name="horizontalLayout_12" stretch="0,0">
+                  <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0">
                    <property name="leftMargin">
                     <number>0</number>
                    </property>
@@ -609,7 +609,7 @@ background:transparent;
                 </item>
                 <item>
                  <widget class="QWidget" name="contentUrl" native="true">
-                  <layout class="QHBoxLayout" name="horizontalLayout_12" stretch="0,0">
+                  <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="0,0">
                    <property name="leftMargin">
                     <number>0</number>
                    </property>

--- a/src/qt/pivx/forms/proposalinfodialog.ui
+++ b/src/qt/pivx/forms/proposalinfodialog.ui
@@ -406,7 +406,7 @@ background:transparent;
                  </widget>
                 </item>
                 <item>
-                 <widget class="QLabel" name="labelDividerID">
+                 <widget class="QLabel" name="labelDividerName">
                   <property name="maximumSize">
                    <size>
                     <width>16777215</width>
@@ -422,8 +422,8 @@ background:transparent;
                  </widget>
                 </item>
                 <item>
-                 <widget class="QWidget" name="gridName" native="true">
-                  <layout class="QGridLayout" name="contentConfDateStatus">
+                 <widget class="QWidget" name="gridRecipient" native="true">
+                  <layout class="QGridLayout" name="contentRecipient">
                    <property name="leftMargin">
                     <number>0</number>
                    </property>
@@ -486,7 +486,7 @@ background:transparent;
                  </widget>
                 </item>
                 <item>
-                 <widget class="QLabel" name="labelDividerName">
+                 <widget class="QLabel" name="labelDividerRecipient">
                   <property name="maximumSize">
                    <size>
                     <width>16777215</width>

--- a/src/qt/pivx/forms/votedialog.ui
+++ b/src/qt/pivx/forms/votedialog.ui
@@ -10,7 +10,7 @@
     <height>450</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_3">
+  <layout class="QVBoxLayout" name="verticalLayout_1">
    <property name="spacing">
     <number>0</number>
    </property>
@@ -54,12 +54,12 @@
        <number>20</number>
       </property>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <layout class="QHBoxLayout" name="horizontalLayout_1">
         <property name="spacing">
          <number>0</number>
         </property>
         <item>
-         <spacer name="horizontalSpacer_2">
+         <spacer name="horizontalSpacer_1">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -100,7 +100,7 @@
          </widget>
         </item>
         <item>
-         <spacer name="horizontalSpacer">
+         <spacer name="horizontalSpacer_2">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -144,7 +144,7 @@
        </widget>
       </item>
       <item>
-       <spacer name="verticalSpacer_2">
+       <spacer name="verticalSpacer_1">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
         </property>
@@ -160,7 +160,7 @@
        </spacer>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
          <spacer name="horizontalSpacer_3">
           <property name="orientation">
@@ -238,7 +238,7 @@
           <height>50</height>
          </size>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout">
+        <layout class="QVBoxLayout" name="verticalLayout_3">
          <property name="spacing">
           <number>6</number>
          </property>
@@ -272,7 +272,7 @@
        </widget>
       </item>
       <item>
-       <spacer name="verticalSpacer_5">
+       <spacer name="verticalSpacer_2">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
         </property>
@@ -295,7 +295,7 @@
           <height>36</height>
          </size>
         </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1,0,1">
+        <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="1,0,1">
          <property name="spacing">
           <number>0</number>
          </property>
@@ -394,7 +394,7 @@
        </widget>
       </item>
       <item>
-       <spacer name="verticalSpacer_6">
+       <spacer name="verticalSpacer_3">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
         </property>
@@ -420,7 +420,7 @@
        </widget>
       </item>
       <item>
-       <spacer name="verticalSpacer">
+       <spacer name="verticalSpacer_4">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
         </property>
@@ -436,9 +436,9 @@
        </spacer>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,2,2,0">
+       <layout class="QHBoxLayout" name="horizontalLayout_4" stretch="0,2,2,0">
         <item>
-         <spacer name="horizontalSpacer">
+         <spacer name="horizontalSpacer_6">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -483,7 +483,7 @@
          </widget>
         </item>
         <item>
-         <spacer name="horizontalSpacer_2">
+         <spacer name="horizontalSpacer_7">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -498,7 +498,7 @@
        </layout>
       </item>
       <item>
-       <spacer name="verticalSpacer_3">
+       <spacer name="verticalSpacer_5">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
         </property>
@@ -514,7 +514,7 @@
        </spacer>
       </item>
       <item>
-       <spacer name="verticalSpacer_7">
+       <spacer name="verticalSpacer_6">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
         </property>
@@ -534,7 +534,7 @@
        </widget>
       </item>
       <item>
-       <spacer name="verticalSpacer_4">
+       <spacer name="verticalSpacer_7">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
         </property>

--- a/src/qt/pivx/proposalinfodialog.cpp
+++ b/src/qt/pivx/proposalinfodialog.cpp
@@ -20,7 +20,7 @@ ProposalInfoDialog::ProposalInfoDialog(QWidget *parent) :
     setCssProperty(ui->frame, "container-dialog");
     setCssProperty(ui->labelTitle, "text-title-dialog");
     setCssProperty({ui->labelAmount, ui->labelName, ui->labelUrl, ui->labelRecipient, ui->labelPosVotes, ui->labelId, ui->labelNegVotes, ui->labelEndDate, ui->labelDate, ui->labelStatus}, "text-subtitle");
-    setCssProperty({ui->labelDividerID, ui->labelDividerChange, ui->labelDividerMemo}, "container-divider");
+    setCssProperty({ui->labelDividerID, ui->labelDividerName, ui->labelDividerRecipient, ui->labelDividerChange, ui->labelDividerMemo}, "container-divider");
     setCssProperty({ui->textAmount, ui->textName, ui->textUrl, ui->textRecipient, ui->textPosVotes, ui->textId, ui->textNegVotes, ui->textEndDate, ui->textDate, ui->textStatus} , "text-body3-dialog");
     setCssProperty({ui->pushCopy, ui->btnUrlCopy, ui->btnNameCopy}, "ic-copy-big");
     setCssProperty(ui->btnEsc, "ic-close");


### PR DESCRIPTION
The new governance UI has introduced some item naming conflicts that result in build-time warnings. This cleans up the issue as well as sanitizes the various layout/spacer item names to be in sequential order within respective files.