### PR TITLE
[test] wallet_zapwallettxes.py whitelist peers to speed up tx relay.

### DIFF
--- a/test/functional/wallet_zapwallettxes.py
+++ b/test/functional/wallet_zapwallettxes.py
@@ -25,6 +25,8 @@ class ZapWalletTXesTest (PivxTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 2
+        # whitelist all peers to speed up tx relay / mempool sync
+        self.extra_args = [["-whitelist=127.0.0.1"]] * self.num_nodes
 
     def run_test(self):
         self.log.info("Mining blocks...")
@@ -54,9 +56,9 @@ class ZapWalletTXesTest (PivxTestFramework):
         assert_equal(self.nodes[1].getwalletinfo()["unconfirmed_balance"], 20)
         assert_equal(self.nodes[1].getunconfirmedbalance(), 20)
 
-        # Stop-start node0. Both confirmed and unconfirmed transactions remain in the wallet.
-        self.stop_node(0)
-        self.start_node(0)
+        # Restart node0. Both confirmed and unconfirmed transactions remain in the wallet.
+        self.restart_node(0)
+
         assert_equal(self.nodes[0].gettransaction(txid1)['txid'], txid1)
         assert_equal(self.nodes[0].gettransaction(txid2)['txid'], txid2)
 


### PR DESCRIPTION
Same rationale as #2633, whitelist peers so the trickle mechanism does not delay the mempool txs relay.

Saw it failing for this reason in master: https://github.com/PIVX-Project/PIVX/runs/4821849471?check_suite_focus=true