### PR TITLE
Bech32 export/import encoding format for BLS keys

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,6 +397,7 @@ set(COMMON_SOURCES
         ./src/bls/bls_ies.cpp
         ./src/bls/bls_worker.cpp
         ./src/bls/bls_wrapper.cpp
+        ./src/bls/key_io.cpp
         ./src/budget/budgetdb.cpp
         ./src/budget/budgetmanager.cpp
         ./src/budget/budgetproposal.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -153,6 +153,7 @@ BITCOIN_CORE_H = \
   bls/bls_ies.h \
   bls/bls_worker.h \
   bls/bls_wrapper.h \
+  bls/key_io.h \
   chain.h \
   chainparams.h \
   chainparamsbase.h \
@@ -345,6 +346,7 @@ libbitcoin_server_a_SOURCES = \
   bls/bls_ies.cpp \
   bls/bls_worker.cpp \
   bls/bls_wrapper.cpp \
+  bls/key_io.cpp \
   chain.cpp \
   checkpoints.cpp \
   consensus/params.cpp \

--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -6,6 +6,7 @@
 #include "activemasternode.h"
 
 #include "addrman.h"
+#include "bls/key_io.h"
 #include "bls/bls_wrapper.h"
 #include "masternode.h"
 #include "masternodeconfig.h"
@@ -61,9 +62,12 @@ OperationResult CActiveDeterministicMasternodeManager::SetOperatorKey(const std:
     if (strMNOperatorPrivKey.empty()) {
         return errorOut("ERROR: Masternode operator priv key cannot be empty.");
     }
-    if (!info.keyOperator.SetHexStr(strMNOperatorPrivKey)) {
+
+    auto opSk = bls::DecodeSecret(Params(), strMNOperatorPrivKey);
+    if (!opSk) {
         return errorOut(_("Invalid mnoperatorprivatekey. Please see the documentation."));
     }
+    info.keyOperator = *opSk;
     info.pubKeyOperator = info.keyOperator.GetPublicKey();
     return OperationResult(true);
 }

--- a/src/bls/bls_wrapper.h
+++ b/src/bls/bls_wrapper.h
@@ -129,21 +129,6 @@ public:
         return cachedHash;
     }
 
-    bool SetHexStr(const std::string& str)
-    {
-        if (!IsHex(str)) {
-            Reset();
-            return false;
-        }
-        auto b = ParseHex(str);
-        if (b.size() != SerSize) {
-            Reset();
-            return false;
-        }
-        SetByteVector(b);
-        return IsValid();
-    }
-
 public:
     template <typename Stream>
     inline void Serialize(Stream& s) const
@@ -173,7 +158,7 @@ public:
         }
         return true;
     }
-    
+
     // hex-encoding. Used only for signatures.
     // For secret/public keys use bls::EncodeSecret/EncodePublic
     inline std::string ToString() const

--- a/src/bls/bls_wrapper.h
+++ b/src/bls/bls_wrapper.h
@@ -173,7 +173,9 @@ public:
         }
         return true;
     }
