### PR TITLE
[Core] Unify binary exit codes

### DIFF
--- a/src/bench/bench_pivx.cpp
+++ b/src/bench/bench_pivx.cpp
@@ -42,7 +42,7 @@ int main(int argc, char** argv)
                   << HelpMessageOpt("-plot-width=<x>", strprintf(_("Plot width in pixel (default: %u)"), DEFAULT_PLOT_WIDTH))
                   << HelpMessageOpt("-plot-height=<x>", strprintf(_("Plot height in pixel (default: %u)"), DEFAULT_PLOT_HEIGHT));
 
-        return 0;
+        return EXIT_SUCCESS;
     }
 
     RandomInit();
@@ -81,4 +81,6 @@ int main(int argc, char** argv)
     CleanupBLSTests();
 
     ECC_Stop();
+
+    return EXIT_SUCCESS;
 }

--- a/src/pivx-tx.cpp
+++ b/src/pivx-tx.cpp
@@ -27,8 +27,13 @@
 
 static bool fCreateBlank;
 static std::map<std::string, UniValue> registers;
+static const int CONTINUE_EXECUTION=-1;
 
-static bool AppInitRawTx(int argc, char* argv[])
+//
+// This function returns either one of EXIT_ codes when it's expected to stop the process or
+// CONTINUE_EXECUTION when it's expected to continue further.
+//
+static int AppInitRawTx(int argc, char* argv[])
 {
     //
     // Parameters
@@ -40,7 +45,7 @@ static bool AppInitRawTx(int argc, char* argv[])
         SelectParams(gArgs.GetChainName());
     } catch(const std::exception& e) {
         fprintf(stderr, "Error: %s\n", e.what());
-        return false;
+        return EXIT_FAILURE;
     }
 
     fCreateBlank = gArgs.GetBoolArg("-create", false);
@@ -85,9 +90,13 @@ static bool AppInitRawTx(int argc, char* argv[])
         strUsage += HelpMessageOpt("set=NAME:JSON-STRING", "Set register NAME to given JSON-STRING");
         fprintf(stdout, "%s", strUsage.c_str());
 
-        return false;
+        if (argc < 2) {
+            fprintf(stderr, "Error: too few parameters\n");
+            return EXIT_FAILURE;
+        }
+        return EXIT_SUCCESS;
     }
-    return true;
+    return CONTINUE_EXECUTION;
 }
 
 static void RegisterSetJson(const std::string& key, const std::string& rawJson)
@@ -740,8 +749,9 @@ int main(int argc, char* argv[])
     SetupEnvironment();
 
     try {
-        if (!AppInitRawTx(argc, argv))
-            return EXIT_FAILURE;
+        int ret = AppInitRawTx(argc, argv);
+        if (ret != CONTINUE_EXECUTION)
+            return ret;
     } catch (const std::exception& e) {
         PrintExceptionContinue(&e, "AppInitRawTx()");
         return EXIT_FAILURE;

--- a/src/pivxd.cpp
+++ b/src/pivxd.cpp
@@ -70,7 +70,7 @@ bool AppInit(int argc, char* argv[])
         }
 
         fprintf(stdout, "%s", strUsage.c_str());
