### PR TITLE
[Test] Speed up functional tests

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -166,7 +166,6 @@ class PivxTestFramework():
                 raise SkipTest("--usecli specified but test does not support using CLI")
             self.setup_chain()
             self.setup_network()
-            time.sleep(5)
             self.run_test()
             success = TestStatus.PASSED
         except JSONRPCException:
@@ -298,8 +297,6 @@ class PivxTestFramework():
         node.start(*args, **kwargs)
         node.wait_for_rpc_connection()
 
-        time.sleep(10)
-
         if self.options.coveragedir is not None:
             coverage.write_all_rpc_commands(self.options.coveragedir, node.rpc)
 
@@ -319,8 +316,6 @@ class PivxTestFramework():
             self.stop_nodes()
             raise
 
-        time.sleep(10)
-
         if self.options.coveragedir is not None:
             for node in self.nodes:
                 coverage.write_all_rpc_commands(self.options.coveragedir, node.rpc)
@@ -338,7 +333,6 @@ class PivxTestFramework():
 
         for node in self.nodes:
             # Wait for nodes to stop
-            time.sleep(5)
             node.wait_until_stopped()
 
     def restart_node(self, i, extra_args=None):

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -131,7 +131,6 @@ class TestNode():
         """Sets up an RPC connection to the pivxd process. Returns False if unable to connect."""
         # Poll at a rate of four times per second
         poll_per_s = 4
-        time.sleep(5)
         for _ in range(poll_per_s * self.rpc_timeout):
             assert self.process.poll() is None, "pivxd exited with status %i during initialization" % self.process.returncode
             try:

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -202,7 +202,6 @@ class TestNode():
 
         Returns True if the node has stopped. False otherwise.
         This method is responsible for freeing resources (self.process)."""
-        time.sleep(20)
         if not self.running:
             return True
         return_code = self.process.poll()


### PR DESCRIPTION
The aim of this PR is making functional test run faster

First commit:
Sleeping inside `wait_for_rpc_connection`  is useless since in case of failure it will try again rather than throwing error.

Second commit:
profiling showed that waiting for all nodes to connect to each other was very slow (`8` nodes took about ~`32` seconds on my PC). If we connect them in parallel time is much faster ( more or less `4` seconds on my PC)

Third commit:
sleeping inside `is_node_stopped` is useless since it is always used in operations like `wait_until_stopped`, and in case a node is not stopped it will wait and try again rather than throwing error.

Fourth commit:
removed many other big `time.sleep()` that made everything go overall much slower. This is the only commit that I'm not 100% sure so if we see that some test fail at the beginning (I mean before `run_test()` is called) this one can be reverted.

Fifth commit:
Make faster and solve the failure of `p2p_invalid_messages.py`:
When receiving lots of messages use a timeout system, instead of sleeping for an arbitrary amount of time (30 seconds, which sometimes was not enough)

