### PR TITLE
[DMNs] Implement lru cache

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -312,6 +312,7 @@ BITCOIN_CORE_H = \
   guiinterfaceutil.h \
   uint256.h \
   undo.h \
+  unordered_lru_cache.h \
   util/asmap.h \
   util/blockstatecatcher.h \
   util/system.h \

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -11,6 +11,8 @@
 #include "consensus/params.h"
 #include "evo/deterministicmns.h"
 #include "evo/evodb.h"
+#include "saltedhasher.h"
+#include "unordered_lru_cache.h"
 #include "validationinterface.h"
 
 namespace llmq
@@ -84,7 +86,8 @@ private:
     CDKGSessionManager& dkgManager;
 
     RecursiveMutex quorumsCacheCs;
-    std::map<std::pair<Consensus::LLMQType, uint256>, CQuorumPtr> quorumsCache;
+    mutable std::map<Consensus::LLMQType, unordered_lru_cache<uint256, CQuorumCPtr, StaticSaltedHasher>> mapQuorumsCache;
+    mutable std::map<Consensus::LLMQType, unordered_lru_cache<uint256, std::vector<CQuorumCPtr>, StaticSaltedHasher>> scanQuorumsCache;
 
 public:
     CQuorumManager(CEvoDB& _evoDb, CBLSWorker& _blsWorker, CDKGSessionManager& _dkgManager);

--- a/src/llmq/quorums_blockprocessor.h
+++ b/src/llmq/quorums_blockprocessor.h
@@ -9,8 +9,10 @@
 #include "consensus/params.h"
 #include "llmq/quorums_commitment.h"
 #include "primitives/transaction.h"
+#include "saltedhasher.h"
 #include "sync.h"
 #include "uint256.h"
+#include "unordered_lru_cache.h"
 
 #include <map>
 
@@ -36,6 +38,8 @@ private:
     std::map<std::pair<uint8_t, uint256>, uint256> minableCommitmentsByQuorum;
     // commitment hash --> final commitment
     std::map<uint256, CFinalCommitment> minableCommitments;
+    // for each llmqtype map quorum_hash --> (bool final_commitment_mined)
+    mutable std::map<Consensus::LLMQType, unordered_lru_cache<uint256, bool, StaticSaltedHasher>> mapHasMinedCommitmentCache GUARDED_BY(minableCommitmentsCs);
 
 public:
     explicit CQuorumBlockProcessor(CEvoDB& _evoDb);

--- a/src/llmq/quorums_utils.cpp
+++ b/src/llmq/quorums_utils.cpp
@@ -75,6 +75,8 @@ void InitQuorumsCache(CacheType& cache)
 }
 
 template void InitQuorumsCache<std::map<Consensus::LLMQType, unordered_lru_cache<uint256, bool, StaticSaltedHasher>>>(std::map<Consensus::LLMQType, unordered_lru_cache<uint256, bool, StaticSaltedHasher>>& cache);
+template void InitQuorumsCache<std::map<Consensus::LLMQType, unordered_lru_cache<uint256, std::vector<CQuorumCPtr>, StaticSaltedHasher>>>(std::map<Consensus::LLMQType, unordered_lru_cache<uint256, std::vector<CQuorumCPtr>, StaticSaltedHasher>>& cache);
+template void InitQuorumsCache<std::map<Consensus::LLMQType, unordered_lru_cache<uint256, CQuorumCPtr, StaticSaltedHasher>>>(std::map<Consensus::LLMQType, unordered_lru_cache<uint256, CQuorumCPtr, StaticSaltedHasher>>& cache);
 
 } // namespace llmq::utils
 

--- a/src/llmq/quorums_utils.cpp
+++ b/src/llmq/quorums_utils.cpp
@@ -65,6 +65,17 @@ bool IsQuorumActive(Consensus::LLMQType llmqType, const uint256& quorumHash)
     return false;
 }
 
+template <typename CacheType>
+void InitQuorumsCache(CacheType& cache)
+{
+    for (auto& llmq : Params().GetConsensus().llmqs) {
+        cache.emplace(std::piecewise_construct, std::forward_as_tuple(llmq.first),
+            std::forward_as_tuple(llmq.second.signingActiveQuorumCount + 1));
+    }
+}
+
+template void InitQuorumsCache<std::map<Consensus::LLMQType, unordered_lru_cache<uint256, bool, StaticSaltedHasher>>>(std::map<Consensus::LLMQType, unordered_lru_cache<uint256, bool, StaticSaltedHasher>>& cache);
+
 } // namespace llmq::utils
 
 } // namespace llmq

