### PR TITLE
[Cleanup] Remove un-necessary const qualifiers in function declarations

### DIFF
--- a/src/blockassembler.h
+++ b/src/blockassembler.h
@@ -160,7 +160,7 @@ private:
     const bool defaultPrintPriority{false};
 
 public:
-    BlockAssembler(const CChainParams& chainparams, const bool defaultPrintPriority);
+    BlockAssembler(const CChainParams& chainparams, bool defaultPrintPriority);
     /** Construct a new block template with coinbase to scriptPubKeyIn */
     std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn,
                                    CWallet* pwallet = nullptr,

--- a/src/budget/budgetmanager.h
+++ b/src/budget/budgetmanager.h
@@ -152,7 +152,7 @@ public:
     bool UpdateFinalizedBudget(const CFinalizedBudgetVote& vote, CNode* pfrom, std::string& strError);
     TrxValidationStatus IsTransactionValid(const CTransaction& txNew, const uint256& nBlockHash, int nBlockHeight) const;
     std::string GetRequiredPaymentsString(int nBlockHeight);
-    bool FillBlockPayee(CMutableTransaction& txCoinbase, CMutableTransaction& txCoinstake, const int nHeight, bool fProofOfStake) const;
+    bool FillBlockPayee(CMutableTransaction& txCoinbase, CMutableTransaction& txCoinstake, int nHeight, bool fProofOfStake) const;
 
     // Only initialized masternodes: sign and submit votes on valid finalized budgets
     void VoteOnFinalizedBudgets();

--- a/src/budget/budgetutil.h
+++ b/src/budget/budgetutil.h
@@ -21,7 +21,7 @@ class CWallet;
 UniValue mnLocalBudgetVoteInner(bool fLegacyMN, const uint256& budgetHash, bool fFinal,
                                        const CBudgetVote::VoteDirection& nVote);
 
