### PR TITLE
[GA] Bump GA linux workers to Ubuntu 20.04

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,7 +6,7 @@ jobs:
     env:
       SHELLCHECK_VERSION: v0.7.1
       LC_ALL: C
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     defaults:
       run:
         shell: bash
@@ -74,7 +74,7 @@ jobs:
       matrix:
         config:
           - name: Linux
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             packages: python3-zmq qttools5-dev qtbase5-dev qttools5-dev-tools libqt5svg5-dev libqt5charts5-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libqrencode-dev libgmp-dev libsodium-dev cargo
             cc: gcc
             cxx: g++
@@ -141,33 +141,33 @@ jobs:
       matrix:
         config:
           - name: ARM 32-bit
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             host: arm-linux-gnueabihf
             apt_get: python3 g++-arm-linux-gnueabihf
 
           - name: AARCH64
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             host: aarch64-linux-gnu
             apt_get: python3 g++-aarch64-linux-gnu
 
           - name: Win64
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             host: x86_64-w64-mingw32
             apt_get: python3 nsis g++-mingw-w64-x86-64 wine-binfmt wine64
 
           - name: 32-bit + dash
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             host: i686-pc-linux-gnu
             apt_get: g++-multilib python3-zmq
 
           - name: x86_64 Linux
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             host: x86_64-unknown-linux-gnu
             apt_get: python3-zmq qtbase5-dev qttools5-dev-tools libqt5svg5-dev libqt5charts5-dev libqrencode-dev libdbus-1-dev libharfbuzz-dev
             dep_opts: NO_QT=1 NO_UPNP=1 NO_NATPMP=1 DEBUG=1 ALLOW_HOST_PACKAGES=1
 
           - name: macOS 10.12
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             host: x86_64-apple-darwin16
             apt_get: cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python3-dev python3-setuptools
             XCODE_VERSION: 11.3.1
@@ -249,7 +249,7 @@ jobs:
         config:
           - name: ARM 32-bit [GOAL:install]  [no unit or functional tests]
             id: ARM32
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             host: arm-linux-gnueabihf
             apt_get: python3 g++-arm-linux-gnueabihf
             unit_tests: false
@@ -261,7 +261,7 @@ jobs:
 
           - name: AARCH64 [GOAL:install] [no unit or functional tests]
             id: ARM64
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             host: aarch64-linux-gnu
             apt_get: python3 g++-aarch64-linux-gnu
             unit_tests: false
@@ -271,7 +271,7 @@ jobs:
 
           - name: Win64  [GOAL:deploy] [no unit or functional tests]
             id: Win64
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             host: x86_64-w64-mingw32
             apt_get: python3 nsis g++-mingw-w64-x86-64 wine-binfmt wine64
             unit_tests: false
@@ -279,9 +279,9 @@ jobs:
             goal: deploy
             BITCOIN_CONFIG: "--with-gui=auto --enable-reduce-exports --disable-online-rust"
 
-          - name: x86_64 Linux  [GOAL:install]  [bionic]
+          - name: x86_64 Linux  [GOAL:install]  [focal]
             id: Linux-x86_64
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             host: x86_64-unknown-linux-gnu
             apt_get: python3-zmq qtbase5-dev qttools5-dev-tools libqt5svg5-dev libqt5charts5-dev libqrencode-dev libdbus-1-dev libharfbuzz-dev
             unit_tests: true
@@ -290,9 +290,9 @@ jobs:
             test_runner_extra: "--coverage --all  --exclude feature_dbcrash"
             BITCOIN_CONFIG: "--enable-zmq --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports --disable-online-rust"
 
-          - name: x86_64 Linux  [GOAL:install]  [bionic] [no GUI no unit tests - only functional tests on legacy pre-HD wallets]
+          - name: x86_64 Linux  [GOAL:install]  [focal] [no GUI no unit tests - only functional tests on legacy pre-HD wallets]
             id: Linux-x86_64-nogui
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             host: x86_64-unknown-linux-gnu
             apt_get: python3-zmq
             unit_tests: false
@@ -301,9 +301,9 @@ jobs:
             test_runner_extra: "--legacywallet"
             BITCOIN_CONFIG: "--enable-zmq --with-gui=no --enable-glibc-back-compat --enable-reduce-exports --disable-online-rust"
 
-          - name: x86_64 Linux  [GOAL:install]  [bionic]  [no depends only system libs]
+          - name: x86_64 Linux  [GOAL:install]  [focal]  [no depends only system libs]
             id: Linux-x86_64-nodepends
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             host: x86_64-unknown-linux-gnu
             apt_get: python3-zmq qtbase5-dev qttools5-dev-tools libqt5svg5-dev libqt5charts5-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev libqrencode-dev libgmp-dev libsodium-dev cargo
             unit_tests: true
@@ -313,7 +313,7 @@ jobs:
 
           - name: macOS 10.12  [GOAL:deploy] [no functional tests]
             id: macOS10.12
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             host: x86_64-apple-darwin16
             apt_get: cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python3-dev python3-setuptools
             XCODE_VERSION: 11.3.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ find_package(GMP REQUIRED)
 find_package(ZMQ)
 find_package(Miniupnp)
 find_package(NAT-PMP)
-find_package(Boost COMPONENTS system filesystem thread REQUIRED)
+find_package(Boost COMPONENTS system filesystem chrono thread REQUIRED)
 find_package(Sodium REQUIRED)
 
 # run autogen.sh if missing header files from configure on Linux/Mac

--- a/src/bench/CMakeLists.txt
+++ b/src/bench/CMakeLists.txt
@@ -2,7 +2,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.14)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 set(Boost_USE_STATIC_LIBS ON)
-find_package(Boost COMPONENTS system filesystem thread unit_test_framework REQUIRED)
+find_package(Boost COMPONENTS system filesystem chrono thread unit_test_framework REQUIRED)
 
 set(RAW_TEST_FILES  ${CMAKE_CURRENT_SOURCE_DIR}/data/block2680960.raw)
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -2,7 +2,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.14)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 set(Boost_USE_STATIC_LIBS ON)
-find_package(Boost COMPONENTS system filesystem thread unit_test_framework REQUIRED)
+find_package(Boost COMPONENTS system filesystem chrono thread unit_test_framework REQUIRED)
 
 set(JSON_TEST_FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/data/script_tests.json


### PR DESCRIPTION
This is the final (for now) PR needed to fully update our GA workers/actions to non-deprecated versions.

Previous work was done in the following PRs:
#2787
#2807
