### PR TITLE
[TierTwo] Introduce network requests manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,6 +454,7 @@ set(COMMON_SOURCES
         ./src/tiertwo/masternode_meta_manager.cpp
         ./src/evo/mnauth.cpp
         ./src/tiertwo/net_masternodes.cpp
+        ./src/tiertwo/netfulfilledman.cpp
         ./src/tiertwo/tiertwo_sync_state.cpp
         ./src/warnings.cpp
         )

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -291,6 +291,7 @@ BITCOIN_CORE_H = \
   threadinterrupt.h \
   timedata.h \
   tinyformat.h \
+  tiertwo/netfulfilledman.h \
   tiertwo/tiertwo_sync_state.h \
   torcontrol.h \
   txdb.h \
@@ -556,6 +557,7 @@ libbitcoin_common_a_SOURCES = \
   script/sign.cpp \
   script/standard.cpp \
   tiertwo_networksync.cpp \
+  tiertwo/netfulfilledman.cpp \
   tiertwo/tiertwo_sync_state.cpp \
   warnings.cpp \
   script/script_error.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -125,6 +125,7 @@ BITCOIN_TESTS =\
   test/miner_tests.cpp \
   test/net_tests.cpp \
   test/netbase_tests.cpp \
+  test/netfulfilledman_tests.cpp \
   test/pmt_tests.cpp \
   test/policyestimator_tests.cpp \
   test/prevector_tests.cpp \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -352,6 +352,9 @@ public:
         consensus.llmqs[Consensus::LLMQ_400_85] = llmq400_85;
 
         nLLMQConnectionRetryTimeout = 60;
+
+        // Tier two
+        nFulfilledRequestExpireTime = 60 * 60; // fulfilled requests expire in 1 hour
     }
 
     const CCheckpointData& Checkpoints() const
@@ -490,6 +493,9 @@ public:
         consensus.llmqs[Consensus::LLMQ_400_85] = llmq400_85;
 
         nLLMQConnectionRetryTimeout = 60;
+
+        // Tier two
+        nFulfilledRequestExpireTime = 60 * 60; // fulfilled requests expire in 1 hour
     }
 
     const CCheckpointData& Checkpoints() const
@@ -625,6 +631,9 @@ public:
         // long living quorum params
         consensus.llmqs[Consensus::LLMQ_TEST] = llmq_test;
         nLLMQConnectionRetryTimeout = 5;
+
+        // Tier two
+        nFulfilledRequestExpireTime = 60 * 60; // fulfilled requests expire in 1 hour
     }
 
     const CCheckpointData& Checkpoints() const

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -97,6 +97,9 @@ public:
     bool IsRegTestNet() const { return NetworkIDString() == CBaseChainParams::REGTEST; }
     bool IsTestnet() const { return NetworkIDString() == CBaseChainParams::TESTNET; }
 
+    /** Tier two requests blockage mark expiration time */
+    int FulfilledRequestExpireTime() const { return nFulfilledRequestExpireTime; }
+
     void UpdateNetworkUpgradeParameters(Consensus::UpgradeIndex idx, int nActivationHeight);
 protected:
     CChainParams() {}
@@ -114,6 +117,7 @@ protected:
 
     // Tier two
     int nLLMQConnectionRetryTimeout;