-UniValue mnBudgetVoteInner(CWallet* const pwallet, bool fLegacyMN, const uint256& budgetHash, bool fFinal,
+UniValue mnBudgetVoteInner(CWallet* pwallet, bool fLegacyMN, const uint256& budgetHash, bool fFinal,
                                   const CBudgetVote::VoteDirection& nVote, const Optional<std::string>& mnAliasFilter);
 
 #endif //PIVX_BUDGETUTIL_H

--- a/src/chain.h
+++ b/src/chain.h
@@ -229,7 +229,7 @@ public:
     unsigned int GetStakeEntropyBit() const;
     bool SetStakeEntropyBit(unsigned int nEntropyBit);
     bool GeneratedStakeModifier() const { return (nFlags & BLOCK_STAKE_MODIFIER); }
-    void SetStakeModifier(const uint64_t nStakeModifier, bool fGeneratedStakeModifier);
+    void SetStakeModifier(uint64_t nStakeModifier, bool fGeneratedStakeModifier);
     void SetNewStakeModifier();                             // generates and sets new v1 modifier
     void SetStakeModifier(const uint256& nStakeModifier);
     void SetNewStakeModifier(const uint256& prevoutId);     // generates and sets new v2 modifier

--- a/src/core_io.h
+++ b/src/core_io.h
@@ -18,7 +18,7 @@ class UniValue;
 
 // core_read.cpp
 extern CScript ParseScript(std::string s);
-extern std::string ScriptToAsmStr(const CScript& script, const bool fAttemptSighashDecode = false);
+extern std::string ScriptToAsmStr(const CScript& script, bool fAttemptSighashDecode = false);
 extern bool DecodeHexTx(CMutableTransaction& tx, const std::string& strHexTx);
 extern bool DecodeHexBlk(CBlock&, const std::string& strHexBlk);
 extern uint256 ParseHashUV(const UniValue& v, const std::string& strName);

--- a/src/crypter.h
+++ b/src/crypter.h
@@ -91,7 +91,7 @@ private:
     int BytesToKeySHA512AES(const std::vector<unsigned char>& chSalt, const SecureString& strKeyData, int count, unsigned char *key,unsigned char *iv) const;
 
 public:
-    bool SetKeyFromPassphrase(const SecureString& strKeyData, const std::vector<unsigned char>& chSalt, const unsigned int nRounds, const unsigned int nDerivationMethod);
+    bool SetKeyFromPassphrase(const SecureString& strKeyData, const std::vector<unsigned char>& chSalt, unsigned int nRounds, unsigned int nDerivationMethod);
     bool Encrypt(const CKeyingMaterial& vchPlaintext, std::vector<unsigned char>& vchCiphertext) const;
     bool Decrypt(const std::vector<unsigned char>& vchCiphertext, CKeyingMaterial& vchPlaintext) const;
     bool SetKey(const CKeyingMaterial& chNewKey, const std::vector<unsigned char>& chNewIV);

--- a/src/destination_io.h
+++ b/src/destination_io.h
@@ -13,7 +13,7 @@ typedef boost::variant<CTxDestination, libzcash::SaplingPaymentAddress> CWDestin
 
 namespace Standard {
 
-    std::string EncodeDestination(const CWDestination &address, const CChainParams::Base58Type addrType = CChainParams::PUBKEY_ADDRESS);
+    std::string EncodeDestination(const CWDestination &address, CChainParams::Base58Type addrType = CChainParams::PUBKEY_ADDRESS);
 
     CWDestination DecodeDestination(const std::string& strAddress);
     CWDestination DecodeDestination(const std::string& strAddress, bool& isStaking);

--- a/src/hash.h
+++ b/src/hash.h
@@ -334,7 +334,7 @@ public:
 
 unsigned int MurmurHash3(unsigned int nHashSeed, const std::vector<unsigned char>& vDataToHash);
 
-void BIP32Hash(const ChainCode chainCode, unsigned int nChild, unsigned char header, const unsigned char data[32], unsigned char output[64]);
+void BIP32Hash(ChainCode chainCode, unsigned int nChild, unsigned char header, const unsigned char data[32], unsigned char output[64]);
 
 //int HMAC_SHA512_Init(HMAC_SHA512_CTX *pctx, const void *pkey, size_t len);
 //int HMAC_SHA512_Update(HMAC_SHA512_CTX *pctx, const void *pdata, size_t len);

--- a/src/kernel.h
+++ b/src/kernel.h
@@ -20,7 +20,7 @@ public:
      * @param[in]   nBits           target difficulty bits of the kernel block
      * @param[in]   nTimeTx         time of the kernel block
      */
-    CStakeKernel(const CBlockIndex* const pindexPrev, CStakeInput* stakeInput, unsigned int nBits, int nTimeTx);
+    CStakeKernel(const CBlockIndex* pindexPrev, CStakeInput* stakeInput, unsigned int nBits, int nTimeTx);
 
     // Return stake kernel hash
     uint256 GetHash() const;

--- a/src/key_io.h
+++ b/src/key_io.h
@@ -14,7 +14,7 @@
 #include <string>
 
 std::string EncodeDestination(const CTxDestination& dest, bool isStaking);
-std::string EncodeDestination(const CTxDestination& dest, const CChainParams::Base58Type addrType = CChainParams::PUBKEY_ADDRESS);
+std::string EncodeDestination(const CTxDestination& dest, CChainParams::Base58Type addrType = CChainParams::PUBKEY_ADDRESS);
 // DecodeDestinationisStaking flag is set to true when the string arg is from an staking address
 CTxDestination DecodeDestination(const std::string& str, bool& isStaking);
 CTxDestination DecodeDestination(const std::string& str);

--- a/src/libzerocoin/Coin.h
+++ b/src/libzerocoin/Coin.h
@@ -36,7 +36,7 @@ namespace libzerocoin
     bool IsValidSerial(const ZerocoinParams* params, const CBigNum& bnSerial);
     bool IsValidCommitmentToCoinRange(const ZerocoinParams* params, const CBigNum& bnCommitment);
     CBigNum GetAdjustedSerial(const CBigNum& bnSerial);
-    CBigNum ExtractSerialFromPubKey(const CPubKey pubkey);
+    CBigNum ExtractSerialFromPubKey(CPubKey pubkey);
 
 /** A Public coin is the part of a coin that
  * is published to the network and what is handled
@@ -61,7 +61,7 @@ public:
      * @param coin the value of the commitment.
      * @param denomination The denomination of the coin.
      */
-    PublicCoin(const ZerocoinParams* p, const CBigNum& coin, const CoinDenomination d);
+    PublicCoin(const ZerocoinParams* p, const CBigNum& coin, CoinDenomination d);
     const CBigNum& getValue() const { return this->value; }
 
     CoinDenomination getDenomination() const { return this->denomination; }

--- a/src/libzerocoin/CoinRandomnessSchnorrSignature.h
+++ b/src/libzerocoin/CoinRandomnessSchnorrSignature.h
@@ -27,7 +27,7 @@ public:
      * @param randomness the coin we are going to use for the signature (sk := randomness, pk := h^sk mod p).
      * @param msghash hash of meta data to create a signature on.
      */
-    CoinRandomnessSchnorrSignature(const ZerocoinParams* zcparams, const CBigNum randomness, const uint256 msghash);
+    CoinRandomnessSchnorrSignature(const ZerocoinParams* zcparams, CBigNum randomness, uint256 msghash);
 
     /** Verifies the Schnorr signature on message msghash with public key pk = Cg^-S mod p
      *
@@ -37,7 +37,7 @@ public:
      * @param msghash hash of meta data to verify the signature on.
      * @return
      */
-    bool Verify(const ZerocoinParams* zcparams, const CBigNum& S, const CBigNum& C, const uint256 msghash) const;
+    bool Verify(const ZerocoinParams* zcparams, const CBigNum& S, const CBigNum& C, uint256 msghash) const;
 
     SERIALIZE_METHODS(CoinRandomnessSchnorrSignature, obj) { READWRITE(obj.alpha, obj.beta); }
 

--- a/src/libzerocoin/bignum.h
+++ b/src/libzerocoin/bignum.h
@@ -102,7 +102,7 @@ public:
         * @param e the exponent as an int
         * @return
         */
-    CBigNum pow(const int e) const;
+    CBigNum pow(int e) const;
 
     /**
      * exponentiation this^e
@@ -146,7 +146,7 @@ public:
     *                          default causes error rate of 2^-80.
     * @return true if prime
     */
-    bool isPrime(const int checks=15) const;
+    bool isPrime(int checks=15) const;
 
     bool isOne() const;
     bool operator!() const;

--- a/src/masternode-sync.h
+++ b/src/masternode-sync.h
@@ -91,7 +91,7 @@ private:
     void PushMessage(CNode* pnode, const char* msg, Args&&... args);
 
     // update peer sync state data
-    bool UpdatePeerSyncState(const NodeId& id, const char* msg, const int nextSyncStatus);
+    bool UpdatePeerSyncState(const NodeId& id, const char* msg, int nextSyncStatus);
 
     // Check if an update is needed
     void CheckAndUpdateSyncStatus();

--- a/src/messagesigner.h
+++ b/src/messagesigner.h
@@ -75,7 +75,7 @@ public:
 
     // Sign-Verify message
     bool Sign(const CKey& key, const CKeyID& keyID);
-    bool Sign(const std::string strSignKey);
+    bool Sign(std::string strSignKey);
     bool CheckSignature(const CKeyID& keyID) const;
 
     // Pure virtual functions (used in Sign-Verify functions)

--- a/src/net.h
+++ b/src/net.h
@@ -364,7 +364,7 @@ private:
     void ThreadOpenAddedConnections();
     void AddOneShot(const std::string& strDest);
     void ProcessOneShot();
-    void ThreadOpenConnections(const std::vector<std::string> connect);
+    void ThreadOpenConnections(std::vector<std::string> connect);
     void ThreadMessageHandler();
     void AcceptConnection(const ListenSocket& hListenSocket);
     void DisconnectNodes();

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -204,7 +204,7 @@ public:
     std::vector<unsigned char> GetAddrBytes() const;
     int GetReachabilityFrom(const CNetAddr* paddrPartner = nullptr) const;
 
-    CNetAddr(const struct in6_addr& pipv6Addr, const uint32_t scope = 0);
+    CNetAddr(const struct in6_addr& pipv6Addr, uint32_t scope = 0);
     bool GetIn6Addr(struct in6_addr* pipv6Addr) const;
 
     friend bool operator==(const CNetAddr& a, const CNetAddr& b);

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -104,11 +104,11 @@ private:
                            const Optional<QString>& stakerAddress,
                            const QString& sWalletLabel,
                            const uint256& txhash,
-                           const uint32_t outIndex,
-                           const CAmount nValue,
-                           const int64_t nTime,
-                           const int nDepth,
-                           const bool isChange);
+                           uint32_t outIndex,
+                           CAmount nValue,
+                           int64_t nTime,
+                           int nDepth,
+                           bool isChange);
 
     // calculate sums for selected amount, number of inputs, change, fee, after fee value, and transaction size
     TotalAmounts getTotals() const;

