### PR TITLE
[Depends] Bump zlib to v1.2.13

### DIFF
--- a/depends/packages/zlib.mk
+++ b/depends/packages/zlib.mk
@@ -1,8 +1,8 @@
 package=zlib
-$(package)_version=1.2.11
+$(package)_version=1.2.13
 $(package)_download_path=https://www.zlib.net
-$(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+$(package)_file_name=$(package)-$($(package)_version).tar.xz
+$(package)_sha256_hash=d14c38e313afc35a9a8760dadf26042f51ea0f5d154b0630a31da0540107fb98
 
 define $(package)_set_vars
 $(package)_build_opts= CC="$($(package)_cc)"


### PR DESCRIPTION
zlib v1.2.11 is no longer available from official sources. Bump to latest available version (v1.2.13).