### PR TITLE
[Wallet] Clear Shield notes witness cache before a full rescan

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4280,7 +4280,11 @@ CWallet* CWallet::CreateWalletFromFile(const std::string& name, const fs::path& 
 
     LOCK(cs_main);
     CBlockIndex* pindexRescan = chainActive.Genesis();
-    if (!gArgs.GetBoolArg("-rescan", false)) {
+
+    if (gArgs.GetBoolArg("-rescan", false)) {
+        // clear note witness cache before a full rescan
+        walletInstance->ClearNoteWitnessCache();
+    } else {
         WalletBatch batch(*walletInstance->database);
         CBlockLocator locator;
         if (batch.ReadBestBlock(locator))
@@ -4620,6 +4624,8 @@ void CWallet::IncrementNoteWitnesses(const CBlockIndex* pindex,
                             SaplingMerkleTree& saplingTree) { m_sspk_man->IncrementNoteWitnesses(pindex, pblock, saplingTree); }
 
 void CWallet::DecrementNoteWitnesses(const CBlockIndex* pindex) { m_sspk_man->DecrementNoteWitnesses(pindex->nHeight); }
+
+void CWallet::ClearNoteWitnessCache() { m_sspk_man->ClearNoteWitnessCache(); }
 
 bool CWallet::AddSaplingZKey(const libzcash::SaplingExtendedSpendingKey &key) { return m_sspk_man->AddSaplingZKey(key); }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -930,6 +930,9 @@ public:
     //! pindex is the old tip being disconnected.
     void DecrementNoteWitnesses(const CBlockIndex* pindex);
 
+    //! clear note witness cache
+    void ClearNoteWitnessCache();
+
 
     //! Adds Sapling spending key to the store, and saves it to disk
     bool AddSaplingZKey(const libzcash::SaplingExtendedSpendingKey &key);


### PR DESCRIPTION
So they are rebuilt via `ScanForWalletTransactions` --> `ChainTipAdded`, and a corrupted cache can be fixed with a simple `-rescan` of the chain data (instead of a complete reindex).