### PR TITLE
[zmq] Call va_end() on va_start()ed args.

### DIFF
--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -30,6 +30,7 @@ static int zmq_send_multipart(void *sock, const void* data, size_t size, ...)
         if (rc != 0)
         {
             zmqError("Unable to initialize ZMQ msg");
+            va_end(args);
             return -1;
         }
 
@@ -43,6 +44,7 @@ static int zmq_send_multipart(void *sock, const void* data, size_t size, ...)
         {
             zmqError("Unable to send ZMQ msg");
             zmq_msg_close(&msg);
+            va_end(args);
             return -1;
         }
 
@@ -53,6 +55,7 @@ static int zmq_send_multipart(void *sock, const void* data, size_t size, ...)
 
         size = va_arg(args, size_t);
     }
+    va_end(args);
     return 0;
 }
 


### PR DESCRIPTION
> A function that invokes `va_start`, shall also invoke `va_end` before it returns.
(http://www.cplusplus.com/reference/cstdarg/va_start/)

> If there is no corresponding call to `va_start` or `va_copy`, or if `va_end` is not called before a function that calls `va_start` or `va_copy` returns, the behavior is undefined.
http://en.cppreference.com/w/cpp/utility/variadic/va_end

Ref: https://github.com/bitcoin/bitcoin/pull/10056