### PR TITLE
[GA] Resolve latest macos-14 runner build failures

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -146,6 +146,12 @@ jobs:
           key: ${{ runner.os }}-cmake-${{ matrix.config.name }}-ccache
           restore-keys: ${{ runner.os }}-cmake-${{ matrix.config.name }}-ccache
 
+      - name: Set Xcode Version
+        if: matrix.config.os == 'macos-14'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '15.0.1'
+
       - name: Configure CMake Wallet
         run: |
           CC=${{ matrix.config.cc }}
@@ -265,6 +271,12 @@ jobs:
           path: .ccache
           key: ${{ runner.os }}-${{ matrix.config.id }}-native-ccache
           restore-keys: ${{ runner.os }}-${{ matrix.config.id }}-native-ccache
+
+      - name: Set Xcode Version
+        if: matrix.config.os == 'macos-14'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '15.0.1'
 
       - name: Configure Native Wallet
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -133,6 +133,7 @@ jobs:
       - name: Setup Environment
         run: |
           if [[ ${{ matrix.config.os }} = ubuntu* ]]; then
+            sudo apt-get update
             sudo apt-get install --no-install-recommends --no-upgrade -qq "$APT_BASE" ${{ matrix.config.packages }}
           fi
           if [[ ${{ matrix.config.os }} = macos* ]]; then
@@ -258,6 +259,7 @@ jobs:
       - name: Setup Environment
         run: |
           if [[ ${{ matrix.config.os }} = ubuntu* ]]; then
+            sudo apt-get update
             sudo apt-get install --no-install-recommends --no-upgrade -qq "$APT_BASE" ${{ matrix.config.packages }}
           fi
           if [[ ${{ matrix.config.os }} = macos* ]]; then
@@ -406,6 +408,7 @@ jobs:
       - name: Setup Environment
         run: |
           if [[ ${{ matrix.config.os }} = ubuntu* ]]; then
+            sudo apt-get update
             sudo apt-get install --no-install-recommends --no-upgrade -qq ${{ matrix.config.packages }}
           fi
           if [[ ${{ matrix.config.os }} = macos* ]]; then
@@ -787,6 +790,7 @@ jobs:
         run: |
           if [[ ${{ matrix.config.packages }} != None ]]; then
             if [[ ${{ matrix.config.os }} = ubuntu* ]]; then
+              sudo apt-get update
               sudo apt-get install --no-install-recommends --no-upgrade -qq ${{ matrix.config.packages }}
             fi
             if [[ ${{ matrix.config.os }} = macos* ]]; then

--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -133,7 +133,6 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
       _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)],[-lqxcb -lxcb-static])
       AC_DEFINE([QT_QPA_PLATFORM_XCB], [1], [Define this symbol if the Qt platform is XCB])
     elif test "x$TARGET_OS" = xdarwin; then
-      AX_CHECK_LINK_FLAG([-framework IOKit], [QT_LIBS="$QT_LIBS -framework IOKit"], [AC_MSG_ERROR([could not link iokit framework])])
       _BITCOIN_QT_CHECK_STATIC_PLUGINS([Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin)],[-lqcocoa])
       AC_DEFINE([QT_QPA_PLATFORM_COCOA], [1], [Define this symbol if the Qt platform is Cocoa])
     fi
@@ -204,7 +203,7 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
     *darwin*)
      BITCOIN_QT_CHECK([
        MOC_DEFS="${MOC_DEFS} -DQ_OS_MAC"
-       base_frameworks="-framework Foundation -framework ApplicationServices -framework AppKit"
+       base_frameworks="-framework Foundation -framework AppKit"
        AX_CHECK_LINK_FLAG([$base_frameworks], [QT_LIBS="$QT_LIBS $base_frameworks"], [AC_MSG_ERROR([could not find base frameworks])])
      ])
     ;;

--- a/src/qt/notificator.cpp
+++ b/src/qt/notificator.cpp
@@ -18,13 +18,8 @@
 #include <QtDBus>
 #include <stdint.h>
 #endif
-// Include ApplicationServices.h after QtDbus to avoid redefinition of check().
-// This affects at least OSX 10.6. See /usr/include/AssertMacros.h for details.
-// Note: This could also be worked around using:
-// #define __ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES 0
 #ifdef Q_OS_MAC
 #include "macnotificationhandler.h"
-#include <ApplicationServices/ApplicationServices.h>
 #endif
 
 


### PR DESCRIPTION
GA updated the version of XCode used for their macos-14 runners to a version that has known compatibility issues. For now, we can get around this by pinning the XCode version the runner's environment uses.

Semi-related: included a commit to remove un-used macOS framework libs (ref: https://github.com/bitcoin/bitcoin/pull/20496)

And lastly, while finalizing this PR, GA's apt cache decided to go out of sync, so now force an apt update prior to package installation.