### PR TITLE
RPC: Backport scantxoutset from BitCoin Core v0.17.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -449,6 +449,7 @@ set(COMMON_SOURCES
         ./src/pubkey.cpp
         ./src/saltedhasher.cpp
         ./src/scheduler.cpp
+        ./src/script/descriptor.cpp
         ./src/script/interpreter.cpp
         ./src/script/script.cpp
         ./src/script/sign.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -269,6 +269,7 @@ BITCOIN_CORE_H = \
   rpc/server.h \
   saltedhasher.h \
   scheduler.h \
+  script/descriptor.h \
   script/interpreter.h \
   script/keyorigin.h \
   script/script.h \
@@ -564,6 +565,7 @@ libbitcoin_common_a_SOURCES = \
   pubkey.cpp \
   saltedhasher.cpp \
   scheduler.cpp \
+  script/descriptor.cpp \
   script/interpreter.cpp \
   script/script.cpp \
   script/sign.cpp \

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1515,11 +1515,9 @@ UniValue scantxoutset(const JSONRPCRequest& request)
             "Examples of output descriptors are:\n"
             "    addr(<address>)                      Outputs whose scriptPubKey corresponds to the specified address (does not include P2PK)\n"
             "    raw(<hex script>)                    Outputs whose scriptPubKey equals the specified hex scripts\n"
-//original BitCoin            "    combo(<pubkey>)                      P2PK, P2PKH, P2WPKH, and P2SH-P2WPKH outputs for the given pubkey\n"
             "    combo(<pubkey>)                      P2PK and P2PKH outputs for the given pubkey\n"
             "    pkh(<pubkey>)                        P2PKH outputs for the given pubkey\n"
             "    sh(multi(<n>,<pubkey>,<pubkey>,...)) P2SH-multisig outputs for the given threshold and pubkeys\n"
-//original BitCoin            "\nIn the above, <pubkey> either refers to a fixed public key in hexadecimal notation, or to an xpub/xprv optionally followed by one\n"
             "\nIn the above, <pubkey> either refers to a fixed public key in hexadecimal notation, or to an DRKV/DRKP optionally followed by one\n"
             "or more path elements separated by \"/\", and optionally ending in \"/*\" (unhardened), or \"/*'\" or \"/*h\" (hardened) to specify all\n"
             "unhardened or hardened child keys.\n"
@@ -1644,7 +1642,6 @@ UniValue scantxoutset(const JSONRPCRequest& request)
             UniValue unspent(UniValue::VOBJ);
             unspent.pushKV("txid", outpoint.hash.GetHex());
             unspent.pushKV("vout", (int32_t)outpoint.n);
-//original BitCoin            unspent.pushKV("scriptPubKey", HexStr(txo.scriptPubKey.begin(), txo.scriptPubKey.end()));
             unspent.pushKV("scriptPubKey", HexStr(txo.scriptPubKey));
             unspent.pushKV("amount", ValueFromAmount(txo.nValue));
             unspent.pushKV("height", (int32_t)coin.nHeight);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin developers
 // Copyright (c) 2014-2015 The Dash developers
-// Copyright (c) 2015-2020 The PIVX developers
+// Copyright (c) 2015-2022 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
@@ -16,6 +16,7 @@
 #include "policy/feerate.h"
 #include "policy/policy.h"
 #include "rpc/server.h"
+#include "script/descriptor.h"
 #include "sync.h"
 #include "txdb.h"
 #include "util/system.h"
@@ -1444,6 +1445,220 @@ UniValue getfeeinfo(const JSONRPCRequest& request)
     return getblockindexstats(newRequest);
 }
 
