### PR TITLE
[TierTwo] P2SH Proposal Payouts

### DIFF
--- a/src/budget/budgetmanager.cpp
+++ b/src/budget/budgetmanager.cpp
@@ -324,19 +324,18 @@ bool CBudgetManager::AddProposal(CBudgetProposal& budgetProposal)
 {
     AssertLockNotHeld(cs_proposals);    // need to lock cs_main here (CheckCollateral)
     const uint256& nHash = budgetProposal.GetHash();
-
+    int nCurrentHeight = GetBestHeight();
     if (WITH_LOCK(cs_proposals, return mapProposals.count(nHash))) {
         LogPrint(BCLog::MNBUDGET,"%s: proposal %s already added\n", __func__, nHash.ToString());
         return false;
     }
 
-    if (!budgetProposal.IsWellFormed(GetTotalBudget(budgetProposal.GetBlockStart()))) {
+    if (!budgetProposal.IsWellFormed(GetTotalBudget(budgetProposal.GetBlockStart()), nCurrentHeight)) {
         LogPrint(BCLog::MNBUDGET,"%s: Invalid budget proposal %s %s\n", __func__, nHash.ToString(), budgetProposal.IsInvalidLogStr());
         return false;
     }
 
     std::string strError;
-    int nCurrentHeight = GetBestHeight();
     const uint256& feeTxId = budgetProposal.GetFeeTXHash();
     if (!CheckCollateral(feeTxId, nHash, strError, budgetProposal.nTime, nCurrentHeight, false)) {
         LogPrint(BCLog::MNBUDGET,"%s: invalid budget proposal (%s) collateral id=%s - %s\n",

--- a/src/budget/budgetproposal.cpp
+++ b/src/budget/budgetproposal.cpp
@@ -123,11 +123,11 @@ bool CBudgetProposal::CheckAmount(const CAmount& nTotalBudget)
     return true;
 }
 
-bool CBudgetProposal::CheckAddress()
+bool CBudgetProposal::CheckAddress(const int nCurrentHeight)
 {
-    // !TODO: There might be an issue with multisig in the coinbase on mainnet
-    // we will add support for it in a future release.
-    if (address.IsPayToScriptHash()) {
+    // Multisig is supported only after v6
+    bool isV6Enforced = Params().GetConsensus().NetworkUpgradeActive(nCurrentHeight, Consensus::UPGRADE_V6_0);
+    if (!isV6Enforced && address.IsPayToScriptHash()) {
         strInvalid = "Multisig is not currently supported.";
         return false;
     }
@@ -160,9 +160,9 @@ bool CBudgetProposal::CheckStrings()
     }
 }
 
-bool CBudgetProposal::IsWellFormed(const CAmount& nTotalBudget)
+bool CBudgetProposal::IsWellFormed(const CAmount& nTotalBudget, const int nCurrentHeight)
 {
-    return CheckStartEnd() && CheckAmount(nTotalBudget) && CheckAddress();
+    return CheckStartEnd() && CheckAmount(nTotalBudget) && CheckAddress(nCurrentHeight);
 }
 
 bool CBudgetProposal::updateExpired(int nCurrentHeight)

--- a/src/budget/budgetproposal.cpp
+++ b/src/budget/budgetproposal.cpp
@@ -5,6 +5,7 @@
 
 #include "budget/budgetproposal.h"
 #include "chainparams.h"
+#include "logging.h"
 #include "script/standard.h"
 #include "utilstrencodings.h"
 
@@ -146,9 +147,6 @@ bool CBudgetProposal::CheckAddress(const int nCurrentHeight)
     return true;
 }
 
-/* TODO: Add this to IsWellFormed() for the next hard-fork
- * This will networkly reject malformed proposal names and URLs
- */
 bool CBudgetProposal::CheckStrings()
 {
     if (strProposalName != SanitizeString(strProposalName)) {
@@ -157,11 +155,17 @@ bool CBudgetProposal::CheckStrings()
     }
     if (strURL != SanitizeString(strURL)) {
         strInvalid = "Proposal URL contains illegal characters.";
+        return false;
     }
+    return true;
 }
 
 bool CBudgetProposal::IsWellFormed(const CAmount& nTotalBudget, const int nCurrentHeight)
 {
+    bool isV6Enforced = Params().GetConsensus().NetworkUpgradeActive(nCurrentHeight, Consensus::UPGRADE_V6_0);
+    if (isV6Enforced && !CheckStrings()) {
+        return false;
+    }
     return CheckStartEnd() && CheckAmount(nTotalBudget) && CheckAddress(nCurrentHeight);
 }
 

--- a/src/budget/budgetproposal.h
+++ b/src/budget/budgetproposal.h
@@ -41,7 +41,7 @@ private:
     bool updateExpired(int nCurrentHeight);
     bool CheckStartEnd();
     bool CheckAmount(const CAmount& nTotalBudget);
-    bool CheckAddress();
+    bool CheckAddress(const int nCurrentHeight);
     bool CheckStrings();
 
 protected:
@@ -71,7 +71,7 @@ public:
     // sets fValid and strInvalid, returns fValid
     bool UpdateValid(int nHeight, int mnCount);
     // Static checks that should be done only once - sets strInvalid
-    bool IsWellFormed(const CAmount& nTotalBudget);
+    bool IsWellFormed(const CAmount& nTotalBudget, const int nCurrentHeight);
     bool IsValid() const  { return fValid; }
     void SetStrInvalid(const std::string& _strInvalid) { strInvalid = _strInvalid; }
     std::string IsInvalidReason() const { return strInvalid; }

--- a/src/qt/pivx/governancemodel.cpp
+++ b/src/qt/pivx/governancemodel.cpp
@@ -245,7 +245,7 @@ OperationResult GovernanceModel::createProposal(const std::string& strProposalNa
 
     // Validate proposal
     CBudgetProposal proposal(strProposalName, strURL, nPaymentCount, scriptPubKey, nAmount, nBlockStart, UINT256_ZERO);
-    if (!proposal.IsWellFormed(g_budgetman.GetTotalBudget(proposal.GetBlockStart()))) {
+    if (!proposal.IsWellFormed(g_budgetman.GetTotalBudget(proposal.GetBlockStart()), clientModel->getNumBlocks())) {
         return {false, strprintf(_("Proposal is not valid %s"), proposal.IsInvalidReason())};
     }
 

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -147,7 +147,7 @@ UniValue preparebudget(const JSONRPCRequest& request)
     // create transaction 15 minutes into the future, to allow for confirmation time
     CBudgetProposal proposal(strProposalName, strURL, nPaymentCount, scriptPubKey, nAmount, nBlockStart, UINT256_ZERO);
     const uint256& nHash = proposal.GetHash();
-    if (!proposal.IsWellFormed(g_budgetman.GetTotalBudget(proposal.GetBlockStart())))
+    if (!proposal.IsWellFormed(g_budgetman.GetTotalBudget(proposal.GetBlockStart()), GetChainTip()->nHeight))
         throw std::runtime_error("Proposal is not valid " + proposal.IsInvalidReason());
 
     CTransactionRef wtx;


### PR DESCRIPTION
the idea of this PR is taken from https://github.com/PIVX-Project/PIVX/pull/2265.
Having the governance system accept P2SH proposals is a nice addition since, for example, the work of a team can be paid in a single multisig address.
P2SH proposals will be enabled after v6.0 and is not backward compatible: in particular with the current implementation a v6 node will relay a p2sh proposal even to non-v6 nodes (and will lead to non v6 nodes banning the v6 node). 
Since v6.0 will be a huge mandatory update I don't think it will be an issue