### PR TITLE
Add header files

### DIFF
--- a/src/support/lockedpool.h
+++ b/src/support/lockedpool.h
@@ -5,11 +5,12 @@
 #ifndef BITCOIN_SUPPORT_LOCKEDPOOL_H
 #define BITCOIN_SUPPORT_LOCKEDPOOL_H
 
-#include <stdint.h>
 #include <list>
 #include <map>
-#include <mutex>
 #include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <stdint.h>
 #include <unordered_map>
 
 /**

--- a/src/sync.h
+++ b/src/sync.h
@@ -11,8 +11,9 @@
 #include "util/macros.h"
 
 #include <condition_variable>
-#include <thread>
 #include <mutex>
+#include <string>
+#include <thread>
 
 
 /////////////////////////////////////////////////

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <cstring>
 #include <functional>
 #include <string>


### PR DESCRIPTION
PIVX no longer compiles on arch based distros due to missing header files.
This PR adds the necessary header files
