### PR TITLE
Error out at startup if there was an internal problem during DMN init

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -175,6 +175,7 @@ void CActiveDeterministicMasternodeManager::Init(const CBlockIndex* pindexTip)
     info.proTxHash = dmn->proTxHash;
     g_connman->GetTierTwoConnMan()->setLocalDMN(info.proTxHash);
     state = MASTERNODE_READY;
+    LogPrintf("Deterministic Masternode initialized\n");
 }
 
 void CActiveDeterministicMasternodeManager::Reset(masternode_state_t _state, const CBlockIndex* pindexTip)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1725,7 +1725,6 @@ bool AppInitMain()
     }
 
     LoadTierTwo(chain_active_height, load_cache_files);
-    if (!InitActiveMN()) return false;
     RegisterTierTwoValidationInterface();
 
     // set the mode of budget voting for this node
@@ -1839,6 +1838,9 @@ bool AppInitMain()
         threadGroup.create_thread(std::bind(&ThreadStakeMinter));
     }
 #endif
+
+    // Enable active MN
+    if (!InitActiveMN()) return false;
 
     // ********************************************************* Step 12: finished
 

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -707,8 +707,6 @@ void CMasternodePayments::UpdatedBlockTip(const CBlockIndex *pindexNew, const CB
 
 void CMasternodePayments::ProcessBlock(int nBlockHeight)
 {
-    LogPrintf("%s: Processing block %d\n", __func__, nBlockHeight);
-
     // No more mnw messages after transition to DMN
     if (deterministicMNManager->LegacyMNObsolete(nBlockHeight)) {
         return;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -23,7 +23,6 @@
 #include "primitives/transaction.h"
 #include "scheduler.h"
 #include "tiertwo/net_masternodes.h"
-#include "tiertwo/tiertwo_sync_state.h"
 #include "validation.h"
 
 #ifdef WIN32
@@ -1119,13 +1118,6 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
 
     if (IsBanned(addr) && !whitelisted) {
         LogPrint(BCLog::NET, "connection from %s dropped (banned)\n", addr.ToString());
-        CloseSocket(hSocket);
-        return;
-    }
-
-    // if we are a MN, don't accept incoming connections until fully synced
-    if (fMasterNode && !g_tiertwo_sync_state.IsSynced()) {
-        LogPrint(BCLog::NET, "AcceptConnection -- masternode is not synced yet, skipping inbound connection attempt\n");
         CloseSocket(hSocket);
         return;
     }

--- a/src/tiertwo/init.cpp
+++ b/src/tiertwo/init.cpp
@@ -251,6 +251,9 @@ bool InitActiveMN()
             // Init active masternode
             const CBlockIndex* pindexTip = WITH_LOCK(cs_main, return chainActive.Tip(););
             activeMasternodeManager->Init(pindexTip);
+            if (activeMasternodeManager->GetState() == CActiveDeterministicMasternodeManager::MASTERNODE_ERROR) {
+                return UIError(activeMasternodeManager->GetStatus()); // state logged internally
+            }
         } else {
             // Check enforcement
             if (deterministicMNManager->LegacyMNObsolete()) {


### PR DESCRIPTION
Follow-up to #2742.

1) Notify user if the Deterministic MN initialization failed for a local non-recoverable error.

2) Moved the startup Masternode activation after the connection manager initialization.
Without it, as the network module isn't initialized, the MN connectivity check always fails.

3) Removed an overkill check that was rejecting incoming connections on Masternodes if the node wasn't, tier two wise, synchronized.
The tier two sync preference for outbound connections can, and will, be achieved differently on a subsequent PR.