### PR TITLE
[P2P] Rate limiting rumored address processing

### DIFF
--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -64,6 +64,8 @@ struct CNodeStateStats {
     int nSyncHeight;
     int nCommonHeight;
     std::vector<int> vHeightInFlight;
+    uint64_t m_addr_processed = 0;
+    uint64_t m_addr_rate_limited = 0;
 };
 
 /** Get statistics from node state */
@@ -71,5 +73,12 @@ bool GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats);
 /** Increase a node's misbehavior score. */
 void Misbehaving(NodeId nodeid, int howmuch, const std::string& message="") EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 bool IsBanned(NodeId nodeid);
+
+
+using SecondsDouble = std::chrono::duration<double, std::chrono::seconds::period>;
+/**
+ * Helper to count the seconds in any std::chrono::duration type
+ */
+inline double CountSecondsDouble(SecondsDouble t) { return t.count(); }
 
 #endif // BITCOIN_NET_PROCESSING_H

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -101,6 +101,8 @@ UniValue getpeerinfo(const JSONRPCRequest& request)
             "       n,                        (numeric) The heights of blocks we're currently asking from this peer\n"
             "       ...\n"
             "    ]\n"
+            "    \"addr_processed\": n,       (numeric) The total number of addresses processed, excluding those dropped due to rate limiting\n"
+            "    \"addr_rate_limited\": n,       (numeric) The total number of addresses dropped due to rate limiting\n"
             "    \"bytessent_per_msg\": {\n"
             "       \"addr\": n,             (numeric) The total bytes sent aggregated by message type\n"
             "       ...\n"
@@ -166,6 +168,8 @@ UniValue getpeerinfo(const JSONRPCRequest& request)
                 heights.push_back(height);
             }
             obj.pushKV("inflight", heights);
+            obj.pushKV("addr_processed", statestats.m_addr_processed);
+            obj.pushKV("addr_rate_limited", statestats.m_addr_rate_limited);
         }
         obj.pushKV("whitelisted", stats.fWhitelisted);
 

