### PR TITLE
[Refactor] Avoid double lookups in sapling maps

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1617,8 +1617,9 @@ UniValue viewshieldtransaction(const JSONRPCRequest& request)
     // Sapling outputs
     for (uint32_t i = 0; i < wtx.tx->sapData->vShieldedOutput.size(); ++i) {
         auto op = SaplingOutPoint(hash, i);
-        if (!wtx.mapSaplingNoteData.count(op)) continue;
-        const auto& nd = wtx.mapSaplingNoteData.at(op);
+        auto it = wtx.mapSaplingNoteData.find(op);
+        if (it == wtx.mapSaplingNoteData.end()) continue;
+        const auto& nd = it->second;
 
         const bool isOutgoing = !nd.IsMyNote();
         std::string addrStr = "unknown";

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1445,9 +1445,9 @@ void CWallet::MarkAffectedTransactionsDirty(const CTransaction& tx)
     if (HasSaplingSPKM() && tx.IsShieldedTx()) {
         for (const SpendDescription &spend : tx.sapData->vShieldedSpend) {
             const uint256& nullifier = spend.nullifier;
-            if (m_sspk_man->mapSaplingNullifiersToNotes.count(nullifier) &&
-                mapWallet.count(m_sspk_man->mapSaplingNullifiersToNotes[nullifier].hash)) {
-                auto it = mapWallet.find(m_sspk_man->mapSaplingNullifiersToNotes[nullifier].hash);
+            auto nit = m_sspk_man->mapSaplingNullifiersToNotes.find(nullifier);
+            if (nit != m_sspk_man->mapSaplingNullifiersToNotes.end()) {
+                auto it = mapWallet.find(nit->second.hash);
                 if (it != mapWallet.end()) {
                     it->second.MarkDirty();
                 }


### PR DESCRIPTION
Based on top of
- [x] #2679 

Does the same for other Sapling-related maps (`mapSaplingNoteData`, `mapSaplingNullifiersToNotes`).