--- a/src/qt/pivx/coldstakingmodel.h
+++ b/src/qt/pivx/coldstakingmodel.h
@@ -66,7 +66,7 @@ public:
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
     bool whitelist(const QModelIndex& modelIndex);
     bool blacklist(const QModelIndex& index);
-    void removeRowAndEmitDataChanged(const int idx);
+    void removeRowAndEmitDataChanged(int idx);
     void updateCSList();
     CAmount getTotalAmount() const { return cachedAmount; }
 
@@ -86,7 +86,7 @@ private:
     QList<CSDelegation> cachedDelegations;
     CAmount cachedAmount;
 
-    bool parseCSDelegation(const CTxOut& out, CSDelegation& ret, const QString& txId, const int utxoIndex);
+    bool parseCSDelegation(const CTxOut& out, CSDelegation& ret, const QString& txId, int utxoIndex);
 };
 
 #endif // COLDSTAKINGMODEL_H

--- a/src/qt/pivx/coldstakingwidget.h
+++ b/src/qt/pivx/coldstakingwidget.h
@@ -69,7 +69,7 @@ private Q_SLOTS:
     void onCopyOwnerClicked();
     void onAddressCopyClicked();
     void onAddressEditClicked();
-    void onTxArrived(const QString& hash, const bool isCoinStake, const bool isMNReward, const bool isCSAnyType);
+    void onTxArrived(const QString& hash, bool isCoinStake, bool isMNReward, bool isCSAnyType);
     void onContactsClicked(bool ownerAdd);
     void clearAll();
     void onLabelClicked();
@@ -122,7 +122,7 @@ private:
     void onContactsClicked();
     void tryRefreshDelegations();
     bool refreshDelegations();
-    void onLabelClicked(QString dialogTitle, const QModelIndex &index, const bool isMyColdStakingAddresses);
+    void onLabelClicked(QString dialogTitle, const QModelIndex &index, bool isMyColdStakingAddresses);
     void updateStakingTotalLabel();
     void sortAddresses();
     void setCoinControlPayAmounts();

