### PR TITLE
[Build] Fix build with configure flag --enable-mining-rpc

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -21,6 +21,7 @@
 #include "wallet/db.h"
 #include "wallet/wallet.h"
 #endif
+#include "warnings.h"
 
 #include <univalue.h>
 
@@ -235,7 +236,7 @@ UniValue GetNetworkHashPS(int lookup, int height)
     if (minTime == maxTime)
         return 0;
 
-    uint256 workDiff = pb->nChainWork - pb0->nChainWork;
+    arith_uint256 workDiff = pb->nChainWork - pb0->nChainWork;
     int64_t timeDiff = maxTime - minTime;
 
     return (int64_t)(workDiff.getdouble() / timeDiff);


### PR DESCRIPTION
## Issue being fixed #2811
Build fails with configure flag "--enable-mining-rpc"
When attempting to build using the "--enable-mining-rpc" flag, the build fails.
## What was done
- add include warnings.h
- change uint256 to arith_uint256
## Before
Build fails
```
  CXX      rpc/libbitcoin_server_a-mining.o
rpc/mining.cpp: In function 'UniValue GetNetworkHashPS(int, int)':
rpc/mining.cpp:238:39: error: conversion from 'const base_uint<256>' to non-scalar type 'uint256' requested
     uint256 workDiff = pb->nChainWork - pb0->nChainWork;
                        ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
rpc/mining.cpp:241:31: error: 'class uint256' has no member named 'getdouble'
     return (int64_t)(workDiff.getdouble() / timeDiff);
                               ^~~~~~~~~
rpc/mining.cpp: In function 'UniValue getmininginfo(const JSONRPCRequest&)':
rpc/mining.cpp:395:26: error: 'GetWarnings' was not declared in this scope
     obj.pushKV("errors", GetWarnings("statusbar"));
                          ^~~~~~~~~~~
rpc/mining.cpp:395:26: note: suggested alternative: 'GetMainSignals'
     obj.pushKV("errors", GetWarnings("statusbar"));
                          ^~~~~~~~~~~
                          GetMainSignals
Makefile:9548: recipe for target 'rpc/libbitcoin_server_a-mining.o' failed
```
## After
Build succeeds