### PR TITLE
[DMNs] signing share optimizations

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -191,6 +191,7 @@ void Interrupt()
     InterruptREST();
     InterruptTorControl();
     InterruptMapPort();
+    InterruptTierTwo();
     if (g_connman)
         g_connman->Interrupt();
 }

--- a/src/llmq/quorums_init.cpp
+++ b/src/llmq/quorums_init.cpp
@@ -74,4 +74,11 @@ void StopLLMQSystem()
     }
 }
 
+void InterruptLLMQSystem()
+{
+    if (quorumSigSharesManager) {
+        quorumSigSharesManager->InterruptWorkerThread();
+    }
+}
+
 } // namespace llmq

--- a/src/llmq/quorums_init.cpp
+++ b/src/llmq/quorums_init.cpp
@@ -57,6 +57,7 @@ void StartLLMQSystem()
         quorumDKGSessionManager->StartThreads();
     }
     if (quorumSigSharesManager) {
+        quorumSigSharesManager->RegisterAsRecoveredSigsListener();
         quorumSigSharesManager->StartWorkerThread();
     }
 }
@@ -68,6 +69,7 @@ void StopLLMQSystem()
     }
     if (quorumSigSharesManager) {
         quorumSigSharesManager->StopWorkerThread();
+        quorumSigSharesManager->UnregisterAsRecoveredSigsListener();
     }
     if (blsWorker) {
         blsWorker->Stop();

--- a/src/llmq/quorums_init.h
+++ b/src/llmq/quorums_init.h
@@ -21,6 +21,7 @@ void DestroyLLMQSystem();
 // Manage scheduled tasks, threads, listeners etc.
 void StartLLMQSystem();
 void StopLLMQSystem();
+void InterruptLLMQSystem();
 
 } // namespace llmq
 

--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -344,14 +344,14 @@ void CSigningManager::CollectPendingRecoveredSigsToVerify(
     }
 }
 
-void CSigningManager::ProcessPendingRecoveredSigs(CConnman& connman)
+bool CSigningManager::ProcessPendingRecoveredSigs(CConnman& connman)
 {
     std::map<NodeId, std::list<CRecoveredSig>> recSigsByNode;
     std::map<std::pair<Consensus::LLMQType, uint256>, CQuorumCPtr> quorums;
 
     CollectPendingRecoveredSigsToVerify(32, recSigsByNode, quorums);
     if (recSigsByNode.empty()) {
-        return;
+        return false;
     }
 
     // It's ok to perform insecure batched verification here as we verify against the quorum public keys, which are not
@@ -397,6 +397,7 @@ void CSigningManager::ProcessPendingRecoveredSigs(CConnman& connman)
             ProcessRecoveredSig(nodeId, recSig, quorum, connman);
         }
     }
+    return true;
 }
 
 // signature must be verified already

--- a/src/llmq/quorums_signing.h
+++ b/src/llmq/quorums_signing.h
@@ -138,7 +138,7 @@ private:
     bool PreVerifyRecoveredSig(NodeId nodeId, const CRecoveredSig& recoveredSig, bool& retBan);
 
     void CollectPendingRecoveredSigsToVerify(size_t maxUniqueSessions, std::map<NodeId, std::list<CRecoveredSig>>& retSigShares, std::map<std::pair<Consensus::LLMQType, uint256>, CQuorumCPtr>& retQuorums);
-    void ProcessPendingRecoveredSigs(CConnman& connman); // called from the worker thread of CSigSharesManager
+    bool ProcessPendingRecoveredSigs(CConnman& connman); // called from the worker thread of CSigSharesManager
     void ProcessRecoveredSig(NodeId nodeId, const CRecoveredSig& recoveredSig, const CQuorumCPtr& quorum, CConnman& connman);
     void Cleanup(); // called from the worker thread of CSigSharesManager
 

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -519,7 +519,7 @@ bool CSigSharesManager::ProcessPendingSigShares(CConnman& connman)
         }
     }
 
-    cxxtimer::Timer verifyTimer;
+    cxxtimer::Timer verifyTimer(true);
     batchVerifier.Verify();
     verifyTimer.stop();
 

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -349,31 +349,27 @@ bool CSigSharesManager::PreVerifyBatchedSigShares(NodeId nodeId, const CBatchedS
         return false;
     }
 
