### PR TITLE
[GUI] Decouple legacy MNs code from the GUI elements

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -234,6 +234,7 @@ public:
         consensus.nMaxMoneyOut = 21000000 * COIN;
         consensus.nMNCollateralAmt = 10000 * COIN;
         consensus.nMNBlockReward = 3 * COIN;
+        consensus.nMNCollateralMinConf = 15;
         consensus.nProposalEstablishmentTime = 60 * 60 * 24;    // must be at least a day old to make it into a budget
         consensus.nStakeMinAge = 60 * 60;
         consensus.nStakeMinDepth = 600;
@@ -385,6 +386,7 @@ public:
         consensus.nMaxMoneyOut = 21000000 * COIN;
         consensus.nMNCollateralAmt = 10000 * COIN;
         consensus.nMNBlockReward = 3 * COIN;
+        consensus.nMNCollateralMinConf = 15;
         consensus.nProposalEstablishmentTime = 60 * 5;  // at least 5 min old to make it into a budget
         consensus.nStakeMinAge = 60 * 60;
         consensus.nStakeMinDepth = 100;
@@ -518,6 +520,7 @@ public:
         consensus.nMaxMoneyOut = 43199500 * COIN;
         consensus.nMNCollateralAmt = 100 * COIN;
         consensus.nMNBlockReward = 3 * COIN;
