### PR TITLE
rpc: Backport getblock verbosity

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -530,11 +530,14 @@ UniValue getblock(const JSONRPCRequest& request)
             "getblock \"blockhash\" ( verbosity )\n"
             "\nIf verbosity is 0, returns a string that is serialized, hex-encoded data for block 'hash'.\n"
             "If verbosity is 1, returns an Object with information about block <hash>.\n"
-            "If verbosity is 2, returns an Object with information about block <hash> and information about each transaction. \n"
+            "If verbosity is 2, returns an Object with information about block <hash> and information about each transaction.\n"
 
             "\nArguments:\n"
             "1. \"blockhash\"            (string, required) The block hash\n"
             "2. verbosity              (numeric, optional, default=1) 0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data\n"
+
+            "\nResult (for verbosity = 0):\n"
+            "\"data\"             (string) A string that is serialized, hex-encoded data for block 'hash'.\n"
 
             "\nResult (for verbosity = 1):\n"
             "{\n"
@@ -561,8 +564,14 @@ UniValue getblock(const JSONRPCRequest& request)
             "  }\n"
             "}\n"
 
-            "\nResult (for verbose=false):\n"
-            "\"data\"             (string) A string that is serialized, hex-encoded data for block 'hash'.\n"
+            "\nResult (for verbosity = 2):\n"
+            "{\n"
+            "  ...,                     Same output as verbosity = 1.\n"
+            "  \"tx\" : [               (array of Objects) The transactions in the format of the getrawtransaction RPC. Different from verbosity = 1 \"tx\" result.\n"
+            "         ,...\n"
+            "  ],\n"
+            "  ,...                     Same output as verbosity = 1.\n"
+            "}\n"
 
             "\nExamples:\n" +
             HelpExampleCli("getblock", "\"00000000000fd08c2fb661d2fcb0d49abb3a91e5f27082ce64feed3b4dede2e2\"") +
@@ -1454,7 +1463,7 @@ static const CRPCCommand commands[] =
   //  --------------------- ------------------------  -----------------------  ------ --------
     { "blockchain",         "getbestblockhash",       &getbestblockhash,       true,  {} },
     { "blockchain",         "getbestsaplinganchor",   &getbestsaplinganchor,   true,  {} },
