### PR TITLE
[DMNs] Quorum Signing optimizations

### DIFF
--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -133,13 +133,9 @@ void CRecoveredSigsDb::WriteRecoveredSig(const llmq::CRecoveredSig& recSig)
     auto k4 = std::make_tuple('s', signHash);
     batch.Write(k4, (uint8_t)1);
 
-    // remove the votedForId entry as we won't need it anymore
-    auto k5 = std::make_tuple('v', recSig.llmqType, recSig.id);
-    batch.Erase(k5);
-
     // store by current time. Allows fast cleanup of old recSigs
-    auto k6 = std::make_tuple('t', (uint32_t)htobe32(GetAdjustedTime()), recSig.llmqType, recSig.id);
-    batch.Write(k6, (uint8_t)1);
+    auto k5 = std::make_tuple('t', (uint32_t)htobe32(GetAdjustedTime()), recSig.llmqType, recSig.id);
+    batch.Write(k5, (uint8_t)1);
 
     db.WriteBatch(batch);
     {
@@ -196,12 +192,10 @@ void CRecoveredSigsDb::CleanupOldRecoveredSigs(int64_t maxAge)
             auto k2 = std::make_tuple('r', recSig.llmqType, recSig.id, recSig.msgHash);
             auto k3 = std::make_tuple('h', recSig.GetHash());
             auto k4 = std::make_tuple('s', signHash);
-            auto k5 = std::make_tuple('v', recSig.llmqType, recSig.id);
             batch.Erase(k1);
             batch.Erase(k2);
             batch.Erase(k3);
             batch.Erase(k4);
-            batch.Erase(k5);
 
             hasSigForIdCache.erase(std::make_pair((Consensus::LLMQType)recSig.llmqType, recSig.id));
             hasSigForSessionCache.erase(signHash);
@@ -236,8 +230,55 @@ bool CRecoveredSigsDb::GetVoteForId(Consensus::LLMQType llmqType, const uint256&
 
 void CRecoveredSigsDb::WriteVoteForId(Consensus::LLMQType llmqType, const uint256& id, const uint256& msgHash)
 {
-    auto k = std::make_tuple('v', (uint8_t)llmqType, id);
-    db.Write(k, msgHash);
+    auto k1 = std::make_tuple('v', (uint8_t)llmqType, id);
+    auto k2 = std::make_tuple(std::string("vt"), (uint32_t)htobe32(GetAdjustedTime()), (uint8_t)llmqType, id);
+
+    CDBBatch batch;
+    batch.Write(k1, msgHash);
+    batch.Write(k2, (uint8_t)1);
+
+    db.WriteBatch(batch);
+}
+
+void CRecoveredSigsDb::CleanupOldVotes(int64_t maxAge)
+{
+    std::unique_ptr<CDBIterator> pcursor(db.NewIterator());
+
+    auto start = std::make_tuple(std::string("vt"), (uint32_t)0, (uint8_t)0, uint256());
+    uint32_t endTime = (uint32_t)(GetAdjustedTime() - maxAge);
+    pcursor->Seek(start);
+
+    CDBBatch batch;
+    size_t cnt = 0;
+    while (pcursor->Valid()) {
+        decltype(start) k;
+
+        if (!pcursor->GetKey(k) || std::get<0>(k) != "vt") {
+            break;
+        }
+        if (be32toh(std::get<1>(k)) >= endTime) {
+            break;
+        }
+
+        uint8_t llmqType = std::get<2>(k);
+        const uint256& id = std::get<3>(k);
+
+        batch.Erase(k);
+        batch.Erase(std::make_tuple('v', llmqType, id));
+
+        cnt++;
+
+        pcursor->Next();
+    }
+    pcursor.reset();
+
+    if (cnt == 0) {
+        return;
+    }
+
+    db.WriteBatch(batch);
+
+    LogPrintf("CRecoveredSigsDb::%d -- deleted %d entries\n", __func__, cnt);
 }
 
 //////////////////
@@ -501,6 +542,7 @@ void CSigningManager::Cleanup()
     int64_t maxAge = DEFAULT_MAX_RECOVERED_SIGS_AGE;
 
     db.CleanupOldRecoveredSigs(maxAge);
+    db.CleanupOldVotes(maxAge);
 
     lastCleanupTime = GetTimeMillis();
 }

--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -409,7 +409,7 @@ void CSigningManager::ProcessPendingRecoveredSigs(CConnman& connman)
         }
     }
 
-    cxxtimer::Timer verifyTimer;
+    cxxtimer::Timer verifyTimer(true);
     batchVerifier.Verify();
     verifyTimer.stop();
 

