### PR TITLE
[Test] speed un tiertwo_governance_sync_basic

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1054,14 +1054,12 @@ class PivxTestFramework():
                 node.mnping()["sent"]
             except:
                 pass
-            time.sleep(1)
 
 
     def stake_and_sync(self, node_id, num_blocks):
         for i in range(num_blocks):
             self.mocktime = self.generate_pos(node_id, self.mocktime)
         self.sync_blocks()
-        time.sleep(1)
 
 
     def stake_and_ping(self, node_id, num_blocks, with_ping_mns=None):

--- a/test/functional/tiertwo_governance_sync_basic.py
+++ b/test/functional/tiertwo_governance_sync_basic.py
@@ -375,6 +375,7 @@ class MasternodeGovernanceBasicTest(PivxTier2TestFramework):
         self.ownerTwo.setmocktime(self.mocktime)
         self.connect_to_all(self.ownerTwoPos)
         self.stake(2, [self.remoteOne, self.remoteTwo])
+        time.sleep(5) # wait a little bit
 
         self.log.info("syncing node..")
         self.wait_until_mnsync_finished()


### PR DESCRIPTION
`tiertwo_governance_sync_basic` is by far the slowest test that we have. Profiling showed that most of the time was spent in the function stake() which slept for a total of 2 seconds in each call.

Those 2 seconds sleep were actually useless and have been removed.
With this simple change the total running time of the test on my machine dropped from `15` minutes to only `6` minutes.

To prove that indeed sleeping was useless I tried to run the same test in parallel 15 times, and it never failed, see here:
https://github.com/panleone/PIVX/actions/runs/8420343441
