### PR TITLE
[Wallet] Crypter code cleanup, updates and styling corrections

### DIFF
--- a/src/crypter.cpp
+++ b/src/crypter.cpp
@@ -231,19 +231,17 @@ bool CCryptoKeyStore::GetPubKey(const CKeyID& address, CPubKey& vchPubKeyOut) co
     return false;
 }
 
-void CCryptoKeyStore::GetKeys(std::set<CKeyID>& setAddress) const
+std::set<CKeyID> CCryptoKeyStore::GetKeys() const
 {
     LOCK(cs_KeyStore);
     if (!IsCrypted()) {
-        CBasicKeyStore::GetKeys(setAddress);
-        return;
+        return CBasicKeyStore::GetKeys();
     }
-    setAddress.clear();
-    CryptedKeyMap::const_iterator mi = mapCryptedKeys.begin();
-    while (mi != mapCryptedKeys.end()) {
-        setAddress.insert((*mi).first);
-        mi++;
+    std::set<CKeyID> set_address;
+    for (const auto& mi : mapCryptedKeys) {
+        set_address.insert(mi.first);
     }
+    return set_address;
 }
 
 bool CCryptoKeyStore::EncryptKeys(CKeyingMaterial& vMasterKeyIn)

--- a/src/crypter.h
+++ b/src/crypter.h
@@ -143,6 +143,8 @@ protected:
 
     CryptedKeyMap mapCryptedKeys;
 
+    static bool DecryptKey(const CKeyingMaterial& vMasterKey, const std::vector<unsigned char>& vchCryptedSecret, const CPubKey& vchPubKey, CKey& key);
+
     // Unlock Sapling keys
     bool UnlockSaplingKeys(const CKeyingMaterial& vMasterKeyIn, bool fDecryptionThoroughlyChecked);
 

--- a/src/crypter.h
+++ b/src/crypter.h
@@ -22,13 +22,13 @@ const unsigned int WALLET_CRYPTO_IV_SIZE = 16;
 /**
  * Private key encryption is done based on a CMasterKey,
  * which holds a salt and random encryption key.
- * 
+ *
  * CMasterKeys are encrypted using AES-256-CBC using a key
  * derived using derivation method nDerivationMethod
  * (0 == EVP_sha512()) and derivation iterations nDeriveIterations.
  * vchOtherDerivationParameters is provided for alternative algorithms
  * which may require more parameters (such as scrypt).
- * 
+ *
  * Wallet Private Keys are then encrypted using AES-256-CBC
  * with the double-sha256 of the public key as the IV, and the
  * master key's key as the encryption key (see keystore.[ch]).
@@ -196,11 +196,10 @@ public:
     }
 
     //! Sapling
-    virtual bool AddCryptedSaplingSpendingKey(
-            const libzcash::SaplingExtendedFullViewingKey &extfvk,
-            const std::vector<unsigned char> &vchCryptedSecret);
-    bool HaveSaplingSpendingKey(const libzcash::SaplingExtendedFullViewingKey &extfvk) const;
-    bool GetSaplingSpendingKey(const libzcash::SaplingExtendedFullViewingKey &extfvk, libzcash::SaplingExtendedSpendingKey &skOut) const;
+    virtual bool AddCryptedSaplingSpendingKey(const libzcash::SaplingExtendedFullViewingKey& extfvk,
+                                              const std::vector<unsigned char>& vchCryptedSecret);
+    bool HaveSaplingSpendingKey(const libzcash::SaplingExtendedFullViewingKey& extfvk) const override;
+    bool GetSaplingSpendingKey(const libzcash::SaplingExtendedFullViewingKey& extfvk, libzcash::SaplingExtendedSpendingKey& skOut) const override;
 
     /**
      * Wallet status (encrypted, locked) changed.

--- a/src/crypter.h
+++ b/src/crypter.h
@@ -158,7 +158,7 @@ public:
 
     bool GetKey(const CKeyID& address, CKey& keyOut) const override;
     bool GetPubKey(const CKeyID& address, CPubKey& vchPubKeyOut) const override;
-    void GetKeys(std::set<CKeyID>& setAddress) const override;
+    std::set<CKeyID> GetKeys() const override;
 
     //! Sapling
     virtual bool AddCryptedSaplingSpendingKey(const libzcash::SaplingExtendedFullViewingKey& extfvk,

--- a/src/crypter.h
+++ b/src/crypter.h
@@ -149,51 +149,16 @@ protected:
 public:
     CCryptoKeyStore() : fUseCrypto(false) { }
 
-    bool IsCrypted() const
-    {
-        return fUseCrypto;
-    }
-
-    bool IsLocked() const
-    {
-        if (!IsCrypted())
-            return false;
-        bool result;
-        {
-            LOCK(cs_KeyStore);
-            result = vMasterKey.empty();
-        }
-        return result;
-    }
+    bool IsCrypted() const { return fUseCrypto; }
+    bool IsLocked() const;
 
     virtual bool AddCryptedKey(const CPubKey& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret);
-    bool AddKeyPubKey(const CKey& key, const CPubKey& pubkey);
-    bool HaveKey(const CKeyID& address) const
-    {
-        {
-            LOCK(cs_KeyStore);
-            if (!IsCrypted())
-                return CBasicKeyStore::HaveKey(address);
-            return mapCryptedKeys.count(address) > 0;
-        }
-        return false;
-    }
-    bool GetKey(const CKeyID& address, CKey& keyOut) const;
-    bool GetPubKey(const CKeyID& address, CPubKey& vchPubKeyOut) const;
-    void GetKeys(std::set<CKeyID>& setAddress) const
-    {
-        LOCK(cs_KeyStore);
-        if (!IsCrypted()) {
-            CBasicKeyStore::GetKeys(setAddress);
-            return;
-        }
-        setAddress.clear();
-        CryptedKeyMap::const_iterator mi = mapCryptedKeys.begin();
-        while (mi != mapCryptedKeys.end()) {
-            setAddress.insert((*mi).first);
-            mi++;
-        }
-    }
+    bool AddKeyPubKey(const CKey& key, const CPubKey& pubkey) override;
+    bool HaveKey(const CKeyID& address) const override;
+
+    bool GetKey(const CKeyID& address, CKey& keyOut) const override;
+    bool GetPubKey(const CKeyID& address, CPubKey& vchPubKeyOut) const override;
+    void GetKeys(std::set<CKeyID>& setAddress) const override;
 
     //! Sapling
     virtual bool AddCryptedSaplingSpendingKey(const libzcash::SaplingExtendedFullViewingKey& extfvk,

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -123,17 +123,14 @@ bool CBasicKeyStore::HaveKey(const CKeyID& address) const
     return result;
 }
 
-void CBasicKeyStore::GetKeys(std::set<CKeyID>& setAddress) const
+std::set<CKeyID> CBasicKeyStore::GetKeys() const
 {
-    setAddress.clear();
-    {
-        LOCK(cs_KeyStore);
-        KeyMap::const_iterator mi = mapKeys.begin();
-        while (mi != mapKeys.end()) {
-            setAddress.insert((*mi).first);
-            mi++;
-        }
+    LOCK(cs_KeyStore);
+    std::set<CKeyID> set_address;
+    for (const auto& mi : mapKeys) {
+        set_address.insert(mi.first);
     }
+    return set_address;
 }
 
 bool CBasicKeyStore::GetKey(const CKeyID& address, CKey& keyOut) const

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -16,7 +16,7 @@ bool CKeyStore::AddKey(const CKey& key)
     return AddKeyPubKey(key, key.GetPubKey());
 }
 
-bool CBasicKeyStore::GetPubKey(const CKeyID &address, CPubKey &vchPubKeyOut) const
+bool CBasicKeyStore::GetPubKey(const CKeyID& address, CPubKey& vchPubKeyOut) const
 {
     CKey key;
     if (!GetKey(address, key)) {
@@ -65,7 +65,7 @@ bool CBasicKeyStore::GetCScript(const CScriptID& hash, CScript& redeemScriptOut)
     return false;
 }
 
-static bool ExtractPubKey(const CScript &dest, CPubKey& pubKeyOut)
+static bool ExtractPubKey(const CScript& dest, CPubKey& pubKeyOut)
 {
     //TODO: Use Solver to extract this?
     CScript::const_iterator pc = dest.begin();
@@ -135,20 +135,18 @@ std::set<CKeyID> CBasicKeyStore::GetKeys() const
 
 bool CBasicKeyStore::GetKey(const CKeyID& address, CKey& keyOut) const
 {
-    {
-        LOCK(cs_KeyStore);
-        KeyMap::const_iterator mi = mapKeys.find(address);
-        if (mi != mapKeys.end()) {
-            keyOut = mi->second;
-            return true;
-        }
+    LOCK(cs_KeyStore);
+    KeyMap::const_iterator mi = mapKeys.find(address);
+    if (mi != mapKeys.end()) {
+        keyOut = mi->second;
+        return true;
     }
     return false;
 }
 
 //! Sapling
 bool CBasicKeyStore::AddSaplingSpendingKey(
-    const libzcash::SaplingExtendedSpendingKey &sk)
+    const libzcash::SaplingExtendedSpendingKey& sk)
 {
     LOCK(cs_KeyStore);
     auto extfvk = sk.ToXFVK();
@@ -164,7 +162,7 @@ bool CBasicKeyStore::AddSaplingSpendingKey(
 }
 
 bool CBasicKeyStore::AddSaplingFullViewingKey(
-    const libzcash::SaplingExtendedFullViewingKey &extfvk)
+    const libzcash::SaplingExtendedFullViewingKey& extfvk)
 {
     LOCK(cs_KeyStore);
     auto ivk = extfvk.fvk.in_viewing_key();
@@ -177,8 +175,8 @@ bool CBasicKeyStore::AddSaplingFullViewingKey(
 // If we add an address that is already in the map, the map will
 // remain unchanged as each address only has one ivk.
 bool CBasicKeyStore::AddSaplingIncomingViewingKey(
-        const libzcash::SaplingIncomingViewingKey &ivk,
-        const libzcash::SaplingPaymentAddress &addr)
+    const libzcash::SaplingIncomingViewingKey& ivk,
+    const libzcash::SaplingPaymentAddress& addr)
 {
     LOCK(cs_KeyStore);
 
@@ -188,22 +186,22 @@ bool CBasicKeyStore::AddSaplingIncomingViewingKey(
     return true;
 }
 
-bool CBasicKeyStore::HaveSaplingSpendingKey(const libzcash::SaplingExtendedFullViewingKey &extfvk) const
+bool CBasicKeyStore::HaveSaplingSpendingKey(const libzcash::SaplingExtendedFullViewingKey& extfvk) const
 {
     return WITH_LOCK(cs_KeyStore, return mapSaplingSpendingKeys.count(extfvk) > 0);
 }
 
-bool CBasicKeyStore::HaveSaplingFullViewingKey(const libzcash::SaplingIncomingViewingKey &ivk) const
+bool CBasicKeyStore::HaveSaplingFullViewingKey(const libzcash::SaplingIncomingViewingKey& ivk) const
 {
     return WITH_LOCK(cs_KeyStore, return mapSaplingFullViewingKeys.count(ivk) > 0);
 }
 
-bool CBasicKeyStore::HaveSaplingIncomingViewingKey(const libzcash::SaplingPaymentAddress &addr) const
+bool CBasicKeyStore::HaveSaplingIncomingViewingKey(const libzcash::SaplingPaymentAddress& addr) const
 {
     return WITH_LOCK(cs_KeyStore, return mapSaplingIncomingViewingKeys.count(addr) > 0);
 }
 
-bool CBasicKeyStore::GetSaplingSpendingKey(const libzcash::SaplingExtendedFullViewingKey &extfvk, libzcash::SaplingExtendedSpendingKey &skOut) const
+bool CBasicKeyStore::GetSaplingSpendingKey(const libzcash::SaplingExtendedFullViewingKey& extfvk, libzcash::SaplingExtendedSpendingKey& skOut) const
 {
     LOCK(cs_KeyStore);
     SaplingSpendingKeyMap::const_iterator mi = mapSaplingSpendingKeys.find(extfvk);
@@ -215,8 +213,8 @@ bool CBasicKeyStore::GetSaplingSpendingKey(const libzcash::SaplingExtendedFullVi
 }
 
 bool CBasicKeyStore::GetSaplingFullViewingKey(
-    const libzcash::SaplingIncomingViewingKey &ivk,
-    libzcash::SaplingExtendedFullViewingKey &extfvkOut) const
+    const libzcash::SaplingIncomingViewingKey& ivk,
+    libzcash::SaplingExtendedFullViewingKey& extfvkOut) const
 {
     LOCK(cs_KeyStore);
     SaplingFullViewingKeyMap::const_iterator mi = mapSaplingFullViewingKeys.find(ivk);
@@ -227,8 +225,8 @@ bool CBasicKeyStore::GetSaplingFullViewingKey(
     return false;
 }
 
-bool CBasicKeyStore::GetSaplingIncomingViewingKey(const libzcash::SaplingPaymentAddress &addr,
-                                   libzcash::SaplingIncomingViewingKey &ivkOut) const
+bool CBasicKeyStore::GetSaplingIncomingViewingKey(const libzcash::SaplingPaymentAddress& addr,
+    libzcash::SaplingIncomingViewingKey& ivkOut) const
 {
     LOCK(cs_KeyStore);
     SaplingIncomingViewingKeyMap::const_iterator mi = mapSaplingIncomingViewingKeys.find(addr);
@@ -239,25 +237,25 @@ bool CBasicKeyStore::GetSaplingIncomingViewingKey(const libzcash::SaplingPayment
     return false;
 }
 
-bool CBasicKeyStore::GetSaplingExtendedSpendingKey(const libzcash::SaplingPaymentAddress &addr,
-                                    libzcash::SaplingExtendedSpendingKey &extskOut) const {
+bool CBasicKeyStore::GetSaplingExtendedSpendingKey(const libzcash::SaplingPaymentAddress& addr,
+    libzcash::SaplingExtendedSpendingKey& extskOut) const
+{
     libzcash::SaplingIncomingViewingKey ivk;
     libzcash::SaplingExtendedFullViewingKey extfvk;
 
     LOCK(cs_KeyStore);
     return GetSaplingIncomingViewingKey(addr, ivk) &&
-            GetSaplingFullViewingKey(ivk, extfvk) &&
-            GetSaplingSpendingKey(extfvk, extskOut);
+           GetSaplingFullViewingKey(ivk, extfvk) &&
+           GetSaplingSpendingKey(extfvk, extskOut);
 }
 
-void CBasicKeyStore::GetSaplingPaymentAddresses(std::set<libzcash::SaplingPaymentAddress> &setAddress) const
+void CBasicKeyStore::GetSaplingPaymentAddresses(std::set<libzcash::SaplingPaymentAddress>& setAddress) const
 {
     setAddress.clear();
     {
         LOCK(cs_KeyStore);
         auto mi = mapSaplingIncomingViewingKeys.begin();
-        while (mi != mapSaplingIncomingViewingKeys.end())
-        {
+        while (mi != mapSaplingIncomingViewingKeys.end()) {
             setAddress.insert((*mi).first);
             mi++;
         }

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -34,7 +34,7 @@ public:
     //! Check whether a key corresponding to a given address is present in the store.
     virtual bool HaveKey(const CKeyID& address) const = 0;
     virtual bool GetKey(const CKeyID& address, CKey& keyOut) const = 0;
-    virtual void GetKeys(std::set<CKeyID>& setAddress) const = 0;
+    virtual std::set<CKeyID> GetKeys() const = 0;
     virtual bool GetPubKey(const CKeyID& address, CPubKey& vchPubKeyOut) const = 0;
 
     //! Support for BIP 0013 : see https://github.com/bitcoin/bips/blob/master/bip-0013.mediawiki
@@ -113,7 +113,7 @@ public:
     bool AddKeyPubKey(const CKey& key, const CPubKey& pubkey);
     bool GetPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const;
     bool HaveKey(const CKeyID& address) const;
-    void GetKeys(std::set<CKeyID>& setAddress) const;
+    std::set<CKeyID> GetKeys() const;
     bool GetKey(const CKeyID& address, CKey& keyOut) const;
 
     virtual bool AddCScript(const CScript& redeemScript);

--- a/src/sapling/crypter_sapling.cpp
+++ b/src/sapling/crypter_sapling.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2020 The ZCash developers
 // Copyright (c) 2020 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 #include "crypter.h"
 
@@ -9,8 +9,6 @@
 #include "script/standard.h"
 #include "util/system.h"
 #include "uint256.h"
-
-#include "wallet/wallet.h"
 
 bool CCryptoKeyStore::AddCryptedSaplingSpendingKey(
         const libzcash::SaplingExtendedFullViewingKey &extfvk,
@@ -36,7 +34,7 @@ static bool DecryptSaplingSpendingKey(const CKeyingMaterial& vMasterKey,
                                       libzcash::SaplingExtendedSpendingKey& sk)
 {
     CKeyingMaterial vchSecret;
-    if(!DecryptSecret(vMasterKey, vchCryptedSecret, extfvk.fvk.GetFingerprint(), vchSecret))
+    if (!DecryptSecret(vMasterKey, vchCryptedSecret, extfvk.fvk.GetFingerprint(), vchSecret))
         return false;
 
     if (vchSecret.size() != ZIP32_XSK_SIZE)
@@ -48,35 +46,27 @@ static bool DecryptSaplingSpendingKey(const CKeyingMaterial& vMasterKey,
 }
 
 bool CCryptoKeyStore::GetSaplingSpendingKey(
-        const libzcash::SaplingExtendedFullViewingKey &extfvk,
-        libzcash::SaplingExtendedSpendingKey &skOut) const
-{
-    {
-        LOCK(cs_KeyStore);
-        if (!IsCrypted())
-            return CBasicKeyStore::GetSaplingSpendingKey(extfvk, skOut);
-
-        for (auto entry : mapCryptedSaplingSpendingKeys) { // Work more on this flow..
-            if (entry.first == extfvk) {
-                const std::vector<unsigned char> &vchCryptedSecret = entry.second;
-                return DecryptSaplingSpendingKey(vMasterKey, vchCryptedSecret, entry.first, skOut);
-            }
-        }
-    }
-    return false;
-}
-
-bool CCryptoKeyStore::HaveSaplingSpendingKey(const libzcash::SaplingExtendedFullViewingKey &extfvk) const
+        const libzcash::SaplingExtendedFullViewingKey& extfvk,
+        libzcash::SaplingExtendedSpendingKey& skOut) const
 {
     LOCK(cs_KeyStore);
-    if (!IsCrypted())
-        return CBasicKeyStore::HaveSaplingSpendingKey(extfvk);
-    for (auto entry : mapCryptedSaplingSpendingKeys) { // work more on this flow..
-        if (entry.first == extfvk) {
-            return true;
-        }
+    if (!IsCrypted()) {
+        return CBasicKeyStore::GetSaplingSpendingKey(extfvk, skOut);
     }
-    return false;
+
+    auto it = mapCryptedSaplingSpendingKeys.find(extfvk);
+    if (it == mapCryptedSaplingSpendingKeys.end()) return false;
+    const std::vector<unsigned char>& vchCryptedSecret = it->second;
+    return DecryptSaplingSpendingKey(vMasterKey, vchCryptedSecret, it->first, skOut);
+}
+
+bool CCryptoKeyStore::HaveSaplingSpendingKey(const libzcash::SaplingExtendedFullViewingKey& extfvk) const
+{
+    LOCK(cs_KeyStore);
+    if (!IsCrypted()) {
+        return CBasicKeyStore::HaveSaplingSpendingKey(extfvk);
+    }
+    return mapCryptedSaplingSpendingKeys.count(extfvk) > 0;
 }
 
 bool CCryptoKeyStore::UnlockSaplingKeys(const CKeyingMaterial& vMasterKeyIn, bool fDecryptionThoroughlyChecked)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3943,13 +3943,10 @@ void CWallet::GetKeyBirthTimes(std::map<CKeyID, int64_t>& mapKeyBirth) const
     // map in which we'll infer heights of other keys
     CBlockIndex* pindexMax = chainActive[std::max(0, chainActive.Height() - 144)]; // the tip can be reorganised; use a 144-block safety margin
     std::map<CKeyID, CBlockIndex*> mapKeyFirstBlock;
-    std::set<CKeyID> setKeys;
-    GetKeys(setKeys);
-    for (const CKeyID& keyid : setKeys) {
+    for (const CKeyID& keyid : GetKeys()) {
         if (mapKeyBirth.count(keyid) == 0)
             mapKeyFirstBlock[keyid] = pindexMax;
     }
-    setKeys.clear();
 
     // if there are no such keys, we're done
     if (mapKeyFirstBlock.empty())

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -415,18 +415,8 @@ bool CWallet::Unlock(const CKeyingMaterial& vMasterKeyIn)
         for (; mi != mapCryptedKeys.end(); ++mi) {
             const CPubKey& vchPubKey = (*mi).second.first;
             const std::vector<unsigned char>& vchCryptedSecret = (*mi).second.second;
-            CKeyingMaterial vchSecret;
-            if (!DecryptSecret(vMasterKeyIn, vchCryptedSecret, vchPubKey.GetHash(), vchSecret)) {
-                keyFail = true;
-                break;
-            }
-            if (vchSecret.size() != 32) {
-                keyFail = true;
-                break;
-            }
             CKey key;
-            key.Set(vchSecret.begin(), vchSecret.end(), vchPubKey.IsCompressed());
-            if (key.GetPubKey() != vchPubKey) {
+            if (!DecryptKey(vMasterKeyIn, vchCryptedSecret, vchPubKey, key)) {
                 keyFail = true;
                 break;
             }


### PR DESCRIPTION
Grouped some updates to the wallet crypter sources.

* Cleaned Sapling crypter code.
* Backported #11272.
* Return result in `GetKeys()` instead of writing to reference (#10916).