-
+    
+    // hex-encoding. Used only for signatures.
+    // For secret/public keys use bls::EncodeSecret/EncodePublic
     inline std::string ToString() const
     {
         std::vector<uint8_t> buf = ToByteVector();

--- a/src/bls/key_io.cpp
+++ b/src/bls/key_io.cpp
@@ -15,7 +15,7 @@ static std::string EncodeBLS(const CChainParams& params,
                              const BLSKey& key,
                              CChainParams::Bech32Type type)
 {
-    assert(key.IsValid());
+    if (!key.IsValid()) return "";
     auto vec{key.ToByteVector()};
     // ConvertBits requires unsigned char, but CDataStream uses char
     std::vector<unsigned char> ss(vec.begin(), vec.end());

--- a/src/bls/key_io.cpp
+++ b/src/bls/key_io.cpp
@@ -57,7 +57,7 @@ std::string EncodeSecret(const CChainParams& params, const CBLSSecretKey& key)
 
 std::string EncodePublic(const CChainParams& params, const CBLSPublicKey& pk)
 {
-    return EncodeBLS(params, pk, CChainParams::BLS_PUBLIC_KEY);
+    return EncodeBLS<CBLSPublicKey>(params, pk, CChainParams::BLS_PUBLIC_KEY);
 }
 
 const size_t ConvertedBlsSkSize = (BLS_CURVE_SECKEY_SIZE * 8 + 4) / 5;

--- a/src/bls/key_io.cpp
+++ b/src/bls/key_io.cpp
@@ -1,0 +1,76 @@
+// Copyright (c) 2022 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include "bls/key_io.h"
+
+#include "chainparams.h"
+#include "bech32.h"
+#include "bls/bls_wrapper.h"
+
+namespace bls {
+
+template<typename BLSKey>
+static std::string EncodeBLS(const CChainParams& params,
+                             const BLSKey& key,
+                             CChainParams::Bech32Type type)
+{
+    assert(key.IsValid());
+    auto vec{key.ToByteVector()};
+    // ConvertBits requires unsigned char, but CDataStream uses char
+    std::vector<unsigned char> ss(vec.begin(), vec.end());
+    std::vector<unsigned char> data;
+    // See calculation comment below
+    data.reserve((ss.size() * 8 + 4) / 5);
+    ConvertBits<8, 5, true>([&](unsigned char c) { data.push_back(c); }, ss.begin(), ss.end());
+    auto res = bech32::Encode(params.Bech32HRP(type), data);
+    memory_cleanse(ss.data(), ss.size());
+    memory_cleanse(data.data(), data.size());
+    return res;
+}
+
+template<typename BLSKey>
+static Optional<BLSKey> DecodeBLS(const CChainParams& params,
+                                  const std::string& keyStr,
+                                  CChainParams::Bech32Type type,
+                                  unsigned int keySize)
+{
+    if (keyStr.empty()) return nullopt;
+    auto bech = bech32::Decode(keyStr);
+    if (bech.first == params.Bech32HRP(type) && bech.second.size() == keySize) {
+        std::vector<unsigned char> data;
+        data.reserve((bech.second.size() * 5) / 8);
+        if (ConvertBits<5, 8, false>([&](unsigned char c) { data.push_back(c); }, bech.second.begin(), bech.second.end())) {
+            CDataStream ss(data, SER_NETWORK, PROTOCOL_VERSION);
+            BLSKey key;
+            ss >> key;
+            if (key.IsValid()) return {key};
+        }
+    }
+    return nullopt;
+}
+
+std::string EncodeSecret(const CChainParams& params, const CBLSSecretKey& key)
+{
+    return EncodeBLS<CBLSSecretKey>(params, key, CChainParams::BLS_SECRET_KEY);
+}
+
+std::string EncodePublic(const CChainParams& params, const CBLSPublicKey& pk)
+{
+    return EncodeBLS(params, pk, CChainParams::BLS_PUBLIC_KEY);
+}
+
+const size_t ConvertedBlsSkSize = (BLS_CURVE_SECKEY_SIZE * 8 + 4) / 5;
+const size_t ConvertedBlsPkSize = (BLS_CURVE_PUBKEY_SIZE * 8 + 4) / 5;
+
+Optional<CBLSSecretKey> DecodeSecret(const CChainParams& params, const std::string& keyStr)
+{
+    return DecodeBLS<CBLSSecretKey>(params, keyStr, CChainParams::BLS_SECRET_KEY, ConvertedBlsSkSize);
+}
+
+Optional<CBLSPublicKey> DecodePublic(const CChainParams& params, const std::string& keyStr)
+{
+    return DecodeBLS<CBLSPublicKey>(params, keyStr, CChainParams::BLS_PUBLIC_KEY, ConvertedBlsPkSize);
+}
+
+} // end bls namespace

--- a/src/bls/key_io.cpp
+++ b/src/bls/key_io.cpp
@@ -16,15 +16,12 @@ static std::string EncodeBLS(const CChainParams& params,
                              CChainParams::Bech32Type type)
 {
     if (!key.IsValid()) return "";
-    auto vec{key.ToByteVector()};
-    // ConvertBits requires unsigned char, but CDataStream uses char
-    std::vector<unsigned char> ss(vec.begin(), vec.end());
+    std::vector<unsigned char> vec{key.ToByteVector()};
     std::vector<unsigned char> data;
-    // See calculation comment below
-    data.reserve((ss.size() * 8 + 4) / 5);
-    ConvertBits<8, 5, true>([&](unsigned char c) { data.push_back(c); }, ss.begin(), ss.end());
+    data.reserve((vec.size() * 8 + 4) / 5);
+    ConvertBits<8, 5, true>([&](unsigned char c) { data.push_back(c); }, vec.begin(), vec.end());
     auto res = bech32::Encode(params.Bech32HRP(type), data);
-    memory_cleanse(ss.data(), ss.size());
+    memory_cleanse(vec.data(), vec.size());
     memory_cleanse(data.data(), data.size());
     return res;
 }

--- a/src/bls/key_io.h
+++ b/src/bls/key_io.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2022 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#ifndef PIVX_BLS_KEY_IO_H
+#define PIVX_BLS_KEY_IO_H
+
+#include "optional.h"
+
+class CChainParams;
+class CBLSPublicKey;
+class CBLSSecretKey;
+
+namespace bls {
+
+    std::string EncodeSecret(const CChainParams& params, const CBLSSecretKey& key);
+    Optional<CBLSSecretKey> DecodeSecret(const CChainParams& params, const std::string& keyStr);
+
+    std::string EncodePublic(const CChainParams& params, const CBLSPublicKey& pk);
+    Optional<CBLSPublicKey> DecodePublic(const CChainParams& params, const std::string& keyStr);
+
+} // end bls namespace
+
+#endif //PIVX_BLS_KEY_IO_H

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -334,6 +334,9 @@ public:
         bech32HRPs[SAPLING_EXTENDED_SPEND_KEY]   = "p-secret-spending-key-main";
         bech32HRPs[SAPLING_EXTENDED_FVK]         = "pxviews";
 
+        bech32HRPs[BLS_SECRET_KEY]               = "bls-sk";
+        bech32HRPs[BLS_PUBLIC_KEY]               = "bls-pk";
+
         // long living quorum params
         consensus.llmqs[Consensus::LLMQ_50_60] = llmq50_60;
         consensus.llmqs[Consensus::LLMQ_400_60] = llmq400_60;
@@ -468,6 +471,9 @@ public:
         bech32HRPs[SAPLING_EXTENDED_SPEND_KEY]   = "p-secret-spending-key-test";
         bech32HRPs[SAPLING_EXTENDED_FVK]         = "pxviewtestsapling";
 
+        bech32HRPs[BLS_SECRET_KEY]               = "bls-sk-test";
+        bech32HRPs[BLS_PUBLIC_KEY]               = "bls-pk-test";
+
         // long living quorum params
         consensus.llmqs[Consensus::LLMQ_50_60] = llmq50_60;
         consensus.llmqs[Consensus::LLMQ_400_60] = llmq400_60;
@@ -601,6 +607,9 @@ public:
         bech32HRPs[SAPLING_INCOMING_VIEWING_KEY] = "pivktestsapling";
         bech32HRPs[SAPLING_EXTENDED_SPEND_KEY]   = "p-secret-spending-key-test";
         bech32HRPs[SAPLING_EXTENDED_FVK]         = "pxviewtestsapling";
+
+        bech32HRPs[BLS_SECRET_KEY]               = "bls-sk-test";
+        bech32HRPs[BLS_PUBLIC_KEY]               = "bls-pk-test";
 
         // long living quorum params
         consensus.llmqs[Consensus::LLMQ_TEST] = llmq_test;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -62,6 +62,9 @@ public:
         SAPLING_EXTENDED_SPEND_KEY,
         SAPLING_EXTENDED_FVK,
 
+        BLS_SECRET_KEY,
+        BLS_PUBLIC_KEY,
+
         MAX_BECH32_TYPES
     };
 

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -5,6 +5,7 @@
 
 #include "evo/deterministicmns.h"
 
+#include "bls/key_io.h"
 #include "chain.h"
 #include "coins.h"
 #include "chainparams.h"
@@ -41,7 +42,7 @@ std::string CDeterministicMNState::ToString() const
 
     return strprintf("CDeterministicMNState(nRegisteredHeight=%d, nLastPaidHeight=%d, nPoSePenalty=%d, nPoSeRevivedHeight=%d, nPoSeBanHeight=%d, nRevocationReason=%d, ownerAddress=%s, operatorPubKey=%s, votingAddress=%s, addr=%s, payoutAddress=%s, operatorPayoutAddress=%s)",
         nRegisteredHeight, nLastPaidHeight, nPoSePenalty, nPoSeRevivedHeight, nPoSeBanHeight, nRevocationReason,
-        EncodeDestination(keyIDOwner), pubKeyOperator.Get().ToString(), EncodeDestination(keyIDVoting), addr.ToStringIPPort(), payoutAddress, operatorPayoutAddress);
+        EncodeDestination(keyIDOwner), bls::EncodePublic(Params(), pubKeyOperator.Get()), EncodeDestination(keyIDVoting), addr.ToStringIPPort(), payoutAddress, operatorPayoutAddress);
 }
 
 void CDeterministicMNState::ToJson(UniValue& obj) const
