### PR TITLE
[Net] Add Liquid DNS Seeder for mainnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -323,7 +323,7 @@ public:
         // Note that of those with the service bits flag, most only support a subset of possible options
         vSeeds.emplace_back("pivx.seed.fuzzbawls.pw", true);     // Primary DNS Seeder from Fuzzbawls
         vSeeds.emplace_back("pivx.seed2.fuzzbawls.pw", true);    // Secondary DNS Seeder from Fuzzbawls
-        vSeeds.emplace_back("pivx-seed.furszy.net", true);     // Primary DNS Seeder from furszy
+        vSeeds.emplace_back("dnsseed.liquid369.wtf", true);     // Primary DNS Seeder from Liquid369
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1, 30);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1, 13);


### PR DESCRIPTION
This is a newly setup DNS Seeder to help the PIVX network in peer discovery. Furszy’s old seeder is now defunct and not working, in order for everything not to fall onto @Fuzzbawls shoulders(and seeders), I have created another instance.