--- a/test/functional/p2p_addr_relay.py
+++ b/test/functional/p2p_addr_relay.py
@@ -6,8 +6,6 @@
 Test addr relay
 """
 
-import time
-
 from test_framework.messages import (
     CAddress,
     NODE_NETWORK,
@@ -15,11 +13,13 @@ from test_framework.messages import (
 )
 from test_framework.mininode import (
     P2PInterface,
+    mininode_lock
 )
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import (
-    assert_equal,
-)
+from test_framework.util import assert_equal
+
+import random
+import time
 
 ADDRS = []
 for i in range(10):
@@ -32,17 +32,33 @@ for i in range(10):
 
 
 class AddrReceiver(P2PInterface):
+    _tokens = 10
     def on_addr(self, message):
         for addr in message.addrs:
             assert_equal(addr.nServices, 1)
             assert addr.ip.startswith('123.123.123.')
             assert (8333 <= addr.port < 8343)
 
+    def on_getaddr(self, message):
+        # When the node sends us a getaddr, it increments the addr relay tokens for the connection by 1000
+        self._tokens += 1000
+
+    @property
+    def tokens(self):
+        with mininode_lock:
+            return self._tokens
+
+    def increment_tokens(self, n):
+        # When we move mocktime forward, the node increments the addr relay tokens for its peers
+        with mininode_lock:
+            self._tokens += n
+
 
 class AddrTest(PivxTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = False
         self.num_nodes = 1
+        self.extra_args = [["-whitelist=127.0.0.1"]]
 
     def run_test(self):
         self.log.info('Create connection that sends addr messages')
@@ -57,6 +73,8 @@ class AddrTest(PivxTestFramework):
         self.log.info('Check that addr message content is relayed and added to addrman')
         addr_receiver = self.nodes[0].add_p2p_connection(AddrReceiver())
         msg.addrs = ADDRS
+        self.mocktime += 10
+        self.nodes[0].setmocktime(self.mocktime)
         with self.nodes[0].assert_debug_log([
                 'Added 10 addresses from 127.0.0.1: 0 tried',
                 'received: addr (301 bytes) peer=0',
@@ -65,6 +83,71 @@ class AddrTest(PivxTestFramework):
             addr_source.send_and_ping(msg)
             self.nodes[0].setmocktime(int(time.time()) + 30 * 60)
             addr_receiver.sync_with_ping()
+            self.rate_limit_tests()
+
+    def setup_rand_addr_msg(self, num):
+        addrs = []
+        for i in range(num):
+            addr = CAddress()
+            addr.time = self.mocktime + i
+            addr.nServices = NODE_NETWORK
+            addr.ip = f"{random.randrange(128,169)}.{random.randrange(1,255)}.{random.randrange(1,255)}.{random.randrange(1,255)}"
+            addr.port = 8333
+            addrs.append(addr)
+        msg = msg_addr()
+        msg.addrs = addrs
+        return msg
+
+    def send_addrs_and_test_rate_limiting(self, peer, new_addrs, total_addrs):
+        """Send an addr message and check that the number of addresses processed and rate-limited is as expected"""
+
+        peer.send_and_ping(self.setup_rand_addr_msg(new_addrs))
+
+        peerinfo = self.nodes[0].getpeerinfo()[2]
+        addrs_processed = peerinfo['addr_processed']
+        addrs_rate_limited = peerinfo['addr_rate_limited']
+        self.log.info(f'addrs_processed = {addrs_processed}, addrs_rate_limited = {addrs_rate_limited}')
+        self.log.info(f'peer_tokens = {peer.tokens}')
+
+        assert_equal(addrs_processed, min(total_addrs, peer.tokens))
+        assert_equal(addrs_rate_limited, max(0, total_addrs - peer.tokens))
+
+    def rate_limit_tests(self):
+
+        self.mocktime = int(time.time())
+        self.nodes[0].setmocktime(self.mocktime)
+
+        peer = self.nodes[0].add_p2p_connection(AddrReceiver())
+
+        self.log.info(f'Test rate limiting of addr processing for inbound peers')
+
+        # Send 600 addresses.
+        self.send_addrs_and_test_rate_limiting(peer, 600, 600)
+
+        # Send 400 more addresses.
+        self.send_addrs_and_test_rate_limiting(peer, 400, 1000)
+
+        # Send 10 more. As we reached the processing limit for nodes, no more addresses should be procesesd.
+        self.send_addrs_and_test_rate_limiting(peer, 10, 1010)
+
+        # Advance the time by 100 seconds, permitting the processing of 10 more addresses.
+        # Send 200 and verify that 10 are processed.
+        self.mocktime += 100
+        self.nodes[0].setmocktime(self.mocktime)
+        peer.increment_tokens(10)
+
+        self.send_addrs_and_test_rate_limiting(peer, 200, 1210)
+
+        # Advance the time by 1000 seconds, permitting the processing of 100 more addresses.
+        # Send 200 and verify that 100 are processed.
+        self.mocktime += 1000
+        self.nodes[0].setmocktime(self.mocktime)
+        peer.increment_tokens(100)
+
+        self.send_addrs_and_test_rate_limiting(peer, 200, 1410)
+
+        self.nodes[0].disconnect_p2ps()
+
 
 
 if __name__ == '__main__':

--- a/test/functional/p2p_addrv2_relay.py
+++ b/test/functional/p2p_addrv2_relay.py
@@ -38,7 +38,7 @@ class AddrReceiver(P2PInterface):
             assert_equal(addr.nServices, 1) # NODE_NETWORK
             assert addr.ip.startswith('123.123.123.')
             assert (8333 <= addr.port < 8343)
-        self.addrv2_received_and_checked = True
+            self.addrv2_received_and_checked = True
 
     def wait_for_addrv2(self):
         self.wait_until(lambda: "addrv2" in self.last_message)
@@ -62,6 +62,8 @@ class AddrTest(PivxTestFramework):
         self.log.info('Check that addrv2 message content is relayed and added to addrman')
         addr_receiver = self.nodes[0].add_p2p_connection(AddrReceiver())
         msg.addrs = ADDRS
+        self.mocktime += 10
+        self.nodes[0].setmocktime(self.mocktime)
         with self.nodes[0].assert_debug_log([
                 'Added 10 addresses from 127.0.0.1: 0 tried',
                 'received: addrv2 (131 bytes) peer=0',
@@ -70,7 +72,6 @@ class AddrTest(PivxTestFramework):
             addr_source.send_and_ping(msg)
             self.nodes[0].setmocktime(int(time.time()) + 30 * 60)
             addr_receiver.wait_for_addrv2()
-
         assert addr_receiver.addrv2_received_and_checked
 
 

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -174,8 +174,8 @@ class InvalidMessagesTest(PivxTestFramework):
         self.test_addrv2('unrecognized network',
             [
                 'received: addrv2 (25 bytes)',
-                'IP 9.9.9.9 mapped',
-                'Added 1 addresses',
+                'Received addr: 2 addresses (2 processed, 0 rate-limited)',
+                'received: ping (8 bytes)',
             ],
             hex_str_to_bytes(
                 '02' +     # number of entries

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -62,6 +62,7 @@ BASE_SCRIPTS= [
     'mempool_persist.py',                       # ~ 417 sec
     'p2p_quorum_connect.py',                    # ~ 400 sec
     'wallet_reorgsrestore.py',                  # ~ 391 sec
+    'p2p_addr_relay.py',                        # ~ 380 sec
 
     # vv Tests less than 5m vv
     'wallet_hd.py',                             # ~ 300 sec
@@ -135,7 +136,6 @@ BASE_SCRIPTS= [
     'rpc_decodescript.py',                      # ~ 50 sec
     'rpc_blockchain.py',                        # ~ 50 sec
     'wallet_disable.py',                        # ~ 50 sec
-    'p2p_addr_relay.py',                        # ~ 49 sec
     'p2p_addrv2_relay.py',                      # ~ 49 sec
     'wallet_autocombine.py',                    # ~ 49 sec
     'mining_v5_upgrade.py',                     # ~ 48 sec


### PR DESCRIPTION
As of recent there was a release on https://www.halborn.com/blog/post/halborn-discovers-zero-day-impacting-dogecoin-and-280-networks
We want to address potential situation that can cause network instability and node attacks.

This PR back ports
https://github.com/bitcoin/bitcoin/pull/22387
https://github.com/bitcoin/bitcoin/pull/15617

This implements a token bucket for rate limiting addresses, allowing up to 1000 in one request. Getaddr requests are exempt from this rate limiting. Then we are also no longer going to relay to other nodes peers we have banned. Functional tests included.