### PR TITLE
[Misc] Cleanup whitespace and guard RPC tables from clang-format

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1670,6 +1670,7 @@ UniValue scantxoutset(const JSONRPCRequest& request)
     return result;
 }
 
+// clang-format off
 static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         okSafe argNames
   //  --------------------- ------------------------  -----------------------  ------ --------
@@ -1689,9 +1690,8 @@ static const CRPCCommand commands[] =
     { "blockchain",         "getsupplyinfo",          &getsupplyinfo,          true,  {"force_update"} },
     { "blockchain",         "gettxout",               &gettxout,               true,  {"txid","n","include_mempool"} },
     { "blockchain",         "gettxoutsetinfo",        &gettxoutsetinfo,        true,  {} },
-    { "blockchain",         "verifychain",            &verifychain,            true,  {"nblocks"} },
-
     { "blockchain",         "scantxoutset",           &scantxoutset,           true,  {"action", "scanobjects"} },
+    { "blockchain",         "verifychain",            &verifychain,            true,  {"nblocks"} },
 
     /* Not shown in help */
     { "hidden",             "invalidateblock",        &invalidateblock,        true,  {"blockhash"} },
@@ -1700,9 +1700,8 @@ static const CRPCCommand commands[] =
     { "hidden",             "waitforblockheight",     &waitforblockheight,     true,  {"height","timeout"} },
     { "hidden",             "waitfornewblock",        &waitfornewblock,        true,  {"timeout"} },
     { "hidden",             "syncwithvalidationinterfacequeue", &syncwithvalidationinterfacequeue, true,  {} },
-
-
 };
+// clang-format on
 
 void RegisterBlockchainRPCCommands(CRPCTable &tableRPC)
 {

--- a/src/rpc/budget.cpp
+++ b/src/rpc/budget.cpp
@@ -752,6 +752,7 @@ UniValue cleanbudget(const JSONRPCRequest& request)
     return NullUniValue;
 }
 
+// clang-format off
 static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         okSafe argNames
   //  --------------------- ------------------------  -----------------------  ------ --------
@@ -766,12 +767,12 @@ static const CRPCCommand commands[] =
     { "budget",             "preparebudget",          &preparebudget,          true,  {"name","url","npayments","start","address","monthly_payment"} },
     { "budget",             "submitbudget",           &submitbudget,           true,  {"name","url","npayments","start","address","monthly_payment","fee_txid"}  },
 
-    /* Not shown in help */
+    /** Not shown in help */
     { "hidden",             "mnfinalbudgetsuggest",   &mnfinalbudgetsuggest,   true,  {} },
     { "hidden",             "createrawmnfinalbudget", &createrawmnfinalbudget, true,  {"budgetname", "blockstart", "proposals", "feetxid"} },
     { "hidden",             "cleanbudget",            &cleanbudget,            true,  {"try_sync"} },
-
 };
+// clang-format on
 
 void RegisterBudgetRPCCommands(CRPCTable &tableRPC)
 {

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -19,6 +19,7 @@ public:
     std::string paramName; //!< parameter name
 };
 
