### PR TITLE
Finish moving tier two initialization code from init.cpp to tiertwo/init.cpp and add disabledkg init flag

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -89,7 +89,6 @@ static const bool DEFAULT_PROXYRANDOMIZE = true;
 static const bool DEFAULT_REST_ENABLE = false;
 static const bool DEFAULT_DISABLE_SAFEMODE = false;
 static const bool DEFAULT_STOPAFTERBLOCKIMPORT = false;
-static const bool DEFAULT_MNCONFLOCK = true;
 
 std::unique_ptr<CConnman> g_connman;
 std::unique_ptr<PeerLogicValidation> peerLogic;
@@ -516,14 +515,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-shrinkdebugfile", "Shrink debug.log file on client startup (default: 1 when no -debug)");
     AppendParamsHelpMessages(strUsage, showDebug);
 
-    strUsage += HelpMessageGroup("Masternode options:");
-    strUsage += HelpMessageOpt("-masternode=<n>", strprintf("Enable the client to act as a masternode (0-1, default: %u)", DEFAULT_MASTERNODE));
-    strUsage += HelpMessageOpt("-mnconf=<file>", strprintf("Specify masternode configuration file (default: %s)", PIVX_MASTERNODE_CONF_FILENAME));
-    strUsage += HelpMessageOpt("-mnconflock=<n>", strprintf("Lock masternodes from masternode configuration file (default: %u)", DEFAULT_MNCONFLOCK));
-    strUsage += HelpMessageOpt("-masternodeprivkey=<n>", "Set the masternode private key");
-    strUsage += HelpMessageOpt("-masternodeaddr=<n>", strprintf("Set external address:port to get to this masternode (example: %s)", "128.127.106.235:51472"));
-    strUsage += HelpMessageOpt("-budgetvotemode=<mode>", "Change automatic finalized budget voting behavior. mode=auto: Vote for only exact finalized budget match to my generated budget. (string, default: auto)");
-    strUsage += HelpMessageOpt("-mnoperatorprivatekey=<WIF>", "Set the masternode operator private key. Only valid with -masternode=1. When set, the masternode acts as a deterministic masternode.");
+    strUsage += GetTierTwoHelpString(showDebug);
     if (showDebug) {
         strUsage += HelpMessageOpt("-pushversion",
                                    strprintf("Modifies the mnauth serialization if the version is lower than %d."

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1750,10 +1750,13 @@ bool AppInitMain()
 
     // automatic lock for DMN
     if (gArgs.GetBoolArg("-mnconflock", DEFAULT_MNCONFLOCK)) {
+        LogPrintf("Locking masternode collaterals...\n");
         const auto& mnList = deterministicMNManager->GetListAtChainTip();
-        for (CWallet* pwallet : vpwallets) {
-            pwallet->ScanMasternodeCollateralsAndLock(mnList);
-        }
+        mnList.ForEachMN(false, [&](const CDeterministicMNCPtr& dmn) {
+            for (CWallet* pwallet : vpwallets) {
+                pwallet->LockOutpointIfMineWithMutex(nullptr, dmn->collateralOutpoint);
+            }
+        });
     }
 #endif
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -511,11 +511,6 @@ std::string HelpMessage(HelpMessageMode mode)
     AppendParamsHelpMessages(strUsage, showDebug);
 
     strUsage += GetTierTwoHelpString(showDebug);
-    if (showDebug) {
-        strUsage += HelpMessageOpt("-pushversion",
-                                   strprintf("Modifies the mnauth serialization if the version is lower than %d."
-                                             "testnet/regtest only; ", MNAUTH_NODE_VER_VERSION));
-    }
 
     strUsage += HelpMessageGroup("Node relay options:");
     if (showDebug) {

--- a/src/tiertwo/init.cpp
+++ b/src/tiertwo/init.cpp
@@ -16,6 +16,19 @@
 
 #include <boost/thread.hpp>
 
+std::string GetTierTwoHelpString(bool showDebug)
+{
+    std::string strUsage = HelpMessageGroup("Masternode options:");
+    strUsage += HelpMessageOpt("-masternode=<n>", strprintf("Enable the client to act as a masternode (0-1, default: %u)", DEFAULT_MASTERNODE));
+    strUsage += HelpMessageOpt("-mnconf=<file>", strprintf("Specify masternode configuration file (default: %s)", PIVX_MASTERNODE_CONF_FILENAME));
+    strUsage += HelpMessageOpt("-mnconflock=<n>", strprintf("Lock masternodes from masternode configuration file (default: %u)", DEFAULT_MNCONFLOCK));
+    strUsage += HelpMessageOpt("-masternodeprivkey=<n>", "Set the masternode private key");
+    strUsage += HelpMessageOpt("-masternodeaddr=<n>", strprintf("Set external address:port to get to this masternode (example: %s)", "128.127.106.235:51472"));
+    strUsage += HelpMessageOpt("-budgetvotemode=<mode>", "Change automatic finalized budget voting behavior. mode=auto: Vote for only exact finalized budget match to my generated budget. (string, default: auto)");
+    strUsage += HelpMessageOpt("-mnoperatorprivatekey=<WIF>", "Set the masternode operator private key. Only valid with -masternode=1. When set, the masternode acts as a deterministic masternode.");
+    return strUsage;
+}
+
 // Sets the last CACHED_BLOCK_HASHES hashes into masternode manager cache
 static void LoadBlockHashesCache(CMasternodeMan& man)
 {

--- a/src/tiertwo/init.cpp
+++ b/src/tiertwo/init.cpp
@@ -29,6 +29,11 @@ std::string GetTierTwoHelpString(bool showDebug)
     strUsage += HelpMessageOpt("-masternodeaddr=<n>", strprintf("Set external address:port to get to this masternode (example: %s)", "128.127.106.235:51472"));
     strUsage += HelpMessageOpt("-budgetvotemode=<mode>", "Change automatic finalized budget voting behavior. mode=auto: Vote for only exact finalized budget match to my generated budget. (string, default: auto)");
     strUsage += HelpMessageOpt("-mnoperatorprivatekey=<WIF>", "Set the masternode operator private key. Only valid with -masternode=1. When set, the masternode acts as a deterministic masternode.");
+    if (showDebug) {
+        strUsage += HelpMessageOpt("-pushversion", strprintf("Modifies the mnauth serialization if the version is lower than %d."
+                                                             "testnet/regtest only; ", MNAUTH_NODE_VER_VERSION));
+        strUsage += HelpMessageOpt("-disabledkg", "Disable the DKG sessions process threads for the entire lifecycle. testnet/regtest only.");
+    }
     return strUsage;
 }
 
@@ -235,8 +240,17 @@ bool InitActiveMN()
 void StartTierTwoThreadsAndScheduleJobs(boost::thread_group& threadGroup, CScheduler& scheduler)
 {
     threadGroup.create_thread(std::bind(&ThreadCheckMasternodes));
-    // start LLMQ system
-    llmq::StartLLMQSystem();
+
+    // Start LLMQ system
+    if (gArgs.GetBoolArg("-disabledkg", false)) {
+        if (Params().NetworkIDString() == CBaseChainParams::MAIN) {
+            throw std::runtime_error("DKG system can be disabled only on testnet/regtest");
+        } else {
+            LogPrintf("DKG system disabled.\n");
+        }
+    } else {
+        llmq::StartLLMQSystem();
+    }
 }
 
 void StopTierTwoThreads()

--- a/src/tiertwo/init.h
+++ b/src/tiertwo/init.h
@@ -17,6 +17,12 @@ namespace boost {
 
 std::string GetTierTwoHelpString(bool showDebug);
 
+/** Inits the tier two global objects */
+void InitTierTwoPreChainLoad(bool fReindex);
+
+/** Inits the tier two global objects that require access to the coins tip cache */
+void InitTierTwoPostCoinsCacheLoad();
+
 /** Loads from disk all the tier two related objects */
 bool LoadTierTwo(int chain_active_height, bool fReindexChainState);
 
@@ -33,6 +39,12 @@ bool InitActiveMN();
 
 /** Starts tier two threads and jobs */
 void StartTierTwoThreadsAndScheduleJobs(boost::thread_group& threadGroup, CScheduler& scheduler);
+
+/** Stops tier two workers */
+void StopTierTwoThreads();
+
+/** Cleans manager and worker objects pointers */
+void DeleteTierTwo();
 
 
 #endif //PIVX_TIERTWO_INIT_H

--- a/src/tiertwo/init.h
+++ b/src/tiertwo/init.h
@@ -8,11 +8,14 @@
 #include <string>
 
 static const bool DEFAULT_MASTERNODE  = false;
+static const bool DEFAULT_MNCONFLOCK = true;
 
 class CScheduler;
 namespace boost {
     class thread_group;
 }
+
+std::string GetTierTwoHelpString(bool showDebug);
 
 /** Loads from disk all the tier two related objects */
 bool LoadTierTwo(int chain_active_height, bool fReindexChainState);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -13,7 +13,7 @@
 
 #include "checkpoints.h"
 #include "coincontrol.h"
-#include "evo/deterministicmns.h"
+#include "evo/providertx.h"
 #include "guiinterfaceutil.h"
 #include "masternode.h"
 #include "policy/policy.h"
@@ -4121,6 +4121,11 @@ void CWallet::AutoCombineDust(CConnman* connman)
     }
 }
 
+void CWallet::LockOutpointIfMineWithMutex(const CTransactionRef& ptx, const COutPoint& c)
+{
+    WITH_LOCK(cs_wallet, LockOutpointIfMine(ptx, c));
+}
+
 void CWallet::LockOutpointIfMine(const CTransactionRef& ptx, const COutPoint& c)
 {
     AssertLockHeld(cs_wallet);
@@ -4138,17 +4143,6 @@ void CWallet::LockOutpointIfMine(const CTransactionRef& ptx, const COutPoint& c)
     if (!txout.IsNull() && IsMine(txout) != ISMINE_NO && !IsSpent(c)) {
         LockCoin(c);
     }
-}
-
-// Called during Init
-void CWallet::ScanMasternodeCollateralsAndLock(const CDeterministicMNList& mnList)
-{
-    LOCK(cs_wallet);
-
-    LogPrintf("Locking masternode collaterals...\n");
-    mnList.ForEachMN(false, [&](const CDeterministicMNCPtr& dmn) {
-        LockOutpointIfMine(nullptr, dmn->collateralOutpoint);
-    });
 }
 
 // Called from AddToWalletIfInvolvingMe

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -99,7 +99,6 @@ class ScriptPubKeyMan;
 class SaplingScriptPubKeyMan;
 class SaplingNoteData;
 struct SaplingNoteEntry;
-class CDeterministicMNList;
 
 /** (client) version numbers for particular wallet features */
 enum WalletFeature {
@@ -886,13 +885,11 @@ public:
      *  -- If ptx is null, c is the output of a transaction in mapWallet
      */
     void LockOutpointIfMine(const CTransactionRef& ptx, const COutPoint& c);
-
     /*
-     *  Locks cs_wallet
-     *  Called during Init. If a DMN collateral is found in the wallet,
-     *  lock the corresponding coin, to prevent accidental spending.
+     * Same functionality as above but locking the cs_wallet mutex internally.
+     * future: add capability to lock the mutex from outside of this class without exposing it.
      */
-    void ScanMasternodeCollateralsAndLock(const CDeterministicMNList& mnList);
+    void LockOutpointIfMineWithMutex(const CTransactionRef& ptx, const COutPoint& c);
 
     /*
      *  Requires cs_wallet lock.

--- a/test/functional/p2p_quorum_connect.py
+++ b/test/functional/p2p_quorum_connect.py
@@ -32,7 +32,7 @@ class DMNConnectionTest(PivxTestFramework):
         self.minerPos = 0
         self.controllerPos = 1
         self.setup_clean_chain = True
-        self.extra_args = [["-nuparams=v5_shield:1", "-nuparams=v6_evo:101"]] * self.num_nodes
+        self.extra_args = [["-nuparams=v5_shield:1", "-nuparams=v6_evo:101", "-disabledkg"]] * self.num_nodes
         self.extra_args[0].append("-sporkkey=932HEevBSujW2ud7RfB1YF91AFygbBRQj3de3LyaCRqNzKKgWXi")
 
     def add_new_dmn(self, mns, strType, op_keys=None, from_out=None):

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -43,7 +43,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "chain -> legacy/stakemodifier -> stakeinput -> chain"
     "chain -> legacy/stakemodifier -> validation -> chain"
     "chainparamsbase -> util/system -> logging -> chainparamsbase"
-    "evo/deterministicmns -> masternode -> wallet/wallet -> evo/deterministicmns"
     "kernel -> stakeinput -> wallet/wallet -> kernel"
     "legacy/validation_zerocoin_legacy -> wallet/wallet -> validation -> legacy/validation_zerocoin_legacy"
     "qt/askpassphrasedialog -> qt/pivx/pivxgui -> qt/pivx/topbar -> qt/askpassphrasedialog"


### PR DESCRIPTION
Follow-up to #2684, built on top of #2647. Starting in 296e6fa0.

Focused on the following points:

1) Move init arguments help messages to a new `GetTierTwoHelpString()`, the tier two objects initializers and the Masternodes collateral output locking process to the tiertwo/init files.
2) Improve DMN collateral locking process:
   * Walking through the DMN list only once instead of one-time per wallet.
   * Removing the wallet dependency on `evo/deterministicmns.h`.
3) Add `-disabledkg` init argument so the `p2p_quorum_connect.py` functional test does not get affected by the automatic DKG sessions processes (coming in #2722). The same flag will be used in other future tests that perform manual operations as well.