### PR TITLE
[GA] Use explicit llvm version for macOS CMake build.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -81,9 +81,9 @@ jobs:
 
           - name: macOS
             os: macos-11
-            packages: python3 autoconf automake berkeley-db4 libtool boost miniupnpc libnatpmp pkg-config qt5 zmq libevent qrencode gmp libsodium rust
-            cc: $(brew --prefix llvm)/bin/clang
-            cxx: $(brew --prefix llvm)/bin/clang++
+            packages: llvm@13 python3 autoconf automake berkeley-db@4 libtool boost miniupnpc libnatpmp pkg-config qt5 zmq libevent qrencode gmp libsodium rust
+            cc: $(brew --prefix llvm@13)/bin/clang
+            cxx: $(brew --prefix llvm@13)/bin/clang++
 
     steps:
       - name: Get Source


### PR DESCRIPTION
GA's macOS image update has once again clobbered the llvm compiler environment variable, so we need to set an explicit version to be installed via homebrew.