### PR TITLE
[GA] Overhaul GA caches

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -80,8 +80,20 @@ jobs:
             cc: gcc
             cxx: g++
 
+          - name: Linux-latest
+            os: ubuntu-latest
+            packages: python3-zmq qttools5-dev qtbase5-dev qttools5-dev-tools libqt5svg5-dev libqt5charts5-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libqrencode-dev libgmp-dev libsodium-dev cargo
+            cc: gcc
+            cxx: g++
+
           - name: macOS
             os: macos-11
+            packages: llvm@13 python3 autoconf automake berkeley-db@4 libtool boost miniupnpc libnatpmp pkg-config qt5 zmq libevent qrencode gmp libsodium rust
+            cc: $(brew --prefix llvm@13)/bin/clang
+            cxx: $(brew --prefix llvm@13)/bin/clang++
+
+          - name: macOS-latest
+            os: macos-latest
             packages: llvm@13 python3 autoconf automake berkeley-db@4 libtool boost miniupnpc libnatpmp pkg-config qt5 zmq libevent qrencode gmp libsodium rust
             cc: $(brew --prefix llvm@13)/bin/clang
             cxx: $(brew --prefix llvm@13)/bin/clang++

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -144,7 +144,6 @@ jobs:
           - name: x64-Linux
             id: Linux-x86_64-nodepends
             os: ubuntu-20.04
-            host: x86_64-unknown-linux-gnu
             apt_get: python3-zmq qtbase5-dev qttools5-dev-tools libqt5svg5-dev libqt5charts5-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev libqrencode-dev libgmp-dev libsodium-dev cargo
             unit_tests: true
             functional_tests: true
@@ -154,7 +153,6 @@ jobs:
           - name: x64-macOS-11
             id: macOS11-nodepends
             os: macos-11
-            host: x86_64-apple-darwin20.6.0
             brew_install: autoconf automake ccache berkeley-db4 libtool boost miniupnpc pkg-config python@3.8 qt5 zmq libevent qrencode gmp libsodium rust librsvg
             unit_tests: true
             functional_tests: true
@@ -208,8 +206,8 @@ jobs:
           fi
 
           if [[ ${{ matrix.config.os }} = ubuntu* ]]; then
-            OUTDIR_PATH="$GITHUB_WORKSPACE/$GITHUB_RUN_NUMBER-${{ matrix.config.host }}"
-            BITCOIN_CONFIG_ALL="--disable-dependency-tracking --prefix=$GITHUB_WORKSPACE/${{ matrix.config.host }} --bindir=$OUTDIR_PATH/bin --libdir=$OUTDIR_PATH/lib"
+            OUTDIR_PATH="$GITHUB_WORKSPACE/$GITHUB_RUN_NUMBER"
+            BITCOIN_CONFIG_ALL="--disable-dependency-tracking --prefix=$GITHUB_WORKSPACE --bindir=$OUTDIR_PATH/bin --libdir=$OUTDIR_PATH/lib"
           fi
 
           if [ "${{ matrix.config.unit_tests }}" = "true" ] || [ "${{ matrix.config.functional_tests }}" = "true" ]; then
@@ -221,20 +219,8 @@ jobs:
           ./autogen.sh
           echo ::endgroup::
 
-          mkdir build && cd build
-
           echo ::group::Configure
-          ../configure --cache-file=config.cache $BITCOIN_CONFIG_ALL ${{ matrix.config.BITCOIN_CONFIG }} $PARAMS_FLAGS || ( cat config.log && false)
-          echo ::endgroup::
-
-          echo ::group::Distdir
-          make distdir VERSION=${{ matrix.config.host }}
-          echo ::endgroup::
-
-          cd pivx-${{ matrix.config.host }}
-
-          echo ::group::Configure
-          ./configure --cache-file=../config.cache $BITCOIN_CONFIG_ALL ${{ matrix.config.BITCOIN_CONFIG }} $PARAMS_FLAGS || ( cat config.log && false)
+          ./configure --cache-file=config.cache $BITCOIN_CONFIG_ALL ${{ matrix.config.BITCOIN_CONFIG }} $PARAMS_FLAGS || ( cat config.log && false)
           echo ::endgroup
 
           echo ::group::Build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -101,17 +101,12 @@ jobs:
             brew install "$APT_BASE" ${{ matrix.config.packages }}
           fi
 
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: echo "timestamp=$(date +%Y-%m-%dT%H:%M:%S%z)" >> $GITHUB_OUTPUT
-
       - name: ccache cache files
         uses: actions/cache@v3
         with:
           path: .ccache
