### PR TITLE
[GA] Overhaul Github Actions Workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,7 +1,14 @@
+# Copyright (c) 2020-2024 The PIVX Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 name: CI Actions for PIVX
 
 on: [push, pull_request]
 jobs:
+
+  # Pre-build linting job. This runs various lint tests.
+  # Any failures here will halt the rest of the workflow.
   lint:
     env:
       SHELLCHECK_VERSION: v0.7.1
@@ -39,25 +46,34 @@ jobs:
       - name: Lint
         run: |
           export PATH="/tmp/shellcheck-${SHELLCHECK_VERSION}:${PATH}"
-          echo $PATH
-
           git checkout -qf -B master refs/remotes/origin/master
           git checkout -qf $GITHUB_SHA
+
+          # Ensure git subtrees are not directly modified in-tree.
           test/lint/git-subtree-check.sh src/secp256k1
           test/lint/git-subtree-check.sh src/univalue
           test/lint/git-subtree-check.sh src/leveldb
           test/lint/git-subtree-check.sh src/crc32c
           test/lint/git-subtree-check.sh src/chiabls
           test/lint/git-subtree-check.sh src/immer
+
+          # Check command line argument documentation is present.
           test/lint/check-doc.py
+
+          # Ensure that all logprint(f) calls have the appropriate number of arguments.
           test/lint/logprint-scanner.py
+
+          # Run the remainder of lint tests in `test/lint/`.
           test/lint/lint-all.sh
 
+          # Verify that scripted diffs are deterministically reproducable.
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             COMMIT_RANGE="${{ github.base_ref }}..HEAD"
             test/lint/commit-script-check.sh $COMMIT_RANGE
           fi
 
