### PR TITLE
[validation] Create zerocoin coinspends cache

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1691,10 +1691,15 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
             pindex->nHeight < consensus.height_last_ZC_AccumCheckpoint) {
         // Legacy Zerocoin DB: If Accumulators Checkpoint is changed, cache the checksums
         CacheAccChecksum(pindex, true);
+        // Clean coinspends cache every 50k blocks, so it does not grow unnecessarily
+        if (pindex->nHeight % 50000 == 0) {
+            ZPIVModule::CleanCoinSpendsCache();
+        }
     } else if (accumulatorCache && pindex->nHeight > consensus.height_last_ZC_AccumCheckpoint + 100) {
         // 100 blocks After last Checkpoint block, wipe the checksum database and cache
         accumulatorCache->Wipe();
         accumulatorCache.reset();
+        ZPIVModule::CleanCoinSpendsCache();
     }
 
     // 100 blocks after the last invalid out, clean the map contents

--- a/src/zpiv/zpivmodule.h
+++ b/src/zpiv/zpivmodule.h
@@ -78,6 +78,9 @@ namespace ZPIVModule {
      * @return true if everything went ok
      */
     bool ParseZerocoinPublicSpend(const CTxIn &in, const CTransaction& tx, CValidationState& state, PublicCoinSpend& publicCoinSpend);
+
+    // Clear the coinspend cache
+    void CleanCoinSpendsCache();
 };
 
 


### PR DESCRIPTION
Essentially a zerocoin coinSpends cache layer to speedup the blockchain synchronization process during the period of time where blocks contained zerocoin transactions (which is the slowest period).

The reason behind this is that the sources are parsing and re-parsing the same zc transaction coinspend script over and over in different parts of the block validation circuit such as:
(1) block signature validation, (2) CheckZerocoinSpend, (3) ParseAndValidateZerocoinSpends, (4) CheckInBlockDoubleSpends, (5) IsUnspentOnFork, (6) ZPoS contextual checks, (7) NewZPivStake.

Pending to do: measure the blocks synchronization time improvement.