+//! Search for a given set of pubkey scripts
+bool FindScriptPubKey(std::atomic<int>& scan_progress, const std::atomic<bool>& should_abort, int64_t& count, CCoinsViewCursor* cursor, const std::set<CScript>& needles, std::map<COutPoint, Coin>& out_results) {
+    scan_progress = 0;
+    count = 0;
+    while (cursor->Valid()) {
+        COutPoint key;
+        Coin coin;
+        if (!cursor->GetKey(key) || !cursor->GetValue(coin)) return false;
+        if (++count % 8192 == 0) {
+            boost::this_thread::interruption_point();
+            if (should_abort) {
+                // allow to abort the scan via the abort reference
+                return false;
+            }
+        }
+        if (count % 256 == 0) {
+            // update progress reference every 256 item
+            uint32_t high = 0x100 * *key.hash.begin() + *(key.hash.begin() + 1);
+            scan_progress = (int)(high * 100.0 / 65536.0 + 0.5);
+        }
+        if (needles.count(coin.out.scriptPubKey)) {
+            out_results.emplace(key, coin);
+        }
+        cursor->Next();
+    }
+    scan_progress = 100;
+    return true;
+}
+
+/** RAII object to prevent concurrency issue when scanning the txout set */
+static std::mutex g_utxosetscan;
+static std::atomic<int> g_scan_progress;
+static std::atomic<bool> g_scan_in_progress;
+static std::atomic<bool> g_should_abort_scan;
+class CoinsViewScanReserver
+{
+private:
+    bool m_could_reserve;
+public:
+    explicit CoinsViewScanReserver() : m_could_reserve(false) {}
+
+    bool reserve() {
+        assert (!m_could_reserve);
+        std::lock_guard<std::mutex> lock(g_utxosetscan);
+        if (g_scan_in_progress) {
+            return false;
+        }
+        g_scan_in_progress = true;
+        m_could_reserve = true;
+        return true;
+    }
+
+    ~CoinsViewScanReserver() {
+        if (m_could_reserve) {
+            std::lock_guard<std::mutex> lock(g_utxosetscan);
+            g_scan_in_progress = false;
+        }
+    }
+};
+
+UniValue scantxoutset(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
+        throw std::runtime_error(
+            "scantxoutset <action> ( <scanobjects> )\n"
+            "\nEXPERIMENTAL warning: this call may be removed or changed in future releases.\n"
+            "\nScans the unspent transaction output set for entries that match certain output descriptors.\n"
+            "Examples of output descriptors are:\n"
+            "    addr(<address>)                      Outputs whose scriptPubKey corresponds to the specified address (does not include P2PK)\n"
+            "    raw(<hex script>)                    Outputs whose scriptPubKey equals the specified hex scripts\n"
+//original BitCoin            "    combo(<pubkey>)                      P2PK, P2PKH, P2WPKH, and P2SH-P2WPKH outputs for the given pubkey\n"
+            "    combo(<pubkey>)                      P2PK and P2PKH outputs for the given pubkey\n"
+            "    pkh(<pubkey>)                        P2PKH outputs for the given pubkey\n"
+            "    sh(multi(<n>,<pubkey>,<pubkey>,...)) P2SH-multisig outputs for the given threshold and pubkeys\n"
+//original BitCoin            "\nIn the above, <pubkey> either refers to a fixed public key in hexadecimal notation, or to an xpub/xprv optionally followed by one\n"
+            "\nIn the above, <pubkey> either refers to a fixed public key in hexadecimal notation, or to an DRKV/DRKP optionally followed by one\n"
+            "or more path elements separated by \"/\", and optionally ending in \"/*\" (unhardened), or \"/*'\" or \"/*h\" (hardened) to specify all\n"
+            "unhardened or hardened child keys.\n"
+            "In the latter case, a range needs to be specified by below if different from 1000.\n"
+            "For more information on output descriptors, see the documentation in the doc/descriptors.md file.\n"
+            "\nArguments:\n"
+            "1. \"action\"                       (string, required) The action to execute\n"
+            "                                      \"start\" for starting a scan\n"
+            "                                      \"abort\" for aborting the current scan (returns true when abort was successful)\n"
+            "                                      \"status\" for progress report (in %) of the current scan\n"
+            "2. \"scanobjects\"                  (array, required) Array of scan objects\n"
+            "    [                             Every scan object is either a string descriptor or an object:\n"
+            "        \"descriptor\",             (string, optional) An output descriptor\n"
+            "        {                         (object, optional) An object with output descriptor and metadata\n"
+            "          \"desc\": \"descriptor\",   (string, required) An output descriptor\n"
+            "          \"range\": n,             (numeric, optional) Up to what child index HD chains should be explored (default: 1000)\n"
+            "        },\n"
+            "        ...\n"
+            "    ]\n"
+            "\nResult:\n"
+            "{\n"
+            "  \"unspents\": [\n"
+            "    {\n"
+            "    \"txid\" : \"transactionid\",     (string) The transaction id\n"
+            "    \"vout\": n,                    (numeric) the vout value\n"
+            "    \"scriptPubKey\" : \"script\",    (string) the script key\n"
+            "    \"amount\" : x.xxx,             (numeric) The total amount in " + CURRENCY_UNIT + " of the unspent output\n"
+            "    \"height\" : n,                 (numeric) Height of the unspent transaction output\n"
+            "   }\n"
+            "   ,...], \n"
+            " \"total_amount\" : x.xxx,          (numeric) The total amount of all found unspent outputs in " + CURRENCY_UNIT + "\n"
+            "]\n"
+        );
+
+    RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VARR});
+
+    UniValue result(UniValue::VOBJ);
+    if (request.params[0].get_str() == "status") {
+        CoinsViewScanReserver reserver;
+        if (reserver.reserve()) {
+            // no scan in progress
+            return NullUniValue;
+        }
+        result.pushKV("progress", g_scan_progress);
+        return result;
+    } else if (request.params[0].get_str() == "abort") {
+        CoinsViewScanReserver reserver;
+        if (reserver.reserve()) {
+            // reserve was possible which means no scan was running
+            return false;
+        }
+        // set the abort flag
+        g_should_abort_scan = true;
+        return true;
+    } else if (request.params[0].get_str() == "start") {
+        CoinsViewScanReserver reserver;
+        if (!reserver.reserve()) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "Scan already in progress, use action \"abort\" or \"status\"");
+        }
+        std::set<CScript> needles;
+        CAmount total_in = 0;
+
+        // loop through the scan objects
+        for (const UniValue& scanobject : request.params[1].get_array().getValues()) {
+            std::string desc_str;
+            int range = 1000;
+            if (scanobject.isStr()) {
+                desc_str = scanobject.get_str();
+            } else if (scanobject.isObject()) {
+                UniValue desc_uni = find_value(scanobject, "desc");
+                if (desc_uni.isNull()) throw JSONRPCError(RPC_INVALID_PARAMETER, "Descriptor needs to be provided in scan object");
+                desc_str = desc_uni.get_str();
+                UniValue range_uni = find_value(scanobject, "range");
+                if (!range_uni.isNull()) {
+                    range = range_uni.get_int();
+                    if (range < 0 || range > 1000000) throw JSONRPCError(RPC_INVALID_PARAMETER, "range out of range");
+                }
+            } else {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Scan object needs to be either a string or an object");
+            }
+
+            FlatSigningProvider provider;
+            auto desc = Parse(desc_str, provider);
+            if (!desc) {
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("Invalid descriptor '%s'", desc_str));
+            }
+            if (!desc->IsRange()) range = 0;
+            for (int i = 0; i <= range; ++i) {
+                std::vector<CScript> scripts;
+                if (!desc->Expand(i, provider, scripts, provider)) {
+                    throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("Cannot derive script without private keys: '%s'", desc_str));
+                }
+                needles.insert(scripts.begin(), scripts.end());
+            }
+        }
+
+        // Scan the unspent transaction output set for inputs
+        UniValue unspents(UniValue::VARR);
+        std::vector<CTxOut> input_txos;
+        std::map<COutPoint, Coin> coins;
+        g_should_abort_scan = false;
+        g_scan_progress = 0;
+        int64_t count = 0;
+        std::unique_ptr<CCoinsViewCursor> pcursor;
+        {
+            LOCK(cs_main);
+            FlushStateToDisk();
+            pcursor = std::unique_ptr<CCoinsViewCursor>(pcoinsdbview->Cursor());
+            assert(pcursor);
+        }
+        bool res = FindScriptPubKey(g_scan_progress, g_should_abort_scan, count, pcursor.get(), needles, coins);
+        result.pushKV("success", res);
+        result.pushKV("searched_items", count);
+
+        for (const auto& it : coins) {
+            const COutPoint& outpoint = it.first;
+            const Coin& coin = it.second;
+            const CTxOut& txo = coin.out;
+            input_txos.push_back(txo);
+            total_in += txo.nValue;
+
+            UniValue unspent(UniValue::VOBJ);
+            unspent.pushKV("txid", outpoint.hash.GetHex());
+            unspent.pushKV("vout", (int32_t)outpoint.n);
+//original BitCoin            unspent.pushKV("scriptPubKey", HexStr(txo.scriptPubKey.begin(), txo.scriptPubKey.end()));
+            unspent.pushKV("scriptPubKey", HexStr(txo.scriptPubKey));
+            unspent.pushKV("amount", ValueFromAmount(txo.nValue));
+            unspent.pushKV("height", (int32_t)coin.nHeight);
+
+            unspents.push_back(unspent);
+        }
+        result.pushKV("unspents", unspents);
+        result.pushKV("total_amount", ValueFromAmount(total_in));
+    } else {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid command");
+    }
+    return result;
+}
+
 static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         okSafe argNames
   //  --------------------- ------------------------  -----------------------  ------ --------
@@ -1464,6 +1679,8 @@ static const CRPCCommand commands[] =
     { "blockchain",         "gettxout",               &gettxout,               true,  {"txid","n","include_mempool"} },
     { "blockchain",         "gettxoutsetinfo",        &gettxoutsetinfo,        true,  {} },
     { "blockchain",         "verifychain",            &verifychain,            true,  {"nblocks"} },
+
+    { "blockchain",         "scantxoutset",           &scantxoutset,           true,  {"action", "scanobjects"} },
 
     /* Not shown in help */
     { "hidden",             "invalidateblock",        &invalidateblock,        true,  {"blockhash"} },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin developers
 // Copyright (c) 2014-2015 The Dash developers
-// Copyright (c) 2015-2020 The PIVX developers
+// Copyright (c) 2015-2022 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -141,6 +141,7 @@ static const CRPCConvertParam vRPCConvertParams[] = {
     { "sendmany", 1, "amounts" },
     { "sendmany", 2, "minconf" },
     { "sendmany", 5, "subtract_fee_from" },