@@ -56,7 +57,7 @@ void CDeterministicMNState::ToJson(UniValue& obj) const
     obj.pushKV("PoSeBanHeight", nPoSeBanHeight);
     obj.pushKV("revocationReason", nRevocationReason);
     obj.pushKV("ownerAddress", EncodeDestination(keyIDOwner));
-    obj.pushKV("operatorPubKey", pubKeyOperator.Get().ToString());
+    obj.pushKV("operatorPubKey", bls::EncodePublic(Params(), pubKeyOperator.Get()));
     obj.pushKV("votingAddress", EncodeDestination(keyIDVoting));
 
     CTxDestination dest1;
@@ -389,7 +390,7 @@ void CDeterministicMNList::AddMN(const CDeterministicMNCPtr& dmn, bool fBumpTota
         throw(std::runtime_error(strprintf("%s: can't add a masternode with a duplicate address %s", __func__, dmn->pdmnState->addr.ToStringIPPort())));
     }
     if (HasUniqueProperty(dmn->pdmnState->keyIDOwner) || HasUniqueProperty(dmn->pdmnState->pubKeyOperator)) {
-        throw(std::runtime_error(strprintf("%s: can't add a masternode with a duplicate key (%s or %s)", __func__, EncodeDestination(dmn->pdmnState->keyIDOwner), dmn->pdmnState->pubKeyOperator.Get().ToString())));
+        throw(std::runtime_error(strprintf("%s: can't add a masternode with a duplicate key (%s or %s)", __func__, EncodeDestination(dmn->pdmnState->keyIDOwner), bls::EncodePublic(Params(), dmn->pdmnState->pubKeyOperator.Get()))));
     }
 
     mnMap = mnMap.set(dmn->proTxHash, dmn);

