### PR TITLE
Guard "-maxconnections" arg if the node is a Masternode.

### DIFF
--- a/src/tiertwo/init.cpp
+++ b/src/tiertwo/init.cpp
@@ -171,6 +171,11 @@ bool InitActiveMN()
             return UIError(_("Cannot be a masternode and only connect to specific nodes"));
         }
 
+        if (gArgs.GetArg("-maxconnections", DEFAULT_MAX_PEER_CONNECTIONS) < DEFAULT_MAX_PEER_CONNECTIONS) {
+            return UIError(strprintf(_("Masternode must be able to handle at least %d connections, set %s=%d"),
+                                     DEFAULT_MAX_PEER_CONNECTIONS, "-maxconnections", DEFAULT_MAX_PEER_CONNECTIONS));
+        }
+
         const std::string& mnoperatorkeyStr = gArgs.GetArg("-mnoperatorprivatekey", "");
         const bool fDeterministic = !mnoperatorkeyStr.empty();
         LogPrintf("IS %s MASTERNODE\n", (fDeterministic ? "DETERMINISTIC " : ""));


### PR DESCRIPTION
From v6.0, Deterministic Masternodes have to be connected to as many DMNs as possible (ideally, to all of them) to execute the DKG protocol, the Proof of Service, successfully and not end up being banned.
So, added a guard for the `-maxconnections` argument, to prevent headaches from any user that mistakenly decreases the value (already have seen one that copy-pasted the pivx.conf file).