### PR TITLE
[net] Remove assert(nMaxInbound > 0)

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1037,7 +1037,6 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
     CAddress addr;
     int nInbound = 0;
     int nMaxInbound = nMaxConnections - (nMaxOutbound + nMaxFeeler);
-    assert(nMaxInbound > 0);
 
     if (hSocket != INVALID_SOCKET)
         if (!addr.SetSockAddr((const struct sockaddr*)&sockaddr))


### PR DESCRIPTION
Backports #9008.

> nMaxInbound might very well be 0 or -1, if the user prefers to keep a small number of maxconnections.
>
> Note: nMaxInbound of -1 means that the user set maxconnections
to 8 or less, but we still want to keep an additional slot for
the feeler connection.

Have faced this assertion crash few times in testnet already.