### PR TITLE
[GUI] Fix ban actions in peer list

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -808,15 +808,24 @@ void RPCConsole::banSelectedNode(int bantime)
     if (!clientModel || !g_connman)
         return;
 
+    // No node selected exit out
+    if (cachedNodeid == -1)
+        return;
+
     // Get currently selected peer address
-    QString strNode = GUIUtil::getEntryData(ui->peerWidget, 0, PeerTableModel::Address).toString();
-    // Find possible nodes, ban it and clear the selected node
-    std::string nStr = strNode.toStdString();
+    int selectedNodeRow = clientModel->getPeerTableModel()->getRowByNodeId(cachedNodeid);
+    if (selectedNodeRow < 0)
+        return;
+
+    // Get nodeStats and we will use the addrName string(ip address)
+    const CNodeCombinedStats* stats = clientModel->getPeerTableModel()->getNodeStats(selectedNodeRow);
+
+    std::string nStr = stats->nodeStats.addrName;
     std::string addr;
     int port = 0;
     SplitHostPort(nStr, port, addr);
-
     CNetAddr resolved;
+
     if (!LookupHost(addr.c_str(), resolved, false))
         return;
     g_connman->Ban(resolved, BanReasonManuallyAdded, bantime);


### PR DESCRIPTION
For quite some time in the PIVX GUI we have the old UX for the peer list, and it has not been functional to ban peers using the context menu. 
See below:
![Screenshot 2023-04-17 at 1 40 46 PM](https://user-images.githubusercontent.com/45834289/232580836-d0f39b6e-a258-4347-9245-afeaa197a3de.png)

Any amount of clicks, it will not ban said peer nor will it update the ban list. 

With this PR it is now working as intended again

![Screenshot 2023-04-17 at 1 42 12 PM](https://user-images.githubusercontent.com/45834289/232581174-007668e1-ce65-4ae8-a989-eb916b99b669.png)

Clicking ban node for X time, will automatically disconnect the peer and update the GUI/ban list

Changes:

We now track the nodes address in the NodeStats class, and so now we do not need to resolve the IP but rather pull it from the stats we have access to after syncing the information from the node.


