### PR TITLE
[GUI] Fix bug in proposal creation

### DIFF
--- a/src/qt/pivx/governancemodel.cpp
+++ b/src/qt/pivx/governancemodel.cpp
@@ -363,6 +363,7 @@ void GovernanceModel::txLoaded(const QString& id, const int txType, const int tx
             CDataStream ss(vec, SER_DISK, CLIENT_VERSION);
             CBudgetProposal proposal;
             ss >> proposal;
+            proposal.SetFeeTxHash(wtx->GetHash());
             if (!g_budgetman.HaveProposal(proposal.GetHash()) &&
                 !proposal.IsExpired(clientModel->getNumBlocks()) &&
                 proposal.GetBlockStart() > clientModel->getNumBlocks()) {


### PR DESCRIPTION
The bug:
If you create a governance proposal from the GUI and close the wallet before the proposal has 5 confirmations, when you open again the wallet will partially recover and FAIL to relay the proposal.

Why this is happening:
Basically the `wtx->mapValue.find("proposal");` does not contain the hash of the 50 PIVs fee tx.

How I fixed:
I simply added manually the fee hash.

How to test:
Create a proposal close the wallet before the proposal has 5 confirmation, reopen the wallet and make sure that the proposal is relayed to the network when it reaches 5 confirmations
 