### PR TITLE
[Doc] Don't include dependency paths in Doxygen or Coverage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -193,7 +193,18 @@ $(BITCOIN_CLI_BIN): FORCE
 	$(MAKE) -C src $(@F)
 
 if USE_LCOV
-LCOV_FILTER_PATTERN=-p "/usr/include/" -p "/usr/lib/" -p "src/leveldb/" -p "src/crc32c/" -p "src/univalue" -p "src/secp256k1"
+LCOV_FILTER_PATTERN= \
+        -p "/usr/local/" \
+        -p "/usr/include/" \
+        -p "/usr/lib/" \
+        -p "/usr/lib64" \
+        -p "src/leveldb/" \
+        -p "src/bench/" \
+        -p "src/crc32c/" \
+        -p "src/crypto/ctaes/" \
+        -p "src/univalue" \
+        -p "src/secp256k1" \
+        -p "depends"
 
 baseline.info:
 	$(LCOV) -c -i -d $(abs_builddir)/src -o $@

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -861,11 +861,11 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = src/crc32c \
+EXCLUDE                = src/chiabls \
+                         src/crc32c \
+                         src/immer \
                          src/leveldb \
-                         src/json \
-                         src/test \
-                         src/qt/test
+                         src/json
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded


### PR DESCRIPTION
In-tree dependency libraries don't need to be included in Doxygen or Coverage reports, as doing so only adds extra "fluff" with no real purpose.