### PR TITLE
[Bug] Fix data race

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1319,7 +1319,7 @@ void CWallet::TransactionRemovedFromMempool(const CTransactionRef &ptx, MemPoolR
 void CWallet::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex)
 {
     {
-        LOCK(cs_wallet);
+        LOCK2(cs_main, cs_wallet);
 
         m_last_block_processed = pindex->GetBlockHash();
         m_last_block_processed_time = pindex->GetBlockTime();


### PR DESCRIPTION
Fix the data race in which a thread is trying to write `pcoinsTip.cacheSaplingAnchors`:
`CWallet::BlockConnected -> pcoinsTip->GetSaplingAnchorAt(...)`
At the same time another thread is trying to read `pcoinsTip.cacheSaplingAnchors`:
`ActivateBestChain -> FlushStateToDisk -> pcoinsTip->DynamicMemoryUsage()`.

The fix is trivial `CWallet::BlockConnected` was not locking the mutex `cs_main` that guards `pcoinsTip`.


This data race was causing the functional test `wallet_basic.py` to randomly fail: To see this I created two test branches where I ran `wallet_basic.py` 50 times in parallel. One branch has this fix the other doesn't.

The github action for the branch without this fix failed many times
https://github.com/panleone/PIVX/actions/runs/8428460478

The github action for the branch with this fixed always passed instead
https://github.com/panleone/PIVX/actions/runs/8428472901



