### PR TITLE
[GA] Disable Unit tests for win64 build in GA

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -273,11 +273,11 @@ jobs:
             goal: install
             BITCOIN_CONFIG: "--with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports --disable-online-rust"
 
-          - name: Win64  [GOAL:deploy] [no functional tests]
+          - name: Win64  [GOAL:deploy] [no unit or functional tests]
             os: ubuntu-18.04
             host: x86_64-w64-mingw32
             apt_get: python3 nsis g++-mingw-w64-x86-64 wine-binfmt wine64
-            unit_tests: true
+            unit_tests: false
             functional_tests: false
             goal: deploy
             BITCOIN_CONFIG: "--with-gui=auto --enable-reduce-exports --disable-online-rust"


### PR DESCRIPTION
More recent GA environments have broken the ability to run the win64 build's unit tests via Wine. Disable for now.