### PR TITLE
[Tests] [MN] Properly set Masternode Pings

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -581,7 +581,7 @@ bool CMasternodePing::CheckAndUpdate(int& nDos, bool fRequireAvailable, bool fCh
             // SetLastPing locks masternode cs. Be careful with the lock ordering.
             pmn->SetLastPing(*this);
 
-            //mnodeman.mapSeenMasternodeBroadcast.lastPing is probably outdated, so we'll update it
+            //mnodeman.mapSeenMasternodeBroadcast.lastPing is probably outdated or empty/null, so we'll update it
             CMasternodeBroadcast mnb(*pmn);
             const uint256& hash = mnb.GetHash();
             if (mnodeman.mapSeenMasternodeBroadcast.count(hash)) {

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -174,7 +174,7 @@ public:
     bool IsPingedWithin(int seconds, int64_t now = -1) const
     {
         now == -1 ? now = GetAdjustedTime() : now;
-        return lastPing.IsNull() ? false : now - lastPing.sigTime < seconds;
+        return lastPing.IsNull() ? true : now - lastPing.sigTime < seconds;
     }
 
     void SetSpent()

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -974,11 +974,11 @@ class PivxTestFramework():
         time.sleep(1)
 
 
-    def wait_until_mnsync_finished(self):
+    def wait_until_mnsync_finished(self, _timeout):
         SYNC_FINISHED = [999] * self.num_nodes
         synced = [-1] * self.num_nodes
         time.sleep(2)
-        timeout = time.time() + 45
+        timeout = time.time() + _timeout
         while synced != SYNC_FINISHED and time.time() < timeout:
             for i in range(self.num_nodes):
                 if synced[i] != SYNC_FINISHED[i]:
@@ -1743,7 +1743,7 @@ class PivxTier2TestFramework(PivxTestFramework):
 
         # wait until mnsync complete on all nodes
         self.stake(1)
-        self.wait_until_mnsync_finished()
+        self.wait_until_mnsync_finished(45)
         self.log.info("tier two synced! starting masternodes..")
 
         # Now everything is set, can start both masternodes

--- a/test/functional/tiertwo_governance_invalid_budget.py
+++ b/test/functional/tiertwo_governance_invalid_budget.py
@@ -121,7 +121,7 @@ class GovernanceInvalidBudgetTest(PivxTestFramework):
         self.mn1.initmasternode(self.mnOnePrivkey, "127.0.0.1:"+str(remoteOnePort))
         self.mn2.initmasternode(self.mnTwoPrivkey, "127.0.0.1:"+str(remoteTwoPort))
         self.stake_and_ping(self.minerAPos, 1, [])
-        self.wait_until_mnsync_finished()
+        self.wait_until_mnsync_finished(45)
         self.controller_start_masternode(self.minerA, self.masternodeOneAlias)
         self.controller_start_masternode(self.minerA, self.masternodeTwoAlias)
         self.wait_until_mn_preenabled(self.mnOneCollateral.hash, 40)

--- a/test/functional/tiertwo_governance_reorg.py
+++ b/test/functional/tiertwo_governance_reorg.py
@@ -82,7 +82,7 @@ class GovernanceReorgTest(PivxTestFramework):
         mn1.initmasternode(self.mnOnePrivkey, "127.0.0.1:"+str(remoteOnePort))
         mn2.initmasternode(self.mnTwoPrivkey, "127.0.0.1:"+str(remoteTwoPort))
         self.stake_and_ping(self.minerAPos, 1, [])
-        self.wait_until_mnsync_finished()
+        self.wait_until_mnsync_finished(45)
         self.controller_start_masternodes(minerA, [self.masternodeOneAlias, self.masternodeTwoAlias])
         self.wait_until_mn_preenabled(self.mnOneCollateral.hash, 40)
         self.wait_until_mn_preenabled(self.mnOneCollateral.hash, 40)

--- a/test/functional/tiertwo_governance_sync_basic.py
+++ b/test/functional/tiertwo_governance_sync_basic.py
@@ -353,7 +353,7 @@ class MasternodeGovernanceBasicTest(PivxTier2TestFramework):
         assert_equal(self.remoteOne.getbudgetinfo(), [])
 
         self.log.info("budget cleaned, starting resync")
-        self.wait_until_mnsync_finished()
+        self.wait_until_mnsync_finished(45)
         self.check_budgetprojection(expected_budget)
         for i in range(self.num_nodes):
             assert_equal(len(self.nodes[i].getbudgetinfo()), 16)
@@ -375,7 +375,7 @@ class MasternodeGovernanceBasicTest(PivxTier2TestFramework):
         self.stake(2, [self.remoteOne, self.remoteTwo])
 
         self.log.info("syncing node..")
-        self.wait_until_mnsync_finished()
+        self.wait_until_mnsync_finished(45)
         for i in range(self.num_nodes):
             assert_equal(len(self.nodes[i].getbudgetinfo()), 16)
         self.log.info("resync (2): budget data resynchronized successfully!")

--- a/test/functional/tiertwo_masternode_activation.py
+++ b/test/functional/tiertwo_masternode_activation.py
@@ -38,7 +38,7 @@ class MasternodeActivationTest(PivxTier2TestFramework):
     def reconnect_and_restart_masternodes(self):
         self.log.info("Reconnecting nodes and sending start message again...")
         self.reconnect_remotes()
-        self.wait_until_mnsync_finished()
+        self.wait_until_mnsync_finished(45)
         self.controller_start_all_masternodes()
 
     # Similar to base class wait_until_mn_status but skipping the disconnected nodes

--- a/test/functional/tiertwo_masternode_ping.py
+++ b/test/functional/tiertwo_masternode_ping.py
@@ -85,7 +85,7 @@ class MasternodePingTest(PivxTestFramework):
         # Wait until mnsync is complete (max 120 seconds)
         self.log.info("waiting to complete mnsync...")
         start_time = time.time()
-        self.wait_until_mnsync_finished()
+        self.wait_until_mnsync_finished(120)
         self.log.info("MnSync completed in %d seconds" % (time.time() - start_time))
         miner.generate(1)
         self.sync_blocks()

--- a/test/functional/tiertwo_mn_compatibility.py
+++ b/test/functional/tiertwo_mn_compatibility.py
@@ -190,7 +190,7 @@ class MasternodeCompatibilityTest(PivxTier2TestFramework):
         self.log.info("Staking 30 blocks...")
         self.stake(30, [self.remoteTwo])
         self.sync_blocks()
-        self.wait_until_mnsync_finished()
+        self.wait_until_mnsync_finished(45)
 
         # check projection
         self.log.info("Checking winners...")


### PR DESCRIPTION
IsPingedWithin is meant to check if the lastPing is null or if it is within the time slot for an update to lastPing. But we are not updating the map if lastPing was null initially.

Logically the change should not affect any other areas calling IsPingedWithin, because outside of starting its then only checked for removal/expiration.
If we look at the images below why this change is necessary
 
![image](https://github.com/PIVX-Project/PIVX/assets/45834289/df83be1e-599e-4d44-bfc7-d8ca1284bd89)
Here it states we should update if lastPing is `null` so now let us look at the `IsPingedWithin` function.

![image](https://github.com/PIVX-Project/PIVX/assets/45834289/0a49cb87-aeb8-4777-9b00-d4ee03583840)
This we can see, `lastPing.IsNull() ? false```, the comments in the prior picture say we should move forward if there was no ping, but here it is returning false which would then skip the entire code block below it which updates the MN Ping.

And just for extras, here in the code that gets skipped it then adds to nDos for banning of nodes/peers that was commented out. 
![image](https://github.com/PIVX-Project/PIVX/assets/45834289/501a1a41-1601-44f4-9ba3-d3cc91df71b3)

It remains commented in this PR, as we evaluate and run a few more tests and it gets proper reviews. 


Edit: For tests, the area that was failing should have also taken ~120 seconds max, we have set a timeout param for the wait_until_mnsync_finished function so that it could have the proper timing vs a static 45 seconds that was set in the test case, with other tests applied the 45 second timeout.