### PR TITLE
[net_processing] Fix ignoring get data requests when fPauseSend is set on a peer

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1065,10 +1065,10 @@ void static ProcessGetData(CNode* pfrom, CConnman* connman, const std::atomic<bo
         }
     } // release cs_main
 
-    if (it != pfrom->vRecvGetData.end()) {
+    if (it != pfrom->vRecvGetData.end() && !pfrom->fPauseSend) {
         const CInv &inv = *it;
-        it++;
         if (inv.type == MSG_BLOCK || inv.type == MSG_FILTERED_BLOCK) {
+            it++;
             ProcessGetBlockData(pfrom, inv, connman, interruptMsgProc);
         }
     }


### PR DESCRIPTION
If when the peer is responding to a series of tx or tier two data requests in `getdata` hits the send buffer limit and set `fPauseSend`, it will skip one request per call to `ProcessGetData` (a tx or any of the tier two items).

This is an adaptation of #12392, meaning more for us as the peer will skip tier two items requests.