### PR TITLE
[Bug] [GUI] Fix focus on send transaction

### DIFF
--- a/src/qt/pivx/send.cpp
+++ b/src/qt/pivx/send.cpp
@@ -450,7 +450,6 @@ void SendWidget::ProcessSend(QList<SendCoinsRecipient>& recipients, bool hasShie
         if (sendFinalStep()) {
             updateEntryLabels(ptrModelTx->getRecipients());
         }
-        setFocusOnLastEntry();
     } else if (!processingResultError->isEmpty()){
         inform(*processingResultError);
     }


### PR DESCRIPTION
This is a trivial but quite annoying bug fix. Basically once a transaction is actually sent from the GUI (so a few seconds after the user presses on "SEND" in the confirmation screen) the focus goes back to the "Recipient address" field regardless the screen the user is currently on.

Now once the "SEND" button is pressed the focus on "Recipient address" is already (and istantly) gained by the function `showEvent` in send.cpp, so to fix this issue I simply removed the call to `setFocusOnLastEntry` that happens when the transaction is actually sent (which is therefore completely useless).

This PR also solves #2597


