### PR TITLE
[Build][CMake] Use CMake internal instead of custom command for moc

### DIFF
--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -49,14 +49,6 @@ if (QRCODE_FOUND)
     link_directories ( ${QRCODE_LIBRARY_DIRS} )
 endif()
 
-find_program(MOC_BIN NAMES moc moc-qt5 qt5-moc
-        PATHS /usr/lib/qt5/bin /usr/lib/x86_64-linux-gnu/qt5/bin /usr/local/opt/qt/bin /usr/local/opt/qt5/bin /opt/homebrew/opt/qt5/bin
-        NO_DEFAULT_PATH
-        NO_SYSTEM_ENVIRONMENT_PATH)
-if (MOC_BIN)
-    MESSAGE(STATUS "FOUND MOC ${MOC_BIN}")
-endif ()
-
 add_compile_options("-DQT_NO_KEYWORDS")
 
 # Why isn't this done automatically??
@@ -165,10 +157,7 @@ SET(QT_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/pivx/governancemodel.cpp
         )
 
-execute_process(
-        COMMAND ${MOC_BIN} -o moc_pfborderimage.cpp pfborderimage.h
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/pivx
-)
+qt5_generate_moc(pivx/pfborderimage.h ${CMAKE_CURRENT_SOURCE_DIR}/pivx/moc_pfborderimage.cpp)
 list(APPEND QT_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/pivx/moc_pfborderimage.cpp)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")


### PR DESCRIPTION
CMake has an internal function (`qt5_generate_moc`) that can be used to
forcibly generate a `.moc` file. Use that instead of the generic
`execute_process` function.

This fixes an issue on systems (fe, Arch Linux) where Qt's moc binary
are placed in a different location than debian based distros.