### PR TITLE
Further TierTwo init encapsulation, '-evodir' resync bugfix and more circ dependencies fixes

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1256,28 +1256,17 @@ bool AppInitMain()
         fs::path chainstateDir = GetDataDir() / "chainstate";
         fs::path sporksDir = GetDataDir() / "sporks";
         fs::path zerocoinDir = GetDataDir() / "zerocoin";
+        fs::path evoDir = GetDataDir() / "evodb";
 
-        LogPrintf("Deleting blockchain folders blocks, chainstate, sporks and zerocoin\n");
-        // We delete in 4 individual steps in case one of the folder is missing already
+        LogPrintf("Deleting blockchain folders blocks, chainstate, sporks, zerocoin and evodb\n");
+        std::vector<fs::path> removeDirs{blocksDir, chainstateDir, sporksDir, zerocoinDir, evoDir};
+        // We delete in 5 individual steps in case one of the folder is missing already
         try {
-            if (fs::exists(blocksDir)){
-                fs::remove_all(blocksDir);
-                LogPrintf("-resync: folder deleted: %s\n", blocksDir.string().c_str());
-            }
-
-            if (fs::exists(chainstateDir)){
-                fs::remove_all(chainstateDir);
-                LogPrintf("-resync: folder deleted: %s\n", chainstateDir.string().c_str());
-            }
-
-            if (fs::exists(sporksDir)){
-                fs::remove_all(sporksDir);
-                LogPrintf("-resync: folder deleted: %s\n", sporksDir.string().c_str());
-            }
-
-            if (fs::exists(zerocoinDir)){
-                fs::remove_all(zerocoinDir);
-                LogPrintf("-resync: folder deleted: %s\n", zerocoinDir.string().c_str());
+            for (const auto& dir : removeDirs) {
+                if (fs::exists(dir)) {
+                    fs::remove_all(dir);
+                    LogPrintf("-resync: folder deleted: %s\n", dir.string().c_str());
+                }
             }
         } catch (const fs::filesystem_error& error) {
             LogPrintf("Failed to delete blockchain folders %s\n", error.what());

--- a/src/pivxd.cpp
+++ b/src/pivxd.cpp
@@ -92,13 +92,6 @@ bool AppInit(int argc, char* argv[])
             return false;
         }
 
-        // parse masternode.conf
-        std::string strErr;
-        if (!masternodeConfig.read(strErr)) {
-            fprintf(stderr, "Error reading masternode configuration file: %s\n", strErr.c_str());
-            return false;
-        }
-
         // Error out when loose non-argument tokens are encountered on command line
         for (int i = 1; i < argc; i++) {
             if (!IsSwitchChar(argv[i][0])) {

--- a/src/qt/pivx.cpp
+++ b/src/qt/pivx.cpp
@@ -14,7 +14,6 @@
 #include "fs.h"
 #include "guiinterface.h"
 #include "init.h"
-#include "masternodeconfig.h"
 #include "net.h"
 #include "qt/clientmodel.h"
 #include "qt/guiconstants.h"
@@ -654,14 +653,6 @@ int main(int argc, char* argv[])
     app.updateTranslation();
 
 #ifdef ENABLE_WALLET
-    /// 7a. parse masternode.conf
-    std::string strErr;
-    if (!masternodeConfig.read(strErr)) {
-        QMessageBox::critical(nullptr, PACKAGE_NAME,
-            QObject::tr("Error reading masternode configuration file: %1").arg(strErr.c_str()));
-        return 0;
-    }
-
     /// 8. URI IPC sending
     // - Do this early as we don't want to bother initializing if we are just calling IPC
     // - Do this *after* setting up the data directory, as the data directory hash is used in the name

--- a/src/tiertwo/init.cpp
+++ b/src/tiertwo/init.cpp
@@ -115,6 +115,14 @@ bool LoadTierTwo(int chain_active_height, bool fReindexChainState)
         LogPrintf("Error reading mnpayments.dat - cached data discarded\n");
     }
 
+    // ###################################### //
+    // ## Legacy Parse 'masternodes.conf'  ## //
+    // ###################################### //
+    std::string strErr;
+    if (!masternodeConfig.read(strErr)) {
+        return UIError(strprintf(_("Error reading masternode configuration file: %s"), strErr));
+    }
+
     // ############################## //
     // ## Net MNs Metadata Manager ## //
     // ############################## //

--- a/src/tiertwo/init.cpp
+++ b/src/tiertwo/init.cpp
@@ -6,6 +6,7 @@
 
 #include "budget/budgetdb.h"
 #include "evo/evodb.h"
+#include "evo/evonotificationinterface.h"
 #include "flatdb.h"
 #include "guiinterface.h"
 #include "guiinterfaceutil.h"
@@ -18,6 +19,8 @@
 #include "wallet/wallet.h"
 
 #include <boost/thread.hpp>
+
+static std::unique_ptr<EvoNotificationInterface> pEvoNotificationInterface{nullptr};
 
 std::string GetTierTwoHelpString(bool showDebug)
 {
@@ -37,6 +40,26 @@ std::string GetTierTwoHelpString(bool showDebug)
     return strUsage;
 }
 
+void InitTierTwoInterfaces()
+{
+    pEvoNotificationInterface = std::make_unique<EvoNotificationInterface>();
+    RegisterValidationInterface(pEvoNotificationInterface.get());
+}
+
+void ResetTierTwoInterfaces()
+{
+    if (pEvoNotificationInterface) {
+        UnregisterValidationInterface(pEvoNotificationInterface.get());
+        pEvoNotificationInterface.reset();
+    }
+
+    if (activeMasternodeManager) {
+        UnregisterValidationInterface(activeMasternodeManager);
+        delete activeMasternodeManager;
+        activeMasternodeManager = nullptr;
+    }
+}
+
 void InitTierTwoPreChainLoad(bool fReindex)
 {
     int64_t nEvoDbCache = 1024 * 1024 * 16; // TODO
@@ -50,6 +73,13 @@ void InitTierTwoPostCoinsCacheLoad()
 {
     // Initialize LLMQ system
     llmq::InitLLMQSystem(*evoDb);
+}
+
+void InitTierTwoChainTip()
+{
+    // force UpdatedBlockTip to initialize nCachedBlockHeight for DS, MN payments and budgets
+    // but don't call it directly to prevent triggering of other listeners like zmq etc.
+    pEvoNotificationInterface->InitializeCurrentBlockTip();
 }
 
 // Sets the last CACHED_BLOCK_HASHES hashes into masternode manager cache

--- a/src/tiertwo/init.h
+++ b/src/tiertwo/init.h
@@ -17,11 +17,20 @@ namespace boost {
 
 std::string GetTierTwoHelpString(bool showDebug);
 
+/** Init the interfaces objects */
+void InitTierTwoInterfaces();
+
+/** Resets the interfaces objects */
+void ResetTierTwoInterfaces();
+
 /** Inits the tier two global objects */
 void InitTierTwoPreChainLoad(bool fReindex);
 
 /** Inits the tier two global objects that require access to the coins tip cache */
 void InitTierTwoPostCoinsCacheLoad();
+
+/** Initialize chain tip */
+void InitTierTwoChainTip();
 
 /** Loads from disk all the tier two related objects */
 bool LoadTierTwo(int chain_active_height, bool fReindexChainState);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -851,10 +851,11 @@ public:
     std::map<libzcash::SaplingPaymentAddress, std::vector<SaplingNoteEntry>> ListNotes() const;
 
     /// Get 10000 PIV output and keys which can be used for the Masternode
-    bool GetMasternodeVinAndKeys(CTxIn& txinRet, CPubKey& pubKeyRet,
-            CKey& keyRet, std::string strTxHash, std::string strOutputIndex, std::string& strError);
-    /// Extract txin information and keys from output
-    bool GetVinAndKeysFromOutput(COutput out, CTxIn& txinRet, CPubKey& pubKeyRet, CKey& keyRet, bool fColdStake = false);
+    bool GetMasternodeVinAndKeys(CPubKey& pubKeyRet,
+                                 CKey& keyRet,
+                                 const COutPoint& collateralOut,
+                                 bool fValidateCollateral,
+                                 std::string& strError);
 
     bool IsSpent(const COutPoint& outpoint) const;
     bool IsSpent(const uint256& hash, unsigned int n) const;

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -19,7 +19,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "evo/specialtx_validation -> validation -> evo/specialtx_validation"
     "kernel -> validation -> kernel"
     "masternode -> masternodeman -> masternode"
-    "masternode -> wallet/wallet -> masternode"
     "masternode-payments -> masternodeman -> masternode-payments"
     "masternode-payments -> validation -> masternode-payments"
     "masternode-sync -> masternodeman -> masternode-sync"


### PR DESCRIPTION
Built on top of #2721, decoupled from the DMN GUI branch.

Focused on the following points:

* Unify `masternodeconfig` duplicated initialization inside `tiertwo/init.cpp`. Same for the `pEvoNotificationInterface` class.
* Simplify and unify `CWallet::GetMasternodeVinAndKeys` and `CWallet::GetVinAndKeysFromOutput` functions.
* Bug fix: remove 'evodb' dir during `-resync`.
* Fix the following circular dependencies:
   --> "masternode -> wallet/wallet -> masternode"
   --> "chain -> legacy/stakemodifier -> stakeinput -> wallet/wallet -> evo/deterministicmns -> chain"

Next PR will be exclusively focused on the new tier two module.