+// clang-format off
 /**
  * Specifiy a (method, idx, name) here if the argument is a non-string RPC
  * argument and needs to be converted from JSON.
@@ -35,8 +36,8 @@ static const CRPCConvertParam vRPCConvertParams[] = {
     { "createrawtransaction", 0, "inputs" },
     { "createrawtransaction", 1, "outputs" },
     { "createrawtransaction", 2, "locktime" },
-    {"createrawmnfinalbudget", 1, "blockstart"},
-    {"createrawmnfinalbudget", 2, "proposals"},
+    { "createrawmnfinalbudget", 1, "blockstart" },
+    { "createrawmnfinalbudget", 2, "proposals" },
     { "delegatestake", 1, "amount" },
     { "delegatestake", 3, "ext_owner" },
     { "delegatestake", 4, "include_delegated" },
@@ -127,12 +128,12 @@ static const CRPCConvertParam vRPCConvertParams[] = {
     { "prioritisetransaction", 1, "fee_delta" },
     { "quorumdkgsimerror", 1, "rate" },
     { "quorumdkgstatus", 0, "detail_level" },
-    { "listquorums", 0, "count"},
-    { "getquoruminfo", 0, "llmqType"},
-    { "getquoruminfo", 2, "includeSkShare"},
+    { "listquorums", 0, "count" },
+    { "getquoruminfo", 0, "llmqType" },
+    { "getquoruminfo", 2, "includeSkShare" },
     { "signsession", 0, "llmqType"},
-    { "hasrecoverysignature", 0, "llmqType"},
-    { "issessionconflicting", 0, "llmqType"},
+    { "hasrecoverysignature", 0, "llmqType" },
+    { "issessionconflicting", 0, "llmqType" },
     { "rawdelegatestake", 1, "amount" },
     { "rawdelegatestake", 3, "ext_owner" },
     { "rawdelegatestake", 4, "include_delegated" },
@@ -154,7 +155,7 @@ static const CRPCConvertParam vRPCConvertParams[] = {
     { "setautocombinethreshold", 0, "enable" },
     { "setautocombinethreshold", 1, "threshold" },
     { "setautocombinethreshold", 2, "frequency"},
-    { "setnetworkactive", 0, "active"},
+    { "setnetworkactive", 0, "active" },
     { "setban", 2, "bantime" },
     { "setban", 3, "absolute" },
     { "setgenerate", 0, "generate" },
@@ -196,6 +197,7 @@ static const CRPCConvertParam vRPCConvertParams[] = {
     { "echojson", 8, "arg8" },
     { "echojson", 9, "arg9" },
 };
+// clang-format on
 
 class CRPCConvertTable
 {

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -1094,6 +1094,7 @@ UniValue relaymasternodebroadcast(const JSONRPCRequest& request)
     return strprintf("Masternode broadcast sent (service %s, vin %s)", mnb.addr.ToString(), mnb.vin.ToString());
 }
 
+// clang-format off
 static const CRPCCommand commands[] =
 { //  category              name                         actor (function)            okSafe argNames
   //  --------------------- ---------------------------  --------------------------  ------ --------
@@ -1109,13 +1110,14 @@ static const CRPCCommand commands[] =
     { "masternode",         "listmasternodeconf",        &listmasternodeconf,        true,  {"filter"} },
     { "masternode",         "listmasternodes",           &listmasternodes,           true,  {"filter"} },
     { "masternode",         "masternodecurrent",         &masternodecurrent,         true,  {} },
-    { "masternode",         "relaymasternodebroadcast",  &relaymasternodebroadcast,  true,  {"hexstring"}  },
+    { "masternode",         "relaymasternodebroadcast",  &relaymasternodebroadcast,  true,  {"hexstring"} },
     { "masternode",         "startmasternode",           &startmasternode,           true,  {"set","lock_wallet","alias","reload_conf"} },
 
-    /* Not shown in help */
+    /** Not shown in help */
     { "hidden",             "getcachedblockhashes",      &getcachedblockhashes,      true,  {} },
     { "hidden",             "mnping",                    &mnping,                    true,  {} },
 };
+// clang-format on
 
 void RegisterMasternodeRPCCommands(CRPCTable &tableRPC)
 {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -857,6 +857,7 @@ UniValue estimatesmartfee(const JSONRPCRequest& request)
     return result;
 }
 
+// clang-format off
 static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         okSafe argNames
   //  --------------------- ------------------------  -----------------------  ------ --------
@@ -864,7 +865,7 @@ static const CRPCCommand commands[] =
     { "util",               "estimatesmartfee",       &estimatesmartfee,       true,  {"nblocks"} },
     { "mining",             "prioritisetransaction",  &prioritisetransaction,  true,  {"txid","priority_delta","fee_delta"} },
 
-    /* Not shown in help */
+    /** Not shown in help */
 #ifdef ENABLE_WALLET
     { "hidden",             "generate",               &generate,               true,  {"nblocks"} },
     { "hidden",             "generatetoaddress",      &generatetoaddress,      true,  {"nblocks","address"} },
@@ -881,7 +882,8 @@ static const CRPCCommand commands[] =
 #endif // ENABLE_WALLET
 #endif // ENABLE_MINING_RPC
 
-    };
+};
+// clang-format on
 
 void RegisterMiningRPCCommands(CRPCTable &tableRPC)
 {

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -832,6 +832,7 @@ UniValue mnconnect(const JSONRPCRequest& request)
     return false;
 }
 
+// clang-format off
 static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         okSafe argNames
   //  --------------------- ------------------------  -----------------------  ------ --------
