### PR TITLE
Increase performance of Good

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -153,11 +153,14 @@ void CAddrMan::ClearNew(int nUBucket, int nUBucketPos)
 void CAddrMan::MakeTried(CAddrInfo& info, int nId)
 {
     // remove the entry from all new buckets
-    for (int bucket = 0; bucket < ADDRMAN_NEW_BUCKET_COUNT; bucket++) {
-        int pos = info.GetBucketPosition(nKey, true, bucket);
+    const int start_bucket{info.GetNewBucket(nKey, m_asmap)};
+    for (int n = 0; n < ADDRMAN_NEW_BUCKET_COUNT; ++n) {
+        const int bucket{(start_bucket + n) % ADDRMAN_NEW_BUCKET_COUNT};
+        const int pos{info.GetBucketPosition(nKey, true, bucket)};
         if (vvNew[bucket][pos] == nId) {
             vvNew[bucket][pos] = -1;
             info.nRefCount--;
+            if (info.nRefCount == 0) break;
         }
     }
     nNew--;
@@ -227,22 +230,10 @@ void CAddrMan::Good_(const CService& addr, bool test_before_evict, int64_t nTime
     if (info.fInTried)
         return;
 
-    // find a bucket it is in now
-    int nRnd = insecure_rand.randrange(ADDRMAN_NEW_BUCKET_COUNT);
-    int nUBucket = -1;
-    for (unsigned int n = 0; n < ADDRMAN_NEW_BUCKET_COUNT; n++) {
-        int nB = (n + nRnd) % ADDRMAN_NEW_BUCKET_COUNT;
-        int nBpos = info.GetBucketPosition(nKey, true, nB);
-        if (vvNew[nB][nBpos] == nId) {
-            nUBucket = nB;
-            break;
-        }
-    }
-
-    // if no bucket is found, something bad happened;
-    // TODO: maybe re-add the node, but for now, just bail out
-    if (nUBucket == -1)
+    // if it is not in new, something bad happened
+    if (info.nRefCount <= 0) {
         return;
+    }
 
     // which tried bucket to move the entry to
     int tried_bucket = info.GetTriedBucket(nKey, m_asmap);


### PR DESCRIPTION
This PR actually opens up our need for some more fuzzing and testing to integrate while catching up to various Bitcoin improvements. 

It is a partial back port of #22974 , reasons being we have to isolate more of the fuzz integrations so we can add them into the code base. Although this provides an improvement of over a factor of 100 for the population of the addrman 'good' peers because we iterate the table twice in order to accomplish this.

First loop is modified because in MakeTried() we can speed this up by stopping it mainly at nRefCount == 0, any further it would absolutely hit an assert. And then we can also check from the bucket that it is originating from peer wise, giving us less buckets to check.
Second loop is removed because in Good_() we look for the entry but if it is not corrupted, there's two places it would be, in new, tried or not in addr db at all. Which means at this point we would not need this and can return earlier. 

Some benchmarks from upstream https://github.com/bitcoin/bitcoin/pull/22974#issuecomment-919435266 https://github.com/bitcoin/bitcoin/pull/22974#issuecomment-920445700
