### PR TITLE
[GUI] Differentiate Budget payment output records from MNs block reward records.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -147,6 +147,7 @@ public:
         consensus.nFutureTimeDriftPoS = 180;
         consensus.nMaxMoneyOut = 21000000 * COIN;
         consensus.nMNCollateralAmt = 10000 * COIN;
+        consensus.nMNBlockReward = 3 * COIN;
         consensus.nProposalEstablishmentTime = 60 * 60 * 24;    // must be at least a day old to make it into a budget
         consensus.nStakeMinAge = 60 * 60;
         consensus.nStakeMinDepth = 600;
@@ -290,6 +291,7 @@ public:
         consensus.nFutureTimeDriftPoS = 180;
         consensus.nMaxMoneyOut = 21000000 * COIN;
         consensus.nMNCollateralAmt = 10000 * COIN;
+        consensus.nMNBlockReward = 3 * COIN;
         consensus.nProposalEstablishmentTime = 60 * 5;  // at least 5 min old to make it into a budget
         consensus.nStakeMinAge = 60 * 60;
         consensus.nStakeMinDepth = 100;
@@ -415,6 +417,7 @@ public:
         consensus.nFutureTimeDriftPoS = 180;
         consensus.nMaxMoneyOut = 43199500 * COIN;
         consensus.nMNCollateralAmt = 100 * COIN;
+        consensus.nMNBlockReward = 3 * COIN;
         consensus.nProposalEstablishmentTime = 60 * 5;  // at least 5 min old to make it into a budget
         consensus.nStakeMinAge = 0;
         consensus.nStakeMinDepth = 20;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -101,6 +101,7 @@ struct Params {
     int nFutureTimeDriftPoS;
     CAmount nMaxMoneyOut;
     CAmount nMNCollateralAmt;
+    CAmount nMNBlockReward;
     int64_t nProposalEstablishmentTime;
     int nStakeMinAge;
     int nStakeMinDepth;

--- a/src/qt/pivx/qtutils.cpp
+++ b/src/qt/pivx/qtutils.cpp
@@ -182,6 +182,7 @@ void setSortTxTypeFilter(QComboBox* filter, SortEdit* lineEditType)
     filter->addItem(QObject::tr("Hot stakes"), TransactionFilterProxy::TYPE(TransactionRecord::StakeHot));
     filter->addItem(QObject::tr("Delegated"), TransactionFilterProxy::TYPE(TransactionRecord::P2CSDelegationSent) | TransactionFilterProxy::TYPE(TransactionRecord::P2CSDelegationSentOwner));
     filter->addItem(QObject::tr("Delegations"), TransactionFilterProxy::TYPE(TransactionRecord::P2CSDelegation));
+    filter->addItem(QObject::tr("DAO payment"), TransactionFilterProxy::TYPE(TransactionRecord::BudgetPayment));
 }
 
 void setupSettings(QSettings* settings)

--- a/src/qt/pivx/txrow.cpp
+++ b/src/qt/pivx/txrow.cpp
@@ -78,6 +78,7 @@ void TxRow::setType(bool isLightTheme, int type, bool isConfirmed)
         case TransactionRecord::StakeZPIV:
         case TransactionRecord::MNReward:
         case TransactionRecord::StakeMint:
+        case TransactionRecord::BudgetPayment:
             path = "://ic-transaction-staked";
             css = "text-list-amount-receive";
             break;

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -113,6 +113,6 @@ int TransactionFilterProxy::rowCount(const QModelIndex& parent) const
 bool TransactionFilterProxy::isOrphan(const int status, const int type)
 {
     return ( (type == TransactionRecord::Generated || type == TransactionRecord::StakeMint ||
-            type == TransactionRecord::StakeZPIV || type == TransactionRecord::MNReward)
+            type == TransactionRecord::StakeZPIV || type == TransactionRecord::MNReward || type == TransactionRecord::BudgetPayment)
             && (status == TransactionStatus::Conflicted || status == TransactionStatus::NotAccepted) );
 }

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -55,9 +55,11 @@ bool TransactionRecord::decomposeCoinStake(const CWallet* wallet, const CWalletT
         int nIndexMN = (int) wtx.tx->vout.size() - 1;
         if (ExtractDestination(wtx.tx->vout[nIndexMN].scriptPubKey, destMN) && (mine = IsMine(*wallet, destMN)) ) {
             sub.involvesWatchAddress = mine & ISMINE_WATCH_ONLY;
-            sub.type = TransactionRecord::MNReward;
             sub.address = EncodeDestination(destMN);
             sub.credit = wtx.tx->vout[nIndexMN].nValue;
+            // Simple way to differentiate budget payments from MN rewards.
+            CAmount mn_reward = Params().GetConsensus().nMNBlockReward;
+            sub.type = sub.credit > mn_reward ? TransactionRecord::BudgetPayment : TransactionRecord::MNReward;
         }
     }
 
@@ -612,6 +614,7 @@ void TransactionRecord::updateStatus(const CWalletTx& wtx, int chainHeight)
             type == TransactionRecord::StakeMint ||
             type == TransactionRecord::StakeZPIV ||
             type == TransactionRecord::MNReward ||
+            type == TransactionRecord::BudgetPayment ||
             type == TransactionRecord::StakeDelegated ||
             type == TransactionRecord::StakeHot) {
 

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -81,6 +81,7 @@ public:
         SendToOther,
         RecvWithAddress,
         MNReward,
+        BudgetPayment,
         RecvFromOther,
         SendToSelf,
         ZerocoinMint,

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -435,6 +435,8 @@ QString TransactionTableModel::formatTxType(const TransactionRecord* wtx) const
         return tr("Received with");
     case TransactionRecord::MNReward:
         return tr("Masternode Reward");
+    case TransactionRecord::BudgetPayment:
+        return tr("Budget Payment");
     case TransactionRecord::RecvFromOther:
         return tr("Received from");
     case TransactionRecord::SendToAddress:
@@ -493,6 +495,7 @@ QVariant TransactionTableModel::txAddressDecoration(const TransactionRecord* wtx
     case TransactionRecord::StakeMint:
     case TransactionRecord::StakeZPIV:
     case TransactionRecord::MNReward:
+    case TransactionRecord::BudgetPayment:
         return QIcon(":/icons/tx_mined");
     case TransactionRecord::RecvWithAddress:
     case TransactionRecord::RecvFromOther:
@@ -520,6 +523,7 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord* wtx, b
         return QString::fromStdString(wtx->address) + watchAddress;
     case TransactionRecord::RecvWithAddress:
     case TransactionRecord::MNReward:
+    case TransactionRecord::BudgetPayment:
     case TransactionRecord::SendToAddress:
     case TransactionRecord::Generated:
     case TransactionRecord::StakeMint:

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -834,7 +834,8 @@ CAmount GetBlockValue(int nHeight)
 
 int64_t GetMasternodePayment()
 {
-    return 3 * COIN;
+    // Future: refactor function callers to use this line directly.
+    return Params().GetConsensus().nMNBlockReward;
 }
 
 bool IsInitialBlockDownload()


### PR DESCRIPTION
Fixes #2667. Created a new transaction record type `BudgetPayment` to distinguish MN block rewards from budget payments

In order to do this without duplicate code, moved the MN reward amount value to chainparams.