### PR TITLE
Fix optional memo not being checked

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -180,7 +180,7 @@ bool TransactionRecord::decomposeCreditTransaction(const CWallet* wallet, const 
                 sub.type = TransactionRecord::RecvWithShieldedAddress;
                 sub.credit = sspkm->GetOutPointValue(wtx, out);
                 sub.memo = sspkm->GetOutPointMemo(wtx, out);
-                if (!sub.memo->empty()) {
+                if (sub.memo && !sub.memo->empty()) {
                     sub.type = TransactionRecord::RecvWithShieldedAddressMemo;
                 }
                 sub.idx = i;


### PR DESCRIPTION
Memos return Nullopt instead of empty string when empty.