--- a/src/qt/pivx/dashboardwidget.h
+++ b/src/qt/pivx/dashboardwidget.h
@@ -122,7 +122,7 @@ private Q_SLOTS:
     void onSortTypeChanged(const QString& value);
     void updateDisplayUnit();
     void showList();
-    void onTxArrived(const QString& hash, const bool isCoinStake, const bool isMNReward, const bool isCSAnyType);
+    void onTxArrived(const QString& hash, bool isCoinStake, bool isMNReward, bool isCSAnyType);
 
 #ifdef USE_QTCHARTS
     void windowResizeEvent(QResizeEvent* event);

--- a/src/qt/pivx/governancemodel.h
+++ b/src/qt/pivx/governancemodel.h
@@ -143,7 +143,7 @@ public:
 
 public Q_SLOTS:
     void pollGovernanceChanged();
-    void txLoaded(const QString& hash, const int txType, const int txStatus);
+    void txLoaded(const QString& hash, int txType, int txStatus);
 
 private:
     ClientModel* clientModel{nullptr};

--- a/src/qt/pivx/settings/settingsexportcsv.h
+++ b/src/qt/pivx/settings/settingsexportcsv.h
@@ -23,7 +23,7 @@ public:
     ~SettingsExportCSV();
 
 private Q_SLOTS:
-    void selectFileOutput(const bool isTxExport);
+    void selectFileOutput(bool isTxExport);
     void exportTxes(const QString& filename);
     void exportAddrs(const QString& filename);
 

--- a/src/qt/pivx/settings/settingsfaqwidget.h
+++ b/src/qt/pivx/settings/settingsfaqwidget.h
@@ -36,7 +36,7 @@ public Q_SLOTS:
    void windowResizeEvent(QResizeEvent* event);
    void setSection(Section _section);
 private Q_SLOTS:
-    void onFaqClicked(const QWidget* const widget);
+    void onFaqClicked(const QWidget* widget);
 private:
     Ui::SettingsFaqWidget *ui;
     Section section = INTRO;

--- a/src/qt/pivx/topbar.h
+++ b/src/qt/pivx/topbar.h
@@ -52,7 +52,7 @@ public Q_SLOTS:
     void setNetworkActive(bool active);
     void setStakingStatusActive(bool fActive);
     void updateStakingStatus();
-    void updateHDState(const bool upgraded, const QString& upgradeError);
+    void updateHDState(bool upgraded, const QString& upgradeError);
     void showUpgradeDialog(const QString& message);
 
 Q_SIGNALS:

--- a/src/qt/transactionfilterproxy.h
+++ b/src/qt/transactionfilterproxy.h
@@ -59,7 +59,7 @@ public:
     void setHideOrphans(bool fHide);
 
     int rowCount(const QModelIndex& parent = QModelIndex()) const;
-    static bool isOrphan(const int status, const int type);
+    static bool isOrphan(int status, int type);
 
 protected:
     bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const;

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -85,9 +85,9 @@ public:
 
 Q_SIGNALS:
     // Emitted only during startup when records gets parsed
-    void txLoaded(const QString& hash, const int txType, const int txStatus);
+    void txLoaded(const QString& hash, int txType, int txStatus);
     // Emitted when a transaction that belongs to this wallet gets connected to the chain and/or committed locally.
-    void txArrived(const QString& hash, const bool isCoinStake, const bool isMNReward, const bool isCSAnyType);
+    void txArrived(const QString& hash, bool isCoinStake, bool isMNReward, bool isCSAnyType);
 
 private:
     // Listeners

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -203,10 +203,10 @@ public:
     void setWalletDefaultFee(CAmount fee = DEFAULT_TRANSACTION_FEE);
     bool hasWalletCustomFee();
     bool getWalletCustomFee(CAmount& nFeeRet);
-    void setWalletCustomFee(bool fUseCustomFee, const CAmount nFee = DEFAULT_TRANSACTION_FEE);
+    void setWalletCustomFee(bool fUseCustomFee, CAmount nFee = DEFAULT_TRANSACTION_FEE);
     CAmount getNetMinFee();
 
-    void setWalletStakeSplitThreshold(const CAmount nStakeSplitThreshold);
+    void setWalletStakeSplitThreshold(CAmount nStakeSplitThreshold);
     CAmount getWalletStakeSplitThreshold() const;
     /* Minimum stake split threshold*/
     double getSSTMinimum() const;
@@ -345,7 +345,7 @@ public:
     std::set<COutPoint> listLockedCoins();
 
     void loadReceiveRequests(std::vector<std::string>& vReceiveRequests);
-    bool saveReceiveRequest(const std::string& sAddress, const int64_t nId, const std::string& sRequest);
+    bool saveReceiveRequest(const std::string& sAddress, int64_t nId, const std::string& sRequest);
 
     ClientModel& clientModel() const { return *m_client_model; }
     void setClientModel(ClientModel* client_model);