--- a/src/evo/providertx.cpp
+++ b/src/evo/providertx.cpp
@@ -5,6 +5,7 @@
 
 #include "evo/providertx.h"
 
+#include "bls/key_io.h"
 #include "key_io.h"
 
 std::string ProRegPL::MakeSignString() const
@@ -28,7 +29,7 @@ std::string ProRegPL::ToString() const
     std::string payee = ExtractDestination(scriptPayout, dest) ?
                         EncodeDestination(dest) : "unknown";
     return strprintf("ProRegPL(nVersion=%d, collateralOutpoint=%s, addr=%s, nOperatorReward=%f, ownerAddress=%s, operatorPubKey=%s, votingAddress=%s, scriptPayout=%s)",
-        nVersion, collateralOutpoint.ToStringShort(), addr.ToString(), (double)nOperatorReward / 100, EncodeDestination(keyIDOwner), pubKeyOperator.ToString(), EncodeDestination(keyIDVoting), payee);
+        nVersion, collateralOutpoint.ToStringShort(), addr.ToString(), (double)nOperatorReward / 100, EncodeDestination(keyIDOwner), bls::EncodePublic(Params(), pubKeyOperator), EncodeDestination(keyIDVoting), payee);
 }
 
 void ProRegPL::ToJson(UniValue& obj) const
