### PR TITLE
[Build] Disable libsep256k1's openssl tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1592,7 +1592,7 @@ fi
 
 AC_CONFIG_SUBDIRS([src/chiabls])
 
-ac_configure_args="${ac_configure_args} --disable-shared --with-pic --with-bignum=no --enable-module-recovery --disable-jni"
+ac_configure_args="${ac_configure_args} --disable-shared --with-pic --with-bignum=no --enable-module-recovery --disable-jni --disable-openssl-tests"
 AC_CONFIG_SUBDIRS([src/secp256k1])
 
 AC_OUTPUT


### PR DESCRIPTION
Systems that have OpenSSL 3.x installed cause the lib's openssl based tests to fail. We don't use OpenSSL in PIVX anymore, so these tests are not of much interest.

Ref: https://github.com/bitcoin/bitcoin/pull/23314