### PR TITLE
[Consensus] Set v5.5 activation height for mainnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -291,7 +291,7 @@ public:
         consensus.vUpgrades[Consensus::UPGRADE_V5_0].nActivationHeight          = 2700500;
         consensus.vUpgrades[Consensus::UPGRADE_V5_2].nActivationHeight          = 2927000;
         consensus.vUpgrades[Consensus::UPGRADE_V5_3].nActivationHeight          = 3014000;
-        consensus.vUpgrades[Consensus::UPGRADE_V5_5].nActivationHeight          = 9999999;
+        consensus.vUpgrades[Consensus::UPGRADE_V5_5].nActivationHeight          = 3672000;
         consensus.vUpgrades[Consensus::UPGRADE_V6_0].nActivationHeight =
                 Consensus::NetworkUpgrade::NO_ACTIVATION_HEIGHT;
 


### PR DESCRIPTION
Mainnet activation height set to 3672000