### PR TITLE
[Core] Bump Protocol Version to 70927

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4211,12 +4211,12 @@ void static CheckBlockIndex()
 int ActiveProtocol()
 {
     // SPORK_14 is used for 70926 (v5.5.0), commented out now.
-    if (sporkManager.IsSporkActive(SPORK_14_NEW_PROTOCOL_ENFORCEMENT))
-            return MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT;
-
-    // SPORK_15 is used for 70923 (v5.3.0), commented out now.
-    //if (sporkManager.IsSporkActive(SPORK_15_NEW_PROTOCOL_ENFORCEMENT_2))
+    //if (sporkManager.IsSporkActive(SPORK_14_NEW_PROTOCOL_ENFORCEMENT))
     //        return MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT;
+
+    // SPORK_15 is used for 70927 (v5.6.0), commented out now.
+    if (sporkManager.IsSporkActive(SPORK_15_NEW_PROTOCOL_ENFORCEMENT_2))
+            return MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT;
 
     return MIN_PEER_PROTO_VERSION_BEFORE_ENFORCEMENT;
 }

--- a/src/version.h
+++ b/src/version.h
@@ -11,14 +11,14 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70926;
+static const int PROTOCOL_VERSION = 70927;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
 
 //! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION_BEFORE_ENFORCEMENT = 70923;
-static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT = 70926;
+static const int MIN_PEER_PROTO_VERSION_BEFORE_ENFORCEMENT = 70926;
+static const int MIN_PEER_PROTO_VERSION_AFTER_ENFORCEMENT = 70927;
 
 //! Version where BIP155 was introduced
 static const int MIN_BIP155_PROTOCOL_VERSION = 70923;

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -31,7 +31,7 @@ from .siphash import siphash256
 from .util import hex_str_to_bytes
 
 MIN_VERSION_SUPPORTED = 60001
-MY_VERSION = 70925
+MY_VERSION = 70926
 MY_SUBVERSION = "/python-mininode-tester:0.0.3/"
 MY_RELAY = 1  # from version 70001 onwards, fRelay should be appended to version messages (BIP37)
 


### PR DESCRIPTION
As we integrate new Exchange Addresses into our system, its crucial to ensure compatibility and prevent potential conflicts arising from the new address prefix. So we are updating the protocol version to eliminate any compatibility issues or potentials to fork. 