### PR TITLE
[Tools] Fix case typo in .clang-format

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -25,7 +25,7 @@ DerivePointerAlignment: false
 DisableFormat: false
 IndentCaseLabels: false
 IndentWidth: 4
-IndentWrappedFunctionNames: False
+IndentWrappedFunctionNames: false
 KeepEmptyLinesAtTheStartOfBlocks: false
 MaxEmptyLinesToKeep: 2
 NamespaceIndentation: None


### PR DESCRIPTION
Boolean values in clang-format are case-sensitive, this fixes a typo that resulted in an incorrect value.