### PR TITLE
[QA] Use single node in sapling_changeaddresses

### DIFF
--- a/test/functional/sapling_changeaddresses.py
+++ b/test/functional/sapling_changeaddresses.py
@@ -7,71 +7,63 @@
 from decimal import Decimal
 
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import assert_true, get_coinstake_address
+from test_framework.util import assert_greater_than_or_equal, get_coinstake_address
 
 
 # Test wallet change address behaviour
 class WalletChangeAddressesTest(PivxTestFramework):
 
     def set_test_params(self):
-        self.num_nodes = 2
+        self.num_nodes = 1
         self.setup_clean_chain = True
         saplingUpgrade = ['-nuparams=v5_shield:1']
-        self.extra_args = [saplingUpgrade, saplingUpgrade]
+        self.extra_args = [saplingUpgrade]
 
     def run_test(self):
-        self.nodes[0].generate(110)
+        node = self.nodes[0]
+        node.generate(110)
 
         # Obtain some transparent funds
-        midAddr = self.nodes[0].getnewshieldaddress()
+        midAddr = node.getnewshieldaddress()
         # Shield almost all the balance
-        self.nodes[0].shieldsendmany(get_coinstake_address(self.nodes[0]), [{"address": midAddr, "amount": Decimal(2400)}])
-
-        self.sync_all()
-        self.nodes[1].generate(1)
-        self.sync_all()
-        taddrSource = self.nodes[0].getnewaddress()
+        node.shieldsendmany(get_coinstake_address(node), [{"address": midAddr, "amount": Decimal(2400)}])
+        node.generate(1)
+        taddrSource = node.getnewaddress()
         for _ in range(6):
             recipients = [{"address": taddrSource, "amount": Decimal('3')}]
-            self.nodes[0].shieldsendmany(midAddr, recipients, 1)
-            self.sync_all()
-            self.nodes[1].generate(1)
-            self.sync_all()
+            node.shieldsendmany(midAddr, recipients, 1)
+            node.generate(1)
 
-        def check_change_taddr_reuse(target, isTargetShielded):
+        def check_change_taddr_reuse(target):
             recipients = [{"address": target, "amount": Decimal('1')}]
 
             # Send funds to recipient address twice
-            txid1 = self.nodes[0].shieldsendmany(taddrSource, recipients, 1)
-            self.nodes[1].generate(1)
-            self.sync_all()
-            txid2 = self.nodes[0].shieldsendmany(taddrSource, recipients, 1)
-            self.nodes[1].generate(1)
-            self.sync_all()
+            txid1 = node.shieldsendmany(taddrSource, recipients, 1)
+            node.generate(1)
+            txid2 = node.shieldsendmany(taddrSource, recipients, 1)
+            node.generate(1)
 
             # Verify that the two transactions used different change addresses
-            tx1 = self.nodes[0].getrawtransaction(txid1, 1)
-            tx2 = self.nodes[0].getrawtransaction(txid2, 1)
-            assert_true(len(tx1['vout']) >= 1) # at least one output
-            assert_true(len(tx2['vout']) >= 1)
+            tx1 = node.getrawtransaction(txid1, 1)
+            tx2 = node.getrawtransaction(txid2, 1)
+            assert_greater_than_or_equal(len(tx1['vout']), 1) # at least one output
+            assert_greater_than_or_equal(len(tx2['vout']), 1)
             for i in range(len(tx1['vout'])):
-                tx1OutAddrs = tx1['vout'][i]['scriptPubKey']['addresses']
-                tx2OutAddrs = tx2['vout'][i]['scriptPubKey']['addresses']
-                if tx1OutAddrs != [target]:
-                    print('Source address:     %s' % taddrSource)
-                    print('TX1 change address: %s' % tx1OutAddrs[0])
-                    print('TX2 change address: %s' % tx2OutAddrs[0])
-                    assert(tx1OutAddrs != tx2OutAddrs)
+                tx1OutAddrs = tx1['vout'][i]['scriptPubKey']['addresses'][0]
+                tx2OutAddrs = tx2['vout'][i]['scriptPubKey']['addresses'][0]
+                if tx1OutAddrs != target:
+                    self.log.info('Source address:     %s' % taddrSource)
+                    self.log.info('TX1 change address: %s' % tx1OutAddrs)
+                    self.log.info('TX2 change address: %s' % tx2OutAddrs)
+                    assert tx1OutAddrs != tx2OutAddrs
 
-        taddr = self.nodes[0].getnewaddress()
-        saplingAddr = self.nodes[0].getnewshieldaddress()
+        taddr = node.getnewaddress()
+        saplingAddr = node.getnewshieldaddress()
 
-        print()
-        print('Checking shieldsendmany(taddr->Sapling)')
-        check_change_taddr_reuse(saplingAddr, True)
-        print()
-        print('Checking shieldsendmany(taddr->taddr)')
-        check_change_taddr_reuse(taddr, False)
+        self.log.info('Checking shieldsendmany(taddr->Sapling)')
+        check_change_taddr_reuse(saplingAddr)
+        self.log.info('Checking shieldsendmany(taddr->taddr)')
+        check_change_taddr_reuse(taddr)
 
 if __name__ == '__main__':
     WalletChangeAddressesTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -170,10 +170,10 @@ SAPLING_SCRIPTS = [
     'sapling_wallet_anchorfork.py',             # ~ 345 sec
     'sapling_wallet_nullifiers.py',             # ~ 190 sec
     'sapling_wallet_listreceived.py',           # ~ 157 sec
-    'sapling_changeaddresses.py',               # ~ 151 sec
     'sapling_wallet_send.py',                   # ~ 126 sec
     'sapling_mempool.py',                       # ~ 98 sec
     'sapling_wallet_persistence.py',            # ~ 90 sec
+    'sapling_changeaddresses.py',               # ~ 66 sec
     'sapling_supply.py',                        # ~ 58 sec
     'sapling_malleable_sigs.py',                # ~ 44 sec
 ]


### PR DESCRIPTION
Same problem as #2638, on a different test (GA failed run [here](https://github.com/PIVX-Project/PIVX/runs/4383720230)).

Since there's no need to use two nodes to perform this test, instead of adding the missing `sync_blocks`/`sync_mempools` calls, just remove the second node (which also speeds the test up).