### PR TITLE
Inform and stop node if tier two initialization failed.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1724,7 +1724,9 @@ bool AppInitMain()
         }
     }
 
-    LoadTierTwo(chain_active_height, load_cache_files);
+    if (!LoadTierTwo(chain_active_height, load_cache_files)) {
+        return false; // error informed inside the function
+    }
     RegisterTierTwoValidationInterface();
 
     // set the mode of budget voting for this node

--- a/src/tiertwo/init.cpp
+++ b/src/tiertwo/init.cpp
@@ -162,12 +162,12 @@ bool LoadTierTwo(int chain_active_height, bool load_cache_files)
     CFlatDB<CMasternodeMetaMan> metadb(MN_META_CACHE_FILENAME, MN_META_CACHE_FILE_ID);
     if (load_cache_files) {
         if (!metadb.Load(g_mmetaman)) {
-            return UIError(strprintf(_("Failed to load masternode metadata cache from: %s"), metadb.GetDbPath().string()));
+            LogPrintf("Failed to load masternode metadata cache from: %s", metadb.GetDbPath().string());
         }
     } else {
         CMasternodeMetaMan mmetamanTmp;
         if (!metadb.Dump(mmetamanTmp)) {
-            return UIError(strprintf(_("Failed to clear masternode metadata cache at: %s"), metadb.GetDbPath().string()));
+            LogPrintf("Failed to clear masternode metadata cache at: %s", metadb.GetDbPath().string());
         }
     }
 


### PR DESCRIPTION
Fixing two problems:

1) If tier two initialization failed, shutdown the node at startup after informing the problem to the user. (right now, it could only fail due an invalid masternode configuration file).

2) Do not error out at startup if the masternodes metadata manager was not loaded properly. The node will re-create its state all over while it's running.