### PR TITLE
[GUI][BugFix] Fix missing dashboard chart date filter initialization at startup

### DIFF
--- a/src/qt/pivx/dashboardwidget.cpp
+++ b/src/qt/pivx/dashboardwidget.cpp
@@ -891,6 +891,7 @@ void DashboardWidget::onHideChartsChanged(bool fHide)
         }
         stakesFilter->setSourceModel(txModel);
         hasStakes = stakesFilter->rowCount() > 0;
+        filterUpdateNeeded = true;
     } else {
         if (stakesFilter) {
             stakesFilter->setSourceModel(nullptr);


### PR DESCRIPTION
As per the title says, as the staking date filter is not being initialized at startup the chart shows the entire staking history as it would have happened in the same year.