-          key: cmake-${{ matrix.config.name }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
-          restore-keys: |
-            cmake-${{ matrix.config.name }}-ccache-
+          key: ${{ runner.os }}-cmake-${{ matrix.config.name }}-ccache
+          restore-keys: ${{ runner.os }}-cmake-${{ matrix.config.name }}-ccache
 
       - name: build
         run: |
@@ -184,19 +179,14 @@ jobs:
             pip3.8 install ds_store mac_alias
           fi
 
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: echo "timestamp=$(date +%Y-%m-%dT%H:%M:%S%z)" >> $GITHUB_OUTPUT
-
       - name: ccache cache files
         uses: actions/cache@v3
         with:
           path: |
             .ccache
             .pivx-params
-          key: ${{ matrix.config.id }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
-          restore-keys: |
-            ${{ matrix.config.id }}-ccache-
+          key: ${{ runner.os }}-${{ matrix.config.id }}-native-ccache
+          restore-keys: ${{ runner.os }}-${{ matrix.config.id }}-native-ccache
 
       - name: Build Syslib Wallet
         run: |
@@ -325,10 +315,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install --no-install-recommends --no-upgrade -qq "$APT_BASE" ${{ matrix.config.apt_get }}
 
-      - name: Prepare Depends timestamp
-        id: depends_cache_timestamp
-        run: echo "timestamp=$(date +%Y-%m-%dT%H:%M:%S%z)" >> $GITHUB_OUTPUT
-
       - name: depends cache files
         uses: actions/cache@v3
         with:
@@ -336,9 +322,8 @@ jobs:
             depends/built
             depends/sdk-sources
             depends/${{ matrix.config.host }}
-          key: ${{ runner.os }}-depends-${{ matrix.config.host }}-${{ steps.depends_cache_timestamp.outputs.timestamp }}
-          restore-keys: |
-            ${{ runner.os }}-depends-${{ matrix.config.host }}-
+          key: ${{ runner.os }}-depends-${{ matrix.config.host }}
+          restore-keys: ${{ runner.os }}-depends-${{ matrix.config.host }}
 
       - name: Build Depends
         run: |
@@ -480,13 +465,8 @@ jobs:
             depends/built
             depends/sdk-sources
             depends/${{ matrix.config.host }}
-          key: ${{ runner.os }}-depends-${{ matrix.config.host }}-
-          restore-keys: |
-            ${{ runner.os }}-depends-${{ matrix.config.host }}-
-
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: echo "timestamp=$(date +%Y-%m-%dT%H:%M:%S%z)" >> $GITHUB_OUTPUT
+          key: ${{ runner.os }}-depends-${{ matrix.config.host }}
+          restore-keys: ${{ runner.os }}-depends-${{ matrix.config.host }}
 
       - name: ccache cache files
         uses: actions/cache@v3
@@ -494,9 +474,8 @@ jobs:
           path: |
             .ccache
             .pivx-params
-          key: ${{ matrix.config.id }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
-          restore-keys: |
-            ${{ matrix.config.id }}-ccache-
+          key: ${{ runner.os }}-depbuild-${{ matrix.config.id }}-ccache
+          restore-keys: ${{ runner.os }}-depbuilt-${{ matrix.config.id }}-ccache
 
       - name: Build Wallet
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -150,9 +150,29 @@ jobs:
             goal: install
             BITCOIN_CONFIG: "--enable-zmq --enable-debug --with-incompatible-bdb --with-gui=qt5 CPPFLAGS='-DARENA_DEBUG -DDEBUG_LOCKORDER'"
 
+          - name: x64-Linux-latest
+            id: Linux-x86_64-nodepends-latest
+            os: ubuntu-latest
+            apt_get: python3-zmq qtbase5-dev qttools5-dev-tools libqt5svg5-dev libqt5charts5-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev libqrencode-dev libgmp-dev libsodium-dev cargo
+            unit_tests: true
+            functional_tests: true
+            goal: install
+            BITCOIN_CONFIG: "--enable-zmq --enable-debug --with-incompatible-bdb --with-gui=qt5 CPPFLAGS='-DARENA_DEBUG -DDEBUG_LOCKORDER'"
+
           - name: x64-macOS
             id: macOS-nodepends
             os: macos-11
+            brew_install: autoconf automake ccache berkeley-db@4 libtool boost miniupnpc libnatpmp pkg-config python@3.8 qt5 zmq libevent qrencode gmp libsodium rust librsvg
+            unit_tests: true
+            functional_tests: true
+            goal: deploy
+            cc: clang
+            cxx: clang++
+            BITCOIN_CONFIG: "--enable-zmq --enable-gui --enable-reduce-exports --enable-werror --enable-debug"
+
+          - name: x64-macOS-latest
+            id: macOS-nodepends-latest
+            os: macos-latest
             brew_install: autoconf automake ccache berkeley-db@4 libtool boost miniupnpc libnatpmp pkg-config python@3.8 qt5 zmq libevent qrencode gmp libsodium rust librsvg
             unit_tests: true
             functional_tests: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -150,10 +150,10 @@ jobs:
             goal: install
             BITCOIN_CONFIG: "--enable-zmq --enable-debug --with-incompatible-bdb --with-gui=qt5 CPPFLAGS='-DARENA_DEBUG -DDEBUG_LOCKORDER'"
 
-          - name: x64-macOS-11
-            id: macOS11-nodepends
+          - name: x64-macOS
+            id: macOS-nodepends
             os: macos-11
-            brew_install: autoconf automake ccache berkeley-db4 libtool boost miniupnpc pkg-config python@3.8 qt5 zmq libevent qrencode gmp libsodium rust librsvg
+            brew_install: autoconf automake ccache berkeley-db@4 libtool boost miniupnpc libnatpmp pkg-config python@3.8 qt5 zmq libevent qrencode gmp libsodium rust librsvg
             unit_tests: true
             functional_tests: true
             goal: deploy

--- a/.github/workflows/pr-cache-cleanup.yml
+++ b/.github/workflows/pr-cache-cleanup.yml
@@ -1,0 +1,33 @@
+name: cleanup caches by a branch
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+
+          REPO=${{ github.repository }}
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     message(STATUS "Compiling on macOS")
     set(ENV{target} "Mac")
     add_definitions("-DMAC_OSX")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D'NS_FORMAT_ARGUMENT\(A\)='")
     list(APPEND CMAKE_PREFIX_PATH /usr/local/opt/qt5 /opt/homebrew/opt/qt5)
     list(APPEND CMAKE_PREFIX_PATH /usr/local/Cellar/berkeley-db@4 /opt/homebrew/Cellar/berkeley-db@4)
     # Homebrew default path for apple silicon CPUs is different than for intel CPUs


### PR DESCRIPTION
Re-work the GA cache naming to be more straight forward and efficient overall. The previously attached timestamping was actually working against us, and leading to much wasted cache usage.

At the same time, this adds 4 additional jobs to test `ubuntu-latest` and `macos-latest` runners for both cmake and native autotools, which can help provide early detection of build issues on the newest runner OSes.

A new workflow is also added that will function as a "cache maintenance" workflow to delete PR branch caches when a PR is closed/merged. This is primarily a step to prevent us from exceeding the cache storage size limit and having more useful caches evicted needlessly.

Finally, the last commit is a macOS-latest only workaround to address a bug on Apple's end which was introduced in Xcode 14.x when using a clang compiler version that doesn't match Xcode's own compiler version (which we do because the default bundled clang compilers have been shown to not work with our CMake build system).