-    CQuorumCPtr quorum;
-    {
-        LOCK(cs_main);
+    CQuorumCPtr quorum = quorumManager->GetQuorum(llmqType, batchedSigShares.quorumHash);
 
-        quorum = quorumManager->GetQuorum(llmqType, batchedSigShares.quorumHash);
-        if (!quorum) {
-            // TODO should we ban here?
-            LogPrintf("CSigSharesManager::%s -- quorum %s not found, node=%d\n", __func__,
-                batchedSigShares.quorumHash.ToString(), nodeId);
-            return false;
-        }
-        if (!llmq::utils::IsQuorumActive(llmqType, quorum->pindexQuorum->GetBlockHash())) {
-            // quorum is too old
-            return false;
-        }
-        if (!quorum->IsMember(activeMasternodeManager->GetProTx())) {
-            // we're not a member so we can't verify it (we actually shouldn't have received it)
-            return false;
-        }
-        if (quorum->quorumVvec == nullptr) {
-            // TODO we should allow to ask other nodes for the quorum vvec if we missed it in the DKG
-            LogPrintf("CSigSharesManager::%s -- we don't have the quorum vvec for %s, no verification possible. node=%d\n", __func__,
-                batchedSigShares.quorumHash.ToString(), nodeId);
-            return false;
-        }
+    if (!quorum) {
+        // TODO should we ban here?
+        LogPrintf("CSigSharesManager::%s -- quorum %s not found, node=%d\n", __func__,
+            batchedSigShares.quorumHash.ToString(), nodeId);
+        return false;
+    }
+    if (!llmq::utils::IsQuorumActive(llmqType, quorum->pindexQuorum->GetBlockHash())) {
+        // quorum is too old
+        return false;
+    }
+    if (!quorum->IsMember(activeMasternodeManager->GetProTx())) {
+        // we're not a member so we can't verify it (we actually shouldn't have received it)
+        return false;
+    }
+    if (quorum->quorumVvec == nullptr) {
+        // TODO we should allow to ask other nodes for the quorum vvec if we missed it in the DKG
+        LogPrintf("CSigSharesManager::%s -- we don't have the quorum vvec for %s, no verification possible. node=%d\n", __func__,
+            batchedSigShares.quorumHash.ToString(), nodeId);
+        return false;
     }
 
     std::set<uint16_t> dupMembers;
@@ -995,17 +991,16 @@ void CSigSharesManager::Cleanup()
         }
     }
 