@@ -433,7 +433,7 @@ Q_SIGNALS:
     void notifyReceiveAddressChanged();
 
     /** notify stake-split threshold changed */
-    void notifySSTChanged(const double sstVal);
+    void notifySSTChanged(double sstVal);
 
 public Q_SLOTS:
     /* Wallet balances changes */

--- a/src/random.h
+++ b/src/random.h
@@ -94,7 +94,7 @@ void RandAddPeriodic() noexcept;
  *
  * Thread-safe.
  */
-void RandAddEvent(const uint32_t event_info) noexcept;
+void RandAddEvent(uint32_t event_info) noexcept;
 
 /**
  * Fast randomness source. This is seeded once with secure random data, but

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -56,7 +56,7 @@ struct CCoin {
     }
 };
 
-extern void TxToJSON(CWallet* const pwallet, const CTransaction& tx, const CBlockIndex* tip, const CBlockIndex* blockindex, UniValue& entry);
+extern void TxToJSON(CWallet* pwallet, const CTransaction& tx, const CBlockIndex* tip, const CBlockIndex* blockindex, UniValue& entry);
 extern UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIndex* blockindex, bool txDetails = false);
 extern UniValue mempoolInfoToJSON();
 extern UniValue mempoolToJSON(bool fVerbose = false);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -43,7 +43,7 @@ static std::mutex cs_blockchange;
 static std::condition_variable cond_blockchange;
 static CUpdatedBlock latestblock;
 
-extern void TxToJSON(CWallet* const pwallet, const CTransaction& tx, const CBlockIndex* tip, const CBlockIndex* blockindex, UniValue& entry);
+extern void TxToJSON(CWallet* pwallet, const CTransaction& tx, const CBlockIndex* tip, const CBlockIndex* blockindex, UniValue& entry);
 
 UniValue syncwithvalidationinterfacequeue(const JSONRPCRequest& request)
 {

--- a/src/rust/include/librustzcash.h
+++ b/src/rust/include/librustzcash.h
@@ -98,7 +98,7 @@ extern "C" {
         const unsigned char *diversifier,
         const unsigned char *rcm,
         const unsigned char *ar,
-        const uint64_t value,
+        uint64_t value,
         const unsigned char *anchor,
         const unsigned char *witness,
         unsigned char *cv,
@@ -114,7 +114,7 @@ extern "C" {
         const unsigned char *esk,
         const unsigned char *payment_address,
         const unsigned char *rcm,
-        const uint64_t value,
+        uint64_t value,
         unsigned char *cv,
         unsigned char *zkproof
     );
@@ -182,11 +182,11 @@ extern "C" {
     bool librustzcash_sapling_compute_nf(
         const unsigned char *diversifier,
         const unsigned char *pk_d,
-        const uint64_t value,
+        uint64_t value,
         const unsigned char *r,
         const unsigned char *ak,
         const unsigned char *nk,
-        const uint64_t position,
+        uint64_t position,
         unsigned char *result
     );
 
@@ -199,7 +199,7 @@ extern "C" {
     bool librustzcash_sapling_compute_cm(
         const unsigned char *diversifier,
         const unsigned char *pk_d,
-        const uint64_t value,
+        uint64_t value,
         const unsigned char *r,
         unsigned char *result
     );

--- a/src/sapling/note.h
+++ b/src/sapling/note.h
@@ -47,7 +47,7 @@ public:
     virtual ~SaplingNote() {};
 
     Optional<uint256> cmu() const;
-    Optional<uint256> nullifier(const SaplingFullViewingKey& vk, const uint64_t position) const;
+    Optional<uint256> nullifier(const SaplingFullViewingKey& vk, uint64_t position) const;
 };
 
 class BaseNotePlaintext {

--- a/src/sapling/sapling_operation.h
+++ b/src/sapling/sapling_operation.h
@@ -93,7 +93,7 @@ public:
     void setFromAddress(const libzcash::SaplingPaymentAddress&);
     void clearTx() { txBuilder.Clear(); }
     // In case of no addressFrom filter selected, it will accept any utxo in the wallet as input.
-    SaplingOperation* setSelectTransparentCoins(const bool select, const bool _fIncludeDelegated = false);
+    SaplingOperation* setSelectTransparentCoins(bool select, bool _fIncludeDelegated = false);
     SaplingOperation* setSelectShieldedCoins(const bool select) { selectFromShield = select; return this; };
     SaplingOperation* setRecipients(std::vector<SendManyRecipient>& vec) { recipients = std::move(vec); return this; };
     SaplingOperation* setFee(CAmount _fee) { fee = _fee; return this; }
@@ -133,7 +133,7 @@ private:
     CTransactionRef finalTx;
 
     OperationResult loadUtxos(TxValues& values);
-    OperationResult loadUtxos(TxValues& txValues, const std::vector<COutput>& selectedUTXO, const CAmount selectedUTXOAmount);
+    OperationResult loadUtxos(TxValues& txValues, const std::vector<COutput>& selectedUTXO, CAmount selectedUTXOAmount);
     OperationResult loadUnspentNotes(TxValues& txValues, uint256& ovk);
     OperationResult checkTxValues(TxValues& txValues, bool isFromtAddress, bool isFromShielded);
 };

--- a/src/sapling/sapling_util.h
+++ b/src/sapling/sapling_util.h
@@ -13,7 +13,7 @@
 #include <vector>
 #include <cstdint>
 
-std::vector<unsigned char> convertIntToVectorLE(const uint64_t val_int);
+std::vector<unsigned char> convertIntToVectorLE(uint64_t val_int);
 std::vector<bool> convertBytesVectorToVector(const std::vector<unsigned char>& bytes);
 uint64_t convertVectorToInt(const std::vector<bool>& v);
 

--- a/src/sapling/saplingscriptpubkeyman.h
+++ b/src/sapling/saplingscriptpubkeyman.h
@@ -327,7 +327,7 @@ public:
     //! Return the memo value of a specific outpoint of wallet transaction
     Optional<std::string> GetOutPointMemo(const CWalletTx& tx, const SaplingOutPoint& op) const;
     //! Return the shielded credit of the tx
-    CAmount GetCredit(const CWalletTx& tx, const isminefilter& filter, const bool fUnspent = false) const;
+    CAmount GetCredit(const CWalletTx& tx, const isminefilter& filter, bool fUnspent = false) const;
     //! Return the shielded debit of the tx.
     CAmount GetDebit(const CTransaction& tx, const isminefilter& filter) const;
     //! Return the shielded change of the tx

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -630,7 +630,7 @@ public:
     bool IsPayToScriptHash() const;
     bool IsPayToColdStaking() const;
     bool IsPayToColdStakingLOF() const;
-    bool StartsWithOpcode(const opcodetype opcode) const;
+    bool StartsWithOpcode(opcodetype opcode) const;
     bool IsZerocoinMint() const;
     bool IsZerocoinSpend() const;
     bool IsZerocoinPublicSpend() const;

--- a/src/script/script_error.h
+++ b/src/script/script_error.h
@@ -59,6 +59,6 @@ typedef enum ScriptError_t
 
 #define SCRIPT_ERR_LAST SCRIPT_ERR_ERROR_COUNT
 
-const char* ScriptErrorString(const ScriptError error);
+const char* ScriptErrorString(ScriptError error);
 
 #endif // BITCOIN_SCRIPT_SCRIPT_ERROR_H

--- a/src/sporkdb.h
+++ b/src/sporkdb.h
@@ -19,9 +19,9 @@ private:
     void operator=(const CSporkDB&);
 
 public:
-    bool WriteSpork(const SporkId nSporkId, const CSporkMessage& spork);
-    bool ReadSpork(const SporkId nSporkId, CSporkMessage& spork);
-    bool SporkExists(const SporkId nSporkId);
+    bool WriteSpork(SporkId nSporkId, const CSporkMessage& spork);
+    bool ReadSpork(SporkId nSporkId, CSporkMessage& spork);
+    bool SporkExists(SporkId nSporkId);
 };
 
 

--- a/src/timedata.h
+++ b/src/timedata.h
@@ -76,7 +76,7 @@ int64_t GetAdjustedTime();
 void AddTimeData(const CNetAddr& ip, int64_t nTime, int nOffsetLimit);
 
 // Time Protocol V2
-int64_t GetTimeSlot(const int64_t nTime);
+int64_t GetTimeSlot(int64_t nTime);
 int64_t GetCurrentTimeSlot();
 
 #endif // BITCOIN_TIMEDATA_H

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -166,10 +166,10 @@ public:
     bool EraseCoinSpend(const CBigNum& bnSerial);
 
     /** Accumulators (only for zPoS IBD): [checksum, denom] --> block height **/
