### PR TITLE
Bug: fix missing cs_main lock in AppInitMain and LoadExternalBlockFile

### DIFF
--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -41,7 +41,7 @@ static void DeserializeAndCheckBlockTest(benchmark::State& state)
         assert(rewound);
 
         CValidationState state;
-        assert(CheckBlock(block, state));
+        assert(WITH_LOCK(cs_main, return CheckBlock(block, state); ));
     }
 }
 

--- a/src/evo/specialtx_validation.cpp
+++ b/src/evo/specialtx_validation.cpp
@@ -17,7 +17,6 @@
 #include "primitives/transaction.h"
 #include "primitives/block.h"
 #include "script/standard.h"
-#include "validation.h" // needed by CheckLLMQCommitment (!TODO: remove)
 
 /* -- Helper static functions -- */
 
@@ -473,7 +472,7 @@ bool VerifyLLMQCommitment(const llmq::CFinalCommitment& qfc, const CBlockIndex* 
     return true;
 }
 
-static bool CheckLLMQCommitmentTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state)
+static bool CheckLLMQCommitmentTx(const CTransaction& tx, const CBlockIndex* pindexPrev, CValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
 
@@ -541,6 +540,8 @@ static bool CheckSpecialTxBasic(const CTransaction& tx, CValidationState& state)
 // - pindexPrev=pindex->pprev: ConnectBlock-->ProcessSpecialTxsInBlock-->CheckSpecialTx
 bool CheckSpecialTx(const CTransaction& tx, const CBlockIndex* pindexPrev, const CCoinsViewCache* view, CValidationState& state)
 {
+    AssertLockHeld(cs_main);
+
     if (!CheckSpecialTxBasic(tx, state)) {
         // pass the state returned by the function above
         return false;
@@ -592,6 +593,8 @@ bool CheckSpecialTxNoContext(const CTransaction& tx, CValidationState& state)
 
 bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, const CCoinsViewCache* view, CValidationState& state, bool fJustCheck)
 {
+    AssertLockHeld(cs_main);
+
     // check special txes
     for (const CTransactionRef& tx: block.vtx) {
         if (!CheckSpecialTx(*tx, pindex->pprev, view, state)) {

--- a/src/evo/specialtx_validation.h
+++ b/src/evo/specialtx_validation.h
@@ -7,6 +7,7 @@
 #define PIVX_SPECIALTX_H
 
 #include "llmq/quorums_commitment.h"
+#include "validation.h" // cs_main needed by CheckLLMQCommitment (!TODO: remove)
 #include "version.h"
 
 class CBlock;
@@ -22,18 +23,18 @@ static const unsigned int MAX_SPECIALTX_EXTRAPAYLOAD = 10000;
 /** Payload validity checks (including duplicate unique properties against list at pindexPrev)*/
 // Note: for +v2, if the tx is not a special tx, this method returns true.
 // Note2: This function only performs extra payload related checks, it does NOT checks regular inputs and outputs.
-bool CheckSpecialTx(const CTransaction& tx, const CBlockIndex* pindexPrev, const CCoinsViewCache* view, CValidationState& state);
+bool CheckSpecialTx(const CTransaction& tx, const CBlockIndex* pindexPrev, const CCoinsViewCache* view, CValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 // Basic non-contextual checks for special txes
 // Note: for +v2, if the tx is not a special tx, this method returns true.
-bool CheckSpecialTxNoContext(const CTransaction& tx, CValidationState& state);
+bool CheckSpecialTxNoContext(const CTransaction& tx, CValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 // Update internal tiertwo data when blocks containing special txes get connected/disconnected
-bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, const CCoinsViewCache* view, CValidationState& state, bool fJustCheck);
+bool ProcessSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex, const CCoinsViewCache* view, CValidationState& state, bool fJustCheck) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 bool UndoSpecialTxsInBlock(const CBlock& block, const CBlockIndex* pindex);
 
 // Validate given LLMQ final commitment with the list at pindexQuorum
-bool VerifyLLMQCommitment(const llmq::CFinalCommitment& qfc, const CBlockIndex* pindexPrev, CValidationState& state);
+bool VerifyLLMQCommitment(const llmq::CFinalCommitment& qfc, const CBlockIndex* pindexPrev, CValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 uint256 CalcTxInputsHash(const CTransaction& tx);
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -318,8 +318,10 @@ void MarkBlockAsInFlight(NodeId nodeid, const uint256& hash, const CBlockIndex* 
 }
 
 /** Check whether the last unknown block a peer advertised is not yet known. */
-void ProcessBlockAvailability(NodeId nodeid)
+static void ProcessBlockAvailability(NodeId nodeid) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
+    AssertLockHeld(cs_main);
+
     CNodeState* state = State(nodeid);
     assert(state != nullptr);
 
@@ -334,8 +336,10 @@ void ProcessBlockAvailability(NodeId nodeid)
 }
 
 /** Update tracking information about which blocks a peer is assumed to have. */
-void UpdateBlockAvailability(NodeId nodeid, const uint256& hash)
+static void UpdateBlockAvailability(NodeId nodeid, const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
+    AssertLockHeld(cs_main);
+
     CNodeState* state = State(nodeid);
     assert(state != nullptr);
 
@@ -354,8 +358,10 @@ void UpdateBlockAvailability(NodeId nodeid, const uint256& hash)
 
 /** Update pindexLastCommonBlock and add not-in-flight missing successors to vBlocks, until it has
  *  at most count entries. */
-void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vector<const CBlockIndex*>& vBlocks, NodeId& nodeStaller)
+static void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vector<const CBlockIndex*>& vBlocks, NodeId& nodeStaller) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
+    AssertLockHeld(cs_main);
+
     if (count == 0)
         return;
 

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -223,7 +223,7 @@ static bool rest_block(HTTPRequest* req,
     }
 
     case RF_JSON: {
-        UniValue objBlock = blockToJSON(block, pblockindex, showTxDetails);
+        UniValue objBlock = WITH_LOCK(cs_main, return blockToJSON(block, pblockindex, showTxDetails); );
         std::string strJSON = objBlock.write() + "\n";
         req->WriteHeader("Content-Type", "application/json");
         req->WriteReply(HTTP_OK, strJSON);
@@ -353,7 +353,7 @@ static bool rest_tx(HTTPRequest* req, const std::string& strURIPart)
 
     case RF_JSON: {
         UniValue objTx(UniValue::VOBJ);
-        TxToJSON(nullptr, *tx, hashBlock, objTx);
+        WITH_LOCK(cs_main, TxToJSON(nullptr, *tx, hashBlock, objTx); );
         std::string strJSON = objTx.write() + "\n";
         req->WriteHeader("Content-Type", "application/json");
         req->WriteReply(HTTP_OK, strJSON);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -128,8 +128,10 @@ UniValue blockheaderToJSON(const CBlockIndex* blockindex)
     return result;
 }
 
-UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool txDetails = false)
+UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool txDetails = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
+    AssertLockHeld(cs_main);
+
     UniValue result(UniValue::VOBJ);
     result.pushKV("hash", block.GetHash().GetHex());
     int confirmations = -1;

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -69,8 +69,10 @@ static void PayloadToJSON(const CTransaction& tx, UniValue& entry)
 }
 
 // pwallet can be nullptr. If not null, the json could include information available only to the wallet.
-void TxToJSON(CWallet* const pwallet, const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
+void TxToJSON(CWallet* const pwallet, const CTransaction& tx, const uint256 hashBlock, UniValue& entry) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
+    AssertLockHeld(cs_main);
+
     // Call into TxToUniv() in bitcoin-common to decode the transaction hex.
     //
     // Blockchain contextual information (confirmations and blocktime) is not

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -370,7 +370,7 @@ static std::string SignAndSendSpecialTx(CWallet* const pwallet, CMutableTransact
 
     CValidationState state;
     CCoinsViewCache view(pcoinsTip.get());
-    if (!CheckSpecialTx(tx, GetChainTip(), &view, state)) {
+    if (!WITH_LOCK(cs_main, return CheckSpecialTx(tx, GetChainTip(), &view, state); )) {
         throw JSONRPCError(RPC_MISC_ERROR, FormatStateMessage(state));
     }
 

--- a/src/test/checkblock_tests.cpp
+++ b/src/test/checkblock_tests.cpp
@@ -54,6 +54,7 @@ BOOST_AUTO_TEST_CASE(May15)
     CBlock forkingBlock;
     if (read_block("Mar12Fork.dat", forkingBlock))
     {
+        LOCK(cs_main);
         CValidationState state;
 
         // After May 15'th, big blocks are OK:

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -358,7 +358,7 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         operatorKeys.emplace(txid, operatorKey);
 
         CValidationState dummyState;
-        BOOST_CHECK(CheckSpecialTx(tx, chainTip, view, dummyState));
+        BOOST_CHECK(WITH_LOCK(cs_main, return CheckSpecialTx(tx, chainTip, view, dummyState); ));
         BOOST_CHECK(CheckTransactionSignature(tx));
 
         // also verify that payloads are not malleable after they have been signed
@@ -367,7 +367,7 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         // into account
         auto tx2 = MalleateProTxPayout<ProRegPL>(tx);
         // Technically, the payload is still valid...
-        BOOST_CHECK(CheckSpecialTx(tx2, chainTip, view, dummyState));
+        BOOST_CHECK(WITH_LOCK(cs_main, return CheckSpecialTx(tx2, chainTip, view, dummyState); ));
         // But the signature should not verify anymore
         BOOST_CHECK(!CheckTransactionSignature(tx2));
 
@@ -414,7 +414,7 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         Optional<COutPoint> o = COutPoint(UINT256_ONE, 0);
         auto tx = CreateProRegTx(o, utxos, port, GenerateRandomAddress(), coinbaseKey, GetRandomKey(), GetRandomBLSKey().GetPublicKey());
         CValidationState state;
-        BOOST_CHECK(!CheckSpecialTx(tx, chainTip, view, state));
+        BOOST_CHECK(!WITH_LOCK(cs_main, return CheckSpecialTx(tx, chainTip, view, state); ));
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-protx-collateral");
     }
     // Try to register with invalid external collateral
@@ -432,7 +432,7 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         // create the ProReg tx referencing the invalid collateral
         auto tx = CreateProRegTx(Optional<COutPoint>(coll_out), utxos, port, GenerateRandomAddress(), coinbaseKey, GetRandomKey(), GetRandomBLSKey().GetPublicKey());
         CValidationState state;
-        BOOST_CHECK(!CheckSpecialTx(tx, chainTip, view, state));
+        BOOST_CHECK(!WITH_LOCK(cs_main, return CheckSpecialTx(tx, chainTip, view, state); ));
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-protx-collateral-amount");
 
         // add the coin back to the utxo map
@@ -464,14 +464,14 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         // create the ProReg tx referencing the spent collateral
         auto tx = CreateProRegTx(Optional<COutPoint>(coll_out), utxos, port, GenerateRandomAddress(), coinbaseKey, GetRandomKey(), GetRandomBLSKey().GetPublicKey());
         CValidationState state;
-        BOOST_CHECK(!CheckSpecialTx(tx, chainTip, view, state));
+        BOOST_CHECK(!WITH_LOCK(cs_main, return CheckSpecialTx(tx, chainTip, view, state); ));
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-protx-collateral");
     }
     // Try to register with invalid internal collateral
     {
         auto tx = CreateProRegTx(nullopt, utxos, port, GenerateRandomAddress(), coinbaseKey, GetRandomKey(), GetRandomBLSKey().GetPublicKey(), 0, true);
         CValidationState state;
-        BOOST_CHECK(!CheckSpecialTx(tx, chainTip, view, state));
+        BOOST_CHECK(!WITH_LOCK(cs_main, return CheckSpecialTx(tx, chainTip, view, state); ));
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-protx-collateral-amount");
     }
     // Try to register reusing the collateral key as owner/voting key
@@ -491,7 +491,7 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         // create the ProReg tx reusing the collateral key
         auto tx = CreateProRegTx(Optional<COutPoint>(coll_out), utxos, port, GenerateRandomAddress(), coinbaseKey, coll_key, GetRandomBLSKey().GetPublicKey());
         CValidationState state;
-        BOOST_CHECK(!CheckSpecialTx(tx, chainTip, view, state));
+        BOOST_CHECK(!WITH_LOCK(cs_main, return CheckSpecialTx(tx, chainTip, view, state); ));
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-protx-collateral-reuse");
     }
     // Try to register used owner key
@@ -499,7 +499,7 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         const CKey& ownerKey = ownerKeys.at(dmnHashes[InsecureRandRange(dmnHashes.size())]);
         auto tx = CreateProRegTx(nullopt, utxos, port, GenerateRandomAddress(), coinbaseKey, ownerKey, GetRandomBLSKey().GetPublicKey());
         CValidationState state;
-        BOOST_CHECK(!CheckSpecialTx(tx, chainTip, view, state));
+        BOOST_CHECK(!WITH_LOCK(cs_main, return CheckSpecialTx(tx, chainTip, view, state); ));
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-protx-dup-owner-key");
     }
     // Try to register used operator key
@@ -507,14 +507,14 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         const CBLSSecretKey& operatorKey = operatorKeys.at(dmnHashes[InsecureRandRange(dmnHashes.size())]);
         auto tx = CreateProRegTx(nullopt, utxos, port, GenerateRandomAddress(), coinbaseKey, GetRandomKey(), operatorKey.GetPublicKey());
         CValidationState state;
-        BOOST_CHECK(!CheckSpecialTx(tx, chainTip, view, state));
+        BOOST_CHECK(!WITH_LOCK(cs_main, return CheckSpecialTx(tx, chainTip, view, state); ));
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-protx-dup-operator-key");
     }
     // Try to register used IP address
     {
         auto tx = CreateProRegTx(nullopt, utxos, 1 + InsecureRandRange(port-1), GenerateRandomAddress(), coinbaseKey, GetRandomKey(), GetRandomBLSKey().GetPublicKey());
         CValidationState state;
-        BOOST_CHECK(!CheckSpecialTx(tx, chainTip, view, state));
+        BOOST_CHECK(!WITH_LOCK(cs_main, return CheckSpecialTx(tx, chainTip, view, state); ));
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-protx-dup-IP-address");
     }
     // Block with two ProReg txes using same owner key
@@ -529,7 +529,7 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         indexFake.nHeight = nHeight;
         indexFake.pprev = chainTip;
         CValidationState state;
-        BOOST_CHECK(!ProcessSpecialTxsInBlock(block, &indexFake, view, state, true));
+        BOOST_CHECK(!WITH_LOCK(cs_main, return ProcessSpecialTxsInBlock(block, &indexFake, view, state, true); ));
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-protx-dup-owner-key");
         ProcessNewBlock(std::make_shared<const CBlock>(block), nullptr); // todo: move to check reject reason
         BOOST_CHECK_EQUAL(chainActive.Height(), nHeight);   // bad block not connected
@@ -546,7 +546,7 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         indexFake.nHeight = nHeight;
         indexFake.pprev = chainTip;
         CValidationState state;
-        BOOST_CHECK(!ProcessSpecialTxsInBlock(block, &indexFake, view, state, true));
+        BOOST_CHECK(!WITH_LOCK(cs_main, return ProcessSpecialTxsInBlock(block, &indexFake, view, state, true); ));
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-protx-dup-operator-key");
         ProcessNewBlock(std::make_shared<const CBlock>(block), nullptr); // todo: move to check reject reason
         BOOST_CHECK_EQUAL(chainActive.Height(), nHeight);   // bad block not connected
@@ -560,7 +560,7 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         indexFake.nHeight = nHeight;
         indexFake.pprev = chainTip;
         CValidationState state;
-        BOOST_CHECK(!ProcessSpecialTxsInBlock(block, &indexFake, view, state, true));
+        BOOST_CHECK(!WITH_LOCK(cs_main, return ProcessSpecialTxsInBlock(block, &indexFake, view, state, true); ));
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-protx-dup-IP-address");
         ProcessNewBlock(std::make_shared<const CBlock>(block), nullptr); // todo: move to check reject reason
         BOOST_CHECK_EQUAL(chainActive.Height(), nHeight);   // bad block not connected
@@ -579,7 +579,7 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
             operatorKeys.emplace(txid, operatorKey);
 
             CValidationState dummyState;
-            BOOST_CHECK(CheckSpecialTx(tx, chainActive.Tip(), view, dummyState));
+            BOOST_CHECK(WITH_LOCK(cs_main, return CheckSpecialTx(tx, chainActive.Tip(), view, dummyState); ));
             BOOST_CHECK(CheckTransactionSignature(tx));
             txns.emplace_back(tx);
         }
@@ -642,11 +642,11 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         auto tx = CreateProUpServTx(utxos, proTx, operatorKeys.at(proTx), 1000, CScript(), coinbaseKey);
 
         CValidationState dummyState;
-        BOOST_CHECK(CheckSpecialTx(tx, chainTip, view, dummyState));
+        BOOST_CHECK(WITH_LOCK(cs_main, return CheckSpecialTx(tx, chainTip, view, dummyState); ));
         BOOST_CHECK(CheckTransactionSignature(tx));
         // also verify that payloads are not malleable after they have been signed
         auto tx2 = MalleateProUpServTx(tx);
-        BOOST_CHECK(!CheckSpecialTx(tx2, chainTip, view, dummyState));
+        BOOST_CHECK(!WITH_LOCK(cs_main, return CheckSpecialTx(tx2, chainTip, view, dummyState); ));
         BOOST_CHECK_EQUAL(dummyState.GetRejectReason(), "bad-protx-sig");
 
         CreateAndProcessBlock({tx}, coinbaseKey);
@@ -671,7 +671,7 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         auto tx = CreateProUpServTx(utxos, proTx, operatorKeys.at(proTx), new_port, CScript(), coinbaseKey);
 
         CValidationState state;
-        BOOST_CHECK(!CheckSpecialTx(tx, chainTip, view, state));
+        BOOST_CHECK(!WITH_LOCK(cs_main, return CheckSpecialTx(tx, chainTip, view, state); ));
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-protx-dup-addr");
     }
 
