### PR TITLE
[GA] Run unit/functional tests on native macOS 11

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -80,7 +80,7 @@ jobs:
             cxx: g++
 
           - name: macOS
-            os: macos-10.15
+            os: macos-11
             packages: python3 autoconf automake berkeley-db4 libtool boost miniupnpc libnatpmp pkg-config qt5 zmq libevent qrencode gmp libsodium rust
             cc: $(brew --prefix llvm)/bin/clang
             cxx: $(brew --prefix llvm)/bin/clang++
@@ -322,9 +322,9 @@ jobs:
             goal: deploy
             BITCOIN_CONFIG: "--enable-gui --enable-reduce-exports --enable-werror --disable-online-rust"
 
-          - name: macOS 10.15 [GOAL:deploy] [native macOS using syslibs]
-            os: macos-10.15
-            host: x86_64-apple-darwin19.6.0
+          - name: macOS 11 [GOAL:deploy] [native macOS using syslibs]
+            os: macos-11
+            host: x86_64-apple-darwin20.6.0
             brew_install: autoconf automake ccache berkeley-db4 libtool boost miniupnpc pkg-config python3 qt5 zmq libevent qrencode gmp libsodium rust librsvg
             unit_tests: true
             functional_tests: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -322,12 +322,12 @@ jobs:
             goal: deploy
             BITCOIN_CONFIG: "--enable-gui --enable-reduce-exports --enable-werror --disable-online-rust"
 
-          - name: macOS 10.15 [GOAL:deploy] [native macOS using syslibs no unit or functional tests]
+          - name: macOS 10.15 [GOAL:deploy] [native macOS using syslibs]
             os: macos-10.15
             host: x86_64-apple-darwin19.6.0
             brew_install: autoconf automake ccache berkeley-db4 libtool boost miniupnpc pkg-config python3 qt5 zmq libevent qrencode gmp libsodium rust librsvg
-            unit_tests: false
-            functional_tests: false
+            unit_tests: true
+            functional_tests: true
             no_depends: 1
             goal: deploy
             cc: clang

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -325,7 +325,7 @@ jobs:
           - name: macOS 11 [GOAL:deploy] [native macOS using syslibs]
             os: macos-11
             host: x86_64-apple-darwin20.6.0
-            brew_install: autoconf automake ccache berkeley-db4 libtool boost miniupnpc pkg-config python3 qt5 zmq libevent qrencode gmp libsodium rust librsvg
+            brew_install: autoconf automake ccache berkeley-db4 libtool boost miniupnpc pkg-config python@3.8 qt5 zmq libevent qrencode gmp libsodium rust librsvg
             unit_tests: true
             functional_tests: true
             no_depends: 1
@@ -347,7 +347,7 @@ jobs:
           fi
           if [[ ${{ matrix.config.os }} = macos* ]]; then
             brew install ${{ matrix.config.brew_install }}
-            pip3 install ds_store mac_alias
+            pip3.8 install ds_store mac_alias
           fi
 
       - name: depends cache files

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -65,7 +65,7 @@ class MultiWalletTest(PivxTestFramework):
             assert_equal(os.path.isfile(wallet_file(wallet_name)), True)
 
         # should not initialize if wallet path can't be created
-        exp_stderr = "boost::filesystem::create_directory: (The system cannot find the path specified|Not a directory):"
+        exp_stderr = "boost::filesystem::create_director"
         self.nodes[0].assert_start_raises_init_error(['-wallet=wallet.dat/bad'], exp_stderr, match=ErrorMatch.PARTIAL_REGEX)
 
         self.nodes[0].assert_start_raises_init_error(['-walletdir=wallets'], 'Error: Specified -walletdir "wallets" does not exist')


### PR DESCRIPTION
Bump our native macOS GA runner to macOS 11 (as 10.15 is now deprecated and will cease to function in December), as well as enable unit and functional tests for our native macOS runner, and fix an issue with Boost 1.78+ compatibility for the multiwallet functional test.

Last commit inspired by https://github.com/bitcoin/bitcoin/pull/24104

> Lastly, fs::create_directories now has an error message saying create_directories instead of create_directory. This caused wallet_multiwallet.py to fail. The error message check has been updated to be able accept either string.