+    { "scantxoutset", 1, "scanobjects" },
     { "sendrawtransaction", 1, "allowhighfees" },
     { "sendtoaddress", 1, "amount" },
     { "sendtoaddress", 4, "subtract_fee" },

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -1,0 +1,568 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Copyright (c) 2022 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <script/descriptor.h>
+
+#include <key_io.h>
+#include <pubkey.h>
+#include <script/script.h>
+#include <script/standard.h>
+
+#include <span.h>
+#include <util/system.h>
+//#include <util.h> //not PIVX
+#include <utilstrencodings.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////
+// Internal representation                                                //
+////////////////////////////////////////////////////////////////////////////
+
+typedef std::vector<uint32_t> KeyPath;
+
+std::string FormatKeyPath(const KeyPath& path)
+{
+    std::string ret;
+    for (auto i : path) {
+        ret += strprintf("/%i", (i << 1) >> 1);
+        if (i >> 31) ret += '\'';
+    }
+    return ret;
+}
+
+/** Interface for public key objects in descriptors. */
+struct PubkeyProvider
+{
+    virtual ~PubkeyProvider() = default;
+
+    /** Derive a public key. */
+    virtual bool GetPubKey(int pos, const SigningProvider& arg, CPubKey& out) const = 0;
+
+    /** Whether this represent multiple public keys at different positions. */
+    virtual bool IsRange() const = 0;
+
+    /** Get the size of the generated public key(s) in bytes (33 or 65). */
+    virtual size_t GetSize() const = 0;
+
+    /** Get the descriptor string form. */
+    virtual std::string ToString() const = 0;
+
+    /** Get the descriptor string form including private data (if available in arg). */
+    virtual bool ToPrivateString(const SigningProvider& arg, std::string& out) const = 0;
+};
+
+/** An object representing a parsed constant public key in a descriptor. */
+class ConstPubkeyProvider final : public PubkeyProvider
+{
+    CPubKey m_pubkey;
+
+public:
+    ConstPubkeyProvider(const CPubKey& pubkey) : m_pubkey(pubkey) {}
+    bool GetPubKey(int pos, const SigningProvider& arg, CPubKey& out) const override
+    {
+        out = m_pubkey;
+        return true;
+    }
+    bool IsRange() const override { return false; }
+    size_t GetSize() const override { return m_pubkey.size(); }
+    std::string ToString() const override { return HexStr(m_pubkey); }
+    bool ToPrivateString(const SigningProvider& arg, std::string& ret) const override
+    {
+        CKey key;
+        if (!arg.GetKey(m_pubkey.GetID(), key)) return false;
+        ret = KeyIO::EncodeSecret(key);
+        return true;
+    }
+};
+
+enum class DeriveType {
+    NO,
+    UNHARDENED,
+    HARDENED,
+};
+
+/** An object representing a parsed extended public key in a descriptor. */
+class BIP32PubkeyProvider final : public PubkeyProvider
+{
+    CExtPubKey m_extkey;
+    KeyPath m_path;
+    DeriveType m_derive;
+
+    bool GetExtKey(const SigningProvider& arg, CExtKey& ret) const
+    {
+        CKey key;
+        if (!arg.GetKey(m_extkey.pubkey.GetID(), key)) return false;
+        ret.nDepth = m_extkey.nDepth;
+        std::copy(m_extkey.vchFingerprint, m_extkey.vchFingerprint + 4, ret.vchFingerprint);
+        ret.nChild = m_extkey.nChild;
+        ret.chaincode = m_extkey.chaincode;
+        ret.key = key;
+        return true;
+    }
+
+    bool IsHardened() const
+    {
+        if (m_derive == DeriveType::HARDENED) return true;
+        for (auto entry : m_path) {
+            if (entry >> 31) return true;
+        }
+        return false;
+    }
+
+public:
+    BIP32PubkeyProvider(const CExtPubKey& extkey, KeyPath path, DeriveType derive) : m_extkey(extkey), m_path(std::move(path)), m_derive(derive) {}
+    bool IsRange() const override { return m_derive != DeriveType::NO; }
+    size_t GetSize() const override { return 33; }
+    bool GetPubKey(int pos, const SigningProvider& arg, CPubKey& out) const override
+    {
+        if (IsHardened()) {
+            CExtKey key;
+            if (!GetExtKey(arg, key)) return false;
+            for (auto entry : m_path) {
+                key.Derive(key, entry);
+            }
+            if (m_derive == DeriveType::UNHARDENED) key.Derive(key, pos);
+            if (m_derive == DeriveType::HARDENED) key.Derive(key, pos | 0x80000000UL);
+            out = key.Neuter().pubkey;
+        } else {
+            // TODO: optimize by caching
+            CExtPubKey key = m_extkey;
+            for (auto entry : m_path) {
+                key.Derive(key, entry);
+            }
+            if (m_derive == DeriveType::UNHARDENED) key.Derive(key, pos);
+            assert(m_derive != DeriveType::HARDENED);
+            out = key.pubkey;
+        }
+        return true;
+    }
+    std::string ToString() const override
+    {
+        std::string ret = KeyIO::EncodeExtPubKey(m_extkey) + FormatKeyPath(m_path);
+        if (IsRange()) {
+            ret += "/*";
+            if (m_derive == DeriveType::HARDENED) ret += '\'';
+        }
+        return ret;
+    }
+    bool ToPrivateString(const SigningProvider& arg, std::string& out) const override
+    {
+        CExtKey key;
+        if (!GetExtKey(arg, key)) return false;
+        out = KeyIO::EncodeExtKey(key) + FormatKeyPath(m_path);
+        if (IsRange()) {
+            out += "/*";
+            if (m_derive == DeriveType::HARDENED) out += '\'';
+        }
+        return true;
+    }
+};
+
+/** A parsed addr(A) descriptor. */
+class AddressDescriptor final : public Descriptor
+{
+    CTxDestination m_destination;
+
+public:
+    AddressDescriptor(CTxDestination destination) : m_destination(std::move(destination)) {}
+
+    bool IsRange() const override { return false; }
+    std::string ToString() const override { return "addr(" + EncodeDestination(m_destination) + ")"; }
+    bool ToPrivateString(const SigningProvider& arg, std::string& out) const override { out = ToString(); return true; }
+    bool Expand(int pos, const SigningProvider& arg, std::vector<CScript>& output_scripts, FlatSigningProvider& out) const override
+    {
+        output_scripts = std::vector<CScript>{GetScriptForDestination(m_destination)};
+        return true;
+    }
+};
+
+/** A parsed raw(H) descriptor. */
+class RawDescriptor final : public Descriptor
+{
+    CScript m_script;
+
+public:
+    RawDescriptor(CScript script) : m_script(std::move(script)) {}
+
+    bool IsRange() const override { return false; }
+    std::string ToString() const override { return "raw(" + HexStr(m_script) + ")"; }
+    bool ToPrivateString(const SigningProvider& arg, std::string& out) const override { out = ToString(); return true; }
+    bool Expand(int pos, const SigningProvider& arg, std::vector<CScript>& output_scripts, FlatSigningProvider& out) const override
+    {
+        output_scripts = std::vector<CScript>{m_script};
+        return true;
+    }
+};
+
+/** A parsed pk(P), pkh(P), or wpkh(P) descriptor. */
+class SingleKeyDescriptor final : public Descriptor
+{
+    const std::function<CScript(const CPubKey&)> m_script_fn;
+    const std::string m_fn_name;
+    std::unique_ptr<PubkeyProvider> m_provider;
+
+public:
+    SingleKeyDescriptor(std::unique_ptr<PubkeyProvider> prov, const std::function<CScript(const CPubKey&)>& fn, const std::string& name) : m_script_fn(fn), m_fn_name(name), m_provider(std::move(prov)) {}
+
+    bool IsRange() const override { return m_provider->IsRange(); }
+    std::string ToString() const override { return m_fn_name + "(" + m_provider->ToString() + ")"; }
+    bool ToPrivateString(const SigningProvider& arg, std::string& out) const override
+    {
+        std::string ret;
+        if (!m_provider->ToPrivateString(arg, ret)) return false;
+        out = m_fn_name + "(" + std::move(ret) + ")";
+        return true;
+    }
+    bool Expand(int pos, const SigningProvider& arg, std::vector<CScript>& output_scripts, FlatSigningProvider& out) const override
+    {
+        CPubKey key;
+        if (!m_provider->GetPubKey(pos, arg, key)) return false;
+        output_scripts = std::vector<CScript>{m_script_fn(key)};
+        out.pubkeys.emplace(key.GetID(), std::move(key));
+        return true;
+    }
+};
+
+CScript P2PKHGetScript(const CPubKey& pubkey) { return GetScriptForDestination(pubkey.GetID()); }
+CScript P2PKGetScript(const CPubKey& pubkey) { return GetScriptForRawPubKey(pubkey); }
+//CScript P2WPKHGetScript(const CPubKey& pubkey) { return GetScriptForDestination(WitnessV0KeyHash(pubkey.GetID())); } //not PIVX
+
+/** A parsed multi(...) descriptor. */
+class MultisigDescriptor : public Descriptor
+{
+    int m_threshold;
+    std::vector<std::unique_ptr<PubkeyProvider>> m_providers;
+
+public:
+    MultisigDescriptor(int threshold, std::vector<std::unique_ptr<PubkeyProvider>> providers) : m_threshold(threshold), m_providers(std::move(providers)) {}
+
+    bool IsRange() const override
+    {
+        for (const auto& p : m_providers) {
+            if (p->IsRange()) return true;
+        }
+        return false;
+    }
+
+    std::string ToString() const override
+    {
+        std::string ret = strprintf("multi(%i", m_threshold);
+        for (const auto& p : m_providers) {
+            ret += "," + p->ToString();
+        }
+        return std::move(ret) + ")";
+    }
+
+    bool ToPrivateString(const SigningProvider& arg, std::string& out) const override
+    {
+        std::string ret = strprintf("multi(%i", m_threshold);
+        for (const auto& p : m_providers) {
+            std::string sub;
+            if (!p->ToPrivateString(arg, sub)) return false;
+            ret += "," + std::move(sub);
+        }
+        out = std::move(ret) + ")";
+        return true;
+    }
+
+    bool Expand(int pos, const SigningProvider& arg, std::vector<CScript>& output_scripts, FlatSigningProvider& out) const override
+    {
+        std::vector<CPubKey> pubkeys;
+        pubkeys.reserve(m_providers.size());
+        for (const auto& p : m_providers) {
+            CPubKey key;
+            if (!p->GetPubKey(pos, arg, key)) return false;
+            pubkeys.push_back(key);
+        }
+        for (const CPubKey& key : pubkeys) {
+            out.pubkeys.emplace(key.GetID(), std::move(key));
+        }
+        output_scripts = std::vector<CScript>{GetScriptForMultisig(m_threshold, pubkeys)};
+        return true;
+    }
+};
+
+/** A parsed sh(S) or wsh(S) descriptor. */
+class ConvertorDescriptor : public Descriptor
+{
+    const std::function<CScript(const CScript&)> m_convert_fn;
+    const std::string m_fn_name;
+    std::unique_ptr<Descriptor> m_descriptor;
+
+public:
+    ConvertorDescriptor(std::unique_ptr<Descriptor> descriptor, const std::function<CScript(const CScript&)>& fn, const std::string& name) : m_convert_fn(fn), m_fn_name(name), m_descriptor(std::move(descriptor)) {}
+
+    bool IsRange() const override { return m_descriptor->IsRange(); }
+    std::string ToString() const override { return m_fn_name + "(" + m_descriptor->ToString() + ")"; }
+    bool ToPrivateString(const SigningProvider& arg, std::string& out) const override
+    {
+        std::string ret;
+        if (!m_descriptor->ToPrivateString(arg, ret)) return false;
+        out = m_fn_name + "(" + std::move(ret) + ")";
+        return true;
+    }
+    bool Expand(int pos, const SigningProvider& arg, std::vector<CScript>& output_scripts, FlatSigningProvider& out) const override
+    {
+        std::vector<CScript> sub;
+        if (!m_descriptor->Expand(pos, arg, sub, out)) return false;
+        output_scripts.clear();
+        for (const auto& script : sub) {
+            CScriptID id(script);
+            out.scripts.emplace(CScriptID(script), script);
+            output_scripts.push_back(m_convert_fn(script));
+        }
+        return true;
+    }
+};
+
+CScript ConvertP2SH(const CScript& script) { return GetScriptForDestination(CScriptID(script)); }
+//CScript ConvertP2WSH(const CScript& script) { return GetScriptForDestination(WitnessV0ScriptHash(script)); } //not PIVX
+
+/** A parsed combo(P) descriptor. */
+class ComboDescriptor final : public Descriptor
+{
+    std::unique_ptr<PubkeyProvider> m_provider;
+
+public:
+    ComboDescriptor(std::unique_ptr<PubkeyProvider> provider) : m_provider(std::move(provider)) {}
+
+    bool IsRange() const override { return m_provider->IsRange(); }
+    std::string ToString() const override { return "combo(" + m_provider->ToString() + ")"; }
+    bool ToPrivateString(const SigningProvider& arg, std::string& out) const override
+    {
+        std::string ret;
+        if (!m_provider->ToPrivateString(arg, ret)) return false;
+        out = "combo(" + std::move(ret) + ")";
+        return true;
+    }
+    bool Expand(int pos, const SigningProvider& arg, std::vector<CScript>& output_scripts, FlatSigningProvider& out) const override
+    {
+        CPubKey key;
+        if (!m_provider->GetPubKey(pos, arg, key)) return false;
+        CKeyID keyid = key.GetID();
+        {
+            CScript p2pk = GetScriptForRawPubKey(key);
+            CScript p2pkh = GetScriptForDestination(keyid);
+            output_scripts = std::vector<CScript>{std::move(p2pk), std::move(p2pkh)};
+            out.pubkeys.emplace(keyid, key);
+        }
+        if (key.IsCompressed()) {
+/*            CScript p2wpkh = GetScriptForDestination(WitnessV0KeyHash(keyid)); //not PIVX
+            CScriptID p2wpkh_id(p2wpkh);
+            CScript p2sh_p2wpkh = GetScriptForDestination(p2wpkh_id);
+            out.scripts.emplace(p2wpkh_id, p2wpkh);
+            output_scripts.push_back(std::move(p2wpkh));
+            output_scripts.push_back(std::move(p2sh_p2wpkh));*/
+        }
+        return true;
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////
+// Parser                                                                 //
+////////////////////////////////////////////////////////////////////////////
+
+enum class ParseScriptContext {
+    TOP,
+    P2SH,
+//    P2WSH, //not PIVX
+};
+
+/** Parse a constant. If succesful, sp is updated to skip the constant and return true. */
+bool Const(const std::string& str, Span<const char>& sp)
+{
+    if ((size_t)sp.size() >= str.size() && std::equal(str.begin(), str.end(), sp.begin())) {
+        sp = sp.subspan(str.size());
+        return true;
+    }
+    return false;
+}
+
+/** Parse a function call. If succesful, sp is updated to be the function's argument(s). */
+bool Func(const std::string& str, Span<const char>& sp)
+{
+    if ((size_t)sp.size() >= str.size() + 2 && sp[str.size()] == '(' && sp[sp.size() - 1] == ')' && std::equal(str.begin(), str.end(), sp.begin())) {
+        sp = sp.subspan(str.size() + 1, sp.size() - str.size() - 2);
+        return true;
+    }
+    return false;
+}
+
+/** Return the expression that sp begins with, and update sp to skip it. */
+Span<const char> Expr(Span<const char>& sp)
+{
+    int level = 0;
+    auto it = sp.begin();
+    while (it != sp.end()) {
+        if (*it == '(') {
+            ++level;
+        } else if (level && *it == ')') {
+            --level;
+        } else if (level == 0 && (*it == ')' || *it == ',')) {
+            break;
+        }
+        ++it;
+    }
+    Span<const char> ret = sp.first(it - sp.begin());
+    sp = sp.subspan(it - sp.begin());
+    return ret;
+}
+
+/** Split a string on every instance of sep, returning a vector. */
+std::vector<Span<const char>> Split(const Span<const char>& sp, char sep)
+{
+    std::vector<Span<const char>> ret;
+    auto it = sp.begin();
+    auto start = it;
+    while (it != sp.end()) {
+        if (*it == sep) {
+            ret.emplace_back(start, it);
+            start = it + 1;
+        }
+        ++it;
+    }
+    ret.emplace_back(start, it);
+    return ret;
+}
+
+/** Parse a key path, being passed a split list of elements (the first element is ignored). */
+bool ParseKeyPath(const std::vector<Span<const char>>& split, KeyPath& out)
+{
+    for (size_t i = 1; i < split.size(); ++i) {
+        Span<const char> elem = split[i];
+        bool hardened = false;
+        if (elem.size() > 0 && (elem[elem.size() - 1] == '\'' || elem[elem.size() - 1] == 'h')) {
+            elem = elem.first(elem.size() - 1);
+            hardened = true;
+        }
+        uint32_t p;
+        if (!ParseUInt32(std::string(elem.begin(), elem.end()), &p) || p > 0x7FFFFFFFUL) return false;
+        out.push_back(p | (((uint32_t)hardened) << 31));
+    }
+    return true;
+}
+
+std::unique_ptr<PubkeyProvider> ParsePubkey(const Span<const char>& sp, bool permit_uncompressed, FlatSigningProvider& out)
+{
+    auto split = Split(sp, '/');
+    std::string str(split[0].begin(), split[0].end());
+    if (split.size() == 1) {
+        if (IsHex(str)) {
+            std::vector<unsigned char> data = ParseHex(str);
+            CPubKey pubkey(data);
+            if (pubkey.IsFullyValid() && (permit_uncompressed || pubkey.IsCompressed())) return std::make_unique<ConstPubkeyProvider>(pubkey);
+        }
+        CKey key = KeyIO::DecodeSecret(str);
+        if (key.IsValid() && (permit_uncompressed || key.IsCompressed())) {
+            CPubKey pubkey = key.GetPubKey();
+            out.keys.emplace(pubkey.GetID(), key);
+            return std::make_unique<ConstPubkeyProvider>(pubkey);
+        }
+    }
+    CExtKey extkey = KeyIO::DecodeExtKey(str);
+    CExtPubKey extpubkey = KeyIO::DecodeExtPubKey(str);
+    if (!extkey.key.IsValid() && !extpubkey.pubkey.IsValid()) return nullptr;
+    KeyPath path;
+    DeriveType type = DeriveType::NO;
+    if (split.back() == MakeSpan("*").first(1)) {
+        split.pop_back();
+        type = DeriveType::UNHARDENED;
+    } else if (split.back() == MakeSpan("*'").first(2) || split.back() == MakeSpan("*h").first(2)) {
+        split.pop_back();
+        type = DeriveType::HARDENED;
+    }
+    if (!ParseKeyPath(split, path)) return nullptr;
+    if (extkey.key.IsValid()) {
+        extpubkey = extkey.Neuter();
+        out.keys.emplace(extpubkey.pubkey.GetID(), extkey.key);
+    }
+    return std::make_unique<BIP32PubkeyProvider>(extpubkey, std::move(path), type);
+}
+
+/** Parse a script in a particular context. */
+std::unique_ptr<Descriptor> ParseScript(Span<const char>& sp, ParseScriptContext ctx, FlatSigningProvider& out)
+{
+    auto expr = Expr(sp);
+    if (Func("pk", expr)) {
+        auto pubkey = ParsePubkey(expr, true/*ctx != ParseScriptContext::P2WSH//not PIVX*/, out);
+        if (!pubkey) return nullptr;
+        return std::make_unique<SingleKeyDescriptor>(std::move(pubkey), P2PKGetScript, "pk");
+    }
+    if (Func("pkh", expr)) {
+        auto pubkey = ParsePubkey(expr, true/*ctx != ParseScriptContext::P2WSH//not PIVX*/, out);
+        if (!pubkey) return nullptr;
+        return std::make_unique<SingleKeyDescriptor>(std::move(pubkey), P2PKHGetScript, "pkh");
+    }
+    if (ctx == ParseScriptContext::TOP && Func("combo", expr)) {
+        auto pubkey = ParsePubkey(expr, true, out);
+        if (!pubkey) return nullptr;
+        return std::make_unique<ComboDescriptor>(std::move(pubkey));
+    }
+    if (Func("multi", expr)) {
+        auto threshold = Expr(expr);
+        uint32_t thres;
+        std::vector<std::unique_ptr<PubkeyProvider>> providers;
+        if (!ParseUInt32(std::string(threshold.begin(), threshold.end()), &thres)) return nullptr;
+        size_t script_size = 0;
+        while (expr.size()) {
+            if (!Const(",", expr)) return nullptr;
+            auto arg = Expr(expr);
+            auto pk = ParsePubkey(arg, true/*ctx != ParseScriptContext::P2WSH//not PIVX*/, out);
+            if (!pk) return nullptr;
+            script_size += pk->GetSize() + 1;
+            providers.emplace_back(std::move(pk));
+        }
+        if (providers.size() < 1 || providers.size() > 16 || thres < 1 || thres > providers.size()) return nullptr;
+        if (ctx == ParseScriptContext::TOP) {
+            if (providers.size() > 3) return nullptr; // Not more than 3 pubkeys for raw multisig
+        }
+        if (ctx == ParseScriptContext::P2SH) {
+            if (script_size + 3 > 520) return nullptr; // Enforce P2SH script size limit
+        }
+        return std::make_unique<MultisigDescriptor>(thres, std::move(providers));
+    }
+/*    if (ctx != ParseScriptContext::P2WSH && Func("wpkh", expr)) { //not PIVX
+        auto pubkey = ParsePubkey(expr, false, out);
+        if (!pubkey) return nullptr;
+        return std::make_unique<SingleKeyDescriptor>(std::move(pubkey), P2WPKHGetScript, "wpkh");
+    }*/
+    if (ctx == ParseScriptContext::TOP && Func("sh", expr)) {
+        auto desc = ParseScript(expr, ParseScriptContext::P2SH, out);
+        if (!desc || expr.size()) return nullptr;
+        return std::make_unique<ConvertorDescriptor>(std::move(desc), ConvertP2SH, "sh");
+    }
+/*    if (ctx != ParseScriptContext::P2WSH && Func("wsh", expr)) { //not PIVX
+        auto desc = ParseScript(expr, ParseScriptContext::P2WSH, out);
+        if (!desc || expr.size()) return nullptr;
+        return std::make_unique<ConvertorDescriptor>(std::move(desc), ConvertP2WSH, "wsh");
+    }*/
+    if (ctx == ParseScriptContext::TOP && Func("addr", expr)) {
+        CTxDestination dest = DecodeDestination(std::string(expr.begin(), expr.end()));
+        if (!IsValidDestination(dest)) return nullptr;
+        return std::make_unique<AddressDescriptor>(std::move(dest));
+    }
+    if (ctx == ParseScriptContext::TOP && Func("raw", expr)) {
+        std::string str(expr.begin(), expr.end());
+        if (!IsHex(str)) return nullptr;
+        auto bytes = ParseHex(str);
+        return std::make_unique<RawDescriptor>(CScript(bytes.begin(), bytes.end()));
+    }
+    return nullptr;
+}
+
+} // namespace
+
+std::unique_ptr<Descriptor> Parse(const std::string& descriptor, FlatSigningProvider& out)
+{
+    Span<const char> sp(descriptor.data(), descriptor.size());
+    auto ret = ParseScript(sp, ParseScriptContext::TOP, out);
+    if (sp.size() == 0 && ret) return ret;
+    return nullptr;
+}

--- a/src/script/descriptor.h
+++ b/src/script/descriptor.h
@@ -1,0 +1,56 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Copyright (c) 2022 The PIVX developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SCRIPT_DESCRIPTOR_H
+#define BITCOIN_SCRIPT_DESCRIPTOR_H
+
+#include <script/script.h>
+#include <script/sign.h>
+
+#include <vector>
+
+// Descriptors are strings that describe a set of scriptPubKeys, together with
+// all information necessary to solve them. By combining all information into
+// one, they avoid the need to separately import keys and scripts.
+//
+// Descriptors may be ranged, which occurs when the public keys inside are
+// specified in the form of HD chains (xpubs).
+//
+// Descriptors always represent public information - public keys and scripts -
+// but in cases where private keys need to be conveyed along with a descriptor,
+// they can be included inside by changing public keys to private keys (WIF
+// format), and changing xpubs by xprvs.
+//
+// Reference documentation about the descriptor language can be found in
+// doc/descriptors.md.
+
+/** Interface for parsed descriptor objects. */
+struct Descriptor {
+    virtual ~Descriptor() = default;
+
+    /** Whether the expansion of this descriptor depends on the position. */
+    virtual bool IsRange() const = 0;
+
+    /** Convert the descriptor back to a string, undoing parsing. */
+    virtual std::string ToString() const = 0;
+
+    /** Convert the descriptor to a private string. This fails if the provided provider does not have the relevant private keys. */
+    virtual bool ToPrivateString(const SigningProvider& provider, std::string& out) const = 0;
+
+    /** Expand a descriptor at a specified position.
+     *
+     * pos: the position at which to expand the descriptor. If IsRange() is false, this is ignored.
+     * provider: the provider to query for private keys in case of hardened derivation.
+     * output_script: the expanded scriptPubKeys will be put here.
+     * out: scripts and public keys necessary for solving the expanded scriptPubKeys will be put here (may be equal to provider).
+     */
+    virtual bool Expand(int pos, const SigningProvider& provider, std::vector<CScript>& output_scripts, FlatSigningProvider& out) const = 0;
+};
+
+/** Parse a descriptor string. Included private keys are put in out. Returns nullptr if parsing fails. */
+std::unique_ptr<Descriptor> Parse(const std::string& descriptor, FlatSigningProvider& out);
+
+#endif // BITCOIN_SCRIPT_DESCRIPTOR_H
+

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin developers
-// Copyright (c) 2016-2019 The PIVX developers
+// Copyright (c) 2016-2022 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -378,6 +378,17 @@ bool DummySignatureCreator::CreateSig(std::vector<unsigned char>& vchSig, const 
     return true;
 }
 
