### PR TITLE
[Consensus] Set v5.5.0 superblock checkpoint block hash.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -181,6 +181,7 @@ static MapCheckpoints mapCheckpoints = {
     {2678402, uint256S("580a26ff0a45177a7a6f387f009c5b26140ea48b4790a857d9a796f8b3c25899")}, //!< Network split here
     {3014000, uint256S("78ad99b7225f73c42238bd7ca841ff700542b92bba75a0ef2ed351caa560f87f")}, //!< PIVX v5.3.0 enforced
     {3024000, uint256S("be4bc75afcfb9136924810f7483b2695089a366cc4ee27fd6dc3ecd5396e1f0f")}, //!< Superblock
+    {3715200, uint256S("a676b9a598c393c82b949c37dd35013aeda55f5d18ab062349db6a8235972aaa")}, //!< Superblock for 5.5.0 mainnet rewards changeover
 };
 
 static const CCheckpointData data = {


### PR DESCRIPTION
Hard codes the correct block hash for the mainnet v5.5.0 superblock.

A network fork occurred at this block. The forked chain expected **NO** proposal payouts whatsoever, when there was clearly MN consensus for proposal payouts. It was clear that the forked chain that didn't want any proposal payouts was "in the wrong" here, so this PR hard codes the proper block hash of the first superblock of this particular round, which **does** include the expected proposal payouts.