### PR TITLE
[GA] Fix macOS runs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -89,13 +89,16 @@ jobs:
 
           - name: macOS
             os: macos-11
-            packages: llvm@13 python3 autoconf automake berkeley-db@4 libtool boost miniupnpc libnatpmp pkg-config qt5 zmq libevent qrencode gmp libsodium rust
-            cc: $(brew --prefix llvm@13)/bin/clang
-            cxx: $(brew --prefix llvm@13)/bin/clang++
+            packages: llvm@12 python@3.8 autoconf automake berkeley-db@4 libtool boost@1.76 miniupnpc libnatpmp pkg-config libevent qrencode gmp libsodium rust
+            no_qt: true
+            boost_root: true
+            cc: $(brew --prefix llvm@12)/bin/clang
+            cxx: $(brew --prefix llvm@12)/bin/clang++
 
           - name: macOS-latest
             os: macos-latest
-            packages: llvm@13 python3 autoconf automake berkeley-db@4 libtool boost miniupnpc libnatpmp pkg-config qt5 zmq libevent qrencode gmp libsodium rust
+            packages: llvm@13 python@3.8 autoconf automake berkeley-db@4 libtool boost@1.76 miniupnpc libnatpmp pkg-config qt5 zmq libevent qrencode gmp libsodium rust
+            boost_root: true
             cc: $(brew --prefix llvm@13)/bin/clang
             cxx: $(brew --prefix llvm@13)/bin/clang++
 
@@ -126,8 +129,14 @@ jobs:
           CC=${{ matrix.config.cc }}
           CXX=${{ matrix.config.cxx }}
           if [[ ${{ matrix.config.os }} = macos* ]]; then
-            export CPPFLAGS="-I/usr/local/Cellar/gmp/6.2.1/include"
-            export LDFLAGS="-L/usr/local/Cellar/gmp/6.2.1/lib"
+            if [ "${{ matrix.config.no_qt }}" = "true" ]; then
+              export NO_QT=1
+            fi
+            if [ "${{ matrix.config.boost_root }}" = "true" ]; then
+              export CI_BOOST=1
+              export CPPFLAGS="-I/usr/local/opt/boost@1.76/include"
+              export LDFLAGS="-L/usr/local/opt/boost@1.76/lib"
+            fi
           fi
           export CC
           export CXX
@@ -175,24 +184,23 @@ jobs:
           - name: x64-macOS
             id: macOS-nodepends
             os: macos-11
-            brew_install: autoconf automake ccache berkeley-db@4 libtool boost miniupnpc libnatpmp pkg-config python@3.8 qt5 zmq libevent qrencode gmp libsodium rust librsvg
+            brew_install: autoconf automake ccache berkeley-db@4 libtool boost@1.76 miniupnpc libnatpmp pkg-config python@3.8 libevent qrencode gmp libsodium rust librsvg
             unit_tests: true
             functional_tests: true
-            goal: deploy
             cc: clang
             cxx: clang++
-            BITCOIN_CONFIG: "--enable-zmq --enable-gui --enable-reduce-exports --enable-werror --enable-debug"
+            BITCOIN_CONFIG: "--enable-zmq --enable-gui --enable-reduce-exports --enable-werror --enable-debug --with-boost=/usr/local/opt/boost@1.76"
 
           - name: x64-macOS-latest
             id: macOS-nodepends-latest
             os: macos-latest
-            brew_install: autoconf automake ccache berkeley-db@4 libtool boost miniupnpc libnatpmp pkg-config python@3.8 qt5 zmq libevent qrencode gmp libsodium rust librsvg
+            brew_install: autoconf automake ccache berkeley-db@4 libtool boost@1.76 miniupnpc libnatpmp pkg-config python@3.8 qt5 zmq libevent qrencode gmp libsodium rust librsvg
             unit_tests: true
             functional_tests: true
             goal: deploy
             cc: clang
             cxx: clang++
-            BITCOIN_CONFIG: "--enable-zmq --enable-gui --enable-reduce-exports --enable-werror --enable-debug"
+            BITCOIN_CONFIG: "--enable-zmq --enable-gui --enable-reduce-exports --enable-werror --enable-debug --with-boost=/usr/local/opt/boost@1.76"
 
     steps:
       - name: Get Source

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,18 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     if(ENDIAN_INCLUDES)
         message(STATUS "Found endian.h: ${ENDIAN_INCLUDES}")
     endif()
