### PR TITLE
[Core] Remove unused PoW block signing code

### DIFF
--- a/src/blocksignature.cpp
+++ b/src/blocksignature.cpp
@@ -35,19 +35,8 @@ bool SignBlockWithKey(CBlock& block, const CKey& key)
 bool SignBlock(CBlock& block, const CKeyStore& keystore)
 {
     CKeyID keyID;
-    if (block.IsProofOfWork()) {
-        bool fFoundID = false;
-        for (const CTxOut& txout : block.vtx[0]->vout) {
-            if (!GetKeyIDFromUTXO(txout, keyID))
-                continue;
-            fFoundID = true;
-            break;
-        }
-        if (!fFoundID)
-            return error("%s: failed to find key for PoW", __func__);
-    } else {
-        if (!GetKeyIDFromUTXO(block.vtx[1]->vout[1], keyID))
-            return error("%s: failed to find key for PoS", __func__);
+    if (!GetKeyIDFromUTXO(block.vtx[1]->vout[1], keyID)) {
+        return error("%s: failed to find key for PoS", __func__);
     }
 
     CKey key;


### PR DESCRIPTION
I know that we are no longer POW but nevertheless mining in POW phase would no longer work since we are signing the block