### PR TITLE
[RPC] listunspent: pre-filter coins by destination in AvailableCoins

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3760,6 +3760,8 @@ UniValue listunspent(const JSONRPCRequest& request)
         nMaxDepth = request.params[1].get_int();
     }
 
+    CWallet::AvailableCoinsFilter coinFilter;
+
     std::set<CTxDestination> destinations;
     if (request.params.size() > 2) {
         RPCTypeCheckArgument(request.params[2], UniValue::VARR);
@@ -3773,6 +3775,7 @@ UniValue listunspent(const JSONRPCRequest& request)
                 throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Invalid parameter, duplicated address: ") + input.get_str());
             destinations.insert(dest);
         }
+        coinFilter.onlyFilteredDest = &destinations;
     }
 
     // List watch only utxo
@@ -3784,7 +3787,6 @@ UniValue listunspent(const JSONRPCRequest& request)
             nWatchonlyConfig = 1;
     }
 
-    CWallet::AvailableCoinsFilter coinFilter;
     if (request.params.size() > 4) {
         const UniValue& options = request.params[4].get_obj();
 
@@ -3828,19 +3830,13 @@ UniValue listunspent(const JSONRPCRequest& request)
         if (out.nDepth < nMinDepth || out.nDepth > nMaxDepth)
             continue;
 
-        CTxDestination address;
-        const CScript& scriptPubKey = out.tx->tx->vout[out.i].scriptPubKey;
-        bool fValidAddress = ExtractDestination(scriptPubKey, address);
-
-        if (!destinations.empty() && (!fValidAddress || !destinations.count(address))) {
-            continue;
-        }
-
         UniValue entry(UniValue::VOBJ);
         entry.pushKV("txid", out.tx->GetHash().GetHex());
         entry.pushKV("vout", out.i);
         entry.pushKV("generated", out.tx->IsCoinStake() || out.tx->IsCoinBase());
-        if (fValidAddress) {
+        CTxDestination address;
+        const CScript& scriptPubKey = out.tx->tx->vout[out.i].scriptPubKey;
+        if (ExtractDestination(scriptPubKey, address)) {
             entry.pushKV("address", EncodeDestination(address));
             if (pwallet->HasAddressBook(address)) {
                 entry.pushKV("label", pwallet->GetNameForAddressBookEntry(address));


### PR DESCRIPTION
As per title, instead of returning all coins (after checking the availability of each one) and then filtering by address in the rpc code.