### PR TITLE
[Refactor] Deduplicate final commitment validity checks

### DIFF
--- a/src/consensus/params.cpp
+++ b/src/consensus/params.cpp
@@ -22,4 +22,13 @@ bool Params::NetworkUpgradeActive(int nHeight, Consensus::UpgradeIndex idx) cons
     return NetworkUpgradeState(nHeight, *this, idx) == UPGRADE_ACTIVE;
 }
 
+Optional<LLMQParams> Params::GetLLMQParams(uint8_t llmqtype) const
+{
+    const auto it = llmqs.find((LLMQType)llmqtype);
+    if (it == llmqs.end()) {
+        return nullopt;
+    }
+    return Optional<LLMQParams>(it->second);
+}
+
 } // End consensus namespace

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -269,6 +269,7 @@ struct Params {
 
     // LLMQ
     std::map<LLMQType, LLMQParams> llmqs;
+    Optional<LLMQParams> GetLLMQParams(uint8_t llmqtype) const;
 };
 } // namespace Consensus
 

--- a/src/consensus/validation.h
+++ b/src/consensus/validation.h
@@ -93,6 +93,7 @@ public:
     unsigned int GetRejectCode() const { return chRejectCode; }
     std::string GetRejectReason() const { return strRejectReason; }
     std::string GetDebugMessage() const { return strDebugMessage; }
