### PR TITLE
ipv6 and tor support for DMNs

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -40,7 +40,7 @@ static bool GetLocalAddress(CService& addrRet)
     if (!fFound) {
         // If we have some peers, let's try to find our local address from one of them
         g_connman->ForEachNodeContinueIf([&fFound, &addrRet](CNode* pnode) {
-            if (pnode->addr.IsIPv4() || pnode->addr.IsIPv6())
+            if (pnode->addr.IsIPv4() || pnode->addr.IsIPv6() || pnode->addr.IsTor())
                 fFound = GetLocal(addrRet, &pnode->addr) && CActiveDeterministicMasternodeManager::IsValidNetAddr(addrRet);
             return !fFound;
         });

--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -40,7 +40,7 @@ static bool GetLocalAddress(CService& addrRet)
     if (!fFound) {
         // If we have some peers, let's try to find our local address from one of them
         g_connman->ForEachNodeContinueIf([&fFound, &addrRet](CNode* pnode) {
-            if (pnode->addr.IsIPv4())
+            if (pnode->addr.IsIPv4() || pnode->addr.IsIPv6())
                 fFound = GetLocal(addrRet, &pnode->addr) && CActiveDeterministicMasternodeManager::IsValidNetAddr(addrRet);
             return !fFound;
         });

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -10,6 +10,7 @@
 #include "libzerocoin/Params.h"
 #include "optional.h"
 #include "uint256.h"
+#include <cstdint>
 #include <map>
 #include <string>
 
@@ -83,6 +84,16 @@ struct NetworkUpgrade {
      * work of this block, otherwise this detection will have false positives.
      */
     Optional<uint256> hashActivationBlock;
+};
+
+
+enum LLMQIpType : uint8_t
+{
+    LLMQ_UNKNOWN =0,
+    LLMQ_IPV4 = 1,
+    LLMQ_IPV6 = 2,
+    LLMQ_TOR = 3,
+    
 };
 
 enum LLMQType : uint8_t

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -86,14 +86,12 @@ struct NetworkUpgrade {
     Optional<uint256> hashActivationBlock;
 };
 
-
-enum LLMQIpType : uint8_t
-{
-    LLMQ_UNKNOWN =0,
+enum LLMQIpType : uint8_t {
+    LLMQ_UNKNOWN = 0,
     LLMQ_IPV4 = 1,
     LLMQ_IPV6 = 2,
     LLMQ_TOR = 3,
-    
+
 };
 
 enum LLMQType : uint8_t

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -1015,7 +1015,7 @@ std::vector<CDeterministicMNCPtr> CDeterministicMNManager::GetAllQuorumMembers(C
 }
 Consensus::LLMQIpType CDeterministicMNManager::GetQuorumIpType(Consensus::LLMQParams params, const CBlockIndex* pindexQuorum)
 {
-    uint8_t id = pindexQuorum->nHeight % (3 * params.dkgInterval) + 1;
+    uint8_t id = ((pindexQuorum->nHeight % (3 * params.dkgInterval))/params.dkgInterval) + 1;
     if (id > Consensus::LLMQIpType::LLMQ_TOR || id < Consensus::LLMQIpType::LLMQ_IPV4) {
         // Should never happen but in this case we just output ipv4
         LogPrint(BCLog::DKG, "CDeterministicMNManager::%s -- ip type unkown, nHeight: %d, dkgInterval: %d", __func__, pindexQuorum->nHeight, params.dkgInterval);

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -8,6 +8,7 @@
 
 #include "arith_uint256.h"
 #include "bls/bls_wrapper.h"
+#include "consensus/params.h"
 #include "dbwrapper.h"
 #include "evo/evodb.h"
 #include "evo/providertx.h"
@@ -203,6 +204,7 @@ public:
     COutPoint collateralOutpoint;
     uint16_t nOperatorReward;
     CDeterministicMNStateCPtr pdmnState;
+    Consensus::LLMQIpType GetIpType() const;
 
 public:
     SERIALIZE_METHODS(CDeterministicMN, obj)
@@ -383,7 +385,7 @@ public:
      * @param modifier
      * @return
      */
-    std::vector<CDeterministicMNCPtr> CalculateQuorum(size_t maxSize, const uint256& modifier) const;
+    std::vector<CDeterministicMNCPtr> CalculateQuorum(size_t maxSize, const uint256& modifier, Consensus::LLMQIpType quorumIpType) const;
     std::vector<std::pair<arith_uint256, CDeterministicMNCPtr>> CalculateScores(const uint256& modifier) const;
 
     /**
@@ -591,6 +593,8 @@ public:
 
     // Get the list of members for a given quorum type and index
     std::vector<CDeterministicMNCPtr> GetAllQuorumMembers(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum);
+
+    Consensus::LLMQIpType GetQuorumIpType(Consensus::LLMQParams params, const CBlockIndex* pindexQuorum);
 
 private:
     void CleanupCache(int nHeight);

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -433,12 +433,12 @@ public:
     template <typename T>
     bool HasUniqueProperty(const T& v) const
     {
-        return mnUniquePropertyMap.count(::SerializeHash(v)) != 0;
+        return mnUniquePropertyMap.count(::SerializeHash(v,SER_GETHASH, PROTOCOL_VERSION | ADDRV2_FORMAT)) != 0;
     }
     template <typename T>
     CDeterministicMNCPtr GetUniquePropertyMN(const T& v) const
     {
-        auto p = mnUniquePropertyMap.find(::SerializeHash(v));
+        auto p = mnUniquePropertyMap.find(::SerializeHash(v,SER_GETHASH, PROTOCOL_VERSION | ADDRV2_FORMAT));
         if (!p) {
             return nullptr;
         }
@@ -452,7 +452,7 @@ private:
         static const T nullValue;
         assert(v != nullValue);
 
-        auto hash = ::SerializeHash(v);
+        auto hash = ::SerializeHash(v,SER_GETHASH, PROTOCOL_VERSION | ADDRV2_FORMAT);
         auto oldEntry = mnUniquePropertyMap.find(hash);
         assert(!oldEntry || oldEntry->first == dmn->proTxHash);
         std::pair<uint256, uint32_t> newEntry(dmn->proTxHash, 1);
@@ -467,7 +467,7 @@ private:
         static const T nullValue;
         assert(oldValue != nullValue);
 
-        auto oldHash = ::SerializeHash(oldValue);
+        auto oldHash = ::SerializeHash(oldValue,SER_GETHASH, PROTOCOL_VERSION | ADDRV2_FORMAT);
         auto p = mnUniquePropertyMap.find(oldHash);
         assert(p && p->first == dmn->proTxHash);
         if (p->second == 1) {

--- a/src/evo/specialtx_validation.cpp
+++ b/src/evo/specialtx_validation.cpp
@@ -40,8 +40,8 @@ static bool CheckService(const CService& addr, CValidationState& state)
         return state.DoS(10, false, REJECT_INVALID, "bad-protx-ipaddr-port");
     }
 
-    // !TODO: add support for Tor
-    if (!(addr.IsIPv4() || addr.IsIPv6())) {
+
+    if (!(addr.IsIPv4() || addr.IsIPv6() || addr.IsTor())) {
         return state.DoS(10, false, REJECT_INVALID, "bad-protx-ipaddr");
     }
 

--- a/src/evo/specialtx_validation.cpp
+++ b/src/evo/specialtx_validation.cpp
@@ -40,8 +40,8 @@ static bool CheckService(const CService& addr, CValidationState& state)
         return state.DoS(10, false, REJECT_INVALID, "bad-protx-ipaddr-port");
     }
 
-    // !TODO: add support for IPv6 and Tor
-    if (!addr.IsIPv4()) {
+    // !TODO: add support for Tor
+    if (!(addr.IsIPv4() || addr.IsIPv6())) {
         return state.DoS(10, false, REJECT_INVALID, "bad-protx-ipaddr");
     }
 

--- a/src/llmq/quorums_dkgsessionhandler.cpp
+++ b/src/llmq/quorums_dkgsessionhandler.cpp
@@ -7,9 +7,11 @@
 
 #include "activemasternode.h"
 #include "chainparams.h"
+#include "evo/deterministicmns.h"
 #include "llmq/quorums_blockprocessor.h"
 #include "llmq/quorums_connections.h"
 #include "llmq/quorums_debug.h"
+#include "logging.h"
 #include "net_processing.h"
 #include "shutdown.h"
 #include "util/threadnames.h"
@@ -170,7 +172,7 @@ bool CDKGSessionHandler::InitNewQuorum(const CBlockIndex* pindexQuorum)
     }
 
     auto mns = deterministicMNManager->GetAllQuorumMembers(params.type, pindexQuorum);
-
+    LogPrintf("CDKGSessionHandler::%s -- trying to initialize quorum of type: %d", __func__, deterministicMNManager->GetQuorumIpType(params, pindexQuorum));
     if (!curSession->Init(pindexQuorum, mns, activeMasternodeManager->GetProTx())) {
         LogPrintf("CDKGSessionHandler::%s -- quorum initialiation failed for %s\n", __func__, curSession->params.name);
         return false;

--- a/src/llmq/quorums_dkgsessionhandler.h
+++ b/src/llmq/quorums_dkgsessionhandler.h
@@ -13,6 +13,7 @@
 namespace llmq
 {
 
+
 enum QuorumPhase {
     QuorumPhase_None = -1,
     QuorumPhase_Initialized = 1,

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -9,6 +9,7 @@
 
 #include "amount.h"
 #include "memusage.h"
+#include "netaddress.h"
 #include "script/script.h"
 #include "serialize.h"
 #include "optional.h"
@@ -461,7 +462,7 @@ static inline CTransactionRef MakeTransactionRef(CTransactionRef&& txIn) { retur
 template <typename T>
 inline bool GetTxPayload(const std::vector<unsigned char>& payload, T& obj)
 {
-    CDataStream ds(payload, SER_NETWORK, PROTOCOL_VERSION);
+    CDataStream ds(payload, SER_NETWORK, PROTOCOL_VERSION | ADDRV2_FORMAT);
     try {
         ds >> obj;
     } catch (std::exception& e) {
@@ -483,7 +484,7 @@ inline bool GetTxPayload(const CTransaction& tx, T& obj)
 template <typename T>
 void SetTxPayload(CMutableTransaction& tx, const T& payload)
 {
-    CDataStream ds(SER_NETWORK, PROTOCOL_VERSION);
+    CDataStream ds(SER_NETWORK, PROTOCOL_VERSION | ADDRV2_FORMAT);
     ds << payload;
     tx.extraPayload.emplace(ds.begin(), ds.end());
 }

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -10,7 +10,13 @@ export LC_ALL=C
 
 EXPECTED_CIRCULAR_DEPENDENCIES=(
     "activemasternode -> masternodeman -> activemasternode"
+    "activemasternode -> evo/deterministicmns -> llmq/quorums_dkgsessionhandler -> activemasternode"
+    "activemasternode -> evo/deterministicmns -> llmq/quorums_dkgsessionhandler -> net_processing -> evo/mnauth -> activemasternode"
+    "activemasternode -> evo/deterministicmns -> llmq/quorums_dkgsessionhandler -> net_processing -> masternode-sync -> activemasternode"
     "budget/budgetmanager -> validation -> budget/budgetmanager"
+    "budget/budgetmanager -> evo/deterministicmns -> llmq/quorums_dkgsessionhandler -> net_processing -> budget/budgetmanager"
+    "budget/budgetmanager -> evo/deterministicmns -> llmq/quorums_dkgsessionhandler -> net_processing -> masternode-payments -> budget/budgetmanager"
+    "budget/budgetmanager -> evo/deterministicmns -> llmq/quorums_dkgsessionhandler -> net_processing -> masternode-sync -> budget/budgetmanager"
     "chain -> legacy/stakemodifier -> chain"
     "chainparamsbase -> util/system -> chainparamsbase"
     "consensus/params -> consensus/upgrades -> consensus/params"
@@ -40,7 +46,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "chain -> legacy/stakemodifier -> stakeinput -> chain"
     "chain -> legacy/stakemodifier -> validation -> chain"
     "legacy/validation_zerocoin_legacy -> wallet/wallet -> validation -> legacy/validation_zerocoin_legacy"
-    "llmq/quorums -> llmq/quorums_connections -> llmq/quorums"
     "llmq/quorums_dkgsession -> llmq/quorums_dkgsessionmgr -> llmq/quorums_dkgsessionhandler -> llmq/quorums_dkgsession"
     "llmq/quorums_dkgsessionhandler -> net_processing -> llmq/quorums_dkgsessionmgr -> llmq/quorums_dkgsessionhandler"
     "chain -> legacy/stakemodifier -> validation -> validationinterface -> chain"
@@ -48,8 +53,16 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "chain -> legacy/stakemodifier -> validation -> checkpoints -> chain"
     "chain -> legacy/stakemodifier -> validation -> undo -> chain"
     "chain -> legacy/stakemodifier -> validation -> pow -> chain"
-    "evo/deterministicmns -> masternodeman -> net -> tiertwo/net_masternodes -> evo/deterministicmns"
-    "evo/deterministicmns -> masternodeman -> validation -> validationinterface -> evo/deterministicmns"
+    "evo/deterministicmns -> llmq/quorums_dkgsessionhandler -> evo/deterministicmns"
+    "evo/deterministicmns -> llmq/quorums_dkgsessionhandler -> llmq/quorums_connections -> evo/deterministicmns"
+    "evo/deterministicmns -> llmq/quorums_dkgsessionhandler -> llmq/quorums_debug -> evo/deterministicmns"
+    "evo/deterministicmns -> llmq/quorums_dkgsessionhandler -> llmq/quorums_dkgsession -> evo/deterministicmns"
+    "evo/deterministicmns -> llmq/quorums_dkgsessionhandler -> net_processing -> evo/deterministicmns"
+    "evo/deterministicmns -> llmq/quorums_dkgsessionhandler -> net_processing -> masternode-payments -> evo/deterministicmns"
+    "evo/deterministicmns -> llmq/quorums_dkgsessionhandler -> net_processing -> masternode-sync -> evo/deterministicmns"
+    "evo/deterministicmns -> llmq/quorums_dkgsessionhandler -> llmq/quorums_connections -> tiertwo/net_masternodes -> evo/deterministicmns"
+    "evo/deterministicmns -> llmq/quorums_dkgsessionhandler -> net_processing -> validationinterface -> evo/deterministicmns"
+
 )
 
 EXIT_CODE=0

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -40,6 +40,7 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "chain -> legacy/stakemodifier -> stakeinput -> chain"
     "chain -> legacy/stakemodifier -> validation -> chain"
     "legacy/validation_zerocoin_legacy -> wallet/wallet -> validation -> legacy/validation_zerocoin_legacy"
+    "llmq/quorums -> llmq/quorums_connections -> llmq/quorums"
     "llmq/quorums_dkgsession -> llmq/quorums_dkgsessionmgr -> llmq/quorums_dkgsessionhandler -> llmq/quorums_dkgsession"
     "llmq/quorums_dkgsessionhandler -> net_processing -> llmq/quorums_dkgsessionmgr -> llmq/quorums_dkgsessionhandler"
     "chain -> legacy/stakemodifier -> validation -> validationinterface -> chain"


### PR DESCRIPTION
Co-authored with @Liquid369
Abstract:
The aim of this PR is adding ipv6 and tor support for DMNs. We have two main ideas to implement this feature:
1) having ipv4 only quorums, ipv6 only quorums and tor only quorums; 
2) implementing mixed quorums of ipv4 and ipv6 by adding a new kind of relay masternode that is required to have both ipv4 and ipv6 and same for ipv4 tor.

Both solutions have their drawbacks, for example if we go on with 1) We will make sure the have in any time enough ipv4, ipv6, tor masternodes
for 2) instead we will make sure to have always enough relays.
TODO list for 1:
1) Change LLQM initializaion phase in such a way that there are quorums with ONLY ipv4 and quorums with ONLY ipv6; 
 2)  same for tor
 
TODO list for 2:
1) Extend ProRegTx to include up to 2 ip addresses
2) Change LLQM Initialization phase in such a way that ipv4 only DMNs will not connect directly to ipv6 only DMNs
3) Add another quorum phase that will verify if relays are working correctly
4) test, test and more test
5) same for tor
For the moment we will be implementing solution 1) but in any case we can change in the future/ during testing.