@@ -681,7 +681,7 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         auto tx = CreateProUpServTx(utxos, GetRandHash(), operatorKey, port, CScript(), coinbaseKey);
 
         CValidationState state;
-        BOOST_CHECK(!CheckSpecialTx(tx, chainTip, view, state));
+        BOOST_CHECK(!WITH_LOCK(cs_main, return CheckSpecialTx(tx, chainTip, view, state); ));
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-protx-hash");
     }
 
@@ -717,7 +717,7 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         const CScript& operatorPayee = GenerateRandomAddress();
         auto tx = CreateProUpServTx(utxos, dmnHashes[0], operatorKeys.at(dmnHashes[0]), 1, operatorPayee, coinbaseKey);
         CValidationState state;
-        BOOST_CHECK(!CheckSpecialTx(tx, chainTip, view, state));
+        BOOST_CHECK(!WITH_LOCK(cs_main, return CheckSpecialTx(tx, chainTip, view, state); ));
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-protx-operator-payee");
     }
 
@@ -733,7 +733,7 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         indexFake.nHeight = nHeight;
         indexFake.pprev = chainTip;
         CValidationState state;
-        BOOST_CHECK(!ProcessSpecialTxsInBlock(block, &indexFake, view, state, true));
+        BOOST_CHECK(!WITH_LOCK(cs_main, return ProcessSpecialTxsInBlock(block, &indexFake, view, state, true); ));
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-protx-dup-addr");
         ProcessNewBlock(std::make_shared<const CBlock>(block), nullptr); // todo: move to ProcessBlockAndCheckRejectionReason.
         BOOST_CHECK_EQUAL(chainActive.Height(), nHeight);   // bad block not connected
