### PR TITLE
[GUI] Fix proposal name and URL size limit validation

### DIFF
--- a/src/budget/budgetproposal.h
+++ b/src/budget/budgetproposal.h
@@ -18,6 +18,10 @@ static const int64_t BUDGET_VOTE_UPDATE_MIN = 60 * 60;
 // Minimum value for a proposal to be considered valid
 static const CAmount PROPOSAL_MIN_AMOUNT = 10 * COIN;
 
+// Net ser values
+static const size_t PROP_URL_MAX_SIZE = 64;
+static const size_t PROP_NAME_MAX_SIZE = 20;
+
 class CBudgetManager;
 
 //
@@ -113,8 +117,8 @@ public:
     // Serialization for local DB
     SERIALIZE_METHODS(CBudgetProposal, obj)
     {
-        READWRITE(LIMITED_STRING(obj.strProposalName, 20));
-        READWRITE(LIMITED_STRING(obj.strURL, 64));
+        READWRITE(LIMITED_STRING(obj.strProposalName, PROP_NAME_MAX_SIZE));
+        READWRITE(LIMITED_STRING(obj.strURL, PROP_URL_MAX_SIZE));
         READWRITE(obj.nBlockStart);
         READWRITE(obj.nBlockEnd);
         READWRITE(obj.nAmount);

--- a/src/qt/pivx/createproposaldialog.cpp
+++ b/src/qt/pivx/createproposaldialog.cpp
@@ -137,7 +137,7 @@ void CreateProposalDialog::setupPageThree()
 
 void CreateProposalDialog::propNameChanged(const QString& newText)
 {
-    bool isValid = !newText.isEmpty() && IsValidUTF8(newText.toStdString());
+    bool isValid = !newText.isEmpty() && IsValidUTF8(newText.toStdString()) && govModel->validatePropName(newText).getRes();
     setCssEditLine(ui->lineEditPropName, isValid, true);
 }
 
@@ -182,6 +182,12 @@ bool CreateProposalDialog::validatePageOne()
         return false;
     }
 
+    auto res = govModel->validatePropName(propName);
+    if (!res) {
+        inform(QString::fromStdString(res.getError()));
+        return false;
+    }
+
     // For now, only accept UTF8 valid strings.
     if (!IsValidUTF8(propName.toStdString())) {
         setCssEditLine(ui->lineEditPropName, false, true);
@@ -189,8 +195,7 @@ bool CreateProposalDialog::validatePageOne()
         return false;
     }
 
-
-    auto res = govModel->validatePropURL(ui->lineEditURL->text());
+    res = govModel->validatePropURL(ui->lineEditURL->text());
     if (!res) inform(QString::fromStdString(res.getError()));
     return res.getRes();
 }

--- a/src/qt/pivx/governancemodel.cpp
+++ b/src/qt/pivx/governancemodel.cpp
@@ -180,6 +180,14 @@ std::vector<VoteInfo> GovernanceModel::getLocalMNsVotesForProposal(const Proposa
     return localVotes;
 }
 
+OperationResult GovernanceModel::validatePropName(const QString& name) const
+{
+    if (name.toUtf8().size() > PROP_NAME_MAX_SIZE) { // limit
+        return {false, _("Invalid name, maximum size exceeded")};
+    }
+    return {true};
+}
+
 OperationResult GovernanceModel::validatePropURL(const QString& url) const
 {
     std::string strError;

--- a/src/qt/pivx/governancemodel.cpp
+++ b/src/qt/pivx/governancemodel.cpp
@@ -197,21 +197,21 @@ OperationResult GovernanceModel::validatePropURL(const QString& url) const
 OperationResult GovernanceModel::validatePropAmount(CAmount amount) const
 {
     if (amount < PROPOSAL_MIN_AMOUNT) { // Future: move constant to a budget interface.
-        return {false, strprintf("Amount below the minimum of %s PIV", FormatMoney(PROPOSAL_MIN_AMOUNT))};
+        return {false, strprintf(_("Amount below the minimum of %s PIV"), FormatMoney(PROPOSAL_MIN_AMOUNT))};
     }
 
     if (amount > getMaxAvailableBudgetAmount()) {
-        return {false, strprintf("Amount exceeding the maximum available of %s PIV", FormatMoney(getMaxAvailableBudgetAmount()))};
+        return {false, strprintf(_("Amount exceeding the maximum available of %s PIV"), FormatMoney(getMaxAvailableBudgetAmount()))};
     }
     return {true};
 }
 
 OperationResult GovernanceModel::validatePropPaymentCount(int paymentCount) const
 {
-    if (paymentCount < 1) return { false, "Invalid payment count, must be greater than zero."};
+    if (paymentCount < 1) return { false, _("Invalid payment count, must be greater than zero.")};
     int nMaxPayments = getPropMaxPaymentsCount();
     if (paymentCount > nMaxPayments) {
-        return { false, strprintf("Invalid payment count, cannot be greater than %d", nMaxPayments)};
+        return { false, strprintf(_("Invalid payment count, cannot be greater than %d"), nMaxPayments)};
     }
     return {true};
 }
@@ -232,13 +232,13 @@ OperationResult GovernanceModel::createProposal(const std::string& strProposalNa
 
     // Parse address
     const CTxDestination* dest = Standard::GetTransparentDestination(Standard::DecodeDestination(strPaymentAddr));
-    if (!dest) return {false, "invalid recipient address for the proposal"};
+    if (!dest) return {false, _("invalid recipient address for the proposal")};
     CScript scriptPubKey = GetScriptForDestination(*dest);
 
     // Validate proposal
     CBudgetProposal proposal(strProposalName, strURL, nPaymentCount, scriptPubKey, nAmount, nBlockStart, UINT256_ZERO);
     if (!proposal.IsWellFormed(g_budgetman.GetTotalBudget(proposal.GetBlockStart()))) {
-        return {false, strprintf("Proposal is not valid %s", proposal.IsInvalidReason())};
+        return {false, strprintf(_("Proposal is not valid %s"), proposal.IsInvalidReason())};
     }
 
     // Craft and send transaction.

--- a/src/qt/pivx/governancemodel.h
+++ b/src/qt/pivx/governancemodel.h
@@ -88,7 +88,6 @@ QT_END_NAMESPACE
 
 class GovernanceModel : public QObject
 {
-    static const int PROP_URL_MAX_SIZE = 100;
 
 public:
     explicit GovernanceModel(ClientModel* _clientModel, MNModel* _mnModel);
@@ -120,6 +119,7 @@ public:
     std::vector<VoteInfo> getLocalMNsVotesForProposal(const ProposalInfo& propInfo);
     // Check if the URL is valid.
     OperationResult validatePropURL(const QString& url) const;
+    OperationResult validatePropName(const QString& name) const;
     OperationResult validatePropAmount(CAmount amount) const;
     OperationResult validatePropPaymentCount(int paymentCount) const;
     // Whether the tier two network synchronization has finished or not


### PR DESCRIPTION
Fixes #2666 crash. Which is related to the size, in bytes, of the proposal name and/or the URL that can exceed the maximum allowed size, then crash during the limited string unserialization process.