+  # CMake build jobs to ensure building with CMake remains viable.
+  # Currently this only supports native linux and macOS.
   cmake:
     name: CMake-${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
@@ -89,8 +105,7 @@ jobs:
 
           - name: macOS
             os: macos-12
-            packages: llvm@13 python@3.8 autoconf automake berkeley-db@4 libtool boost@1.76 miniupnpc libnatpmp pkg-config libevent qrencode gmp libsodium rust
-            no_qt: true
+            packages: llvm@13 python@3.8 autoconf automake berkeley-db@4 libtool boost@1.76 miniupnpc libnatpmp pkg-config qt@5 zmq libevent qrencode gmp libsodium rust
             boost_root: true
             cc: $(brew --prefix llvm@13)/bin/clang
             cxx: $(brew --prefix llvm@13)/bin/clang++
@@ -109,8 +124,6 @@ jobs:
       - name: Setup Environment
         run: |
           if [[ ${{ matrix.config.os }} = ubuntu* ]]; then
-            sudo apt-add-repository "ppa:ondrej/php" -y
-            sudo apt-get --yes update
             sudo apt-get install --no-install-recommends --no-upgrade -qq "$APT_BASE" ${{ matrix.config.packages }}
           fi
           if [[ ${{ matrix.config.os }} = macos* ]]; then
@@ -124,7 +137,7 @@ jobs:
           key: ${{ runner.os }}-cmake-${{ matrix.config.name }}-ccache
           restore-keys: ${{ runner.os }}-cmake-${{ matrix.config.name }}-ccache
 
-      - name: build
+      - name: Configure CMake Wallet
         run: |
           CC=${{ matrix.config.cc }}
           CXX=${{ matrix.config.cxx }}
@@ -146,9 +159,15 @@ jobs:
           export CC
           export CXX
           mkdir -p ${{ github.workspace }}/cmake-build-debug && cd ${{ github.workspace }}/cmake-build-debug
-          cmake -DCMAKE_BUILD_TYPE=Debug -G "CodeBlocks - Unix Makefiles" ${{ github.workspace }}
+          cmake -DCMAKE_BUILD_TYPE=Debug -G "Unix Makefiles" ${{ github.workspace }}
+
+      - name: Build CMake Wallet
+        run: |
+          cd ${{ github.workspace }}/cmake-build-debug
           cmake --build ${{ github.workspace }}/cmake-build-debug --target all -- -j 2
 
+  # Autotools based build job for native linux and macOS.
+  # These builds use system/distro packages to satisfy dependencies.
   build_native_wallet:
     name: Native-${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
@@ -158,7 +177,6 @@ jobs:
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       CCACHE_SIZE: 500M
       CCACHE_COMPRESS: 1
-      PARAMS_DIR: ${{ github.workspace }}/.pivx-params
       WINEDEBUG: fixme-all
       BOOST_TEST_RANDOM: 1 # random seed based on the current time
     defaults:
@@ -171,7 +189,7 @@ jobs:
           - name: x64-Linux
             id: Linux-x86_64-nodepends
             os: ubuntu-20.04
-            apt_get: python3-zmq qtbase5-dev qttools5-dev-tools libqt5svg5-dev libqt5charts5-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev libqrencode-dev libgmp-dev libsodium-dev cargo
+            packages: python3-zmq qtbase5-dev qttools5-dev-tools libqt5svg5-dev libqt5charts5-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev libqrencode-dev libgmp-dev libsodium-dev cargo
             unit_tests: true
             functional_tests: true
             goal: install
@@ -180,7 +198,7 @@ jobs:
           - name: x64-Linux-latest
             id: Linux-x86_64-nodepends-latest
             os: ubuntu-latest
-            apt_get: python3-zmq qtbase5-dev qttools5-dev-tools libqt5svg5-dev libqt5charts5-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev libqrencode-dev libgmp-dev libsodium-dev cargo
+            packages: python3-zmq qtbase5-dev qttools5-dev-tools libqt5svg5-dev libqt5charts5-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev libqrencode-dev libgmp-dev libsodium-dev cargo
             unit_tests: true
             functional_tests: true
             goal: install
@@ -189,17 +207,17 @@ jobs:
           - name: x64-macOS
             id: macOS-nodepends
             os: macos-12
-            brew_install: autoconf automake ccache berkeley-db@4 libtool boost@1.76 miniupnpc libnatpmp pkg-config python@3.8 libevent qrencode gmp libsodium rust librsvg
+            packages: autoconf automake ccache berkeley-db@4 libtool boost@1.76 miniupnpc libnatpmp pkg-config python@3.8 libevent qrencode gmp libsodium rust librsvg
             unit_tests: true
             functional_tests: true
             cc: clang
             cxx: clang++
             BITCOIN_CONFIG: "--enable-zmq --enable-gui --enable-reduce-exports --enable-werror --enable-debug --with-boost=/usr/local/opt/boost@1.76"
 
-          - name: x64-macOS-latest
+          - name: arm64-macOS-latest
             id: macOS-nodepends-latest
             os: macos-14
-            brew_install: autoconf automake ccache berkeley-db@4 libtool boost@1.76 miniupnpc libnatpmp pkg-config python@3.8 qt@5 zmq libevent qrencode gmp libsodium rust librsvg
+            packages: autoconf automake ccache berkeley-db@4 libtool boost@1.76 miniupnpc libnatpmp pkg-config python@3.8 qt@5 zmq libevent qrencode gmp libsodium rust librsvg
             unit_tests: true
             functional_tests: true
             goal: deploy
@@ -214,31 +232,22 @@ jobs:
       - name: Setup Environment
         run: |
           if [[ ${{ matrix.config.os }} = ubuntu* ]]; then
-            sudo apt-add-repository "ppa:ondrej/php" -y
-            sudo apt-get --yes update
-            sudo apt-get install --no-install-recommends --no-upgrade -qq "$APT_BASE" ${{ matrix.config.apt_get }}
+            sudo apt-get install --no-install-recommends --no-upgrade -qq "$APT_BASE" ${{ matrix.config.packages }}
           fi
           if [[ ${{ matrix.config.os }} = macos* ]]; then
-            brew install ${{ matrix.config.brew_install }}
+            brew install ${{ matrix.config.packages }}
             pip3.8 install ds_store mac_alias
           fi
 
       - name: ccache cache files
         uses: actions/cache@v4
         with:
-          path: |
-            .ccache
-            .pivx-params
+          path: .ccache
           key: ${{ runner.os }}-${{ matrix.config.id }}-native-ccache
           restore-keys: ${{ runner.os }}-${{ matrix.config.id }}-native-ccache
 
-      - name: Build Syslib Wallet
+      - name: Configure Native Wallet
         run: |
-          export LC_ALL=C.UTF-8
-
-          echo $CCACHE_DIR
-          echo $PARAMS_DIR
-
           PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
           # Add llvm-symbolizer directory to PATH. Needed to get symbolized stack traces from the sanitizers.
           PATH=$PATH:/usr/lib/llvm-6.0/bin/
@@ -257,40 +266,124 @@ jobs:
           fi
 
           if [ "${{ matrix.config.unit_tests }}" = "true" ] || [ "${{ matrix.config.functional_tests }}" = "true" ]; then
-            mkdir -p $PARAMS_DIR
-            PARAMS_FLAGS="--with-params-dir=$PARAMS_DIR"
+            ./params/install-params.sh
           fi
 
           echo ::group::Autogen
           ./autogen.sh
           echo ::endgroup::
 
+          mkdir build && cd build
+
           echo ::group::Configure
-          ./configure --cache-file=config.cache $BITCOIN_CONFIG_ALL ${{ matrix.config.BITCOIN_CONFIG }} $PARAMS_FLAGS || ( cat config.log && false)
+          ../configure --cache-file=config.cache $BITCOIN_CONFIG_ALL ${{ matrix.config.BITCOIN_CONFIG }} || ( cat config.log && false)
           echo ::endgroup
 
-          echo ::group::Build
-          make -j2 ${{ matrix.config.goal }} || ( echo "Build failure. Verbose build follows." && make ${{ matrix.config.goal }} V=1 ; false )
+          echo ::group::Distdir
+          make distdir VERSION=${{ matrix.config.os }}
           echo ::endgroup::
 
-          if [ "${{ matrix.config.unit_tests }}" = "true" ] || [ "${{ matrix.config.functional_tests }}" = "true" ]; then
-            echo ::group::Params
-            ./params/install-params.sh $PARAMS_DIR
-            echo ::endgroup::
+          cd pivx-${{ matrix.config.os }}
+
+          echo ::group::Configure
+          ./configure --cache-file=../config.cache $BITCOIN_CONFIG_ALL ${{ matrix.config.BITCOIN_CONFIG }} || ( cat config.log && false)
+          echo ::endgroup
+
+      - name: Build Native Wallet
+        run: |
+          cd build/pivx-${{ matrix.config.os }}/
+          make -j2 ${{ matrix.config.goal }} || ( echo "Build failure. Verbose build follows." && make ${{ matrix.config.goal }} V=1 ; false )
+
+      - name: Run Unit Tests
+        if: matrix.config.unit_tests == true
+        run: |
+          cd build/pivx-${{ matrix.config.os }}/
+          make -j2 check VERBOSE=1
+
+      - name: Create Tar Archive
+        if: matrix.config.functional_tests == true
+        run: |
+          strip build/pivx-${{ matrix.config.os }}/src/pivxd
+          strip build/pivx-${{ matrix.config.os }}/src/pivx-cli
+          tar -hcvf native-${{ matrix.config.os }}-built.tar \
+            build/pivx-${{ matrix.config.os }}/share/rpcauth/ \
+            build/pivx-${{ matrix.config.os }}/test/ \
+            build/pivx-${{ matrix.config.os }}/params/ \
+            build/pivx-${{ matrix.config.os }}/src/pivxd \
+            build/pivx-${{ matrix.config.os }}/src/pivx-cli \
+            build/pivx-${{ matrix.config.os }}/src/test/data/asmap.raw
+
+      - name: Upload Build Artifact
+        if: matrix.config.functional_tests == true
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-${{ matrix.config.os }}-built
+          path: native-${{ matrix.config.os }}-built.tar
+          retention-days: 5
+
+  # Job to run the python functional test suite for native linux and macOS builds.
+  # Uses a build artifact from the previous job to provide pivxd/pivx-cli and the test suite files.
+  test_native_wallet:
+    name: Native-${{ matrix.config.name }}-tests
+    runs-on: ${{ matrix.config.os }}
+    needs: build_native_wallet
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: x64-Linux
+            id: Linux-x86_64-nodepends-tests
+            os: ubuntu-20.04
+            packages: python3-zmq libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev libqrencode-dev libgmp-dev libsodium-dev
+
+          - name: x64-Linux-latest
+            id: Linux-x86_64-nodepends-latest-tests
+            os: ubuntu-latest
+            packages: python3-zmq libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev libqrencode-dev libgmp-dev libsodium-dev
+
+          - name: x64-macOS
+            id: macOS-nodepends
+            os: macos-12
+            packages: python@3.8 berkeley-db@4 boost@1.76 miniupnpc libnatpmp pkg-config zmq libevent qrencode gmp libsodium
+
+          - name: arm64-macOS-latest
+            id: macOS-nodepends-latest
+            os: macos-14
+            packages: python@3.8 berkeley-db@4 boost@1.76 miniupnpc libnatpmp pkg-config zmq libevent qrencode gmp libsodium
+
+    steps:
+      - name: Setup Environment
+        run: |
+          if [[ ${{ matrix.config.os }} = ubuntu* ]]; then
+            sudo apt-get install --no-install-recommends --no-upgrade -qq ${{ matrix.config.packages }}
+          fi
+          if [[ ${{ matrix.config.os }} = macos* ]]; then
+            brew install ${{ matrix.config.packages }}
           fi
 
-          if [ "${{ matrix.config.unit_tests }}" = "true" ]; then
-            echo ::group::Unit-Tests
-            make -j2 check VERBOSE=1
-            echo ::endgroup::
-          fi
+      - name: Download Build Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: native-${{ matrix.config.os }}-built
 
-          if [ "${{ matrix.config.functional_tests }}" = "true" ]; then
-            echo ::group::Functional-Tests
-            test/functional/test_runner.py --combinedlogslen=4000 ${{ matrix.config.test_runner_extra }}
-            echo ::endgroup::
-          fi
+      - name: Extract Artifact Archive
+        run: tar -xvf native-${{ matrix.config.os }}-built.tar
 
+      - name: Install PIVX Params
+        run: |
+          cd build/pivx-${{ matrix.config.os }}/params/
+          ./install-params.sh
+
+      - name: Run Functional Tests
+        run: |
+          cd build/pivx-${{ matrix.config.os }}/
+          test/functional/test_runner.py --combinedlogslen=4000 ${{ matrix.config.test_runner_extra }}
+
+  # Job to compile all dependencies deterministically using the depends build system.
+  # Results are cached for repeat use across workflow runs.
   build_depends:
     name: Depends-${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
@@ -308,33 +401,33 @@ jobs:
           - name: ARM 32-bit
             os: ubuntu-20.04
             host: arm-linux-gnueabihf
-            apt_get: python3 g++-arm-linux-gnueabihf
+            packages: python3 g++-arm-linux-gnueabihf
 
           - name: AARCH64
             os: ubuntu-20.04
             host: aarch64-linux-gnu
-            apt_get: python3 g++-aarch64-linux-gnu
+            packages: python3 g++-aarch64-linux-gnu
 
           - name: Win64
             os: ubuntu-20.04
             host: x86_64-w64-mingw32
-            apt_get: python3 nsis g++-mingw-w64-x86-64 wine-binfmt wine64
+            packages: python3 nsis g++-mingw-w64-x86-64 wine-binfmt wine64
 
           - name: 32-bit + dash
             os: ubuntu-20.04
             host: i686-pc-linux-gnu
-            apt_get: g++-multilib python3-zmq
+            packages: g++-multilib python3-zmq
 
           - name: x86_64 Linux
             os: ubuntu-20.04
             host: x86_64-unknown-linux-gnu
-            apt_get: python3-zmq
+            packages: python3-zmq
             dep_opts: DEBUG=1
 
           - name: macOS 10.12
             os: ubuntu-20.04
             host: x86_64-apple-darwin16
-            apt_get: cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python3-dev python3-setuptools
+            packages: cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python3-dev python3-setuptools
             XCODE_VERSION: 11.3.1
             XCODE_BUILD_ID: 11C505
 
@@ -343,9 +436,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Environment
-        run: |
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends --no-upgrade -qq "$APT_BASE" ${{ matrix.config.apt_get }}
+        run: sudo apt-get install --no-install-recommends --no-upgrade -qq "$APT_BASE" ${{ matrix.config.packages }}
 
       - name: depends cache files
         uses: actions/cache@v4
@@ -359,8 +450,6 @@ jobs:
 
       - name: Build Depends
         run: |
-          export LC_ALL=C.UTF-8
-
           PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
           # Add llvm-symbolizer directory to PATH. Needed to get symbolized stack traces from the sanitizers.
           PATH=$PATH:/usr/lib/llvm-6.0/bin/
@@ -388,6 +477,8 @@ jobs:
             make -j2 -C depends HOST=${{ matrix.config.host }} ${{ matrix.config.dep_opts }}
           fi
 
+  # Autotools based build job for depends based builds.
+  # These builds use cached depends results to satisfy dependencies.
   build_depends_wallet:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
@@ -395,9 +486,8 @@ jobs:
     env:
       APT_BASE: ccache
       CCACHE_DIR: ${{ github.workspace }}/.ccache
-      CCACHE_SIZE: 500M
+      CCACHE_SIZE: 900M
       CCACHE_COMPRESS: 1
-      PARAMS_DIR: ${{ github.workspace }}/.pivx-params
       WINEDEBUG: fixme-all
       BOOST_TEST_RANDOM: 1 # random seed based on the current time
     defaults:
@@ -407,11 +497,11 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - name: ARM 32-bit [GOAL:install] [no unit or functional tests]
-            id: ARM32
+          - name: ARM 32-bit [GOAL:install]
+            id: ARM32-build
             os: ubuntu-20.04
             host: arm-linux-gnueabihf
-            apt_get: python3 g++-arm-linux-gnueabihf
+            packages: python3 g++-arm-linux-gnueabihf
             unit_tests: false
             functional_tests: false
             goal: install
@@ -419,21 +509,21 @@ jobs:
             # This could be removed once the ABI change warning does not show up by default
             BITCOIN_CONFIG: "--with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports --disable-online-rust CXXFLAGS=-Wno-psabi LDFLAGS=-static-libstdc++"
 
-          - name: AARCH64 [GOAL:install] [no unit or functional tests]
-            id: ARM64
+          - name: AARCH64 [GOAL:install]
+            id: ARM64-build
             os: ubuntu-20.04
             host: aarch64-linux-gnu
-            apt_get: python3 g++-aarch64-linux-gnu
+            packages: python3 g++-aarch64-linux-gnu
             unit_tests: false
             functional_tests: false
             goal: install
             BITCOIN_CONFIG: "--with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports --disable-online-rust LDFLAGS=-static-libstdc++"
 
-          - name: Win64 [GOAL:deploy] [no unit or functional tests]
-            id: Win64
+          - name: Win64 [GOAL:deploy]
+            id: Win64-build
             os: ubuntu-20.04
             host: x86_64-w64-mingw32
-            apt_get: python3 nsis g++-mingw-w64-x86-64 wine-binfmt wine64
+            packages: python3 nsis g++-mingw-w64-x86-64 wine-binfmt wine64
             unit_tests: false
             functional_tests: false
             symbol_check: true
@@ -441,36 +531,24 @@ jobs:
             BITCOIN_CONFIG: "--with-gui=auto --enable-reduce-exports --disable-online-rust"
 
           - name: x86_64 Linux [GOAL:install]
-            id: Linux-x86_64
+            id: Linux-x86_64-build
             os: ubuntu-20.04
             host: x86_64-unknown-linux-gnu
-            apt_get: python3-zmq
+            packages: python3-zmq
             unit_tests: true
             functional_tests: true
             goal: install
-            test_runner_extra: "--coverage --all  --exclude feature_dbcrash"
             BITCOIN_CONFIG: "--enable-zmq --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports --disable-online-rust LDFLAGS=-static-libstdc++"
 
-          - name: x86_64 Linux [GOAL:install] [no GUI, no unit tests, only functional tests on legacy pre-HD wallets]
-            id: Linux-x86_64-nogui
-            os: ubuntu-20.04
-            host: x86_64-unknown-linux-gnu
-            apt_get: python3-zmq
-            unit_tests: false
-            functional_tests: true
-            goal: install
-            test_runner_extra: "--legacywallet"
-            BITCOIN_CONFIG: "--enable-zmq --with-gui=no --enable-glibc-back-compat --enable-reduce-exports --disable-online-rust LDFLAGS=-static-libstdc++"
-
-          - name: macOS 10.12 [GOAL:deploy] [no unit or functional tests]
-            id: macOS10.12
+          - name: macOS 10.12 [GOAL:deploy]
+            id: macOS10.12-build
             os: ubuntu-20.04
             host: x86_64-apple-darwin16
-            apt_get: cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python3-dev python3-setuptools
+            packages: cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python3-dev python3-setuptools
             XCODE_VERSION: 11.3.1
             XCODE_BUILD_ID: 11C505
             unit_tests: false
-            functional_tests: false
+            functional_tests: true
             symbol_check: true
             goal: deploy
             BITCOIN_CONFIG: "--enable-gui --enable-reduce-exports --enable-werror --disable-online-rust"
@@ -480,16 +558,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Environment
-        run: |
-          if [[ ${{ matrix.config.os }} = ubuntu* ]]; then
-            sudo apt-add-repository "ppa:ondrej/php" -y
-            sudo apt-get --yes update
-            sudo apt-get install --no-install-recommends --no-upgrade -qq "$APT_BASE" ${{ matrix.config.apt_get }}
-          fi
-          if [[ ${{ matrix.config.os }} = macos* ]]; then
-            brew install ${{ matrix.config.brew_install }}
-            pip3.8 install ds_store mac_alias
-          fi
+        run: sudo apt-get install --no-install-recommends --no-upgrade -qq "$APT_BASE" ${{ matrix.config.packages }}
 
       - name: depends cache files
         if: matrix.config.no_depends != 1
@@ -505,19 +574,12 @@ jobs:
       - name: ccache cache files
         uses: actions/cache@v4
         with:
-          path: |
-            .ccache
-            .pivx-params
+          path: .ccache
           key: ${{ runner.os }}-depbuild-${{ matrix.config.id }}-ccache
           restore-keys: ${{ runner.os }}-depbuilt-${{ matrix.config.id }}-ccache
 
-      - name: Build Wallet
+      - name: Configure Wallet
         run: |
-          export LC_ALL=C.UTF-8
-
-          echo $CCACHE_DIR
-          echo $PARAMS_DIR
-
           PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
           # Add llvm-symbolizer directory to PATH. Needed to get symbolized stack traces from the sanitizers.
           PATH=$PATH:/usr/lib/llvm-6.0/bin/
@@ -542,21 +604,13 @@ jobs:
             sudo update-binfmts --import /usr/share/binfmts/wine
           fi
 
-          if [[ ${{ matrix.config.os }} = macos* ]]; then
-            CC=${{ matrix.config.cc }}
-            CXX=${{ matrix.config.cxx }}
-            export CC
-            export CXX
-          fi
-
           if [[ ${{ matrix.config.os }} = ubuntu* ]]; then
             OUTDIR_PATH="$GITHUB_WORKSPACE/$GITHUB_RUN_NUMBER-${{ matrix.config.host }}"
             BITCOIN_CONFIG_ALL="--disable-dependency-tracking --prefix=$GITHUB_WORKSPACE/depends/${{ matrix.config.host }} --bindir=$OUTDIR_PATH/bin --libdir=$OUTDIR_PATH/lib"
           fi
 
           if [ "${{ matrix.config.unit_tests }}" = "true" ] || [ "${{ matrix.config.functional_tests }}" = "true" ]; then
-            mkdir -p $PARAMS_DIR
-            PARAMS_FLAGS="--with-params-dir=$PARAMS_DIR"
+            ./params/install-params.sh
           fi
 
           echo ::group::Autogen
@@ -566,7 +620,7 @@ jobs:
           mkdir build && cd build
 
           echo ::group::Configure
-          ../configure --cache-file=config.cache $BITCOIN_CONFIG_ALL ${{ matrix.config.BITCOIN_CONFIG }} $PARAMS_FLAGS || ( cat config.log && false)
+          ../configure --cache-file=config.cache $BITCOIN_CONFIG_ALL ${{ matrix.config.BITCOIN_CONFIG }} || ( cat config.log && false)
           echo ::endgroup::
 
           echo ::group::Distdir
@@ -576,41 +630,117 @@ jobs:
           cd pivx-${{ matrix.config.host }}
 
           echo ::group::Configure
-          ./configure --cache-file=../config.cache $BITCOIN_CONFIG_ALL ${{ matrix.config.BITCOIN_CONFIG }} $PARAMS_FLAGS || ( cat config.log && false)
+          ./configure --cache-file=../config.cache $BITCOIN_CONFIG_ALL ${{ matrix.config.BITCOIN_CONFIG }} || ( cat config.log && false)
           echo ::endgroup
 
-          echo ::group::Build
+      - name: Build Wallet
+        run: |
+          cd build/pivx-${{ matrix.config.host }}/
           make -j2 ${{ matrix.config.goal }} || ( echo "Build failure. Verbose build follows." && make ${{ matrix.config.goal }} V=1 ; false )
-          echo ::endgroup::
 
-          if [ "${{ matrix.config.unit_tests }}" = "true" ] || [ "${{ matrix.config.functional_tests }}" = "true" ]; then
-            echo ::group::Params
-            ./params/install-params.sh $PARAMS_DIR
-            echo ::endgroup::
-          fi
-
-          echo ::group::Security-Check
+      - name: Check Security
+        run: |
+          cd build/pivx-${{ matrix.config.host }}/
           make -j2 -C src check-security
-          echo ::endgroup::
 
-          if [ "${{matrix.config.symbol_check }}" = "true" ]; then
-            echo ::group::Symbol-Check
-            make -j2 -C src check-symbols
-            echo ::endgroup::
+      - name: Check Exported Symbols
+        if: matrix.config.symbol_check == true
+        run: |
+          cd build/pivx-${{ matrix.config.host }}/
+          make -j2 -C src check-symbols
+
+      - name: Run Unit Tests
+        if: matrix.config.unit_tests == true
+        run: |
+          cd build/pivx-${{ matrix.config.host }}
+          make -j2 check VERBOSE=1
+
+      - name: Create Tar Archive
+        if: matrix.config.functional_tests == true
+        run: |
+          if [[ ${{ matrix.config.host }} != *apple* ]]; then
+            strip build/pivx-${{ matrix.config.host }}/src/pivxd
+            strip build/pivx-${{ matrix.config.host }}/src/pivx-cli
+          fi
+          tar -hcvf ${{ matrix.config.host }}-built.tar \
+            build/pivx-${{ matrix.config.host }}/share/rpcauth \
+            build/pivx-${{ matrix.config.host }}/test/ \
+            build/pivx-${{ matrix.config.host }}/params/ \
+            build/pivx-${{ matrix.config.host }}/src/pivxd \
+            build/pivx-${{ matrix.config.host }}/src/pivx-cli \
+            build/pivx-${{ matrix.config.host }}/src/test/data/asmap.raw
+
+      - name: Upload Build Artifact
+        if: matrix.config.functional_tests == true
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.config.host }}-built
+          path: ${{ matrix.config.host }}-built.tar
+          retention-days: 5
+
+  # Job to run the python functional test suite for depends based linux builds.
+  # Uses a build artifact from the previous job to provide pivxd/pivx-cli and the test suite files.
+  test_depends_wallet:
+    name: Test-Depends-${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    needs: build_depends_wallet
+    env:
+      PARAMS_DIR: ${{ github.workspace }}/.pivx-params
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: x86_64 Linux [Full Functional Tests]
+            id: Linux-x86_64-tests
+            os: ubuntu-20.04
+            host: x86_64-unknown-linux-gnu
+            packages: python3-zmq
+            test_runner_extra: "--coverage --all --exclude feature_dbcrash"
+
+          - name: x86_64 Linux [Only functional tests on legacy pre-HD wallets]
+            id: Linux-x86_64-legacy-tests
+            os: ubuntu-20.04
+            host: x86_64-unknown-linux-gnu
+            packages: python3-zmq
+            test_runner_extra: "--legacywallet"
+
+          - name: x86_64 macOS [Full Functional Tests]
+            id: macos-x86_64-tests
+            os: macos-12
+            host: x86_64-apple-darwin16
+            packages: python@3.8
+            test_runner_extra: "--all --exclude feature_dbcrash"
+
+    steps:
+      - name: Setup Environment
+        run: |
+          if [[ ${{ matrix.config.os }} = ubuntu* ]]; then
+            sudo apt-get install --no-install-recommends --no-upgrade -qq ${{ matrix.config.packages }}
+          fi
+          if [[ ${{ matrix.config.os }} = macos* ]]; then
+            brew install ${{ matrix.config.packages }}
           fi
 
-          if [ "${{ matrix.config.unit_tests }}" = "true" ]; then
-            echo ::group::Unit-Tests
-            if [[ ${{ matrix.config.os }} = ubuntu* ]]; then
-              LD_LIBRARY_PATH=$GITHUB_WORKSPACE/depends/"${{ matrix.config.host }}"/lib make -j2 check VERBOSE=1
-            else
-              make -j2 check VERBOSE=1
-            fi
-            echo ::endgroup::
-          fi
+      - name: Download Build Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.config.host }}-built
 
