### PR TITLE
[Wallet] Some sapling wallet improvements

### DIFF
--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -613,7 +613,7 @@ QString AddressTableModel::getAddressToShow(bool isShielded) const
 
     for (auto it = wallet->NewAddressBookIterator(); it.IsValid(); it.Next()) {
         const auto addrData = it.GetValue();
-
+        CWDestination x = *it.GetDestKey();
         if (!isShielded) {
             if (addrData.purpose == AddressBook::AddressBookPurpose::RECEIVE) {
                 const auto &address = *it.GetCTxDestKey();
@@ -622,10 +622,9 @@ QString AddressTableModel::getAddressToShow(bool isShielded) const
                 }
             }
         } else {
-            // todo: add shielded address support to IsUsed
             if (addrData.purpose == AddressBook::AddressBookPurpose::SHIELDED_RECEIVE) {
                 const auto &address = *it.GetShieldedDestKey();
-                if (IsValidPaymentAddress(address) && IsMine(*wallet, address)) {
+                if (IsValidPaymentAddress(address) && IsMine(*wallet, address) && !wallet->IsUsed(address)) {
                     return QString::fromStdString(KeyIO::EncodePaymentAddress(address));
                 }
             }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1474,6 +1474,23 @@ bool CWallet::IsUsed(const CTxDestination address) const
     return false;
 }
 
+bool CWallet::IsUsed(const libzcash::SaplingPaymentAddress address) const
+{
+    LOCK(cs_wallet);
+    if (!::IsMine(*this, address)) {
+        return false;
+    }
+
+    for (const auto& it : mapWallet) {
+        const CWalletTx& wtx = it.second;
+        for (const auto& txout : wtx.mapSaplingNoteData) {
+            if (txout.second.address && *txout.second.address == address)
+                return true;
+        }
+    }
+    return false;
+}
+
 CAmount CWallet::GetDebit(const CTxIn& txin, const isminefilter& filter) const
 {
     {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1141,6 +1141,7 @@ public:
     bool CreateBudgetFeeTX(CTransactionRef& tx, const uint256& hash, CReserveKey& keyChange, CAmount fee);
 
     bool IsUsed(const CTxDestination address) const;
+    bool IsUsed(const libzcash::SaplingPaymentAddress address) const;
 
     isminetype IsMine(const CTxIn& txin) const;
     CAmount GetDebit(const CTxIn& txin, const isminefilter& filter) const;


### PR DESCRIPTION
first commit: filter sapling credit/debit only when the appropriate flag has been set in the filter
second commit: in the qt wallet don't generate shield addresses that have already been used 