### PR TITLE
[TierTwo] Refresh non-auth connection if DMNs become quorum members

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -604,7 +604,7 @@ public:
 
         // long living quorum params
         consensus.llmqs[Consensus::LLMQ_TEST] = llmq_test;
-        nLLMQConnectionRetryTimeout = 5;
+        nLLMQConnectionRetryTimeout = 10;
     }
 
     const CCheckpointData& Checkpoints() const

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1794,8 +1794,18 @@ void CConnman::OpenNetworkConnection(const CAddress& addrConnect, bool fCountFai
             FindNode(static_cast<CNetAddr>(addrConnect)) || IsBanned(addrConnect) ||
             FindNode(addrConnect.ToStringIPPort()))
             return;
-    } else if (FindNode(pszDest))
-        return;
+    } else {
+        CNode* pnode = FindNode(pszDest);
+        if (pnode) {
+            // If this is a mnauth connection and the node is already connected normally,
+            // disconnect it and open a new connection
+            if (masternode_connection && !pnode->m_masternode_connection) {
+                pnode->fDisconnect = true;
+            } else {
+                return;
+            }
+        }
+    }
 
     CNode* pnode = ConnectNode(addrConnect, pszDest, fCountFailure);
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -760,6 +760,7 @@ const char* SINGLE_CONN = "single_conn";
 const char* QUORUM_MEMBERS_CONN = "quorum_members_conn";
 const char* IQR_MEMBERS_CONN = "iqr_members_conn";
 const char* PROBE_CONN = "probe_conn";
+const char* CLEAR_CONN = "clear_conn";
 
 /* What essentially does is add a pending MN connection
  * Can be in the following forms:
@@ -767,12 +768,13 @@ const char* PROBE_CONN = "probe_conn";
  * 2) Quorum members connection (set of DMNs to connect).
  * 3) Quorum relay members connections (set of DMNs to connect and relay intra-quorum messages).
  * 4) Probe DMN connection.
+ * 5) Clear tier two net connections cache
 **/
 UniValue mnconnect(const JSONRPCRequest& request)
 {
-    if (request.fHelp || request.params.size() < 2 || request.params.size() > 4) {
+    if (request.fHelp || request.params.size() > 4) {
         throw std::runtime_error(
-                "mnconnect \"op_type\" \"[pro_tx_hash, pro_tx_hash,..]\" (llmq_type \"quorum_hash\")\n"
+                "mnconnect \"op_type\" (\"[pro_tx_hash, pro_tx_hash,..]\" llmq_type \"quorum_hash\")\n"
                 "\nAdd manual quorum members connections for internal testing purposes of the tier two p2p network layer\n"
         );
     }
@@ -781,7 +783,19 @@ UniValue mnconnect(const JSONRPCRequest& request)
     if (!chainparams.IsRegTestNet())
         throw std::runtime_error("mnconnect for regression testing (-regtest mode) only");
 
-    RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VARR});
+    // Connection type
+    RPCTypeCheck(request.params, {UniValue::VSTR});
+    const std::string& op_type = request.params[0].get_str();
+
+    // DMNs pro_tx list
+    std::set<uint256> set_dmn_protxhash;
+    if (request.params.size() > 1) {
+        RPCTypeCheckArgument(request.params[1], UniValue::VARR);
+        const auto& array{request.params[1].get_array()};
+        for (unsigned int i = 0; i < array.size(); i++) {
+            set_dmn_protxhash.emplace(uint256S(array[i].get_str()));
+        }
+    }
 
     Consensus::LLMQType llmq_type = Consensus::LLMQ_NONE;
     if (request.params.size() > 2) {
@@ -793,15 +807,6 @@ UniValue mnconnect(const JSONRPCRequest& request)
     if (request.params.size() > 3) {
         RPCTypeCheckArgument(request.params[3], UniValue::VSTR);
         quorum_hash = uint256S(request.params[3].get_str());
-    }
-
-    // First obtain the connection type
-    const std::string& op_type = request.params[0].get_str();
-    // Check provided mn_list
-    const auto& array{request.params[1].get_array()};
-    std::set<uint256> set_dmn_protxhash;
-    for (unsigned int i = 0; i < array.size(); i++) {
-        set_dmn_protxhash.emplace(uint256S(array[i].get_str()));
     }
 
     const auto& mn_connan =  g_connman->GetTierTwoConnMan();
@@ -820,6 +825,9 @@ UniValue mnconnect(const JSONRPCRequest& request)
         return true;
     } else if (op_type == PROBE_CONN) {
         mn_connan->addPendingProbeConnections(set_dmn_protxhash);
+        return true;
+    } else if (op_type == CLEAR_CONN) {
+        mn_connan->clear();
         return true;
     }
     return false;

