### PR TITLE
[Refactor] Move tier two managers initialization from init.cpp to tiertwo/init.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,7 @@ set(SERVER_SOURCES
         ./src/httpserver.cpp
         ./src/indirectmap.h
         ./src/init.cpp
+        ./src/tiertwo/init.cpp
         ./src/interfaces/handler.cpp
         ./src/interfaces/wallet.cpp
         ./src/dbwrapper.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -196,6 +196,7 @@ BITCOIN_CORE_H = \
   httpserver.h \
   indirectmap.h \
   init.h \
+  tiertwo/init.h \
   interfaces/handler.h \
   interfaces/wallet.h \
   invalid.h \
@@ -350,6 +351,7 @@ libbitcoin_server_a_SOURCES = \
   httprpc.cpp \
   httpserver.cpp \
   init.cpp \
+  tiertwo/init.cpp \
   dbwrapper.cpp \
   legacy/validation_zerocoin_legacy.cpp \
   sapling/sapling_validation.cpp \
@@ -729,6 +731,7 @@ CLEANFILES = $(EXTRA_LIBRARIES)
 
 CLEANFILES += *.gcda *.gcno
 CLEANFILES += budget/*.gcda budget/*.gcno
+CLEANFILES += bls/*.gcda bls/*.gcno
 CLEANFILES += compat/*.gcda compat/*.gcno
 CLEANFILES += consensus/*.gcda consensus/*.gcno
 CLEANFILES += crc32c/src/*.gcda crc32c/src/*.gcno
@@ -744,6 +747,7 @@ CLEANFILES += sapling/*.gcda sapling/*.gcno
 CLEANFILES += script/*.gcda script/*.gcno
 CLEANFILES += support/*.gcda support/*.gcno
 CLEANFILES += test/librust/*.gcda test/librust/*.gcno
+CLEANFILES += tiertwo/*.gcda tiertwo/*.gcno
 CLEANFILES += univalue/*.gcda univalue/*.gcno
 CLEANFILES += util/*.gcda util/*.gcno
 CLEANFILES += wallet/*.gcda wallet/*.gcno

--- a/src/budget/budgetmanager.cpp
+++ b/src/budget/budgetmanager.cpp
@@ -1308,8 +1308,6 @@ bool CBudgetManager::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
 
 int CBudgetManager::ProcessMessageInner(CNode* pfrom, std::string& strCommand, CDataStream& vRecv)
 {
-    // lite mode is not supported
-    if (fLiteMode) return 0;
     if (!masternodeSync.IsBlockchainSynced()) return 0;
 
     if (strCommand == NetMsgType::BUDGETVOTESYNC) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -48,6 +48,7 @@
 #include "spork.h"
 #include "sporkdb.h"
 #include "evo/evodb.h"
+#include "tiertwo/init.h"
 #include "txdb.h"
 #include "torcontrol.h"
 #include "guiinterface.h"
@@ -947,19 +948,6 @@ static std::string ResolveErrMsg(const char * const optname, const std::string& 
     return strprintf(_("Cannot resolve -%s address: '%s'"), optname, strBind);
 }
 
-// Sets the last CACHED_BLOCK_HASHES hashes into masternode manager cache
-static void LoadBlockHashesCache(CMasternodeMan& man)
-{
-    LOCK(cs_main);
-    const CBlockIndex* pindex = chainActive.Tip();
-    unsigned int inserted = 0;
-    while (pindex && inserted < CACHED_BLOCK_HASHES) {
-        man.CacheBlockHash(pindex);
-        pindex = pindex->pprev;
-        ++inserted;
-    }
-}
-
 void InitLogging()
 {
     g_logger->m_print_to_file = !gArgs.IsArgNegated("-debuglogfile");
@@ -1742,49 +1730,8 @@ bool AppInitMain()
 
     // ********************************************************* Step 10: setup layer 2 data
 
-    uiInterface.InitMessage(_("Loading masternode cache..."));
-
-    mnodeman.SetBestHeight(chain_active_height);
-    LoadBlockHashesCache(mnodeman);
-    CMasternodeDB mndb;
-    CMasternodeDB::ReadResult readResult = mndb.Read(mnodeman);
-    if (readResult == CMasternodeDB::FileError)
-        LogPrintf("Missing masternode cache file - mncache.dat, will try to recreate\n");
-    else if (readResult != CMasternodeDB::Ok) {
-        LogPrintf("Error reading mncache.dat - cached data discarded\n");
-    }
-
-    uiInterface.InitMessage(_("Loading budget cache..."));
-
-    CBudgetDB budgetdb;
-    const bool fDryRun = (chain_active_height <= 0);
-    if (!fDryRun) g_budgetman.SetBestHeight(chain_active_height);
-    CBudgetDB::ReadResult readResult2 = budgetdb.Read(g_budgetman, fDryRun);
-
-    if (readResult2 == CBudgetDB::FileError)
-        LogPrintf("Missing budget cache - budget.dat, will try to recreate\n");
-    else if (readResult2 != CBudgetDB::Ok) {
-        LogPrintf("Error reading budget.dat - cached data discarded\n");
-    }
-
-    //flag our cached items so we send them to our peers
-    g_budgetman.ResetSync();
-    g_budgetman.ReloadMapSeen();
-
-    RegisterValidationInterface(&g_budgetman);
-
-    uiInterface.InitMessage(_("Loading masternode payment cache..."));
-
-    CMasternodePaymentDB mnpayments;
-    CMasternodePaymentDB::ReadResult readResult3 = mnpayments.Read(masternodePayments);
-
-    RegisterValidationInterface(&masternodePayments);
-
-    if (readResult3 == CMasternodePaymentDB::FileError)
-        LogPrintf("Missing masternode payment cache - mnpayments.dat, will try to recreate\n");
-    else if (readResult3 != CMasternodePaymentDB::Ok) {
-        LogPrintf("Error reading mnpayments.dat - cached data discarded\n");
-    }
+    LoadTierTwo(chain_active_height);
+    RegisterTierTwoValidationInterface();
 
     fMasterNode = gArgs.GetBoolArg("-masternode", DEFAULT_MASTERNODE);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -18,8 +18,6 @@
 #include "addrman.h"
 #include "amount.h"
 #include "bls/bls_wrapper.h"
-#include "budget/budgetdb.h"
-#include "budget/budgetmanager.h"
 #include "checkpoints.h"
 #include "compat/sanity.h"
 #include "consensus/upgrades.h"
@@ -31,7 +29,6 @@
 #include "invalid.h"
 #include "key.h"
 #include "mapport.h"
-#include "masternode-payments.h"
 #include "masternodeconfig.h"
 #include "masternodeman.h"
 #include "miner.h"
@@ -228,9 +225,7 @@ void Shutdown()
     g_connman.reset();
     peerLogic.reset();
 
-    DumpMasternodes();
-    DumpBudgets(g_budgetman);
-    DumpMasternodePayments();
+    DumpTierTwo();
     if (::mempool.IsLoaded() && gArgs.GetBoolArg("-persistmempool", DEFAULT_PERSIST_MEMPOOL)) {
         DumpMempool(::mempool);
     }
@@ -1772,8 +1767,8 @@ bool AppInitMain()
         }
     }
 
-    //get the mode of budget voting for this masternode
-    g_budgetman.strBudgetMode = gArgs.GetArg("-budgetvotemode", "auto");
+    // set the mode of budget voting for this node
+    SetBudgetFinMode(gArgs.GetArg("-budgetvotemode", "auto"));
 
 #ifdef ENABLE_WALLET
     // !TODO: remove after complete transition to DMN
@@ -1807,7 +1802,6 @@ bool AppInitMain()
     }
 
     LogPrintf("fLiteMode %d\n", fLiteMode);
-    LogPrintf("Budget Mode %s\n", g_budgetman.strBudgetMode.c_str());
 
     threadGroup.create_thread(std::bind(&ThreadCheckMasternodes));
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -30,7 +30,6 @@
 #include "key.h"
 #include "mapport.h"
 #include "masternodeconfig.h"
-#include "masternodeman.h"
 #include "miner.h"
 #include "netbase.h"
 #include "net_processing.h"
@@ -1755,7 +1754,8 @@ bool AppInitMain()
     }
 #endif
 
-    threadGroup.create_thread(std::bind(&ThreadCheckMasternodes));
+    // Start tier two threads and jobs
+    StartTierTwoThreadsAndScheduleJobs(threadGroup, scheduler);
 
     if (ShutdownRequested()) {
         LogPrintf("Shutdown requested. Exiting.\n");

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -514,7 +514,6 @@ std::string HelpMessage(HelpMessageMode mode)
     }
     strUsage += HelpMessageOpt("-shrinkdebugfile", "Shrink debug.log file on client startup (default: 1 when no -debug)");
     AppendParamsHelpMessages(strUsage, showDebug);
-    strUsage += HelpMessageOpt("-litemode=<n>", strprintf("Disable all PIVX specific functionality (Masternodes, Budgeting) (0-1, default: %u)", 0));
 
     strUsage += HelpMessageGroup("Masternode options:");
     strUsage += HelpMessageOpt("-masternode=<n>", strprintf("Enable the client to act as a masternode (0-1, default: %u)", DEFAULT_MASTERNODE));
@@ -1755,14 +1754,6 @@ bool AppInitMain()
         }
     }
 #endif
-
-    // lite mode disables all Masternode related functionality
-    fLiteMode = gArgs.GetBoolArg("-litemode", false);
-    if (fMasterNode && fLiteMode) {
-        return UIError(_("You can not start a masternode in litemode"));
-    }
-
-    LogPrintf("fLiteMode %d\n", fLiteMode);
 
     threadGroup.create_thread(std::bind(&ThreadCheckMasternodes));
 

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -399,15 +399,14 @@ bool CMasternodePayments::ProcessMessageMasternodePayments(CNode* pfrom, std::st
 {
     if (!masternodeSync.IsBlockchainSynced()) return true;
 
-    if (fLiteMode) return true; //disable all Masternode related functionality
-
     // Skip after legacy obsolete. !TODO: remove when transition to DMN is complete
     if (deterministicMNManager->LegacyMNObsolete()) {
         LogPrint(BCLog::MASTERNODE, "mnw - skip obsolete message %s\n", strCommand);
         return true;
     }
 
-    if (strCommand == NetMsgType::GETMNWINNERS) { //Masternode Payments Request Sync
+    if (strCommand == NetMsgType::GETMNWINNERS) {
+        //Masternode Payments Request Sync
         int nCountNeeded;
         vRecv >> nCountNeeded;
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -950,7 +950,6 @@ bool CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
 
 int CMasternodeMan::ProcessMessageInner(CNode* pfrom, std::string& strCommand, CDataStream& vRecv)
 {
-    if (fLiteMode) return 0; //disable all Masternode related functionality
     if (!masternodeSync.IsBlockchainSynced()) return 0;
 
     // Skip after legacy obsolete. !TODO: remove when transition to DMN is complete
@@ -1156,8 +1155,6 @@ bool CMasternodeMan::IsWithinDepth(const uint256& nHash, int depth) const
 
 void ThreadCheckMasternodes()
 {
-    if (fLiteMode) return; //disable all Masternode related functionality
-
     // Make this thread recognisable as the wallet flushing thread
     util::ThreadRename("pivx-masternodeman");
     LogPrintf("Masternodes thread started\n");

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -86,8 +86,6 @@ void CSporkManager::LoadSporksFromDB()
 
 bool CSporkManager::ProcessSpork(CNode* pfrom, std::string& strCommand, CDataStream& vRecv, int& dosScore)
 {
-    if (fLiteMode) return true; // disable all masternode related functionality
-
     if (strCommand == NetMsgType::SPORK) {
         dosScore = ProcessSporkMsg(vRecv);
         return dosScore == 0;

--- a/src/tiertwo/init.cpp
+++ b/src/tiertwo/init.cpp
@@ -81,3 +81,16 @@ void RegisterTierTwoValidationInterface()
     RegisterValidationInterface(&g_budgetman);
     RegisterValidationInterface(&masternodePayments);
 }
+
+void DumpTierTwo()
+{
+    DumpMasternodes();
+    DumpBudgets(g_budgetman);
+    DumpMasternodePayments();
+}
+
+void SetBudgetFinMode(const std::string& mode)
+{
+    g_budgetman.strBudgetMode = mode;
+    LogPrintf("Budget Mode %s\n", g_budgetman.strBudgetMode);
+}

--- a/src/tiertwo/init.cpp
+++ b/src/tiertwo/init.cpp
@@ -1,0 +1,83 @@
+// Copyright (c) 2021 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include "tiertwo/init.h"
+
+#include "budget/budgetdb.h"
+#include "guiinterface.h"
+#include "masternodeman.h"
+#include "masternode-payments.h"
+#include "validation.h"
+
+// Sets the last CACHED_BLOCK_HASHES hashes into masternode manager cache
+static void LoadBlockHashesCache(CMasternodeMan& man)
+{
+    LOCK(cs_main);
+    const CBlockIndex* pindex = chainActive.Tip();
+    unsigned int inserted = 0;
+    while (pindex && inserted < CACHED_BLOCK_HASHES) {
+        man.CacheBlockHash(pindex);
+        pindex = pindex->pprev;
+        ++inserted;
+    }
+}
+
+bool LoadTierTwo(int chain_active_height)
+{
+    // ################################# //
+    // ## Legacy Masternodes Manager ### //
+    // ################################# //
+    uiInterface.InitMessage(_("Loading masternode cache..."));
+
+    mnodeman.SetBestHeight(chain_active_height);
+    LoadBlockHashesCache(mnodeman);
+    CMasternodeDB mndb;
+    CMasternodeDB::ReadResult readResult = mndb.Read(mnodeman);
+    if (readResult == CMasternodeDB::FileError)
+        LogPrintf("Missing masternode cache file - mncache.dat, will try to recreate\n");
+    else if (readResult != CMasternodeDB::Ok) {
+        LogPrintf("Error reading mncache.dat - cached data discarded\n");
+    }
+
+    // ##################### //
+    // ## Budget Manager ### //
+    // ##################### //
+    uiInterface.InitMessage(_("Loading budget cache..."));
+
+    CBudgetDB budgetdb;
+    const bool fDryRun = (chain_active_height <= 0);
+    if (!fDryRun) g_budgetman.SetBestHeight(chain_active_height);
+    CBudgetDB::ReadResult readResult2 = budgetdb.Read(g_budgetman, fDryRun);
+
+    if (readResult2 == CBudgetDB::FileError)
+        LogPrintf("Missing budget cache - budget.dat, will try to recreate\n");
+    else if (readResult2 != CBudgetDB::Ok) {
+        LogPrintf("Error reading budget.dat - cached data discarded\n");
+    }
+
+    // flag our cached items so we send them to our peers
+    g_budgetman.ResetSync();
+    g_budgetman.ReloadMapSeen();
+
+    // ######################################### //
+    // ## Legacy Masternodes-Payments Manager ## //
+    // ######################################### //
+    uiInterface.InitMessage(_("Loading masternode payment cache..."));
+
+    CMasternodePaymentDB mnpayments;
+    CMasternodePaymentDB::ReadResult readResult3 = mnpayments.Read(masternodePayments);
+    if (readResult3 == CMasternodePaymentDB::FileError)
+        LogPrintf("Missing masternode payment cache - mnpayments.dat, will try to recreate\n");
+    else if (readResult3 != CMasternodePaymentDB::Ok) {
+        LogPrintf("Error reading mnpayments.dat - cached data discarded\n");
+    }
+
+    return true;
+}
+
+void RegisterTierTwoValidationInterface()
+{
+    RegisterValidationInterface(&g_budgetman);
+    RegisterValidationInterface(&masternodePayments);
+}

--- a/src/tiertwo/init.cpp
+++ b/src/tiertwo/init.cpp
@@ -12,6 +12,8 @@
 #include "masternodeconfig.h"
 #include "validation.h"
 
+#include <boost/thread.hpp>
+
 // Sets the last CACHED_BLOCK_HASHES hashes into masternode manager cache
 static void LoadBlockHashesCache(CMasternodeMan& man)
 {
@@ -143,4 +145,9 @@ bool InitActiveMN()
     }
     // All good
     return true;
+}
+
+void StartTierTwoThreadsAndScheduleJobs(boost::thread_group& threadGroup, CScheduler& scheduler)
+{
+    threadGroup.create_thread(std::bind(&ThreadCheckMasternodes));
 }

--- a/src/tiertwo/init.h
+++ b/src/tiertwo/init.h
@@ -1,0 +1,16 @@
+// Copyright (c) 2021 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#ifndef PIVX_TIERTWO_INIT_H
+#define PIVX_TIERTWO_INIT_H
+
+
+/** Loads from disk all the tier two related objects */
+bool LoadTierTwo(int chain_active_height);
+
+/** Register all tier two objects */
+void RegisterTierTwoValidationInterface();
+
+
+#endif //PIVX_TIERTWO_INIT_H

--- a/src/tiertwo/init.h
+++ b/src/tiertwo/init.h
@@ -5,6 +5,7 @@
 #ifndef PIVX_TIERTWO_INIT_H
 #define PIVX_TIERTWO_INIT_H
 
+static const bool DEFAULT_MASTERNODE  = false;
 
 /** Loads from disk all the tier two related objects */
 bool LoadTierTwo(int chain_active_height);
@@ -16,6 +17,9 @@ void RegisterTierTwoValidationInterface();
 void DumpTierTwo();
 
 void SetBudgetFinMode(const std::string& mode);
+
+/** Initialize the active Masternode manager */
+bool InitActiveMN();
 
 
 #endif //PIVX_TIERTWO_INIT_H

--- a/src/tiertwo/init.h
+++ b/src/tiertwo/init.h
@@ -12,5 +12,10 @@ bool LoadTierTwo(int chain_active_height);
 /** Register all tier two objects */
 void RegisterTierTwoValidationInterface();
 
+/** Dump tier two managers to disk */
+void DumpTierTwo();
+
+void SetBudgetFinMode(const std::string& mode);
+
 
 #endif //PIVX_TIERTWO_INIT_H

--- a/src/tiertwo/init.h
+++ b/src/tiertwo/init.h
@@ -5,7 +5,14 @@
 #ifndef PIVX_TIERTWO_INIT_H
 #define PIVX_TIERTWO_INIT_H
 
+#include <string>
+
 static const bool DEFAULT_MASTERNODE  = false;
+
+class CScheduler;
+namespace boost {
+    class thread_group;
+}
 
 /** Loads from disk all the tier two related objects */
 bool LoadTierTwo(int chain_active_height);
@@ -20,6 +27,9 @@ void SetBudgetFinMode(const std::string& mode);
 
 /** Initialize the active Masternode manager */
 bool InitActiveMN();
+
+/** Starts tier two threads and jobs */
+void StartTierTwoThreadsAndScheduleJobs(boost::thread_group& threadGroup, CScheduler& scheduler);
 
 
 #endif //PIVX_TIERTWO_INIT_H

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -86,7 +86,6 @@ const char * const PIVX_MASTERNODE_CONF_FILENAME = "masternode.conf";
 // PIVX only features
 // Masternode
 std::atomic<bool> fMasterNode{false};
-bool fLiteMode = false;
 
 ArgsManager gArgs;
 

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -55,7 +55,6 @@ extern const char * const DEFAULT_DEBUGLOGFILE;
 //PIVX only features
 
 extern std::atomic<bool> fMasterNode;
-extern bool fLiteMode;
 
 extern CTranslationInterface translationInterface;
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2055,10 +2055,8 @@ bool static ConnectTip(CValidationState& state, CBlockIndex* pindexNew, const st
     // Update chainActive & related variables.
     UpdateTip(pindexNew);
     // Update TierTwo managers
-    if (!fLiteMode) {
-        mnodeman.SetBestHeight(pindexNew->nHeight);
-        g_budgetman.SetBestHeight(pindexNew->nHeight);
-    }
+    mnodeman.SetBestHeight(pindexNew->nHeight);
+    g_budgetman.SetBestHeight(pindexNew->nHeight);
     // Update MN manager cache
     mnodeman.CacheBlockHash(pindexNew);
     mnodeman.CheckSpentCollaterals(blockConnecting.vtx);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2216,8 +2216,6 @@ CAmount CWallet::GetDelegatedBalance() const
 
 CAmount CWallet::GetLockedCoins() const
 {
-    if (fLiteMode) return 0;
-
     LOCK(cs_wallet);
     if (setLockedCoins.empty()) return 0;
 


### PR DESCRIPTION
It's primarily a move-only refactoring, breaking up a bit more the long monolithic `init.cpp`. Placing the tier two components initialization in a separate `tiertwo/init.cpp` file.

This will make future inclusions easier, like #2647 introducing the new tier two MN metadata manager and the network sync requests manager.

And, as an extra cleanup, removed the broken `litemode` flag. Because, as is now, it simply makes no sense.. it's a "turn this on to fork your node".