### PR TITLE
[Net_processing]  Do not log "notfound" msg as unknown.

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -854,8 +854,7 @@ static void RelayAddress(const CAddress& addr, bool fReachable, CConnman* connma
 bool static PushTierTwoGetDataRequest(const CInv& inv,
                                       CNode* pfrom,
                                       CConnman* connman,
-                                      CNetMsgMaker& msgMaker,
-                                      int chainHeight)
+                                      CNetMsgMaker& msgMaker)
 {
     if (inv.type == MSG_SPORK) {
         if (mapSporks.count(inv.hash)) {
@@ -1027,7 +1026,6 @@ void static ProcessGetData(CNode* pfrom, CConnman* connman, const std::atomic<bo
     CNetMsgMaker msgMaker(pfrom->GetSendVersion());
     {
         LOCK(cs_main);
-        int chainHeight = chainActive.Height();
 
         while (it != pfrom->vRecvGetData.end() && (it->type == MSG_TX || IsTierTwoInventoryTypeKnown(it->type))) {
             if (interruptMsgProc)
@@ -1054,7 +1052,7 @@ void static ProcessGetData(CNode* pfrom, CConnman* connman, const std::atomic<bo
 
             if (!pushed) {
                 // Now check if it's a tier two data request and push it.
-                pushed = PushTierTwoGetDataRequest(inv, pfrom, connman, msgMaker, chainHeight);
+                pushed = PushTierTwoGetDataRequest(inv, pfrom, connman, msgMaker);
             }
 
             if (!pushed) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1979,7 +1979,7 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
 
     msg.SetVersion(pfrom->GetRecvVersion());
     // Scan for message start
-    if (memcmp(msg.hdr.pchMessageStart, Params().MessageStart(), MESSAGE_START_SIZE) != 0) {
+    if (memcmp(msg.hdr.pchMessageStart, Params().MessageStart(), CMessageHeader::MESSAGE_START_SIZE) != 0) {
         LogPrint(BCLog::NET, "PROCESSMESSAGE: INVALID MESSAGESTART %s peer=%d\n", SanitizeString(msg.hdr.GetCommand()), pfrom->GetId());
         pfrom->fDisconnect = true;
         return false;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1913,6 +1913,12 @@ bool static ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vR
         pfrom->fRelayTxes = true;
     }
 
+    else if (strCommand == NetMsgType::NOTFOUND) {
+        // We do not care about the NOTFOUND message (for now), but logging an Unknown Command
+        // message is undesirable as we transmit it ourselves.
+        return true;
+    }
+
     else {
         // Tier two msg type search
         const std::vector<std::string>& allMessages = getTierTwoNetMessageTypes();

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -21,8 +21,6 @@
 #include <stdint.h>
 #include <string>
 
-#define MESSAGE_START_SIZE 4
-
 /** Message header.
  * (4) message start.
  * (12) command.
@@ -32,6 +30,7 @@
 class CMessageHeader
 {
 public:
+    static constexpr size_t MESSAGE_START_SIZE = 4;
     static constexpr size_t COMMAND_SIZE = 12;
     static constexpr size_t MESSAGE_SIZE_SIZE = 4;
     static constexpr size_t CHECKSUM_SIZE = 4;
@@ -52,8 +51,6 @@ public:
 
     SERIALIZE_METHODS(CMessageHeader, obj) { READWRITE(obj.pchMessageStart, obj.pchCommand, obj.nMessageSize, obj.pchChecksum); }
 
-    // TODO: make private (improves encapsulation)
-public:
     char pchMessageStart[MESSAGE_START_SIZE];
     char pchCommand[COMMAND_SIZE];
     uint32_t nMessageSize;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3918,11 +3918,11 @@ bool LoadExternalBlockFile(FILE* fileIn, FlatFilePos* dbp)
             unsigned int nSize = 0;
             try {
                 // locate a header
-                unsigned char buf[MESSAGE_START_SIZE];
+                unsigned char buf[CMessageHeader::MESSAGE_START_SIZE];
                 blkdat.FindByte(Params().MessageStart()[0]);
                 nRewind = blkdat.GetPos()+1;
                 blkdat >> buf;
-                if (memcmp(buf, Params().MessageStart(), MESSAGE_START_SIZE))
+                if (memcmp(buf, Params().MessageStart(), CMessageHeader::MESSAGE_START_SIZE))
                     continue;
                 // read size
                 blkdat >> nSize;


### PR DESCRIPTION
Grouped few findings that discovered testing #2659.

* The "not found" message is not being processed properly. Logging an unnecessary "unknown message type" error.
It become even more evident syncing a peer running 2659 from a normal network peer, because of the non-updated peer blockage from relaying budget items that described there (the `ClearSeen` bug..). 

* Then some extra refactoring, removing unneeded chain height argument in `PushTierTwoGetDataRequest` and adapted 2c09a520 to our sources as well.