### PR TITLE
Decrease chain indexes RAM usage using Optional values

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -192,11 +192,11 @@ public:
     //! block header
     int32_t nVersion{0};
     uint256 hashMerkleRoot{};
-    uint256 hashFinalSaplingRoot{};
+    Optional<uint256> hashFinalSaplingRoot{};
     uint32_t nTime{0};
     uint32_t nBits{0};
     uint32_t nNonce{0};
-    uint256 nAccumulatorCheckpoint{};
+    Optional<uint256> nAccumulatorCheckpoint{};
 
     //! (memory only) Sequential id assigned to distinguish order in which blocks are received.
     uint32_t nSequenceId{0};
@@ -297,12 +297,25 @@ public:
             READWRITE(obj.nTime);
             READWRITE(obj.nBits);
             READWRITE(obj.nNonce);
-            if(obj.nVersion > 3 && obj.nVersion < 7)
-                READWRITE(obj.nAccumulatorCheckpoint);
+            if(this->nVersion > 3 && this->nVersion < 7) {
+                if (ser_action.ForRead()) {
+                    uint256 _nAccumulatorCheckpoint;
+                    READWRITE(_nAccumulatorCheckpoint);
+                    nAccumulatorCheckpoint = _nAccumulatorCheckpoint;
+                } else {
+                    READWRITE(*nAccumulatorCheckpoint);
+                }
+            }
 
             // Sapling blocks
             if (obj.nVersion >= 8) {
-                READWRITE(obj.hashFinalSaplingRoot);
+                if (ser_action.ForRead()) {
+                    uint256 _hashFinalSaplingRoot;
+                    READWRITE(_hashFinalSaplingRoot);
+                    hashFinalSaplingRoot = _hashFinalSaplingRoot;
+                } else {
+                    READWRITE(*hashFinalSaplingRoot);
+                }
                 READWRITE(obj.nSaplingValue);
             }
         } else if (nSerVersion > DBI_OLD_SER_VERSION && ser_action.ForRead()) {
@@ -320,7 +333,11 @@ public:
             READWRITE(obj.nNonce);
             if (obj.nVersion > 3) {
                 READWRITE(mapZerocoinSupply);
-                if (obj.nVersion < 7) READWRITE(obj.nAccumulatorCheckpoint);
+                if(this->nVersion < 7) {
+                    uint256 _nAccumulatorCheckpoint;
+                    READWRITE(_nAccumulatorCheckpoint);
+                    nAccumulatorCheckpoint = _nAccumulatorCheckpoint;
+                }
             }
         } else if (ser_action.ForRead()) {
             // Serialization with CLIENT_VERSION = 4009900-
@@ -355,7 +372,9 @@ public:
             if (obj.nVersion > 3) {
                 std::map<libzerocoin::CoinDenomination, int64_t> mapZerocoinSupply;
                 std::vector<libzerocoin::CoinDenomination> vMintDenominationsInBlock;
-                READWRITE(obj.nAccumulatorCheckpoint);
+                uint256 _nAccumulatorCheckpoint;
+                READWRITE(_nAccumulatorCheckpoint);
+                nAccumulatorCheckpoint = _nAccumulatorCheckpoint;
                 READWRITE(mapZerocoinSupply);
                 READWRITE(vMintDenominationsInBlock);
             }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -269,8 +269,6 @@ public:
                 "31438167899885040445364023527381951378636564391212010397122822120720357";
         consensus.ZC_MaxPublicSpendsPerTx = 637;    // Assume about 220 bytes each input
         consensus.ZC_MaxSpendsPerTx = 7;            // Assume about 20kb each input
-        consensus.ZC_MinMintConfirmations = 20;
-        consensus.ZC_MinMintFee = 1 * CENT;
         consensus.ZC_MinStakeDepth = 200;
         consensus.ZC_TimeStart = 1508214600;        // October 17, 2017 4:30:00 AM
         consensus.ZC_HeightStart = 863735;
@@ -426,8 +424,6 @@ public:
                 "31438167899885040445364023527381951378636564391212010397122822120720357";
         consensus.ZC_MaxPublicSpendsPerTx = 637;    // Assume about 220 bytes each input
         consensus.ZC_MaxSpendsPerTx = 7;            // Assume about 20kb each input
-        consensus.ZC_MinMintConfirmations = 20;
-        consensus.ZC_MinMintFee = 1 * CENT;
         consensus.ZC_MinStakeDepth = 200;
         consensus.ZC_TimeStart = 1508214600;        // October 17, 2017 4:30:00 AM
 
@@ -571,8 +567,6 @@ public:
                 "31438167899885040445364023527381951378636564391212010397122822120720357";
         consensus.ZC_MaxPublicSpendsPerTx = 637;    // Assume about 220 bytes each input
         consensus.ZC_MaxSpendsPerTx = 7;            // Assume about 20kb each input
-        consensus.ZC_MinMintConfirmations = 10;
-        consensus.ZC_MinMintFee = 1 * CENT;
         consensus.ZC_MinStakeDepth = 10;
         consensus.ZC_TimeStart = 0;                 // not implemented on regtest
         consensus.ZC_HeightStart = 0;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -250,8 +250,6 @@ struct Params {
     std::string ZC_Modulus;  // parsed in Zerocoin_Params (either as hex or dec string)
     int ZC_MaxPublicSpendsPerTx;
     int ZC_MaxSpendsPerTx;
-    int ZC_MinMintConfirmations;
-    CAmount ZC_MinMintFee;
     int ZC_MinStakeDepth;
     int ZC_TimeStart;
     int ZC_HeightStart;

--- a/src/legacy/stakemodifier.cpp
+++ b/src/legacy/stakemodifier.cpp
@@ -117,7 +117,7 @@ bool GetOldStakeModifier(CStakeInput* stake, uint64_t& nStakeModifier)
         const int nHeightStop = std::min(chainActive.Height(), Params().GetConsensus().height_last_ZC_AccumCheckpoint-1);
         while (pindexFrom && pindexFrom->nHeight + 1 <= nHeightStop) {
             if (pindexFrom->GetBlockTime() - nTimeBlockFrom > 60 * 60) {
-                nStakeModifier = pindexFrom->nAccumulatorCheckpoint.GetCheapHash();
+                nStakeModifier = pindexFrom->nAccumulatorCheckpoint->GetCheapHash();
                 return true;
             }
             pindexFrom = chainActive.Next(pindexFrom);

--- a/src/legacy/validation_zerocoin_legacy.cpp
+++ b/src/legacy/validation_zerocoin_legacy.cpp
@@ -54,8 +54,8 @@ void CacheAccChecksum(const CBlockIndex* pindex, bool fWrite)
         pindex->nAccumulatorCheckpoint == pindex->pprev->nAccumulatorCheckpoint)
         return;
 
-    arith_uint256 accCurr = UintToArith256(pindex->nAccumulatorCheckpoint);
-    arith_uint256 accPrev = UintToArith256(pindex->pprev->nAccumulatorCheckpoint);
+    arith_uint256 accCurr = UintToArith256(*pindex->nAccumulatorCheckpoint);
+    arith_uint256 accPrev = UintToArith256(*pindex->pprev->nAccumulatorCheckpoint);
     // add/remove changed checksums to/from cache
     for (int i = (int)libzerocoin::zerocoinDenomList.size()-1; i >= 0; i--) {
         const uint32_t nChecksum = accCurr.Get32();

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -41,7 +41,7 @@ std::string CBlock::ToString() const
         hashPrevBlock.ToString(),
         hashMerkleRoot.ToString(),
         nTime, nBits, nNonce,
-        hashFinalSaplingRoot.ToString(),
+        hashFinalSaplingRoot->ToString(),
         vtx.size());
     for (unsigned int i = 0; i < vtx.size(); i++)
     {

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -30,8 +30,8 @@ public:
     uint32_t nTime;
     uint32_t nBits;
     uint32_t nNonce;
-    uint256 nAccumulatorCheckpoint;             // only for version 4, 5 and 6.
-    uint256 hashFinalSaplingRoot;               // only for version 8+
+    Optional<uint256> nAccumulatorCheckpoint;             // only for version 4, 5 and 6.
+    Optional<uint256> hashFinalSaplingRoot;               // only for version 8+
 
     CBlockHeader()
     {
@@ -42,12 +42,26 @@ public:
         READWRITE(obj.nVersion, obj.hashPrevBlock, obj.hashMerkleRoot, obj.nTime, obj.nBits, obj.nNonce);
 
         //zerocoin active, header changes to include accumulator checksum
-        if(obj.nVersion > 3 && obj.nVersion < 7)
-            READWRITE(obj.nAccumulatorCheckpoint);
+        if(nVersion > 3 && nVersion < 7) {
+            if (ser_action.ForRead()) {
+                uint256 _nAccumulatorCheckpoint;
+                READWRITE(_nAccumulatorCheckpoint);
+                nAccumulatorCheckpoint = _nAccumulatorCheckpoint;
+            } else {
+                READWRITE(*nAccumulatorCheckpoint);
+            }
+        }
 
         // Sapling active
-        if (obj.nVersion >= 8)
-            READWRITE(obj.hashFinalSaplingRoot);
+        if (nVersion >= 8) {
+            if (ser_action.ForRead()) {
+                uint256 _hashFinalSaplingRoot;
+                READWRITE(_hashFinalSaplingRoot);
+                hashFinalSaplingRoot = _hashFinalSaplingRoot;
+            } else {
+                READWRITE(*hashFinalSaplingRoot);
+            }
+        }
     }
 
     void SetNull()
@@ -58,8 +72,8 @@ public:
         nTime = 0;
         nBits = 0;
         nNonce = 0;
-        nAccumulatorCheckpoint.SetNull();
-        hashFinalSaplingRoot.SetNull();
+        nAccumulatorCheckpoint.reset();
+        hashFinalSaplingRoot.reset();
     }
 
     bool IsNull() const

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -126,7 +126,7 @@ UniValue blockheaderToJSON(const CBlockIndex* tip, const CBlockIndex* blockindex
     result.pushKV("bits", strprintf("%08x", blockindex->nBits));
     result.pushKV("difficulty", GetDifficulty(blockindex));
     result.pushKV("chainwork", blockindex->nChainWork.GetHex());
-    result.pushKV("acc_checkpoint", blockindex->nAccumulatorCheckpoint.GetHex());
+    result.pushKV("acc_checkpoint", blockindex->nAccumulatorCheckpoint->GetHex());
     // Sapling shield pool value
     result.pushKV("shield_pool_value", ValuePoolDesc(blockindex->nChainSaplingValue, blockindex->nSaplingValue));
     if (blockindex->pprev)
@@ -147,8 +147,8 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIn
     result.pushKV("height", blockindex->nHeight);
     result.pushKV("version", block.nVersion);
     result.pushKV("merkleroot", block.hashMerkleRoot.GetHex());
-    result.pushKV("acc_checkpoint", block.nAccumulatorCheckpoint.GetHex());
-    result.pushKV("finalsaplingroot", block.hashFinalSaplingRoot.GetHex());
+    result.pushKV("acc_checkpoint", block.nAccumulatorCheckpoint->GetHex());
+    result.pushKV("finalsaplingroot", block.hashFinalSaplingRoot->GetHex());
     UniValue txs(UniValue::VARR);
     for (const auto& txIn : block.vtx) {
         const CTransaction& tx = *txIn;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1364,7 +1364,7 @@ DisconnectResult DisconnectBlock(CBlock& block, const CBlockIndex* pindex, CCoin
     // the Sapling activation height. Otherwise, the last anchor was the
     // empty root.
     if (consensus.NetworkUpgradeActive(pindex->pprev->nHeight, Consensus::UPGRADE_V5_0)) {
-        view.PopAnchor(pindex->pprev->hashFinalSaplingRoot);
+        view.PopAnchor(*pindex->pprev->hashFinalSaplingRoot);
     } else {
         view.PopAnchor(SaplingMerkleTree::empty_root());
     }
@@ -1603,7 +1603,7 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
     if (isV5UpgradeEnforced) {
         // If Sapling is active, block.hashFinalSaplingRoot must be the
         // same as the root of the Sapling tree
-        if (block.hashFinalSaplingRoot != sapling_tree.root()) {
+        if (*block.hashFinalSaplingRoot != sapling_tree.root()) {
             return state.DoS(100,
                              error("ConnectBlock(): block's hashFinalSaplingRoot is incorrect (should be Sapling tree root)"),
                              REJECT_INVALID, "bad-sapling-root-in-block");

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1327,7 +1327,7 @@ void CWallet::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const 
                                Params().GetConsensus().NetworkUpgradeActive(pprev->nHeight,
                                                                             Consensus::UPGRADE_V5_0);
         if (isSaplingActive) {
-            assert(pcoinsTip->GetSaplingAnchorAt(pprev->hashFinalSaplingRoot, oldSaplingTree));
+            assert(pcoinsTip->GetSaplingAnchorAt(*pprev->hashFinalSaplingRoot, oldSaplingTree));
         } else {
             assert(pcoinsTip->GetSaplingAnchorAt(SaplingMerkleTree::empty_root(), oldSaplingTree));
         }
@@ -1925,7 +1925,7 @@ CBlockIndex* CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, CBlock
                 if (pindex->pprev) {
                     if (Params().GetConsensus().NetworkUpgradeActive(pindex->pprev->nHeight, Consensus::UPGRADE_V5_0)) {
                         SaplingMerkleTree saplingTree;
-                        assert(pcoinsTip->GetSaplingAnchorAt(pindex->pprev->hashFinalSaplingRoot, saplingTree));
+                        assert(pcoinsTip->GetSaplingAnchorAt(*pindex->pprev->hashFinalSaplingRoot, saplingTree));
                         // Increment note witness caches
                         ChainTipAdded(pindex, &block, saplingTree);
                     }

--- a/src/zpiv/zpos.cpp
+++ b/src/zpiv/zpos.cpp
@@ -42,7 +42,7 @@ static const CBlockIndex* FindIndexFrom(uint32_t nChecksum, libzerocoin::CoinDen
 
     CBlockIndex* pindex = chainActive[(cpHeight/10)*10 - 10];
     if (!pindex) return nullptr;
-    while (ParseAccChecksum(pindex->nAccumulatorCheckpoint, denom) == nChecksum && pindex->nHeight > zc_activation) {
+    while (ParseAccChecksum(*pindex->nAccumulatorCheckpoint, denom) == nChecksum && pindex->nHeight > zc_activation) {
         //Skip backwards in groups of 10 blocks since checkpoints only change every 10 blocks
         pindex = chainActive[pindex->nHeight - 10];
     }
@@ -85,7 +85,7 @@ CLegacyZPivStake* CLegacyZPivStake::NewZPivStake(const CTxIn& txin, int nHeight)
 
     // The checkpoint needs to be from 200 blocks ago
     const int cpHeight = nHeight - 1 - consensus.ZC_MinStakeDepth;
-    if (ParseAccChecksum(chainActive[cpHeight]->nAccumulatorCheckpoint, _denom) != _nChecksum) {
+    if (ParseAccChecksum(*chainActive[cpHeight]->nAccumulatorCheckpoint, _denom) != _nChecksum) {
         LogPrint(BCLog::LEGACYZC, "%s : accum. checksum at height %d is wrong.", __func__, nHeight);
     }
 


### PR DESCRIPTION
Redoing of #2315

Some users have noticed with 5.5 theres a need for some optimization, while hunting it down also figured to bring back this to assist in daemon optimization

Explanation from prior PR: 

This PR migrates two uint256 fields, that aren't needed to be initialized for every block index that ever existed, to optional values. Only initializing them in the lapse of time where the data is/was available.

1. The zc accumulator checkpoint: added to the header in the block version 3 and was active up to block version 7.
2. The sapling tree root hash: added to the header in block version 8.