### PR TITLE
[GUI][BUG] Properly validate proposal creation Name/URL

### DIFF
--- a/src/budget/budgetproposal.cpp
+++ b/src/budget/budgetproposal.cpp
@@ -6,6 +6,7 @@
 #include "budget/budgetproposal.h"
 #include "chainparams.h"
 #include "script/standard.h"
+#include "utilstrencodings.h"
 
 CBudgetProposal::CBudgetProposal():
         nAllotted(0),
@@ -143,6 +144,20 @@ bool CBudgetProposal::CheckAddress()
     }
 
     return true;
+}
+
+/* TODO: Add this to IsWellFormed() for the next hard-fork
+ * This will networkly reject malformed proposal names and URLs
+ */
+bool CBudgetProposal::CheckStrings()
+{
+    if (strProposalName != SanitizeString(strProposalName)) {
+        strInvalid = "Proposal name contains illegal characters.";
+        return false;
+    }
+    if (strURL != SanitizeString(strURL)) {
+        strInvalid = "Proposal URL contains illegal characters.";
+    }
 }
 
 bool CBudgetProposal::IsWellFormed(const CAmount& nTotalBudget)

--- a/src/budget/budgetproposal.h
+++ b/src/budget/budgetproposal.h
@@ -42,6 +42,7 @@ private:
     bool CheckStartEnd();
     bool CheckAmount(const CAmount& nTotalBudget);
     bool CheckAddress();
+    bool CheckStrings();
 
 protected:
     std::map<COutPoint, CBudgetVote> mapVotes;

--- a/src/qt/pivx/forms/createproposaldialog.ui
+++ b/src/qt/pivx/forms/createproposaldialog.ui
@@ -774,11 +774,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QLineEdit" name="lineEditPropName">
-                 <property name="maxLength">
-                  <number>20</number>
-                 </property>
-                </widget>
+                <widget class="QLineEdit" name="lineEditPropName"/>
                </item>
               </layout>
              </item>
@@ -795,11 +791,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QLineEdit" name="lineEditURL">
-                 <property name="maxLength">
-                  <number>64</number>
-                 </property>
-                </widget>
+                <widget class="QLineEdit" name="lineEditURL"/>
                </item>
               </layout>
              </item>

--- a/src/qt/pivx/governancemodel.cpp
+++ b/src/qt/pivx/governancemodel.cpp
@@ -182,16 +182,24 @@ std::vector<VoteInfo> GovernanceModel::getLocalMNsVotesForProposal(const Proposa
 
 OperationResult GovernanceModel::validatePropName(const QString& name) const
 {
-    if (name.toUtf8().size() > (int)PROP_NAME_MAX_SIZE) { // limit
-        return {false, _("Invalid name, maximum size exceeded")};
+    std::string strName = SanitizeString(name.toStdString());
+    if (strName != name.toStdString()) { // invalid characters
+        return {false, _("Invalid name, invalid characters")};
+    }
+    if (strName.size() > (int)PROP_NAME_MAX_SIZE) { // limit
+        return {false, strprintf(_("Invalid name, maximum size of %d exceeded"), PROP_NAME_MAX_SIZE)};
     }
     return {true};
 }
 
 OperationResult GovernanceModel::validatePropURL(const QString& url) const
 {
+    std::string strURL = SanitizeString(url.toStdString());
+    if (strURL != url.toStdString()) {
+        return {false, _("Invalid URL, invalid characters")};
+    }
     std::string strError;
-    return {validateURL(url.toStdString(), strError, PROP_URL_MAX_SIZE), strError};
+    return {validateURL(strURL, strError, PROP_URL_MAX_SIZE), strError};
 }
 
 OperationResult GovernanceModel::validatePropAmount(CAmount amount) const

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -53,7 +53,7 @@ bool validateURL(const std::string& strURL, std::string& strErr, unsigned int ma
     }
 
     // Validate URL
-    std::regex url_regex("^(https?)://[^\\s/$.?#][^\\s]*[^\\s/.]\\.[^\\s/.][^\\s]*[^\\s.]$");
+    std::regex url_regex(R"(^(https?)://[^\s/$.?#][^\s]*[^\s/.]\.[^\s/.][^\s]*[^\s.]$)");
     if (!std::regex_match(strURL, url_regex)) {
         strErr = "Invalid URL";
         return false;

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -38,13 +38,13 @@ std::string SanitizeString(const std::string& str, int rule)
     return strResult;
 }
 
-bool validateURL(std::string strURL)
+bool validateURL(const std::string& strURL)
 {
     std::string strErr;
     return validateURL(strURL, strErr);
 }
 
-bool validateURL(std::string strURL, std::string& strErr, unsigned int maxSize)
+bool validateURL(const std::string& strURL, std::string& strErr, unsigned int maxSize)
 {
     // Check URL size
     if (strURL.size() > maxSize) {

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -49,8 +49,8 @@ std::string SanitizeString(const std::string& str, int rule = SAFE_CHARS_DEFAULT
 * @param[in] maxSize  An unsigned int, defaulted to 64, to restrict the length
 * @return             A bool, true if valid, false if not (reason in strErr)
 */
-bool validateURL(std::string strURL, std::string& strErr, unsigned int maxSize = 64);
-bool validateURL(std::string strURL);
+bool validateURL(const std::string& strURL, std::string& strErr, unsigned int maxSize = 64);
+bool validateURL(const std::string& strURL);
 
 std::vector<unsigned char> ParseHex(const char* psz);
 std::vector<unsigned char> ParseHex(const std::string& str);


### PR DESCRIPTION
Remove the hard input cap of the name/URL inputs in the proposal creation UI so that the underlaying validation methods can give visual feedback when input lengths are too long (prevents silent cut-offs when pasting a too-long string).

Sanitize both fields to ensure that no illegal characters are accepted, matching the RPC interface's functionality.

introduce a future-forward (not yet implemented) method of verifying name/url fields on the network level.