### PR TITLE
[Wallet] Avoid second mapWallet lookup

### DIFF
--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -162,8 +162,9 @@ UniValue preparebudget(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_WALLET_ERROR, res.ToString());
 
     // Store proposal name as a comment
-    assert(pwallet->mapWallet.count(wtx->GetHash()));
-    pwallet->mapWallet.at(wtx->GetHash()).SetComment("Proposal: " + strProposalName);
+    auto it = pwallet->mapWallet.find(wtx->GetHash());
+    assert(it != pwallet->mapWallet.end());
+    it->second.SetComment("Proposal: " + strProposalName);
 
     return wtx->GetHash().ToString();
 }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1094,12 +1094,13 @@ static UniValue ShieldSendManyTo(CWallet * const pwallet,
 
     // add comments
     const uint256& txHash = uint256S(txid);
-    assert(pwallet->mapWallet.count(txHash));
+    auto it = pwallet->mapWallet.find(txHash);
+    assert(it != pwallet->mapWallet.end());
     if (!commentStr.empty()) {
-        pwallet->mapWallet.at(txHash).mapValue["comment"] = commentStr;
+        it->second.mapValue["comment"] = commentStr;
     }
     if (!toStr.empty()) {
-        pwallet->mapWallet.at(txHash).mapValue["to"] = toStr;
+        it->second.mapValue["to"] = toStr;
     }
 
     return txid;
@@ -1532,9 +1533,10 @@ UniValue viewshieldtransaction(const JSONRPCRequest& request)
     hash.SetHex(request.params[0].get_str());
 
     UniValue entry(UniValue::VOBJ);
-    if (!pwallet->mapWallet.count(hash))
+    auto it = pwallet->mapWallet.find(hash);
+    if (it == pwallet->mapWallet.end())
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid or non-wallet transaction id");
-    const CWalletTx& wtx = pwallet->mapWallet.at(hash);
+    const CWalletTx& wtx = it->second;
 
     if (!wtx.tx->IsShieldedTx()) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid transaction, no shield data available");
@@ -2807,8 +2809,9 @@ UniValue listreceivedbyshieldaddress(const JSONRPCRequest& request)
         int index = -1;
         int64_t time = 0;
 
-        if (pwallet->mapWallet.count(entry.op.hash)) {
-            const CWalletTx& wtx = pwallet->mapWallet.at(entry.op.hash);
+        auto it = pwallet->mapWallet.find(entry.op.hash);
+        if (it != pwallet->mapWallet.end()) {
+            const CWalletTx& wtx = it->second;
             if (!wtx.m_confirm.hashBlock.IsNull())
                 height = mapBlockIndex[wtx.m_confirm.hashBlock]->nHeight;
             index = wtx.m_confirm.nIndex;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3295,9 +3295,11 @@ UniValue gettransaction(const JSONRPCRequest& request)
             filter = filter | ISMINE_WATCH_ONLY;
 
     UniValue entry(UniValue::VOBJ);
-    if (!pwallet->mapWallet.count(hash))
+    auto it = pwallet->mapWallet.find(hash);
+    if (it == pwallet->mapWallet.end()) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid or non-wallet transaction id");
-    const CWalletTx& wtx = pwallet->mapWallet.at(hash);
+    }
+    const CWalletTx& wtx = it->second;
 
     CAmount nCredit = wtx.GetCredit(filter);
     CAmount nDebit = wtx.GetDebit(filter);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -755,8 +755,9 @@ void CWallet::AddToSpends(const COutPoint& outpoint, const uint256& wtxid)
 
 void CWallet::AddToSpends(const uint256& wtxid)
 {
-    assert(mapWallet.count(wtxid));
-    CWalletTx& thisTx = mapWallet.at(wtxid);
+    auto it = mapWallet.find(wtxid);
+    assert(it != mapWallet.end());
+    CWalletTx& thisTx = it->second;
     if (thisTx.IsCoinBase()) // Coinbases don't spend anything!
         return;
 


### PR DESCRIPTION
Completes the backport of bitcoin#11039 (which was partially done elsewhere)
Also extends it to pivx-specific code (sapling, budget).

> All calls to mapWallet.count() have the intent to detect if a txid exists and most are followed by a second lookup to retrieve the CWalletTx.
>
> This PR replaces all mapWallet.count() calls with mapWallet.find() to avoid the second lookup.