@@ -845,12 +846,13 @@ static const CRPCCommand commands[] =
     { "util",               "validateaddress",        &validateaddress,        true,  {"pivxaddress"} }, /* uses wallet if enabled */
     { "util",               "verifymessage",          &verifymessage,          true,  {"pivxaddress","signature","message"} },
 
-    /* Not shown in help */
-    { "hidden",             "echo",                   &echo,                   true,  {"arg0","arg1","arg2","arg3","arg4","arg5","arg6","arg7","arg8","arg9"}},
-    { "hidden",             "echojson",               &echo,                   true,  {"arg0","arg1","arg2","arg3","arg4","arg5","arg6","arg7","arg8","arg9"}},
+    /** Not shown in help */
+    { "hidden",             "echo",                   &echo,                   true,  {"arg0","arg1","arg2","arg3","arg4","arg5","arg6","arg7","arg8","arg9"} },
+    { "hidden",             "echojson",               &echo,                   true,  {"arg0","arg1","arg2","arg3","arg4","arg5","arg6","arg7","arg8","arg9"} },
     { "hidden",             "setmocktime",            &setmocktime,            true,  {"timestamp"} },
     { "hidden",             "mnconnect",              &mnconnect,              true,  {"op_type", "mn_list", "llmq_type", "quorum_hash"} },
 };
+// clang-format on
 
 void RegisterMiscRPCCommands(CRPCTable &tableRPC)
 {

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -701,6 +701,7 @@ UniValue setnetworkactive(const JSONRPCRequest& request)
     return g_connman->GetNetworkActive();
 }
 
+// clang-format off
 static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         okSafe argNames
   //  --------------------- ------------------------  -----------------------  ------ --------
@@ -716,11 +717,12 @@ static const CRPCCommand commands[] =
     { "network",            "listbanned",             &listbanned,             true,  {} },
     { "network",            "ping",                   &ping,                   true,  {} },
     { "network",            "setban",                 &setban,                 true,  {"subnet", "command", "bantime", "absolute"} },
-    { "network",            "setnetworkactive",       &setnetworkactive,       true,  {"active"}},
+    { "network",            "setnetworkactive",       &setnetworkactive,       true,  {"active"} },
 
-    // Hidden, for testing only
+    /** Not shown in help */
     { "hidden",             "addpeeraddress",         &addpeeraddress,         true,  {"address", "port"} },
 };
+// clang-format on
 
 void RegisterNetRPCCommands(CRPCTable &tableRPC)
 {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -892,6 +892,7 @@ UniValue sendrawtransaction(const JSONRPCRequest& request)
     return hashTx.GetHex();
 }
 
+// clang-format off
 static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         okSafe argNames
   //  --------------------- ------------------------  -----------------------  ------ --------
@@ -902,6 +903,7 @@ static const CRPCCommand commands[] =
     { "rawtransactions",    "sendrawtransaction",     &sendrawtransaction,     false, {"hexstring","allowhighfees"} },
     { "rawtransactions",    "signrawtransaction",     &signrawtransaction,     false, {"hexstring","prevtxs","privkeys","sighashtype"} }, /* uses wallet if enabled */
 };
+// clang-format on
 
 void RegisterRawTransactionRPCCommands(CRPCTable &tableRPC)
 {

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -1060,22 +1060,23 @@ UniValue generateblskeypair(const JSONRPCRequest& request)
     return ret;
 }
 
