### PR TITLE
[BUG] Fix SPORK-21 check in CMasternodePayments::ProcessBlock

### DIFF
--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -709,7 +709,7 @@ void CMasternodePayments::ProcessBlock(int nBlockHeight)
     LogPrintf("%s: Processing block %d\n", __func__, nBlockHeight);
 
     // No more mnw messages after transition to DMN
-    if (deterministicMNManager->LegacyMNObsolete()) {
+    if (deterministicMNManager->LegacyMNObsolete(nBlockHeight)) {
         return;
     }
     if (!fMasterNode) return;

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -541,7 +541,7 @@ static bool canScheduleMN(bool fFilterSigTime, const MasternodeRef& mn, int minP
 MasternodeRef CMasternodeMan::GetNextMasternodeInQueueForPayment(int nBlockHeight, bool fFilterSigTime, int& nCount, const CBlockIndex* pChainTip) const
 {
     // Skip after legacy obsolete. !TODO: remove when transition to DMN is complete
-    if (deterministicMNManager->LegacyMNObsolete()) {
+    if (deterministicMNManager->LegacyMNObsolete(nBlockHeight)) {
         LogPrintf("%s: ERROR - called after legacy system disabled\n", __func__);
         return nullptr;
     }
@@ -1024,7 +1024,6 @@ void CMasternodeMan::UpdateMasternodeList(CMasternodeBroadcast& mnb)
 {
     // Skip after legacy obsolete. !TODO: remove when transition to DMN is complete
     if (deterministicMNManager->LegacyMNObsolete()) {
-        LogPrint(BCLog::MASTERNODE, "Removing all legacy mn due to SPORK 21\n");
         return;
     }
 


### PR DESCRIPTION
Since this function is called "10 blocks in advance", the status of SPORK-21 should be checked with `nBlockHeight`, not with the current chain tip height.