--- a/src/tiertwo/net_masternodes.cpp
+++ b/src/tiertwo/net_masternodes.cpp
@@ -123,6 +123,15 @@ void TierTwoConnMan::addPendingProbeConnections(const std::set<uint256>& proTxHa
     masternodePendingProbes.insert(proTxHashes.begin(), proTxHashes.end());
 }
 
+void TierTwoConnMan::clear()
+{
+    LOCK(cs_vPendingMasternodes);
+    masternodeQuorumNodes.clear();
+    masternodeQuorumRelayMembers.clear();
+    vPendingMasternodes.clear();
+    masternodePendingProbes.clear();
+}
+
 void TierTwoConnMan::start(CScheduler& scheduler, const TierTwoConnMan::Options& options)
 {
     // Must be started after connman

--- a/src/tiertwo/net_masternodes.h
+++ b/src/tiertwo/net_masternodes.h
@@ -58,6 +58,9 @@ public:
     // Set the local DMN so the node does not try to connect to himself
     void setLocalDMN(const uint256& pro_tx_hash) { WITH_LOCK(cs_vPendingMasternodes, local_dmn_pro_tx_hash = pro_tx_hash;); }
 
+    // Clear connections cache
+    void clear();
+
     // Manages the MN connections
     void ThreadOpenMasternodeConnections();
     void start(CScheduler& scheduler, const TierTwoConnMan::Options& options);

--- a/test/functional/p2p_quorum_connect.py
+++ b/test/functional/p2p_quorum_connect.py
@@ -14,6 +14,7 @@ from test_framework.util import (
     assert_equal,
     assert_true,
     bytes_to_hex_str,
+    connect_nodes,
     connect_nodes_clique,
     hash256,
     hex_str_to_bytes,
@@ -128,7 +129,17 @@ class DMNConnectionTest(PivxTestFramework):
 
     def has_mn_auth_connection(self, node, expected_proreg_tx_hash):
         peer_info = node.getpeerinfo()
-        return (len(peer_info) == 1) and (peer_info[0]["verif_mn_proreg_tx_hash"] == expected_proreg_tx_hash)
+        return (len(peer_info) == 1) and "verif_mn_proreg_tx_hash" in peer_info[0]\
+               and (peer_info[0]["verif_mn_proreg_tx_hash"] == expected_proreg_tx_hash)
+
+    def has_single_regular_connection(self, node):
+        peer_info = node.getpeerinfo()
+        return len(peer_info) == 1 and "verif_mn_proreg_tx_hash" not in peer_info[0]
+
+    def clean_conns_and_disconnect(self, node):
+        node.mnconnect("clear_conn")
+        self.disconnect_peers(node)
+        wait_until(lambda: len(node.getpeerinfo()) == 0, timeout=30)
 
     def run_test(self):
         self.disable_mocktime()
@@ -224,6 +235,29 @@ class DMNConnectionTest(PivxTestFramework):
         assert_equal(len(self.miner.getpeerinfo()), 0)
         self.log.info("Regular node disconnected auth connection successfully")
 
+        ##############################################################################
+        # 6) Now test regular connection refresh after selecting peer as quorum member
+        ##############################################################################
+        self.log.info("6) Now test regular connection refresh after selecting peer as quorum member..")
+        # Cleaning internal data first
+        mn5_node = self.nodes[mn5.idx]
+        self.clean_conns_and_disconnect(mn5_node)
+        self.clean_conns_and_disconnect(mn6_node)
+
+        # Create the regular connection
+        connect_nodes(mn5_node, mn6.idx)
+        wait_until(lambda: len(mn5_node.getpeerinfo()) == 1, timeout=30)
+        assert_true(self.has_single_regular_connection(mn5_node))
+        assert_true(self.has_single_regular_connection(mn6_node))
+
+        # Now refresh it to be a quorum member connection
+        quorum_hash = mn5_node.getbestblockhash()
+        assert mn5_node.mnconnect("quorum_members_conn", [mn6.proTx], 1, quorum_hash)
+        assert mn5_node.mnconnect("iqr_members_conn", [mn6.proTx], 1, quorum_hash)
+        assert mn6_node.mnconnect("iqr_members_conn", [mn5.proTx], 1, quorum_hash)
+
+        wait_until(lambda: self.has_mn_auth_connection(mn5_node, mn6.proTx), timeout=60)
+        self.log.info("Connection refreshed!")
 
 if __name__ == '__main__':
     DMNConnectionTest().main()


### PR DESCRIPTION
Built on top of #2647. Starting on e258281d.

Solving the situation where DMNs are already connected between each other through a regular connection and they become quorum members. The connection requires to be refreshed to become an authenticated iqr connection.
Included test coverage as well.