-
+// clang-format off
 static const CRPCCommand commands[] =
 { //  category       name                              actor (function)         okSafe argNames
   //  -------------- --------------------------------- ------------------------ ------ --------
-    { "evo",         "generateblskeypair",             &generateblskeypair,     true,  {}  },
-    { "evo",         "protx_list",                     &protx_list,             true,  {"detailed","wallet_only","valid_only","height"}  },
+    { "evo",         "generateblskeypair",             &generateblskeypair,     true,  {} },
+    { "evo",         "protx_list",                     &protx_list,             true,  {"detailed","wallet_only","valid_only","height"} },
 #ifdef ENABLE_WALLET
     { "evo",         "protx_register",                 &protx_register,         true,  {"collateralHash","collateralIndex","ipAndPort","ownerAddress","operatorPubKey","votingAddress","payoutAddress","operatorReward","operatorPayoutAddress"} },
     { "evo",         "protx_register_fund",            &protx_register_fund,    true,  {"collateralAddress","ipAndPort","ownerAddress","operatorPubKey","votingAddress","payoutAddress","operatorReward","operatorPayoutAddress"} },
     { "evo",         "protx_register_prepare",         &protx_register_prepare, true,  {"collateralHash","collateralIndex","ipAndPort","ownerAddress","operatorPubKey","votingAddress","payoutAddress","operatorReward","operatorPayoutAddress"} },
-    { "evo",         "protx_register_submit",          &protx_register_submit,  true,  {"tx","sig"}  },
-    { "evo",         "protx_revoke",                   &protx_revoke,           true,  {"proTxHash","operatorKey","reason"}  },
-    { "evo",         "protx_update_registrar",         &protx_update_registrar, true,  {"proTxHash","operatorPubKey","votingAddress","payoutAddress","ownerKey"}  },
-    { "evo",         "protx_update_service",           &protx_update_service,   true,  {"proTxHash","ipAndPort","operatorPayoutAddress","operatorKey"}  },
+    { "evo",         "protx_register_submit",          &protx_register_submit,  true,  {"tx","sig"} },
+    { "evo",         "protx_revoke",                   &protx_revoke,           true,  {"proTxHash","operatorKey","reason"} },
+    { "evo",         "protx_update_registrar",         &protx_update_registrar, true,  {"proTxHash","operatorPubKey","votingAddress","payoutAddress","ownerKey"} },
+    { "evo",         "protx_update_service",           &protx_update_service,   true,  {"proTxHash","ipAndPort","operatorPayoutAddress","operatorKey"} },
 #endif  //ENABLE_WALLET
 };
+// clang-format on
 
 void RegisterEvoRPCCommands(CRPCTable& _tableRPC)
 {

--- a/src/rpc/rpcquorums.cpp
+++ b/src/rpc/rpcquorums.cpp
@@ -376,6 +376,7 @@ UniValue quorumdkgsimerror(const JSONRPCRequest& request)
     return NullUniValue;
 }
 
+// clang-format off
 static const CRPCCommand commands[] =
 { //  category       name                      actor (function)      okSafe argNames
   //  -------------- ------------------------- --------------------- ------ --------
@@ -385,10 +386,13 @@ static const CRPCCommand commands[] =
     { "evo",         "quorumdkgstatus",        &quorumdkgstatus,     true,  {"detail_level"}  },
     { "evo",         "listquorums",            &listquorums,         true,  {"count"}  },
     { "evo",         "getquoruminfo",          &getquoruminfo,       true,  {"llmqType", "quorumHash", "includeSkShare"}  },
-    { "hidden",      "signsession",            &signsession,         true,  {"llmqType", "id", "msgHash"}},
-    { "hidden",      "hasrecoverysignature",   &hasrecoverysignature,true,  {"llmqType", "id", "msgHash"}},
-    { "hidden",      "issessionconflicting",   &issessionconflicting,true,  {"llmqType", "id", "msgHash"}},
+
+    /** Not shown in help */
+    { "hidden",      "signsession",            &signsession,         true,  {"llmqType", "id", "msgHash"} },
+    { "hidden",      "hasrecoverysignature",   &hasrecoverysignature,true,  {"llmqType", "id", "msgHash"} },
+    { "hidden",      "issessionconflicting",   &issessionconflicting,true,  {"llmqType", "id", "msgHash"} },
  };
+// clang-format on
 
 void RegisterQuorumsRPCCommands(CRPCTable& tableRPC)
 {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4686,6 +4686,7 @@ extern UniValue importsaplingkey(const JSONRPCRequest& request);
 extern UniValue importsaplingviewingkey(const JSONRPCRequest& request);
 extern UniValue exportsaplingviewingkey(const JSONRPCRequest& request);
 
+// clang-format off
 static const CRPCCommand commands[] =
 { //  category              name                        actor (function)           okSafe argNames
   //  --------------------- ------------------------    -----------------------    ------ --------
@@ -4769,6 +4770,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "listreceivedbylabel",      &listreceivedbylabel,      false, {"minconf","include_empty","include_watchonly"} },
     { "wallet",             "setlabel",                 &setlabel,                 true,  {"address","label"} },
 };
+// clang-format on
 
 void RegisterWalletRPCCommands(CRPCTable &tableRPC)
 {


### PR DESCRIPTION
We use a more human-friendly visual layout for RPC tables in our source code that doesn't play nicely with `clang-format`.

This does a sweep of whitespace cleanup in the various tables and adds guard macros so that `clang-format` will not try to automatically reformat the code layout.