### PR TITLE
[Lint] Introduce lint-includes.sh script

### DIFF
--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -11,7 +11,6 @@
 #include <map>
 #include <string>
 #include <vector>
-#include <chrono>
 
 #include <boost/preprocessor/cat.hpp>
 #include <boost/preprocessor/stringize.hpp>

--- a/src/bench/bench_pivx.cpp
+++ b/src/bench/bench_pivx.cpp
@@ -8,10 +8,9 @@
 #include <bls/bls_wrapper.h>
 #include <crypto/sha256.h>
 #include <key.h>
-#include <validation.h>
 #include <random.h>
-
-#include <boost/lexical_cast.hpp>
+#include <utilstrencodings.h>
+#include <validation.h>
 
 #include <memory>
 
@@ -60,8 +59,11 @@ int main(int argc, char** argv)
     std::string scaling_str = gArgs.GetArg("-scaling", DEFAULT_BENCH_SCALING);
     bool is_list_only = gArgs.GetBoolArg("-list", false);
 
-    double scaling_factor = boost::lexical_cast<double>(scaling_str);
-
+    double scaling_factor;
+    if (!ParseDouble(scaling_str, &scaling_factor)) {
+        fprintf(stderr, "Error parsing scaling factor as double: %s\n", scaling_str.c_str());
+        return EXIT_FAILURE;
+    }
 
     std::unique_ptr<benchmark::Printer> printer(new benchmark::ConsolePrinter());
     std::string printer_arg = gArgs.GetArg("-printer", DEFAULT_BENCH_PRINTER);

--- a/src/qt/pivx/settings/settingssignmessagewidgets.cpp
+++ b/src/qt/pivx/settings/settingssignmessagewidgets.cpp
@@ -13,8 +13,6 @@
 #include "qt/walletmodel.h"
 #include "util/validation.h"
 
-#include "messagesigner.h"
-
 #include <string>
 #include <vector>
 

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -5,7 +5,6 @@
 #include "addrdb.h"
 #include "addrman.h"
 #include "primitives/block.h"
-#include "addrman.h"
 #include "chain.h"
 #include "coins.h"
 #include "compressor.h"

--- a/src/test/reverselock_tests.cpp
+++ b/src/test/reverselock_tests.cpp
@@ -5,9 +5,6 @@
 
 #include "sync.h"
 
-#include <boost/random/mersenne_twister.hpp>
-#include <boost/random/uniform_int_distribution.hpp>
-#include <boost/thread.hpp>
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(reverselock_tests)

--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -10,8 +10,6 @@
 #include "config/pivx-config.h"
 #endif
 
-#include <boost/random/mersenne_twister.hpp>
-#include <boost/random/uniform_int_distribution.hpp>
 #include <boost/thread.hpp>
 #include <boost/test/unit_test.hpp>
 
@@ -46,10 +44,10 @@ BOOST_AUTO_TEST_CASE(manythreads)
 
     boost::mutex counterMutex[10];
     int counter[10] = { 0 };
-    boost::random::mt19937 rng(42);
-    boost::random::uniform_int_distribution<> zeroToNine(0, 9);
-    boost::random::uniform_int_distribution<> randomMsec(-11, 1000);
-    boost::random::uniform_int_distribution<> randomDelta(-1000, 1000);
+    FastRandomContext rng(42);
+    auto zeroToNine = [](FastRandomContext& rc) -> int { return rc.randrange(10); }; // [0, 9]
+    auto randomMsec = [](FastRandomContext& rc) -> int { return -11 + rc.randrange(1012); }; // [-11, 1000]
+    auto randomDelta = [](FastRandomContext& rc) -> int { return -1000 + rc.randrange(2001); }; // [-1000, 1000]
 
     std::chrono::system_clock::time_point start = std::chrono::system_clock::now();
     std::chrono::system_clock::time_point now = start;

--- a/src/test/torcontrol_tests.cpp
+++ b/src/test/torcontrol_tests.cpp
@@ -3,9 +3,16 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "torcontrol.cpp"
+#include "torcontrol.h"
 
 #include <boost/test/unit_test.hpp>
