### PR TITLE
[DMNs] Quorums optimizations

### DIFF
--- a/src/evo/evonotificationinterface.cpp
+++ b/src/evo/evonotificationinterface.cpp
@@ -27,7 +27,7 @@ void EvoNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
     // background thread updates
     llmq::chainLocksHandler->UpdatedBlockTip(pindexNew, pindexFork);
     llmq::quorumDKGSessionManager->UpdatedBlockTip(pindexNew, fInitialDownload);
-    llmq::quorumManager->UpdatedBlockTip(pindexNew, pindexFork, fInitialDownload);
+    llmq::quorumManager->UpdatedBlockTip(pindexNew, fInitialDownload);
 }
 
 void EvoNotificationInterface::NotifyMasternodeListChanged(bool undo, const CDeterministicMNList& oldMNList, const CDeterministicMNListDiff& diff)

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -43,7 +43,9 @@ CQuorum::~CQuorum()
 {
     // most likely the thread is already done
     stopCachePopulatorThread = true;
-    if (cachePopulatorThread.joinable()) {
+    // watch out to not join the thread when we're called from inside the thread, which might happen on shutdown. This
+    // is because on shutdown the thread is the last owner of the shared CQuorum instance and thus the destroyer of it.
+    if (cachePopulatorThread.joinable() && cachePopulatorThread.get_id() != std::this_thread::get_id()) {
         cachePopulatorThread.join();
     }
 }

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -96,16 +96,20 @@ public:
 
     // all these methods will lock cs_main
     CQuorumCPtr GetQuorum(Consensus::LLMQType llmqType, const uint256& quorumHash);
-    CQuorumCPtr GetQuorum(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum);
 
     std::vector<CQuorumCPtr> ScanQuorums(Consensus::LLMQType llmqType, size_t maxCount);
-    std::vector<CQuorumCPtr> ScanQuorums(Consensus::LLMQType llmqType, const uint256& startBlock, size_t maxCount);
+
+    // this method will not lock cs_main
+    std::vector<CQuorumCPtr> ScanQuorums(Consensus::LLMQType llmqType, const CBlockIndex* pindexStart, size_t maxCount);
 
 private:
+    // all these methods will not lock cs_main
     void EnsureQuorumConnections(Consensus::LLMQType llmqType, const CBlockIndex* pindexNew);
 
     bool BuildQuorumFromCommitment(const CFinalCommitment& qc, const CBlockIndex* pindexQuorum, const uint256& minedBlockHash, std::shared_ptr<CQuorum>& quorum) const;
     bool BuildQuorumContributions(const CFinalCommitment& fqc, std::shared_ptr<CQuorum>& quorum) const;
+
+    CQuorumCPtr GetQuorum(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum);
 };
 
 extern std::unique_ptr<CQuorumManager> quorumManager;

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -89,7 +89,7 @@ private:
 public:
     CQuorumManager(CEvoDB& _evoDb, CBLSWorker& _blsWorker, CDKGSessionManager& _dkgManager);
 
-    void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload);
+    void UpdatedBlockTip(const CBlockIndex* pindexNew, bool fInitialDownload);
 
 public:
     bool HasQuorum(Consensus::LLMQType llmqType, const uint256& quorumHash);
@@ -98,7 +98,6 @@ public:
     CQuorumCPtr GetQuorum(Consensus::LLMQType llmqType, const uint256& quorumHash);
     CQuorumCPtr GetQuorum(Consensus::LLMQType llmqType, const CBlockIndex* pindexQuorum);
 
-    CQuorumCPtr GetNewestQuorum(Consensus::LLMQType llmqType);
     std::vector<CQuorumCPtr> ScanQuorums(Consensus::LLMQType llmqType, size_t maxCount);
     std::vector<CQuorumCPtr> ScanQuorums(Consensus::LLMQType llmqType, const uint256& startBlock, size_t maxCount);
 

