### PR TITLE
Do not fully sort all nodes for addr relay

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -862,24 +862,32 @@ static void RelayTransaction(const CTransaction& tx, CConnman* connman)
 static void RelayAddress(const CAddress& addr, bool fReachable, CConnman* connman)
 {
     if (!fReachable && !addr.IsRelayable()) return;
-    int nRelayNodes = fReachable ? 2 : 1; // limited relaying of addresses outside our network(s)
+    unsigned int nRelayNodes = fReachable ? 2 : 1; // limited relaying of addresses outside our network(s)
 
     // Relay to a limited number of other nodes
     // Use deterministic randomness to send to the same nodes for 24 hours
     // at a time so the addrKnowns of the chosen nodes prevent repeats
     uint64_t hashAddr = addr.GetHash();
-    std::multimap<uint64_t, CNode*> mapMix;
     const CSipHasher hasher = connman->GetDeterministicRandomizer(RANDOMIZER_ID_ADDRESS_RELAY).Write(hashAddr << 32).Write((GetTime() + hashAddr) / (24*60*60));
+    FastRandomContext insecure_rand;
 
-    auto sortfunc = [&mapMix, &hasher](CNode* pnode) {
+    std::array<std::pair<uint64_t, CNode*>,2> best{{{0, nullptr}, {0, nullptr}}};
+
+    auto sortfunc = [&best, &hasher, nRelayNodes](CNode* pnode) {
         uint64_t hashKey = CSipHasher(hasher).Write(pnode->GetId()).Finalize();
-        mapMix.emplace(hashKey, pnode);
+        for (unsigned int i = 0; i < nRelayNodes; i++) {
+            if (hashKey > best[i].first) {
+                std::copy(best.begin() + i, best.begin() + nRelayNodes - 1, best.begin() + i + 1);
+                best[i] = std::make_pair(hashKey, pnode);
+                break;
+            }
+        }
     };
 
-    auto pushfunc = [&addr, &mapMix, &nRelayNodes] {
-        FastRandomContext insecure_rand;
-        for (auto mi = mapMix.begin(); mi != mapMix.end() && nRelayNodes-- > 0; ++mi)
-            mi->second->PushAddress(addr, insecure_rand);
+    auto pushfunc = [&addr, &best, nRelayNodes, &insecure_rand] {
+        for (unsigned int i = 0; i < nRelayNodes && best[i].first != 0; i++) {
+            best[i].second->PushAddress(addr, insecure_rand);
+        }
     };
 
     connman->ForEachNodeThen(std::move(sortfunc), std::move(pushfunc));


### PR DESCRIPTION
This PR offers some performance improvement when dealing with peers and networking. Rather than creating a map of every address being relayed and picking the top ones, we can just compute the top ones directly. This will save a good amount of the heavy computation and leave it to a quote artimethic

bitcoin#8690