@@ -40,7 +41,7 @@ void ProRegPL::ToJson(UniValue& obj) const
     obj.pushKV("collateralIndex", (int)collateralOutpoint.n);
     obj.pushKV("service", addr.ToString());
     obj.pushKV("ownerAddress", EncodeDestination(keyIDOwner));
-    obj.pushKV("operatorPubKey", pubKeyOperator.ToString());
+    obj.pushKV("operatorPubKey", bls::EncodePublic(Params(), pubKeyOperator));
     obj.pushKV("votingAddress", EncodeDestination(keyIDVoting));
 
     CTxDestination dest1;
@@ -84,7 +85,7 @@ std::string ProUpRegPL::ToString() const
     std::string payee = ExtractDestination(scriptPayout, dest) ?
                         EncodeDestination(dest) : "unknown";
     return strprintf("ProUpRegPL(nVersion=%d, proTxHash=%s, operatorPubKey=%s, votingAddress=%s, payoutAddress=%s)",
-        nVersion, proTxHash.ToString(), pubKeyOperator.ToString(), EncodeDestination(keyIDVoting), payee);
+        nVersion, proTxHash.ToString(), bls::EncodePublic(Params(), pubKeyOperator), EncodeDestination(keyIDVoting), payee);
 }
 
 void ProUpRegPL::ToJson(UniValue& obj) const
@@ -98,7 +99,7 @@ void ProUpRegPL::ToJson(UniValue& obj) const
     if (ExtractDestination(scriptPayout, dest)) {
         obj.pushKV("payoutAddress", EncodeDestination(dest));
     }
-    obj.pushKV("operatorPubKey", pubKeyOperator.ToString());
+    obj.pushKV("operatorPubKey", bls::EncodePublic(Params(), pubKeyOperator));
     obj.pushKV("inputsHash", inputsHash.ToString());
 }
 

--- a/src/llmq/quorums_blockprocessor.cpp
+++ b/src/llmq/quorums_blockprocessor.cpp
@@ -5,6 +5,7 @@
 
 #include "llmq/quorums_blockprocessor.h"
 
+#include "bls/key_io.h"
 #include "chain.h"
 #include "chainparams.h"
 #include "consensus/validation.h"
@@ -181,7 +182,7 @@ bool CQuorumBlockProcessor::ProcessCommitment(int nHeight, const uint256& blockH
     }
 
     LogPrintf("%s: processed commitment from block. type=%d, quorumHash=%s, signers=%s, validMembers=%d, quorumPublicKey=%s\n", __func__,
-              qc.llmqType, quorumHash.ToString(), qc.CountSigners(), qc.CountValidMembers(), ""/*qc.quorumPublicKey.ToString()*/);
+              qc.llmqType, quorumHash.ToString(), qc.CountSigners(), qc.CountValidMembers(), bls::EncodePublic(Params(), qc.quorumPublicKey));
 
     return true;
 }

--- a/src/llmq/quorums_commitment.cpp
+++ b/src/llmq/quorums_commitment.cpp
@@ -5,6 +5,7 @@
 
 #include "llmq/quorums_commitment.h"
 
+#include "bls/key_io.h"
 #include "chainparams.h"
 #include "llmq/quorums_utils.h"
 #include "logging.h"
@@ -47,7 +48,7 @@ void CFinalCommitment::ToJson(UniValue& obj) const
     obj.pushKV("signers", utils::ToHexStr(signers));
     obj.pushKV("validMembersCount", CountValidMembers());
     obj.pushKV("validMembers", utils::ToHexStr(validMembers));
-    obj.pushKV("quorumPublicKey", quorumPublicKey.ToString());
+    obj.pushKV("quorumPublicKey", bls::EncodePublic(Params(), quorumPublicKey));
     obj.pushKV("quorumVvecHash", quorumVvecHash.ToString());
     obj.pushKV("quorumSig", quorumSig.ToString());
     obj.pushKV("membersSig", membersSig.ToString());

