### PR TITLE
[RPC][MN] Serialize in ADDRV2 for TorV3 in RPC's

### DIFF
--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -10,6 +10,7 @@
 #include "masternode-payments.h"
 #include "masternodeconfig.h"
 #include "masternodeman.h"
+#include "netaddress.h"
 #include "netbase.h"
 #include "tiertwo/tiertwo_sync_state.h"
 #include "rpc/server.h"
@@ -390,7 +391,7 @@ void RelayMNB(CMasternodeBroadcast& mnb, const bool fSucces)
 
 void SerializeMNB(UniValue& statusObjRet, const CMasternodeBroadcast& mnb, const bool fSuccess, int& successful, int& failed)
 {
-    bool isBIP155 = PROTOCOL_VERSION >= MIN_BIP155_PROTOCOL_VERSION;
+    bool isBIP155 = mnb.addr.IsAddrV1Compatible();
     int version = isBIP155 ? PROTOCOL_VERSION | ADDRV2_FORMAT : PROTOCOL_VERSION;
     if(fSuccess) {
         successful++;
@@ -877,15 +878,9 @@ UniValue getmasternodescores(const JSONRPCRequest& request)
     return obj;
 }
 
-bool DecodeHexMnb(CMasternodeBroadcast& mnb, std::string strHexMnb) {
-
-    if (!IsHex(strHexMnb))
-        return false;
-
-    bool isBIP155 = PROTOCOL_VERSION >= MIN_BIP155_PROTOCOL_VERSION;
-    int version = isBIP155 ? PROTOCOL_VERSION | ADDRV2_FORMAT : PROTOCOL_VERSION;
+bool DecodeAddrV1(CMasternodeBroadcast& mnb, std::string strHexMnb) {
     std::vector<unsigned char> mnbData(ParseHex(strHexMnb));
-    CDataStream ssData(mnbData, SER_NETWORK, version);
+    CDataStream ssData(mnbData, SER_NETWORK, PROTOCOL_VERSION);
     try {
         ssData >> mnb;
     }
@@ -895,6 +890,27 @@ bool DecodeHexMnb(CMasternodeBroadcast& mnb, std::string strHexMnb) {
 
     return true;
 }
+
+bool DecodeHexMnb(CMasternodeBroadcast& mnb, std::string strHexMnb) {
+
+    if (!IsHex(strHexMnb))
+        return false;
+
+    bool MNAddrV1 = DecodeAddrV1(mnb, strHexMnb);
+    if (!MNAddrV1) {
+        std::vector<unsigned char> mnbData(ParseHex(strHexMnb));
+        CDataStream ssData(mnbData, SER_NETWORK, PROTOCOL_VERSION | ADDRV2_FORMAT);
+        try {
+            ssData >> mnb;
+        }
+        catch (const std::exception&) {
+            return false;
+        }
+        return true;
+    }
+    return true;
+}
+
 UniValue createmasternodebroadcast(const JSONRPCRequest& request)
 {
     CWallet * const pwallet = GetWalletForJSONRPCRequest(request);

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -390,9 +390,11 @@ void RelayMNB(CMasternodeBroadcast& mnb, const bool fSucces)
 
 void SerializeMNB(UniValue& statusObjRet, const CMasternodeBroadcast& mnb, const bool fSuccess, int& successful, int& failed)
 {
+    bool isBIP155 = PROTOCOL_VERSION >= MIN_BIP155_PROTOCOL_VERSION;
+    int version = isBIP155 ? PROTOCOL_VERSION | ADDRV2_FORMAT : PROTOCOL_VERSION;
     if(fSuccess) {
         successful++;
-        CDataStream ssMnb(SER_NETWORK, PROTOCOL_VERSION);
+        CDataStream ssMnb(SER_NETWORK, version);
         ssMnb << mnb;
         statusObjRet.pushKV("hex", HexStr(ssMnb));
     } else {
@@ -880,8 +882,10 @@ bool DecodeHexMnb(CMasternodeBroadcast& mnb, std::string strHexMnb) {
     if (!IsHex(strHexMnb))
         return false;
 
+    bool isBIP155 = PROTOCOL_VERSION >= MIN_BIP155_PROTOCOL_VERSION;
+    int version = isBIP155 ? PROTOCOL_VERSION | ADDRV2_FORMAT : PROTOCOL_VERSION;
     std::vector<unsigned char> mnbData(ParseHex(strHexMnb));
-    CDataStream ssData(mnbData, SER_NETWORK, PROTOCOL_VERSION);
+    CDataStream ssData(mnbData, SER_NETWORK, version);
     try {
         ssData >> mnb;
     }


### PR DESCRIPTION
With some work being done in PIVX-Labs by @Duddino we noticed that the RPC's for decoding and creating master node broadcasts are in Pre-BIP 155 format or AddrV1 serialization.
In order for us to create support for Tor master nodes in MPW, we need these RPC's to be able to serialize a TorV3 address.

There's a few caveats for decoding that there may be other solutions provided by someone else, but for now since receiving the stream, we cannot tell if its PreBIP155 or not, so we unserialize by AddrV1 first and if it fails, we check and attempt AddrV2.