@@ -748,16 +748,16 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         // try first with wrong owner key
         CValidationState state;
         auto tx = CreateProUpRegTx(utxos, proTx, GetRandomKey(), new_operatorKey.GetPublicKey(), new_votingKey, new_payee, coinbaseKey);
-        BOOST_CHECK_MESSAGE(!CheckSpecialTx(tx, chainTip, view, state), "ProUpReg verifies with wrong owner key");
+        BOOST_CHECK_MESSAGE(!WITH_LOCK(cs_main, return CheckSpecialTx(tx, chainTip, view, state); ), "ProUpReg verifies with wrong owner key");
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-protx-sig");
         // then use the proper key
         state = CValidationState();
         tx = CreateProUpRegTx(utxos, proTx, ownerKeys.at(proTx), new_operatorKey.GetPublicKey(), new_votingKey, new_payee, coinbaseKey);
-        BOOST_CHECK_MESSAGE(CheckSpecialTx(tx, chainTip, view, state), state.GetRejectReason());
+        BOOST_CHECK_MESSAGE(WITH_LOCK(cs_main, return CheckSpecialTx(tx, chainTip, view, state); ), state.GetRejectReason());
         BOOST_CHECK_MESSAGE(CheckTransactionSignature(tx), "ProUpReg signature verification failed");
         // also verify that payloads are not malleable after they have been signed
         auto tx2 = MalleateProTxPayout<ProUpRegPL>(tx);