--- a/src/test/bls_tests.cpp
+++ b/src/test/bls_tests.cpp
@@ -13,24 +13,6 @@
 
 BOOST_FIXTURE_TEST_SUITE(bls_tests, BasicTestingSetup)
 
-BOOST_AUTO_TEST_CASE(bls_sethexstr_tests)
-{
-    CBLSSecretKey sk;
-    std::string strValidSecret = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
-    // Note: invalid string passed to SetHexStr() should cause it to fail and reset key internal data
-    BOOST_CHECK(sk.SetHexStr(strValidSecret));
-    BOOST_CHECK(!sk.SetHexStr("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1g")); // non-hex
-    BOOST_CHECK(!sk.IsValid());
-    BOOST_CHECK(sk == CBLSSecretKey());
-    // Try few more invalid strings
-    BOOST_CHECK(sk.SetHexStr(strValidSecret));
-    BOOST_CHECK(!sk.SetHexStr("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e")); // hex but too short
-    BOOST_CHECK(!sk.IsValid());
-    BOOST_CHECK(sk.SetHexStr(strValidSecret));
-    BOOST_CHECK(!sk.SetHexStr("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20")); // hex but too long
-    BOOST_CHECK(!sk.IsValid());
-}
-
 BOOST_AUTO_TEST_CASE(bls_sig_tests)
 {
     CBLSSecretKey sk1, sk2;
@@ -251,12 +233,19 @@ BOOST_AUTO_TEST_CASE(bls_ies_tests)
     BOOST_CHECK(decrypted_message2 != message);
 }
 