+
+#include <map>
+#include <string>
+#include <utility>
+
+std::pair<std::string, std::string> SplitTorReplyLine(const std::string& s);
+std::map<std::string, std::string> ParseTorReplyMapping(const std::string& s);
 
 
 BOOST_AUTO_TEST_SUITE(torcontrol_tests)

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -252,7 +252,7 @@ bool TorControlConnection::Command(const std::string &cmd, const ReplyHandlerCB&
  * Grammar is implicitly defined in https://spec.torproject.org/control-spec by
  * the server reply formats for PROTOCOLINFO (S3.21) and AUTHCHALLENGE (S3.24).
  */
-static std::pair<std::string,std::string> SplitTorReplyLine(const std::string &s)
+std::pair<std::string,std::string> SplitTorReplyLine(const std::string &s)
 {
     size_t ptr=0;
     std::string type;
@@ -271,7 +271,7 @@ static std::pair<std::string,std::string> SplitTorReplyLine(const std::string &s
  * the server reply formats for PROTOCOLINFO (S3.21), AUTHCHALLENGE (S3.24),
  * and ADD_ONION (S3.27). See also sections 2.1 and 2.3.
  */
-static std::map<std::string,std::string> ParseTorReplyMapping(const std::string &s)
+std::map<std::string,std::string> ParseTorReplyMapping(const std::string &s)
 {
     std::map<std::string,std::string> mapping;
     size_t ptr=0;

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Check for duplicate includes.
+# Guard against accidental introduction of new Boost dependencies.
+# Check includes: Check for duplicate includes. Enforce bracket syntax includes.
+
+export LC_ALL=C
+IGNORE_REGEXP="/(chiabls|leveldb|secp256k1|univalue|crc32c)/"
+
+# cd to root folder of git repo for git ls-files to work properly
+cd "$(dirname "$0")/../.." || exit 1
+
+filter_suffix() {
+    git ls-files | grep -E "^src/.*\.${1}"'$' | grep -Ev "${IGNORE_REGEXP}"
+}
+
+EXIT_CODE=0
+
+for HEADER_FILE in $(filter_suffix h); do
+    DUPLICATE_INCLUDES_IN_HEADER_FILE=$(grep -E "^#include " < "${HEADER_FILE}" | sort | uniq -d)
+    if [[ ${DUPLICATE_INCLUDES_IN_HEADER_FILE} != "" ]]; then
+        echo "Duplicate include(s) in ${HEADER_FILE}:"
+        echo "${DUPLICATE_INCLUDES_IN_HEADER_FILE}"
+        echo
+        EXIT_CODE=1
+    fi
+done
+
+for CPP_FILE in $(filter_suffix cpp); do
+    DUPLICATE_INCLUDES_IN_CPP_FILE=$(grep -E "^#include " < "${CPP_FILE}" | sort | uniq -d)
+    if [[ ${DUPLICATE_INCLUDES_IN_CPP_FILE} != "" ]]; then
+        echo "Duplicate include(s) in ${CPP_FILE}:"
+        echo "${DUPLICATE_INCLUDES_IN_CPP_FILE}"
+        echo
+        EXIT_CODE=1
+    fi
+done
+
+INCLUDED_CPP_FILES=$(git grep -E "^#include [<\"][^>\"]+\.cpp[>\"]" -- "*.cpp" "*.h")
+if [[ ${INCLUDED_CPP_FILES} != "" ]]; then
+    echo "The following files #include .cpp files:"
+    echo "${INCLUDED_CPP_FILES}"
+    echo
+    EXIT_CODE=1
+fi
+
+EXPECTED_BOOST_INCLUDES=(
+    boost/algorithm/string.hpp
+    boost/algorithm/string/classification.hpp
+    boost/algorithm/string/replace.hpp
+    boost/algorithm/string/split.hpp
+    boost/date_time/posix_time/posix_time.hpp
+    boost/filesystem.hpp
+    boost/filesystem/fstream.hpp
+    boost/multi_index/sequenced_index.hpp
+    boost/optional.hpp
+    boost/pool/pool_alloc.hpp
+    boost/preprocessor/cat.hpp
+    boost/preprocessor/stringize.hpp
+    boost/signals2/connection.hpp
+    boost/signals2/last_value.hpp
+    boost/signals2/signal.hpp
+    boost/test/unit_test.hpp
+    boost/thread.hpp
+    boost/thread/condition_variable.hpp
+    boost/thread/mutex.hpp
+    boost/thread/thread.hpp
+    boost/tokenizer.hpp
+    boost/variant.hpp
+    boost/variant/apply_visitor.hpp
+    boost/variant/static_visitor.hpp
+)
+
+for BOOST_INCLUDE in $(git grep '^#include <boost/' -- "*.cpp" "*.h" | cut -f2 -d: | cut -f2 -d'<' | cut -f1 -d'>' | sort -u); do
+    IS_EXPECTED_INCLUDE=0
+    for EXPECTED_BOOST_INCLUDE in "${EXPECTED_BOOST_INCLUDES[@]}"; do
+        if [[ "${BOOST_INCLUDE}" == "${EXPECTED_BOOST_INCLUDE}" ]]; then
+            IS_EXPECTED_INCLUDE=1
+            break
+        fi
+    done
+    if [[ ${IS_EXPECTED_INCLUDE} == 0 ]]; then
+        EXIT_CODE=1
+        echo "A new Boost dependency in the form of \"${BOOST_INCLUDE}\" appears to have been introduced:"
+        git grep "${BOOST_INCLUDE}" -- "*.cpp" "*.h"
+        echo
+    fi
+done
+
+for EXPECTED_BOOST_INCLUDE in "${EXPECTED_BOOST_INCLUDES[@]}"; do
+    if ! git grep -q "^#include <${EXPECTED_BOOST_INCLUDE}>" -- "*.cpp" "*.h"; then
+        echo "Good job! The Boost dependency \"${EXPECTED_BOOST_INCLUDE}\" is no longer used."
+        echo "Please remove it from EXPECTED_BOOST_INCLUDES in $0"
+        echo "to make sure this dependency is not accidentally reintroduced."
+        echo
+        EXIT_CODE=1
+    fi
+done
+
+# TODO: Uncomment this check once we move to bracket includes
+#QUOTE_SYNTAX_INCLUDES=$(git grep '^#include "' -- "*.cpp" "*.h" | grep -Ev "${IGNORE_REGEXP}")
+#if [[ ${QUOTE_SYNTAX_INCLUDES} != "" ]]; then
+#    echo "Please use bracket syntax includes (\"#include <foo.h>\") instead of quote syntax includes:"
+#    echo "${QUOTE_SYNTAX_INCLUDES}"
+#    echo
+#    EXIT_CODE=1
+#fi
+
+exit ${EXIT_CODE}


### PR DESCRIPTION
This brings in the `lint-includes.sh` shell script from upstream (first introduced in https://github.com/bitcoin/bitcoin/pull/11878) to automatically check for duplicate includes and expanded in https://github.com/bitcoin/bitcoin/pull/13301 and https://github.com/bitcoin/bitcoin/pull/13385 to check for the inclusion of `.cpp` files and the introduction of new boost includes, respectively.

The check for enforcing bracket include syntax (https://github.com/bitcoin/bitcoin/pull/13230) is also included, but currently disabled, as we have yet to systematically switch to that syntax preference.

Three other upstream PRs are backported here as they are directly related to the removal of some boost dependencies and are very straight forward:
- https://github.com/bitcoin/bitcoin/pull/10547
- https://github.com/bitcoin/bitcoin/pull/13291
- https://github.com/bitcoin/bitcoin/pull/13383

**NOTE: #2711 removes the dependency on `boost/tuple/tuple.hpp`, so it makes sense to merge that first. submitting this now so the general concept/functionality can be reviewed prior to that PR being merged**