### PR TITLE
Wallet: Fix stake split output count calculation

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3332,6 +3332,7 @@ bool CWallet::CreateCoinStake(
 
     // Kernel Search
     CAmount nCredit;
+    CAmount nMasternodePayment;
     CScript scriptPubKeyKernel;
     bool fKernelFound = false;
     int nAttempts = 0;
@@ -3374,10 +3375,11 @@ bool CWallet::CreateCoinStake(
 
         // Add block reward to the credit
         nCredit += GetBlockValue(pindexPrev->nHeight + 1);
+        nMasternodePayment = GetMasternodePayment(pindexPrev->nHeight + 1);
 
         // Create the output transaction(s)
         std::vector<CTxOut> vout;
-        if (!CreateCoinstakeOuts(stakeInput, vout, nCredit)) {
+        if (!CreateCoinstakeOuts(stakeInput, vout, nCredit - nMasternodePayment)) {
             LogPrintf("%s : failed to create output\n", __func__);
             it++;
             continue;


### PR DESCRIPTION
## Issue being fixed #1571
The UTXO value of a stake split is sometimes smaller then the stake split threshold
The help description for `setstakesplitthreshold` states:
```
This will set the stake-split threshold value.
Whenever a successful stake is found, the stake amount is split across as many outputs 
(each with a value higher than the threshold) as possible.
```
So you would not expect the value of the UTXOs to be lower then the threshold value
This happens because the number of stake split outputs is calculated including the masternode payment
An example (for testnet) with a UTXO with a value of 9992 and the stake split threshold set to 500:
```
9992 + 10 (total block reward: 4 stake reward + 6 masternode payment) = 10002
10002 / 500 = 20.004
(int) 20.004 = 20
```
However the staker only receives the stake reward (4) so the total amount after staking will be 9996 which is split across 20 UTXOs with a value of 499.8 each  
## What was done
The masternode payment is excluded from the stake split output count calculation
## How Has This Been Tested
On testnet 2 UTXOs were made (9992 each) and the stake split threshold was set to 500
The expected outcome would be a split across 19 UTXOs with a value of 526.1 each
```
9992 + 4 (stake reward) = 9996
9996 / 500 = 19.992
(int) 19.992 = 19
9996 / 19 = 526.1
```
#### Before
On stake 20 UTXOs, with a value of 499.8 each, were created
https://testnet.rockdev.org/tx/b966ff04d35ecae596f0dfde3977862268995d63939af3ab90bb172b38c37f20
#### After
On stake 19 UTXOs, with a value of 526.1 each were created
https://testnet.rockdev.org/tx/e80c79ad1ac41aa096b4613462be348e7a1a4a70755c4943087a83be8865de7a