+template<typename M, typename K, typename V>
+bool LookupHelper(const M& map, const K& key, V& value)
+{
+    auto it = map.find(key);
+    if (it != map.end()) {
+        value = it->second;
+        return true;
+    }
+    return false;
+}
+
 bool IsSolvable(const CKeyStore& store, const CScript& script, bool fColdStaking)
 {
     // This check is to make sure that the script we created can actually be solved for and signed by us
@@ -391,4 +402,30 @@ bool IsSolvable(const CKeyStore& store, const CScript& script, bool fColdStaking
         return true;
     }
     return false;
+}
+
+bool PublicOnlySigningProvider::GetCScript(const CScriptID &scriptid, CScript& script) const
+{
+    return m_provider->GetCScript(scriptid, script);
+}
+
+bool PublicOnlySigningProvider::GetPubKey(const CKeyID &address, CPubKey& pubkey) const
+{
+    return m_provider->GetPubKey(address, pubkey);
+}
+
+bool FlatSigningProvider::GetCScript(const CScriptID& scriptid, CScript& script) const { return LookupHelper(scripts, scriptid, script); }
+bool FlatSigningProvider::GetPubKey(const CKeyID& keyid, CPubKey& pubkey) const { return LookupHelper(pubkeys, keyid, pubkey); }
+bool FlatSigningProvider::GetKey(const CKeyID& keyid, CKey& key) const { return LookupHelper(keys, keyid, key); }
+
+FlatSigningProvider Merge(const FlatSigningProvider& a, const FlatSigningProvider& b)
+{
+    FlatSigningProvider ret;
+    ret.scripts = a.scripts;
+    ret.scripts.insert(b.scripts.begin(), b.scripts.end());
+    ret.pubkeys = a.pubkeys;
+    ret.pubkeys.insert(b.pubkeys.begin(), b.pubkeys.end());
+    ret.keys = a.keys;
+    ret.keys.insert(b.keys.begin(), b.keys.end());
+    return ret;
 }

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin developers
-// Copyright (c) 2016-2019 The PIVX developers
+// Copyright (c) 2016-2022 The PIVX developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -9,12 +9,50 @@
 
 #include "script/interpreter.h"
 
