### PR TITLE
Fix DMN operator connectivity check and local address lookup

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -162,7 +162,7 @@ void CActiveDeterministicMasternodeManager::Init(const CBlockIndex* pindexTip)
         LogPrintf("%s -- ERROR: %s\n", __func__, strError);
         return;
     }
-    bool fConnected = ConnectSocketDirectly(info.service, hSocket, nConnectTimeout) && IsSelectableSocket(hSocket);
+    bool fConnected = ConnectSocketDirectly(info.service, hSocket, nConnectTimeout, true) && IsSelectableSocket(hSocket);
     CloseSocket(hSocket);
 
     if (!fConnected) {

--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -76,7 +76,7 @@ OperationResult CActiveDeterministicMasternodeManager::SetOperatorKey(const std:
     }
     info.keyOperator = *opSk;
     info.pubKeyOperator = info.keyOperator.GetPublicKey();
-    return OperationResult(true);
+    return {true};
 }
 
 OperationResult CActiveDeterministicMasternodeManager::GetOperatorKey(CBLSSecretKey& key, CDeterministicMNCPtr& dmn) const
@@ -93,7 +93,7 @@ OperationResult CActiveDeterministicMasternodeManager::GetOperatorKey(CBLSSecret
     }
     // return key
     key = info.keyOperator;
-    return OperationResult(true);
+    return {true};
 }
 
 void CActiveDeterministicMasternodeManager::Init(const CBlockIndex* pindexTip)
@@ -266,7 +266,7 @@ OperationResult initMasternode(const std::string& _strMasterNodePrivKey, const s
         return errorOut(strprintf(_("Invalid -masternodeaddr port %d, only %d is supported on %s-net."),
                                            nPort, nDefaultPort, Params().NetworkIDString()));
     }
-    CService addrTest(LookupNumeric(strHost.c_str(), nPort));
+    CService addrTest(LookupNumeric(strHost, nPort));
     if (!addrTest.IsValid()) {
         return errorOut(strprintf(_("Invalid -masternodeaddr address: %s"), _strMasterNodeAddr));
     }
@@ -295,7 +295,7 @@ OperationResult initMasternode(const std::string& _strMasterNodePrivKey, const s
         if (pmn) activeMasternode.EnableHotColdMasterNode(pmn->vin, pmn->addr);
     }
 
-    return OperationResult(true);
+    return {true};
 }
 
 //
@@ -426,7 +426,7 @@ bool CActiveMasternode::SendMasternodePing(std::string& errorMessage)
 
     // Update lastPing for our masternode in Masternode list
     CMasternode* pmn = mnodeman.Find(vin->prevout);
