### PR TITLE
[RPC] Fix Invalidateblock

### DIFF
--- a/src/sapling/saplingscriptpubkeyman.cpp
+++ b/src/sapling/saplingscriptpubkeyman.cpp
@@ -7,7 +7,14 @@
 
 #include "chain.h" // for CBlockIndex
 #include "primitives/transaction.h"
+#include "primitives/block.h"
+#include "sapling/incrementalmerkletree.h"
+#include "uint256.h"
 #include "validation.h" // for ReadBlockFromDisk()
+#include "wallet/wallet.h"
+#include <algorithm>
+#include <map>
+#include <vector>
 
 void SaplingScriptPubKeyMan::AddToSaplingSpends(const uint256& nullifier, const uint256& wtxid)
 {
@@ -210,6 +217,93 @@ void UpdateWitnessHeights(NoteDataMap& noteDataMap, int indexHeight, int64_t nWi
     }
 }
 
+bool SaplingScriptPubKeyMan::BuildWitnessChain(const CBlockIndex* pTargetBlock)
+{
+    LOCK2(cs_main, wallet->cs_wallet);
+    // Target is the last block we want to invalidate
+    rollbackTargetHeight = pTargetBlock->nHeight;
+    cachedWitnessMap.clear();
+
+    // Find the oldest sapling note
+    int minHeight = INT_MAX;
+    for (auto& it : wallet->mapWallet) {
+        CWalletTx& wtx = it.second;
+        if (wtx.mapSaplingNoteData.empty()) continue;
+        // Skip abandoned and conflicted txs for which the block_height is not defined (more precisely it it set to 0 by default)
+        if (wtx.m_confirm.status != CWalletTx::CONFIRMED) continue;
+        minHeight = std::min(wtx.m_confirm.block_height, minHeight);
+    }
+
+    // For the moment as a maximum rollback span we use 1 month or 43200 blocks
+    if ((chainActive.Height() - minHeight) > 43200) {
+        cachedWitnessMap.clear();
+        rollbackTargetHeight = -1;
+        return false;
+    }
+
+    // Read blocks from the disk from chaintip to the minimum found height
+    std::vector<CBlock> cblocks;
+    const CBlockIndex* pIndex = GetChainTip();
+    int currentHeight = GetChainTip()->nHeight;
+    while (currentHeight >= minHeight) {
+        CBlock cblock;
+        ReadBlockFromDisk(cblock, pIndex);
+        cblocks.insert(cblocks.begin(), cblock);
+        pIndex = pIndex->pprev;
+        currentHeight = pIndex->nHeight;
+    }
+
+    // Load the SaplingMerkleTree for the block before the oldest note
+    SaplingMerkleTree initialSaplingTree;
+    if (!pcoinsTip->GetSaplingAnchorAt(pIndex->hashFinalSaplingRoot, initialSaplingTree)) {
+        return false;
+    }
+    // Finally build the witness cache for each sapling note of your wallet
+    for (CBlock& block : cblocks) {
+        // Finally build the witness cache for each sapling note
+        std::vector<uint256> noteCommitments;
+        std::vector<SaplingNoteData*> inBlockArrivingNotes;
+        for (const auto& tx : block.vtx) {
+            const auto& hash = tx->GetHash();
+            auto it = wallet->mapWallet.find(hash);
+            bool txIsOurs = it != wallet->mapWallet.end();
+
+            if (!tx->IsShieldedTx()) continue;
+            for (uint32_t i = 0; i < tx->sapData->vShieldedOutput.size(); i++) {
+                const auto& cmu = tx->sapData->vShieldedOutput[i].cmu;
+                noteCommitments.emplace_back(cmu);
+                for (auto& item : inBlockArrivingNotes) {
+                    item->witnesses.front().append(cmu);
+                }
+                initialSaplingTree.append(cmu);
+                if (txIsOurs) {
+                    CWalletTx* wtx = &it->second;
+                    auto ndIt = wtx->mapSaplingNoteData.find({hash, i});
+                    if (ndIt != wtx->mapSaplingNoteData.end()) {
+                        SaplingNoteData* nd = &ndIt->second;
+                        nd->witnesses.push_front(initialSaplingTree.witness());
+                        inBlockArrivingNotes.emplace_back(nd);
+                    }
+                }
+            }
+        }
+        for (auto& it2 : cachedWitnessMap) {
+            it2.second.emplace_front(it2.second.front());
+            for (auto& noteComm : noteCommitments) {
+                it2.second.front().append(noteComm);
+            }
+        }
+        for (auto nd : inBlockArrivingNotes) {
+            if (nd->nullifier) {
+                std::list<SaplingWitness> witnesses;
+                witnesses.push_front(nd->witnesses.front());
+                cachedWitnessMap.emplace(*(nd->nullifier), witnesses);
+            }
+        }
+    }
+    return true;
+}
+
 void SaplingScriptPubKeyMan::IncrementNoteWitnesses(const CBlockIndex* pindex,
                                                     const CBlock* pblock,
                                                     SaplingMerkleTree& saplingTreeRes)