-        BOOST_CHECK_MESSAGE(!CheckSpecialTx(tx2, chainTip, view, state), "Malleated ProUpReg accepted");
+        BOOST_CHECK_MESSAGE(!WITH_LOCK(cs_main, return CheckSpecialTx(tx2, chainTip, view, state); ), "Malleated ProUpReg accepted");
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-protx-sig");
 
         CreateAndProcessBlock({tx}, coinbaseKey);
@@ -813,7 +813,7 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         auto tx = CreateProUpRegTx(utxos, GetRandHash(), GetRandomKey(), operatorKey.GetPublicKey(), votingKey, GenerateRandomAddress(), coinbaseKey);
 
         CValidationState state;
-        BOOST_CHECK_MESSAGE(!CheckSpecialTx(tx, chainTip, view, state), "Accepted ProUpReg with invalid protx hash");
+        BOOST_CHECK_MESSAGE(!WITH_LOCK(cs_main, return CheckSpecialTx(tx, chainTip, view, state); ), "Accepted ProUpReg with invalid protx hash");
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-protx-hash");
     }
 
@@ -828,7 +828,7 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         auto tx = CreateProUpRegTx(utxos, proTx, ownerKeys.at(proTx), new_operatorKey.GetPublicKey(), GetRandomKey(), GenerateRandomAddress(), coinbaseKey);
 
         CValidationState state;
