### PR TITLE
[Qt] Don't always clear coin control

### DIFF
--- a/src/qt/pivx/send.cpp
+++ b/src/qt/pivx/send.cpp
@@ -783,11 +783,13 @@ void SendWidget::onCheckBoxChanged()
 
 void SendWidget::onPIVSelected(bool _isTransparent)
 {
-    isTransparent = _isTransparent;
-    resetChangeAddress();
-    resetCoinControl();
-    tryRefreshAmounts();
-    updateStyle(coinIcon);
+    if (isTransparent != _isTransparent) {
+        isTransparent = _isTransparent;
+        resetChangeAddress();
+        resetCoinControl();
+        tryRefreshAmounts();
+        updateStyle(coinIcon);
+    }
 }
 
 void SendWidget::onContactsClicked(SendMultiRow* entry)


### PR DESCRIPTION
Another trivial bug fix:  On creating a transaction with the GUI don't clear the Coin Control if the user presses the "Transparent" button when the transaction is already set on "Transparent" and same for "Shielded" (see the picture)
![2023-04-21-132113_1366x768_scrot](https://user-images.githubusercontent.com/22001825/233624199-89a7bc2b-bbe2-4bf7-a549-d2b78a398577.png)
