### PR TITLE
[Refactor] differentiate bad-qc-quorum-hash: not-found/not-active-chain

### DIFF
--- a/src/evo/specialtx_validation.cpp
+++ b/src/evo/specialtx_validation.cpp
@@ -444,7 +444,7 @@ bool VerifyLLMQCommitment(const llmq::CFinalCommitment& qfc, const CBlockIndex* 
         // Get quorum index
         auto it = mapBlockIndex.find(qfc.quorumHash);
         if (it == mapBlockIndex.end()) {
-            return state.DoS(100, false, REJECT_INVALID, "bad-qc-quorum-hash");
+            return state.DoS(100, false, REJECT_INVALID, "bad-qc-quorum-hash-not-found");
         }
         const CBlockIndex* pindexQuorum = it->second;
 
@@ -456,7 +456,7 @@ bool VerifyLLMQCommitment(const llmq::CFinalCommitment& qfc, const CBlockIndex* 
 
         if (pindexQuorum != pindexPrev->GetAncestor(pindexQuorum->nHeight)) {
             // not part of active chain
-            return state.DoS(100, false, REJECT_INVALID, "bad-qc-quorum-hash");
+            return state.DoS(100, false, REJECT_INVALID, "bad-qc-quorum-hash-not-active-chain");
         }
 
         // Get members and check signatures (for not-null commitments)

--- a/src/test/test_pivx.cpp
+++ b/src/test/test_pivx.cpp
@@ -174,7 +174,8 @@ CBlock TestChainSetup::CreateBlock(const std::vector<CMutableTransaction>& txns,
                                    const CScript& scriptPubKey,
                                    bool fNoMempoolTx,
                                    bool fTestBlockValidity,
-                                   bool fIncludeQfc)
+                                   bool fIncludeQfc,
+                                   CBlockIndex* customPrevBlock)
 {
     std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler(
             Params(), DEFAULT_PRINTPRIORITY).CreateNewBlock(scriptPubKey,
@@ -183,7 +184,7 @@ CBlock TestChainSetup::CreateBlock(const std::vector<CMutableTransaction>& txns,
                                                             nullptr, // availableCoins
                                                             fNoMempoolTx,
                                                             fTestBlockValidity,
-                                                            nullptr,
+                                                            customPrevBlock,
                                                             true,
                                                             fIncludeQfc);
     std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>(pblocktemplate->block);
@@ -193,7 +194,8 @@ CBlock TestChainSetup::CreateBlock(const std::vector<CMutableTransaction>& txns,
         pblock->vtx.push_back(MakeTransactionRef(tx));
     }
 
-    const int nHeight = WITH_LOCK(cs_main, return chainActive.Height()) + 1;
+    const int nHeight = (customPrevBlock != nullptr ? customPrevBlock->nHeight + 1
+                                                    : WITH_LOCK(cs_main, return chainActive.Height()) + 1);
 
     // Re-compute sapling root
     pblock->hashFinalSaplingRoot = CalculateSaplingTreeRoot(pblock.get(), nHeight, Params());

--- a/src/test/test_pivx.h
+++ b/src/test/test_pivx.h
@@ -98,7 +98,8 @@ struct TestChainSetup : public TestingSetup
                        const CScript& scriptPubKey,
                        bool fNoMempoolTx = true,
                        bool fTestBlockValidity = true,
-                       bool fIncludeQfc = true);
+                       bool fIncludeQfc = true,
+                       CBlockIndex* customPrevBlock = nullptr);
     CBlock CreateBlock(const std::vector<CMutableTransaction>& txns, const CKey& scriptKey, bool fTestBlockValidity = true);
 
     std::vector<CTransaction> coinbaseTxns; // For convenience, coinbase transactions


### PR DESCRIPTION
As discussed in #2699 , split `bad-qc-quorum-hash` reject reason in two different cases for "hash not found" and "hash not in active chain" and add unit test coverage.