@@ -293,6 +387,34 @@ void SaplingScriptPubKeyMan::IncrementNoteWitnesses(const CBlockIndex* pindex,
     // CWallet::SetBestChain() (which also ensures that overall consistency
     // of the wallet.dat is maintained).
 }
+/*
+ * Clear and eventually reset each witness of noteDataMap with the corresponding front-value of cachedWitnessMap, indexHeight is the blockHeight being invalidated
+ */
+void ResetNoteWitnesses(std::map<SaplingOutPoint, SaplingNoteData>& noteDataMap, std::map<uint256, std::list<SaplingWitness>>& cachedWitnessMap, int indexHeight)
+{
+    // For each note that you own:
+    for (auto& item : noteDataMap) {
+        auto& nd = (item.second);
+        // skip externally sent notes
+        if (!nd.IsMyNote()) continue;
+        // Clear the cache
+        nd.witnesses.clear();
+        // The withnessHeight must be EITHER -1 or equal to the block indexHeight
+        // The case in which indexHeight > witnessHeight is due to conflicted notes, which are irrelevant
+        // TODO: Allow invalidating blocks only if there are not conflicted txs?
+        if (nd.witnessHeight <= indexHeight) {
+            assert((nd.witnessHeight == -1) || (nd.witnessHeight == indexHeight));
+        }
+        // Decrease the witnessHeight
+        nd.witnessHeight = indexHeight - 1;
+        if (nd.nullifier && cachedWitnessMap.at(*nd.nullifier).size() > 0) {
+            // Update the witness value with the cached one
+            nd.witnesses.push_front(cachedWitnessMap.at(*nd.nullifier).front());
+            cachedWitnessMap.at(*nd.nullifier).pop_front();
+        }
+    }
+}
+
 
 template<typename NoteDataMap>
 void DecrementNoteWitnesses(NoteDataMap& noteDataMap, int indexHeight, int64_t nWitnessCacheSize)
@@ -336,9 +458,30 @@ void DecrementNoteWitnesses(NoteDataMap& noteDataMap, int indexHeight, int64_t n
     }
 }
 