-    #add_definitions("-D__BYTE_ORDER -D__LITTLE_ENDIAN -D__GLIBC__ -DHAVE_DECL_BSWAP_16=0 -DHAVE_DECL_BSWAP_32=0 -DHAVE_DECL_BSWAP_64=0")
+endif()
+
+# Disable Qt GUI wallet build
+if(DEFINED ENV{NO_QT})
+    message(STATUS "Skipping GUI Wallet Build!")
+endif()
+
+# Github Actions specific Boost override
+if(DEFINED ENV{CI_BOOST})
+    set(BOOST_R "--with-boost=/usr/local/opt/boost@1.76")
+    set(ENV{BOOSTROOT} "/usr/local/opt/boost@1.76")
+    message(STATUS "Boost Root set to: ${BOOST_R}")
 endif()
 
 # Find Dependencies
@@ -89,6 +100,8 @@ find_package(NAT-PMP)
 find_package(Boost COMPONENTS system filesystem chrono thread REQUIRED)
 find_package(Sodium REQUIRED)
 
+include_directories(${GMP_INCLUDE_DIR})
+
 # run autogen.sh if missing header files from configure on Linux/Mac
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/configure")
 else()
@@ -102,7 +115,7 @@ endif()
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/config/pivx-config.h")
 else()
     execute_process(
-        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/configure ${CONFIGSITE} ${BDB_CONFIGURE_FLAGS} ${BIGNUM_CONFIGURE_FLAGS}
+        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/configure ${BDB_CONFIGURE_FLAGS} ${BOOST_R}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endif()
@@ -287,7 +300,7 @@ target_include_directories(SERVER_A PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src
     ${CMAKE_CURRENT_SOURCE_DIR}/src/chiabls/src
     ${relic_SOURCE_DIR}/include
     ${relic_BINARY_DIR}/include
-    ${ZMQ_INCLUDE_DIR} ${LIBEVENT_INCLUDE_DIR} ${BerkeleyDB_INCLUDE_DIRS}
+    ${LIBEVENT_INCLUDE_DIR} ${BerkeleyDB_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${sodium_INCLUDE_DIR}
     )
 
 if(ZMQ_FOUND)
@@ -297,7 +310,7 @@ if(ZMQ_FOUND)
         ./src/zmq/zmqpublishnotifier.cpp
     )
     add_library(ZMQ_A STATIC ${BitcoinHeaders} ${ZMQ_SOURCES} ${ZMQ_LIB})
-    target_include_directories(ZMQ_A PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src ${ZMQ_INCLUDE_DIR})
+    target_include_directories(ZMQ_A PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src ${ZMQ_INCLUDE_DIR} ${Boost_INCLUDE_DIRS})
     target_compile_definitions(ZMQ_A PUBLIC "-DZMQ_STATIC")
 endif()
 
@@ -329,7 +342,7 @@ target_include_directories(WALLET_A PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src
         ${CMAKE_CURRENT_SOURCE_DIR}/src/chiabls/src
         ${relic_SOURCE_DIR}/include
         ${relic_BINARY_DIR}/include
-        ${BerkeleyDB_INCLUDE_DIRS}
+        ${BerkeleyDB_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${sodium_INCLUDE_DIR} ${GMP_INCLUDE_DIR}
         )
 
 set(BITCOIN_CRYPTO_SOURCES
@@ -394,7 +407,7 @@ set(ZEROCOIN_SOURCES
         ./src/libzerocoin/Params.cpp
         )
 add_library(ZEROCOIN_A STATIC ${ZEROCOIN_SOURCES})
-target_include_directories(ZEROCOIN_A PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+target_include_directories(ZEROCOIN_A PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src ${GMP_INCLUDE_DIR} ${Boost_INCLUDE_DIRS})
 
 set(COMMON_SOURCES
         ./src/activemasternode.cpp
@@ -478,7 +491,7 @@ target_include_directories(COMMON_A PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src
         ${CMAKE_CURRENT_SOURCE_DIR}/src/chiabls/src
         ${relic_SOURCE_DIR}/include
         ${relic_BINARY_DIR}/include
-        ${BerkeleyDB_INCLUDE_DIRS}
+        ${BerkeleyDB_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${sodium_INCLUDE_DIR}
         )
 
 set(UTIL_SOURCES
@@ -511,6 +524,7 @@ add_library(UTIL_A STATIC ${BitcoinHeaders} ${UTIL_SOURCES})
 target_include_directories(UTIL_A PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src
         ${CMAKE_CURRENT_SOURCE_DIR}/src/univalue/include
         ${CMAKE_CURRENT_SOURCE_DIR}/src/rust/include
+        ${Boost_INCLUDE_DIRS} ${sodium_INCLUDE_DIR}
         )
 
 set(CLI_A_SOURCES ./src/rpc/client.cpp)
@@ -542,7 +556,7 @@ target_include_directories(SAPLING_A PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src
         ${CMAKE_CURRENT_SOURCE_DIR}/src/sapling
         ${CMAKE_CURRENT_SOURCE_DIR}/src/rust/include
         ${CMAKE_CURRENT_SOURCE_DIR}/src/univalue/include
-        ${BerkeleyDB_INCLUDE_DIRS}
+        ${BerkeleyDB_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${sodium_INCLUDE_DIR}
         )
 
 link_directories(
@@ -654,6 +668,9 @@ endif()
 
 target_link_libraries(pivxd ${sodium_LIBRARY_RELEASE} -ldl -lpthread)
 
-add_subdirectory(src/qt)
+if(NOT DEFINED ENV{NO_QT})
+  add_subdirectory(src/qt)
+endif()
+
 add_subdirectory(src/test)
 add_subdirectory(src/bench)

--- a/src/bench/CMakeLists.txt
+++ b/src/bench/CMakeLists.txt
@@ -66,7 +66,9 @@ target_include_directories(bench_pivx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_SOURCE_DIR}/src/leveldb/include
         ${CMAKE_SOURCE_DIR}/src/leveldb/helpers/memenv
         ${LIBEVENT_INCLUDE_DIR}
-        ${GMP_INCLUDE_DIR})
+        ${GMP_INCLUDE_DIR}
+        ${Boost_INCLUDE_DIRS}
+        ${sodium_INCLUDE_DIR})
 target_link_libraries(bench_pivx PRIVATE
         SERVER_A
         CLI_A

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -177,6 +177,7 @@ target_include_directories(qt_stuff PUBLIC ${CMAKE_SOURCE_DIR}/src
         ${CMAKE_CURRENT_SOURCE_DIR}/pivx
         ${CMAKE_CURRENT_SOURCE_DIR}/pivx/settings
         ${BerkeleyDB_INCLUDE_DIRS}
+        ${Boost_INCLUDE_DIRS}
         )
 set_property(TARGET qt_stuff PROPERTY CXX_STANDARD 14)
 
@@ -193,7 +194,7 @@ QT5_ADD_RESOURCES(QRC_LOCALE_RESOURCE pivx_locale.qrc)
 
 add_executable(pivx-qt pivx.cpp ${QM} ${QRC_RESOURCE} ${QRC_LOCALE_RESOURCE})
 add_dependencies(pivx-qt translations_target libunivalue libsecp256k1 libzcashrust leveldb crc32c bls)
-target_include_directories(pivx-qt PUBLIC ${ENDIAN_INCLUDES} ${GMP_INCLUDE_DIR})
+target_include_directories(pivx-qt PUBLIC ${ENDIAN_INCLUDES} ${GMP_INCLUDE_DIR} ${Boost_INCLUDE_DIRS} ${sodium_INCLUDE_DIR})
 target_link_libraries(pivx-qt
         qt_stuff
         univalue

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -194,7 +194,9 @@ target_include_directories(test_pivx PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_SOURCE_DIR}/src/leveldb/include
         ${CMAKE_SOURCE_DIR}/src/leveldb/helpers/memenv
         ${LIBEVENT_INCLUDE_DIR}
-        ${GMP_INCLUDE_DIR})
+        ${GMP_INCLUDE_DIR}
+        ${Boost_INCLUDE_DIRS}
+        ${sodium_INCLUDE_DIR})
 target_link_libraries(test_pivx PRIVATE
         SERVER_A
         CLI_A

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -218,7 +218,7 @@ class InvalidMessagesTest(PivxTestFramework):
         msg = messages.msg_inv(invs)
         conn.send_message(msg)
 
-        time.sleep(20) # wait a bit
+        time.sleep(30)  # wait a bit
         assert_equal(conn.getdata_count, 50000)
 
         # Prior #2611 the node was blocking any follow-up request.


### PR DESCRIPTION
Homebrew no longer supports pre-built (binary) packages on macOS 11.
Some binary packages remain (for now). This means that packages are
built from source instead, which causes a runner timeout to occur when
trying to build the Qt and ZMQ packages.

A secondary issue came up with the newer Boost 1.83 version supplied by
homebrew for all macOS versions that was causing build errors.

To work around this, I've re-worked the CI and CMake workflows to
not include Qt/ZMQ on macOS 11 runners, and also set a specific Boost
version (1.76) that is still binary compatible with macOS 11.

llvm 13 ships with macos 11 runners natively, but is still not working for our
CMake builds (we previously used Homebrew's `llvm@13` package, which is
also no longer available on macos 11 runners in binary format), so I've
dropped down to llvm 12 instead.

Lastly, and as it's own commit, I was consistently running into an assertion
error with the p2p_invalid_messages.py functional test with counting the
number of `mnping` messages. An increased wait time has cleared up this
issue.