-    bool WriteAccChecksum(const uint32_t nChecksum, const libzerocoin::CoinDenomination denom, const int nHeight);
-    bool ReadAccChecksum(const uint32_t nChecksum, const libzerocoin::CoinDenomination denom, int& nHeightRet);
+    bool WriteAccChecksum(uint32_t nChecksum, libzerocoin::CoinDenomination denom, int nHeight);
+    bool ReadAccChecksum(uint32_t nChecksum, libzerocoin::CoinDenomination denom, int& nHeightRet);
     bool ReadAll(std::map<std::pair<uint32_t, libzerocoin::CoinDenomination>, int>& mapCheckpoints);
-    bool EraseAccChecksum(const uint32_t nChecksum, const libzerocoin::CoinDenomination denom);
+    bool EraseAccChecksum(uint32_t nChecksum, libzerocoin::CoinDenomination denom);
     void WipeAccChecksums();
 };
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -559,7 +559,7 @@ public:
     /** Affect CreateNewBlock prioritisation of transactions */
     void PrioritiseTransaction(const uint256& hash, const CAmount& nFeeDelta);
     void ApplyDelta(const uint256& hash, CAmount& nFeeDelta) const;
-    void ClearPrioritisation(const uint256 hash);
+    void ClearPrioritisation(uint256 hash);
 
     bool nullifierExists(const uint256& nullifier) const;
 

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -138,7 +138,7 @@ T FindFirstNonZero(T itbegin, T itend)
 /**
  * Convert a span of bytes to a lower-case hexadecimal string.
  */