-void SaplingScriptPubKeyMan::DecrementNoteWitnesses(int nChainHeight)
+void SaplingScriptPubKeyMan::DecrementNoteWitnesses(const CBlockIndex* pindex)
 {
+    assert(pindex);
     LOCK(wallet->cs_wallet);
+    int nChainHeight = pindex->nHeight;
+    // if the targetHeight is different from -1 we have a cache to use
+    if (rollbackTargetHeight != -1) {
+        for (std::pair<const uint256, CWalletTx>& wtxItem : wallet->mapWallet) {
+            if (!wtxItem.second.mapSaplingNoteData.empty()) {
+                // For each sapling note that you own reset the current witness with the cached one
+                ResetNoteWitnesses(wtxItem.second.mapSaplingNoteData, cachedWitnessMap, nChainHeight);
+            }
+        }
+        nWitnessCacheSize = 1;
+        nWitnessCacheNeedsUpdate = true;
+        // If we reached the target height empty the cache and reset the target height to -1
+        // Remember that the targetHeight is indeed the last block we want to invalidate
+        if (rollbackTargetHeight == pindex->nHeight) {
+            cachedWitnessMap.clear();
+            rollbackTargetHeight = -1;
+        }
+        return;
+    }
+
     for (std::pair<const uint256, CWalletTx>& wtxItem : wallet->mapWallet) {
         ::DecrementNoteWitnesses(wtxItem.second.mapSaplingNoteData, nChainHeight, nWitnessCacheSize);
     }
@@ -517,7 +660,6 @@ void SaplingScriptPubKeyMan::GetFilteredNotes(
         for (const auto& it : wtx.mapSaplingNoteData) {
             const SaplingOutPoint& op = it.first;
             const SaplingNoteData& nd = it.second;
-
             // skip sent notes
             if (!nd.IsMyNote()) continue;
 

--- a/src/sapling/saplingscriptpubkeyman.h
+++ b/src/sapling/saplingscriptpubkeyman.h
@@ -161,7 +161,7 @@ public:
     /**
      * Build the old witness chain.
      */
-    bool BuildWitnessChain(const CBlockIndex* pTargetBlock);
+    bool BuildWitnessChain(const CBlockIndex* pTargetBlock, const Consensus::Params& params, std::string& errorStr);
 
     /**
      * pindex is the new tip being connected.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -6,6 +6,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "optional.h"
+#include "validation.h"
 #if defined(HAVE_CONFIG_H)
 #include "config/pivx-config.h"
 #endif
@@ -1369,7 +1370,7 @@ void CWallet::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, con
 
     if (Params().GetConsensus().NetworkUpgradeActive(nBlockHeight, Consensus::UPGRADE_V5_0)) {
         // Update Sapling cached incremental witnesses
-        m_sspk_man->DecrementNoteWitnesses(nBlockHeight);
+        m_sspk_man->DecrementNoteWitnesses(mapBlockIndex[blockHash]);
         m_sspk_man->UpdateSaplingNullifierNoteMapForBlock(pblock.get());
     }
 }
@@ -4688,7 +4689,7 @@ void CWallet::IncrementNoteWitnesses(const CBlockIndex* pindex,
                             const CBlock* pblock,
                             SaplingMerkleTree& saplingTree) { m_sspk_man->IncrementNoteWitnesses(pindex, pblock, saplingTree); }
 
-void CWallet::DecrementNoteWitnesses(const CBlockIndex* pindex) { m_sspk_man->DecrementNoteWitnesses(pindex->nHeight); }
+void CWallet::DecrementNoteWitnesses(const CBlockIndex* pindex) { m_sspk_man->DecrementNoteWitnesses(pindex); }
 
 void CWallet::ClearNoteWitnessCache() { m_sspk_man->ClearNoteWitnessCache(); }
 

--- a/test/functional/rpc_invalidateblock.py
+++ b/test/functional/rpc_invalidateblock.py
@@ -7,10 +7,12 @@
 from test_framework.test_framework import PivxTestFramework
 from test_framework.util import assert_equal, connect_nodes, wait_until
 
+
 class InvalidateTest(PivxTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 3
+        self.extra_args = [["-nuparams=v5_shield:1"]] * self.num_nodes
 
     def setup_network(self):
         self.setup_nodes()
@@ -76,6 +78,18 @@ class InvalidateTest(PivxTestFramework):
         assert_equal(self.nodes[1].getbestblockhash(), blocks[-5])
         # Reconsider only the previous tip
         self.nodes[1].reconsiderblock(blocks[-4])
+        # Should be back at the tip by now
+        assert_equal(self.nodes[1].getbestblockhash(), blocks[-1])
+
+        self.log.info("Verify that it works for more than 100 blocks (sapling cache reconstruction)")
+        blocks = self.nodes[1].generate(200)
+        assert_equal(self.nodes[0].getblockchaininfo()['upgrades']['v5 shield']['status'], 'active')
+        assert_equal(self.nodes[1].getbestblockhash(), blocks[-1])
+        # Invalidate a block deeper than the maximum cache size (i.e deeper than 100 blocks)
+        self.nodes[1].invalidateblock(blocks[-140])
+        assert_equal(self.nodes[1].getbestblockhash(), blocks[-141])
+        # Reconsider only the previous tip
+        self.nodes[1].reconsiderblock(blocks[-140])
         # Should be back at the tip by now
         assert_equal(self.nodes[1].getbestblockhash(), blocks[-1])
 


### PR DESCRIPTION
Invalidateblock has not been working since sapling came out. This happens because the current maximum witness cache has a depth of only 100 blocks. With this PR I want to fix this issue by manually building the witness cache if the block has a depth bigger than the cache size.
Since this operation can become pretty lengthy, the RPC will just return error if your oldest sapling note is older than 1 month (43200 blocks behind the chain tip).

Note: After using invalidateblock the user might need to do
`-> debug ->wallet repair -> recover transactions `  in order to recover the correct balance. This is not a limit of this PR and you can test that it already happens with the current implementation of invalidateblock.
Anyways "recover transactions" also cleans the wallet GUI from "conflicted" txs that you get after invalidating a block so it would be useful regardless.

Overall invalidating + eventually using recover transactions is faster than the current rescanning the blockchain from 0
Solves #2605