+class CKey;
 class CKeyID;
 class CKeyStore;
 class CScript;
+class CScriptID;
 class CTransaction;
 
 struct CMutableTransaction;
+
+/** An interface to be implemented by keystores that support signing. */
+class SigningProvider
+{
+public:
+    virtual ~SigningProvider() {}
+    virtual bool GetCScript(const CScriptID &scriptid, CScript& script) const { return false; }
+    virtual bool GetPubKey(const CKeyID &address, CPubKey& pubkey) const { return false; }
+    virtual bool GetKey(const CKeyID &address, CKey& key) const { return false; }
+};
+
+extern const SigningProvider& DUMMY_SIGNING_PROVIDER;
+
+class PublicOnlySigningProvider : public SigningProvider
+{
+private:
+    const SigningProvider* m_provider;
+
+public:
+    PublicOnlySigningProvider(const SigningProvider* provider) : m_provider(provider) {}
+    bool GetCScript(const CScriptID &scriptid, CScript& script) const;
+    bool GetPubKey(const CKeyID &address, CPubKey& pubkey) const;
+};
+
+struct FlatSigningProvider final : public SigningProvider
+{
+    std::map<CScriptID, CScript> scripts;
+    std::map<CKeyID, CPubKey> pubkeys;
+    std::map<CKeyID, CKey> keys;
+
+    bool GetCScript(const CScriptID& scriptid, CScript& script) const override;
+    bool GetPubKey(const CKeyID& keyid, CPubKey& pubkey) const override;
+    bool GetKey(const CKeyID& keyid, CKey& key) const override;
+};
+
+FlatSigningProvider Merge(const FlatSigningProvider& a, const FlatSigningProvider& b);
 
 /** Virtual base class for signature creators. */
 class BaseSignatureCreator {

--- a/test/functional/rpc_scantxoutset.py
+++ b/test/functional/rpc_scantxoutset.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Core developers
+# Copyright (c) 2022 The PIVX developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the scantxoutset rpc call."""
+from test_framework.test_framework import PivxTestFramework
+from test_framework.util import assert_equal
+
+from decimal import Decimal
+import shutil
+import os
+
+class ScantxoutsetTest(PivxTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        self.log.info("Mining blocks...")
+        self.nodes[0].generate(110)
+
+        addr1 = self.nodes[0].getnewaddress("")
+        pubk1 = self.nodes[0].validateaddress(addr1)['pubkey']
+        addr2 = self.nodes[0].getnewaddress("")
+        pubk2 = self.nodes[0].validateaddress(addr2)['pubkey']
+        addr3 = self.nodes[0].getnewaddress("")
+        pubk3 = self.nodes[0].validateaddress(addr3)['pubkey']
+        self.nodes[0].sendtoaddress(addr1, 0.001)
+        self.nodes[0].sendtoaddress(addr2, 0.002)
+        self.nodes[0].sendtoaddress(addr3, 0.004)
+
+        #send to child keys of DRKPuUWy7gEYo13wzMa8dntopw4ZJ7rKddnhnhi3f9tGkaDNpKSSPqMVwxqgTnZhrExKAUSZSo8uKnzcEkjFae1udSMQcvecJbLdmi9PHCETZy7V
+        self.nodes[0].sendtoaddress("y1kNaESNDkcshcLsFJ53XYsJi21N1qjTwv", 0.008) # (m/0'/0'/0')
+        self.nodes[0].sendtoaddress("xzHN1U7N3mzrksMMZ8jpMtm1Qc2BzMZhQc", 0.016) # (m/0'/0'/1')
+        self.nodes[0].sendtoaddress("yJaWjJzAEsypAV4JkLRmpjrtqQ3X8NfXiW", 0.032) # (m/0'/0'/1500')
+        self.nodes[0].sendtoaddress("y6u2zs2CfRJhu69fed1AuiR1uK6DGM3Jzo", 0.064) # (m/0'/0'/0)
+        self.nodes[0].sendtoaddress("y3vZeiqaj6q8bRUkR4F2ojrdjDnF5vcA2x", 0.128) # (m/0'/0'/1)
+        self.nodes[0].sendtoaddress("y27mmfSF2X81Ymv8td9jnovCuo985wduP4", 0.256) # (m/0'/0'/1500)
+        self.nodes[0].sendtoaddress("xzbsq3Cf4fc7QfiMt9Liy4gsLvPuvSTqNf", 0.512) # (m/1/1/0')
+        self.nodes[0].sendtoaddress("xwFDPMkJYwmFUw8SQHEGwA1S6AbtkCz2Vn", 1.024) # (m/1/1/1')
+        self.nodes[0].sendtoaddress("y5MzBDMpTRzKGSFSZcJRg43yQkHHaNqpvZ", 2.048) # (m/1/1/1500')
+        self.nodes[0].sendtoaddress("yA8NNWw22P3Rtf4rWgLj2naYbw26nu8X4k", 4.096) # (m/1/1/0)
+        self.nodes[0].sendtoaddress("yEH1WA5CK49MzU2saBMKR1YvWBVguZmATi", 8.192) # (m/1/1/1)
+        self.nodes[0].sendtoaddress("y5s2Rr6Earyz52Cq6qa2366oMHjA4ytdk3", 16.384) # (m/1/1/1500)
+
+
+        self.nodes[0].generate(1)
+
+        self.log.info("Stop node, remove wallet, mine again some blocks...")
+        self.stop_node(0)
+        shutil.rmtree(os.path.join(self.nodes[0].datadir, "regtest", 'wallets'))
+        self.start_node(0)
+        self.nodes[0].generate(110)
+
+        self.restart_node(0, ['-nowallet'])
+        self.log.info("Test if we have found the non HD unspent outputs.")
+        assert_equal(self.nodes[0].scantxoutset("start", [ "pkh(" + pubk1 + ")", "pkh(" + pubk2 + ")", "pkh(" + pubk3 + ")"])['total_amount'], Decimal("0.007"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ "combo(" + pubk1 + ")", "combo(" + pubk2 + ")", "combo(" + pubk3 + ")"])['total_amount'], Decimal("0.007"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ "addr(" + addr1 + ")", "addr(" + addr2 + ")", "addr(" + addr3 + ")"])['total_amount'], Decimal("0.007"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ "addr(" + addr1 + ")", "addr(" + addr2 + ")", "combo(" + pubk3 + ")"])['total_amount'], Decimal("0.007"))
+
+        self.log.info("Test extended key derivation.")
+        assert_equal(self.nodes[0].scantxoutset("start", [ "combo(DRKPuUWy7gEYo13wzMa8dntopw4ZJ7rKddnhnhi3f9tGkaDNpKSSPqMVwxqgTnZhrExKAUSZSo8uKnzcEkjFae1udSMQcvecJbLdmi9PHCETZy7V/0'/0h/0h)"])['total_amount'], Decimal("0.008"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ "combo(DRKPuUWy7gEYo13wzMa8dntopw4ZJ7rKddnhnhi3f9tGkaDNpKSSPqMVwxqgTnZhrExKAUSZSo8uKnzcEkjFae1udSMQcvecJbLdmi9PHCETZy7V/0'/0'/1h)"])['total_amount'], Decimal("0.016"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ "combo(DRKPuUWy7gEYo13wzMa8dntopw4ZJ7rKddnhnhi3f9tGkaDNpKSSPqMVwxqgTnZhrExKAUSZSo8uKnzcEkjFae1udSMQcvecJbLdmi9PHCETZy7V/0h/0'/1500')"])['total_amount'], Decimal("0.032"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ "combo(DRKPuUWy7gEYo13wzMa8dntopw4ZJ7rKddnhnhi3f9tGkaDNpKSSPqMVwxqgTnZhrExKAUSZSo8uKnzcEkjFae1udSMQcvecJbLdmi9PHCETZy7V/0h/0h/0)"])['total_amount'], Decimal("0.064"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ "combo(DRKPuUWy7gEYo13wzMa8dntopw4ZJ7rKddnhnhi3f9tGkaDNpKSSPqMVwxqgTnZhrExKAUSZSo8uKnzcEkjFae1udSMQcvecJbLdmi9PHCETZy7V/0'/0h/1)"])['total_amount'], Decimal("0.128"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ "combo(DRKPuUWy7gEYo13wzMa8dntopw4ZJ7rKddnhnhi3f9tGkaDNpKSSPqMVwxqgTnZhrExKAUSZSo8uKnzcEkjFae1udSMQcvecJbLdmi9PHCETZy7V/0h/0'/1500)"])['total_amount'], Decimal("0.256"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ {"desc": "combo(DRKPuUWy7gEYo13wzMa8dntopw4ZJ7rKddnhnhi3f9tGkaDNpKSSPqMVwxqgTnZhrExKAUSZSo8uKnzcEkjFae1udSMQcvecJbLdmi9PHCETZy7V/0'/0h/*h)", "range": 1499}])['total_amount'], Decimal("0.024"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ {"desc": "combo(DRKPuUWy7gEYo13wzMa8dntopw4ZJ7rKddnhnhi3f9tGkaDNpKSSPqMVwxqgTnZhrExKAUSZSo8uKnzcEkjFae1udSMQcvecJbLdmi9PHCETZy7V/0'/0'/*h)", "range": 1500}])['total_amount'], Decimal("0.056"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ {"desc": "combo(DRKPuUWy7gEYo13wzMa8dntopw4ZJ7rKddnhnhi3f9tGkaDNpKSSPqMVwxqgTnZhrExKAUSZSo8uKnzcEkjFae1udSMQcvecJbLdmi9PHCETZy7V/0h/0'/*)", "range": 1499}])['total_amount'], Decimal("0.192"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ {"desc": "combo(DRKPuUWy7gEYo13wzMa8dntopw4ZJ7rKddnhnhi3f9tGkaDNpKSSPqMVwxqgTnZhrExKAUSZSo8uKnzcEkjFae1udSMQcvecJbLdmi9PHCETZy7V/0'/0h/*)", "range": 1500}])['total_amount'], Decimal("0.448"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ "combo(DRKPuUWy7gEYo13wzMa8dntopw4ZJ7rKddnhnhi3f9tGkaDNpKSSPqMVwxqgTnZhrExKAUSZSo8uKnzcEkjFae1udSMQcvecJbLdmi9PHCETZy7V/1/1/0')"])['total_amount'], Decimal("0.512"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ "combo(DRKPuUWy7gEYo13wzMa8dntopw4ZJ7rKddnhnhi3f9tGkaDNpKSSPqMVwxqgTnZhrExKAUSZSo8uKnzcEkjFae1udSMQcvecJbLdmi9PHCETZy7V/1/1/1')"])['total_amount'], Decimal("1.024"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ "combo(DRKPuUWy7gEYo13wzMa8dntopw4ZJ7rKddnhnhi3f9tGkaDNpKSSPqMVwxqgTnZhrExKAUSZSo8uKnzcEkjFae1udSMQcvecJbLdmi9PHCETZy7V/1/1/1500h)"])['total_amount'], Decimal("2.048"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ "combo(DRKPuUWy7gEYo13wzMa8dntopw4ZJ7rKddnhnhi3f9tGkaDNpKSSPqMVwxqgTnZhrExKAUSZSo8uKnzcEkjFae1udSMQcvecJbLdmi9PHCETZy7V/1/1/0)"])['total_amount'], Decimal("4.096"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ "combo(DRKPuUWy7gEYo13wzMa8dntopw4ZJ7rKddnhnhi3f9tGkaDNpKSSPqMVwxqgTnZhrExKAUSZSo8uKnzcEkjFae1udSMQcvecJbLdmi9PHCETZy7V/1/1/1)"])['total_amount'], Decimal("8.192"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ "combo(DRKPuUWy7gEYo13wzMa8dntopw4ZJ7rKddnhnhi3f9tGkaDNpKSSPqMVwxqgTnZhrExKAUSZSo8uKnzcEkjFae1udSMQcvecJbLdmi9PHCETZy7V/1/1/1500)"])['total_amount'], Decimal("16.384"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ "combo(DRKVrRjogj3bNiLD8T7yviZvdFiEmRZcQktS3TuQ9au4Md7YzJgc7RZ4P4fkj9s5WMk5scoiNRQM2pUq7x9XGiwH7YDSFiJJJaGrCCro2yXUob2k/1/1/0)"])['total_amount'], Decimal("4.096"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ "combo(DRKVrRjogj3bNiLD8T7yviZvdFiEmRZcQktS3TuQ9au4Md7YzJgc7RZ4P4fkj9s5WMk5scoiNRQM2pUq7x9XGiwH7YDSFiJJJaGrCCro2yXUob2k/1/1/1)"])['total_amount'], Decimal("8.192"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ "combo(DRKVrRjogj3bNiLD8T7yviZvdFiEmRZcQktS3TuQ9au4Md7YzJgc7RZ4P4fkj9s5WMk5scoiNRQM2pUq7x9XGiwH7YDSFiJJJaGrCCro2yXUob2k/1/1/1500)"])['total_amount'], Decimal("16.384"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ {"desc": "combo(DRKPuUWy7gEYo13wzMa8dntopw4ZJ7rKddnhnhi3f9tGkaDNpKSSPqMVwxqgTnZhrExKAUSZSo8uKnzcEkjFae1udSMQcvecJbLdmi9PHCETZy7V/1/1/*')", "range": 1499}])['total_amount'], Decimal("1.536"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ {"desc": "combo(DRKPuUWy7gEYo13wzMa8dntopw4ZJ7rKddnhnhi3f9tGkaDNpKSSPqMVwxqgTnZhrExKAUSZSo8uKnzcEkjFae1udSMQcvecJbLdmi9PHCETZy7V/1/1/*')", "range": 1500}])['total_amount'], Decimal("3.584"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ {"desc": "combo(DRKPuUWy7gEYo13wzMa8dntopw4ZJ7rKddnhnhi3f9tGkaDNpKSSPqMVwxqgTnZhrExKAUSZSo8uKnzcEkjFae1udSMQcvecJbLdmi9PHCETZy7V/1/1/*)", "range": 1499}])['total_amount'], Decimal("12.288"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ {"desc": "combo(DRKPuUWy7gEYo13wzMa8dntopw4ZJ7rKddnhnhi3f9tGkaDNpKSSPqMVwxqgTnZhrExKAUSZSo8uKnzcEkjFae1udSMQcvecJbLdmi9PHCETZy7V/1/1/*)", "range": 1500}])['total_amount'], Decimal("28.672"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ {"desc": "combo(DRKVrRjogj3bNiLD8T7yviZvdFiEmRZcQktS3TuQ9au4Md7YzJgc7RZ4P4fkj9s5WMk5scoiNRQM2pUq7x9XGiwH7YDSFiJJJaGrCCro2yXUob2k/1/1/*)", "range": 1499}])['total_amount'], Decimal("12.288"))
+        assert_equal(self.nodes[0].scantxoutset("start", [ {"desc": "combo(DRKVrRjogj3bNiLD8T7yviZvdFiEmRZcQktS3TuQ9au4Md7YzJgc7RZ4P4fkj9s5WMk5scoiNRQM2pUq7x9XGiwH7YDSFiJJJaGrCCro2yXUob2k/1/1/*)", "range": 1500}])['total_amount'], Decimal("28.672"))
+
+if __name__ == '__main__':
+    ScantxoutsetTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -73,6 +73,7 @@ BASE_SCRIPTS= [
     'wallet_import_rescan.py',                  # ~ 204 sec
     'p2p_invalid_block.py',                     # ~ 213 sec
     'feature_reindex.py',                       # ~ 205 sec
+    'rpc_scantxoutset.py',
     'feature_logging.py',                       # ~ 195 sec
     'wallet_multiwallet.py',                    # ~ 190 sec
     'rpc_bind.py --ipv6',                       # ~ 191 sec


### PR DESCRIPTION
## Issue being fixed or feature implemented
As I didn't like the idea of backporting partial functionality of an upstream feature I looked at how `scantxoutset` and descriptors where implemented in BitCoin Core. Thanks to @tecnovert in #2778 I was able to easily locate the introduction point of `scantxoutset` and descriptors into BitCoin Core. As there were only a few files involved I tried to backport the complete functionality from [BitCoin Core v0.17.2](https://github.com/bitcoin/bitcoin/tree/v0.17.2).

## What was done
- added `script/descriptor.cpp` and `script/descriptor.h` from BitCoin Core
- removed non PIVX compatible code from `script/descriptor.cpp`
  - changed `#include <util.h>` to `#include <util/system.h>`
  - removed wpkh, wsh support
- added `scantxoutset` related code to `rpc/blockchain.cpp` and `rpc/client.cpp`
- made some minor adjustments in backported code in `rpc/blockchain.cpp`
  - changed `HexStr` call used for outputting scriptPubKey
  - removed P2WPKH references from the help description
  - changed _xpub/xprv_ to _DRKV/DRKP_ as prefix for extended keys in the help description
- added SigningProvider related code to `script/sign.cpp` and `script/sign.h`
- added the functional test `rpc_scantxoutset.py` from BitCoin Core
  - changed the addresses and keys to fit PIVX requirements
  - changed the first of the "non HD unspent outputs" tests from 0.002 to 0.007, because PIVX does not have P2SH_SEGWIT or BECH32 addresses only LEGACY addresses are used in this test
  - https://github.com/dashpay/dash/commit/4127918e86d7b905d2edceffa6913633747664e9

## How Has This Been Tested
This was tested using pivx-cli and pivx-qt, by scanning for unspent transaction output with different descriptors and with the functional test.

## Breaking Changes