### PR TITLE
[Refactor] Create coinstake outputs moved from stakeInput to the wallet class.

### DIFF
--- a/src/stakeinput.cpp
+++ b/src/stakeinput.cpp
@@ -6,7 +6,7 @@
 
 #include "chain.h"
 #include "txdb.h"
-#include "wallet/wallet.h"
+#include "validation.h"
 
 static bool HasStakeMinAgeOrDepth(int nHeight, uint32_t nTime, const CBlockIndex* pindex)
 {
@@ -77,44 +77,6 @@ CTxIn CPivStake::GetTxIn() const
 CAmount CPivStake::GetValue() const
 {
     return outputFrom.nValue;
-}
-
-bool CPivStake::CreateTxOuts(const CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) const
-{
-    std::vector<valtype> vSolutions;
-    txnouttype whichType;
-    CScript scriptPubKeyKernel = outputFrom.scriptPubKey;
-    if (!Solver(scriptPubKeyKernel, whichType, vSolutions))
-        return error("%s: failed to parse kernel", __func__);
-
-    if (whichType != TX_PUBKEY && whichType != TX_PUBKEYHASH && whichType != TX_COLDSTAKE)
-        return error("%s: type=%d (%s) not supported for scriptPubKeyKernel", __func__, whichType, GetTxnOutputType(whichType));
-
-    CKey key;
-    if (whichType == TX_PUBKEYHASH || whichType == TX_COLDSTAKE) {
-        // if P2PKH or P2CS check that we have the input private key
-        if (!pwallet->GetKey(CKeyID(uint160(vSolutions[0])), key))
-            return error("%s: Unable to get staking private key", __func__);
-    }
-
-    vout.emplace_back(0, scriptPubKeyKernel);
-
-    // Calculate if we need to split the output
-    if (pwallet->nStakeSplitThreshold > 0) {
-        int nSplit = static_cast<int>(nTotal / pwallet->nStakeSplitThreshold);
-        if (nSplit > 1) {
-            // if nTotal is twice or more of the threshold; create more outputs
-            int txSizeMax = MAX_STANDARD_TX_SIZE >> 11; // limit splits to <10% of the max TX size (/2048)
-            if (nSplit > txSizeMax)
-                nSplit = txSizeMax;
-            for (int i = nSplit; i > 1; i--) {
-                LogPrintf("%s: StakeSplit: nTotal = %d; adding output %d of %d\n", __func__, nTotal, (nSplit-i)+2, nSplit);
-                vout.emplace_back(0, scriptPubKeyKernel);
-            }
-        }
-    }
-
-    return true;
 }
 
 CDataStream CPivStake::GetUniqueness() const

--- a/src/stakeinput.h
+++ b/src/stakeinput.h
@@ -46,7 +46,6 @@ public:
     CAmount GetValue() const override;
     CDataStream GetUniqueness() const override;
     CTxIn GetTxIn() const;
-    bool CreateTxOuts(const CWallet* pwallet, std::vector<CTxOut>& vout, CAmount nTotal) const;
     bool IsZPIV() const override { return false; }
 };
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1096,6 +1096,8 @@ public:
     };
     CWallet::CommitResult CommitTransaction(CTransactionRef tx, CReserveKey& opReservekey, CConnman* connman);
     CWallet::CommitResult CommitTransaction(CTransactionRef tx, CReserveKey* reservekey, CConnman* connman, mapValue_t* extraValues=nullptr);
+
+    bool CreateCoinstakeOuts(const CPivStake& stakeInput, std::vector<CTxOut>& vout, CAmount nTotal) const;
     bool CreateCoinStake(const CBlockIndex* pindexPrev,
                          unsigned int nBits,
                          CMutableTransaction& txNew,

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -39,7 +39,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "wallet/wallet -> wallet/walletdb -> wallet/wallet"
     "chain -> legacy/stakemodifier -> stakeinput -> chain"
     "chain -> legacy/stakemodifier -> validation -> chain"
-    "kernel -> stakeinput -> wallet/wallet -> kernel"
     "legacy/validation_zerocoin_legacy -> wallet/wallet -> validation -> legacy/validation_zerocoin_legacy"
     "llmq/quorums_dkgsession -> llmq/quorums_dkgsessionmgr -> llmq/quorums_dkgsessionhandler -> llmq/quorums_dkgsession"
     "llmq/quorums_dkgsessionhandler -> net_processing -> llmq/quorums_dkgsessionmgr -> llmq/quorums_dkgsessionhandler"


### PR DESCRIPTION
Fixing the circular dependency:
"kernel -> stakeinput -> wallet/wallet -> kernel"