### PR TITLE
[RPC] Add options -stdin and -stdinrpcpass to pivx-cli

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -18,28 +18,6 @@ Notable Changes
 (Developers: add your notes here as part of your pull requests whenever possible)
 
 
-### Deprecated autocombinerewards RPC Command
-
-The `autocombinerewards` RPC command was soft-deprecated in v5.3.0 and replaced with explicit setter/getter commands `setautocombinethreshold`/`getautocombinethreshold`. PIVX Core, by default, will no longer accept the `autocombinerewards` command, returning a deprecation error, unless the `pivxd`/`pivx-qt` is started with the `-deprecatedrpc=autocombinerewards` option.
-
-This command will be fully removed in v6.0.0.
-
-### Shield address support for RPC label commands
-
-The `setlabel` RPC command now supports a shield address input argument to allow users to set labels for shield addresses. Additionally, the `getaddressesbylabel` RPC command will also now return shield addresses with a matching label.
-
-### Specify optional label for getnewshieldaddress
-
-The `getnewshieldaddress` RPC command now takes an optional argument `label (string)` to denote the desired label for the generated address.
-
-P2P connection management
---------------------------
-
-- Peers manually added through the addnode option or addnode RPC now have their own
-  limit of sixteen connections which does not compete with other inbound or outbound
-  connection usage and is not subject to the maxconnections limitation.
-
-- New connections to manually added peers are much faster.
 
 *version* Change log
 ==============
@@ -47,8 +25,6 @@ P2P connection management
 Detailed release notes follow. This overview includes changes that affect behavior, not code moves, refactors and string updates. For convenience in locating the code changes and accompanying discussion, both the pull request and git merge commit are mentioned.
 
 ### Core Features
-
-### Build System
 
 ### P2P Protocol and Network Code
 
@@ -58,7 +34,15 @@ Detailed release notes follow. This overview includes changes that affect behavi
 
 ### Wallet
 
-### Miscellaneous
+### Tier Two Network
+
+### Build Systems
+
+### Testing
+
+### Cleanup/Refactoring
+
+### Docs/Output
 
 ## Credits
 

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -17,7 +17,18 @@ Notable Changes
 
 (Developers: add your notes here as part of your pull requests whenever possible)
 
+pivx-cli: arguments privacy
+--------------------------------
 
+The RPC command line client gained a new argument, `-stdin`
+to read extra arguments from standard input, one per line until EOF/Ctrl-D.
+For example:
+
+    $ echo -e "mysecretcode\n120" | src/pivx-cli -stdin walletpassphrase
+
+It is recommended to use this for sensitive information such as wallet
+passphrases, as command-line arguments can usually be read from the process
+table by any user on the system.
 
 *version* Change log
 ==============

--- a/src/pivx-cli.cpp
+++ b/src/pivx-cli.cpp
@@ -47,6 +47,7 @@ std::string HelpMessageCli()
     strUsage += HelpMessageOpt("-rpcuser=<user>", "Username for JSON-RPC connections");
     strUsage += HelpMessageOpt("-rpcpassword=<pw>", "Password for JSON-RPC connections");
     strUsage += HelpMessageOpt("-rpcclienttimeout=<n>", strprintf("Timeout in seconds during HTTP requests, or 0 for no timeout. (default: %d)", DEFAULT_HTTP_CLIENT_TIMEOUT));
+    strUsage += HelpMessageOpt("-stdin", ("Read extra arguments from standard input, one per line until EOF/Ctrl-D (recommended for sensitive information such as passphrases)"));
     strUsage += HelpMessageOpt("-rpcwallet=<walletname>", "Send RPC for non-default wallet on RPC server (needs to exactly match corresponding -wallet option passed to pivxd)");
 
     return strUsage;
@@ -296,19 +297,21 @@ int CommandLineRPC(int argc, char* argv[])
             argc--;
             argv++;
         }
-
-        // Method
-        if (argc < 2)
-            throw std::runtime_error("too few parameters");
-        std::string strMethod = argv[1];
-
-        // Parameters default to strings
-        std::vector<std::string> strParams(&argv[2], &argv[argc]);
+        std::vector<std::string> args = std::vector<std::string>(&argv[1], &argv[argc]);
+        if (gArgs.GetBoolArg("-stdin", false)) {
+            // Read one arg per line from stdin and append
+            std::string line;
+            while (std::getline(std::cin,line))
+                args.push_back(line);
+        }
+        if (args.size() < 1)
+            throw std::runtime_error("too few parameters (need at least command)");
+        std::string strMethod = args[0];
         UniValue params;
