### PR TITLE
[Bug] Exit early for budget submission when the wallet is locked

### DIFF
--- a/src/budget/budgetmanager.cpp
+++ b/src/budget/budgetmanager.cpp
@@ -165,6 +165,11 @@ uint256 CBudgetManager::SubmitFinalBudget()
             LogPrint(BCLog::MNBUDGET,"%s: Wallet not found\n", __func__);
             return UINT256_ZERO;
         }
+        // Exit if wallet is locked
+        if (vpwallets[0]->IsLocked()) {
+            LogPrint(BCLog::MNBUDGET, "%s: Wallet is locked, can't make collateral transaction.\n", __func__);
+            return UINT256_ZERO;
+        }
         CReserveKey keyChange(vpwallets[0]);
         if (!vpwallets[0]->CreateBudgetFeeTX(wtx, budgetHash, keyChange, BUDGET_FEE_TX)) {
             LogPrint(BCLog::MNBUDGET,"%s: Can't make collateral transaction\n", __func__);


### PR DESCRIPTION
When the wallet is configured for budget submission, an issue arises where the keypool gets exhausted when the wallet is locked, causing a crash. This prevents such behavior.