+        consensus.nMNCollateralMinConf = 1;
         consensus.nProposalEstablishmentTime = 60 * 5;  // at least 5 min old to make it into a budget
         consensus.nStakeMinAge = 0;
         consensus.nStakeMinDepth = 20;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -180,6 +180,7 @@ struct Params {
     int nFutureTimeDriftPoS;
     CAmount nMaxMoneyOut;
     CAmount nMNCollateralAmt;
+    int nMNCollateralMinConf;
     CAmount nMNBlockReward;
     int64_t nProposalEstablishmentTime;
     int nStakeMinAge;
@@ -212,6 +213,7 @@ struct Params {
     uint256 ProofOfStakeLimit(const bool fV2) const { return fV2 ? posLimitV2 : posLimitV1; }
     bool MoneyRange(const CAmount& nValue) const { return (nValue >= 0 && nValue <= nMaxMoneyOut); }
     bool IsTimeProtocolV2(const int nHeight) const { return NetworkUpgradeActive(nHeight, UPGRADE_V4_0); }
+    int MasternodeCollateralMinConf() const { return nMNCollateralMinConf; }
 
     int FutureBlockTimeDrift(const int nHeight) const
     {

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -12,24 +12,18 @@
 #include "tiertwo/tiertwo_sync_state.h"
 #include "wallet/wallet.h"
 
-#define MASTERNODE_MIN_CONFIRMATIONS_REGTEST 1
 #define MASTERNODE_MIN_MNP_SECONDS_REGTEST 90
 #define MASTERNODE_MIN_MNB_SECONDS_REGTEST 25
 #define MASTERNODE_PING_SECONDS_REGTEST 25
 #define MASTERNODE_EXPIRATION_SECONDS_REGTEST 12 * 60
 #define MASTERNODE_REMOVAL_SECONDS_REGTEST 13 * 60
 
-#define MASTERNODE_MIN_CONFIRMATIONS 15
 #define MASTERNODE_MIN_MNP_SECONDS (10 * 60)
 #define MASTERNODE_MIN_MNB_SECONDS (5 * 60)
 #define MASTERNODE_PING_SECONDS (5 * 60)
 #define MASTERNODE_EXPIRATION_SECONDS (120 * 60)
 #define MASTERNODE_REMOVAL_SECONDS (130 * 60)
 #define MASTERNODE_CHECK_SECONDS 5
-
-// keep track of the scanning errors I've seen
-std::map<uint256, int> mapSeenMasternodeScanningErrors;
-
 
 int MasternodeMinPingSeconds()
 {
@@ -39,11 +33,6 @@ int MasternodeMinPingSeconds()
 int MasternodeBroadcastSeconds()
 {
     return Params().IsRegTestNet() ? MASTERNODE_MIN_MNB_SECONDS_REGTEST : MASTERNODE_MIN_MNB_SECONDS;
-}
-
-int MasternodeCollateralMinConf()
-{
-    return Params().IsRegTestNet() ? MASTERNODE_MIN_CONFIRMATIONS_REGTEST : MASTERNODE_MIN_CONFIRMATIONS;
 }
 
 int MasternodePingSeconds()

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -30,7 +30,6 @@ typedef std::shared_ptr<const CDeterministicMN> CDeterministicMNCPtr;
 
 int MasternodeMinPingSeconds();
 int MasternodeBroadcastSeconds();
-int MasternodeCollateralMinConf();
 int MasternodePingSeconds();
 int MasternodeExpirationSeconds();
 int MasternodeRemovalSeconds();

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -98,11 +98,6 @@ QString ClientModel::getMasternodesCountString()
     return cachedMasternodeCountString;
 }
 
-CAmount ClientModel::getMNCollateralRequiredAmount()
-{
-    return Params().GetConsensus().nMNCollateralAmt;
-}
-
 int ClientModel::getNumBlocks()
 {
     if (!cacheTip) {

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -110,9 +110,6 @@ public:
     QString getMasternodesCountString();
     int getMasternodesCount() const { return m_cached_masternodes_count; }
 
-    // Return the specific chain amount value for the MN collateral output.
-    CAmount getMNCollateralRequiredAmount();
-
 private:
     // Listeners
     std::unique_ptr<interfaces::Handler> m_handler_show_progress;

--- a/src/qt/pivx/guitransactionsutils.cpp
+++ b/src/qt/pivx/guitransactionsutils.cpp
@@ -8,9 +8,9 @@
 
 namespace GuiTransactionsUtils {
 
-    QString ProcessSendCoinsReturn(PWidget::Translator *parent, const WalletModel::SendCoinsReturn &sendCoinsReturn,
-                                WalletModel *walletModel, CClientUIInterface::MessageBoxFlags& informType, const QString &msgArg,
-                                bool fPrepare)
+    QString ProcessSendCoinsReturn(const WalletModel::SendCoinsReturn &sendCoinsReturn, WalletModel *walletModel,
+                                   CClientUIInterface::MessageBoxFlags& informType, const QString &msgArg,
+                                   bool fPrepare)
     {
         QString retStr;
         informType = CClientUIInterface::MSG_WARNING;
@@ -19,27 +19,27 @@ namespace GuiTransactionsUtils {
         // are used only in WalletModel::sendCoins(). All others are used only in WalletModel::prepareTransaction()
         switch (sendCoinsReturn.status) {
             case WalletModel::InvalidAddress:
-                retStr = parent->translate("The recipient address is not valid, please recheck.");
+                retStr = QObject::tr("The recipient address is not valid, please recheck.");
                 break;
             case WalletModel::InvalidAmount:
-                retStr = parent->translate("The amount to pay must be larger than 0.");
+                retStr = QObject::tr("The amount to pay must be larger than 0.");
                 break;
             case WalletModel::AmountExceedsBalance:
-                retStr = parent->translate("The amount to pay exceeds the available balance.");
+                retStr = QObject::tr("The amount to pay exceeds the available balance.");
                 break;
             case WalletModel::AmountWithFeeExceedsBalance:
-                retStr = parent->translate(
+                retStr = QObject::tr(
                         "The total amount to pay exceeds the available balance when the %1 transaction fee is included.").arg(msgArg);
                 break;
             case WalletModel::DuplicateAddress:
-                retStr = parent->translate(
+                retStr = QObject::tr(
                         "Duplicate address found, can only send to each address once per send operation.");
                 break;
             case WalletModel::TransactionCreationFailed:
                 informType = CClientUIInterface::MSG_ERROR;
                 break;
             case WalletModel::TransactionCheckFailed:
-                retStr = parent->translate("The transaction is not valid!");
+                retStr = QObject::tr("The transaction is not valid!");
                 informType = CClientUIInterface::MSG_ERROR;
                 break;
             case WalletModel::TransactionCommitFailed:
@@ -52,14 +52,14 @@ namespace GuiTransactionsUtils {
                     // Unlock wallet if it wasn't fully unlocked already
                     WalletModel::UnlockContext ctx(walletModel->requestUnlock());
                     if (!ctx.isValid()) {
-                        retStr = parent->translate(
+                        retStr = QObject::tr(
                                 "Error: The wallet was unlocked for staking only. Unlock canceled.");
                     }
                 } else
-                    retStr = parent->translate("Error: The wallet is unlocked for staking only. Fully unlock the wallet to send the transaction.");
+                    retStr = QObject::tr("Error: The wallet is unlocked for staking only. Fully unlock the wallet to send the transaction.");
                 break;
             case WalletModel::InsaneFee:
-                retStr = parent->translate(
+                retStr = QObject::tr(
                         "A fee %1 times higher than %2 per kB is considered an insanely high fee.").arg(10000).arg(
                         BitcoinUnits::formatWithUnit(walletModel->getOptionsModel()->getDisplayUnit(),
                                                      ::minRelayTxFee.GetFeePerK()));
@@ -76,8 +76,8 @@ namespace GuiTransactionsUtils {
     void ProcessSendCoinsReturnAndInform(PWidget* parent, const WalletModel::SendCoinsReturn& sendCoinsReturn, WalletModel* walletModel, const QString& msgArg, bool fPrepare)
     {
         CClientUIInterface::MessageBoxFlags informType;
-        QString informMsg = ProcessSendCoinsReturn(parent, sendCoinsReturn, walletModel, informType, msgArg, fPrepare);
-        if (!informMsg.isEmpty()) parent->emitMessage(parent->translate("Send Coins"), informMsg, informType, 0);
+        QString informMsg = ProcessSendCoinsReturn(sendCoinsReturn, walletModel, informType, msgArg, fPrepare);
+        if (!informMsg.isEmpty()) parent->emitMessage(QObject::tr("Send Coins"), informMsg, informType, nullptr);
     }
 
 }

--- a/src/qt/pivx/guitransactionsutils.h
+++ b/src/qt/pivx/guitransactionsutils.h
@@ -15,7 +15,6 @@ namespace GuiTransactionsUtils {
     // of a message and message flags for use in emit message().
     // Additional parameter msgArg can be used via .arg(msgArg).
     QString ProcessSendCoinsReturn(
-            PWidget::Translator* parent,
             const WalletModel::SendCoinsReturn& sendCoinsReturn,
             WalletModel* walletModel,
             CClientUIInterface::MessageBoxFlags& informType,

--- a/src/qt/pivx/masternodeswidget.cpp
+++ b/src/qt/pivx/masternodeswidget.cpp
@@ -10,7 +10,6 @@
 #include "qt/pivx/mninfodialog.h"
 #include "qt/pivx/masternodewizarddialog.h"
 
-#include "activemasternode.h"
 #include "clientmodel.h"
 #include "fs.h"
 #include "guiutil.h"
@@ -471,14 +470,14 @@ void MasterNodesWidget::onCreateMNClicked()
         return;
     }
 
-    CAmount mnCollateralAmount = clientModel->getMNCollateralRequiredAmount();
+    CAmount mnCollateralAmount = mnModel->getMNCollateralRequiredAmount();
     if (walletModel->getBalance() <= mnCollateralAmount) {
         inform(tr("Not enough balance to create a masternode, %1 required.")
             .arg(GUIUtil::formatBalance(mnCollateralAmount, BitcoinUnits::PIV)));
         return;
     }
     showHideOp(true);
-    MasterNodeWizardDialog *dialog = new MasterNodeWizardDialog(walletModel, clientModel, window);
+    MasterNodeWizardDialog *dialog = new MasterNodeWizardDialog(walletModel, mnModel, window);
     if (openDialogWithOpaqueBackgroundY(dialog, window, 5, 7)) {
         if (dialog->isOk) {
             // Update list

--- a/src/qt/pivx/masternodeswidget.cpp
+++ b/src/qt/pivx/masternodeswidget.cpp
@@ -204,23 +204,9 @@ void MasterNodesWidget::onEditMNClicked()
             }
         } else {
             inform(tr("Cannot start masternode, the collateral transaction has not been confirmed by the network yet.\n"
-                    "Please wait few more minutes (masternode collaterals require %1 confirmations).").arg(MasternodeCollateralMinConf()));
+                    "Please wait few more minutes (masternode collaterals require %1 confirmations).").arg(mnModel->getMasternodeCollateralMinConf()));
         }
     }
-}
-
-static bool startMN(const CMasternodeConfig::CMasternodeEntry& mne, int chainHeight, std::string& strError)
-{
-    CMasternodeBroadcast mnb;
-    if (!CMasternodeBroadcast::Create(mne.getIp(), mne.getPrivKey(), mne.getTxHash(), mne.getOutputIndex(), strError, mnb, false, chainHeight))
-        return false;
-
-    mnodeman.UpdateMasternodeList(mnb);
-    if (activeMasternode.pubKeyMasternode == mnb.GetPubKey()) {
-        activeMasternode.EnableHotColdMasterNode(mnb.vin, mnb.addr);
-    }
-    mnb.Relay();
-    return true;
 }
 
 void MasterNodesWidget::startAlias(const QString& strAlias)

--- a/src/qt/pivx/masternodeswidget.h
+++ b/src/qt/pivx/masternodeswidget.h
@@ -8,7 +8,6 @@
 #include "qt/pivx/pwidget.h"
 #include "qt/pivx/furabstractlistitemdelegate.h"
 #include "qt/pivx/tooltipmenu.h"
-#include "walletmodel.h"
 
 #include <atomic>
 

--- a/src/qt/pivx/masternodewizarddialog.cpp
+++ b/src/qt/pivx/masternodewizarddialog.cpp
@@ -8,6 +8,7 @@
 #include "key_io.h"
 #include "qt/pivx/mnmodel.h"
 #include "qt/pivx/qtutils.h"
+#include "qt/walletmodel.h"
 
 #include <QIntValidator>
 #include <QRegularExpression>

--- a/src/qt/pivx/masternodewizarddialog.cpp
+++ b/src/qt/pivx/masternodewizarddialog.cpp
@@ -231,7 +231,7 @@ bool MasterNodeWizardDialog::createMN()
         return false;
     }
 
-    returnStr = tr("Masternode created! Wait %1 confirmations before starting it.").arg(MasternodeCollateralMinConf());
+    returnStr = tr("Masternode created! Wait %1 confirmations before starting it.").arg(mnModel->getMasternodeCollateralMinConf());
     return true;
 }
 

--- a/src/qt/pivx/masternodewizarddialog.cpp
+++ b/src/qt/pivx/masternodewizarddialog.cpp
@@ -20,6 +20,19 @@ static inline QString formatHtmlContent(const QString& str) {
     return "<html><body>" + str + "</body></html>";
 }
 
+static void initBtn(std::initializer_list<QPushButton*> args)
+{
+    QSize BUTTON_SIZE = QSize(22, 22);
+    for (QPushButton* btn : args) {
+        btn->setMinimumSize(BUTTON_SIZE);
+        btn->setMaximumSize(BUTTON_SIZE);
+        btn->move(0, 0);
+        btn->show();
+        btn->raise();
+        btn->setVisible(false);
+    }
+}
+
 MasterNodeWizardDialog::MasterNodeWizardDialog(WalletModel* model, MNModel* _mnModel, QWidget *parent) :
     FocusedDialog(parent),
     ui(new Ui::MasterNodeWizardDialog),
@@ -127,7 +140,6 @@ void MasterNodeWizardDialog::accept()
             break;
         }
         case 1: {
-
             // No empty names accepted.
             if (ui->lineEditName->text().isEmpty()) {
                 setCssEditLine(ui->lineEditName, false, true);
@@ -141,20 +153,15 @@ void MasterNodeWizardDialog::accept()
             ui->pushName1->setChecked(true);
             icConfirm3->setVisible(true);
             ui->pushNumber4->setChecked(true);
-            ui->btnBack->setVisible(true);
             ui->lineEditIpAddress->setFocus();
             break;
         }
         case 2: {
-
             // No empty address accepted
             if (ui->lineEditIpAddress->text().isEmpty()) {
                 return;
             }
-
             icConfirm4->setVisible(true);
-            ui->btnBack->setVisible(true);
-            ui->btnBack->setVisible(true);
             isOk = createMN();
             QDialog::accept();
         }
@@ -260,7 +267,7 @@ void MasterNodeWizardDialog::onBackClicked()
     }
 }
 
-void MasterNodeWizardDialog::inform(QString text)
+void MasterNodeWizardDialog::inform(const QString& text)
 {
     if (!snackBar)
         snackBar = new SnackBar(nullptr, this);
@@ -269,21 +276,8 @@ void MasterNodeWizardDialog::inform(QString text)
     openDialog(snackBar, this);
 }
 
-QSize BUTTON_SIZE = QSize(22, 22);
-void MasterNodeWizardDialog::initBtn(std::initializer_list<QPushButton*> args)
-{
-    for (QPushButton* btn : args) {
-        btn->setMinimumSize(BUTTON_SIZE);
-        btn->setMaximumSize(BUTTON_SIZE);
-        btn->move(0, 0);
-        btn->show();
-        btn->raise();
-        btn->setVisible(false);
-    }
-}
-
 MasterNodeWizardDialog::~MasterNodeWizardDialog()
 {
-    if (snackBar) delete snackBar;
+    delete snackBar;
     delete ui;
 }

--- a/src/qt/pivx/masternodewizarddialog.cpp
+++ b/src/qt/pivx/masternodewizarddialog.cpp
@@ -6,7 +6,6 @@
 #include "qt/pivx/forms/ui_masternodewizarddialog.h"
 
 #include "activemasternode.h"
-#include "clientmodel.h"
 #include "key_io.h"
 #include "optionsmodel.h"
 #include "qt/pivx/mnmodel.h"
@@ -27,14 +26,14 @@ static inline QString formatHtmlContent(const QString& str) {
     return "<html><body>" + str + "</body></html>";
 }
 
-MasterNodeWizardDialog::MasterNodeWizardDialog(WalletModel* model, ClientModel* _clientModel, QWidget *parent) :
+MasterNodeWizardDialog::MasterNodeWizardDialog(WalletModel* model, MNModel* _mnModel, QWidget *parent) :
     FocusedDialog(parent),
     ui(new Ui::MasterNodeWizardDialog),
     icConfirm1(new QPushButton(this)),
     icConfirm3(new QPushButton(this)),
     icConfirm4(new QPushButton(this)),
     walletModel(model),
-    clientModel(_clientModel)
+    mnModel(_mnModel)
 {
     ui->setupUi(this);
 
@@ -59,7 +58,7 @@ MasterNodeWizardDialog::MasterNodeWizardDialog(WalletModel* model, ClientModel* 
     setCssProperty(ui->labelMessage1a, "text-main-grey");
     setCssProperty(ui->labelMessage1b, "text-main-purple");
 
-    QString collateralAmountStr = GUIUtil::formatBalance(clientModel->getMNCollateralRequiredAmount());
+    QString collateralAmountStr = GUIUtil::formatBalance(mnModel->getMNCollateralRequiredAmount());
     ui->labelMessage1a->setText(formatHtmlContent(
                 formatParagraph(tr("To create a PIVX Masternode you must dedicate %1 (the unit of PIVX) "
                         "to the network (however, these coins are still yours and will never leave your possession).").arg(collateralAmountStr)) +
@@ -231,7 +230,7 @@ bool MasterNodeWizardDialog::createMN()
         SendCoinsRecipient sendCoinsRecipient(
                 QString::fromStdString(r.getObjResult()->ToString()),
                 QString::fromStdString(alias),
-                clientModel->getMNCollateralRequiredAmount(),
+                mnModel->getMNCollateralRequiredAmount(),
                 "");
 
         // Send the 10 tx to one of your address
@@ -281,7 +280,7 @@ bool MasterNodeWizardDialog::createMN()
         int indexOut = -1;
         for (int i=0; i < (int)walletTx->vout.size(); i++) {
             const CTxOut& out = walletTx->vout[i];
-            if (out.nValue == clientModel->getMNCollateralRequiredAmount()) {
+            if (out.nValue == mnModel->getMNCollateralRequiredAmount()) {
                 indexOut = i;
                 break;
             }

--- a/src/qt/pivx/masternodewizarddialog.h
+++ b/src/qt/pivx/masternodewizarddialog.h
@@ -11,8 +11,8 @@
 #include "masternodeconfig.h"
 #include "qt/pivx/pwidget.h"
 
+class MNModel;
 class WalletModel;
-class ClientModel;
 
 namespace Ui {
 class MasterNodeWizardDialog;
@@ -25,7 +25,7 @@ class MasterNodeWizardDialog : public FocusedDialog, public PWidget::Translator
 
 public:
     explicit MasterNodeWizardDialog(WalletModel* walletMode,
-                                    ClientModel* clientModel,
+                                    MNModel* mnModel,
                                     QWidget *parent = nullptr);
     ~MasterNodeWizardDialog();
     void showEvent(QShowEvent *event) override;
@@ -47,7 +47,7 @@ private:
     int pos = 0;
 
     WalletModel* walletModel{nullptr};
-    ClientModel* clientModel{nullptr};
+    MNModel* mnModel{nullptr};
     bool createMN();
     void inform(QString text);
     void initBtn(std::initializer_list<QPushButton*> args);

--- a/src/qt/pivx/masternodewizarddialog.h
+++ b/src/qt/pivx/masternodewizarddialog.h
@@ -27,7 +27,7 @@ public:
     explicit MasterNodeWizardDialog(WalletModel* walletMode,
                                     MNModel* mnModel,
                                     QWidget *parent = nullptr);
-    ~MasterNodeWizardDialog();
+    ~MasterNodeWizardDialog() override;
     void showEvent(QShowEvent *event) override;
     QString translate(const char *msg) override { return tr(msg); }
 
@@ -49,8 +49,7 @@ private:
     WalletModel* walletModel{nullptr};
     MNModel* mnModel{nullptr};
     bool createMN();
-    void inform(QString text);
-    void initBtn(std::initializer_list<QPushButton*> args);
+    void inform(const QString& text);
 };
 
 #endif // MASTERNODEWIZARDDIALOG_H

--- a/src/qt/pivx/masternodewizarddialog.h
+++ b/src/qt/pivx/masternodewizarddialog.h
@@ -5,7 +5,6 @@
 #ifndef MASTERNODEWIZARDDIALOG_H
 #define MASTERNODEWIZARDDIALOG_H
 
-#include "walletmodel.h"
 #include "qt/pivx/focuseddialog.h"
 #include "qt/pivx/snackbar.h"
 #include "masternodeconfig.h"

--- a/src/qt/pivx/mnmodel.cpp
+++ b/src/qt/pivx/mnmodel.cpp
@@ -9,7 +9,6 @@
 #include "net.h"        // for validateMasternodeIP
 #include "tiertwo/tiertwo_sync_state.h"
 #include "uint256.h"
-#include "wallet/wallet.h"
 
 MNModel::MNModel(QObject *parent) : QAbstractTableModel(parent) {}
 
@@ -151,26 +150,26 @@ bool MNModel::addMn(CMasternodeConfig::CMasternodeEntry* mne)
     return true;
 }
 
-int MNModel::getMNState(QString mnAlias)
+int MNModel::getMNState(const QString& mnAlias)
 {
     QMap<QString, std::pair<QString, CMasternode*>>::const_iterator it = nodes.find(mnAlias);
     if (it != nodes.end()) return it.value().second->GetActiveState();
     throw std::runtime_error(std::string("Masternode alias not found"));
 }
 
-bool MNModel::isMNInactive(QString mnAlias)
+bool MNModel::isMNInactive(const QString& mnAlias)
 {
     int activeState = getMNState(mnAlias);
     return activeState == CMasternode::MASTERNODE_EXPIRED || activeState == CMasternode::MASTERNODE_REMOVE;
 }
 
-bool MNModel::isMNActive(QString mnAlias)
+bool MNModel::isMNActive(const QString& mnAlias)
 {
     int activeState = getMNState(mnAlias);
     return activeState == CMasternode::MASTERNODE_PRE_ENABLED || activeState == CMasternode::MASTERNODE_ENABLED;
 }
 
-bool MNModel::isMNCollateralMature(QString mnAlias)
+bool MNModel::isMNCollateralMature(const QString& mnAlias)
 {
     QMap<QString, std::pair<QString, CMasternode*>>::const_iterator it = nodes.find(mnAlias);
     if (it != nodes.end()) return collateralTxAccepted.value(it.value().second->vin.prevout.hash.GetHex());
@@ -185,4 +184,9 @@ bool MNModel::isMNsNetworkSynced()
 bool MNModel::validateMNIP(const QString& addrStr)
 {
     return validateMasternodeIP(addrStr.toStdString());
+}
+
+CAmount MNModel::getMNCollateralRequiredAmount()
+{
+    return Params().GetConsensus().nMNCollateralAmt;
 }

--- a/src/qt/pivx/mnmodel.cpp
+++ b/src/qt/pivx/mnmodel.cpp
@@ -4,7 +4,7 @@
 
 #include "qt/pivx/mnmodel.h"
 
-#include "activemasternode.h"
+#include "masternode.h"
 #include "masternodeman.h"
 #include "net.h"        // for validateMasternodeIP
 #include "tiertwo/tiertwo_sync_state.h"
@@ -27,6 +27,7 @@ void MNModel::init()
 
 void MNModel::updateMNList()
 {
+    int mnMinConf = getMasternodeCollateralMinConf();
     int end = nodes.size();
     nodes.clear();
     collateralTxAccepted.clear();
@@ -43,7 +44,7 @@ void MNModel::updateMNList()
         }
         nodes.insert(QString::fromStdString(mne.getAlias()), std::make_pair(QString::fromStdString(mne.getIp()), pmn));
         if (walletModel) {
-            collateralTxAccepted.insert(mne.getTxHash(), walletModel->getWalletTxDepth(txHash) >= MasternodeCollateralMinConf());
+            collateralTxAccepted.insert(mne.getTxHash(), walletModel->getWalletTxDepth(txHash) >= mnMinConf);
         }
     }
     Q_EMIT dataChanged(index(0, 0, QModelIndex()), index(end, 5, QModelIndex()) );
@@ -197,6 +198,11 @@ bool MNModel::validateMNIP(const QString& addrStr)
 CAmount MNModel::getMNCollateralRequiredAmount()
 {
     return Params().GetConsensus().nMNCollateralAmt;
+}
+
+int MNModel::getMasternodeCollateralMinConf()
+{
+    return Params().GetConsensus().MasternodeCollateralMinConf();
 }
 
 bool MNModel::createMNCollateral(

--- a/src/qt/pivx/mnmodel.h
+++ b/src/qt/pivx/mnmodel.h
@@ -6,9 +6,10 @@
 #define MNMODEL_H
 
 #include <QAbstractTableModel>
-#include "masternode.h"
 #include "masternodeconfig.h"
 #include "qt/walletmodel.h"
+
+class CMasternode;
 
 class MNModel : public QAbstractTableModel
 {
@@ -59,6 +60,8 @@ public:
 
     // Return the specific chain amount value for the MN collateral output.
     CAmount getMNCollateralRequiredAmount();
+    // Return the specific chain min conf for the collateral tx
+    int getMasternodeCollateralMinConf();
     // Generates the collateral transaction
     bool createMNCollateral(const QString& alias, const QString& addr, COutPoint& ret_outpoint, QString& ret_error);
 

--- a/src/qt/pivx/mnmodel.h
+++ b/src/qt/pivx/mnmodel.h
@@ -69,6 +69,8 @@ public:
                                                         const std::string& mnKeyString,
                                                         QString& ret_error);
 
+    bool removeLegacyMN(const std::string& alias_to_remove, const std::string& tx_id, unsigned int out_index, QString& ret_error);
+
 private:
     WalletModel* walletModel;
     // alias mn node ---> pair <ip, master node>

--- a/src/qt/pivx/mnmodel.h
+++ b/src/qt/pivx/mnmodel.h
@@ -59,6 +59,8 @@ public:
 
     // Return the specific chain amount value for the MN collateral output.
     CAmount getMNCollateralRequiredAmount();
+    // Generates the collateral transaction
+    bool createMNCollateral(const QString& alias, const QString& addr, COutPoint& ret_outpoint, QString& ret_error);
 
 private:
     WalletModel* walletModel;

--- a/src/qt/pivx/mnmodel.h
+++ b/src/qt/pivx/mnmodel.h
@@ -62,6 +62,13 @@ public:
     // Generates the collateral transaction
     bool createMNCollateral(const QString& alias, const QString& addr, COutPoint& ret_outpoint, QString& ret_error);
 
+    CMasternodeConfig::CMasternodeEntry* createLegacyMN(COutPoint& collateralOut,
+                                                        const std::string& alias,
+                                                        std::string& serviceAddr,
+                                                        const std::string& port,
+                                                        const std::string& mnKeyString,
+                                                        QString& ret_error);
+
 private:
     WalletModel* walletModel;
     // alias mn node ---> pair <ip, master node>

--- a/src/qt/pivx/mnmodel.h
+++ b/src/qt/pivx/mnmodel.h
@@ -47,16 +47,18 @@ public:
 
     bool isMNsNetworkSynced();
     // Returns the MN activeState field.
-    int getMNState(QString alias);
+    int getMNState(const QString& mnAlias);
     // Checks if the masternode is inactive
-    bool isMNInactive(QString mnAlias);
+    bool isMNInactive(const QString& mnAlias);
     // Masternode is active if it's in PRE_ENABLED OR ENABLED state
-    bool isMNActive(QString mnAlias);
+    bool isMNActive(const QString& mnAlias);
     // Masternode collateral has enough confirmations
-    bool isMNCollateralMature(QString mnAlias);
+    bool isMNCollateralMature(const QString& mnAlias);
     // Validate string representing a masternode IP address
     static bool validateMNIP(const QString& addrStr);
 
+    // Return the specific chain amount value for the MN collateral output.
+    CAmount getMNCollateralRequiredAmount();
 
 private:
     WalletModel* walletModel;

--- a/src/qt/pivx/mnmodel.h
+++ b/src/qt/pivx/mnmodel.h
@@ -64,6 +64,10 @@ public:
     int getMasternodeCollateralMinConf();
     // Generates the collateral transaction
     bool createMNCollateral(const QString& alias, const QString& addr, COutPoint& ret_outpoint, QString& ret_error);
+    // Creates the mnb and broadcast it to the network
+    bool startLegacyMN(const CMasternodeConfig::CMasternodeEntry& mne, int chainHeight, std::string& strError);
+    void startAllLegacyMNs(bool onlyMissing, int& amountOfMnFailed, int& amountOfMnStarted,
+                           std::string* aliasFilter = nullptr, std::string* error_ret = nullptr);
 
     CMasternodeConfig::CMasternodeEntry* createLegacyMN(COutPoint& collateralOut,
                                                         const std::string& alias,

--- a/src/qt/pivx/pivxgui.cpp
+++ b/src/qt/pivx/pivxgui.cpp
@@ -611,7 +611,7 @@ int PIVXGUI::getNavWidth()
 void PIVXGUI::openFAQ(SettingsFaqWidget::Section section)
 {
     showHide(true);
-    SettingsFaqWidget* dialog = new SettingsFaqWidget(this, clientModel);
+    SettingsFaqWidget* dialog = new SettingsFaqWidget(this, mnModel);
     dialog->setSection(section);
     openDialogWithOpaqueBackgroundFullScreen(dialog, this);
     dialog->deleteLater();
@@ -625,9 +625,10 @@ void PIVXGUI::setGovModel(GovernanceModel* govModel)
     governancewidget->setGovModel(govModel);
 }
 
-void PIVXGUI::setMNModel(MNModel* mnModel)
+void PIVXGUI::setMNModel(MNModel* _mnModel)
 {
     if (!stackedContainer || !clientModel) return;
+    mnModel = _mnModel;
     governancewidget->setMNModel(mnModel);
     masterNodesWidget->setMNModel(mnModel);
 }

--- a/src/qt/pivx/pivxgui.h
+++ b/src/qt/pivx/pivxgui.h
@@ -126,6 +126,7 @@ private:
 
     bool enableWallet;
     ClientModel* clientModel = nullptr;
+    MNModel* mnModel = nullptr;
 
     // Actions
     QAction* quitAction = nullptr;

--- a/src/qt/pivx/send.cpp
+++ b/src/qt/pivx/send.cpp
@@ -485,7 +485,6 @@ OperationResult SendWidget::prepareTransparent(WalletModelTransaction* currentTr
     // process prepareStatus and on error generate message shown to user
     CClientUIInterface::MessageBoxFlags informType;
     QString informMsg = GuiTransactionsUtils::ProcessSendCoinsReturn(
-            this,
             prepareStatus,
             walletModel,
             informType,

--- a/src/qt/pivx/settings/settingsfaqwidget.cpp
+++ b/src/qt/pivx/settings/settingsfaqwidget.cpp
@@ -8,16 +8,15 @@
 
 #include "qt/pivx/settings/settingsfaqwidget.h"
 #include "qt/pivx/settings/forms/ui_settingsfaqwidget.h"
-#include "clientmodel.h"
+#include "qt/pivx/mnmodel.h"
 #include "qt/pivx/qtutils.h"
 
 #include <QScrollBar>
 #include <QMetaObject>
 
-SettingsFaqWidget::SettingsFaqWidget(PIVXGUI* parent, ClientModel* _model) :
+SettingsFaqWidget::SettingsFaqWidget(PIVXGUI* parent, MNModel* mnModel) :
     QDialog(parent),
-    ui(new Ui::SettingsFaqWidget),
-    clientModel(_model)
+    ui(new Ui::SettingsFaqWidget)
 {
     ui->setupUi(this);
     this->setStyleSheet(parent->styleSheet());
@@ -124,7 +123,7 @@ SettingsFaqWidget::SettingsFaqWidget(PIVXGUI* parent, ClientModel* _model) :
                "to the network and in return, receive a portion of the block reward "
                "regularly. These services include:")
                 .arg(PACKAGE_NAME)
-                .arg(GUIUtil::formatBalance(clientModel->getMNCollateralRequiredAmount(), BitcoinUnits::PIV)) +
+                .arg(GUIUtil::formatBalance(mnModel->getMNCollateralRequiredAmount(), BitcoinUnits::PIV)) +
             formatFAQUnorderedList(
                 formatFAQListItem(tr("A decentralized governance (Proposal Voting)")) +
                 formatFAQListItem(tr("A decentralized budgeting system (Treasury)")) +
@@ -145,7 +144,7 @@ SettingsFaqWidget::SettingsFaqWidget(PIVXGUI* parent, ClientModel* _model) :
             tr("Requirements:") +
             formatFAQUnorderedList(
                 formatFAQListItem(tr("%1 per single Masternode instance")
-                        .arg(GUIUtil::formatBalance(clientModel->getMNCollateralRequiredAmount(), BitcoinUnits::PIV))) +
+                        .arg(GUIUtil::formatBalance(mnModel->getMNCollateralRequiredAmount(), BitcoinUnits::PIV))) +
                 formatFAQListItem(tr("Must be stored in a core wallet")) +
                 formatFAQListItem(tr("Need dedicated IP address")) +
                 formatFAQListItem(tr("Masternode wallet to remain online")))));
@@ -157,7 +156,7 @@ SettingsFaqWidget::SettingsFaqWidget(PIVXGUI* parent, ClientModel* _model) :
                "can reside during a Controller-Remote masternode setup. It is a wallet "
                "that can activate the remote masternode wallet(s) and allows you to keep "
                "your collateral coins offline while the remote masternode remains online.")
-                    .arg(GUIUtil::formatBalance(clientModel->getMNCollateralRequiredAmount(), BitcoinUnits::PIV))));
+                    .arg(GUIUtil::formatBalance(mnModel->getMNCollateralRequiredAmount(), BitcoinUnits::PIV))));
     ui->labelContent_MNController->setText(mNControllerContent);
 
 

--- a/src/qt/pivx/settings/settingsfaqwidget.h
+++ b/src/qt/pivx/settings/settingsfaqwidget.h
@@ -7,8 +7,8 @@
 
 #include <QDialog>
 
+class MNModel;
 class PIVXGUI;
-class ClientModel;
 
 namespace Ui {
 class SettingsFaqWidget;
@@ -27,7 +27,7 @@ public:
         MNCONTROLLER
     };
 
-    explicit SettingsFaqWidget(PIVXGUI* parent, ClientModel* _model);
+    explicit SettingsFaqWidget(PIVXGUI* parent, MNModel* _model);
     ~SettingsFaqWidget();
 
     void showEvent(QShowEvent *event) override;
@@ -39,7 +39,6 @@ private Q_SLOTS:
     void onFaqClicked(const QWidget* const widget);
 private:
     Ui::SettingsFaqWidget *ui;
-    ClientModel* clientModel{nullptr};
     Section section = INTRO;
 
     // This needs to be edited if changes are made to the Section enum.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2442,7 +2442,8 @@ bool CWallet::GetMasternodeVinAndKeys(CTxIn& txinRet, CPubKey& pubKeyRet, CKey& 
     CTxOut txOut = wtx->tx->vout[nOutputIndex];
 
     // Masternode collateral value
-    if (txOut.nValue != Params().GetConsensus().nMNCollateralAmt) {
+    const auto& consensus = Params().GetConsensus();
+    if (txOut.nValue != consensus.nMNCollateralAmt) {
         strError = strprintf("Invalid collateral tx value, must be %s PIV", FormatMoney(Params().GetConsensus().nMNCollateralAmt));
         return error("%s: tx %s, index %d not a masternode collateral", __func__, strTxHash, nOutputIndex);
     }
@@ -2465,8 +2466,8 @@ bool CWallet::GetMasternodeVinAndKeys(CTxIn& txinRet, CPubKey& pubKeyRet, CKey& 
     }
 
     // Depth must be at least MASTERNODE_MIN_CONFIRMATIONS
-    if (nDepth < MasternodeCollateralMinConf()) {
-        strError = strprintf("Collateral tx must have at least %d confirmations, has %d", MasternodeCollateralMinConf(), nDepth);
+    if (nDepth < consensus.MasternodeCollateralMinConf()) {
+        strError = strprintf("Collateral tx must have at least %d confirmations, has %d", consensus.MasternodeCollateralMinConf(), nDepth);
         return error("%s: %s", __func__, strError);
     }
 


### PR DESCRIPTION
Encapsulating the legacy Masternodes code that is spread over the GUI widgets inside the MN module.

Plus, as is a value shared between legacy and deterministic Masternodes, moved the collateral min conf field to `chainparams`. Which allowed to remove the following circular dependency: `"evo/deterministicmns -> masternode -> wallet/wallet -> evo/deterministicmns"`

Part of the building blocks for adding visual support for the new deterministic Masternodes features.