+template<typename BLSKey>
+BLSKey FromHex(const std::string& str)
+{
+    BLSKey k;
+    k.SetByteVector(ParseHex(str));
+    return k;
+}
+
 BOOST_AUTO_TEST_CASE(bls_sk_io_tests)
 {
     const auto& params = Params();
 
-    CBLSSecretKey sk;
-    sk.SetHexStr("2eb071f4c520b3102e8cb9f520783da252d33993dba0313b501d69d113af9d39");
+    CBLSSecretKey sk = FromHex<CBLSSecretKey>("2eb071f4c520b3102e8cb9f520783da252d33993dba0313b501d69d113af9d39");
     BOOST_ASSERT(sk.IsValid());
 
     // Basic encoding-decoding roundtrip
@@ -282,8 +271,7 @@ BOOST_AUTO_TEST_CASE(bls_pk_io_tests)
 {
     const auto& params = Params();
 
-    CBLSPublicKey pk;
-    pk.SetHexStr("901138a12a352c7e30408c071b1ec097f32ab735a12c8dbb43c637612a3f805668a6bb73894982366d287cf0b02aaf5b");
+    CBLSPublicKey pk = FromHex<CBLSPublicKey>("901138a12a352c7e30408c071b1ec097f32ab735a12c8dbb43c637612a3f805668a6bb73894982366d287cf0b02aaf5b");
     BOOST_ASSERT(pk.IsValid());
 
     // Basic encoding-decoding roundtrip

--- a/src/test/bls_tests.cpp
+++ b/src/test/bls_tests.cpp
@@ -4,6 +4,7 @@
 
 #include "test/test_pivx.h"
 #include "bls/bls_ies.h"
+#include "bls/key_io.h"
 #include "bls/bls_worker.h"
 #include "bls/bls_wrapper.h"
 #include "random.h"
@@ -248,6 +249,60 @@ BOOST_AUTO_TEST_CASE(bls_ies_tests)
     GetRandBytes(iesEnc.iv, sizeof(iesEnc.iv));
     iesEnc.Decrypt(bobSk, decrypted_message2, PROTOCOL_VERSION);
     BOOST_CHECK(decrypted_message2 != message);
+}
+
+BOOST_AUTO_TEST_CASE(bls_sk_io_tests)
+{
+    const auto& params = Params();
+
+    CBLSSecretKey sk;
+    sk.SetHexStr("2eb071f4c520b3102e8cb9f520783da252d33993dba0313b501d69d113af9d39");
+    BOOST_ASSERT(sk.IsValid());
+
+    // Basic encoding-decoding roundtrip
+    std::string encodedSk = bls::EncodeSecret(params, sk);
+    auto opSk2 = bls::DecodeSecret(params, encodedSk);
+    BOOST_CHECK(opSk2 != nullopt);
+    CBLSSecretKey sk2 = *opSk2;
+    BOOST_CHECK(sk == sk2);
+
+    // Invalid sk, one extra char
+    encodedSk.push_back('f');
+    auto opSk3 = bls::DecodeSecret(params, encodedSk);
+    BOOST_CHECK(opSk3 == nullopt);
+
+    // Invalid sk, one less char
+    encodedSk.pop_back();
+    encodedSk.pop_back();
+    auto opSk4 = bls::DecodeSecret(params, encodedSk);
+    BOOST_CHECK(opSk4 == nullopt);
+}
+
+BOOST_AUTO_TEST_CASE(bls_pk_io_tests)
+{
+    const auto& params = Params();
+
+    CBLSPublicKey pk;
+    pk.SetHexStr("901138a12a352c7e30408c071b1ec097f32ab735a12c8dbb43c637612a3f805668a6bb73894982366d287cf0b02aaf5b");
+    BOOST_ASSERT(pk.IsValid());
+
+    // Basic encoding-decoding roundtrip
+    std::string encodedPk = bls::EncodePublic(params, pk);
+    auto opPk2 = bls::DecodePublic(params, encodedPk);
+    BOOST_CHECK(opPk2 != nullopt);
+    CBLSPublicKey pk2 = *opPk2;
+    BOOST_CHECK(pk == pk2);
+
+    // Invalid pk, one extra char
+    encodedPk.push_back('f');
+    auto oppk3 = bls::DecodePublic(params, encodedPk);
+    BOOST_CHECK(oppk3 == nullopt);
+
+    // Invalid pk, one less char
+    encodedPk.pop_back();
+    encodedPk.pop_back();
+    auto oppk4 = bls::DecodePublic(params, encodedPk);
+    BOOST_CHECK(oppk4 == nullopt);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/p2p_quorum_connect.py
+++ b/test/functional/p2p_quorum_connect.py
@@ -16,7 +16,7 @@ from test_framework.util import (
     bytes_to_hex_str,
     connect_nodes_clique,
     hash256,
-    hex_str_to_bytes,
+    bech32_str_to_bytes,
     wait_until,
 )
 
@@ -108,7 +108,7 @@ class DMNConnectionTest(PivxTestFramework):
     def check_peer_info(self, peer_info, mn, is_iqr_conn, inbound=False):
         assert_equal(peer_info["masternode"], True)
         assert_equal(peer_info["verif_mn_proreg_tx_hash"], mn.proTx)
-        assert_equal(peer_info["verif_mn_operator_pubkey_hash"], bytes_to_hex_str(hash256(hex_str_to_bytes(mn.operator_pk))))
+        assert_equal(peer_info["verif_mn_operator_pubkey_hash"], bytes_to_hex_str(hash256(bech32_str_to_bytes(mn.operator_pk))))
         assert_equal(peer_info["masternode_iqr_conn"], is_iqr_conn)
         # An inbound connection has obviously a different internal port.
         if not inbound:

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1492,7 +1492,7 @@ class Masternode(object):
 
     def revoked(self):
         self.ipport = "[::]:0"
-        self.operator_pk = "0" * 96
+        self.operator_pk = ""
         self.operator_sk = None
 
     def __repr__(self):


### PR DESCRIPTION
Instead of exporting the BLS keys as plain hex strings, encode them into proper bech32 strings.

Gaining the following benefits:

1) Easily recognizable unique prefix for each BLS key type:
"bls-sk" for secret keys and  "bls-pk" for public keys.
2) The character set minimizes ambiguity, all characters are lowercase.
3) Error detection algorithm.

More info about the bech32 format can be found at [BIP173](https://en.bitcoin.it/wiki/BIP_0173)