### PR TITLE
[Consensus] Set testnet new rewards height

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -447,7 +447,7 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_V5_0].nActivationHeight          = 201;
         consensus.vUpgrades[Consensus::UPGRADE_V5_2].nActivationHeight          = 262525;
         consensus.vUpgrades[Consensus::UPGRADE_V5_3].nActivationHeight          = 332300;
-        consensus.vUpgrades[Consensus::UPGRADE_V5_5].nActivationHeight          = 9999999;
+        consensus.vUpgrades[Consensus::UPGRADE_V5_5].nActivationHeight          = 925056;
         consensus.vUpgrades[Consensus::UPGRADE_V6_0].nActivationHeight =
                 Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
 


### PR DESCRIPTION
Sets the 5.5 new rewards changeover block for testnet to 925056.