### PR TITLE
[DB] Upgrade evoDB and llmqDB to V2 serializer

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -52,7 +52,7 @@ static leveldb::Options GetOptions(size_t nCacheSize)
     return options;
 }
 
-CDBWrapper::CDBWrapper(const fs::path& path, size_t nCacheSize, bool fMemory, bool fWipe)
+CDBWrapper::CDBWrapper(const fs::path& path, size_t nCacheSize, bool fMemory, bool fWipe, int nVersion)
 {
     penv = nullptr;
     readoptions.verify_checksums = true;
@@ -61,6 +61,7 @@ CDBWrapper::CDBWrapper(const fs::path& path, size_t nCacheSize, bool fMemory, bo
     syncoptions.sync = true;
     options = GetOptions(nCacheSize);
     options.create_if_missing = true;
+    this->nVersion = nVersion;
     if (fMemory) {
         penv = leveldb::NewMemEnv(leveldb::Env::Default());
         options.env = penv;

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -51,14 +51,13 @@ private:
 
     CDataStream ssKey;
     CDataStream ssValue;
-
     size_t size_estimate;
 
 public:
     /**
-     * @param[in] _parent   CDBWrapper that this batch is to be submitted to
+     * @param[in] _nVersion         The version used to serialize data.
      */
-    CDBBatch() : ssKey(SER_DISK, CLIENT_VERSION), ssValue(SER_DISK, CLIENT_VERSION), size_estimate(0) { };
+    explicit CDBBatch(int nVersion) : ssKey(SER_DISK, nVersion), ssValue(SER_DISK, nVersion), size_estimate(0){};
 
     void Clear()
     {
@@ -80,7 +79,6 @@ public:
     {
         leveldb::Slice slKey(_ssKey.data(), _ssKey.size());
 
-        CDataStream ssValue(SER_DISK, CLIENT_VERSION);
         ssValue.reserve(DBWRAPPER_PREALLOC_VALUE_SIZE);
         ssValue << value;
         leveldb::Slice slValue(ssValue.data(), ssValue.size());
@@ -128,12 +126,14 @@ class CDBIterator
 {
 private:
     leveldb::Iterator *piter;
+    int nVersion;
 
 public:
     /**
      * @param[in] _piter            The original leveldb iterator.
+     * @param[in] _nVersion         The version used to serialize data.
      */
-    CDBIterator(leveldb::Iterator *_piter) : piter(_piter) { };
+    CDBIterator(leveldb::Iterator* _piter, int _nVersion) : piter(_piter), nVersion(_nVersion){};
     ~CDBIterator();
 
     bool Valid();
@@ -142,7 +142,7 @@ public:
 
     template<typename K> void Seek(const K& key)
     {
-        CDataStream ssKey(SER_DISK, CLIENT_VERSION);
+        CDataStream ssKey(SER_DISK, nVersion);
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
         Seek(ssKey);
@@ -170,14 +170,14 @@ public:
     CDataStream GetKey()
     {
         leveldb::Slice slKey = piter->key();
-        return CDataStream(slKey.data(), slKey.data() + slKey.size(), SER_DISK, CLIENT_VERSION);
+        return CDataStream(slKey.data(), slKey.data() + slKey.size(), SER_DISK, nVersion);
     }
 
     template<typename V> bool GetValue(V& value)
     {
         leveldb::Slice slValue = piter->value();
         try {
-            CDataStream ssValue(slValue.data(), slValue.data() + slValue.size(), SER_DISK, CLIENT_VERSION);
+            CDataStream ssValue(slValue.data(), slValue.data() + slValue.size(), SER_DISK, nVersion);
             ssValue >> value;
         } catch(const std::exception& e) {
             return false;
@@ -216,20 +216,24 @@ private:
     //! the database itself
     leveldb::DB* pdb;
 
+    //! the version used to serialize data
+    int nVersion;
+
 public:
     /**
      * @param[in] path        Location in the filesystem where leveldb data will be stored.
      * @param[in] nCacheSize  Configures various leveldb cache settings.
      * @param[in] fMemory     If true, use leveldb's memory environment.
      * @param[in] fWipe       If true, remove all existing data.
+     * @param[in] nVersion    The version used to serialize data.
      */
-    CDBWrapper(const fs::path& path, size_t nCacheSize, bool fMemory = false, bool fWipe = false);
+    CDBWrapper(const fs::path& path, size_t nCacheSize, bool fMemory = false, bool fWipe = false, int nVersion = CLIENT_VERSION);
     ~CDBWrapper();
 
     template <typename K>
     bool ReadDataStream(const K& key, CDataStream& ssValue) const
     {
-        CDataStream ssKey(SER_DISK, CLIENT_VERSION);
+        CDataStream ssKey(SER_DISK, nVersion);
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
         return ReadDataStream(ssKey, ssValue);
@@ -247,7 +251,7 @@ public:
             LogPrintf("LevelDB read failure: %s\n", status.ToString());
             dbwrapper_private::HandleError(status);
         }
-        CDataStream ssValueTmp(strValue.data(), strValue.data() + strValue.size(), SER_DISK, CLIENT_VERSION);
+        CDataStream ssValueTmp(strValue.data(), strValue.data() + strValue.size(), SER_DISK, nVersion);
         ssValue = std::move(ssValueTmp);
         return true;
     }
@@ -255,7 +259,7 @@ public:
     template <typename K, typename V>
     bool Read(const K& key, V& value) const
     {
-        CDataStream ssKey(SER_DISK, CLIENT_VERSION);
+        CDataStream ssKey(SER_DISK, nVersion);
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
         return Read(ssKey, value);
@@ -264,7 +268,7 @@ public:
     template <typename V>
     bool Read(const CDataStream& ssKey, V& value) const
     {
-        CDataStream ssValue(SER_DISK, CLIENT_VERSION);
+        CDataStream ssValue(SER_DISK, nVersion);
         if (!ReadDataStream(ssKey, ssValue)) {
             return false;
         }
@@ -279,7 +283,7 @@ public:
     template <typename K, typename V>
     bool Write(const K& key, const V& value, bool fSync = false)
     {
-        CDBBatch batch;
+        CDBBatch batch(nVersion);
         batch.Write(key, value);
         return WriteBatch(batch, fSync);
     }
@@ -287,7 +291,7 @@ public:
     template <typename K>
     bool Exists(const K& key) const
     {
-        CDataStream ssKey(SER_DISK, CLIENT_VERSION);
+        CDataStream ssKey(SER_DISK, nVersion);
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
         return Exists(ssKey);
@@ -311,7 +315,7 @@ public:
     template <typename K>
     bool Erase(const K& key, bool fSync = false)
     {
-        CDBBatch batch;
+        CDBBatch batch(nVersion);
         batch.Erase(key);
         return WriteBatch(batch, fSync);
     }
@@ -326,14 +330,14 @@ public:
 
     bool Sync()
     {
-        CDBBatch batch;
+        CDBBatch batch(nVersion);
         return WriteBatch(batch, true);
     }
 
     // not exactly clean encapsulation, but it's easiest for now
     CDBIterator* NewIterator()
     {
-        return new CDBIterator(pdb->NewIterator(iteroptions));
+        return new CDBIterator(pdb->NewIterator(iteroptions), nVersion);
     }
 
    /**
@@ -344,7 +348,7 @@ public:
     template<typename K>
     size_t EstimateSize(const K& key_begin, const K& key_end) const
     {
-        CDataStream ssKey1(SER_DISK, CLIENT_VERSION), ssKey2(SER_DISK, CLIENT_VERSION);
+        CDataStream ssKey1(SER_DISK, nVersion), ssKey2(SER_DISK, nVersion);
         ssKey1.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey2.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey1 << key_begin;
@@ -363,7 +367,7 @@ public:
     template<typename K>
     void CompactRange(const K& key_begin, const K& key_end) const
     {
-        CDataStream ssKey1(SER_DISK, CLIENT_VERSION), ssKey2(SER_DISK, CLIENT_VERSION);
+        CDataStream ssKey1(SER_DISK, nVersion), ssKey2(SER_DISK, nVersion);
         ssKey1.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey2.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey1 << key_begin;
@@ -395,12 +399,13 @@ private:
     typename CDBTransaction::WritesMap::iterator transactionIt;
     std::unique_ptr<ParentIterator> parentIt;
     CDataStream parentKey;
+    int nVersion;
     bool curIsParent{false};
 
 public:
-    CDBTransactionIterator(CDBTransaction& _transaction) :
-            transaction(_transaction),
-            parentKey(SER_DISK, CLIENT_VERSION)
+    CDBTransactionIterator(CDBTransaction& _transaction, int _nVersion) : transaction(_transaction),
+                                                                          parentKey(SER_DISK, _nVersion),
+                                                                          nVersion(_nVersion)
     {
         transactionIt = transaction.writes.end();
         parentIt = std::unique_ptr<ParentIterator>(transaction.parent.NewIterator());
@@ -417,7 +422,7 @@ public:
     template<typename K>
     void Seek(const K& key)
     {
-        Seek(CDBTransaction::KeyToDataStream(key));
+        Seek(CDBTransaction::KeyToDataStream(key, nVersion));
     }
 
     void Seek(const CDataStream& ssKey)
@@ -473,7 +478,7 @@ public:
     CDataStream GetKey()
     {
         if (!Valid()) {
-            return CDataStream(SER_DISK, CLIENT_VERSION);
+            return CDataStream(SER_DISK, nVersion);
         }
         if (curIsParent) {
             return parentIt->GetKey();
@@ -563,10 +568,10 @@ protected:
         V value;
     };
 
-    template<typename K>
-    static CDataStream KeyToDataStream(const K& key)
+    template <typename K>
+    static CDataStream KeyToDataStream(const K& key, int nVersion)
     {
-        CDataStream ssKey(SER_DISK, CLIENT_VERSION);
+        CDataStream ssKey(SER_DISK, nVersion);
         ssKey.reserve(DBWRAPPER_PREALLOC_KEY_SIZE);
         ssKey << key;
         return ssKey;
@@ -577,20 +582,21 @@ protected:
 
     WritesMap writes;
     DeletesSet deletes;
+    int nVersion;
 
 public:
-    CDBTransaction(Parent &_parent, CommitTarget &_commitTarget) : parent(_parent), commitTarget(_commitTarget) {}
+    CDBTransaction(Parent& _parent, CommitTarget& _commitTarget, int _nVersion) : parent(_parent), commitTarget(_commitTarget), nVersion(_nVersion) {}
 
     template <typename K, typename V>
     void Write(const K& key, const V& v)
     {
-        Write(KeyToDataStream(key), v);
+        Write(KeyToDataStream(key, nVersion), v);
     }
 
     template <typename V>
     void Write(const CDataStream& ssKey, const V& v)
     {
-        auto valueMemoryUsage = ::GetSerializeSize(v, CLIENT_VERSION);
+        auto valueMemoryUsage = ::GetSerializeSize(v, nVersion);
         if (deletes.erase(ssKey)) {
             memoryUsage -= ssKey.size();
         }
@@ -606,7 +612,7 @@ public:
     template <typename K, typename V>
     bool Read(const K& key, V& value)
     {
-        return Read(KeyToDataStream(key), value);
+        return Read(KeyToDataStream(key, nVersion), value);
     }
 
     template <typename V>
@@ -632,7 +638,7 @@ public:
     template <typename K>
     bool Exists(const K& key)
     {
-        return Exists(KeyToDataStream(key));
+        return Exists(KeyToDataStream(key, nVersion));
     }
 
     bool Exists(const CDataStream& ssKey)
@@ -651,7 +657,7 @@ public:
     template <typename K>
     void Erase(const K& key)
     {
-        return Erase(KeyToDataStream(key));
+        return Erase(KeyToDataStream(key, nVersion));
     }
 
     void Erase(const CDataStream& ssKey)
@@ -705,11 +711,11 @@ public:
 
     CDBTransactionIterator<CDBTransaction>* NewIterator()
     {
-        return new CDBTransactionIterator<CDBTransaction>(*this);
+        return new CDBTransactionIterator<CDBTransaction>(*this, nVersion);
     }
     std::unique_ptr<CDBTransactionIterator<CDBTransaction>> NewIteratorUniquePtr()
     {
-        return std::make_unique<CDBTransactionIterator<CDBTransaction>>(*this);
+        return std::make_unique<CDBTransactionIterator<CDBTransaction>>(*this, nVersion);
     }
 };
 

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -12,8 +12,11 @@
 #include "evo/evodb.h"
 #include "evo/providertx.h"
 #include "llmq/quorums_commitment.h"
+#include "netaddress.h"
 #include "saltedhasher.h"
+#include "serialize.h"
 #include "sync.h"
+#include "version.h"
 
 #include <immer/map.hpp>
 #include <immer/map_transient.hpp>
@@ -431,12 +434,12 @@ public:
     template <typename T>
     bool HasUniqueProperty(const T& v) const
     {
-        return mnUniquePropertyMap.count(::SerializeHash(v)) != 0;
+        return mnUniquePropertyMap.count(::SerializeHash(v, SER_GETHASH, PROTOCOL_VERSION | ADDRV2_FORMAT)) != 0;
     }
     template <typename T>
     CDeterministicMNCPtr GetUniquePropertyMN(const T& v) const
     {
-        auto p = mnUniquePropertyMap.find(::SerializeHash(v));
+        auto p = mnUniquePropertyMap.find(::SerializeHash(v, SER_GETHASH, PROTOCOL_VERSION | ADDRV2_FORMAT));
         if (!p) {
             return nullptr;
         }
@@ -450,7 +453,7 @@ private:
         static const T nullValue;
         assert(v != nullValue);
 
-        auto hash = ::SerializeHash(v);
+        auto hash = ::SerializeHash(v, SER_GETHASH, PROTOCOL_VERSION | ADDRV2_FORMAT);
         auto oldEntry = mnUniquePropertyMap.find(hash);
         assert(!oldEntry || oldEntry->first == dmn->proTxHash);
         std::pair<uint256, uint32_t> newEntry(dmn->proTxHash, 1);
@@ -465,7 +468,7 @@ private:
         static const T nullValue;
         assert(oldValue != nullValue);
 
-        auto oldHash = ::SerializeHash(oldValue);
+        auto oldHash = ::SerializeHash(oldValue, SER_GETHASH, PROTOCOL_VERSION | ADDRV2_FORMAT);
         auto p = mnUniquePropertyMap.find(oldHash);
         assert(p && p->first == dmn->proTxHash);
         if (p->second == 1) {

--- a/src/evo/evodb.cpp
+++ b/src/evo/evodb.cpp
@@ -4,6 +4,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "evodb.h"
+#include "clientversion.h"
+#include "netaddress.h"
 
 std::unique_ptr<CEvoDB> evoDb;
 
@@ -32,11 +34,10 @@ void CEvoDBScopedCommitter::Rollback()
     evoDB.RollbackCurTransaction();
 }
 
-CEvoDB::CEvoDB(size_t nCacheSize, bool fMemory, bool fWipe) :
-        db(fMemory ? "" : (GetDataDir() / "evodb"), nCacheSize, fMemory, fWipe),
-        rootBatch(),
-        rootDBTransaction(db, rootBatch),
-        curDBTransaction(rootDBTransaction, rootDBTransaction)
+CEvoDB::CEvoDB(size_t nCacheSize, bool fMemory, bool fWipe) : db(fMemory ? "" : (GetDataDir() / "evodb"), nCacheSize, fMemory, fWipe, CLIENT_VERSION | ADDRV2_FORMAT),
+                                                              rootBatch(CLIENT_VERSION | ADDRV2_FORMAT),
+                                                              rootDBTransaction(db, rootBatch, CLIENT_VERSION | ADDRV2_FORMAT),
+                                                              curDBTransaction(rootDBTransaction, rootDBTransaction, CLIENT_VERSION | ADDRV2_FORMAT)
 {
 }
 

--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -4,6 +4,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "quorums_signing.h"
+#include "clientversion.h"
+#include "netaddress.h"
 #include "quorums_signing_shares.h"
 #include "quorums_utils.h"
 
@@ -21,7 +23,7 @@ namespace llmq
 
 CSigningManager* quorumSigningManager;
 
-CRecoveredSigsDb::CRecoveredSigsDb(bool fMemory) : db(fMemory ? "" : (GetDataDir() / "llmq"), 1 << 20, fMemory)
+CRecoveredSigsDb::CRecoveredSigsDb(bool fMemory) : db(fMemory ? "" : (GetDataDir() / "llmq"), 1 << 20, fMemory, false, CLIENT_VERSION | ADDRV2_FORMAT)
 {
 }
 
@@ -84,7 +86,7 @@ bool CRecoveredSigsDb::GetRecoveredSigById(Consensus::LLMQType llmqType, const u
 
 void CRecoveredSigsDb::WriteRecoveredSig(const llmq::CRecoveredSig& recSig)
 {
-    CDBBatch batch;
+    CDBBatch batch(CLIENT_VERSION | ADDRV2_FORMAT);
 
     // we put these close to each other to leverage leveldb's key compaction
     // this way, the second key can be used for fast HasRecoveredSig checks while the first key stores the recSig
@@ -144,7 +146,7 @@ void CRecoveredSigsDb::CleanupOldRecoveredSigs(int64_t maxAge)
         return;
     }
 
-    CDBBatch batch;
+    CDBBatch batch(CLIENT_VERSION | ADDRV2_FORMAT);
     for (auto& e : toDelete) {
         CRecoveredSig recSig;
         if (!ReadRecoveredSig(e.first, e.second, recSig)) {

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -9,9 +9,10 @@
 
 #include "amount.h"
 #include "memusage.h"
+#include "netaddress.h"
+#include "optional.h"
 #include "script/script.h"
 #include "serialize.h"
-#include "optional.h"
 #include "uint256.h"
 
 #include "sapling/sapling_transaction.h"
@@ -461,7 +462,7 @@ static inline CTransactionRef MakeTransactionRef(CTransactionRef&& txIn) { retur
 template <typename T>
 inline bool GetTxPayload(const std::vector<unsigned char>& payload, T& obj)
 {
-    CDataStream ds(payload, SER_NETWORK, PROTOCOL_VERSION);
+    CDataStream ds(payload, SER_NETWORK, PROTOCOL_VERSION | ADDRV2_FORMAT);
     try {
         ds >> obj;
     } catch (std::exception& e) {
@@ -483,7 +484,7 @@ inline bool GetTxPayload(const CTransaction& tx, T& obj)
 template <typename T>
 void SetTxPayload(CMutableTransaction& tx, const T& payload)
 {
-    CDataStream ds(SER_NETWORK, PROTOCOL_VERSION);
+    CDataStream ds(SER_NETWORK, PROTOCOL_VERSION | ADDRV2_FORMAT);
     ds << payload;
     tx.extraPayload.emplace(ds.begin(), ds.end());
 }

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "clientversion.h"
 #include "dbwrapper.h"
 #include "uint256.h"
 #include "random.h"
@@ -125,7 +126,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_batch)
         uint256 in3 = GetRandHash();
 
         uint256 res;
-        CDBBatch batch;
+        CDBBatch batch(CLIENT_VERSION);
 
         batch.Write(key, in);
         batch.Write(key2, in2);

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -6,8 +6,9 @@
 
 #include "txdb.h"
 
-#include "random.h"
+#include "clientversion.h"
 #include "pow.h"
+#include "random.h"
 #include "uint256.h"
 #include "util/system.h"
 #include "util/vector.h"
@@ -79,7 +80,7 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap& mapCoins,
                               CAnchorsSaplingMap& mapSaplingAnchors,
                               CNullifiersMap& mapSaplingNullifiers)
 {
-    CDBBatch batch;
+    CDBBatch batch(CLIENT_VERSION);
     size_t count = 0;
     size_t changed = 0;
     size_t batch_size = (size_t) gArgs.GetArg("-dbbatchsize", nDefaultDbBatchSize);
@@ -236,7 +237,7 @@ void CCoinsViewDBCursor::Next()
 }
 
 bool CBlockTreeDB::WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*> >& fileInfo, int nLastFile, const std::vector<const CBlockIndex*>& blockinfo) {
-    CDBBatch batch;
+    CDBBatch batch(CLIENT_VERSION);
     for (std::vector<std::pair<int, const CBlockFileInfo*> >::const_iterator it=fileInfo.begin(); it != fileInfo.end(); it++) {
         batch.Write(std::make_pair(DB_BLOCK_FILES, it->first), *it->second);
     }
@@ -254,7 +255,7 @@ bool CBlockTreeDB::ReadTxIndex(const uint256& txid, CDiskTxPos& pos)
 
 bool CBlockTreeDB::WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos> >& vect)
 {
-    CDBBatch batch;
+    CDBBatch batch(CLIENT_VERSION);
     for (std::vector<std::pair<uint256, CDiskTxPos> >::const_iterator it = vect.begin(); it != vect.end(); it++)
         batch.Write(std::make_pair(DB_TXINDEX, it->first), it->second);
     return WriteBatch(batch);
@@ -346,7 +347,7 @@ CZerocoinDB::CZerocoinDB(size_t nCacheSize, bool fMemory, bool fWipe) : CDBWrapp
 
 bool CZerocoinDB::WriteCoinSpendBatch(const std::vector<std::pair<CBigNum, uint256> >& spendInfo)
 {
-    CDBBatch batch;
+    CDBBatch batch(CLIENT_VERSION);
     size_t count = 0;
     for (std::vector<std::pair<CBigNum, uint256> >::const_iterator it=spendInfo.begin(); it != spendInfo.end(); it++) {
         CBigNum bnSerial = it->first;
@@ -519,7 +520,7 @@ bool CCoinsViewDB::Upgrade() {
 
     LogPrintf("Upgrading database...\n");
     size_t batch_size = 1 << 24;
-    CDBBatch batch;
+    CDBBatch batch(CLIENT_VERSION);
     while (pcursor->Valid()) {
         boost::this_thread::interruption_point();
         std::pair<unsigned char, uint256> key;


### PR DESCRIPTION
This PR upgrades the `evoDB` and `llmqDB` serializer version to V2 in order to support TOR DMNs. In order to keep a potential backward compatibility all others databases (like spork, blocks...) kept the old V1 serializer.

The PR also also upgrades to V2 the way `extraPayload` in transaction is serialized  and the way keys of `mnUniquePropertyMap` are serialized 