-        if(gArgs.GetBoolArg("-named", DEFAULT_NAMED)) {
-            params = RPCConvertNamedValues(strMethod, strParams);
+        if (gArgs.GetBoolArg("-named", DEFAULT_NAMED)) {
+            params = RPCConvertNamedValues(strMethod, std::vector<std::string>(args.begin()+1, args.end()));
         } else {
-            params = RPCConvertValues(strMethod, strParams);
+            params = RPCConvertValues(strMethod, std::vector<std::string>(args.begin()+1, args.end()));
         }
 
         // Execute and handle connection failures with -rpcwait

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -37,6 +37,12 @@ class TestBitcoinCli(PivxTestFramework):
         assert_equal(["foo", "bar"], self.nodes[0].cli('-rpcuser=%s' % user, '-stdin', '-stdinrpcpass', input=password + "\nfoo\nbar").echo())
         assert_raises_process_error(1, "Incorrect rpcuser or rpcpassword", self.nodes[0].cli('-rpcuser=%s' % user, '-stdin', '-stdinrpcpass', input="foo").echo)
 
+        self.log.info("Test connecting to a non-existing server")
+        assert_raises_process_error(1, "Could not connect to the server", self.nodes[0].cli('-rpcport=1').echo)
+
+        self.log.info("Test connecting with non-existing RPC cookie file")
+        assert_raises_process_error(1, "Could not locate RPC credentials", self.nodes[0].cli('-rpccookiefile=does-not-exist', '-rpcpassword=').echo)
+
         self.log.info("Compare responses from `pivx-cli -getinfo` and the RPCs data is retrieved from.")
         cli_get_info = self.nodes[0].cli('getinfo').send_cli()
         wallet_info = self.nodes[0].getwalletinfo()

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 # Copyright (c) 2017 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
-# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# file COPYING or https://www.opensource.org/licenses/mit-license.php.
 """Test pivx-cli"""
-
-import time
 
 from test_framework.test_framework import PivxTestFramework
 from test_framework.util import assert_equal, get_auth_cookie
@@ -18,9 +16,6 @@ class TestBitcoinCli(PivxTestFramework):
 
     def run_test(self):
         """Main test logic"""
-
-        self.log.info("Sleeping 30 seconds...")
-        time.sleep(30)
 
         self.log.info("Compare responses from gewalletinfo RPC and `pivx-cli getwalletinfo`")
         cli_response = self.nodes[0].cli.getwalletinfo()

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -5,7 +5,7 @@
 """Test pivx-cli"""
 
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import assert_equal, get_auth_cookie
+from test_framework.util import assert_equal, assert_raises_process_error, get_auth_cookie
 
 
 class TestBitcoinCli(PivxTestFramework):
@@ -28,6 +28,14 @@ class TestBitcoinCli(PivxTestFramework):
         assert_equal(cli_response, rpc_response)
 
         user, password = get_auth_cookie(self.nodes[0].datadir)
+
+        self.log.info("Test -stdinrpcpass option")
+        assert_equal(0, self.nodes[0].cli('-rpcuser=%s' % user, '-stdinrpcpass', input=password).getblockcount())
+        assert_raises_process_error(1, "Incorrect rpcuser or rpcpassword", self.nodes[0].cli('-rpcuser=%s' % user, '-stdinrpcpass', input="foo").echo)
+
+        self.log.info("Test -stdin and -stdinrpcpass")
+        assert_equal(["foo", "bar"], self.nodes[0].cli('-rpcuser=%s' % user, '-stdin', '-stdinrpcpass', input=password + "\nfoo\nbar").echo())
+        assert_raises_process_error(1, "Incorrect rpcuser or rpcpassword", self.nodes[0].cli('-rpcuser=%s' % user, '-stdin', '-stdinrpcpass', input="foo").echo)
 
         self.log.info("Compare responses from `pivx-cli -getinfo` and the RPCs data is retrieved from.")
         cli_get_info = self.nodes[0].cli('getinfo').send_cli()


### PR DESCRIPTION
To allow sensitive data such as RPC password, walletpasshrase etc. to be read from standard input.
Command line data can (usually) be seen by other users on the system in the `ps` output..

This ports:
* #7550
* #10997
* #11125
* #12652

TO DO:
Add release-notes.