-        BOOST_CHECK_MESSAGE(!CheckSpecialTx(tx, chainTip, view, state), "Accepted ProUpReg with duplicate operator key");
+        BOOST_CHECK_MESSAGE(!WITH_LOCK(cs_main, return CheckSpecialTx(tx, chainTip, view, state); ), "Accepted ProUpReg with duplicate operator key");
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-protx-dup-key");
     }
 
@@ -850,7 +850,7 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         indexFake.nHeight = nHeight;
         indexFake.pprev = chainTip;
         CValidationState state;
-        BOOST_CHECK_MESSAGE(!ProcessSpecialTxsInBlock(block, &indexFake, view, state, true),
+        BOOST_CHECK_MESSAGE(!WITH_LOCK(cs_main, return ProcessSpecialTxsInBlock(block, &indexFake, view, state, true); ),
                             "Accepted block with duplicate operator key in ProUpReg txes");
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-protx-dup-operator-key");
         ProcessNewBlock(std::make_shared<const CBlock>(block), nullptr);
@@ -870,7 +870,7 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         indexFake.nHeight = nHeight;
         indexFake.pprev = chainTip;
         CValidationState state;
-        BOOST_CHECK_MESSAGE(!ProcessSpecialTxsInBlock(block, &indexFake, view, state, true),
+        BOOST_CHECK_MESSAGE(!WITH_LOCK(cs_main, return ProcessSpecialTxsInBlock(block, &indexFake, view, state, true); ),
                             "Accepted block with duplicate operator key in ProReg+ProUpReg txes");
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-protx-dup-operator-key");
         ProcessNewBlock(std::make_shared<const CBlock>(block), nullptr);
@@ -884,16 +884,16 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         // try first with wrong operator key
         CValidationState state;
         auto tx = CreateProUpRevTx(utxos, proTx, reason, GetRandomBLSKey(), coinbaseKey);
-        BOOST_CHECK_MESSAGE(!CheckSpecialTx(tx, chainTip, view, state), "ProUpReg verifies with wrong owner key");
+        BOOST_CHECK_MESSAGE(!WITH_LOCK(cs_main, return CheckSpecialTx(tx, chainTip, view, state); ), "ProUpReg verifies with wrong owner key");
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-protx-sig");
         // then use the proper key
         state = CValidationState();
         tx = CreateProUpRevTx(utxos, proTx, reason, operatorKeys.at(proTx), coinbaseKey);
-        BOOST_CHECK_MESSAGE(CheckSpecialTx(tx, chainTip, view, state), state.GetRejectReason());
+        BOOST_CHECK_MESSAGE(WITH_LOCK(cs_main, return CheckSpecialTx(tx, chainTip, view, state); ), state.GetRejectReason());
         BOOST_CHECK_MESSAGE(CheckTransactionSignature(tx), "ProUpReg signature verification failed");
         // also verify that payloads are not malleable after they have been signed
         auto tx2 = MalleateProUpRevTx(tx);
-        BOOST_CHECK_MESSAGE(!CheckSpecialTx(tx2, chainTip, view, state), "Malleated ProUpReg accepted");
+        BOOST_CHECK_MESSAGE(!WITH_LOCK(cs_main, return CheckSpecialTx(tx2, chainTip, view, state); ), "Malleated ProUpReg accepted");
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-protx-sig");
 
         CreateAndProcessBlock({tx}, coinbaseKey);

--- a/src/test/evo_specialtx_tests.cpp
+++ b/src/test/evo_specialtx_tests.cpp
@@ -130,6 +130,8 @@ static bool EqualCommitments(const llmq::CFinalCommitment& a, const llmq::CFinal
 
 BOOST_AUTO_TEST_CASE(protx_validation_test)
 {
+    LOCK(cs_main);
+
     CMutableTransaction mtx;
     CValidationState state;
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -325,7 +325,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts(std::function<CBlockIndex*(const uint256&)
 
                 if (!Params().GetConsensus().NetworkUpgradeActive(pindexNew->nHeight, Consensus::UPGRADE_POS)) {
                     if (!CheckProofOfWork(pindexNew->GetBlockHash(), pindexNew->nBits))
-                        return error("LoadBlockIndex() : CheckProofOfWork failed: %s", pindexNew->ToString());
+                        return error("%s : CheckProofOfWork failed: %s", __func__, pindexNew->ToString());
                 }
 
                 pcursor->Next();

--- a/src/validation.h
+++ b/src/validation.h
@@ -185,9 +185,9 @@ bool LoadExternalBlockFile(FILE* fileIn, FlatFilePos* dbp = NULL);
 bool LoadGenesisBlock();
 /** Load the block tree and coins database from disk,
  * initializing state if we're running with -reindex. */
-bool LoadBlockIndex(std::string& strError);
+bool LoadBlockIndex(std::string& strError) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 /** Update the chain tip based on database information. */
-bool LoadChainTip(const CChainParams& chainparams);
+bool LoadChainTip(const CChainParams& chainparams) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 /** Unload database information */
 void UnloadBlockIndex();
 /** See whether the protocol update is enforced for connected nodes */
@@ -210,18 +210,20 @@ bool ActivateBestChain(CValidationState& state, std::shared_ptr<const CBlock> pb
 CAmount GetBlockValue(int nHeight);
 
 /** Create a new block index entry for a given block hash */
-CBlockIndex* InsertBlockIndex(uint256 hash);
+CBlockIndex* InsertBlockIndex(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 /** Flush all state, indexes and buffers to disk. */
 void FlushStateToDisk();
 
 
 /** (try to) add transaction to memory pool **/
-bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransactionRef& tx, bool fLimitFree, bool* pfMissingInputs, bool fOverrideMempoolLimit = false, bool fRejectInsaneFee = false, bool ignoreFees = false);
+bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState& state, const CTransactionRef& tx, bool fLimitFree,
+                        bool* pfMissingInputs, bool fOverrideMempoolLimit = false,
+                        bool fRejectInsaneFee = false, bool ignoreFees = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /** (try to) add transaction to memory pool with a specified acceptance time **/
 bool AcceptToMemoryPoolWithTime(CTxMemPool& pool, CValidationState &state, const CTransactionRef &tx, bool fLimitFree,
                                 bool* pfMissingInputs, int64_t nAcceptTime, bool fOverrideMempoolLimit = false,
-                                bool fRejectInsaneFee = false, bool ignoreFees = false);
+                                bool fRejectInsaneFee = false, bool ignoreFees = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 CAmount GetMinRelayFee(const CTransaction& tx, const CTxMemPool& pool, unsigned int nBytes);
 CAmount GetMinRelayFee(unsigned int nBytes);
@@ -314,17 +316,17 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex);
 /** Functions for validating blocks and updating the block tree */
 
 /** Context-independent validity checks */
-bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW = true, bool fCheckMerkleRoot = true, bool fCheckSig = true);
+bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW = true, bool fCheckMerkleRoot = true, bool fCheckSig = true) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 bool CheckWork(const CBlock& block, const CBlockIndex* const pindexPrev);
 
 /** Context-dependent validity checks */
-bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& state, CBlockIndex* pindexPrev);
+bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& state, CBlockIndex* pindexPrev) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIndex* pindexPrev);
 
 /** Check a block is completely valid from start to finish (only works on top of our current best block, with cs_main held) */
