### PR TITLE
[validation] Reject valid qfc older than a certain depth.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -77,6 +77,8 @@ static Consensus::LLMQParams llmq_test = {
 
         .keepOldConnections = 3,
         .recoveryMembers = 3,
+
+        .cacheDkgInterval = 180,
 };
 
 static Consensus::LLMQParams llmq50_60 = {
@@ -96,6 +98,8 @@ static Consensus::LLMQParams llmq50_60 = {
 
         .keepOldConnections = 25,
         .recoveryMembers = 25,
+
+        .cacheDkgInterval = 600,
 };
 
 static Consensus::LLMQParams llmq400_60 = {
@@ -115,6 +119,8 @@ static Consensus::LLMQParams llmq400_60 = {
 
         .keepOldConnections = 5,
         .recoveryMembers = 100,
+
+        .cacheDkgInterval = 60 * 12 * 10, // dkgInterval * 10
 };
 
 // Used for deployment and min-proto-version signaling, so it needs a higher threshold
@@ -135,6 +141,8 @@ static Consensus::LLMQParams llmq400_85 = {
 
         .keepOldConnections = 5,
         .recoveryMembers = 100,
+
+        .cacheDkgInterval = 60 * 24 * 10, // dkgInterval * 10
 };
 
 /**

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -158,6 +158,9 @@ struct LLMQParams {
 
     // How many members should we try to send all sigShares to before we give up.
     int recoveryMembers;
+
+    // The limit of blocks up until where the dkg qfc will be accepted.
+    int cacheDkgInterval;
 };
 
 /**

--- a/src/evo/specialtx_validation.cpp
+++ b/src/evo/specialtx_validation.cpp
@@ -454,6 +454,11 @@ bool VerifyLLMQCommitment(const llmq::CFinalCommitment& qfc, const CBlockIndex* 
             return state.DoS(100, false, REJECT_INVALID, "bad-qc-quorum-height");
         }
 
+        // Check height limit
+        if (pindexPrev->nHeight - pindexQuorum->nHeight > params->cacheDkgInterval) {
+            return state.DoS(100, false, REJECT_INVALID, "bad-qc-quorum-height-old");
+        }
+
         if (pindexQuorum != pindexPrev->GetAncestor(pindexQuorum->nHeight)) {
             // not part of active chain
             return state.DoS(100, false, REJECT_INVALID, "bad-qc-quorum-hash-not-active-chain");


### PR DESCRIPTION
Built on top of #2713.

Added a depth limit for the acceptance of LLMQ final commitments to prevent spam attacks like the relay of old valid qfc through the inv system.