### PR TITLE
lockedpool: avoid sensitive data in core dumps

### DIFF
--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -257,8 +257,10 @@ void *PosixLockedPageAllocator::AllocateLocked(size_t len, bool *lockingSuccess)
     }
     if (addr) {
         *lockingSuccess = mlock(addr, len) == 0;
-#ifdef MADV_DONTDUMP
+#if defined(MADV_DONTDUMP) // Linux
         madvise(addr, len, MADV_DONTDUMP);
+#elif defined(MADV_NOCORE) // FreeBSD
+        madvise(addr, len, MADV_NOCORE);
 #endif
     }
     return addr;

--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -257,6 +257,9 @@ void *PosixLockedPageAllocator::AllocateLocked(size_t len, bool *lockingSuccess)
     }
     if (addr) {
         *lockingSuccess = mlock(addr, len) == 0;
+#ifdef MADV_DONTDUMP
+        madvise(addr, len, MADV_DONTDUMP);
+#endif
     }
     return addr;
 }


### PR DESCRIPTION
Backports of bitcoin#15600 and bitcoin#18443 patching [CVE-2019-15947](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15947).