### PR TITLE
[GUI] Don't error on zero amount for new cold staking address

### DIFF
--- a/src/qt/pivx/requestdialog.cpp
+++ b/src/qt/pivx/requestdialog.cpp
@@ -68,9 +68,9 @@ void RequestDialog::setWalletModel(WalletModel *model)
     ui->comboBoxCoin->setText(BitcoinUnits::name(this->walletModel->getOptionsModel()->getDisplayUnit()));
 }
 
-void RequestDialog::setPaymentRequest(bool isPaymentRequest)
+void RequestDialog::setPaymentRequest(bool _isPaymentRequest)
 {
-    this->isPaymentRequest = isPaymentRequest;
+    this->isPaymentRequest = _isPaymentRequest;
     if (!this->isPaymentRequest) {
         ui->labelMessage->setText(tr("Creates an address to receive coin delegations and be able to stake them."));
         ui->labelTitle->setText(tr("New Cold Staking Address"));

--- a/src/qt/pivx/requestdialog.cpp
+++ b/src/qt/pivx/requestdialog.cpp
@@ -92,10 +92,10 @@ void RequestDialog::accept()
         }
 
         int displayUnit = walletModel->getOptionsModel()->getDisplayUnit();
-        auto value = ui->lineEditAmount->text().isEmpty() ? -1 :
+        auto value = ui->lineEditAmount->text().isEmpty() ? 0 :
                 GUIUtil::parseValue(ui->lineEditAmount->text(), displayUnit);
 
-        if (value <= 0) {
+        if (value <= 0 && this->isPaymentRequest) {
             inform(tr("Invalid amount"));
             return;
         }

--- a/src/qt/pivx/requestdialog.h
+++ b/src/qt/pivx/requestdialog.h
@@ -27,7 +27,7 @@ public:
     ~RequestDialog();
 
     void setWalletModel(WalletModel *model);
-    void setPaymentRequest(bool isPaymentRequest);
+    void setPaymentRequest(bool _isPaymentRequest);
     void showEvent(QShowEvent *event) override;
     int res = -1;
 


### PR DESCRIPTION
For new payment requests via the UI, it doesn't make sense to have an empty/zero value for the amount being requested, but when creating a new cold staking address it is up to the sender how much they want to delegate, so the value at address creation time is completely optional.

This fixes the hard requirement of setting a non-zero value for cold staking address creation, and will no longer throw an error when the amount value is omitted (as the GUI indicates it is optional, which should be the intended behavior).

Also fixes a variable shadowing issue.