+    int GetDoSScore() const { return nDoS; }
 };
 
 #endif // BITCOIN_CONSENSUS_VALIDATION_H

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -808,7 +808,7 @@ void CDeterministicMNManager::HandleQuorumCommitment(llmq::CFinalCommitment& qc,
 {
     // The commitment has already been validated at this point so it's safe to use members of it
 
-    auto members = llmq::utils::GetAllQuorumMembers((Consensus::LLMQType)qc.llmqType, pindexQuorum);
+    auto members = GetAllQuorumMembers((Consensus::LLMQType)qc.llmqType, pindexQuorum);
 
     for (size_t i = 0; i < members.size(); i++) {
         if (!mnList.HasMN(members[i]->proTxHash)) {
@@ -971,4 +971,12 @@ void CDeterministicMNManager::CleanupCache(int nHeight)
     for (const auto& h : toDeleteDiffs) {
         mnListDiffsCache.erase(h);
     }
+}
+
+std::vector<CDeterministicMNCPtr> CDeterministicMNManager::GetAllQuorumMembers(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum)
+{
+    auto& params = Params().GetConsensus().llmqs.at(llmqType);
+    auto allMns = GetListForBlock(pindexQuorum);
+    auto modifier = ::SerializeHash(std::make_pair(static_cast<uint8_t>(llmqType), pindexQuorum->GetBlockHash()));
+    return allMns.CalculateQuorum(params.size, modifier);
 }

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -589,6 +589,9 @@ public:
     bool LegacyMNObsolete(int nHeight) const;
     bool LegacyMNObsolete() const;
 
+    // Get the list of members for a given quorum type and index
+    std::vector<CDeterministicMNCPtr> GetAllQuorumMembers(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum);
+
 private:
     void CleanupCache(int nHeight);
 };

--- a/src/evo/specialtx_validation.cpp
+++ b/src/evo/specialtx_validation.cpp
@@ -420,17 +420,64 @@ static bool CheckProUpRevTx(const CTransaction& tx, const CBlockIndex* pindexPre
 }
 
 // LLMQ final commitment Payload
-bool VerifyLLMQCommitment(const llmq::CFinalCommitment& qfc, const CBlockIndex* pindexQuorum)
+bool VerifyLLMQCommitment(const llmq::CFinalCommitment& qfc, const CBlockIndex* pindexPrev, CValidationState& state)
 {
-    std::vector<CBLSPublicKey> allkeys;
-    for (const auto m : deterministicMNManager->GetAllQuorumMembers((Consensus::LLMQType)qfc.llmqType, pindexQuorum)) {
-        allkeys.emplace_back(m->pdmnState->pubKeyOperator.Get());
+    AssertLockHeld(cs_main);
+
+    // Check version
+    if (qfc.nVersion == 0 || qfc.nVersion > llmq::CFinalCommitment::CURRENT_VERSION) {
+        return state.DoS(100, false, REJECT_INVALID, "bad-qc-quorum-version");
     }
-    return qfc.Verify(allkeys);
+
+    // Check type
+    Optional<Consensus::LLMQParams> params = Params().GetConsensus().GetLLMQParams(qfc.llmqType);
+    if (params == nullopt) {
+        return state.DoS(100, false, REJECT_INVALID, "bad-qc-quorum-type");
+    }
+
+    // Check sizes
+    if (!qfc.VerifySizes(*params)) {
+        return state.DoS(100, false, REJECT_INVALID, "bad-qc-quorum-sizes");
+    }
+
+    if (pindexPrev) {
+        // Get quorum index
+        auto it = mapBlockIndex.find(qfc.quorumHash);
+        if (it == mapBlockIndex.end()) {
+            return state.DoS(100, false, REJECT_INVALID, "bad-qc-quorum-hash");
+        }
+        const CBlockIndex* pindexQuorum = it->second;
+
+        // Check height
+        if (pindexQuorum->nHeight % params->dkgInterval != 0) {
+            // not first block of DKG interval
+            return state.DoS(100, false, REJECT_INVALID, "bad-qc-quorum-height");
+        }
+
+        if (pindexQuorum != pindexPrev->GetAncestor(pindexQuorum->nHeight)) {
+            // not part of active chain
+            return state.DoS(100, false, REJECT_INVALID, "bad-qc-quorum-hash");
+        }
+
+        // Get members and check signatures (for not-null commitments)
+        if (!qfc.IsNull()) {
+            std::vector<CBLSPublicKey> allkeys;
+            for (const auto m : deterministicMNManager->GetAllQuorumMembers((Consensus::LLMQType)qfc.llmqType, pindexQuorum)) {
+                allkeys.emplace_back(m->pdmnState->pubKeyOperator.Get());
+            }
+            if (!qfc.Verify(allkeys, *params)) {
+                return state.DoS(100, false, REJECT_INVALID, "bad-qc-invalid");
+            }
+        }
+    }
+
+    return true;
 }
 
 static bool CheckLLMQCommitmentTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state)
 {
+    AssertLockHeld(cs_main);
+
     llmq::LLMQCommPL pl;
     if (!GetTxPayload(tx, pl)) {
         return state.DoS(100, false, REJECT_INVALID, "bad-qc-payload");
@@ -440,35 +487,11 @@ static bool CheckLLMQCommitmentTx(const CTransaction& tx, const CBlockIndex* pin
         return state.DoS(100, false, REJECT_INVALID, "bad-qc-version");
     }
 
-    Optional<Consensus::LLMQParams> params = Params().GetConsensus().GetLLMQParams(pl.commitment.llmqType);
-    if (params == nullopt) {
-        return state.DoS(100, false, REJECT_INVALID, "bad-qc-type");
+    if (pindexPrev && pl.nHeight != (uint32_t)pindexPrev->nHeight + 1) {
+        return state.DoS(100, false, REJECT_INVALID, "bad-qc-height");
     }
 
-    if (!pl.commitment.VerifySizes(*params)) {
-        return state.DoS(100, false, REJECT_INVALID, "bad-qc-invalid-sizes");
-    }
-
-    if (pindexPrev) {
-        if (pl.nHeight != (uint32_t)pindexPrev->nHeight + 1) {
-            return state.DoS(100, false, REJECT_INVALID, "bad-qc-height");
-        }
-
-        if (!mapBlockIndex.count(pl.commitment.quorumHash)) {
-            return state.DoS(100, false, REJECT_INVALID, "bad-qc-quorum-hash");
-        }
-        const CBlockIndex* pindexQuorum = mapBlockIndex.at(pl.commitment.quorumHash);
-        if (pindexQuorum != pindexPrev->GetAncestor(pindexQuorum->nHeight)) {
-            // not part of active chain
-            return state.DoS(100, false, REJECT_INVALID, "bad-qc-quorum-hash");
-        }
-
-        if (!VerifyLLMQCommitment(pl.commitment, pindexQuorum)) {
-            return state.DoS(100, false, REJECT_INVALID, "bad-qc-invalid");
-        }
-    }
-
-    return true;
+    return VerifyLLMQCommitment(pl.commitment, pindexPrev, state);
 }
 
 // Basic non-contextual checks for all tx types

--- a/src/evo/specialtx_validation.cpp
+++ b/src/evo/specialtx_validation.cpp
@@ -432,12 +432,12 @@ static bool CheckLLMQCommitment(const CTransaction& tx, const CBlockIndex* pinde
         return state.DoS(100, false, REJECT_INVALID, "bad-qc-version");
     }
 
-    if (!Params().GetConsensus().llmqs.count((Consensus::LLMQType)pl.commitment.llmqType)) {
+    Optional<Consensus::LLMQParams> params = Params().GetConsensus().GetLLMQParams(pl.commitment.llmqType);
+    if (params == nullopt) {
         return state.DoS(100, false, REJECT_INVALID, "bad-qc-type");
     }
-    const auto& params = Params().GetConsensus().llmqs.at((Consensus::LLMQType)pl.commitment.llmqType);
 
-    if (!pl.commitment.VerifySizes(params)) {
+    if (!pl.commitment.VerifySizes(*params)) {
         return state.DoS(100, false, REJECT_INVALID, "bad-qc-invalid-sizes");
     }
 

--- a/src/evo/specialtx_validation.h
+++ b/src/evo/specialtx_validation.h
@@ -33,7 +33,7 @@ bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, co
 bool UndoSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex);
 
 // Validate given LLMQ final commitment with the list at pindexQuorum
-bool VerifyLLMQCommitment(const llmq::CFinalCommitment& qfc, const CBlockIndex* pindexQuorum);
+bool VerifyLLMQCommitment(const llmq::CFinalCommitment& qfc, const CBlockIndex* pindexPrev, CValidationState& state);
 
 uint256 CalcTxInputsHash(const CTransaction& tx);
 

--- a/src/evo/specialtx_validation.h
+++ b/src/evo/specialtx_validation.h
@@ -6,14 +6,14 @@
 #ifndef PIVX_SPECIALTX_H
 #define PIVX_SPECIALTX_H
 
-#include "streams.h"
+#include "llmq/quorums_commitment.h"
 #include "version.h"
-#include "primitives/transaction.h"
 
 class CBlock;
 class CBlockIndex;
 class CCoinsViewCache;
 class CValidationState;
+class CTransaction;
 class uint256;
 
 /** The maximum allowed size of the extraPayload (for any TxType) */
@@ -31,6 +31,9 @@ bool CheckSpecialTxNoContext(const CTransaction& tx, CValidationState& state);
 // Update internal tiertwo data when blocks containing special txes get connected/disconnected
 bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, const CCoinsViewCache* view, CValidationState& state, bool fJustCheck);
 bool UndoSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex);
+
+// Validate given LLMQ final commitment with the list at pindexQuorum
+bool VerifyLLMQCommitment(const llmq::CFinalCommitment& qfc, const CBlockIndex* pindexQuorum);
 
 uint256 CalcTxInputsHash(const CTransaction& tx);
 

--- a/src/llmq/quorums_blockprocessor.cpp
+++ b/src/llmq/quorums_blockprocessor.cpp
@@ -10,6 +10,7 @@
 #include "consensus/validation.h"
 #include "llmq/quorums_utils.h"
 #include "evo/evodb.h"
+#include "evo/specialtx_validation.h"
 #include "net.h"
 #include "primitives/block.h"
 #include "validation.h"
@@ -93,7 +94,7 @@ void CQuorumBlockProcessor::ProcessMessage(CNode* pfrom, CDataStream& vRecv, int
         return;
     }
 
-    if (!qc.Verify(pquorumIndex)) {
+    if (!VerifyLLMQCommitment(qc, pquorumIndex)) {
         retMisbehavingScore = LogMisbehaving(pfrom, 100, "invalid commtiment for quorum", qc.quorumHash.ToString());
         return;
     }

--- a/src/llmq/quorums_commitment.cpp
+++ b/src/llmq/quorums_commitment.cpp
@@ -6,6 +6,7 @@
 #include "llmq/quorums_commitment.h"
 
 #include "chainparams.h"
+#include "evo/deterministicmns.h"
 #include "llmq/quorums_utils.h"
 #include "logging.h"
 #include "validation.h"
@@ -106,7 +107,7 @@ bool CFinalCommitment::Verify(const CBlockIndex* pQuorumIndex) const
         return errorFinalCommitment("quorumSig");
     }
 
-    auto members = utils::GetAllQuorumMembers(params.type, pQuorumIndex);
+    auto members = deterministicMNManager->GetAllQuorumMembers(params.type, pQuorumIndex);
     for (int i = members.size(); i < params.size; i++) {
         if (validMembers[i]) {
             return errorFinalCommitment("validMembers bitset (bit %d should not be set)", i);

--- a/src/llmq/quorums_commitment.h
+++ b/src/llmq/quorums_commitment.h
@@ -48,7 +48,7 @@ public:
     bool IsNull() const;
     void ToJson(UniValue& obj) const;
 
-    bool Verify(const CBlockIndex* pQuorumIndex) const;
+    bool Verify(const std::vector<CBLSPublicKey>& allkeys) const;
     bool VerifySizes(const Consensus::LLMQParams& params) const;
 
     SERIALIZE_METHODS(CFinalCommitment, obj)

--- a/src/llmq/quorums_commitment.h
+++ b/src/llmq/quorums_commitment.h
@@ -86,8 +86,6 @@ public:
     void ToJson(UniValue& obj) const;
 };
 
-bool CheckLLMQCommitment(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state);
-
 } // namespace llmq
 
 #endif // PIVX_QUORUMS_COMMITMENT_H

--- a/src/llmq/quorums_commitment.h
+++ b/src/llmq/quorums_commitment.h
@@ -48,7 +48,7 @@ public:
     bool IsNull() const;
     void ToJson(UniValue& obj) const;
 
-    bool Verify(const std::vector<CBLSPublicKey>& allkeys) const;
+    bool Verify(const std::vector<CBLSPublicKey>& allkeys, const Consensus::LLMQParams& params) const;
     bool VerifySizes(const Consensus::LLMQParams& params) const;
 
     SERIALIZE_METHODS(CFinalCommitment, obj)

--- a/src/llmq/quorums_init.cpp
+++ b/src/llmq/quorums_init.cpp
@@ -7,7 +7,6 @@
 
 #include "bls/bls_worker.h"
 #include "llmq/quorums_blockprocessor.h"
-#include "llmq/quorums_commitment.h"
 
 
 namespace llmq

--- a/src/llmq/quorums_utils.cpp
+++ b/src/llmq/quorums_utils.cpp
@@ -8,21 +8,12 @@
 #include "chainparams.h"
 #include "random.h"
 #include "spork.h"
-#include "validation.h"
 
 namespace llmq
 {
 
 namespace utils
 {
-
-std::vector<CDeterministicMNCPtr> GetAllQuorumMembers(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum)
-{
-    auto& params = Params().GetConsensus().llmqs.at(llmqType);
-    auto allMns = deterministicMNManager->GetListForBlock(pindexQuorum);
-    auto modifier = ::SerializeHash(std::make_pair(static_cast<uint8_t>(llmqType), pindexQuorum->GetBlockHash()));
-    return allMns.CalculateQuorum(params.size, modifier);
-}
 
 uint256 BuildCommitmentHash(Consensus::LLMQType llmqType, const uint256& blockHash, const std::vector<bool>& validMembers, const CBLSPublicKey& pubKey, const uint256& vvecHash)
 {

--- a/src/llmq/quorums_utils.h
+++ b/src/llmq/quorums_utils.h
@@ -6,7 +6,6 @@
 #define PIVX_QUORUMS_UTILS_H
 
 #include "consensus/params.h"
-#include "evo/deterministicmns.h"
 #include "net.h"
 
 #include <vector>
@@ -18,9 +17,6 @@ namespace llmq
 
 namespace utils
 {
-
-std::vector<CDeterministicMNCPtr> GetAllQuorumMembers(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum);
-
 uint256 BuildCommitmentHash(Consensus::LLMQType llmqType, const uint256& blockHash, const std::vector<bool>& validMembers, const CBLSPublicKey& pubKey, const uint256& vvecHash);
 uint256 BuildSignHash(Consensus::LLMQType llmqType, const uint256& quorumHash, const uint256& id, const uint256& msgHash);
 

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -1185,7 +1185,7 @@ BOOST_FIXTURE_TEST_CASE(dkg_pose_and_qfc_invalid_paths, TestChain400Setup)
     std::vector<CBLSSecretKey> skeys2(skeys.begin(), skeys.end()-1);
     llmq::CFinalCommitment qfc2 = CreateFinalCommitment(pkeys2, skeys2, quorumHash);
     BOOST_CHECK(!qfc2.IsNull());
-    BOOST_CHECK(qfc2.Verify(quorumIndex));
+    BOOST_CHECK(VerifyLLMQCommitment(qfc2, quorumIndex));
     ProcessQuorum(llmq::quorumBlockProcessor.get(), qfc2, &dummyNode);
     // final commitment received and accepted
     BOOST_CHECK(llmq::quorumBlockProcessor->HasMinableCommitment(::SerializeHash(qfc2)));
@@ -1193,7 +1193,7 @@ BOOST_FIXTURE_TEST_CASE(dkg_pose_and_qfc_invalid_paths, TestChain400Setup)
     // Now receive another commitment for the same quorum hash, but with all 3 signatures
     qfc = CreateFinalCommitment(pkeys, skeys, quorumHash);
     BOOST_CHECK(!qfc.IsNull());
-    BOOST_CHECK(qfc.Verify(quorumIndex));
+    BOOST_CHECK(VerifyLLMQCommitment(qfc, quorumIndex));
     ProcessQuorum(llmq::quorumBlockProcessor.get(), qfc, &dummyNode);
     BOOST_CHECK(qfc.CountSigners() > qfc2.CountSigners());
 

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -1046,7 +1046,7 @@ BOOST_FIXTURE_TEST_CASE(dkg_pose_and_qfc_invalid_paths, TestChain400Setup)
     const CBlockIndex* quorumIndex = mapBlockIndex.at(quorumHash);
 
     // get quorum mns
-    auto members = llmq::utils::GetAllQuorumMembers(Consensus::LLMQ_TEST, quorumIndex);
+    auto members = deterministicMNManager->GetAllQuorumMembers(Consensus::LLMQ_TEST, quorumIndex);
     std::vector<CBLSPublicKey> pkeys;
     std::vector<CBLSSecretKey> skeys;
     for (size_t i = 0; i < members.size()-1; i++) {             // all, except the last one...
@@ -1059,11 +1059,7 @@ BOOST_FIXTURE_TEST_CASE(dkg_pose_and_qfc_invalid_paths, TestChain400Setup)
     llmq::CFinalCommitment qfc = CreateFinalCommitment(pkeys, skeys, quorumHash);
     BOOST_CHECK(!qfc.IsNull());
     BOOST_CHECK(qfc.Verify(quorumIndex));
-    // verify that it fails against different members
-    do {
-        quorumIndex = quorumIndex->pprev;
-    } while(llmq::utils::GetAllQuorumMembers(Consensus::LLMQ_TEST, quorumIndex) == members);
-    BOOST_CHECK(!qfc.Verify(quorumIndex));
+    // verify that it fails changing the key of one of the signers (!TODO)
 
     // receive final commitment message
     CNode dummyNode(id++, NODE_NETWORK, 0, INVALID_SOCKET, CAddress(ip(0xa0b0c001), NODE_NONE), 0, 0, "", true);
@@ -1178,7 +1174,7 @@ BOOST_FIXTURE_TEST_CASE(dkg_pose_and_qfc_invalid_paths, TestChain400Setup)
     BOOST_CHECK_EQUAL(nHeight, 481);
     quorumHash = chainActive[nHeight - (nHeight % params.dkgInterval)]->GetBlockHash();
     quorumIndex = mapBlockIndex.at(quorumHash);
-    members = llmq::utils::GetAllQuorumMembers(Consensus::LLMQ_TEST, quorumIndex);
+    members = deterministicMNManager->GetAllQuorumMembers(Consensus::LLMQ_TEST, quorumIndex);
     pkeys.clear();
     skeys.clear();
     for (size_t i = 0; i < members.size(); i++) {

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -15,7 +15,7 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "chainparamsbase -> util/system -> chainparamsbase"
     "consensus/params -> consensus/upgrades -> consensus/params"
     "evo/deterministicmns -> masternodeman -> evo/deterministicmns"
-    "evo/deterministicmns -> llmq/quorums_commitment -> evo/deterministicmns"
+    "evo/specialtx_validation -> llmq/quorums_blockprocessor -> evo/specialtx_validation"
     "evo/specialtx_validation -> validation -> evo/specialtx_validation"
     "kernel -> validation -> kernel"
     "masternode -> masternodeman -> masternode"

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -15,7 +15,7 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "chainparamsbase -> util/system -> chainparamsbase"
     "consensus/params -> consensus/upgrades -> consensus/params"
     "evo/deterministicmns -> masternodeman -> evo/deterministicmns"
-    "evo/deterministicmns -> llmq/quorums_utils -> evo/deterministicmns"
+    "evo/deterministicmns -> llmq/quorums_commitment -> evo/deterministicmns"
     "kernel -> validation -> kernel"
     "masternode -> masternodeman -> masternode"
     "masternode -> wallet/wallet -> masternode"

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -16,6 +16,7 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "consensus/params -> consensus/upgrades -> consensus/params"
     "evo/deterministicmns -> masternodeman -> evo/deterministicmns"
     "evo/deterministicmns -> llmq/quorums_commitment -> evo/deterministicmns"
+    "evo/specialtx_validation -> validation -> evo/specialtx_validation"
     "kernel -> validation -> kernel"
     "masternode -> masternodeman -> masternode"
     "masternode -> wallet/wallet -> masternode"
@@ -42,7 +43,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "chain -> legacy/stakemodifier -> validation -> chain"
     "chainparamsbase -> util/system -> logging -> chainparamsbase"
     "evo/deterministicmns -> masternode -> wallet/wallet -> evo/deterministicmns"
-    "evo/specialtx_validation -> llmq/quorums_blockprocessor -> validation -> evo/specialtx_validation"
     "kernel -> stakeinput -> wallet/wallet -> kernel"
     "legacy/validation_zerocoin_legacy -> wallet/wallet -> validation -> legacy/validation_zerocoin_legacy"
     "qt/askpassphrasedialog -> qt/pivx/pivxgui -> qt/pivx/topbar -> qt/askpassphrasedialog"
@@ -54,7 +54,7 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "chain -> legacy/stakemodifier -> validation -> checkpoints -> chain"
     "chain -> legacy/stakemodifier -> validation -> undo -> chain"
     "chain -> legacy/stakemodifier -> validation -> pow -> chain"
-    "evo/deterministicmns -> llmq/quorums_commitment -> validation -> validationinterface -> evo/deterministicmns"
+    "evo/deterministicmns -> masternodeman -> validation -> validationinterface -> evo/deterministicmns"
 )
 
 EXIT_CODE=0


### PR DESCRIPTION
And remove circular dependency `evo/deterministicmns` <-> `llmq/quorums_utils`.