-bool TestBlockValidity(CValidationState& state, const CBlock& block, CBlockIndex* pindexPrev, bool fCheckPOW = true, bool fCheckMerkleRoot = true, bool fCheckBlockSig = true);
+bool TestBlockValidity(CValidationState& state, const CBlock& block, CBlockIndex* pindexPrev, bool fCheckPOW = true, bool fCheckMerkleRoot = true, bool fCheckBlockSig = true) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
-bool AcceptBlockHeader(const CBlock& block, CValidationState& state, CBlockIndex** ppindex = nullptr, CBlockIndex* pindexPrev = nullptr);
+bool AcceptBlockHeader(const CBlock& block, CValidationState& state, CBlockIndex** ppindex = nullptr, CBlockIndex* pindexPrev = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 
 /** RAII wrapper for VerifyDB: Verify consistency of the block and coin databases */
@@ -339,7 +341,7 @@ public:
 /** Replay blocks that aren't fully applied to the database. */
 bool ReplayBlocks(const CChainParams& params, CCoinsView* view);
 
-inline CBlockIndex* LookupBlockIndex(const uint256& hash)
+inline CBlockIndex* LookupBlockIndex(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
     BlockMap::const_iterator it = mapBlockIndex.find(hash);
@@ -347,10 +349,10 @@ inline CBlockIndex* LookupBlockIndex(const uint256& hash)
 }
 
 /** Find the last common block between the parameter chain and a locator. */
-CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& locator);
+CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& locator) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /** Mark a block as invalid. */
-bool InvalidateBlock(CValidationState& state, const CChainParams& chainparams, CBlockIndex* pindex);
+bool InvalidateBlock(CValidationState& state, const CChainParams& chainparams, CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /** Remove invalidity status from a block and its descendants. */
 bool ReconsiderBlock(CValidationState& state, CBlockIndex* pindex);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -73,8 +73,10 @@ void EnsureWalletIsUnlocked(CWallet* const pwallet, bool fAllowAnonOnly)
         throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Please enter the wallet passphrase with walletpassphrase first.");
 }
 
