### PR TITLE
[Wallet] Fix AutoCombineDust and improve setautocombinethreshold

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -29,8 +29,6 @@ static const CRPCConvertParam vRPCConvertParams[] = {
     { "addmultisigaddress", 0, "nrequired" },
     { "addmultisigaddress", 1, "keys" },
     { "addpeeraddress", 1, "port" },
-    { "autocombinerewards", 0, "enable" },
-    { "autocombinerewards", 1, "threshold" },
     { "cleanbudget", 0, "try_sync" },
     { "createmultisig", 0, "nrequired" },
     { "createmultisig", 1, "keys" },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -149,6 +149,7 @@ static const CRPCConvertParam vRPCConvertParams[] = {
     { "sendtoaddress", 4, "subtract_fee" },
     { "setautocombinethreshold", 0, "enable" },
     { "setautocombinethreshold", 1, "threshold" },
+    { "setautocombinethreshold", 2, "frequency"},
     { "setnetworkactive", 0, "active"},
     { "setban", 2, "bantime" },
     { "setban", 3, "absolute" },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4450,54 +4450,6 @@ UniValue getstakesplitthreshold(const JSONRPCRequest& request)
     return ValueFromAmount(pwallet->GetStakeSplitThreshold());
 }
 
-UniValue autocombinerewards(const JSONRPCRequest& request)
-{
-    if (!IsDeprecatedRPCEnabled("autocombinerewards")) {
-        if (request.fHelp) {
-            throw std::runtime_error("autocombinerewards (Deprecated, will be removed in v6.0. To use this command, start pivxd with -deprecatedrpc=autocombinerewards)");
-        }
-        throw JSONRPCError(RPC_METHOD_DEPRECATED, "autocombinerewards is deprecated and will be removed in v6.0. To use this command, start pivxd with -deprecatedrpc=autocombinerewards");
-    }
-
-    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
-
-    if (!EnsureWalletIsAvailable(pwallet, request.fHelp))
-        return NullUniValue;
-
-    bool fEnable = !request.params.empty() && request.params[0].get_bool();
-
-    if (request.fHelp || request.params.empty() || (fEnable && request.params.size() != 2) || request.params.size() > 2)
-        throw std::runtime_error(
-            "autocombinerewards enable ( threshold )\n"
-            "\nDEPRECATED!!! This command has been replaced with setautocombinethreshold and getautocombinethreshold and will be removed in a future version!!!\n"
-            "\nWallet will automatically monitor for any coins with value below the threshold amount, and combine them if they reside with the same PIVX address\n"
-            "When autocombinerewards runs it will create a transaction, and therefore will be subject to transaction fees.\n"
-
-            "\nArguments:\n"
-            "1. enable          (boolean, required) Enable auto combine (true) or disable (false)\n"
-            "2. threshold       (numeric, optional, required if enable=True) Threshold amount (default: 0)\n"
-
-            "\nExamples:\n" +
-            HelpExampleCli("autocombinerewards", "true 500") + HelpExampleRpc("autocombinerewards", "true 500"));
-
-    WalletBatch batch(pwallet->GetDBHandle());
-    CAmount nThreshold = 0;
-
-    if (fEnable && request.params.size() > 1) {
-        nThreshold = AmountFromValue(request.params[1]);
-        if (nThreshold < COIN)
-            throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("The threshold value cannot be less than %s", FormatMoney(COIN)));
-    }
-
-    pwallet->fCombineDust = fEnable;
-    pwallet->nAutoCombineThreshold = nThreshold;
-
-    if (!batch.WriteAutoCombineSettings(fEnable, nThreshold))
-        throw std::runtime_error("Changed settings in wallet but failed to save to database\n");
-
-    return NullUniValue;
-}
-
 UniValue setautocombinethreshold(const JSONRPCRequest& request)
 {
     CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
@@ -4738,7 +4690,6 @@ static const CRPCCommand commands[] =
 { //  category              name                        actor (function)           okSafe argNames
   //  --------------------- ------------------------    -----------------------    ------ --------
     { "wallet",             "getaddressinfo",           &getaddressinfo,           true,  {"address"} },
-    { "wallet",             "autocombinerewards",       &autocombinerewards,       false, {"enable","threshold"} },
     { "wallet",             "setautocombinethreshold",  &setautocombinethreshold,  false, {"enable","threshold"} },
     { "wallet",             "getautocombinethreshold",  &getautocombinethreshold,  false, {} },
     { "wallet",             "abandontransaction",       &abandontransaction,       false, {"txid"} },

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4094,7 +4094,8 @@ void CWallet::AutoCombineDust(CConnman* connman)
         int nChangePosInOut = -1;
 
         // 10% safety margin to avoid "Insufficient funds" errors
-        vecSend[0].nAmount = nTotalRewardsValue - (nTotalRewardsValue / 10);
+        long safetyThreshold = nTotalRewardsValue - (nTotalRewardsValue / 10);
+        vecSend[0].nAmount = safetyThreshold;
 
         {
             // For now, CreateTransaction requires cs_main lock.
@@ -4107,7 +4108,7 @@ void CWallet::AutoCombineDust(CConnman* connman)
         }
 
         //we don't combine below the threshold unless the fees are 0 to avoid paying fees over fees over fees
-        if (!maxSize && nTotalRewardsValue < nAutoCombineThreshold && nFeeRet > 0)
+        if (!maxSize && safetyThreshold < nAutoCombineThreshold && nFeeRet > 0)
             continue;
 
         const CWallet::CommitResult& res = CommitTransaction(wtx, keyChange, connman);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -742,6 +742,7 @@ public:
     //Auto Combine Inputs
     bool fCombineDust;
     CAmount nAutoCombineThreshold;
+    int frequency;
 
     /** Get database handle used by this wallet. Ideally this function would
      * not be necessary.

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -165,7 +165,7 @@ public:
     bool WriteStakeSplitThreshold(const CAmount& nStakeSplitThreshold);
     bool WriteUseCustomFee(bool fUse);
     bool WriteCustomFeeValue(const CAmount& nCustomFee);
-    bool WriteAutoCombineSettings(bool fEnable, CAmount nCombineThreshold);
+    bool WriteAutoCombineSettings(bool fEnable, CAmount nCombineThreshold, int frequency);
 
     bool ReadPool(int64_t nPool, CKeyPool& keypool);
     bool WritePool(int64_t nPool, const CKeyPool& keypool);

--- a/test/functional/rpc_deprecated.py
+++ b/test/functional/rpc_deprecated.py
@@ -5,14 +5,14 @@
 """Test deprecation of RPC calls."""
 
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import assert_raises_rpc_error
+# from test_framework.util import assert_raises_rpc_error
 
 
 class DeprecatedRpcTest(PivxTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
         self.setup_clean_chain = True
-        self.extra_args = [[], ["-deprecatedrpc=autocombinerewards"]]
+        # self.extra_args = [[], ["-deprecatedrpc=rpcname"]] add deprecated rpc here
 
     def run_test(self):
         # This test should be used to verify correct behaviour of deprecated
@@ -21,13 +21,7 @@ class DeprecatedRpcTest(PivxTestFramework):
         # self.log.info("Make sure that -deprecatedrpc=accounts allows it to take accounts")
         # assert_raises_rpc_error(-32, "listaccounts is deprecated", self.nodes[0].listaccounts)
         # self.nodes[1].listaccounts()
-
-        self.log.info("Test autocombinerewards deprecation")
-        # The autocombinerewards RPC method has been deprecated
-        assert_raises_rpc_error(-32, "autocombinerewards is deprecated", self.nodes[0].autocombinerewards, True, 500)
-        self.nodes[1].autocombinerewards(True, 500)
-
-        # self.log.info("No test cases to run")  # remove this when adding any tests to this file
+        self.log.info("No test cases to run")  # remove this when adding any tests to this file
 
 
 if __name__ == '__main__':

--- a/test/functional/wallet_autocombine.py
+++ b/test/functional/wallet_autocombine.py
@@ -25,6 +25,8 @@ class AutoCombineTest(PivxTestFramework):
         # Check the failure conditions for setautocombinethreshold
         assert_raises_rpc_error(-8, "Missing threshold value", self.nodes[0].setautocombinethreshold, True)
         assert_raises_rpc_error(-8, "The threshold value cannot be less than 1.00", self.nodes[0].setautocombinethreshold, True, 0.99)
+        assert_raises_rpc_error(-8, "Frequency must be greater than 0", self.nodes[0].setautocombinethreshold, True, 2, -1)
+        assert_raises_rpc_error(-8, "The threshold value cannot be less than 1.00", self.nodes[0].setautocombinethreshold, True, 0.99)
 
         self.log.info("Mining initial 100 blocks...")
         self.nodes[0].generate(100)
@@ -37,22 +39,27 @@ class AutoCombineTest(PivxTestFramework):
         self.nodes[0].generate(2)
 
         walletinfo = self.nodes[0].getwalletinfo()
-        assert_equal(walletinfo['balance'], 500)
+        assert_equal(walletinfo['balance'], 250*2)
         assert_equal(walletinfo['txcount'], 102)
 
-        self.log.info("Set autocombine to 500 PIV")
-        setautocombine = self.nodes[0].setautocombinethreshold(True, 500)
+        self.log.info("Set autocombine to 500 PIV and frequency of 10")
+        setautocombine = self.nodes[0].setautocombinethreshold(True, 500, 10)
         assert_equal(setautocombine['enabled'], True)
         assert_equal(setautocombine['threshold'], 500)
+        assert_equal(setautocombine['frequency'], 10)
         getautocombine = self.nodes[0].getautocombinethreshold()
         assert_equal(getautocombine['enabled'], True)
         assert_equal(getautocombine['threshold'], 500)
+        assert_equal(getautocombine['frequency'], 10)
         walletinfo = self.nodes[0].getwalletinfo()
         assert_equal(walletinfo['autocombine_enabled'], True)
         assert_equal(walletinfo['autocombine_threshold'], 500)
+        assert_equal(walletinfo['autocombine_frequency'], 10)
 
-        self.log.info("Mine 1 more block to initiate an autocombine transaction")
-        self.nodes[0].generate(1)
+        self.log.info("Mine 8 more block to initiate an autocombine transaction")
+
+        self.nodes[0].generate(8)  # we need 8 more blocks to get a multiple of 10
+        assert_equal(0, self.nodes[0].getblockcount() % 10)
         time.sleep(1)
 
         mempool = self.nodes[0].getrawmempool()
@@ -60,16 +67,18 @@ class AutoCombineTest(PivxTestFramework):
         tx = mempool[0]
         nFee = self.nodes[0].getrawmempool(True)[mempool[0]]['fee']
         walletinfo = self.nodes[0].getwalletinfo()
-        assert_equal(walletinfo['balance'], 750 - nFee)
-        assert_equal(walletinfo['txcount'], 104)
+        assert_equal(walletinfo['balance'], 250*10 - nFee)
+        assert_equal(walletinfo['txcount'], 111)  # 110 coinbase txs + 1 to autocollect
 
         self.log.info("Mine 1 more block to confirm the autocombine transaction")
         block = self.nodes[0].generate(1)
         time.sleep(1)
 
         walletinfo = self.nodes[0].getwalletinfo()
-        assert_equal(walletinfo['balance'], 250 + 750 - nFee)
-        assert_equal(walletinfo['txcount'], 105)
+        assert_equal(walletinfo['balance'], 250*11 - nFee)
+        # 111 coinbase txs + 1 autocollect, good autocollect was not called again since nBlock % 10 = 1
+        assert_equal(1, self.nodes[0].getblockcount() % 10)
+        assert_equal(walletinfo['txcount'], 112)
 
         txinfo = self.nodes[0].gettransaction(tx)
         assert_equal(txinfo['fee'], 0 - nFee)
@@ -81,12 +90,17 @@ class AutoCombineTest(PivxTestFramework):
         setautocombine = self.nodes[0].setautocombinethreshold(False)
         assert_equal(setautocombine['enabled'], False)
         assert_equal(setautocombine['threshold'], 0)
+        assert_equal(setautocombine['frequency'], 30)  # set back to default value
+
         getautocombine = self.nodes[0].getautocombinethreshold()
         assert_equal(getautocombine['enabled'], False)
         assert_equal(getautocombine['threshold'], 0)
+        assert_equal(getautocombine['frequency'], 30)
+
         walletinfo = self.nodes[0].getwalletinfo()
         assert_equal(walletinfo['autocombine_enabled'], False)
         assert_equal(walletinfo['autocombine_threshold'], 0)
+        assert_equal(walletinfo['autocombine_frequency'], 30)
 
         self.log.info("Mine 1 more block to make sure autocombine is disabled")
         self.nodes[0].generate(1)
@@ -96,8 +110,8 @@ class AutoCombineTest(PivxTestFramework):
         assert_equal(len(mempool), 0)
 
         walletinfo = self.nodes[0].getwalletinfo()
-        assert_equal(walletinfo['balance'], 250 + 250 + 750 - nFee)
-        assert_equal(walletinfo['txcount'], 106)
+        assert_equal(walletinfo['balance'], 250*12 - nFee)
+        assert_equal(walletinfo['txcount'], 113)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
AutoCombineDust has been bugged since an old PR see (https://github.com/PIVX-Project/PIVX/pull/953  https://github.com/PIVX-Project/PIVX/pull/518).

To make an example of what's happening let's consider for simplicity  nAutoCombineThreshold = 100 and let's say that the user has 2 UTXOs one of 90 PIVs and the other of 15 PIVs.

With the current code of AutoCombineDust we will therefore try to send a total of 90+15 = 105 PIVs to ourself, more precisely to avoid the "Insufficient funds" the primary output will contain only the 90% =94.5 PIVs and the remaining 10% = 10.5 PIVs is used to pay fees + sent as a change to ourself. As you can see we end up with two new UTXOs, which are still both smaller than the threshold. 

This process is iterated block by block until we end up with a single UTXO which is smaller than the threshold, i.e in this example 5 PIVs will be burn in fees.

Moreover the process of "checking all UTXOs at each block for each address of your wallet"  can potentially consume a lot of resources especially if the user has a lot of small UTXOs, therefore I added a new parameter "frequency" which will check for dust every N blocks (where N is the value of frequency), and which is set by default at N = 30.

Finally I removed the old autocombinerewards since it is deprecated and was planned to be removed in v6.0 (https://github.com/PIVX-Project/PIVX/blob/master/doc/release-notes.md)