+    int nFulfilledRequestExpireTime;
 };
 
 /**

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1741,7 +1741,16 @@ bool AppInitMain()
 
     // ********************************************************* Step 10: setup layer 2 data
 
-    LoadTierTwo(chain_active_height, fReindexChainState);
+    bool load_cache_files = !(fReindex || fReindexChainState);
+    {
+        LOCK(cs_main);
+        // was blocks/chainstate deleted?
+        if (chainActive.Tip() == nullptr) {
+            load_cache_files = false;
+        }
+    }
+
+    LoadTierTwo(chain_active_height, load_cache_files);
     if (!InitActiveMN()) return false;
     RegisterTierTwoValidationInterface();
 

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -11,6 +11,7 @@
 #include "budget/budgetmanager.h"
 #include "masternodeman.h"
 #include "netmessagemaker.h"
+#include "tiertwo/netfulfilledman.h"
 #include "spork.h"
 #include "sync.h"
 #include "tiertwo/tiertwo_sync_state.h"
@@ -411,13 +412,13 @@ bool CMasternodePayments::ProcessMessageMasternodePayments(CNode* pfrom, std::st
         vRecv >> nCountNeeded;
 
         if (Params().NetworkIDString() == CBaseChainParams::MAIN) {
-            if (pfrom->HasFulfilledRequest(NetMsgType::GETMNWINNERS)) {
+            if (g_netfulfilledman.HasFulfilledRequest(pfrom->addr, NetMsgType::GETMNWINNERS)) {
                 LogPrint(BCLog::MASTERNODE, "%s: mnget - peer already asked me for the list\n", __func__);
                 return state.DoS(20, false, REJECT_INVALID, "getmnwinners-request-already-fulfilled");
             }
         }
 
-        pfrom->FulfilledRequest(NetMsgType::GETMNWINNERS);
+        g_netfulfilledman.AddFulfilledRequest(pfrom->addr, NetMsgType::GETMNWINNERS);
         Sync(pfrom, nCountNeeded);
         LogPrint(BCLog::MASTERNODE, "mnget - Sent Masternode winners to peer %i\n", pfrom->GetId());
     } else if (strCommand == NetMsgType::MNWINNER) {

--- a/src/net.h
+++ b/src/net.h
@@ -710,8 +710,6 @@ protected:
     mapMsgCmdSize mapSendBytesPerMsgCmd;
     mapMsgCmdSize mapRecvBytesPerMsgCmd;
 
-    std::vector<std::string> vecRequestsFulfilled; //keep track of what client has asked for
-
 public:
     uint256 hashContinue;
     std::atomic<int> nStartingHeight;
@@ -891,32 +889,6 @@ public:
     void AskFor(const CInv& inv);
     // inv response received, clear it from the waiting inv set.
     void AskForInvReceived(const uint256& invHash);
-
-    bool HasFulfilledRequest(std::string strRequest)
-    {
-        for (std::string& type : vecRequestsFulfilled) {
-            if (type == strRequest) return true;
-        }
-        return false;
-    }
-
-    void ClearFulfilledRequest(std::string strRequest)
-    {
-        std::vector<std::string>::iterator it = vecRequestsFulfilled.begin();
-        while (it != vecRequestsFulfilled.end()) {
-            if ((*it) == strRequest) {
-                vecRequestsFulfilled.erase(it);
-                return;
-            }
-            ++it;
-        }
-    }
-
-    void FulfilledRequest(std::string strRequest)
-    {
-        if (HasFulfilledRequest(strRequest)) return;
-        vecRequestsFulfilled.push_back(strRequest);
-    }
 
     void CloseSocketDisconnect();
     bool DisconnectOldProtocol(int nVersionIn, int nVersionRequired);

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -142,6 +142,7 @@ set(BITCOIN_TESTS
         ${CMAKE_CURRENT_SOURCE_DIR}/multisig_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/net_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/netbase_tests.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/netfulfilledman_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/pmt_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/policyestimator_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/prevector_tests.cpp

--- a/src/test/netfulfilledman_tests.cpp
+++ b/src/test/netfulfilledman_tests.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2022 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include "netbase.h"
+#include "test/test_pivx.h"
+#include "tiertwo/netfulfilledman.h"
+#include "utiltime.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(netfulfilledman_tests, RegTestingSetup)
+
+BOOST_AUTO_TEST_CASE(netfulfilledman_simple_add_and_expire)
+{
+    int64_t now = GetTime();
+    SetMockTime(now);
+
+    CNetFulfilledRequestManager fulfilledMan;
+    CService service = LookupNumeric("1.1.1.1", 9999);
+    std::string request = "request";
+    BOOST_ASSERT(!fulfilledMan.HasFulfilledRequest(service, request));
+
+    // Add request
+    fulfilledMan.AddFulfilledRequest(service, request);
+    // Verify that the request is there
+    BOOST_ASSERT(fulfilledMan.HasFulfilledRequest(service, request));
+
+    // Advance mock time to surpass FulfilledRequestExpireTime
+    SetMockTime(now + 60 * 60 + 1);
+
+    // Verify that the request exists and expired now
+    BOOST_CHECK(fulfilledMan.Size() == 1);
+    BOOST_CHECK(!fulfilledMan.HasFulfilledRequest(service, request));
+
+    // Verify request removal
+    fulfilledMan.CheckAndRemove();
+    BOOST_CHECK(fulfilledMan.Size() == 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/tiertwo/init.h
+++ b/src/tiertwo/init.h
@@ -6,6 +6,7 @@
 #define PIVX_TIERTWO_INIT_H
 
 #include <string>
+#include "fs.h"
 
 static const bool DEFAULT_MASTERNODE  = false;
 static const bool DEFAULT_MNCONFLOCK = true;
@@ -24,7 +25,7 @@ void InitTierTwoPreChainLoad(bool fReindex);
 void InitTierTwoPostCoinsCacheLoad();
 
 /** Loads from disk all the tier two related objects */
-bool LoadTierTwo(int chain_active_height, bool fReindexChainState);
+bool LoadTierTwo(int chain_active_height, bool load_cache_files);
 
 /** Register all tier two objects */
 void RegisterTierTwoValidationInterface();