-std::string HexStr(const Span<const uint8_t> s);
+std::string HexStr(Span<const uint8_t> s);
 inline std::string HexStr(const Span<const char> s) { return HexStr(MakeUCharSpan(s)); }
 
 /** Reverse the endianess of a string */
@@ -157,7 +157,7 @@ inline std::string ReverseEndianString(std::string in)
  * Format a paragraph of text to a fixed width, adding spaces for
  * indentation to any added line.
  */
-std::string FormatParagraph(const std::string in, size_t width = 79, size_t indent = 0);
+std::string FormatParagraph(std::string in, size_t width = 79, size_t indent = 0);
 
 /**
  * Timing-attack-resistant comparison.

--- a/src/validation.h
+++ b/src/validation.h
@@ -317,7 +317,7 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex);
 
 /** Context-independent validity checks */
 bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW = true, bool fCheckMerkleRoot = true, bool fCheckSig = true) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-bool CheckWork(const CBlock& block, const CBlockIndex* const pindexPrev);
+bool CheckWork(const CBlock& block, const CBlockIndex* pindexPrev);
 
 /** Context-dependent validity checks */
 bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& state, CBlockIndex* pindexPrev) EXCLUSIVE_LOCKS_REQUIRED(cs_main);

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -173,7 +173,7 @@ UniValue abortrescan(const JSONRPCRequest& request)
     return true;
 }
 
-static void ImportAddress(CWallet* const pwallet, const CTxDestination& dest, const std::string& strLabel, const std::string& strPurpose);
+static void ImportAddress(CWallet* pwallet, const CTxDestination& dest, const std::string& strLabel, const std::string& strPurpose);
 
 static void ImportScript(CWallet* const pwallet, const CScript& script, const std::string& strLabel, bool isRedeemScript)
 {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1053,7 +1053,7 @@ static void SendMoney(CWallet* const pwallet, const CTxDestination& address, CAm
         throw JSONRPCError(RPC_WALLET_ERROR, res.ToString());
 }
 
-static SaplingOperation CreateShieldedTransaction(CWallet* const pwallet, const JSONRPCRequest& request);
+static SaplingOperation CreateShieldedTransaction(CWallet* pwallet, const JSONRPCRequest& request);
 
 /*
  * redirect sendtoaddress/sendmany inputs to shieldsendmany implementation (CreateShieldedTransaction)
@@ -2475,7 +2475,7 @@ UniValue sendmany(const JSONRPCRequest& request)
 }
 
 // Defined in rpc/misc.cpp
-extern CScript _createmultisig_redeemScript(CWallet* const pwallet, const UniValue& params);
+extern CScript _createmultisig_redeemScript(CWallet* pwallet, const UniValue& params);
 
 UniValue addmultisigaddress(const JSONRPCRequest& request)
 {

--- a/src/wallet/rpcwallet.h
+++ b/src/wallet/rpcwallet.h
@@ -21,8 +21,8 @@ void RegisterWalletRPCCommands(CRPCTable &tableRPC);
  */
 CWallet* GetWalletForJSONRPCRequest(const JSONRPCRequest& request);
 
-std::string HelpRequiringPassphrase(CWallet* const pwallet);
-bool EnsureWalletIsAvailable(CWallet* const pwallet, bool avoidException);
-void EnsureWalletIsUnlocked(CWallet* const pwallet, bool fAllowAnonOnly = false);
+std::string HelpRequiringPassphrase(CWallet* pwallet);
+bool EnsureWalletIsAvailable(CWallet* pwallet, bool avoidException);
+void EnsureWalletIsUnlocked(CWallet* pwallet, bool fAllowAnonOnly = false);
 
 #endif //PIVX_WALLET_RPCWALLET_H

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -38,7 +38,7 @@ public:
     bool SetupGeneration(bool newKeypool = true, bool force = false, bool memOnly = false);
 
     /** Upgrades the wallet to the specified version */
-    bool Upgrade(const int prev_version, std::string& error);
+    bool Upgrade(int prev_version, std::string& error);
 
     /* Returns true if the wallet can generate new keys */
     bool CanGenerateKeys();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -493,8 +493,8 @@ public:
     CAmount GetAvailableCredit(bool fUseCache = true, const isminefilter& filter=ISMINE_SPENDABLE) const;
     // Return sum of locked coins
     CAmount GetLockedCredit() const;
-    CAmount GetImmatureWatchOnlyCredit(const bool fUseCache = true) const;
-    CAmount GetAvailableWatchOnlyCredit(const bool fUseCache = true) const;
+    CAmount GetImmatureWatchOnlyCredit(bool fUseCache = true) const;
+    CAmount GetAvailableWatchOnlyCredit(bool fUseCache = true) const;
     CAmount GetChange() const;
 
     // Shielded credit/debit/change
@@ -659,13 +659,13 @@ private:
     };
 
     OutputAvailabilityResult CheckOutputAvailability(const CTxOut& output,
-                                                     const unsigned int outIndex,
+                                                     unsigned int outIndex,
                                                      const uint256& wtxid,
                                                      const CCoinControl* coinControl,
-                                                     const bool fCoinsSelected,
-                                                     const bool fIncludeColdStaking,
-                                                     const bool fIncludeDelegated,
-                                                     const bool fIncludeLocked) const;
+                                                     bool fCoinsSelected,
+                                                     bool fIncludeColdStaking,
+                                                     bool fIncludeDelegated,
+                                                     bool fIncludeLocked) const;
 
     /** Return the selected known outputs */
     std::vector<COutput> GetOutputsFromCoinControl(const CCoinControl* coinControl);