-    { "blockchain",         "getblock",               &getblock,               true,  {"blockhash","verbosity"} },
+    { "blockchain",         "getblock",               &getblock,               true,  {"blockhash","verbose|verbosity"} },
     { "blockchain",         "getblockchaininfo",      &getblockchaininfo,      true,  {} },
     { "blockchain",         "getblockcount",          &getblockcount,          true,  {} },
     { "blockchain",         "getblockhash",           &getblockhash,           true,  {"height"} },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -53,7 +53,7 @@ static const CRPCConvertParam vRPCConvertParams[] = {
     { "getbalance", 1, "include_watchonly" },
     { "getbalance", 2, "include_delegated" },
     { "getbalance", 3, "include_shield" },
-    { "getblock", 1, "verbose" },
+    { "getblock", 1, "verbosity" },
     { "getblockhash", 0, "height" },
     { "getblockheader", 1, "verbose" },
     { "getblockindexstats", 0, "height" },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -54,6 +54,7 @@ static const CRPCConvertParam vRPCConvertParams[] = {
     { "getbalance", 2, "include_delegated" },
     { "getbalance", 3, "include_shield" },
     { "getblock", 1, "verbosity" },
+    { "getblock", 1, "verbose" },
     { "getblockhash", 0, "height" },
     { "getblockheader", 1, "verbose" },
     { "getblockindexstats", 0, "height" },

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -22,6 +22,8 @@
 
 #include <boost/signals2/signal.hpp>
 #include <boost/thread.hpp>
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
 
 #include <memory> // for unique_ptr
 #include <unordered_map>
@@ -450,8 +452,16 @@ static inline JSONRPCRequest transformNamedArguments(const JSONRPCRequest& in, c
     }
     // Process expected parameters.
     int hole = 0;
-    for (const std::string &argName: argNames) {
-        auto fr = argsIn.find(argName);
+    for (const std::string &argNamePattern: argNames) {
+        std::vector<std::string> vargNames;
+        boost::algorithm::split(vargNames, argNamePattern, boost::algorithm::is_any_of("|"));
+        auto fr = argsIn.end();
+        for (const std::string & argName : vargNames) {
+            fr = argsIn.find(argName);
+            if (fr != argsIn.end()) {
+                break;
+            }
+        }
         if (fr != argsIn.end()) {
             for (int i = 0; i < hole; ++i) {
                 // Fill hole between specified parameters with JSON nulls,

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -119,7 +119,7 @@ class BlockchainTest(PivxTestFramework):
 
         assert_is_hash_string(node.getblock(besthash, 1)['tx'][0])
         assert_is_hash_string(node.getblock(besthash, True)['tx'][0])
-        assert_is_hex_string(node.getblock(besthash, 2)['tx'][0]['vin'][0]['coinbase']);
+        assert_is_hex_string(node.getblock(besthash, 2)['tx'][0]['vin'][0]['coinbase'])
 
 
 if __name__ == '__main__':

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -114,11 +114,12 @@ class BlockchainTest(PivxTestFramework):
 
         # Test getblock verbosity
         besthash = node.getbestblockhash()
-        assert(isinstance(node.getblock(blockhash=besthash, verbose=False), str))
-        assert(isinstance(node.getblock(blockhash=besthash, verbosity=0), str))
-        assert(isinstance(node.getblock(besthash, 1)['tx'][0], str))
-        assert(isinstance(node.getblock(besthash, True)['tx'][0], str))
-        assert('vin' in node.getblock(besthash, 2)['tx'][0])
+        assert_is_hex_string(node.getblock(blockhash=besthash, verbose=False))
+        assert_is_hex_string(node.getblock(blockhash=besthash, verbosity=0))
+
+        assert_is_hash_string(node.getblock(besthash, 1)['tx'][0])
+        assert_is_hash_string(node.getblock(besthash, True)['tx'][0])
+        assert_is_hex_string(node.getblock(besthash, 2)['tx'][0]['vin'][0]['coinbase']);
 
 
 if __name__ == '__main__':

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -37,6 +37,7 @@ class BlockchainTest(PivxTestFramework):
         self._test_getblockchaininfo()
         self._test_gettxoutsetinfo()
         self._test_getblockheader()
+        self._test_getblock()
         #self._test_getdifficulty()
         self.nodes[0].verifychain(0)
 
@@ -107,6 +108,18 @@ class BlockchainTest(PivxTestFramework):
         # 1 hash in 2 should be valid, so difficulty should be 1/2**31
         # binary => decimal => binary math is why we do this check
         assert abs(difficulty * 2**31 - 1) < 0.0001
+
+    def _test_getblock(self):
+        node = self.nodes[0]
+
+        # Test getblock verbosity
+        besthash = node.getbestblockhash()
+        assert(isinstance(node.getblock(blockhash=besthash, verbose=False), str))
+        assert(isinstance(node.getblock(blockhash=besthash, verbosity=0), str))
+        assert(isinstance(node.getblock(besthash, 1)['tx'][0], str))
+        assert(isinstance(node.getblock(besthash, True)['tx'][0], str))
+        assert('vin' in node.getblock(besthash, 2)['tx'][0])
+
 
 if __name__ == '__main__':
     BlockchainTest().main()

--- a/test/functional/rpc_named_arguments.py
+++ b/test/functional/rpc_named_arguments.py
@@ -30,16 +30,6 @@ class NamedArgumentTest(PivxTestFramework):
         assert_equal(node.echo(arg9=None), [None]*10)
         assert_equal(node.echo(arg0=0,arg3=3,arg9=9), [0] + [None]*2 + [3] + [None]*5 + [9])
 
-        # Test getblock verbosity
-        block = node.getblock(blockhash=h, verbosity=0)
-        assert(isinstance(block, str))
-
-        block = node.getblock(blockhash=h, verbosity=1)
-        assert(isinstance(block['tx'][0], str))
-
-        block = node.getblock(blockhash=h, verbosity=2)
-        assert('vin' in block['tx'][0])
-
 
 if __name__ == '__main__':
     NamedArgumentTest().main()

--- a/test/functional/rpc_named_arguments.py
+++ b/test/functional/rpc_named_arguments.py
@@ -30,5 +30,16 @@ class NamedArgumentTest(PivxTestFramework):
         assert_equal(node.echo(arg9=None), [None]*10)
         assert_equal(node.echo(arg0=0,arg3=3,arg9=9), [0] + [None]*2 + [3] + [None]*5 + [9])
 
+        # Test getblock verbosity
+        block = node.getblock(blockhash=h, verbosity=0)
+        assert(isinstance(block, str))
+
+        block = node.getblock(blockhash=h, verbosity=1)
+        assert(isinstance(block['tx'][0], str))
+
+        block = node.getblock(blockhash=h, verbosity=2)
+        assert('vin' in block['tx'][0])
+
+
 if __name__ == '__main__':
     NamedArgumentTest().main()

--- a/test/functional/rpc_named_arguments.py
+++ b/test/functional/rpc_named_arguments.py
@@ -30,6 +30,5 @@ class NamedArgumentTest(PivxTestFramework):
         assert_equal(node.echo(arg9=None), [None]*10)
         assert_equal(node.echo(arg0=0,arg3=3,arg9=9), [0] + [None]*2 + [3] + [None]*5 + [9])
 
-
 if __name__ == '__main__':
     NamedArgumentTest().main()


### PR DESCRIPTION
Changes the boolean 'verbose' parameter of the getblock rpc command to an integer.
Enables getblock output to include full transaction details.

Backported from Bitcoin v15
https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-0.15.0.md
