### PR TITLE
[RPC] Enable v6.0 commands and remove 'deterministic' flag from initmasternode command

### DIFF
--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -1077,14 +1077,9 @@ static const CRPCCommand commands[] =
 #endif  //ENABLE_WALLET
 };
 
-void RegisterEvoRPCCommands(CRPCTable &tableRPC)
+void RegisterEvoRPCCommands(CRPCTable& _tableRPC)
 {
-    if (!Params().IsRegTestNet()) {
-        // Disabled before PIVX v6.0
-        return;
-    }
-
-    for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++) {
-        tableRPC.appendCommand(commands[vcidx].name, &commands[vcidx]);
+    for (const auto& command : commands) {
+        _tableRPC.appendCommand(command.name, &command);
     }
 }

--- a/src/tiertwo/init.cpp
+++ b/src/tiertwo/init.cpp
@@ -31,9 +31,9 @@ std::string GetTierTwoHelpString(bool showDebug)
     strUsage += HelpMessageOpt("-mnconf=<file>", strprintf("Specify masternode configuration file (default: %s)", PIVX_MASTERNODE_CONF_FILENAME));
     strUsage += HelpMessageOpt("-mnconflock=<n>", strprintf("Lock masternodes from masternode configuration file (default: %u)", DEFAULT_MNCONFLOCK));
     strUsage += HelpMessageOpt("-masternodeprivkey=<n>", "Set the masternode private key");
-    strUsage += HelpMessageOpt("-masternodeaddr=<n>", strprintf("Set external address:port to get to this masternode (example: %s)", "128.127.106.235:51472"));
+    strUsage += HelpMessageOpt("-masternodeaddr=<n>", strprintf("Set external address:port to get to this masternode (example: %s). Only for Legacy Masternodes", "128.127.106.235:51472"));
     strUsage += HelpMessageOpt("-budgetvotemode=<mode>", "Change automatic finalized budget voting behavior. mode=auto: Vote for only exact finalized budget match to my generated budget. (string, default: auto)");
-    strUsage += HelpMessageOpt("-mnoperatorprivatekey=<WIF>", "Set the masternode operator private key. Only valid with -masternode=1. When set, the masternode acts as a deterministic masternode.");
+    strUsage += HelpMessageOpt("-mnoperatorprivatekey=<bech32>", "Set the masternode operator private key. Only valid with -masternode=1. When set, the masternode acts as a deterministic masternode.");
     if (showDebug) {
         strUsage += HelpMessageOpt("-pushversion", strprintf("Modifies the mnauth serialization if the version is lower than %d."
                                                              "testnet/regtest only; ", MNAUTH_NODE_VER_VERSION));

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1434,7 +1434,7 @@ class PivxDMNTestFramework(PivxTestFramework):
             self.add_new_dmn("fund")
         assert_equal(len(self.mns), 6)
         for mn in self.mns:
-            self.nodes[mn.idx].initmasternode(mn.operator_sk, "", True)
+            self.nodes[mn.idx].initmasternode(mn.operator_sk)
             time.sleep(1)
         self.nodes[self.minerPos].generate(1)
         self.sync_blocks()
@@ -1734,7 +1734,7 @@ class PivxTier2TestFramework(PivxTestFramework):
         remoteTwoPort = p2p_port(self.remoteTwoPos)
         self.remoteOne.initmasternode(self.mnOnePrivkey, "127.0.0.1:"+str(remoteOnePort))
         self.remoteTwo.initmasternode(self.mnTwoPrivkey, "127.0.0.1:"+str(remoteTwoPort))
-        self.remoteDMN1.initmasternode(self.dmn1Privkey, "", True)
+        self.remoteDMN1.initmasternode(self.dmn1Privkey)
 
         # wait until mnsync complete on all nodes
         self.stake(1)

--- a/test/functional/tiertwo_deterministicmns.py
+++ b/test/functional/tiertwo_deterministicmns.py
@@ -146,7 +146,7 @@ class DIP3Test(PivxTestFramework):
         self.add_new_dmn(mns, "external")
         self.add_new_dmn(mns, "fund")
         for mn in mns:
-            self.nodes[mn.idx].initmasternode(mn.operator_sk, "", True)
+            self.nodes[mn.idx].initmasternode(mn.operator_sk)
             time.sleep(1)
         miner.generate(1)
         self.sync_blocks()
@@ -160,7 +160,7 @@ class DIP3Test(PivxTestFramework):
         for i in range(3):
             idx = 2 + len(mns) + i
             bls_keypair = controller.generateblskeypair()
-            self.nodes[idx].initmasternode(bls_keypair["secret"], "", True)
+            self.nodes[idx].initmasternode(bls_keypair["secret"])
             op_keys.append([bls_keypair["public"], bls_keypair["secret"]])
             time.sleep(1)
 

--- a/test/functional/tiertwo_mn_compatibility.py
+++ b/test/functional/tiertwo_mn_compatibility.py
@@ -130,7 +130,7 @@ class MasternodeCompatibilityTest(PivxTier2TestFramework):
             self.remoteDMN2Pos,
             "internal"
         )
-        self.remoteDMN2.initmasternode(self.dmn2Privkey, "", True)
+        self.remoteDMN2.initmasternode(self.dmn2Privkey)
 
         # check list and status
         self.check_mn_enabled_count(4, 4) # 2 legacy + 2 DMN
@@ -162,7 +162,7 @@ class MasternodeCompatibilityTest(PivxTier2TestFramework):
         # The remote node is shutting down the pinging service
         self.send_3_pings()
 
-        self.remoteDMN3.initmasternode(self.dmn3Privkey, "", True)
+        self.remoteDMN3.initmasternode(self.dmn3Privkey)
 
         # The legacy masternode must no longer be in the list
         # and the DMN must have taken its place


### PR DESCRIPTION
Following points tackled:

1) Enabled the v6.0 DMN commands for testnet and mainnet.
2) Removed the 'deterministic' flag from `initmasternode` RPC command.
    The masternode type is differentiated using the encoded key prefix.
3) Small fix to the  '-mnoperatorprivatekey' help message.

Another small decoupling from the DMN GUI branch.