### PR TITLE
[LLMQ][BugFix] Fix infinite loop in quorum relay members selection algorithm

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -128,6 +128,7 @@ BITCOIN_TESTS =\
   test/net_tests.cpp \
   test/netbase_tests.cpp \
   test/netfulfilledman_tests.cpp \
+  test/net_quorums_tests.cpp \
   test/pmt_tests.cpp \
   test/policyestimator_tests.cpp \
   test/prevector_tests.cpp \

--- a/src/llmq/quorums_connections.cpp
+++ b/src/llmq/quorums_connections.cpp
@@ -65,11 +65,9 @@ std::set<uint256> GetQuorumRelayMembers(const std::vector<CDeterministicMNCPtr>&
     return calcOutbound(mnList, forMemberIndex, forMember);
 }
 
-static std::set<uint256> GetQuorumConnections(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum, const uint256& forMember, bool onlyOutbound)
+static std::set<uint256> GetQuorumConnections(const std::vector<CDeterministicMNCPtr>& mns, const uint256& forMember, bool onlyOutbound)
 {
-    auto mns = deterministicMNManager->GetAllQuorumMembers(llmqType, pindexQuorum);
     std::set<uint256> result;
-
     for (auto& dmn : mns) {
         if (dmn->proTxHash == forMember) {
             continue;
@@ -120,7 +118,7 @@ void EnsureQuorumConnections(Consensus::LLMQType llmqType, const CBlockIndex* pi
     std::set<uint256> connections;
     std::set<uint256> relayMembers;
     if (isMember) {
-        connections = GetQuorumConnections(llmqType, pindexQuorum, myProTxHash, true);
+        connections = GetQuorumConnections(members, myProTxHash, true);
         unsigned int memberIndex = itMember - members.begin();
         relayMembers = GetQuorumRelayMembers(members, myProTxHash, memberIndex);
     } else {

--- a/src/llmq/quorums_connections.cpp
+++ b/src/llmq/quorums_connections.cpp
@@ -53,6 +53,10 @@ std::set<uint256> GetQuorumRelayMembers(const std::vector<CDeterministicMNCPtr>&
             size_t idx = (i + gap) % mns.size();
             auto& otherDmn = mns[idx];
             if (otherDmn->proTxHash == proTxHash) {
+                if (gap_max == 0 && k == 1) {
+                    // special case, two members quorum.
+                    break;
+                }
                 continue;
             }
             r.emplace(otherDmn->proTxHash);

--- a/src/llmq/quorums_connections.cpp
+++ b/src/llmq/quorums_connections.cpp
@@ -40,9 +40,11 @@ uint256 DeterministicOutboundConnection(const uint256& proTxHash1, const uint256
 std::set<uint256> GetQuorumRelayMembers(const std::vector<CDeterministicMNCPtr>& mnList,
                                         unsigned int forMemberIndex)
 {
+    assert(forMemberIndex < mnList.size());
+
     // Special case
     if (mnList.size() == 2) {
-        return {mnList[(forMemberIndex + 1) % 2]->proTxHash};
+        return {mnList[1 - forMemberIndex]->proTxHash};
     }
 
     auto calcOutbound = [](const std::vector<CDeterministicMNCPtr>& mns, size_t i) {

--- a/src/llmq/quorums_connections.cpp
+++ b/src/llmq/quorums_connections.cpp
@@ -40,6 +40,11 @@ uint256 DeterministicOutboundConnection(const uint256& proTxHash1, const uint256
 std::set<uint256> GetQuorumRelayMembers(const std::vector<CDeterministicMNCPtr>& mnList,
                                         unsigned int forMemberIndex)
 {
+    // Special case
+    if (mnList.size() == 2) {
+        return {mnList[(forMemberIndex + 1) % 2]->proTxHash};
+    }
+
     auto calcOutbound = [](const std::vector<CDeterministicMNCPtr>& mns, size_t i) {
         // Relay to nodes at indexes (i+2^k)%n, where
         //   k: 0..max(1, floor(log2(n-1))-1)

--- a/src/llmq/quorums_connections.cpp
+++ b/src/llmq/quorums_connections.cpp
@@ -37,12 +37,11 @@ uint256 DeterministicOutboundConnection(const uint256& proTxHash1, const uint256
     return proTxHash2;
 }
 
-std::set<uint256> GetQuorumRelayMembers(Consensus::LLMQType llmqType, const CBlockIndex *pindexQuorum, const uint256 &forMember, bool onlyOutbound)
+std::set<uint256> GetQuorumRelayMembers(const std::vector<CDeterministicMNCPtr>& mnList,
+                                        const uint256& forMember,
+                                        unsigned int forMemberIndex)
 {
-    auto mns = deterministicMNManager->GetAllQuorumMembers(llmqType, pindexQuorum);
-    std::set<uint256> result;
-
-    auto calcOutbound = [&](size_t i, const uint256 proTxHash) {
+    auto calcOutbound = [](const std::vector<CDeterministicMNCPtr>& mns, size_t i, const uint256& proTxHash) {
         // Relay to nodes at indexes (i+2^k)%n, where
         //   k: 0..max(1, floor(log2(n-1))-1)
         //   n: size of the quorum/ring
@@ -63,20 +62,7 @@ std::set<uint256> GetQuorumRelayMembers(Consensus::LLMQType llmqType, const CBlo
         return r;
     };
 
-    for (size_t i = 0; i < mns.size(); i++) {
-        auto& dmn = mns[i];
-        if (dmn->proTxHash == forMember) {
-            auto r = calcOutbound(i, dmn->proTxHash);
-            result.insert(r.begin(), r.end());
-        } else if (!onlyOutbound) {
-            auto r = calcOutbound(i, dmn->proTxHash);
-            if (r.count(forMember)) {
-                result.emplace(dmn->proTxHash);
-            }
-        }
-    }
-
-    return result;
+    return calcOutbound(mnList, forMemberIndex, forMember);
 }
 
 static std::set<uint256> GetQuorumConnections(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum, const uint256& forMember, bool onlyOutbound)
@@ -123,8 +109,9 @@ std::set<size_t> CalcDeterministicWatchConnections(Consensus::LLMQType llmqType,
 
 void EnsureQuorumConnections(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum, const uint256& myProTxHash)
 {
-    auto members = deterministicMNManager->GetAllQuorumMembers(llmqType, pindexQuorum);
-    bool isMember = std::find_if(members.begin(), members.end(), [&](const CDeterministicMNCPtr& dmn) { return dmn->proTxHash == myProTxHash; }) != members.end();
+    const auto& members = deterministicMNManager->GetAllQuorumMembers(llmqType, pindexQuorum);
+    auto itMember = std::find_if(members.begin(), members.end(), [&](const CDeterministicMNCPtr& dmn) { return dmn->proTxHash == myProTxHash; });
+    bool isMember = itMember != members.end();
 
     if (!isMember) { // && !CLLMQUtils::IsWatchQuorumsEnabled()) {
         return;
@@ -134,7 +121,8 @@ void EnsureQuorumConnections(Consensus::LLMQType llmqType, const CBlockIndex* pi
     std::set<uint256> relayMembers;
     if (isMember) {
         connections = GetQuorumConnections(llmqType, pindexQuorum, myProTxHash, true);
-        relayMembers = GetQuorumRelayMembers(llmqType, pindexQuorum, myProTxHash, true);
+        unsigned int memberIndex = itMember - members.begin();
+        relayMembers = GetQuorumRelayMembers(members, myProTxHash, memberIndex);
     } else {
         auto cindexes = CalcDeterministicWatchConnections(llmqType, pindexQuorum, members.size(), 1);
         for (auto idx : cindexes) {

--- a/src/llmq/quorums_connections.cpp
+++ b/src/llmq/quorums_connections.cpp
@@ -47,24 +47,20 @@ std::set<uint256> GetQuorumRelayMembers(const std::vector<CDeterministicMNCPtr>&
         return {mnList[1 - forMemberIndex]->proTxHash};
     }
 
-    auto calcOutbound = [](const std::vector<CDeterministicMNCPtr>& mns, size_t i) {
-        // Relay to nodes at indexes (i+2^k)%n, where
-        //   k: 0..max(1, floor(log2(n-1))-1)
-        //   n: size of the quorum/ring
-        std::set<uint256> r;
-        int gap = 1;
-        int gap_max = (int)mns.size() - 1;
-        int k = 0;
-        while ((gap_max >>= 1) || k <= 1) {
-            size_t idx = (i + gap) % mns.size();
-            r.emplace(mns[idx]->proTxHash);
-            gap <<= 1;
-            k++;
-        }
-        return r;
-    };
-
-    return calcOutbound(mnList, forMemberIndex);
+    // Relay to nodes at indexes (i+2^k)%n, where
+    //   k: 0..max(1, floor(log2(n-1))-1)
+    //   n: size of the quorum/ring
+    std::set<uint256> r;
+    int gap = 1;
+    int gap_max = (int)mnList.size() - 1;
+    int k = 0;
+    while ((gap_max >>= 1) || k <= 1) {
+        size_t idx = (forMemberIndex + gap) % mnList.size();
+        r.emplace(mnList[idx]->proTxHash);
+        gap <<= 1;
+        k++;
+    }
+    return r;
 }
 
 static std::set<uint256> GetQuorumConnections(const std::vector<CDeterministicMNCPtr>& mns, const uint256& forMember, bool onlyOutbound)

--- a/src/llmq/quorums_connections.h
+++ b/src/llmq/quorums_connections.h
@@ -9,13 +9,16 @@
 #include "consensus/params.h"
 
 class CBlockIndex;
+class CDeterministicMN;
+typedef std::shared_ptr<const CDeterministicMN> CDeterministicMNCPtr;
 
 namespace llmq {
 
 // Deterministically selects which node should initiate the mnauth process
 uint256 DeterministicOutboundConnection(const uint256& proTxHash1, const uint256& proTxHash2);
 
-std::set<uint256> GetQuorumRelayMembers(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum, const uint256& forMember, bool onlyOutbound);
+// Return the outbound quorum relay members for 'forMember' (proTxHash)
+std::set<uint256> GetQuorumRelayMembers(const std::vector<CDeterministicMNCPtr>& mnList, const uint256& forMember, unsigned int forMemberIndex);
 std::set<size_t> CalcDeterministicWatchConnections(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum, size_t memberCount, size_t connectionCount);
 
 void EnsureQuorumConnections(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum, const uint256& myProTxHash);

--- a/src/llmq/quorums_connections.h
+++ b/src/llmq/quorums_connections.h
@@ -18,7 +18,7 @@ namespace llmq {
 uint256 DeterministicOutboundConnection(const uint256& proTxHash1, const uint256& proTxHash2);
 
 // Return the outbound quorum relay members for 'forMember' (proTxHash)
-std::set<uint256> GetQuorumRelayMembers(const std::vector<CDeterministicMNCPtr>& mnList, const uint256& forMember, unsigned int forMemberIndex);
+std::set<uint256> GetQuorumRelayMembers(const std::vector<CDeterministicMNCPtr>& mnList, unsigned int forMemberIndex);
 std::set<size_t> CalcDeterministicWatchConnections(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum, size_t memberCount, size_t connectionCount);
 
 void EnsureQuorumConnections(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum, const uint256& myProTxHash);

--- a/src/llmq/quorums_dkgsession.cpp
+++ b/src/llmq/quorums_dkgsession.cpp
@@ -130,7 +130,7 @@ bool CDKGSession::Init(const CBlockIndex* _pindexQuorum, const std::vector<CDete
         LogPrint(BCLog::DKG, "CDKGSession::%s: initialized as observer. mns=%d\n", __func__, mns.size());
     } else {
         quorumDKGDebugManager->InitLocalSessionStatus(params.type, pindexQuorum->GetBlockHash(), pindexQuorum->nHeight);
-        relayMembers = GetQuorumRelayMembers(mns, myProTxHash, myIdx);
+        relayMembers = GetQuorumRelayMembers(mns, myIdx);
         LogPrint(BCLog::DKG, "CDKGSession::%s: initialized as member. mns=%d\n", __func__, mns.size());
     }
 

--- a/src/llmq/quorums_dkgsession.cpp
+++ b/src/llmq/quorums_dkgsession.cpp
@@ -130,7 +130,7 @@ bool CDKGSession::Init(const CBlockIndex* _pindexQuorum, const std::vector<CDete
         LogPrint(BCLog::DKG, "CDKGSession::%s: initialized as observer. mns=%d\n", __func__, mns.size());
     } else {
         quorumDKGDebugManager->InitLocalSessionStatus(params.type, pindexQuorum->GetBlockHash(), pindexQuorum->nHeight);
-        relayMembers = GetQuorumRelayMembers(params.type, pindexQuorum, myProTxHash, true);
+        relayMembers = GetQuorumRelayMembers(mns, myProTxHash, myIdx);
         LogPrint(BCLog::DKG, "CDKGSession::%s: initialized as member. mns=%d\n", __func__, mns.size());
     }
 

--- a/src/llmq/quorums_dkgsessionhandler.cpp
+++ b/src/llmq/quorums_dkgsessionhandler.cpp
@@ -179,10 +179,10 @@ bool CDKGSessionHandler::InitNewQuorum(const CBlockIndex* pindexQuorum)
     return true;
 }
 
-std::pair<QuorumPhase, uint256> CDKGSessionHandler::GetPhaseAndQuorumHash() const
+CDKGSessionHandler::QuorumPhaseAndHash CDKGSessionHandler::GetPhaseAndQuorumHash() const
 {
     LOCK(cs);
-    return std::make_pair(phase, quorumHash);
+    return {phase, quorumHash};
 }
 
 class AbortPhaseException : public std::exception {
@@ -199,14 +199,14 @@ void CDKGSessionHandler::WaitForNextPhase(QuorumPhase curPhase,
         if (stopRequested || ShutdownRequested()) {
             throw AbortPhaseException();
         }
-        auto p = GetPhaseAndQuorumHash();
-        if (!expectedQuorumHash.IsNull() && p.second != expectedQuorumHash) {
+        auto currState = GetPhaseAndQuorumHash();
+        if (!expectedQuorumHash.IsNull() && currState.quorumHash != expectedQuorumHash) {
             throw AbortPhaseException();
         }
-        if (p.first == nextPhase) {
+        if (currState.phase == nextPhase) {
             break;
         }
-        if (curPhase != QuorumPhase_None && p.first != curPhase) {
+        if (curPhase != QuorumPhase_None && currState.phase != curPhase) {
             LogPrint(BCLog::DKG, "CDKGSessionHandler::%s -- %s - aborting due unexpected phase change\n", __func__, params.name);
             throw AbortPhaseException();
         }
@@ -237,8 +237,8 @@ void CDKGSessionHandler::WaitForNewQuorum(const uint256& oldQuorumHash)
         if (stopRequested || ShutdownRequested()) {
             throw AbortPhaseException();
         }
-        auto p = GetPhaseAndQuorumHash();
-        if (p.second != oldQuorumHash) {
+        auto currState = GetPhaseAndQuorumHash();
+        if (currState.quorumHash != oldQuorumHash) {
             break;
         }
         MilliSleep(100);

--- a/src/llmq/quorums_dkgsessionhandler.cpp
+++ b/src/llmq/quorums_dkgsessionhandler.cpp
@@ -110,7 +110,7 @@ void CDKGSessionHandler::UpdatedBlockTip(const CBlockIndex* pindexNew)
     LOCK(cs);
 
     int quorumStageInt = pindexNew->nHeight % params.dkgInterval;
-    const CBlockIndex* pindexQuorum = pindexNew->GetAncestor(pindexNew->nHeight - quorumStageInt);
+    const CBlockIndex* pindexQuorum = chainActive[pindexNew->nHeight - quorumStageInt];
 
     currentHeight = pindexNew->nHeight;
     quorumHeight = pindexQuorum->nHeight;

--- a/src/llmq/quorums_dkgsessionhandler.h
+++ b/src/llmq/quorums_dkgsessionhandler.h
@@ -129,7 +129,11 @@ public:
 private:
     bool InitNewQuorum(const CBlockIndex* pindexQuorum);
 
-    std::pair<QuorumPhase, uint256> GetPhaseAndQuorumHash() const;
+    struct QuorumPhaseAndHash {
+        QuorumPhase phase;
+        uint256 quorumHash;
+    };
+    QuorumPhaseAndHash GetPhaseAndQuorumHash() const;
 
     typedef std::function<void()> StartPhaseFunc;
     typedef std::function<bool()> WhileWaitFunc;

--- a/src/llmq/quorums_dkgsessionmgr.h
+++ b/src/llmq/quorums_dkgsessionmgr.h
@@ -22,7 +22,6 @@ class CDKGSessionManager
 private:
     CEvoDB& evoDb;
     CBLSWorker& blsWorker;
-    ctpl::thread_pool messageHandlerPool;
 
     std::map<Consensus::LLMQType, CDKGSessionHandler> dkgSessionHandlers;
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -145,6 +145,7 @@ set(BITCOIN_TESTS
         ${CMAKE_CURRENT_SOURCE_DIR}/net_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/netbase_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/netfulfilledman_tests.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/net_quorums_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/pmt_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/policyestimator_tests.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/prevector_tests.cpp

--- a/src/test/net_quorums_tests.cpp
+++ b/src/test/net_quorums_tests.cpp
@@ -13,10 +13,13 @@ BOOST_AUTO_TEST_SUITE(net_quorums_tests)
 std::set<uint256> GetQuorumRelayMembers(const std::vector<uint256>& mnList,
                                         unsigned int forMemberIndex)
 {
+    assert(forMemberIndex < mnList.size());
+
     // Special case
     if (mnList.size() == 2) {
-        return {mnList[(forMemberIndex + 1) % 2]};
+        return {mnList[1 - forMemberIndex]};
     }
+
     // Relay to nodes at indexes (i+2^k)%n, where
     //   k: 0..max(1, floor(log2(n-1))-1)
     //   n: size of the quorum/ring

--- a/src/test/net_quorums_tests.cpp
+++ b/src/test/net_quorums_tests.cpp
@@ -25,6 +25,10 @@ std::set<uint256> GetQuorumRelayMembers(const std::vector<uint256>& mnList,
         size_t idx = (forMemberIndex + gap) % mnList.size();
         auto& otherDmnId = mnList[idx];
         if (otherDmnId == forMember) {
+            if (gap_max == 0 && k == 1) {
+                // special case, two members quorum.
+                break;
+            }
             continue;
         }
         r.emplace(otherDmnId);

--- a/src/test/net_quorums_tests.cpp
+++ b/src/test/net_quorums_tests.cpp
@@ -13,6 +13,10 @@ BOOST_AUTO_TEST_SUITE(net_quorums_tests)
 std::set<uint256> GetQuorumRelayMembers(const std::vector<uint256>& mnList,
                                         unsigned int forMemberIndex)
 {
+    // Special case
+    if (mnList.size() == 2) {
+        return {mnList[(forMemberIndex + 1) % 2]};
+    }
     // Relay to nodes at indexes (i+2^k)%n, where
     //   k: 0..max(1, floor(log2(n-1))-1)
     //   n: size of the quorum/ring
@@ -52,10 +56,12 @@ void checkQuorumRelayMembers(const std::vector<uint256>& list, unsigned int expe
 
 BOOST_FIXTURE_TEST_CASE(get_quorum_relay_members, BasicTestingSetup)
 {
-    SeedInsecureRand(SeedRand::ZEROS);
-    std::vector<uint256> list = createMNList(1200);
+    // 1) Test special case of 2 members
+    std::vector<uint256> list = createMNList(2);
+    checkQuorumRelayMembers(list, 1);
 
-    // Test quorum sizes 3 to 1200
+    // 2) Test quorum sizes 3 to 1200
+    list = createMNList(1200);
     size_t expectedRet = 2;
     for (size_t i = 3; i < 1201; i++) {
         std::vector<uint256> copyList = list;

--- a/src/test/net_quorums_tests.cpp
+++ b/src/test/net_quorums_tests.cpp
@@ -1,0 +1,85 @@
+// Copyright (c) 2022 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://www.opensource.org/licenses/mit-license.php.
+
+#include "test/test_pivx.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(net_quorums_tests)
+
+// Simplified copy of quorums_connections.h/cpp, GetQuorumRelayMembers function.
+// (merely without the CDeterministicMNCPtr as it's not needed to test the algorithm)
+std::set<uint256> GetQuorumRelayMembers(const std::vector<uint256>& mnList,
+                                        const uint256& forMember,
+                                        unsigned int forMemberIndex)
+{
+    // Relay to nodes at indexes (i+2^k)%n, where
+    //   k: 0..max(1, floor(log2(n-1))-1)
+    //   n: size of the quorum/ring
+    std::set<uint256> r;
+    int gap = 1;
+    int gap_max = (int)mnList.size() - 1;
+    int k = 0;
+    while ((gap_max >>= 1) || k <= 1) {
+        size_t idx = (forMemberIndex + gap) % mnList.size();
+        auto& otherDmnId = mnList[idx];
+        if (otherDmnId == forMember) {
+            continue;
+        }
+        r.emplace(otherDmnId);
+        gap <<= 1;
+        k++;
+    }
+    return r;
+}
+
+std::vector<uint256> createMNList(unsigned int size)
+{
+    std::vector<uint256> mns;
+    for (int i = 0; i < size; i++) {
+        uint256 item;
+        do { item = g_insecure_rand_ctx.rand256(); } while (std::find(mns.begin(), mns.end(), item) != mns.end());
+        mns.emplace_back(item);
+    }
+    return mns;
+}
+
+void checkQuorumRelayMembers(const std::vector<uint256>& list, unsigned int expectedResSize)
+{
+    for (int i = 0; i < list.size(); i++) {
+        const auto& set = GetQuorumRelayMembers(list, list[i], i);
+        BOOST_CHECK_MESSAGE(set.size() == expectedResSize || set.size() == expectedResSize - 1,
+                            strprintf("size %d, expected ret size %d, ret size %d ", list.size(), expectedResSize, set.size()));
+    }
+}
+
+BOOST_FIXTURE_TEST_CASE(get_quorum_relay_members, BasicTestingSetup)
+{
+    SeedInsecureRand(SeedRand::ZEROS);
+    std::vector<uint256> list = createMNList(1200);
+
+    // 1) Test random quorum sizes
+    for (int i = 0; i < 2; i++) {
+        int size = (int) g_insecure_rand_ctx.randbits((int) g_insecure_rand_ctx.randrange(9));
+        int expectedRet = 0;
+        for (int aux = size; aux >>= 1;) { expectedRet++; }
+        std::vector<uint256> copyList = list;
+        copyList.resize(size);
+        checkQuorumRelayMembers(copyList, expectedRet);
+    }
+
+    // 1) Test quorum size of 400, each list should contain 8-9 other elements.
+    list.resize(400);
+    checkQuorumRelayMembers(list, 9);
+    // 2) Test quorum size of 50, each list should contain 5-6 other elements.
+    list.resize(50);
+    checkQuorumRelayMembers(list, 6);
+
+    // 4) Test quorum size of 2, should only return a single element (cannot return himself)
+    // Currently failing, infinite loop
+    list.resize(2);
+    checkQuorumRelayMembers(list, 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/net_quorums_tests.cpp
+++ b/src/test/net_quorums_tests.cpp
@@ -11,7 +11,6 @@ BOOST_AUTO_TEST_SUITE(net_quorums_tests)
 // Simplified copy of quorums_connections.h/cpp, GetQuorumRelayMembers function.
 // (merely without the CDeterministicMNCPtr as it's not needed to test the algorithm)
 std::set<uint256> GetQuorumRelayMembers(const std::vector<uint256>& mnList,
-                                        const uint256& forMember,
                                         unsigned int forMemberIndex)
 {
     // Relay to nodes at indexes (i+2^k)%n, where
@@ -23,15 +22,7 @@ std::set<uint256> GetQuorumRelayMembers(const std::vector<uint256>& mnList,
     int k = 0;
     while ((gap_max >>= 1) || k <= 1) {
         size_t idx = (forMemberIndex + gap) % mnList.size();
-        auto& otherDmnId = mnList[idx];
-        if (otherDmnId == forMember) {
-            if (gap_max == 0 && k == 1) {
-                // special case, two members quorum.
-                break;
-            }
-            continue;
-        }
-        r.emplace(otherDmnId);
+        r.emplace(mnList[idx]);
         gap <<= 1;
         k++;
     }
@@ -41,7 +32,7 @@ std::set<uint256> GetQuorumRelayMembers(const std::vector<uint256>& mnList,
 std::vector<uint256> createMNList(unsigned int size)
 {
     std::vector<uint256> mns;
-    for (int i = 0; i < size; i++) {
+    for (size_t i = 0; i < size; i++) {
         uint256 item;
         do { item = g_insecure_rand_ctx.rand256(); } while (std::find(mns.begin(), mns.end(), item) != mns.end());
         mns.emplace_back(item);
@@ -51,10 +42,11 @@ std::vector<uint256> createMNList(unsigned int size)
 
 void checkQuorumRelayMembers(const std::vector<uint256>& list, unsigned int expectedResSize)
 {
-    for (int i = 0; i < list.size(); i++) {
-        const auto& set = GetQuorumRelayMembers(list, list[i], i);
-        BOOST_CHECK_MESSAGE(set.size() == expectedResSize || set.size() == expectedResSize - 1,
+    for (size_t i = 0; i < list.size(); i++) {
+        const auto& set = GetQuorumRelayMembers(list, i);
+        BOOST_CHECK_MESSAGE(set.size() == expectedResSize,
                             strprintf("size %d, expected ret size %d, ret size %d ", list.size(), expectedResSize, set.size()));
+        BOOST_CHECK(set.count(list[i]) == 0);
     }
 }
 
@@ -63,27 +55,14 @@ BOOST_FIXTURE_TEST_CASE(get_quorum_relay_members, BasicTestingSetup)
     SeedInsecureRand(SeedRand::ZEROS);
     std::vector<uint256> list = createMNList(1200);
 
-    // 1) Test random quorum sizes
-    for (int i = 0; i < 2; i++) {
-        int size = (int) g_insecure_rand_ctx.randbits((int) g_insecure_rand_ctx.randrange(9));
-        int expectedRet = 0;
-        for (int aux = size; aux >>= 1;) { expectedRet++; }
+    // Test quorum sizes 3 to 1200
+    size_t expectedRet = 2;
+    for (size_t i = 3; i < 1201; i++) {
         std::vector<uint256> copyList = list;
-        copyList.resize(size);
+        copyList.resize(i);
+        if ((2 << expectedRet) < (int)i) expectedRet++;
         checkQuorumRelayMembers(copyList, expectedRet);
     }
-
-    // 1) Test quorum size of 400, each list should contain 8-9 other elements.
-    list.resize(400);
-    checkQuorumRelayMembers(list, 9);
-    // 2) Test quorum size of 50, each list should contain 5-6 other elements.
-    list.resize(50);
-    checkQuorumRelayMembers(list, 6);
-
-    // 4) Test quorum size of 2, should only return a single element (cannot return himself)
-    // Currently failing, infinite loop
-    list.resize(2);
-    checkQuorumRelayMembers(list, 1);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Follow-up work to my on-going review of https://github.com/PIVX-Project/PIVX/pull/2722#pullrequestreview-880202607. Starts in eeefe79c.

The current intra-quorum relay members selection algorithm receives a quorum member and selects a number of relay connections equals to the quorum size bits count.
So, for example: each DMN, in a quorum of 400 members, deterministically selects 9 other members and mark them as intra-quorum-relay members.

In the test LLMQ params case, with a quorum of 2, this algorithm falls into an infinite loop. Blocking the node's LLMQ session forever.
The process cannot select the input member for intra-quorum relay and expects to return a minimum of 2 elements.

Added a test case commit first so the issue can be easily verified/tested.

Aside from that, added some other performance improvements and cleanups for the LLMQ sessions: 
1. Faster and cleaner GetQuorumRelayMembers calculation.
    1. No need to re-calculate the quorum members internally, the function' callers already have calculated the DMN list.
    2. As 'onlyOutbound' argument is always true. There is no need to loop over all the quorum members. The function only calculates the local DMN outbound relay connections.
2.  Inside the `CDKGSessionHandler::UpdateBlockTip`: No need to walk-backwards through the chain to get the last quorum index. Can just look it up on chainActive`.
3.  GetPhaseAndQuorumHash() returning an struct instead of a pair.
4. Remove unused 'messageHandlerPool' field in the CDKGSession` class.