### PR TITLE
[GA] Link Boost 1.76 regardless of pre-existing version

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -115,10 +115,10 @@ jobs:
           fi
           if [[ ${{ matrix.config.os }} = macos* ]]; then
             brew install "$APT_BASE" ${{ matrix.config.packages }}
-            # GA's macOS 11 image has recently started leaking the pre-installed boost libraries
-            # despite us setting an explicit path. Temp workaround is to unlink the pre-installed version
+            # GA's macOS 11 image is inconsistent as to if it includes a pre-installed version of boost. Force linking
+            # to the specified version (1.76), which will overwrite the symlinks to a pre-existing version if it exists.
             if [ "${{ matrix.config.os }}" = "macos-11" ]; then
-              brew unlink boost && brew link --overwrite -f boost@1.76
+              brew link --overwrite -f boost@1.76
             fi
           fi
 


### PR DESCRIPTION
GA's macos-11 runner images have been inconsistent in their inclusion of
 a pre-installed version of the Boost library, and trying to gracefully
 unlink a non-existent package results in an error.

Skip the unlink step and just force overwrite linking boost 1.76.