### PR TITLE
[Qt] CoinControl for masternodes

### DIFF
--- a/src/qt/pivx/forms/masternodeswidget.ui
+++ b/src/qt/pivx/forms/masternodeswidget.ui
@@ -337,6 +337,16 @@ and vote on the treasury system receiving a periodic reward.</string>
          <number>6</number>
         </property>
         <item>
+         <widget class="OptionButton" name="btnCoinControl" native="true">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>50</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="OptionButton" name="btnAbout" native="true">
           <property name="minimumSize">
            <size>

--- a/src/qt/pivx/masternodeswidget.h
+++ b/src/qt/pivx/masternodeswidget.h
@@ -5,8 +5,9 @@
 #ifndef MASTERNODESWIDGET_H
 #define MASTERNODESWIDGET_H
 
-#include "qt/pivx/pwidget.h"
+#include "coincontroldialog.h"
 #include "qt/pivx/furabstractlistitemdelegate.h"
+#include "qt/pivx/pwidget.h"
 #include "qt/pivx/tooltipmenu.h"
 
 #include <atomic>
@@ -33,6 +34,7 @@ public:
 
     explicit MasterNodesWidget(PIVXGUI *parent = nullptr);
     ~MasterNodesWidget();
+    void resetCoinControl();
     void setMNModel(MNModel* _mnModel);
 
     void run(int type) override;
@@ -42,6 +44,7 @@ public:
     void hideEvent(QHideEvent *event) override;
 
 private Q_SLOTS:
+    void onCoinControlClicked();
     void onCreateMNClicked();
     void onStartAllClicked(int type);
     void changeTheme(bool isLightTheme, QString &theme) override;
@@ -59,6 +62,7 @@ private:
     TooltipMenu* menu = nullptr;
     QModelIndex index;
     QTimer *timer = nullptr;
+    CoinControlDialog* coinControlDialog = nullptr;
 
     std::atomic<bool> isLoading;
 

--- a/src/qt/pivx/mnmodel.cpp
+++ b/src/qt/pivx/mnmodel.cpp
@@ -4,16 +4,17 @@
 
 #include "qt/pivx/mnmodel.h"
 
+#include "coincontrol.h"
 #include "masternode.h"
 #include "masternodeman.h"
-#include "net.h"        // for validateMasternodeIP
-#include "tiertwo/tiertwo_sync_state.h"
-#include "uint256.h"
+#include "net.h" // for validateMasternodeIP
 #include "qt/bitcoinunits.h"
 #include "qt/optionsmodel.h"
 #include "qt/pivx/guitransactionsutils.h"
 #include "qt/walletmodel.h"
 #include "qt/walletmodeltransaction.h"
+#include "tiertwo/tiertwo_sync_state.h"
+#include "uint256.h"
 
 #include <QFile>
 #include <QHostAddress>
@@ -219,9 +220,8 @@ bool MNModel::createMNCollateral(
     WalletModelTransaction currentTransaction(recipients);
     WalletModel::SendCoinsReturn prepareStatus;
 
-    // no coincontrol, no P2CS delegations
-    prepareStatus = walletModel->prepareTransaction(&currentTransaction, nullptr, false);
-
+    // no P2CS delegations
+    prepareStatus = walletModel->prepareTransaction(&currentTransaction, coinControl, false);
     QString returnMsg = tr("Unknown error");
     // process prepareStatus and on error generate message shown to user
     CClientUIInterface::MessageBoxFlags informType;
@@ -503,4 +503,14 @@ bool MNModel::removeLegacyMN(const std::string& alias_to_remove, const std::stri
     // Remove alias
     masternodeConfig.remove(alias_to_remove);
     return true;
+}
+
+void MNModel::setCoinControl(CCoinControl* coinControl)
+{
+    this->coinControl = coinControl;
+}
+
+void MNModel::resetCoinControl()
+{
+    coinControl = nullptr;
 }

--- a/src/qt/pivx/mnmodel.h
+++ b/src/qt/pivx/mnmodel.h
@@ -77,9 +77,12 @@ public:
                                                         QString& ret_error);
 
     bool removeLegacyMN(const std::string& alias_to_remove, const std::string& tx_id, unsigned int out_index, QString& ret_error);
+    void setCoinControl(CCoinControl* coinControl);
+    void resetCoinControl();
 
 private:
     WalletModel* walletModel;
+    CCoinControl* coinControl;
     // alias mn node ---> pair <ip, master node>
     QMap<QString, std::pair<QString, CMasternode*>> nodes;
     QMap<std::string, bool> collateralTxAccepted;

--- a/src/qt/pivx/pivxgui.cpp
+++ b/src/qt/pivx/pivxgui.cpp
@@ -505,6 +505,7 @@ void PIVXGUI::goToAddresses()
 
 void PIVXGUI::goToMasterNodes()
 {
+    masterNodesWidget->resetCoinControl();
     showTop(masterNodesWidget);
 }
 


### PR DESCRIPTION
This PR add a Coin contol interface for masternode creation. This addition is particularly useful when a user wants to spend a P2CS delegation (or locked coins) to create a masternode.

Solves issues #1608 and #2498