--- a/src/llmq/quorums_connections.cpp
+++ b/src/llmq/quorums_connections.cpp
@@ -109,8 +109,6 @@ std::set<size_t> CalcDeterministicWatchConnections(Consensus::LLMQType llmqType,
 // ensure connection to a given list of quorums
 void EnsureLatestQuorumConnections(Consensus::LLMQType llmqType, const CBlockIndex* pindexNew, const uint256& myProTxHash, std::vector<CQuorumCPtr>& lastQuorums)
 {
-    AssertLockHeld(cs_main);
-
     const auto& params = Params().GetConsensus().llmqs.at(llmqType);
     auto connman = g_connman->GetTierTwoConnMan();
 
@@ -118,7 +116,7 @@ void EnsureLatestQuorumConnections(Consensus::LLMQType llmqType, const CBlockInd
 
     // don't remove connections for the currently in-progress DKG round
     int curDkgHeight = pindexNew->nHeight - (pindexNew->nHeight % params.dkgInterval);
-    auto curDkgBlock = chainActive[curDkgHeight]->GetBlockHash();
+    auto curDkgBlock = pindexNew->GetAncestor(curDkgHeight)->GetBlockHash();
     connmanQuorumsToDelete.erase(curDkgBlock);
 
     for (auto& quorum : lastQuorums) {

--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -550,16 +550,16 @@ CQuorumCPtr CSigningManager::SelectQuorumForSigning(Consensus::LLMQType llmqType
     auto& llmqParams = Params().GetConsensus().llmqs.at(llmqType);
     size_t poolSize = (size_t)llmqParams.signingActiveQuorumCount;
 
-    uint256 startBlock;
+    CBlockIndex* pindexStart;
     {
         LOCK(cs_main);
         if (signHeight > chainActive.Height()) {
             return nullptr;
         }
-        startBlock = chainActive[signHeight - SIGN_HEIGHT_OFFSET]->GetBlockHash();
+        pindexStart = chainActive[signHeight - SIGN_HEIGHT_OFFSET];
     }
 
-    auto quorums = quorumManager->ScanQuorums(llmqType, startBlock, poolSize);
+    auto quorums = quorumManager->ScanQuorums(llmqType, pindexStart, poolSize);
     if (quorums.empty()) {
         return nullptr;
     }

--- a/src/llmq/quorums_utils.cpp
+++ b/src/llmq/quorums_utils.cpp
@@ -50,7 +50,6 @@ std::string ToHexStr(const std::vector<bool>& vBits)
 
 bool IsQuorumActive(Consensus::LLMQType llmqType, const uint256& quorumHash)
 {
-    AssertLockHeld(cs_main);
 
     auto& params = Params().GetConsensus().llmqs.at(llmqType);
 

--- a/src/rpc/rpcquorums.cpp
+++ b/src/rpc/rpcquorums.cpp
@@ -138,7 +138,7 @@ UniValue listquorums(const JSONRPCRequest& request)
     for (auto& p : Params().GetConsensus().llmqs) {
         UniValue v(UniValue::VARR);
 
-        auto quorums = llmq::quorumManager->ScanQuorums(p.first, chainActive.Tip()->GetBlockHash(), count);
+        auto quorums = llmq::quorumManager->ScanQuorums(p.first, chainActive.Tip(), count);
         for (auto& q : quorums) {
             v.push_back(q->pindexQuorum->GetBlockHash().ToString());
         }

--- a/test/functional/tiertwo_chainlocks.py
+++ b/test/functional/tiertwo_chainlocks.py
@@ -35,6 +35,11 @@ class ChainLocksTest(PivxDMNTestFramework):
         (qfc, badmembers) = self.mine_quorum()
         assert_equal(171, miner.getblockcount())
 
+        # in order to avoid sync issues signing sessions quorum selection looks for quorums mined at most at chaintip - 8 blocks.
+        # let's round it and mine 10 blocks
+        miner.generate(10)
+        self.sync_all()
+
         # mine single block, wait for chainlock
         self.nodes[0].generate(1)
         self.wait_for_chainlock_tip_all_nodes()

--- a/test/functional/tiertwo_signing_session.py
+++ b/test/functional/tiertwo_signing_session.py
@@ -30,6 +30,12 @@ class SigningSessionTest(PivxDMNTestFramework):
         self.log.info("----------------------------------")
         (qfc, badmembers) = self.mine_quorum()
         assert_equal(171, miner.getblockcount())
+
+        # in order to avoid sync issues signing sessions quorum selection looks for quorums mined at most at chaintip - 8 blocks.
+        # let's round it and mine 10 blocks
+        miner.generate(10)
+        self.sync_all()
+
         # Quorum members
         members = self.get_quorum_members(qfc['quorumHash'])
 


### PR DESCRIPTION
Cleanup and various optimizations for the quorum class in particular:
- Cleanup unused code/ function parameters
- Don't lock cs_main when it is not needed
- Huge speed up on the ScanQuorums function