### PR TITLE
[GA] Update depreciated actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -108,7 +108,7 @@ jobs:
           message("::set-output name=timestamp::${current_date}")
 
       - name: ccache cache files
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .ccache
           key: cmake-${{ matrix.config.name }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
@@ -193,7 +193,7 @@ jobs:
           message("::set-output name=timestamp::${current_date}")
 
       - name: depends cache files
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             depends/built
@@ -352,7 +352,7 @@ jobs:
 
       - name: depends cache files
         if: matrix.config.no_depends != 1
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             depends/built
@@ -370,7 +370,7 @@ jobs:
           message("::set-output name=timestamp::${current_date}")
 
       - name: ccache cache files
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             .ccache

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -102,10 +102,7 @@ jobs:
 
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
-        shell: cmake -P {0}
-        run: |
-          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("::set-output name=timestamp::${current_date}")
+        run: echo "timestamp=$(date +%Y-%m-%dT%H:%M:%S%z)" >> $GITHUB_OUTPUT
 
       - name: ccache cache files
         uses: actions/cache@v3
@@ -187,10 +184,7 @@ jobs:
 
       - name: Prepare Depends timestamp
         id: depends_cache_timestamp
-        shell: cmake -P {0}
-        run: |
-          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("::set-output name=timestamp::${current_date}")
+        run: echo "timestamp=$(date +%Y-%m-%dT%H:%M:%S%z)" >> $GITHUB_OUTPUT
 
       - name: depends cache files
         uses: actions/cache@v3
@@ -364,10 +358,7 @@ jobs:
 
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
-        shell: cmake -P {0}
-        run: |
-          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("::set-output name=timestamp::${current_date}")
+        run: echo "timestamp=$(date +%Y-%m-%dT%H:%M:%S%z)" >> $GITHUB_OUTPUT
 
       - name: ccache cache files
         uses: actions/cache@v3

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Initialize Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.6
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -87,7 +87,7 @@ jobs:
 
     steps:
       - name: Get Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Environment
         run: |
@@ -178,7 +178,7 @@ jobs:
 
     steps:
       - name: Get Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Environment
         run: |
@@ -336,7 +336,7 @@ jobs:
 
     steps:
       - name: Get Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Environment
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -248,6 +248,7 @@ jobs:
       matrix:
         config:
           - name: ARM 32-bit [GOAL:install]  [no unit or functional tests]
+            id: ARM32
             os: ubuntu-18.04
             host: arm-linux-gnueabihf
             apt_get: python3 g++-arm-linux-gnueabihf
@@ -259,6 +260,7 @@ jobs:
             BITCOIN_CONFIG: "--with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports --disable-online-rust CXXFLAGS=-Wno-psabi"
 
           - name: AARCH64 [GOAL:install] [no unit or functional tests]
+            id: ARM64
             os: ubuntu-18.04
             host: aarch64-linux-gnu
             apt_get: python3 g++-aarch64-linux-gnu
@@ -268,6 +270,7 @@ jobs:
             BITCOIN_CONFIG: "--with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports --disable-online-rust"
 
           - name: Win64  [GOAL:deploy] [no unit or functional tests]
+            id: Win64
             os: ubuntu-18.04
             host: x86_64-w64-mingw32
             apt_get: python3 nsis g++-mingw-w64-x86-64 wine-binfmt wine64
@@ -277,6 +280,7 @@ jobs:
             BITCOIN_CONFIG: "--with-gui=auto --enable-reduce-exports --disable-online-rust"
 
           - name: x86_64 Linux  [GOAL:install]  [bionic]
+            id: Linux-x86_64
             os: ubuntu-18.04
             host: x86_64-unknown-linux-gnu
             apt_get: python3-zmq qtbase5-dev qttools5-dev-tools libqt5svg5-dev libqt5charts5-dev libqrencode-dev libdbus-1-dev libharfbuzz-dev
@@ -287,6 +291,7 @@ jobs:
             BITCOIN_CONFIG: "--enable-zmq --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports --disable-online-rust"
 
           - name: x86_64 Linux  [GOAL:install]  [bionic] [no GUI no unit tests - only functional tests on legacy pre-HD wallets]
+            id: Linux-x86_64-nogui
             os: ubuntu-18.04
             host: x86_64-unknown-linux-gnu
             apt_get: python3-zmq
@@ -297,6 +302,7 @@ jobs:
             BITCOIN_CONFIG: "--enable-zmq --with-gui=no --enable-glibc-back-compat --enable-reduce-exports --disable-online-rust"
 
           - name: x86_64 Linux  [GOAL:install]  [bionic]  [no depends only system libs]
+            id: Linux-x86_64-nodepends
             os: ubuntu-18.04
             host: x86_64-unknown-linux-gnu
             apt_get: python3-zmq qtbase5-dev qttools5-dev-tools libqt5svg5-dev libqt5charts5-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev libqrencode-dev libgmp-dev libsodium-dev cargo
@@ -306,6 +312,7 @@ jobs:
             BITCOIN_CONFIG: "--enable-zmq --with-incompatible-bdb --with-gui=qt5 CPPFLAGS='-DARENA_DEBUG -DDEBUG_LOCKORDER'"
 
           - name: macOS 10.12  [GOAL:deploy] [no functional tests]
+            id: macOS10.12
             os: ubuntu-18.04
             host: x86_64-apple-darwin16
             apt_get: cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python3-dev python3-setuptools
@@ -317,6 +324,7 @@ jobs:
             BITCOIN_CONFIG: "--enable-gui --enable-reduce-exports --enable-werror --disable-online-rust"
 
           - name: macOS 11 [GOAL:deploy] [native macOS using syslibs]
+            id: macOS11
             os: macos-11
             host: x86_64-apple-darwin20.6.0
             brew_install: autoconf automake ccache berkeley-db4 libtool boost miniupnpc pkg-config python@3.8 qt5 zmq libevent qrencode gmp libsodium rust librsvg
@@ -366,9 +374,9 @@ jobs:
           path: |
             .ccache
             .pivx-params
-          key: ${{ matrix.config.name }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          key: ${{ matrix.config.id }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
           restore-keys: |
-            ${{ matrix.config.name }}-ccache-
+            ${{ matrix.config.id }}-ccache-
 
       - name: Build Wallet
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ if(CCACHE_PROGRAM)
     message(STATUS "Found ccache: ${CCACHE_PROGRAM}")
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
     # Set up wrapper scripts
-    set(C_LAUNCHER   "${CCACHE_PROGRAM}")
-    set(CXX_LAUNCHER "${CCACHE_PROGRAM}")
+    set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
 endif()
 
 # Search for the cargo and rustc compilers required to build libzcashrust


### PR DESCRIPTION
Node 12 actions have been depreciated. Update actions to use Node 16 based versions.
Ref: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

`save-state` and `set-output` have been depreciated. Update GA workflow to no longer use these functions.
Ref: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Use shorter ccache cache identifiers

Use explicit CMAKE language launcher variable names