--- a/src/llmq/quorums_utils.h
+++ b/src/llmq/quorums_utils.h
@@ -6,6 +6,7 @@
 #define PIVX_QUORUMS_UTILS_H
 
 #include "consensus/params.h"
+#include "unordered_lru_cache.h"
 
 #include <vector>
 
@@ -59,6 +60,9 @@ static void IterateNodesRandom(NodesContainer& nodeStates, Continue&& cont, Call
        }
    }
 }
+
+template <typename CacheType>
+void InitQuorumsCache(CacheType& cache);
 
 } // namespace llmq::utils
 

--- a/src/unordered_lru_cache.h
+++ b/src/unordered_lru_cache.h
@@ -1,0 +1,115 @@
+// Copyright (c) 2019-2021 The Dash Core developers
+// Copyright (c) 2023 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef PIVX_UNORDERED_LRU_CACHE_H
+#define PIVX_UNORDERED_LRU_CACHE_H
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+template<typename Key, typename Value, typename Hasher, size_t MaxSize = 0, size_t TruncateThreshold = 0>
+class unordered_lru_cache
+{
+private:
+    typedef std::unordered_map<Key, std::pair<Value, int64_t>, Hasher> MapType;
+
+    MapType cacheMap;
+    size_t maxSize;
+    size_t truncateThreshold;
+    int64_t accessCounter{0};
+
+public:
+    explicit unordered_lru_cache(size_t _maxSize = MaxSize, size_t _truncateThreshold = TruncateThreshold) : maxSize(_maxSize),
+                                                                                                             truncateThreshold(_truncateThreshold == 0 ? _maxSize * 2 : _truncateThreshold)
+    {
+        // either specify maxSize through template arguments or the constructor and fail otherwise
+        assert(_maxSize != 0);
+    }
+
+    size_t max_size() const { return maxSize; }
+
+    template<typename Value2>
+    void _emplace(const Key& key, Value2&& v)
+    {
+        auto it = cacheMap.find(key);
+        if (it == cacheMap.end()) {
+            cacheMap.emplace(key, std::make_pair(std::forward<Value2>(v), accessCounter++));
+        } else {
+            it->second.first = std::forward<Value2>(v);
+            it->second.second = accessCounter++;
+        }
+        truncate_if_needed();
+    }
+
+    void emplace(const Key& key, Value&& v)
+    {
+        _emplace(key, v);
+    }
+
+    void insert(const Key& key, const Value& v)
+    {
+        _emplace(key, v);
+    }
+
+    bool get(const Key& key, Value& value)
+    {
+        auto it = cacheMap.find(key);
+        if (it != cacheMap.end()) {
+            it->second.second = accessCounter++;
+            value = it->second.first;
+            return true;
+        }
+        return false;
+    }
+
+    bool exists(const Key& key)
+    {
+        auto it = cacheMap.find(key);
+        if (it != cacheMap.end()) {
+            it->second.second = accessCounter++;
+            return true;
+        }
+        return false;
+    }
+
+    void erase(const Key& key)
+    {
+        cacheMap.erase(key);
+    }
+
+    void clear()
+    {
+        cacheMap.clear();
+    }
+
+private:
+    void truncate_if_needed()
+    {
+        typedef typename MapType::iterator Iterator;
+
+        if (cacheMap.size() <= truncateThreshold) {
+            return;
+        }
+
+        std::vector<Iterator> vec;
+        vec.reserve(cacheMap.size());
+        for (auto it = cacheMap.begin(); it != cacheMap.end(); ++it) {
+            vec.emplace_back(it);
+        }
+        // sort by last access time (descending order)
+        std::sort(vec.begin(), vec.end(), [](const Iterator& it1, const Iterator& it2) {
+            return it1->second.second > it2->second.second;
+        });
+
+        for (size_t i = maxSize; i < vec.size(); i++) {
+            cacheMap.erase(vec[i]);
+        }
+    }
+};
+
+#endif // PIVX_UNORDERED_LRU_CACHE_H


### PR DESCRIPTION
A LRU cache is an (unordered) map where, once it is full, the least recently used element is removed. 
This PR adds a LRU cache that maps  `quorumHash` -> `bool` where `bool` is `true` iff the quorum has been mined on chain.
It is a big optimization compared to checking the database each time