--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -601,10 +601,11 @@ CQuorumCPtr CSigningManager::SelectQuorumForSigning(Consensus::LLMQType llmqType
     CBlockIndex* pindexStart;
     {
         LOCK(cs_main);
-        if (signHeight > chainActive.Height()) {
+        int startBlockHeight = signHeight - SIGN_HEIGHT_OFFSET;
+        if (startBlockHeight > chainActive.Height() || startBlockHeight < 0) {
             return nullptr;
         }
-        pindexStart = chainActive[signHeight - SIGN_HEIGHT_OFFSET];
+        pindexStart = chainActive[startBlockHeight];
     }
 
     auto quorums = quorumManager->ScanQuorums(llmqType, pindexStart, poolSize);

--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -679,14 +679,13 @@ CQuorumCPtr CSigningManager::SelectQuorumForSigning(Consensus::LLMQType llmqType
 
 bool CSigningManager::VerifyRecoveredSig(Consensus::LLMQType llmqType, int signedAtHeight, const uint256& id, const uint256& msgHash, const CBLSSignature& sig)
 {
-    auto& llmqParams = Params().GetConsensus().llmqs.at(Params().GetConsensus().llmqChainLocks);
+    auto quorum = SelectQuorumForSigning(llmqType, signedAtHeight, id);
 
-    auto quorum = SelectQuorumForSigning(llmqParams.type, signedAtHeight, id);
     if (!quorum) {
         return false;
     }
 
-    uint256 signHash = llmq::utils::BuildSignHash(llmqParams.type, quorum->pindexQuorum->GetBlockHash(), id, msgHash);
+    uint256 signHash = llmq::utils::BuildSignHash(llmqType, quorum->pindexQuorum->GetBlockHash(), id, msgHash);
     return sig.VerifyInsecure(quorum->quorumPublicKey, signHash);
 }
 

--- a/src/llmq/quorums_signing.h
+++ b/src/llmq/quorums_signing.h
@@ -10,7 +10,11 @@
 
 #include "chainparams.h"
 #include "net.h"
+#include "saltedhasher.h"
 #include "sync.h"
+#include "unordered_lru_cache.h"
+
+#include <unordered_map>
 
 namespace llmq
 {
@@ -64,11 +68,15 @@ public:
     }
 };
 
-// TODO implement caching to speed things up
 class CRecoveredSigsDb
 {
 private:
     CDBWrapper db;
+
+    RecursiveMutex cs;
+    unordered_lru_cache<std::pair<Consensus::LLMQType, uint256>, bool, StaticSaltedHasher, 30000> hasSigForIdCache;
+    unordered_lru_cache<uint256, bool, StaticSaltedHasher, 30000> hasSigForSessionCache;
+    unordered_lru_cache<uint256, bool, StaticSaltedHasher, 30000> hasSigForHashCache;
 
 public:
     CRecoveredSigsDb(bool fMemory);

--- a/src/llmq/quorums_signing.h
+++ b/src/llmq/quorums_signing.h
@@ -91,10 +91,11 @@ public:
 
     void CleanupOldRecoveredSigs(int64_t maxAge);
 
-    // votes are removed when the recovered sig is written to the db
+    // votes are removed after one week
     bool HasVotedOnId(Consensus::LLMQType llmqType, const uint256& id);
     bool GetVoteForId(Consensus::LLMQType llmqType, const uint256& id, uint256& msgHashRet);
     void WriteVoteForId(Consensus::LLMQType llmqType, const uint256& id, const uint256& msgHash);
+    void CleanupOldVotes(int64_t maxAge);
 
 private:
     bool ReadRecoveredSig(Consensus::LLMQType llmqType, const uint256& id, CRecoveredSig& ret);

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -503,7 +503,7 @@ void CSigSharesManager::ProcessPendingSigShares(CConnman& connman)
         }
     }
 
-    cxxtimer::Timer verifyTimer;
+    cxxtimer::Timer verifyTimer(true);
     batchVerifier.Verify();
     verifyTimer.stop();
 


### PR DESCRIPTION
Adds a bunch of refactor/ bug fixes/ optimizations for the Quorum Signing class:
**Refactor:**

- Don't lock cs_main when it is not necessary
- Start batchVerifier debug timers
- Don't print `conflicting signature` if the recovered signature is not actually conflicting

**Optimizations**
- Use `unordered_lru_cache` instead of fetching each time from the database

**Bug fixes**
- When selecting the quorum for signing check the correct bounds for startingHeight
- Save times on `CRecoveredSigsDb` using big endian (the old way was bugged and old recovered signatures were never deleted)
- remove signing session votes after 1 week (because if the corresponding recovered signature was not present on DB those votes would never be deleted)
- Use the correct llmqType in VerifyRecoveredSig (this was not actually a bug since for the moment chainlocks are our only signing session)