### PR TITLE
Dash llmq backports

### DIFF
--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -558,10 +558,11 @@ CQuorumCPtr CSigningManager::SelectQuorumForSigning(Consensus::LLMQType llmqType
     CBlockIndex* pindexStart;
     {
         LOCK(cs_main);
-        if (signHeight - SIGN_HEIGHT_OFFSET > chainActive.Height()) {
+        int startBlockHeight = signHeight - SIGN_HEIGHT_OFFSET;
+        if (startBlockHeight > chainActive.Height()) {
             return nullptr;
         }
-        pindexStart = chainActive[signHeight - SIGN_HEIGHT_OFFSET];
+        pindexStart = chainActive[startBlockHeight];
     }
 
     auto quorums = quorumManager->ScanQuorums(llmqType, pindexStart, poolSize);

--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -558,7 +558,7 @@ CQuorumCPtr CSigningManager::SelectQuorumForSigning(Consensus::LLMQType llmqType
     CBlockIndex* pindexStart;
     {
         LOCK(cs_main);
-        if (signHeight > chainActive.Height()) {
+        if (signHeight - SIGN_HEIGHT_OFFSET > chainActive.Height()) {
             return nullptr;
         }
         pindexStart = chainActive[signHeight - SIGN_HEIGHT_OFFSET];

--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -118,8 +118,9 @@ void CRecoveredSigsDb::CleanupOldRecoveredSigs(int64_t maxAge)
 {
     std::unique_ptr<CDBIterator> pcursor(db.NewIterator());
 
+    static const uint256 maxUint256 = uint256S("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
     auto start = std::make_tuple('t', (uint32_t)0, (uint8_t)0, uint256());
-    auto end = std::make_tuple('t', (uint32_t)(GetAdjustedTime() - maxAge), (uint8_t)0, uint256());
+    auto end = std::make_tuple('t', (uint32_t)(GetAdjustedTime() - maxAge), (uint8_t)255, maxUint256);
     pcursor->Seek(start);
 
     std::vector<std::pair<Consensus::LLMQType, uint256>> toDelete;

--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -35,14 +35,46 @@ bool CRecoveredSigsDb::HasRecoveredSig(Consensus::LLMQType llmqType, const uint2
 
 bool CRecoveredSigsDb::HasRecoveredSigForId(Consensus::LLMQType llmqType, const uint256& id)
 {
+    int64_t t = GetTimeMillis();
+
+    auto cacheKey = std::make_pair(llmqType, id);
+    {
+        LOCK(cs);
+        auto it = hasSigForIdCache.find(cacheKey);
+        if (it != hasSigForIdCache.end()) {
+            it->second.second = t;
+            return it->second.first;
+        }
+    }
+
+
     auto k = std::make_tuple('r', (uint8_t)llmqType, id);
-    return db.Exists(k);
+    bool ret = db.Exists(k);
+
+    LOCK(cs);
+    hasSigForIdCache.emplace(cacheKey, std::make_pair(ret, t));
+    return ret;
 }
 
 bool CRecoveredSigsDb::HasRecoveredSigForSession(const uint256& signHash)
 {
+    int64_t t = GetTimeMillis();
+
+    {
+        LOCK(cs);
+        auto it = hasSigForSessionCache.find(signHash);
+        if (it != hasSigForSessionCache.end()) {
+            it->second.second = t;
+            return it->second.first;
+        }
+    }
+
     auto k = std::make_tuple('s', signHash);
-    return db.Exists(k);
+    bool ret = db.Exists(k);
+
+    LOCK(cs);
+    hasSigForSessionCache.emplace(signHash, std::make_pair(ret, t));
+    return ret;
 }
 
 bool CRecoveredSigsDb::HasRecoveredSigForHash(const uint256& hash)
@@ -100,7 +132,8 @@ void CRecoveredSigsDb::WriteRecoveredSig(const llmq::CRecoveredSig& recSig)
     batch.Write(k3, std::make_pair(recSig.llmqType, recSig.id));
 
     // store by signHash
-    auto k4 = std::make_tuple('s', llmq::utils::BuildSignHash(recSig));
+    auto signHash = llmq::utils::BuildSignHash(recSig);
+    auto k4 = std::make_tuple('s', signHash);
     batch.Write(k4, (uint8_t)1);
 
     // remove the votedForId entry as we won't need it anymore
@@ -112,6 +145,39 @@ void CRecoveredSigsDb::WriteRecoveredSig(const llmq::CRecoveredSig& recSig)
     batch.Write(k6, (uint8_t)1);
 
     db.WriteBatch(batch);
+
+    {
+        int64_t t = GetTimeMillis();
+
+        LOCK(cs);
+        hasSigForIdCache[std::make_pair((Consensus::LLMQType)recSig.llmqType, recSig.id)] = std::make_pair(true, t);
+        hasSigForSessionCache[signHash] = std::make_pair(true, t);
+    }
+}
+
+template<typename K>
+static void TruncateCacheMap(std::unordered_map<K, std::pair<bool, int64_t>>& m, size_t maxSize, size_t truncateThreshold)
+{
+    typedef typename std::unordered_map<K, std::pair<bool, int64_t>> Map;
+    typedef typename Map::iterator Iterator;
+
+    if (m.size() <= truncateThreshold) {
+        return;
+    }
+
+    std::vector<Iterator> vec;
+    vec.reserve(m.size());
+    for (auto it = m.begin(); it != m.end(); ++it) {
+        vec.emplace_back(it);
+    }
+    // sort by last access time (descending order)
+    std::sort(vec.begin(), vec.end(), [](const Iterator& it1, const Iterator& it2) {
+        return it1->second.second > it2->second.second;
+    });
+
+    for (size_t i = maxSize; i < vec.size(); i++) {
+        m.erase(vec[i]);
+    }
 }
 
 void CRecoveredSigsDb::CleanupOldRecoveredSigs(int64_t maxAge)
@@ -148,22 +214,33 @@ void CRecoveredSigsDb::CleanupOldRecoveredSigs(int64_t maxAge)
     }
 
     CDBBatch batch(CLIENT_VERSION | ADDRV2_FORMAT);
-    for (auto& e : toDelete) {
-        CRecoveredSig recSig;
-        if (!ReadRecoveredSig(e.first, e.second, recSig)) {
-            continue;
+    {
+        LOCK(cs);
+        for (auto& e : toDelete) {
+            CRecoveredSig recSig;
+            if (!ReadRecoveredSig(e.first, e.second, recSig)) {
+                continue;
+            }
+
+            auto signHash = llmq::utils::BuildSignHash(recSig);
+
+            auto k1 = std::make_tuple('r', recSig.llmqType, recSig.id);
+            auto k2 = std::make_tuple('r', recSig.llmqType, recSig.id, recSig.msgHash);
+            auto k3 = std::make_tuple('h', recSig.GetHash());
+            auto k4 = std::make_tuple('s', signHash);
+            auto k5 = std::make_tuple('v', recSig.llmqType, recSig.id);
+            batch.Erase(k1);
+            batch.Erase(k2);
+            batch.Erase(k3);
+            batch.Erase(k4);
+            batch.Erase(k5);
+
+            hasSigForIdCache.erase(std::make_pair((Consensus::LLMQType)recSig.llmqType, recSig.id));
+            hasSigForSessionCache.erase(signHash);
         }
 
-        auto k1 = std::make_tuple('r', recSig.llmqType, recSig.id);
-        auto k2 = std::make_tuple('r', recSig.llmqType, recSig.id, recSig.msgHash);
-        auto k3 = std::make_tuple('h', recSig.GetHash());
-        auto k4 = std::make_tuple('s', llmq::utils::BuildSignHash(recSig));
-        auto k5 = std::make_tuple('v', recSig.llmqType, recSig.id);
-        batch.Erase(k1);
-        batch.Erase(k2);
-        batch.Erase(k3);
-        batch.Erase(k4);
-        batch.Erase(k5);
+        TruncateCacheMap(hasSigForIdCache, MAX_CACHE_SIZE, MAX_CACHE_TRUNCATE_THRESHOLD);
+        TruncateCacheMap(hasSigForSessionCache, MAX_CACHE_SIZE, MAX_CACHE_TRUNCATE_THRESHOLD);
     }
 
     for (auto& e : toDelete2) {

--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -417,14 +417,14 @@ void CSigningManager::CollectPendingRecoveredSigsToVerify(
     }
 }
 
-void CSigningManager::ProcessPendingRecoveredSigs(CConnman& connman)
+bool CSigningManager::ProcessPendingRecoveredSigs(CConnman& connman)
 {
     std::map<NodeId, std::list<CRecoveredSig>> recSigsByNode;
     std::map<std::pair<Consensus::LLMQType, uint256>, CQuorumCPtr> quorums;
 
     CollectPendingRecoveredSigsToVerify(32, recSigsByNode, quorums);
     if (recSigsByNode.empty()) {
-        return;
+        return false;
     }
 
     // It's ok to perform insecure batched verification here as we verify against the quorum public keys, which are not
@@ -470,6 +470,8 @@ void CSigningManager::ProcessPendingRecoveredSigs(CConnman& connman)
             ProcessRecoveredSig(nodeId, recSig, quorum, connman);
         }
     }
+
+    return true;
 }
 
 // signature must be verified already

--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -257,19 +257,15 @@ bool CSigningManager::PreVerifyRecoveredSig(NodeId nodeId, const CRecoveredSig& 
         return false;
     }
 
-    CQuorumCPtr quorum;
-    {
-        LOCK(cs_main);
+    CQuorumCPtr quorum = quorumManager->GetQuorum(llmqType, recoveredSig.quorumHash);
 
-        quorum = quorumManager->GetQuorum(llmqType, recoveredSig.quorumHash);
-        if (!quorum) {
-            LogPrintf("CSigningManager::%s -- quorum %s not found, node=%d\n", __func__,
-                recoveredSig.quorumHash.ToString(), nodeId);
-            return false;
-        }
-        if (!llmq::utils::IsQuorumActive(llmqType, quorum->pindexQuorum->GetBlockHash())) {
-            return false;
-        }
+    if (!quorum) {
+        LogPrintf("CSigningManager::%s -- quorum %s not found, node=%d\n", __func__,
+            recoveredSig.quorumHash.ToString(), nodeId);
+        return false;
+    }
+    if (!llmq::utils::IsQuorumActive(llmqType, quorum->pindexQuorum->GetBlockHash())) {
+        return false;
     }
 
     if (!recoveredSig.sig.IsValid()) {
@@ -312,37 +308,34 @@ void CSigningManager::CollectPendingRecoveredSigsToVerify(
         }
     }
 
-    {
-        LOCK(cs_main);
-        for (auto& p : retSigShares) {
-            NodeId nodeId = p.first;
-            auto& v = p.second;
+    for (auto& p : retSigShares) {
+        NodeId nodeId = p.first;
+        auto& v = p.second;
 
-            for (auto it = v.begin(); it != v.end();) {
-                auto& recSig = *it;
+        for (auto it = v.begin(); it != v.end();) {
+            auto& recSig = *it;
 
-                Consensus::LLMQType llmqType = (Consensus::LLMQType)recSig.llmqType;
-                auto quorumKey = std::make_pair((Consensus::LLMQType)recSig.llmqType, recSig.quorumHash);
-                if (!retQuorums.count(quorumKey)) {
-                    CQuorumCPtr quorum = quorumManager->GetQuorum(llmqType, recSig.quorumHash);
-                    if (!quorum) {
-                        LogPrintf("CSigningManager::%s -- quorum %s not found, node=%d\n", __func__,
-                            recSig.quorumHash.ToString(), nodeId);
-                        it = v.erase(it);
-                        continue;
-                    }
-                    if (!llmq::utils::IsQuorumActive(llmqType, quorum->pindexQuorum->GetBlockHash())) {
-                        LogPrintf("CSigningManager::%s -- quorum %s not active anymore, node=%d\n", __func__,
-                            recSig.quorumHash.ToString(), nodeId);
-                        it = v.erase(it);
-                        continue;
-                    }
-
-                    retQuorums.emplace(quorumKey, quorum);
+            Consensus::LLMQType llmqType = (Consensus::LLMQType)recSig.llmqType;
+            auto quorumKey = std::make_pair((Consensus::LLMQType)recSig.llmqType, recSig.quorumHash);
+            if (!retQuorums.count(quorumKey)) {
+                CQuorumCPtr quorum = quorumManager->GetQuorum(llmqType, recSig.quorumHash);
+                if (!quorum) {
+                    LogPrintf("CSigningManager::%s -- quorum %s not found, node=%d\n", __func__,
+                        recSig.quorumHash.ToString(), nodeId);
+                    it = v.erase(it);
+                    continue;
+                }
+                if (!llmq::utils::IsQuorumActive(llmqType, quorum->pindexQuorum->GetBlockHash())) {
+                    LogPrintf("CSigningManager::%s -- quorum %s not active anymore, node=%d\n", __func__,
+                        recSig.quorumHash.ToString(), nodeId);
+                    it = v.erase(it);
+                    continue;
                 }
 
-                ++it;
+                retQuorums.emplace(quorumKey, quorum);
             }
+
+            ++it;
         }
     }
 }

--- a/src/llmq/quorums_signing.h
+++ b/src/llmq/quorums_signing.h
@@ -12,6 +12,19 @@
 #include "net.h"
 #include "sync.h"
 
+#include <unordered_map>
+
+namespace std {
+    template <>
+    struct hash<std::pair<Consensus::LLMQType, uint256>>
+    {
+        std::size_t operator()(const std::pair<Consensus::LLMQType, uint256>& k) const
+        {
+            return (std::size_t)((k.first + 1) * k.second.GetCheapHash());
+        }
+    };
+}
+
 namespace llmq
 {
 
@@ -67,8 +80,15 @@ public:
 // TODO implement caching to speed things up
 class CRecoveredSigsDb
 {
+    static const size_t MAX_CACHE_SIZE = 30000;
+    static const size_t MAX_CACHE_TRUNCATE_THRESHOLD = 50000;
+
 private:
     CDBWrapper db;
+
+    RecursiveMutex cs;
+    std::unordered_map<std::pair<Consensus::LLMQType, uint256>, std::pair<bool, int64_t>> hasSigForIdCache;
+    std::unordered_map<uint256, std::pair<bool, int64_t>> hasSigForSessionCache;
 
 public:
     CRecoveredSigsDb(bool fMemory);

--- a/src/llmq/quorums_signing.h
+++ b/src/llmq/quorums_signing.h
@@ -158,7 +158,7 @@ private:
     bool PreVerifyRecoveredSig(NodeId nodeId, const CRecoveredSig& recoveredSig, bool& retBan);
 
     void CollectPendingRecoveredSigsToVerify(size_t maxUniqueSessions, std::map<NodeId, std::list<CRecoveredSig>>& retSigShares, std::map<std::pair<Consensus::LLMQType, uint256>, CQuorumCPtr>& retQuorums);
-    void ProcessPendingRecoveredSigs(CConnman& connman); // called from the worker thread of CSigSharesManager
+    bool ProcessPendingRecoveredSigs(CConnman& connman); // called from the worker thread of CSigSharesManager
     void ProcessRecoveredSig(NodeId nodeId, const CRecoveredSig& recoveredSig, const CQuorumCPtr& quorum, CConnman& connman);
     void Cleanup(); // called from the worker thread of CSigSharesManager
 

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -347,31 +347,27 @@ bool CSigSharesManager::PreVerifyBatchedSigShares(NodeId nodeId, const CBatchedS
         return false;
     }
 
-    CQuorumCPtr quorum;
-    {
-        LOCK(cs_main);
+    CQuorumCPtr quorum = quorumManager->GetQuorum(llmqType, batchedSigShares.quorumHash);
 
-        quorum = quorumManager->GetQuorum(llmqType, batchedSigShares.quorumHash);
-        if (!quorum) {
-            // TODO should we ban here?
-            LogPrintf("CSigSharesManager::%s -- quorum %s not found, node=%d\n", __func__,
-                batchedSigShares.quorumHash.ToString(), nodeId);
-            return false;
-        }
-        if (!llmq::utils::IsQuorumActive(llmqType, quorum->pindexQuorum->GetBlockHash())) {
-            // quorum is too old
-            return false;
-        }
-        if (!quorum->IsMember(activeMasternodeManager->GetProTx())) {
-            // we're not a member so we can't verify it (we actually shouldn't have received it)
-            return false;
-        }
-        if (quorum->quorumVvec == nullptr) {
-            // TODO we should allow to ask other nodes for the quorum vvec if we missed it in the DKG
-            LogPrintf("CSigSharesManager::%s -- we don't have the quorum vvec for %s, no verification possible. node=%d\n", __func__,
-                batchedSigShares.quorumHash.ToString(), nodeId);
-            return false;
-        }
+    if (!quorum) {
+        // TODO should we ban here?
+        LogPrintf("CSigSharesManager::%s -- quorum %s not found, node=%d\n", __func__,
+            batchedSigShares.quorumHash.ToString(), nodeId);
+        return false;
+    }
+    if (!llmq::utils::IsQuorumActive(llmqType, quorum->pindexQuorum->GetBlockHash())) {
+        // quorum is too old
+        return false;
+    }
+    if (!quorum->IsMember(activeMasternodeManager->GetProTx())) {
+        // we're not a member so we can't verify it (we actually shouldn't have received it)
+        return false;
+    }
+    if (quorum->quorumVvec == nullptr) {
+        // TODO we should allow to ask other nodes for the quorum vvec if we missed it in the DKG
+        LogPrintf("CSigSharesManager::%s -- we don't have the quorum vvec for %s, no verification possible. node=%d\n", __func__,
+            batchedSigShares.quorumHash.ToString(), nodeId);
+        return false;
     }
 
     std::set<uint16_t> dupMembers;
@@ -993,17 +989,15 @@ void CSigSharesManager::Cleanup()
         }
     }
 
-    {
-        // Find quorums which became inactive
-        LOCK(cs_main);
-        for (auto it = quorumsToCheck.begin(); it != quorumsToCheck.end();) {
-            if (llmq::utils::IsQuorumActive(it->first, it->second)) {
-                it = quorumsToCheck.erase(it);
-            } else {
-                ++it;
-            }
+    // Find quorums which became inactive
+    for (auto it = quorumsToCheck.begin(); it != quorumsToCheck.end();) {
+        if (llmq::utils::IsQuorumActive(it->first, it->second)) {
+            it = quorumsToCheck.erase(it);
+        } else {
+            ++it;
         }
     }
+
     {
         // Now delete sessions which are for inactive quorums
         LOCK(cs);

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -1108,6 +1108,7 @@ void CSigSharesManager::BanNode(NodeId nodeId)
 
 void CSigSharesManager::WorkThreadMain()
 {
+    int64_t lastSendTime = 0;
     while (!interruptSigningShare) {
         bool didWork = false;
 
@@ -1115,7 +1116,12 @@ void CSigSharesManager::WorkThreadMain()
         didWork |= quorumSigningManager->ProcessPendingRecoveredSigs(*g_connman);
         didWork |= ProcessPendingSigShares(*g_connman);
         didWork |= SignPendingSigShares();
-        SendMessages();
+
+        if (GetTimeMillis() - lastSendTime > 100) {
+            SendMessages();
+            lastSendTime = GetTimeMillis();
+        }
+
         Cleanup();
         quorumSigningManager->Cleanup();
 

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -374,11 +374,6 @@ bool CSigSharesManager::PreVerifyBatchedSigShares(NodeId nodeId, const CBatchedS
 
     for (size_t i = 0; i < batchedSigShares.sigShares.size(); i++) {
         auto quorumMember = batchedSigShares.sigShares[i].first;
-        auto& sigShare = batchedSigShares.sigShares[i].second;
-        if (!sigShare.IsValid()) {
-            retBan = true;
-            return false;
-        }
         if (!dupMembers.emplace(quorumMember).second) {
             retBan = true;
             return false;
@@ -482,6 +477,14 @@ void CSigSharesManager::ProcessPendingSigShares(CConnman& connman)
                 continue;
             }
 
+            // we didn't check this earlier because we use a lazy BLS signature and tried to avoid doing the expensive
+            // deserialization in the message thread
+            if (!sigShare.sigShare.Get().IsValid()) {
+                BanNode(nodeId);
+                // don't process any additional shares from this node
+                break;
+            }
+
             auto quorum = quorums.at(std::make_pair((Consensus::LLMQType)sigShare.llmqType, sigShare.quorumHash));
             auto pubKeyShare = quorum->GetPubKeyShare(sigShare.quorumMember);
 
@@ -492,7 +495,7 @@ void CSigSharesManager::ProcessPendingSigShares(CConnman& connman)
                 assert(false);
             }
 
-            batchVerifier.PushMessage(nodeId, sigShare.GetKey(), sigShare.GetSignHash(), sigShare.sigShare, pubKeyShare);
+            batchVerifier.PushMessage(nodeId, sigShare.GetKey(), sigShare.GetSignHash(), sigShare.sigShare.Get(), pubKeyShare);
             verifyCount++;
         }
     }
@@ -616,7 +619,7 @@ void CSigSharesManager::TryRecoverSig(const CQuorumCPtr& quorum, const uint256& 
         idsForRecovery.reserve((size_t)quorum->params.threshold);
         for (auto it = itPair.first; it != itPair.second && sigSharesForRecovery.size() < quorum->params.threshold; ++it) {
             auto& sigShare = it->second;
-            sigSharesForRecovery.emplace_back(sigShare.sigShare);
+            sigSharesForRecovery.emplace_back(sigShare.sigShare.Get());
             idsForRecovery.emplace_back(CBLSId(quorum->members[sigShare.quorumMember]->proTxHash));
         }
 
@@ -1160,8 +1163,8 @@ void CSigSharesManager::Sign(const CQuorumCPtr& quorum, const uint256& id, const
     sigShare.quorumMember = (uint16_t)memberIdx;
     uint256 signHash = llmq::utils::BuildSignHash(sigShare);
 
-    sigShare.sigShare = skShare.Sign(signHash);
-    if (!sigShare.sigShare.IsValid()) {
+    sigShare.sigShare.Set(skShare.Sign(signHash));
+    if (!sigShare.sigShare.Get().IsValid()) {
         LogPrintf("CSigSharesManager::%s -- failed to sign sigShare. id=%s, msgHash=%s, time=%s\n", __func__,
             sigShare.id.ToString(), sigShare.msgHash.ToString(), t.count());
         return;

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -453,14 +453,14 @@ void CSigSharesManager::CollectPendingSigSharesToVerify(
     }
 }
 
-void CSigSharesManager::ProcessPendingSigShares(CConnman& connman)
+bool CSigSharesManager::ProcessPendingSigShares(CConnman& connman)
 {
     std::map<NodeId, std::vector<CSigShare>> sigSharesByNodes;
     std::map<std::pair<Consensus::LLMQType, uint256>, CQuorumCPtr> quorums;
 
     CollectPendingSigSharesToVerify(32, sigSharesByNodes, quorums);
     if (sigSharesByNodes.empty()) {
-        return;
+        return false;
     }
 
     // It's ok to perform insecure batched verification here as we verify against the quorum public key shares,
@@ -520,6 +520,8 @@ void CSigSharesManager::ProcessPendingSigShares(CConnman& connman)
 
         ProcessPendingSigSharesFromNode(nodeId, v, quorums, connman);
     }
+
+    return true;
 }
 
 // It's ensured that no duplicates are passed to this method
@@ -881,7 +883,7 @@ void CSigSharesManager::CollectSigSharesToAnnounce(std::map<NodeId, std::map<uin
     this->sigSharesToAnnounce.clear();
 }
 
-void CSigSharesManager::SendMessages()
+bool CSigSharesManager::SendMessages()
 {
     std::multimap<CService, NodeId> nodesByAddress;
     g_connman->ForEachNode([&nodesByAddress](CNode* pnode) {
@@ -899,6 +901,8 @@ void CSigSharesManager::SendMessages()
         CollectSigSharesToAnnounce(sigSharesToAnnounce);
     }
 
+    bool didSend = false;
+
     g_connman->ForEachNode([&](CNode* pnode) {
         CNetMsgMaker msgMaker(pnode->GetSendVersion());
 
@@ -909,6 +913,7 @@ void CSigSharesManager::SendMessages()
                 LogPrintf("llmq", "CSigSharesManager::SendMessages -- QGETSIGSHARES inv={%s}, node=%d\n",
                     p.second.ToString(), pnode->GetId());
                 g_connman->PushMessage(pnode, msgMaker.Make(NetMsgType::QGETSIGSHARES, p.second));
+                didSend = true;
             }
         }
 
@@ -919,6 +924,7 @@ void CSigSharesManager::SendMessages()
                 LogPrintf("llmq", "CSigSharesManager::SendMessages -- QBSIGSHARES inv={%s}, node=%d\n",
                     p.second.ToInv().ToString(), pnode->GetId());
                 g_connman->PushMessage(pnode, msgMaker.Make(NetMsgType::QBSIGSHARES, p.second));
+                didSend = true;
             }
         }
 
@@ -929,11 +935,14 @@ void CSigSharesManager::SendMessages()
                 LogPrintf("llmq", "CSigSharesManager::SendMessages -- QSIGSHARESINV inv={%s}, node=%d\n",
                     p.second.ToString(), pnode->GetId());
                 g_connman->PushMessage(pnode, msgMaker.Make(NetMsgType::QSIGSHARESINV, p.second));
+                didSend = true;
             }
         }
 
         return true;
     });
+
+    return didSend;
 }
 
 void CSigSharesManager::Cleanup()
@@ -1099,19 +1108,22 @@ void CSigSharesManager::BanNode(NodeId nodeId)
 
 void CSigSharesManager::WorkThreadMain()
 {
-    int64_t lastProcessTime = GetTimeMillis();
     while (!interruptSigningShare) {
+        bool didWork = false;
+
         RemoveBannedNodeStates();
-        quorumSigningManager->ProcessPendingRecoveredSigs(*g_connman);
-        ProcessPendingSigShares(*g_connman);
-        SignPendingSigShares();
+        didWork |= quorumSigningManager->ProcessPendingRecoveredSigs(*g_connman);
+        didWork |= ProcessPendingSigShares(*g_connman);
+        didWork |= SignPendingSigShares();
         SendMessages();
         Cleanup();
         quorumSigningManager->Cleanup();
 
         // TODO Wakeup when pending signing is needed?
-        if (!interruptSigningShare.sleep_for(std::chrono::milliseconds(100))) {
-            return;
+        if(!didWork) {
+            if (!interruptSigningShare.sleep_for(std::chrono::milliseconds(100))) {
+                return;
+            }
         }
     }
 }
@@ -1122,7 +1134,7 @@ void CSigSharesManager::AsyncSign(const CQuorumCPtr& quorum, const uint256& id, 
     pendingSigns.emplace_back(quorum, id, msgHash);
 }
 
-void CSigSharesManager::SignPendingSigShares()
+bool CSigSharesManager::SignPendingSigShares()
 {
     std::vector<std::tuple<const CQuorumCPtr, uint256, uint256>> v;
     {
@@ -1133,6 +1145,8 @@ void CSigSharesManager::SignPendingSigShares()
     for (auto& t : v) {
         Sign(std::get<0>(t), std::get<1>(t), std::get<2>(t));
     }
+
+    return !v.empty();
 }
 
 void CSigSharesManager::Sign(const CQuorumCPtr& quorum, const uint256& id, const uint256& msgHash)

--- a/src/llmq/quorums_signing_shares.h
+++ b/src/llmq/quorums_signing_shares.h
@@ -38,7 +38,7 @@ public:
     uint16_t quorumMember;
     uint256 id;
     uint256 msgHash;
-    CBLSSignature sigShare;
+    CBLSLazySignature sigShare;
 
     SigShareKey key;
 
@@ -94,50 +94,17 @@ public:
     uint256 quorumHash;
     uint256 id;
     uint256 msgHash;
-    std::vector<std::pair<uint16_t, CBLSSignature>> sigShares;
+    std::vector<std::pair<uint16_t, CBLSLazySignature>> sigShares;
 
 public:
-    template <typename Stream, typename Operation>
-    inline void SerializationOpBase(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(CBatchedSigShares, obj)
     {
-        READWRITE(llmqType);
-        READWRITE(quorumHash);
-        READWRITE(id);
-        READWRITE(msgHash);
-        ::Serialize(s, llmqType);
+        READWRITE(obj.llmqType);
+        READWRITE(obj.quorumHash);
+        READWRITE(obj.id);
+        READWRITE(obj.msgHash);
+        READWRITE(obj.sigShares);
     }
-
-    template <typename Stream>
-    inline void Serialize(Stream& s) const
-    {
-        s << llmqType;
-        s << quorumHash;
-        s << id;
-        s << msgHash;
-        // this->SerializationOpBase(s, CSerActionSerialize());
-        s << sigShares;
-    }
-    template <typename Stream>
-    inline void Unserialize(Stream& s)
-    {
-        // this->SerializationOpBase(s, CSerActionUnserialize());
-        s >> llmqType;
-        s >> quorumHash;
-        s >> id;
-        s >> msgHash;
-        // we do custom deserialization here with the malleability check skipped for signatures
-        // we can do this here because we never use the hash of a sig share for identification and are only interested
-        // in validity
-        uint64_t nSize = ReadCompactSize(s);
-        if (nSize > 400) { // we don't support larger quorums, so this is the limit
-            throw std::ios_base::failure(strprintf("too many elements (%d) in CBatchedSigShares", nSize));
-        }
-        sigShares.resize(nSize);
-        for (size_t i = 0; i < nSize; i++) {
-            s >> sigShares[i].first;
-            sigShares[i].second.Unserialize(s, false);
-        }
-    };
 
     CSigShare RebuildSigShare(size_t idx) const
     {

--- a/src/llmq/quorums_signing_shares.h
+++ b/src/llmq/quorums_signing_shares.h
@@ -205,7 +205,7 @@ private:
     bool PreVerifyBatchedSigShares(NodeId nodeId, const CBatchedSigShares& batchedSigShares, bool& retBan);
 
     void CollectPendingSigSharesToVerify(size_t maxUniqueSessions, std::map<NodeId, std::vector<CSigShare>>& retSigShares, std::map<std::pair<Consensus::LLMQType, uint256>, CQuorumCPtr>& retQuorums);
-    void ProcessPendingSigShares(CConnman& connman);
+    bool ProcessPendingSigShares(CConnman& connman);
 
     void ProcessPendingSigSharesFromNode(NodeId nodeId, const std::vector<CSigShare>& sigShares, const std::map<std::pair<Consensus::LLMQType, uint256>, CQuorumCPtr>& quorums, CConnman& connman);
 
@@ -219,11 +219,11 @@ private:
 
     void BanNode(NodeId nodeId);
 
-    void SendMessages();
+    bool SendMessages();
     void CollectSigSharesToRequest(std::map<NodeId, std::map<uint256, CSigSharesInv>>& sigSharesToRequest);
     void CollectSigSharesToSend(std::map<NodeId, std::map<uint256, CBatchedSigShares>>& sigSharesToSend);
     void CollectSigSharesToAnnounce(std::map<NodeId, std::map<uint256, CSigSharesInv>>& sigSharesToAnnounce);
-    void SignPendingSigShares();
+    bool SignPendingSigShares();
     void WorkThreadMain();
 };
 

--- a/src/netmessagemaker.h
+++ b/src/netmessagemaker.h
@@ -18,6 +18,7 @@ public:
     {
         CSerializedNetMsg msg;
         msg.command = std::move(sCommand);
+        msg.data.reserve(4 * 1024);
         CVectorWriter{ SER_NETWORK, nFlags | nVersion, msg.data, 0, std::forward<Args>(args)... };
         return msg;
     }


### PR DESCRIPTION
Backport dash PRs (in the following order):
dashpay#2640
dashpay#2672
dashpay#2674
dashpay#2702
dashpay#2705
dashpay#2706
dashpay#2707

NB: Some or them are partial backports since most of our llmq files are already updated to a more recent upstream version. So I basically ended up picking the commits that touch only the files `quorums_signing_shares.*` and `quorums_signing.*`

I suggest to review by checking each individual commit against the corresponding upstream one