### PR TITLE
[GUI] CoinControl Change

### DIFF
--- a/src/coincontrol.h
+++ b/src/coincontrol.h
@@ -7,8 +7,10 @@
 #ifndef BITCOIN_COINCONTROL_H
 #define BITCOIN_COINCONTROL_H
 
+#include "optional.h"
 #include "policy/feerate.h"
 #include "primitives/transaction.h"
+#include "sapling/address.h"
 #include "script/standard.h"
 #include <unordered_set>
 
@@ -31,6 +33,8 @@ public:
 class CCoinControl
 {
 public:
+    // TODO: upgrade those two fields to a single CWDestination?
+    Optional<libzcash::SaplingPaymentAddress> destShieldChange = boost::none;
     CTxDestination destChange = CNoDestination();
     //! If false, allows unselected inputs, but requires all selected inputs be used
     bool fAllowOtherInputs;

--- a/src/qt/pivx/sendchangeaddressdialog.h
+++ b/src/qt/pivx/sendchangeaddressdialog.h
@@ -5,9 +5,10 @@
 #ifndef SENDCHANGEADDRESSDIALOG_H
 #define SENDCHANGEADDRESSDIALOG_H
 
-#include "script/standard.h"
+#include "destination_io.h"
 #include "qt/pivx/focuseddialog.h"
 #include "qt/pivx/snackbar.h"
+#include "script/standard.h"
 
 class WalletModel;
 
@@ -20,19 +21,20 @@ class SendChangeAddressDialog : public FocusedDialog
     Q_OBJECT
 
 public:
-    explicit SendChangeAddressDialog(QWidget* parent, WalletModel* model);
+    explicit SendChangeAddressDialog(QWidget* parent, WalletModel* model, bool isTransparent);
     ~SendChangeAddressDialog();
 
     void setAddress(QString address);
-    CTxDestination getDestination() const;
+    CWDestination getDestination() const;
 
     void showEvent(QShowEvent* event) override;
 
 private:
+    bool isTransparent;
     WalletModel* walletModel;
     Ui::SendChangeAddressDialog *ui;
     SnackBar *snackBar = nullptr;
-    CTxDestination dest;
+    CWDestination dest;
 
     void inform(const QString& text);
 


### PR DESCRIPTION
This PR extends the functionality of CoinControl change by adding shield addresses.
In particular: 
- In a transparent transaction user can select either a transparent or a sapling shield change
- In a shield transaction user can only use a shield address as change (to preserve privacy)

(NB: with transparent transaction I mean a transaction in which inputs are transparent and analogous definition for shield transaction) 

In addition this PR fixes #2245