### PR TITLE
[wallet] fix ATMP call not contemplating the "missing inputs" error

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4409,10 +4409,17 @@ bool CWalletTx::AcceptToMemoryPool(CValidationState& state)
     // user could call sendmoney in a loop and hit spurious out of funds errors
     // because we think that the transaction they just generated's change is
     // unavailable as we're not yet aware its in mempool.
-    bool fAccepted = ::AcceptToMemoryPool(mempool, state, tx, true, nullptr, false, true, false);
+    bool fMissingInputs;
+    bool fAccepted = ::AcceptToMemoryPool(mempool, state, tx, true, &fMissingInputs, false, true, false);
     fInMempool = fAccepted;
-    if (!fAccepted)
+    if (!fAccepted) {
+        if (fMissingInputs) {
+            // For now, "missing inputs" error is not returning the proper state, so need to set it manually here.
+            // TODO: clean this setting the proper invalid state inside AcceptToMemoryPool (btc#15921).
+            state.Invalid(false, REJECT_INVALID, "Missing inputs");
+        }
         LogPrintf("%s : %s\n", __func__, state.GetRejectReason());
+    }
     return fAccepted;
 }
 


### PR DESCRIPTION
As `AcceptToMemoryPool` does not set the invalid state if the tx inputs requirements are not met, the wallet returns an empty validation state which ends up with an unknown/empty error message being presented to the user.