@@ -875,7 +875,7 @@ public:
     /*
      * Stake Split threshold
      */
-    bool SetStakeSplitThreshold(const CAmount sst);
+    bool SetStakeSplitThreshold(CAmount sst);
     CAmount GetStakeSplitThreshold() const { LOCK(cs_wallet); return nStakeSplitThreshold; }
 
     /*
@@ -900,8 +900,8 @@ public:
     void LockIfMyCollateral(const CTransactionRef& ptx);
 
     //  keystore implementation
-    CallResult<CTxDestination> getNewAddress(const std::string& addressLabel, const std::string purpose,
-                                             const CChainParams::Base58Type addrType = CChainParams::PUBKEY_ADDRESS);
+    CallResult<CTxDestination> getNewAddress(const std::string& addressLabel, std::string purpose,
+                                             CChainParams::Base58Type addrType = CChainParams::PUBKEY_ADDRESS);
     CallResult<CTxDestination> getNewAddress(const std::string& label);
     CallResult<CTxDestination> getNewStakingAddress(const std::string& label);
     int64_t GetKeyCreationTime(const CWDestination& dest);
@@ -1021,7 +1021,7 @@ public:
     /**
      * Upgrade wallet to HD and Sapling if needed. Does nothing if not.
      */
-    bool Upgrade(std::string& error, const int prevVersion);
+    bool Upgrade(std::string& error, int prevVersion);
     bool ActivateSaplingWallet(bool memOnly = false);
 
     int64_t RescanFromTime(int64_t startTime, const WalletRescanReserver& reserver, bool update);
@@ -1045,7 +1045,7 @@ public:
     CAmount GetAvailableBalance(isminefilter& filter, bool useCache = false, int minDepth = 1) const;
     CAmount GetColdStakingBalance() const;  // delegated coins for which we have the staking key
     CAmount GetImmatureColdStakingBalance() const;
-    CAmount GetStakingBalance(const bool fIncludeColdStaking = true) const;
+    CAmount GetStakingBalance(bool fIncludeColdStaking = true) const;
     CAmount GetDelegatedBalance() const;    // delegated coins for which we have the spending key
     CAmount GetImmatureDelegatedBalance() const;
     CAmount GetLockedCoins() const;
@@ -1113,7 +1113,7 @@ public:
     size_t KeypoolCountExternalKeys();
     bool TopUpKeyPool(unsigned int kpSize = 0);
     void KeepKey(int64_t nIndex);
-    void ReturnKey(int64_t nIndex, const bool internal = false, const bool staking = false);
+    void ReturnKey(int64_t nIndex, bool internal = false, bool staking = false);
     bool GetKeyFromPool(CPubKey& key, const uint8_t& type = HDChain::ChangeType::EXTERNAL);
     int64_t GetOldestKeyPoolTime();
 
@@ -1124,7 +1124,7 @@ public:
 
     bool CreateBudgetFeeTX(CTransactionRef& tx, const uint256& hash, CReserveKey& keyChange, CAmount fee);
 
-    bool IsUsed(const CTxDestination address) const;
+    bool IsUsed(CTxDestination address) const;
 
     isminetype IsMine(const CTxIn& txin) const;
     CAmount GetDebit(const CTxIn& txin, const isminefilter& filter) const;
@@ -1151,7 +1151,7 @@ public:
     static std::string ParseIntoAddress(const CWDestination& dest, const std::string& purpose);
 
     bool SetAddressBook(const CWDestination& address, const std::string& strName, const std::string& purpose);
-    bool DelAddressBook(const CWDestination& address, const CChainParams::Base58Type addrType = CChainParams::PUBKEY_ADDRESS);
+    bool DelAddressBook(const CWDestination& address, CChainParams::Base58Type addrType = CChainParams::PUBKEY_ADDRESS);
     bool HasAddressBook(const CWDestination& address) const;
     bool HasDelegator(const CTxOut& out) const;
     int GetAddressBookSize() const { return mapAddressBook.size(); };


### PR DESCRIPTION
const-qualifying parameters only has an effect in function definitions.
This does a full cleanup to remove all meaningless instances of
const-qualifying parameters in function declarations.