### PR TITLE
[Doc] Update Ubuntu ppa source for db4.8

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -76,11 +76,11 @@ Now, you can either build from self-compiled [depends](/depends/README.md) or in
 
 BerkeleyDB is required for the wallet.
 
- **For Ubuntu only:** db4.8 packages are available [here](https://launchpad.net/~pivx/+archive/pivx).
+ **For Ubuntu only:** db4.8 packages are available [here](https://launchpad.net/~pivx/+archive/berkeley-db4).
  You can add the repository using the following command:
 
     sudo apt-get install software-properties-common
-    sudo add-apt-repository ppa:pivx/pivx
+    sudo add-apt-repository ppa:pivx/berkeley-db4
     sudo apt-get update
     sudo apt-get install libdb4.8-dev libdb4.8++-dev
 


### PR DESCRIPTION
In order to cut down on ppa clutter/size, I have setup a new ppa specifically for BerkeleyDB 4 independent from the pivxd/pivx-qt ppa repositories.

This new ppa repo will be the default place to install db4.8 dependencies moving forward for LTS versions of Ubuntu. It currently has package support for Xenial, Bionic, Focal, Jammy, and the upcoming Noble LTS versions.

New CPU architecture riscv64 has been added for OS versions starting from Focal and newer.