### PR TITLE
[GUI] Fix proposal tooltip menu location skewing

### DIFF
--- a/src/qt/pivx/governancewidget.cpp
+++ b/src/qt/pivx/governancewidget.cpp
@@ -10,6 +10,7 @@
 
 #include <QDesktopServices>
 #include <QGraphicsDropShadowEffect>
+#include <QScrollBar>
 #include <QTimer>
 
 void initComboView(PWidget* parent, QComboBox* comboBox, const QString& filterHint, const QList<QString>& values)
@@ -187,7 +188,7 @@ void GovernanceWidget::onMenuClicked(ProposalCard* card)
     QRect rect = card->geometry();
     QPoint pos = rect.topRight();
     pos.setX(pos.x() - 22);
-    pos.setY(pos.y() + (isSync ? 100 : 140));
+    pos.setY(pos.y() + (isSync ? 100 : 140) - ui->scrollArea->verticalScrollBar()->value());
     propMenu->move(pos);
     propMenu->show();
 }


### PR DESCRIPTION
When there are enough proposals to need the GUI to scroll down to see
them all, the location of the tooltip menu gets skewed to the point of
it not being visible. This is because it's location was being based on
the initial position of the proposal card, even for off-screen ones.

This fixes the issue by taking the scrollarea's vertical scrollbar value
 into consideration.

-------
Before:
![linux-before](https://user-images.githubusercontent.com/7393257/144737112-14bcd486-78cc-4a98-9720-3174c14b97ce.png)

After:
![linux-after](https://user-images.githubusercontent.com/7393257/144737115-0e188de1-5526-4898-b5b0-7ed897c8a858.png)