-    {
-        // Find quorums which became inactive
-        LOCK(cs_main);
-        for (auto it = quorumsToCheck.begin(); it != quorumsToCheck.end();) {
-            if (llmq::utils::IsQuorumActive(it->first, it->second)) {
-                it = quorumsToCheck.erase(it);
-            } else {
-                ++it;
-            }
+
+    // Find quorums which became inactive
+    for (auto it = quorumsToCheck.begin(); it != quorumsToCheck.end();) {
+        if (llmq::utils::IsQuorumActive(it->first, it->second)) {
+            it = quorumsToCheck.erase(it);
+        } else {
+            ++it;
         }
     }
+
     {
         // Now delete sessions which are for inactive quorums
         LOCK(cs);

--- a/src/llmq/quorums_signing_shares.h
+++ b/src/llmq/quorums_signing_shares.h
@@ -238,7 +238,7 @@ private:
     bool PreVerifyBatchedSigShares(NodeId nodeId, const CBatchedSigShares& batchedSigShares, bool& retBan);
 
     void CollectPendingSigSharesToVerify(size_t maxUniqueSessions, std::map<NodeId, std::vector<CSigShare>>& retSigShares, std::map<std::pair<Consensus::LLMQType, uint256>, CQuorumCPtr>& retQuorums);
-    void ProcessPendingSigShares(CConnman& connman);
+    bool ProcessPendingSigShares(CConnman& connman);
 
     void ProcessPendingSigSharesFromNode(NodeId nodeId, const std::vector<CSigShare>& sigShares, const std::map<std::pair<Consensus::LLMQType, uint256>, CQuorumCPtr>& quorums, CConnman& connman);
 
@@ -252,11 +252,11 @@ private:
 
     void BanNode(NodeId nodeId);
 
-    void SendMessages();
+    bool SendMessages();
     void CollectSigSharesToRequest(std::map<NodeId, std::map<uint256, CSigSharesInv>>& sigSharesToRequest);
     void CollectSigSharesToSend(std::map<NodeId, std::map<uint256, CBatchedSigShares>>& sigSharesToSend);
     void CollectSigSharesToAnnounce(std::map<NodeId, std::map<uint256, CSigSharesInv>>& sigSharesToAnnounce);
-    void SignPendingSigShares();
+    bool SignPendingSigShares();
     void WorkThreadMain();
 };
 

--- a/src/llmq/quorums_signing_shares.h
+++ b/src/llmq/quorums_signing_shares.h
@@ -16,6 +16,7 @@
 #include "uint256.h"
 
 #include "llmq/quorums.h"
+#include "llmq/quorums_signing.h"
 
 #include <mutex>
 #include <thread>
@@ -190,9 +191,10 @@ public:
     void RemoveSession(const uint256& signHash);
 };
 
-class CSigSharesManager
+class CSigSharesManager : public CRecoveredSigsListener
 {
-    static const int64_t SIGNING_SESSION_TIMEOUT = 60 * 1000;
+    static const int64_t SESSION_NEW_SHARES_TIMEOUT = 60 * 1000;
+    static const int64_t SESSION_TOTAL_TIMEOUT = 5 * 60 * 1000;
     static const int64_t SIG_SHARE_REQUEST_TIMEOUT = 5 * 1000;
 
 private:
@@ -202,7 +204,9 @@ private:
     CThreadInterrupt workInterrupt;
 
     std::map<SigShareKey, CSigShare> sigShares;
-    std::map<uint256, int64_t> firstSeenForSessions;
+
+    // stores time of first and last receivedSigShare. Used to detect timeouts
+    std::map<uint256, std::pair<int64_t, int64_t>> timeSeenForSessions;
 
     std::map<NodeId, CSigSharesNodeState> nodeStates;
     std::map<SigShareKey, std::pair<NodeId, int64_t>> sigSharesRequested;
@@ -221,6 +225,8 @@ public:
 
     void StartWorkerThread();
     void StopWorkerThread();
+    void RegisterAsRecoveredSigsListener();
+    void UnregisterAsRecoveredSigsListener();
     void InterruptWorkerThread();
 
 public:
@@ -228,6 +234,8 @@ public:
 
     void AsyncSign(const CQuorumCPtr& quorum, const uint256& id, const uint256& msgHash);
     void Sign(const CQuorumCPtr& quorum, const uint256& id, const uint256& msgHash);
+
+    void HandleNewRecoveredSig(const CRecoveredSig& recoveredSig);
 
 private:
     void ProcessMessageSigSharesInv(CNode* pfrom, const CSigSharesInv& inv, CConnman& connman);

--- a/src/llmq/quorums_signing_shares.h
+++ b/src/llmq/quorums_signing_shares.h
@@ -199,7 +199,7 @@ private:
     RecursiveMutex cs;
 
     std::thread workThread;
-    std::atomic<bool> stopWorkThread{false};
+    CThreadInterrupt workInterrupt;
 
     std::map<SigShareKey, CSigShare> sigShares;
     std::map<uint256, int64_t> firstSeenForSessions;
@@ -221,6 +221,7 @@ public:
 
     void StartWorkerThread();
     void StopWorkerThread();
+    void InterruptWorkerThread();
 
 public:
     void ProcessMessage(CNode* pnode, const std::string& strCommand, CDataStream& vRecv, CConnman& connman);

--- a/src/tiertwo/init.cpp
+++ b/src/tiertwo/init.cpp
@@ -328,3 +328,8 @@ void DeleteTierTwo()
     deterministicMNManager.reset();
     evoDb.reset();
 }
+
+void InterruptTierTwo()
+{
+    llmq::InterruptLLMQSystem();
+}

--- a/src/tiertwo/init.h
+++ b/src/tiertwo/init.h
@@ -56,5 +56,7 @@ void StopTierTwoThreads();
 /** Cleans manager and worker objects pointers */
 void DeleteTierTwo();
 
+/** Interrupt tier two workers */
+void InterruptTierTwo();
 
 #endif //PIVX_TIERTWO_INIT_H


### PR DESCRIPTION
Adds a bunch of refactor/ bug fixes/ optimizations for the Quorum Signing Share class:

**Refactor:**

- Don't lock cs_main when it is not necessary
- Start pendingShare debug timer
- Remove successful signing session before checking for timeouts (to avoid false positive logprint)
- Improve the sigshare thread start/stop/interrupt cycle

**Optimizations:**

- Call `RemoveSigSharesForSession` once a recovered signature is received
- Don't make the thread sleep if there is likely more work to do
