### PR TITLE
Introduce interfaces Signing Provider/BaseSignatureCreator

### DIFF
--- a/src/keystore.h
+++ b/src/keystore.h
@@ -12,6 +12,12 @@
 #include "sapling/address.h"
 #include "sapling/zip32.h"
 #include "sync.h"
+#include <key.h>
+#include <pubkey.h>
+#include <script/script.h>
+#include <script/sign.h>
+#include <script/standard.h>
+#include <sync.h>
 
 #include <boost/signals2/signal.hpp>
 
@@ -19,14 +25,13 @@ class CScript;
 class CScriptID;
 
 /** A virtual base class for key stores */
-class CKeyStore
+class CKeyStore : public SigningProvider
 {
 public:
     // todo: Make it protected again once we are more advanced in the wallet/spkm decoupling.
     mutable RecursiveMutex cs_KeyStore;
 
-    virtual ~CKeyStore() {}
-
+public:
     //! Add a key to the store.
     virtual bool AddKeyPubKey(const CKey& key, const CPubKey& pubkey) = 0;
     virtual bool AddKey(const CKey& key);

--- a/src/pivx-tx.cpp
+++ b/src/pivx-tx.cpp
@@ -544,7 +544,8 @@ static void MutateTxSign(CMutableTransaction& tx, const std::string& flagStr)
         // Only sign SIGHASH_SINGLE if there's a corresponding output:
         if (!fHashSingle || (i < mergedTx.vout.size()))
             ProduceSignature(
-                    MutableTransactionSignatureCreator(&keystore, &mergedTx, i, amount, nHashType),
+                    keystore,
+                    MutableTransactionSignatureCreator(&mergedTx, i, amount, nHashType),
                     prevPubKey,
                     sigdata,
                     sigversion,

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -766,7 +766,7 @@ UniValue signrawtransaction(const JSONRPCRequest& request)
         SigVersion sigversion = mergedTx.GetRequiredSigVersion();
         // Only sign SIGHASH_SINGLE if there's a corresponding output:
         if (!fHashSingle || (i < mergedTx.vout.size()))
-            ProduceSignature(MutableTransactionSignatureCreator(&keystore, &mergedTx, i, amount, nHashType),
+            ProduceSignature(keystore, MutableTransactionSignatureCreator(&mergedTx, i, amount, nHashType),
                     prevPubKey, sigdata, sigversion, fColdStake);
 
         // ... and merge in other signatures:

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -355,7 +355,9 @@ static OperationResult SignTransaction(CWallet* const pwallet, CMutableTransacti
         SigVersion sv = tx.GetRequiredSigVersion();
         txin.scriptSig.clear();
         SignatureData sigdata;
-        if (!ProduceSignature(MutableTransactionSignatureCreator(pwallet, &tx, i, coin.out.nValue, SIGHASH_ALL),
+        const CKeyStore& keys = *pwallet;
+        if (!ProduceSignature(keys,
+                              MutableTransactionSignatureCreator(&tx, i, coin.out.nValue, SIGHASH_ALL),
                               coin.out.scriptPubKey, sigdata, sv, false)) {
             return errorOut(TxInErrorToString(i, txin, "signature failed"));
         }

--- a/src/sapling/transaction_builder.cpp
+++ b/src/sapling/transaction_builder.cpp
@@ -332,9 +332,9 @@ TransactionBuilderResult TransactionBuilder::ProveAndSign()
         auto tIn = tIns[nIn];
         SignatureData sigdata;
         bool signSuccess = ProduceSignature(
-            TransactionSignatureCreator(
-                keystore, &txNewConst, nIn, tIn.value, SIGHASH_ALL),
-            tIn.scriptPubKey, sigdata, SIGVERSION_SAPLING, false);
+                        *keystore,
+                        TransactionSignatureCreator(&txNewConst, nIn, tIn.value, SIGHASH_ALL),
+                        tIn.scriptPubKey, sigdata, SIGVERSION_SAPLING, false);
 
         if (!signSuccess) {
             return TransactionBuilderResult("Failed to sign transaction");
@@ -366,7 +366,12 @@ TransactionBuilderResult TransactionBuilder::AddDummySignatures()
     for (int nIn = 0; nIn < (int) mtx.vin.size(); nIn++) {
         auto tIn = tIns[nIn];
         SignatureData sigdata;
-        if (!ProduceSignature(DummySignatureCreator(keystore), tIn.scriptPubKey, sigdata, SIGVERSION_SAPLING, false)) {
+        if (!ProduceSignature(*keystore,
+                              DUMMY_SIGNATURE_CREATOR,
+                              tIn.scriptPubKey,
+                              sigdata,
+                              SIGVERSION_SAPLING,
+                              false)) {
             return TransactionBuilderResult("Failed to sign transaction");
         } else {
             UpdateTransaction(mtx, nIn, sigdata);

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -11,14 +11,13 @@
 
 class CKey;
 class CKeyID;
-class CKeyStore;
 class CScript;
 class CScriptID;
 class CTransaction;
 
 struct CMutableTransaction;
 
-/** An interface to be implemented by keystores that support signing. */
+/** An interface to be implemented by providers that support signing. */
 class SigningProvider
 {
 public:
@@ -27,8 +26,6 @@ public:
     virtual bool GetPubKey(const CKeyID &address, CPubKey& pubkey) const { return false; }
     virtual bool GetKey(const CKeyID &address, CKey& key) const { return false; }
 };
-
-extern const SigningProvider& DUMMY_SIGNING_PROVIDER;
 
 class PublicOnlySigningProvider : public SigningProvider
 {
@@ -56,17 +53,16 @@ FlatSigningProvider Merge(const FlatSigningProvider& a, const FlatSigningProvide
 
 /** Virtual base class for signature creators. */
 class BaseSignatureCreator {
+
 protected:
-    const CKeyStore* keystore;
+    const SigningProvider* m_provider;
 
 public:
-    BaseSignatureCreator(const CKeyStore* keystoreIn) : keystore(keystoreIn) {}
-    const CKeyStore& KeyStore() const { return *keystore; };
     virtual ~BaseSignatureCreator() {}
     virtual const BaseSignatureChecker& Checker() const =0;
 
     /** Create a singular (non-script) signature. */
-    virtual bool CreateSig(std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode, SigVersion sigversion) const =0;
+    virtual bool CreateSig(const SigningProvider& provider, std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode, SigVersion sigversion) const =0;
 };
 
 /** A signature creator for transactions. */
@@ -78,25 +74,20 @@ class TransactionSignatureCreator : public BaseSignatureCreator {
     const TransactionSignatureChecker checker;
 
 public:
-    TransactionSignatureCreator(const CKeyStore* keystoreIn, const CTransaction* txToIn, unsigned int nInIn, const CAmount& amountIn, int nHashTypeIn=SIGHASH_ALL);
-    const BaseSignatureChecker& Checker() const { return checker; }
-    bool CreateSig(std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode, SigVersion sigversion) const;
+    TransactionSignatureCreator(const CTransaction* txToIn, unsigned int nInIn, const CAmount& amountIn, int nHashTypeIn=SIGHASH_ALL);
+    const BaseSignatureChecker& Checker() const override { return checker; }
+    bool CreateSig(const SigningProvider& provider, std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode, SigVersion sigversion) const override;
 };
 
 class MutableTransactionSignatureCreator : public TransactionSignatureCreator {
-    const CTransaction tx;
+    CTransaction tx;
 
 public:
-    MutableTransactionSignatureCreator(const CKeyStore* keystoreIn, const CMutableTransaction* txToIn, unsigned int nInIn, const CAmount& amount, int nHashTypeIn) : TransactionSignatureCreator(keystoreIn, &tx, nInIn, amount, nHashTypeIn), tx(*txToIn) {}
+    MutableTransactionSignatureCreator(const CMutableTransaction* txToIn, unsigned int nInIn, const CAmount& amountIn, int nHashTypeIn) : TransactionSignatureCreator(&tx, nInIn, amountIn, nHashTypeIn), tx(*txToIn) {}
 };
 
 /** A signature creator that just produces 72-byte empty signatyres. */
-class DummySignatureCreator : public BaseSignatureCreator {
-public:
-    DummySignatureCreator(const CKeyStore* keystoreIn) : BaseSignatureCreator(keystoreIn) {}
-    const BaseSignatureChecker& Checker() const;
-    bool CreateSig(std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode, SigVersion sigversion) const;
-};
+extern const BaseSignatureCreator& DUMMY_SIGNATURE_CREATOR;
 
 struct SignatureData {
     CScript scriptSig;
@@ -106,11 +97,11 @@ struct SignatureData {
 };
 
 /** Produce a script signature using a generic signature creator. */
-bool ProduceSignature(const BaseSignatureCreator& creator, const CScript& fromPubKey, SignatureData& sigdata, SigVersion sigversion, bool fColdStake, ScriptError* serror = nullptr);
+bool ProduceSignature(const SigningProvider& provider, const BaseSignatureCreator& creator, const CScript& fromPubKey, SignatureData& sigdata, SigVersion sigversion, bool fColdStake, ScriptError* serror = nullptr);
 
 /** Produce a script signature for a transaction. */
-bool SignSignature(const CKeyStore& keystore, const CScript& fromPubKey, CMutableTransaction& txTo, unsigned int nIn, const CAmount& amount, int nHashType, bool fColdStake = false);
-bool SignSignature(const CKeyStore& keystore, const CTransaction& txFrom, CMutableTransaction& txTo, unsigned int nIn, int nHashType, bool fColdStake = false);
+bool SignSignature(const SigningProvider &provider, const CScript& fromPubKey, CMutableTransaction& txTo, unsigned int nIn, const CAmount& amount, int nHashType, bool fColdStake = false);
+bool SignSignature(const SigningProvider &provider, const CTransaction& txFrom, CMutableTransaction& txTo, unsigned int nIn, int nHashType, bool fColdStake = false);
 
 /** Combine two script signatures using a generic signature checker, intelligently, possibly with OP_0 placeholders. */
 SignatureData CombineSignatures(const CScript& scriptPubKey, const BaseSignatureChecker& checker, const SignatureData& scriptSig1, const SignatureData& scriptSig2);
@@ -121,8 +112,8 @@ void UpdateTransaction(CMutableTransaction& tx, unsigned int nIn, const Signatur
 
 /* Check whether we know how to sign for an output like this, assuming we
   * have all private keys. While this function does not need private keys, the passed
-  * keystore is used to look up public keys and redeemscripts by hash.
+  * provider is used to look up public keys and redeemscripts by hash.
   * Solvability is unrelated to whether we consider this output to be ours. */
-bool IsSolvable(const CKeyStore& store, const CScript& script, bool fColdStaking);
+bool IsSolvable(const SigningProvider& provider, const CScript& script, bool fColdStaking);
 
 #endif // BITCOIN_SCRIPT_SIGN_H

--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -34,9 +34,10 @@ CScript GetScriptForType(CPubKey pubKey, BlockSignatureType type)
 
 std::vector<unsigned char> CreateDummyScriptSigWithKey(CPubKey pubKey)
 {
+    SigningProvider provider;
     std::vector<unsigned char> vchSig;
     const CScript scriptCode;
-    DummySignatureCreator(nullptr).CreateSig(vchSig, pubKey.GetID(), scriptCode, SIGVERSION_BASE);
+    DUMMY_SIGNATURE_CREATOR.CreateSig(provider, vchSig, pubKey.GetID(), scriptCode, SIGVERSION_BASE);
     return vchSig;
 }
 

--- a/src/wallet/test/pos_validations_tests.cpp
+++ b/src/wallet/test/pos_validations_tests.cpp
@@ -9,6 +9,7 @@
 #include "util/blockstatecatcher.h"
 #include "blocksignature.h"
 #include "consensus/merkle.h"
+#include "keystore.h"
 #include "primitives/block.h"
 #include "script/sign.h"
 #include "test/util/blocksutil.h"
@@ -26,8 +27,10 @@ void reSignTx(CMutableTransaction& mtx,
     for (int index=0; index < (int) txPrevOutputs.size(); index++) {
         const CTxOut& prevOut = txPrevOutputs.at(index);
         SignatureData sigdata;
+        const CKeyStore& keys = *wallet;
         BOOST_ASSERT(ProduceSignature(
-                TransactionSignatureCreator(wallet, &txNewConst, index, prevOut.nValue, SIGHASH_ALL),
+                keys,
+                TransactionSignatureCreator(&txNewConst, index, prevOut.nValue, SIGHASH_ALL),
                 prevOut.scriptPubKey,
                 sigdata,
                 txNewConst.GetRequiredSigVersion(),

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3158,7 +3158,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend,
                 for (const auto & coin : setCoins) {
                     const CScript& scriptPubKey = coin.first->tx->vout[coin.second].scriptPubKey;
                     SignatureData sigdata;
-                    if (!ProduceSignature(DummySignatureCreator(this), scriptPubKey, sigdata, txNew.GetRequiredSigVersion(), false)) {
+                    if (!ProduceSignature(*this, DUMMY_SIGNATURE_CREATOR, scriptPubKey, sigdata, txNew.GetRequiredSigVersion(), false)) {
                         strFailReason = _("Signing transaction failed");
                         return false;
                     } else {
@@ -3212,7 +3212,8 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend,
                 bool haveKey = coin.first->GetStakeDelegationCredit() > 0;
 
                 if (!ProduceSignature(
-                        TransactionSignatureCreator(this, &txNewConst, nIn, coin.first->tx->vout[coin.second].nValue, SIGHASH_ALL),
+                        *this,
+                        TransactionSignatureCreator(&txNewConst, nIn, coin.first->tx->vout[coin.second].nValue, SIGHASH_ALL),
                         scriptPubKey,
                         sigdata,
                         txNewConst.GetRequiredSigVersion(),
@@ -3419,7 +3420,7 @@ bool CWallet::CreateCoinStake(
 bool CWallet::SignCoinStake(CMutableTransaction& txNew) const
 {
     // Sign it
-    int nIn = 0;
+    unsigned int nIn = 0;
     for (const CTxIn& txIn : txNew.vin) {
         const CWalletTx* wtx = GetWalletTx(txIn.prevout.hash);
         if (!wtx || !SignSignature(*this, *(wtx->tx), txNew, nIn++, SIGHASH_ALL, true))


### PR DESCRIPTION
This PR is the start of the road to implementing [BIP-174](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki)
In order to integrate PSBT, we have several necessary prerequisites that include this PR.

`CKeyStore` class has more than the majority of what the sign functions will use/need, so changing to providing *only* keys and scripts. `CKeyStore` is no longer the interface that signing relies on, thus swapping the dependency around where `CKeyStore` now relies on `SigningProvider`.

Next, we changed `DummySignatureCreator` to a stateless object `DUMMY_SIGNATURE_CREATOR`. `BaseSignatureCreator` is now its own interface and can now implement new derivations for signing with it. Alongside this now provides transaction-specific logic and/or other signing logic.

Lastly, this PR refactored `TransactionSignatureCreator` into a templated `GenericTransactionSignatureCreator` that works with both `CMutableTransaction` and `CTransaction`. Which speeds up the resolution in our Unit testing. 

Backports for reference:
https://github.com/bitcoin/bitcoin/pull/12714
https://github.com/bitcoin/bitcoin/pull/12803
https://github.com/bitcoin/bitcoin/pull/13309