--- a/src/tiertwo/netfulfilledman.cpp
+++ b/src/tiertwo/netfulfilledman.cpp
@@ -1,0 +1,71 @@
+// Copyright (c) 2014-2020 The Dash Core developers
+// Copyright (c) 2022 The PIVX Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include "tiertwo/netfulfilledman.h"
+#include "chainparams.h"
+#include "netaddress.h"
+#include "shutdown.h"
+#include "utiltime.h"
+
+CNetFulfilledRequestManager g_netfulfilledman;
+
+void CNetFulfilledRequestManager::AddFulfilledRequest(const CService& addr, const std::string& strRequest)
+{
+    LOCK(cs_mapFulfilledRequests);
+    mapFulfilledRequests[addr][strRequest] = GetTime() + Params().FulfilledRequestExpireTime();
+}
+
+bool CNetFulfilledRequestManager::HasFulfilledRequest(const CService& addr, const std::string& strRequest) const
+{
+    LOCK(cs_mapFulfilledRequests);
+    auto it = mapFulfilledRequests.find(addr);
+    if (it != mapFulfilledRequests.end()) {
+        auto itReq = it->second.find(strRequest);
+        if (itReq != it->second.end()) {
+            return itReq->second > GetTime();
+        }
+    }
+    return false;
+}
+
+void CNetFulfilledRequestManager::CheckAndRemove()
+{
+    LOCK(cs_mapFulfilledRequests);
+    int64_t now = GetTime();
+    for (auto it = mapFulfilledRequests.begin(); it != mapFulfilledRequests.end();) {
+        for (auto it_entry = it->second.begin(); it_entry != it->second.end();) {
+            if (now > it_entry->second) {
+                it_entry = it->second.erase(it_entry);
+            } else {
+                it_entry++;
+            }
+        }
+        if (it->second.empty()) {
+            it = mapFulfilledRequests.erase(it);
+        } else {
+            it++;
+        }
+    }
+}
+
+void CNetFulfilledRequestManager::Clear()
+{
+    LOCK(cs_mapFulfilledRequests);
+    mapFulfilledRequests.clear();
+}
+
+std::string CNetFulfilledRequestManager::ToString() const
+{
+    LOCK(cs_mapFulfilledRequests);
+    std::ostringstream info;
+    info << "Nodes with fulfilled requests: " << (int)mapFulfilledRequests.size();
+    return info.str();
+}
+
+void CNetFulfilledRequestManager::DoMaintenance()
+{
+    if (ShutdownRequested()) return;
+    CheckAndRemove();
+}

--- a/src/tiertwo/netfulfilledman.h
+++ b/src/tiertwo/netfulfilledman.h
@@ -43,6 +43,7 @@ public:
     void Clear();
 
     std::string ToString() const;
+    int Size() const { return WITH_LOCK(cs_mapFulfilledRequests, return mapFulfilledRequests.size();); }
 
     void DoMaintenance();
 };

--- a/src/tiertwo/netfulfilledman.h
+++ b/src/tiertwo/netfulfilledman.h
@@ -1,0 +1,52 @@
+// Copyright (c) 2014-2020 The Dash Core developers
+// Copyright (c) 2022 The PIVX Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#ifndef PIVX_NETFULFILLEDMAN_H
+#define PIVX_NETFULFILLEDMAN_H
+
+#include "serialize.h"
+#include "sync.h"
+
+#include <map>
+
+class CService;
+
+static const std::string NET_REQUESTS_CACHE_FILENAME = "netrequests.dat";
+static const std::string NET_REQUESTS_CACHE_FILE_ID = "magicNetRequestsCache";
+
+// Fulfilled requests are used to prevent nodes from asking the same data on sync
+// and being banned for doing it too often.
+class CNetFulfilledRequestManager
+{
+private:
+    typedef std::map<std::string, int64_t> fulfilledreqmapentry_t;
+    typedef std::map<CService, fulfilledreqmapentry_t> fulfilledreqmap_t;
+
+    // Keep track of what node has/was asked for and when
+    fulfilledreqmap_t mapFulfilledRequests;
+    mutable Mutex cs_mapFulfilledRequests;
+
+public:
+    CNetFulfilledRequestManager() = default;
+
+    SERIALIZE_METHODS(CNetFulfilledRequestManager, obj) {
+        LOCK(obj.cs_mapFulfilledRequests);
+        READWRITE(obj.mapFulfilledRequests);
+    }
+
+    void AddFulfilledRequest(const CService& addr, const std::string& strRequest);
+    bool HasFulfilledRequest(const CService& addr, const std::string& strRequest) const;
+
+    void CheckAndRemove();
+    void Clear();
+
+    std::string ToString() const;
+
+    void DoMaintenance();
+};
+
+extern CNetFulfilledRequestManager g_netfulfilledman;
+
+#endif // PIVX_NETFULFILLEDMAN_H


### PR DESCRIPTION
Built on top of #2684

An object in charge of cache and store tier two network requests information, preventing possible bans for asking the same data too often.