### PR TITLE
[Util] Resolve fetch-params error

### DIFF
--- a/util/fetch-params.sh
+++ b/util/fetch-params.sh
@@ -136,7 +136,7 @@ function fetch_params {
         cat "${dlname}.part.1" "${dlname}.part.2" > "${dlname}"
         rm "${dlname}.part.1" "${dlname}.part.2"
 
-        "$SHA256CMD" "$SHA256ARGS" -c <<EOF
+        "$SHA256CMD" $SHA256ARGS -c <<EOF
 $expectedhash  $dlname
 EOF
 


### PR DESCRIPTION
While running tests yesterday started a new clean server and went to install PIVX, when trying to run fetch-params.sh we get the following error:
`/usr/bin/sha256sum: '': No such file or directory`
Following this the bash script fails and then does not download the sapling params as necessary.
The PR fixes that issue, double quotes were used and causing us to get an empty SHA256ARGS variable, also because this would contain no spaces its not really necessary