-    if (pmn != NULL) {
+    if (pmn != nullptr) {
         if (pmn->IsPingedWithin(MasternodePingSeconds(), mnp.sigTime)) {
             errorMessage = "Too early to send Masternode Ping";
             return false;
@@ -473,7 +473,7 @@ bool CActiveMasternode::EnableHotColdMasterNode(CTxIn& newVin, CService& newServ
     return true;
 }
 
-void CActiveMasternode::GetKeys(CKey& _privKeyMasternode, CPubKey& _pubKeyMasternode)
+void CActiveMasternode::GetKeys(CKey& _privKeyMasternode, CPubKey& _pubKeyMasternode) const
 {
     if (!privKeyMasternode.IsValid() || !pubKeyMasternode.IsValid()) {
         throw std::runtime_error("Error trying to get masternode keys");

--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -158,7 +158,7 @@ void CActiveDeterministicMasternodeManager::Init(const CBlockIndex* pindexTip)
     SOCKET hSocket = CreateSocket(info.service);
     if (hSocket == INVALID_SOCKET) {
         state = MASTERNODE_ERROR;
-        strError = "Could not create socket to connect to " + info.service.ToString();
+        strError = "DMN connectivity check failed, could not create socket to DMN running at " + strService;
         LogPrintf("%s -- ERROR: %s\n", __func__, strError);
         return;
     }
@@ -167,7 +167,8 @@ void CActiveDeterministicMasternodeManager::Init(const CBlockIndex* pindexTip)
 
     if (!fConnected) {
         state = MASTERNODE_ERROR;
-        LogPrintf("%s ERROR: Could not connect to %s\n", __func__, strService);
+        strError = "DMN connectivity check failed, could not connect to DMN running at " + strService;
+        LogPrintf("%s ERROR: %s\n", __func__, strError);
         return;
     }
 

--- a/src/activemasternode.h
+++ b/src/activemasternode.h
@@ -52,8 +52,8 @@ private:
     CActiveMasternodeInfo info;
 
 public:
-    virtual ~CActiveDeterministicMasternodeManager() = default;
-    virtual void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload);
+    ~CActiveDeterministicMasternodeManager() override = default;
+    void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload) override;
 
     void Init(const CBlockIndex* pindexTip);
     void Reset(masternode_state_t _state, const CBlockIndex* pindexTip);
@@ -106,7 +106,7 @@ public:
     /// Enable cold wallet mode (run a Masternode with no funds)
     bool EnableHotColdMasterNode(CTxIn& vin, CService& addr);
 
-    void GetKeys(CKey& privKeyMasternode, CPubKey& pubKeyMasternode);
+    void GetKeys(CKey& privKeyMasternode, CPubKey& pubKeyMasternode) const;
 };
 
 // Compatibility code: get vin and keys for either legacy or deterministic masternode

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -343,7 +343,7 @@ bool CConnman::CheckIncomingNonce(uint64_t nonce)
     return true;
 }
 
-CNode* CConnman::ConnectNode(CAddress addrConnect, const char* pszDest, bool fCountFailure)
+CNode* CConnman::ConnectNode(CAddress addrConnect, const char* pszDest, bool fCountFailure, bool manual_connection)
 {
     if (pszDest == nullptr) {
         if (IsLocal(addrConnect)) {
@@ -396,7 +396,7 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char* pszDest, bool fCo
             if (hSocket == INVALID_SOCKET) {
                 return nullptr;
             }
-            connected = ConnectSocketDirectly(addrConnect, hSocket, nConnectTimeout);
+            connected = ConnectSocketDirectly(addrConnect, hSocket, nConnectTimeout, manual_connection);
         }
         if (!proxyConnectionFailed) {
             // If a connection to the node was attempted, and failure (if any) is not caused by a problem connecting to
@@ -1916,7 +1916,7 @@ void CConnman::OpenNetworkConnection(const CAddress& addrConnect, bool fCountFai
     } else if (FindNode(pszDest))
         return;
 
-    CNode* pnode = ConnectNode(addrConnect, pszDest, fCountFailure);
+    CNode* pnode = ConnectNode(addrConnect, pszDest, fCountFailure, fAddnode);
 
     if (!pnode)
         return;
@@ -2769,9 +2769,9 @@ bool CConnman::IsNodeConnected(const CAddress& addr)
     return FindNode(addr.ToStringIPPort());
 }
 
-CNode* CConnman::ConnectNode(CAddress addrConnect)
+CNode* CConnman::ConnectNode(const CAddress& addrConnect)
 {
-    return ConnectNode(addrConnect, nullptr, true);
+    return ConnectNode(addrConnect, nullptr, true, true);
 }
 
 // valid, reachable and routable address (except for RegTest)

--- a/src/net.h
+++ b/src/net.h
@@ -280,7 +280,7 @@ public:
     void RelayInv(CInv& inv);
     bool IsNodeConnected(const CAddress& addr);
     // Retrieves a connected peer (if connection success). Used only to check peer address availability for now.
-    CNode* ConnectNode(CAddress addrConnect);
+    CNode* ConnectNode(const CAddress& addrConnect);
 
     // Addrman functions
     void SetServices(const CService &addr, ServiceFlags nServices);
@@ -386,7 +386,7 @@ private:
     CNode* FindNode(const CService& addr);
 
     bool AttemptToEvictConnection(bool fPreferNewConnection);
-    CNode* ConnectNode(CAddress addrConnect, const char* pszDest, bool fCountFailure);
+    CNode* ConnectNode(CAddress addrConnect, const char* pszDest, bool fCountFailure, bool manual_connection);
     bool IsWhitelistedRange(const CNetAddr &addr);
 
     void DeleteNode(CNode* pnode);

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -54,7 +54,7 @@ bool Lookup(const std::string& name, std::vector<CService>& vAddr, int portDefau
 CService LookupNumeric(const std::string& name, int portDefault = 0);
 bool LookupSubNet(const std::string& name, CSubNet& subnet);
 SOCKET CreateSocket(const CService &addrConnect);
-bool ConnectSocketDirectly(const CService& addrConnect, const SOCKET& hSocketRet, int nTimeout);
+bool ConnectSocketDirectly(const CService& addrConnect, const SOCKET& hSocketRet, int nTimeout, bool manual_connection);
 bool ConnectThroughProxy(const proxyType& proxy, const std::string& strDest, int port, const SOCKET& hSocketRet, int nTimeout, bool* outProxyConnectionFailed);
 /** Return readable error string for a network error code */
 std::string NetworkErrorString(int err);


### PR DESCRIPTION
Correcting two issues on the Deterministic Masternode operator side:

1) The DMN service address connectivity check was not being performed (due a non-initialized socket), failing all-the-time on testnet and mainnet. Erring out at startup.

2) `CActiveMasternodeManager::GetLocalAddress` will prefer IPv4 if there are multiple addresses available locally. --> #3304.

3)  `CActiveMasternodeManager::Init` connectivity check was missing to set the error cause.

Plus, now that i'm here, ported #12569 as well.