### PR TITLE
[DMNs] Chainlock optimizations

### DIFF
--- a/src/evo/evonotificationinterface.cpp
+++ b/src/evo/evonotificationinterface.cpp
@@ -25,7 +25,7 @@ void EvoNotificationInterface::AcceptedBlockHeader(const CBlockIndex* pindexNew)
 void EvoNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload)
 {
     // background thread updates
-    llmq::chainLocksHandler->UpdatedBlockTip(pindexNew, pindexFork);
+    llmq::chainLocksHandler->UpdatedBlockTip(pindexNew);
     llmq::quorumDKGSessionManager->UpdatedBlockTip(pindexNew, fInitialDownload);
     llmq::quorumManager->UpdatedBlockTip(pindexNew, pindexFork, fInitialDownload);
 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1541,7 +1541,7 @@ bool AppInitMain()
                 // The on-disk coinsdb is now in a good state, create the cache
                 pcoinsTip.reset(new CCoinsViewCache(pcoinscatcher.get()));
 
-                InitTierTwoPostCoinsCacheLoad(&scheduler);
+                InitTierTwoPostCoinsCacheLoad();
 
                 bool is_coinsview_empty = fReset || fReindexChainState || pcoinsTip->GetBestBlock().IsNull();
                 if (!is_coinsview_empty) {

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -179,55 +179,85 @@ void CChainLocksHandler::AcceptedBlockHeader(const CBlockIndex* pindexNew)
 
 void CChainLocksHandler::UpdatedBlockTip(const CBlockIndex* pindexNew)
 {
+    // don't call TrySignChainTip directly but instead let the scheduler call it. This way we ensure that cs_main is
+    // never locked and TrySignChainTip is not called twice in parallel
+    LOCK(cs);
+    if (tryLockChainTipScheduled) {
+        return;
+    }
+    tryLockChainTipScheduled = true;
+    scheduler->scheduleFromNow([&]() {
+        TrySignChainTip();
+        LOCK(cs);
+        tryLockChainTipScheduled = false;
+    },
+        0);
+}
+
+void CChainLocksHandler::TrySignChainTip()
+{
+    Cleanup();
+
+    const CBlockIndex* pindex;
+    {
+        LOCK(cs_main);
+        pindex = chainActive.Tip();
+    }
+
     if (!fMasterNode) {
         return;
     }
-    if (!pindexNew->pprev) {
+    if (!pindex->pprev) {
         return;
     }
     if (!sporkManager.IsSporkActive(SPORK_23_CHAINLOCKS_ENFORCEMENT)) {
         return;
     }
 
-    Cleanup();
-
     // DIP8 defines a process called "Signing attempts" which should run before the CLSIG is finalized
     // To simplify the initial implementation, we skip this process and directly try to create a CLSIG
     // This will fail when multiple blocks compete, but we accept this for the initial implementation.
     // Later, we'll add the multiple attempts process.
 
-    uint256 requestId = ::SerializeHash(std::make_pair(CLSIG_REQUESTID_PREFIX, pindexNew->nHeight));
-    uint256 msgHash = pindexNew->GetBlockHash();
-
     {
         LOCK(cs);
 
-        if (bestChainLockBlockIndex == pindexNew) {
+        if (bestChainLockBlockIndex == pindex) {
             // we first got the CLSIG, then the header, and then the block was connected.
             // In this case there is no need to continue here.
             return;
         }
 
-        if (InternalHasConflictingChainLock(pindexNew->nHeight, pindexNew->GetBlockHash())) {
-            if (!inEnforceBestChainLock) {
-                // we accepted this block when there was no lock yet, but now a conflicting lock appeared. Invalidate it.
-                LogPrintf("CChainLocksHandler::%s -- conflicting lock after block was accepted, invalidating now\n",
-                          __func__);
-                ScheduleInvalidateBlock(pindexNew);
-            }
+        if (pindex->nHeight == lastSignedHeight) {
+            // already signed this one
             return;
         }
 
-        if (bestChainLock.nHeight >= pindexNew->nHeight) {
+        if (bestChainLock.nHeight >= pindex->nHeight) {
             // already got the same CLSIG or a better one
             return;
         }
 
-        if (pindexNew->nHeight == lastSignedHeight) {
-            // already signed this one
+        if (InternalHasConflictingChainLock(pindex->nHeight, pindex->GetBlockHash())) {
+            if (!inEnforceBestChainLock) {
+                // we accepted this block when there was no lock yet, but now a conflicting lock appeared. Invalidate it.
+                LogPrintf("CChainLocksHandler::%s -- conflicting lock after block was accepted, invalidating now\n",
+                          __func__);
+                ScheduleInvalidateBlock(pindex);
+            }
             return;
         }
-        lastSignedHeight = pindexNew->nHeight;
+    }
+    uint256 requestId = ::SerializeHash(std::make_pair(CLSIG_REQUESTID_PREFIX, pindex->nHeight));
+    uint256 msgHash = pindex->GetBlockHash();
+
+    {
+        LOCK(cs);
+        if (bestChainLock.nHeight >= pindex->nHeight) {
+            // might have happened while we didn't hold cs
+            return;
+        }
+        lastSignedHeight = pindex->nHeight;
         lastSignedRequestId = requestId;
         lastSignedMsgHash = msgHash;
     }

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -39,6 +39,10 @@ CChainLocksHandler::~CChainLocksHandler()
 void CChainLocksHandler::Start()
 {
     quorumSigningManager->RegisterRecoveredSigsListener(this);
+    scheduler->scheduleEvery([&]() {
+        EnforceBestChainLock();
+    },
+        5000);
 }
 
 void CChainLocksHandler::Stop()
@@ -146,7 +150,10 @@ void CChainLocksHandler::ProcessNewChainLock(NodeId from, const llmq::CChainLock
         bestChainLockBlockIndex = pindex;
     }
 
-    EnforceBestChainLock();
+    scheduler->scheduleFromNow([&]() {
+        EnforceBestChainLock();
+    },
+        0);
 
     LogPrintf("CChainLocksHandler::%s -- processed new CLSIG (%s), peer=%d\n",
               __func__, clsig.ToString(), from);
@@ -154,26 +161,23 @@ void CChainLocksHandler::ProcessNewChainLock(NodeId from, const llmq::CChainLock
 
 void CChainLocksHandler::AcceptedBlockHeader(const CBlockIndex* pindexNew)
 {
-    bool doEnforce = false;
-    {
-        LOCK2(cs_main, cs);
+    LOCK2(cs_main, cs);
 
-        if (pindexNew->GetBlockHash() == bestChainLock.blockHash) {
-            LogPrintf("CChainLocksHandler::%s -- block header %s came in late, updating and enforcing\n", __func__, pindexNew->GetBlockHash().ToString());
+    if (pindexNew->GetBlockHash() == bestChainLock.blockHash) {
+        LogPrintf("CChainLocksHandler::%s -- block header %s came in late, updating and enforcing\n", __func__, pindexNew->GetBlockHash().ToString());
 
-            if (bestChainLock.nHeight != pindexNew->nHeight) {
-                // Should not happen, same as the conflict check from ProcessNewChainLock.
-                LogPrintf("CChainLocksHandler::%s -- height of CLSIG (%s) does not match the specified block's height (%d)\n",
-                          __func__, bestChainLock.ToString(), pindexNew->nHeight);
-                return;
-            }
-
-            bestChainLockBlockIndex = pindexNew;
-            doEnforce = true;
+        if (bestChainLock.nHeight != pindexNew->nHeight) {
+            // Should not happen, same as the conflict check from ProcessNewChainLock.
+            LogPrintf("CChainLocksHandler::%s -- height of CLSIG (%s) does not match the specified block's height (%d)\n",
+                __func__, bestChainLock.ToString(), pindexNew->nHeight);
+            return;
         }
-    }
-    if (doEnforce) {
-        EnforceBestChainLock();
+
+        // when EnforceBestChainLock is called later, it might end up invalidating other chains but not activating the
+        // CLSIG locked chain. This happens when only the header is known but the block is still missing yet. The usual
+        // block processing logic will handle this when the block arrives
+        bestChainLockWithKnownBlock = bestChainLock;
+        bestChainLockBlockIndex = pindexNew;
     }
 }
 
@@ -181,12 +185,14 @@ void CChainLocksHandler::UpdatedBlockTip(const CBlockIndex* pindexNew)
 {
     // don't call TrySignChainTip directly but instead let the scheduler call it. This way we ensure that cs_main is
     // never locked and TrySignChainTip is not called twice in parallel
+    // EnforceBestChainLock switching chains.
     LOCK(cs);
     if (tryLockChainTipScheduled) {
         return;
     }
     tryLockChainTipScheduled = true;
     scheduler->scheduleFromNow([&]() {
+        EnforceBestChainLock();
         TrySignChainTip();
         LOCK(cs);
         tryLockChainTipScheduled = false;
@@ -222,12 +228,6 @@ void CChainLocksHandler::TrySignChainTip()
     {
         LOCK(cs);
 
-        if (bestChainLockBlockIndex == pindex) {
-            // we first got the CLSIG, then the header, and then the block was connected.
-            // In this case there is no need to continue here.
-            return;
-        }
-
         if (pindex->nHeight == lastSignedHeight) {
             // already signed this one
             return;
@@ -239,12 +239,8 @@ void CChainLocksHandler::TrySignChainTip()
         }
 
         if (InternalHasConflictingChainLock(pindex->nHeight, pindex->GetBlockHash())) {
-            if (!inEnforceBestChainLock) {
-                // we accepted this block when there was no lock yet, but now a conflicting lock appeared. Invalidate it.
-                LogPrintf("CChainLocksHandler::%s -- conflicting lock after block was accepted, invalidating now\n",
-                          __func__);
-                ScheduleInvalidateBlock(pindex);
-            }
+            // don't sign if another conflicting CLSIG is already present. EnforceBestChainLock will later enforce
+            // the correct chain.
             return;
         }
     }
@@ -266,23 +262,28 @@ void CChainLocksHandler::TrySignChainTip()
 }
 
 // WARNING: cs_main and cs should not be held!
+// This should also not be called from validation signals, as this might result in recursive calls
 void CChainLocksHandler::EnforceBestChainLock()
 {
     CChainLockSig clsig;
     const CBlockIndex* pindex;
+    const CBlockIndex* currentBestChainLockBlockIndex;
     {
         LOCK(cs);
         clsig = bestChainLockWithKnownBlock;
-        pindex = bestChainLockBlockIndex;
+        pindex = currentBestChainLockBlockIndex = this->bestChainLockBlockIndex;
+        if (!currentBestChainLockBlockIndex) {
+            // we don't have the header/block, so we can't do anything right now
+            return;
+        }
     }
-
+    bool activateNeeded;
     {
         LOCK(cs_main);
 
         // Go backwards through the chain referenced by clsig until we find a block that is part of the main chain.
         // For each of these blocks, check if there are children that are NOT part of the chain referenced by clsig
         // and invalidate each of them.
-        inEnforceBestChainLock = true; // avoid unnecessary ScheduleInvalidateBlock calls inside UpdatedBlockTip
         while (pindex && !chainActive.Contains(pindex)) {
             // Invalidate all blocks that have the same prevBlockHash but are not equal to blockHash
             auto itp = mapPrevBlockIndex.equal_range(pindex->pprev->GetBlockHash());
@@ -297,14 +298,21 @@ void CChainLocksHandler::EnforceBestChainLock()
 
             pindex = pindex->pprev;
         }
-        inEnforceBestChainLock = false;
+        // In case blocks from the correct chain are invalid at the moment, reconsider them. The only case where this
+        // can happen right now is when missing superblock triggers caused the main chain to be dismissed first. When
+        // the trigger later appears, this should bring us to the correct chain eventually. Please note that this does
+        // NOT enforce invalid blocks in any way, it just causes re-validation.
+        if (!currentBestChainLockBlockIndex->IsValid()) {
+            CValidationState state;
+            ReconsiderBlock(state, mapBlockIndex.at(currentBestChainLockBlockIndex->GetBlockHash()));
+        }
+
+        activateNeeded = chainActive.Tip()->GetAncestor(currentBestChainLockBlockIndex->nHeight) != currentBestChainLockBlockIndex;
     }
 
     CValidationState state;
-    if (!ActivateBestChain(state)) {
+    if (activateNeeded && !ActivateBestChain(state)) {
         LogPrintf("CChainLocksHandler::%s -- ActivateBestChain failed: %s\n", __func__, state.GetRejectReason());
-        // This should not have happened and we are in a state were it's not safe to continue anymore
-        assert(false);
     }
 }
 
@@ -332,16 +340,6 @@ void CChainLocksHandler::HandleNewRecoveredSig(const llmq::CRecoveredSig& recove
         clsig.sig = recoveredSig.sig;
     }
     ProcessNewChainLock(-1, clsig, ::SerializeHash(clsig));
-}
-
-void CChainLocksHandler::ScheduleInvalidateBlock(const CBlockIndex* pindex)
-{
-    // Calls to InvalidateBlock and ActivateBestChain might result in re-invocation of the UpdatedBlockTip and other
-    // signals, so we can't directly call it from signal handlers. We solve this by doing the call from the scheduler
-
-    scheduler->scheduleFromNow([this, pindex]() {
-        DoInvalidateBlock(pindex, true);
-    }, 0);
 }
 
 // WARNING, do not hold cs while calling this method as we'll otherwise run into a deadlock

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -30,10 +30,18 @@ std::string CChainLockSig::ToString() const
 CChainLocksHandler::CChainLocksHandler(CScheduler* _scheduler) :
     scheduler(_scheduler)
 {
-    quorumSigningManager->RegisterRecoveredSigsListener(this);
 }
 
 CChainLocksHandler::~CChainLocksHandler()
+{
+}
+
+void CChainLocksHandler::Start()
+{
+    quorumSigningManager->RegisterRecoveredSigsListener(this);
+}
+
+void CChainLocksHandler::Stop()
 {
     quorumSigningManager->UnregisterRecoveredSigsListener(this);
 }

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -69,10 +69,10 @@ public:
     bool AlreadyHave(const CInv& inv);
     bool GetChainLockByHash(const uint256& hash, CChainLockSig& ret);
 
-    void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);
+    void ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv);
     void ProcessNewChainLock(NodeId from, const CChainLockSig& clsig, const uint256& hash);
     void AcceptedBlockHeader(const CBlockIndex* pindexNew);
-    void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork);
+    void UpdatedBlockTip(const CBlockIndex* pindexNew);
     void EnforceBestChainLock();
     virtual void HandleNewRecoveredSig(const CRecoveredSig& recoveredSig);
 

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -47,7 +47,6 @@ private:
     CScheduler* scheduler;
     RecursiveMutex cs;
     bool tryLockChainTipScheduled GUARDED_BY(cs) {false};
-    std::atomic<bool> inEnforceBestChainLock{false};
 
     uint256 bestChainLockHash;
     CChainLockSig bestChainLock;
@@ -89,7 +88,6 @@ private:
     bool InternalHasChainLock(int nHeight, const uint256& blockHash);
     bool InternalHasConflictingChainLock(int nHeight, const uint256& blockHash);
 
-    void ScheduleInvalidateBlock(const CBlockIndex* pindex);
     void DoInvalidateBlock(const CBlockIndex* pindex, bool activateBestChain);
 
     void Cleanup();

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -11,6 +11,7 @@
 
 #include "net.h"
 #include "chainparams.h"
+#include "threadsafety.h"
 
 #include <atomic>
 
@@ -45,6 +46,7 @@ class CChainLocksHandler : public CRecoveredSigsListener
 private:
     CScheduler* scheduler;
     RecursiveMutex cs;
+    bool tryLockChainTipScheduled GUARDED_BY(cs) {false};
     std::atomic<bool> inEnforceBestChainLock{false};
 
     uint256 bestChainLockHash;
@@ -75,6 +77,7 @@ public:
     void ProcessNewChainLock(NodeId from, const CChainLockSig& clsig, const uint256& hash);
     void AcceptedBlockHeader(const CBlockIndex* pindexNew);
     void UpdatedBlockTip(const CBlockIndex* pindexNew);
+    void TrySignChainTip();
     void EnforceBestChainLock();
     virtual void HandleNewRecoveredSig(const CRecoveredSig& recoveredSig);
 

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -65,7 +65,9 @@ public:
     CChainLocksHandler(CScheduler* _scheduler);
     ~CChainLocksHandler();
 
-public:
+    void Start();
+    void Stop();
+
     bool AlreadyHave(const CInv& inv);
     bool GetChainLockByHash(const uint256& hash, CChainLockSig& ret);
 

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -11,9 +11,9 @@
 
 #include "net.h"
 #include "chainparams.h"
-#include "threadsafety.h"
 
 #include <atomic>
+#include <boost/thread.hpp>
 
 class CBlockIndex;
 class CScheduler;
@@ -45,6 +45,7 @@ class CChainLocksHandler : public CRecoveredSigsListener
 
 private:
     CScheduler* scheduler;
+    boost::thread* scheduler_thread;
     RecursiveMutex cs;
     bool tryLockChainTipScheduled GUARDED_BY(cs) {false};
 
@@ -63,7 +64,7 @@ private:
     int64_t lastCleanupTime{0};
 
 public:
-    CChainLocksHandler(CScheduler* _scheduler);
+    CChainLocksHandler();
     ~CChainLocksHandler();
 
     void Start();

--- a/src/llmq/quorums_init.cpp
+++ b/src/llmq/quorums_init.cpp
@@ -19,7 +19,7 @@ namespace llmq
 
 CBLSWorker* blsWorker;
 
-void InitLLMQSystem(CEvoDB& evoDb, CScheduler* scheduler, bool unitTests)
+void InitLLMQSystem(CEvoDB& evoDb, bool unitTests)
 {
     blsWorker = new CBLSWorker();
 
@@ -29,7 +29,7 @@ void InitLLMQSystem(CEvoDB& evoDb, CScheduler* scheduler, bool unitTests)
     quorumManager.reset(new CQuorumManager(evoDb, *blsWorker, *quorumDKGSessionManager));
     quorumSigSharesManager = new CSigSharesManager();
     quorumSigningManager = new CSigningManager(unitTests);
-    chainLocksHandler = new CChainLocksHandler(scheduler);
+    chainLocksHandler = new CChainLocksHandler();
 }
 
 void DestroyLLMQSystem()

--- a/src/llmq/quorums_init.cpp
+++ b/src/llmq/quorums_init.cpp
@@ -59,10 +59,16 @@ void StartLLMQSystem()
     if (quorumSigSharesManager) {
         quorumSigSharesManager->StartWorkerThread();
     }
+    if (chainLocksHandler) {
+        chainLocksHandler->Start();
+    }
 }
 
 void StopLLMQSystem()
 {
+    if (chainLocksHandler) {
+        chainLocksHandler->Stop();
+    }
     if (quorumDKGSessionManager) {
         quorumDKGSessionManager->StopThreads();
     }

--- a/src/llmq/quorums_init.h
+++ b/src/llmq/quorums_init.h
@@ -15,7 +15,7 @@ namespace llmq
 {
 
 // Init/destroy LLMQ globals
-void InitLLMQSystem(CEvoDB& evoDb, CScheduler* scheduler, bool unitTests);
+void InitLLMQSystem(CEvoDB& evoDb, bool unitTests);
 void DestroyLLMQSystem();
 
 // Manage scheduled tasks, threads, listeners etc.

--- a/src/test/test_pivx.cpp
+++ b/src/test/test_pivx.cpp
@@ -123,7 +123,7 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
         pblocktree.reset(new CBlockTreeDB(1 << 20, true));
         pcoinsdbview.reset(new CCoinsViewDB(1 << 23, true));
         pcoinsTip.reset(new CCoinsViewCache(pcoinsdbview.get()));
-        llmq::InitLLMQSystem(*evoDb, &scheduler, true);
+        llmq::InitLLMQSystem(*evoDb, true);
         if (!LoadGenesisBlock()) {
             throw std::runtime_error("Error initializing block database");
         }
@@ -141,6 +141,7 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
 TestingSetup::~TestingSetup()
 {
         scheduler.stop();
+        llmq::StopLLMQSystem();
         threadGroup.interrupt_all();
         threadGroup.join_all();
         GetMainSignals().FlushBackgroundCallbacks();

--- a/src/tiertwo/init.cpp
+++ b/src/tiertwo/init.cpp
@@ -71,10 +71,10 @@ void InitTierTwoPreChainLoad(bool fReindex)
     deterministicMNManager.reset(new CDeterministicMNManager(*evoDb));
 }
 
-void InitTierTwoPostCoinsCacheLoad(CScheduler* scheduler)
+void InitTierTwoPostCoinsCacheLoad()
 {
     // Initialize LLMQ system
-    llmq::InitLLMQSystem(*evoDb, scheduler, false);
+    llmq::InitLLMQSystem(*evoDb, false);
 }
 
 void InitTierTwoChainTip()

--- a/src/tiertwo/init.h
+++ b/src/tiertwo/init.h
@@ -28,7 +28,7 @@ void ResetTierTwoInterfaces();
 void InitTierTwoPreChainLoad(bool fReindex);
 
 /** Inits the tier two global objects that require access to the coins tip cache */
-void InitTierTwoPostCoinsCacheLoad(CScheduler* scheduler);
+void InitTierTwoPostCoinsCacheLoad();
 
 /** Initialize chain tip */
 void InitTierTwoChainTip();

--- a/src/tiertwo_networksync.cpp
+++ b/src/tiertwo_networksync.cpp
@@ -82,7 +82,7 @@ bool CMasternodeSync::MessageDispatcher(CNode* pfrom, std::string& strCommand, C
     }
 
     if (strCommand == NetMsgType::CLSIG) {
-        llmq::chainLocksHandler->ProcessMessage(pfrom, strCommand, vRecv, *g_connman);
+        llmq::chainLocksHandler->ProcessMessage(pfrom, strCommand, vRecv);
     }
 
     if (strCommand == NetMsgType::GETMNLIST) {

--- a/test/functional/tiertwo_chainlocks.py
+++ b/test/functional/tiertwo_chainlocks.py
@@ -75,17 +75,17 @@ class ChainLocksTest(PivxDMNTestFramework):
 
         # Keep node connected and let it try to reorg the chain
         good_tip = self.nodes[0].getbestblockhash()
-        self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
         # Restart it so that it forgets all the chainlocks from the past
         self.stop_node(0)
         self.start_node(0, extra_args=self.extra_args[0])
         connect_nodes(self.nodes[0], 1)
+        self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
         # Now try to reorg the chain
         self.nodes[0].generate(2)
-        time.sleep(2)
+        time.sleep(6)
         assert self.nodes[1].getbestblockhash() == good_tip
         self.nodes[0].generate(2)
-        time.sleep(2)
+        time.sleep(6)
         assert self.nodes[1].getbestblockhash() == good_tip
 
         # Now let the node which is on the wrong chain reorg back to the locked chain
@@ -93,6 +93,7 @@ class ChainLocksTest(PivxDMNTestFramework):
         assert self.nodes[0].getbestblockhash() != good_tip
         self.nodes[1].generate(1)
         self.wait_for_chainlock(self.nodes[0], self.nodes[1].getbestblockhash())
+        time.sleep(6)
         assert self.nodes[0].getbestblockhash() == self.nodes[1].getbestblockhash()
 
     def wait_for_chainlock_tip_all_nodes(self):
@@ -109,7 +110,7 @@ class ChainLocksTest(PivxDMNTestFramework):
         while time.time() - t < 15:
             try:
                 block = node.getblock(block_hash)
-                if block["chainlock"]:
+                if block["confirmations"] > 0 and block["chainlock"]:
                     return
             except:
                 # block might not be on the node yet


### PR DESCRIPTION
This PR refactor and fixes bugs of the ChainLock class:

**Refactor:**

- Remove unused variable from `UpdatedBlockTip`
- Decouple init/destroy and start/stop steps as we do for all llmq classes
- Use `LookUpBlockIndex` in place of `mapblockindex`
- Decouple the chainlock signing part from `UpdateBlockTip` to a new function `TrySignChainTip`
- Make `EnforceBestChainLock` the only function where blocks can be invalidated
- Use a local scheduler instead of the global one

**Bug fixes:**

- Call `EnforceBestChainLock` only throught the  scheduler to avoid recursions 
- Don't ban peers if the received chainlock is not valid since it could simply means that the node is not fully synced yet
- Remove non used locks/ lock only when it's necessary
- Improve the functional test that was failing