### PR TITLE
[Core] Solve BLS Memleak

### DIFF
--- a/src/bls/bls_worker.cpp
+++ b/src/bls/bls_worker.cpp
@@ -276,7 +276,13 @@ struct Aggregator : public std::enable_shared_from_this<Aggregator<T>> {
 
     void PushAggQueue(const T& v)
     {
-        aggQueue.push(new T(v));
+        auto copyT = new T(v);
+        try {
+            aggQueue.push(copyT);
+        } catch (...) {
+            delete copyT;
+            throw;
+        }
 
         if (++aggQueueSize >= batchSize) {
             // we've collected enough intermediate results to form a new batch.


### PR DESCRIPTION
Partial backport of https://github.com/dashpay/dash/pull/5202

In term of trying to keep memory down, this is a potential bug where if the object was never entered into the queue it just starts to bloat the memory. 