### PR TITLE
Restore Mainnet 'EXM' Prefix

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -329,7 +329,7 @@ public:
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1, 30);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1, 13);
         base58Prefixes[STAKING_ADDRESS] = std::vector<unsigned char>(1, 63);     // starting with 'S'
-        base58Prefixes[EXCHANGE_ADDRESS] = {0x01, 0xb9};   // starts with EX
+        base58Prefixes[EXCHANGE_ADDRESS] = {0x01, 0xb9, 0xa2};   // starts with EXM
         base58Prefixes[SECRET_KEY] = std::vector<unsigned char>(1, 212);
         base58Prefixes[EXT_PUBLIC_KEY] = {0x02, 0x2D, 0x25, 0x33};
         base58Prefixes[EXT_SECRET_KEY] = {0x02, 0x21, 0x31, 0x2B};


### PR DESCRIPTION
This will restore the Mainnet prefix to `EXM` from the current `EX` setting that is returning `44` in production.