-        return false;
+        return true;
     }
 
     try {

--- a/src/qt/pivx.cpp
+++ b/src/qt/pivx.cpp
@@ -538,7 +538,7 @@ void BitcoinApplication::shutdownResult(int retval)
 void BitcoinApplication::handleRunawayException(const QString& message)
 {
     QMessageBox::critical(nullptr, "Runaway exception", QObject::tr("A fatal error occurred. PIVX can no longer continue safely and will quit.") + QString("\n\n") + message);
-    ::exit(1);
+    ::exit(EXIT_FAILURE);
 }
 
 WId BitcoinApplication::getMainWinId() const
@@ -604,27 +604,27 @@ int main(int argc, char* argv[])
     if (gArgs.IsArgSet("-?") || gArgs.IsArgSet("-h") || gArgs.IsArgSet("-help") || gArgs.IsArgSet("-version")) {
         HelpMessageDialog help(nullptr, gArgs.IsArgSet("-version"));
         help.showOrPrint();
-        return 1;
+        return EXIT_SUCCESS;
     }
 
     /// 5. Now that settings and translations are available, ask user for data directory
     // User language is set up: pick a data directory
     if (!Intro::pickDataDirectory())
-        return 0;
+        return EXIT_SUCCESS;
 
     /// 6. Determine availability of data directory and parse pivx.conf
     /// - Do not call GetDataDir(true) before this step finishes
     if (!CheckDataDirOption()) {
         QMessageBox::critical(nullptr, PACKAGE_NAME,
             QObject::tr("Error: Specified data directory \"%1\" does not exist.").arg(QString::fromStdString(gArgs.GetArg("-datadir", ""))));
-        return 1;
+        return EXIT_FAILURE;
     }
     try {
         gArgs.ReadConfigFile(gArgs.GetArg("-conf", PIVX_CONF_FILENAME));
     } catch (const std::exception& e) {
         QMessageBox::critical(nullptr, PACKAGE_NAME,
             QObject::tr("Error: Cannot parse configuration file: %1. Only use key=value syntax.").arg(e.what()));
-        return 0;
+        return EXIT_FAILURE;
     }
 
     /// 7. Determine network (and switch to network specific options)
@@ -638,7 +638,7 @@ int main(int argc, char* argv[])
         SelectParams(gArgs.GetChainName());
     } catch(const std::exception& e) {
         QMessageBox::critical(nullptr, PACKAGE_NAME, QObject::tr("Error: %1").arg(e.what()));
-        return 1;
+        return EXIT_FAILURE;
     }
 #ifdef ENABLE_WALLET
     // Parse URIs on command line -- this can affect Params()
@@ -660,7 +660,7 @@ int main(int argc, char* argv[])
     // - Do this after creating app and setting up translations, so errors are
     // translated properly.
     if (PaymentServer::ipcSendCommandLine())
-        exit(0);
+        exit(EXIT_SUCCESS);
 
     // Start up the payment server early, too, so impatient users that click on
     // pivx: links repeatedly have their payment requests routed to this process:

--- a/test/functional/feature_help.py
+++ b/test/functional/feature_help.py
@@ -24,7 +24,7 @@ class HelpTest(PivxTestFramework):
         self.nodes[0].start(extra_args=['-?'], stderr=subprocess.PIPE, stdout=subprocess.PIPE)
         # Node should exit immediately and output help to stdout.
         ret_code = self.nodes[0].process.wait(timeout=1)
-        assert_equal(ret_code, 1)
+        assert_equal(ret_code, 0)
         output = self.nodes[0].process.stdout.read()
         assert b'Options' in output
         self.log.info("Help text received: {} (...)".format(output[0:60]))
@@ -34,7 +34,7 @@ class HelpTest(PivxTestFramework):
         self.nodes[0].start(extra_args=['-version'], stderr=subprocess.PIPE, stdout=subprocess.PIPE)
         # Node should exit immediately and output version to stdout.
         ret_code = self.nodes[0].process.wait(timeout=1)
-        assert_equal(ret_code, 1)
+        assert_equal(ret_code, 0)
         output = self.nodes[0].process.stdout.read()
         assert b'version' in output
         self.log.info("Version text received: {} (...)".format(output[0:60]))


### PR DESCRIPTION
* `--help`, `--version` etc should exit with `0` i.e. no error ("not enough args" case should still trigger an error)
* error reading config file should exit with `1`

Ref: https://github.com/bitcoin/bitcoin/pull/9067, https://github.com/bitcoin/bitcoin/pull/9120, https://github.com/bitcoin/bitcoin/pull/13349