-          if [ "${{ matrix.config.functional_tests }}" = "true" ]; then
-            echo ::group::Functional-Tests
-            test/functional/test_runner.py --combinedlogslen=4000 ${{ matrix.config.test_runner_extra }}
-            echo ::endgroup::
+      - name: Extract Artifact Archive
+        run: tar -xvf ${{ matrix.config.host }}-built.tar
+
+      - name: Install PIVX Params
+        run: |
+          cd build/pivx-${{ matrix.config.host }}/params/
+          ./install-params.sh
+
+      - name: Run Functional Tests
+        run: |
+          cd build/pivx-${{ matrix.config.host }}/
+          if [[ ${{ matrix.config.os }} = macos* ]]; then
+            sed -i.old 's/home/Users/' test/config.ini
           fi
+          test/functional/test_runner.py --combinedlogslen=4000 ${{ matrix.config.test_runner_extra }}


### PR DESCRIPTION
This is a major overhaul of our GitHub Actions workflow file that introduces several cleanups and optimizations, as well as new jobs dedicated to running just the python functional test suite. Below are some of the more notable changes:

- Split off functional tests to their own jobs. Often times we will see a trivial failure in one of the functional tests. Prior to this change, this meant needing to re-run the entire build job again. With this change, we can trigger a re-run of just the functional test suite without needing to re-compile the wallet again. This is handled by creating a minimal archive "artifact" in the build job, and passing it to the new functional test jobs. Credit goes to @Duddino for coming up with this idea and doing much of the initial research and testing!
- Split old configure/build/unittest groupings into their own steps. Instead of exclusively relying on older group macros in a single step, I've created new more descriptive steps to improve readability and responsiveness of the actions report portal. This also helps in seeing where any significant bottle-neck is for a particular job configuration.
- Unify the `apt_get` and `brew_install` matrix config params. These two params have been unified to just `packages` across all matrix configurations.
- No longer cache the sapling params. Since the sapling params files are part of our source tree anyways, caching them in GitHub Actions cache files is redundant and only serves to waste valuable cache storage space.
- Add some basic descriptive commentary for jobs. Self-explanatory.

Note: The minimalist build artifacts are ONLY intended to be used within the GitHub Actions environment and expire after 5 days from their creation. Failing functional tests that are not resolved within this expiry time will necessitate a full re-run of the workflow. Any use of these artifacts outside of GitHub Actions is discouraged and unsupported.

---
Reviewer's note: GitHub will report this PR as not having all the "required checks" as passing as the names/IDs of jobs have been changed. Once this PR is merged it will be then possible to update the repository settings to reflect the new job names/IDs in the "required checks" settings.