-void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
+static void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
+    AssertLockHeld(cs_main);
+
     int confirms = wtx.GetDepthInMainChain();
     entry.pushKV("confirmations", confirms);
     entry.pushKV("bcconfirmations", confirms);      // DEPRECATED in 4.3.99
@@ -2958,8 +2960,10 @@ static void MaybePushAddress(UniValue & entry, const CTxDestination &dest)
         entry.pushKV("address", EncodeDestination(dest));
 }
 
-static void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, int nMinDepth, bool fLong, UniValue& ret, const isminefilter& filter)
+static void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, int nMinDepth, bool fLong, UniValue& ret, const isminefilter& filter) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
+    AssertLockHeld(cs_main);
+
     CAmount nFee;
     std::list<COutputEntry> listReceived;
     std::list<COutputEntry> listSent;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -996,8 +996,10 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose)
 }
 
 // Internal function for now, this will be part of a chain interface class in the future.
-Optional<int> getTipBlockHeight(const uint256& hash)
+static Optional<int> getTipBlockHeight(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
+    AssertLockHeld(cs_main);
+
     CBlockIndex* pindex = LookupBlockIndex(hash);
     if (pindex && chainActive.Contains(pindex)) {
         return Optional<int>(pindex->nHeight);
@@ -4414,6 +4416,8 @@ bool CWalletTx::IsInMainChainImmature() const
 
 bool CWalletTx::AcceptToMemoryPool(CValidationState& state)
 {
+    AssertLockHeld(cs_main);
+
     // Quick check to avoid re-setting fInMempool to false
     if (mempool.exists(tx->GetHash())) {
         return false;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -564,7 +564,7 @@ public:
     bool IsCoinStake() const { return tx->IsCoinStake(); }
 
     /** Pass this transaction to the mempool. Fails if absolute fee exceeds absurd fee. */
-    bool AcceptToMemoryPool(CValidationState& state);
+    bool AcceptToMemoryPool(CValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 };
 
 
@@ -1004,7 +1004,7 @@ public:
     bool EncryptWallet(const SecureString& strWalletPassphrase);
 
     std::vector<CKeyID> GetAffectedKeys(const CScript& spk);
-    void GetKeyBirthTimes(std::map<CKeyID, int64_t>& mapKeyBirth) const;
+    void GetKeyBirthTimes(std::map<CKeyID, int64_t>& mapKeyBirth) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /**
      * Increment the next transaction order id


### PR DESCRIPTION
#2715 introduced a locking assertion in `InsertBlockIndex`, which is currently failing (with debug enabled) because `cs_main` is not held during the blockindex load in `AppInitMain` (https://github.com/bitcoin/bitcoin/pull/11041/commits/c651df8b32d82695b497c969bfc9f2b1374081a8).
Also, `LookupBlockIndex` is being called without cs_main in `LoadExternalBlockFile` (https://github.com/bitcoin/bitcoin/pull/11041/commits/f814a3e8fa0d99c3d95ae7866c707617a1dd3d4e).
Finally there's a couple of missing locks in rest.cpp (which can be removed later, porting bitcoin#12151).