### PR TITLE
[TEST] Fix random fee generation

### DIFF
--- a/test/functional/feature_blockindexstats.py
+++ b/test/functional/feature_blockindexstats.py
@@ -106,7 +106,7 @@ class BlockIndexStatsTest(PivxTestFramework):
         for _ in range(NUM_BLOCKS):
             # 1...4=(t->t) 5=(t->z) 6=(z->t) 7=(z->z)
             tx_kind = random.randint(1, 7)
-            fee = round(0.0001 * random.randint(3, 50), 8)
+            fee = round(0.0001 * random.randint(5, 50), 8)
             if tx_kind < 5:
                 # transparent tx
                 self.log.info("Sending t->t with fee %.8f" % fee)


### PR DESCRIPTION
The librustzcash update (PR #2870) made shield txs slightly increase in size, this led the functional test feature_blockindexstats.py to fail when the (random) generated fee is too low. With this PR I simply increase the minimum generated fee in order to avoid the issue.