### PR TITLE
[GA] Use new versioned qt@5 homebrew package name

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -97,7 +97,7 @@ jobs:
 
           - name: macOS-latest
             os: macos-latest
-            packages: llvm@13 python@3.8 autoconf automake berkeley-db@4 libtool boost@1.76 miniupnpc libnatpmp pkg-config qt5 zmq libevent qrencode gmp libsodium rust
+            packages: llvm@13 python@3.8 autoconf automake berkeley-db@4 libtool boost@1.76 miniupnpc libnatpmp pkg-config qt@5 zmq libevent qrencode gmp libsodium rust
             boost_root: true
             cc: $(brew --prefix llvm@13)/bin/clang
             cxx: $(brew --prefix llvm@13)/bin/clang++
@@ -199,7 +199,7 @@ jobs:
           - name: x64-macOS-latest
             id: macOS-nodepends-latest
             os: macos-latest
-            brew_install: autoconf automake ccache berkeley-db@4 libtool boost@1.76 miniupnpc libnatpmp pkg-config python@3.8 qt5 zmq libevent qrencode gmp libsodium rust librsvg
+            brew_install: autoconf automake ccache berkeley-db@4 libtool boost@1.76 miniupnpc libnatpmp pkg-config python@3.8 qt@5 zmq libevent qrencode gmp libsodium rust librsvg
             unit_tests: true
             functional_tests: true
             goal: deploy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(ENV{target} "Mac")
     add_definitions("-DMAC_OSX")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D'NS_FORMAT_ARGUMENT\(A\)='")
-    list(APPEND CMAKE_PREFIX_PATH /usr/local/opt/qt5 /opt/homebrew/opt/qt5)
+    list(APPEND CMAKE_PREFIX_PATH /usr/local/opt/qt5 /usr/local/opt/qt@5 /opt/homebrew/opt/qt5 /opt/homebrew/opt/qt@5)
     list(APPEND CMAKE_PREFIX_PATH /usr/local/Cellar/berkeley-db@4 /opt/homebrew/Cellar/berkeley-db@4)
     # Homebrew default path for apple silicon CPUs is different than for intel CPUs
     if(${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "arm")

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -16,7 +16,7 @@ Then install [Homebrew](https://brew.sh).
 Dependencies
 ----------------------
 
-    brew install autoconf automake berkeley-db4 libtool boost miniupnpc libnatpmp pkg-config python3 qt5 zmq libevent qrencode gmp libsodium rust
+    brew install autoconf automake berkeley-db4 libtool boost miniupnpc libnatpmp pkg-config python3 qt@5 zmq libevent qrencode gmp libsodium rust
 
 See [dependencies.md](dependencies.md) for a complete overview.
 


### PR DESCRIPTION
Homebrew recently removed the legacy symlinks for the `qt5` package and is now only using the versioned `qt@5` naming. Adjust accordingly.