### PR TITLE
[GUI] Governance, do not open the proposal creation wizard if node is in IBD.

### DIFF
--- a/src/qt/pivx/governancewidget.cpp
+++ b/src/qt/pivx/governancewidget.cpp
@@ -142,7 +142,23 @@ void GovernanceWidget::onVoteForPropClicked(const ProposalInfo& proposalInfo)
 
 void GovernanceWidget::onCreatePropClicked()
 {
-    if (!walletModel || !governanceModel) return;
+    if (!walletModel || !governanceModel || !clientModel) return;
+
+    if (!governanceModel->isTierTwoSync()) {
+        inform(tr("Please wait until the node is fully synced"));
+        return;
+    }
+
+    // Do not allow proposals submission 1440 blocks away (1 day) from the next superblock
+    // The budget finalization could have been submitted and the user would never know it, losing the first superblock.
+    // future: customizable future superblock height selection (for now, we are automatically using the next superblock).
+    const int chainHeight = clientModel->getLastBlockProcessedHeight();
+    const int nextSuperblock = governanceModel->getNextSuperblockHeight();
+    const int acceptedRange = (walletModel->isTestNetwork() || walletModel->isRegTestNetwork()) ? 10 : 1440;
+    if (nextSuperblock - acceptedRange < chainHeight) {
+        inform(tr("Cannot create proposal, superblock is too close. Need to wait %1 blocks").arg(nextSuperblock - chainHeight));
+        return;
+    }
 
     auto ptrUnlockedContext = std::make_unique<WalletModel::UnlockContext>(walletModel->requestUnlock());
     if (!ptrUnlockedContext->isValid()) {


### PR DESCRIPTION
Straightforward PR: blocking proposals submission during IBD. 
The wallet could not be able to create the fee transaction for the lack of chain tip coins view and the impossibility to calculate the next superblock height.

Fixes #2669.