### PR TITLE
[GUI] Proposal Generate Address

### DIFF
--- a/src/qt/pivx/createproposaldialog.cpp
+++ b/src/qt/pivx/createproposaldialog.cpp
@@ -56,7 +56,9 @@ CreateProposalDialog::CreateProposalDialog(PIVXGUI* parent, GovernanceModel* _go
     initPageIndexBtn(icConfirm3);
 
     // Connect btns
-    setCssProperty(ui->btnNext, "btn-primary");
+    setCssProperty({ui->btnNext, ui->btnGenAddr}, "btn-primary");
+    ui->btnGenAddr->setVisible(false);
+    ui->btnGenAddr->setText(tr("GENERATE ADDRESS"));
     ui->btnNext->setText(tr("NEXT"));
     setCssProperty(ui->btnBack, "btn-dialog-cancel");
     ui->btnBack->setVisible(false);
@@ -66,6 +68,7 @@ CreateProposalDialog::CreateProposalDialog(PIVXGUI* parent, GovernanceModel* _go
     connect(ui->pushButtonSkip, &QPushButton::clicked, this, &CreateProposalDialog::close);
     connect(ui->btnNext, &QPushButton::clicked, this, &CreateProposalDialog::onNextClicked);
     connect(ui->btnBack, &QPushButton::clicked, this, &CreateProposalDialog::onBackClicked);
+    connect(ui->btnGenAddr, &QPushButton::clicked, this, &CreateProposalDialog::onGenAddressClicked);
 }
 
 void setEditBoxStyle(QLabel* label, QLineEdit* lineEdit, const QString& placeholderText)
@@ -270,6 +273,7 @@ void CreateProposalDialog::onNextClicked()
             ui->pushName1->setChecked(true);
             icConfirm1->setVisible(true);
             ui->btnBack->setVisible(true);
+            ui->btnGenAddr->setVisible(true);
             break;
         }
         case 1: {
@@ -306,6 +310,7 @@ void CreateProposalDialog::onBackClicked()
             ui->pushName1->setChecked(true);
             icConfirm1->setVisible(false);
             ui->btnBack->setVisible(false);
+            ui->btnGenAddr->setVisible(false);
             break;
         }
         case 1: {
@@ -366,6 +371,14 @@ void CreateProposalDialog::onAddrListClicked()
     position.setX(position.x() + 74); // Add widget's fixed padding manually
     menuContacts->move(position);
     menuContacts->show();
+}
+
+void CreateProposalDialog::onGenAddressClicked()
+{
+    std::string addrLabel = ui->lineEditPropName->text().toStdString();
+    CallResult<Destination> addr = !addrLabel.empty() ? walletModel->getNewAddress(addrLabel) : walletModel->getNewAddress("");
+    QString newAddr = QString::fromStdString(addr.getObjResult()->ToString());
+    ui->lineEditAddress->setText(newAddr);
 }
 
 void CreateProposalDialog::keyPressEvent(QKeyEvent *e)

--- a/src/qt/pivx/createproposaldialog.h
+++ b/src/qt/pivx/createproposaldialog.h
@@ -36,6 +36,7 @@ public Q_SLOTS:
     void propAmountChanged(const QString& newText);
     bool propaddressChanged(const QString& newText);
     void onAddrListClicked();
+    void onGenAddressClicked();
     void monthsEditDeselect(int i);
 
 private:

--- a/src/qt/pivx/forms/createproposaldialog.ui
+++ b/src/qt/pivx/forms/createproposaldialog.ui
@@ -352,7 +352,7 @@
             </size>
            </property>
            <property name="currentIndex">
-            <number>0</number>
+            <number>1</number>
            </property>
            <widget class="QWidget" name="pageIcon3">
             <property name="minimumSize">
@@ -669,6 +669,9 @@
           <width>16777215</width>
           <height>350</height>
          </size>
+        </property>
+        <property name="currentIndex">
+         <number>1</number>
         </property>
         <widget class="QWidget" name="page_1">
          <layout class="QVBoxLayout" name="verticalLayout_7" stretch="1,3,0">
@@ -1270,15 +1273,40 @@
        </widget>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout1" stretch="1,2,2">
+       <layout class="QHBoxLayout" name="horizontalLayout1" stretch="0,0,0,2">
+        <item>
+         <widget class="QPushButton" name="btnGenAddr">
+          <property name="minimumSize">
+           <size>
+            <width>180</width>
+            <height>50</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>250</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="focusPolicy">
+           <enum>Qt::NoFocus</enum>
+          </property>
+          <property name="text">
+           <string notr="true">N/A</string>
+          </property>
+         </widget>
+        </item>
         <item>
          <spacer name="horizontalSpacer">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Fixed</enum>
+          </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>40</width>
+            <width>180</width>
             <height>20</height>
            </size>
           </property>


### PR DESCRIPTION
This adds a new button to page 2 of the proposal creation process and uses the proposal name from the first page to assign a label to the newly generated address.

![Screenshot 2023-03-28 at 10 10 55 AM](https://user-images.githubusercontent.com/45834289/228286478-68d91b4c-fd1a-4a99-9e17-017eac046276.png)
![Screenshot 2023-03-28 at 10 11 14 AM](https://user-images.githubusercontent.com/45834289/228286489-e2080a4c-8fdf-4030-b80d-5b69b1985438.png)

This streamlines proposal creation process for users not wanting to re-use addresses and be able to start the process without realizing they may not have copied an address, after having say copied the short URL if they created one and can just continue forward.
As well as tagging the newly created address with the Proposal Name so its easy to find in the Receive tab.