### PR TITLE
[RPC][Backport] JSON-RPC 2.0 when Client requests

### DIFF
--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -63,9 +63,6 @@ static std::unique_ptr<HTTPRPCTimerInterface> httpRPCTimerInterface;
 
 static void JSONErrorReply(HTTPRequest* req, UniValue objError, const JSONRPCRequest& jreq)
 {
-    // Sending HTTP errors is a legacy JSON-RPC behavior.
-    Assume(jreq.m_json_version != JSONRPCVersion::V2);
-
     // Send error reply from json-rpc error object
     int nStatus = HTTP_INTERNAL_SERVER_ERROR;
     int code = find_value(objError, "code").get_int();
@@ -180,22 +177,10 @@ static bool HTTPReq_JSONRPC(HTTPRequest* req, const std::string &)
 
         std::string strReply;
         UniValue reply;
-        bool user_has_whitelist = g_rpc_whitelist.count(jreq.authUser);
-        if (!user_has_whitelist && g_rpc_whitelist_default) {
-            LogPrintf("RPC User %s not allowed to call any methods\n", jreq.authUser);
-            req->WriteReply(HTTP_FORBIDDEN);
-            return false;
 
         // singleton request
         if (valRequest.isObject()) {
             jreq.parse(valRequest);
-            if (user_has_whitelist && !g_rpc_whitelist[jreq.authUser].count(jreq.strMethod)) {
-                LogPrintf("RPC User %s not allowed to call method %s\n", jreq.authUser, jreq.strMethod);
-                req->WriteReply(HTTP_FORBIDDEN);
-                return false;
-            }
-
-            UniValue result = tableRPC.execute(jreq);
 
             // Legacy 1.0/1.1 behavior is for failed requests to throw
             // exceptions which return HTTP errors and RPC errors to the client.
@@ -212,7 +197,37 @@ static bool HTTPReq_JSONRPC(HTTPRequest* req, const std::string &)
 
         // array of requests
         } else if (valRequest.isArray())
-            strReply = JSONRPCExecBatch(valRequest.get_array());
+            // Execute each request
+            reply = UniValue::VARR;
+            for (size_t i{0}; i < valRequest.size(); ++i) {
+                // Batches never throw HTTP errors, they are always just included
+                // in "HTTP OK" responses. Notifications never get any response.
+                UniValue response;
+                try {
+                    jreq.parse(valRequest[i]);
+                    response = JSONRPCExec(jreq, /*catch_errors=*/true);
+                } catch (UniValue& e) {
+                    response = JSONRPCReplyObj(NullUniValue, std::move(e), jreq.id, jreq.m_json_version);
+                } catch (const std::exception& e) {
+                    response = JSONRPCReplyObj(NullUniValue, JSONRPCError(RPC_PARSE_ERROR, e.what()), jreq.id, jreq.m_json_version);
+                }
+                if (!jreq.IsNotification()) {
+                    reply.push_back(std::move(response));
+                }
+            }
+            // Return no response for an all-notification batch, but only if the
+            // batch request is non-empty. Technically according to the JSON-RPC
+            // 2.0 spec, an empty batch request should also return no response,
+            // However, if the batch request is empty, it means the request did
+            // not contain any JSON-RPC version numbers, so returning an empty
+            // response could break backwards compatibility with old RPC clients
+            // relying on previous behavior. Return an empty array instead of an
+            // empty response in this case to favor being backwards compatible
+            // over complying with the JSON-RPC 2.0 spec in this case.
+            if (reply.size() == 0 && valRequest.size() > 0) {
+                req->WriteReply(HTTP_NO_CONTENT);
+                return true;
+            }
         else
             throw JSONRPCError(RPC_PARSE_ERROR, "Top-level object parse error");
 

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -32,7 +32,7 @@ UniValue JSONRPCRequestObj(const std::string& strMethod, const UniValue& params,
     return request;
 }
 
-UniValue JSONRPCReplyObj(UniValue result, UniValue error, std::optional<UniValue> id, JSONRPCVersion jsonrpc_version)
+UniValue JSONRPCReplyObj(UniValue result, UniValue error, Optional<UniValue> id, JSONRPCVersion jsonrpc_version)
 {
     UniValue reply(UniValue::VOBJ);
     // Add JSON-RPC version number field in v2 only.

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -11,7 +11,7 @@
 
 #include <list>
 #include <map>
-#include <optional>
+#include "optional.h"
 #include <stdint.h>
 #include <string>
 
@@ -89,7 +89,7 @@ enum class JSONRPCVersion {
 };
 
 UniValue JSONRPCRequestObj(const std::string& strMethod, const UniValue& params, const UniValue& id);
-UniValue JSONRPCReplyObj(UniValue result, UniValue error, std::optional<UniValue> id, JSONRPCVersion jsonrpc_version);
+UniValue JSONRPCReplyObj(UniValue result, UniValue error, Optional<UniValue> id, JSONRPCVersion jsonrpc_version);
 UniValue JSONRPCError(int code, const std::string& message);
 
 /** Get name of RPC authentication cookie file */

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -11,6 +11,7 @@
 
 #include <list>
 #include <map>
+#include <optional>
 #include <stdint.h>
 #include <string>
 
@@ -19,6 +20,7 @@
 //! HTTP status codes
 enum HTTPStatusCode {
     HTTP_OK                    = 200,
+    HTTP_NO_CONTENT            = 204,
     HTTP_BAD_REQUEST           = 400,
     HTTP_UNAUTHORIZED          = 401,
     HTTP_FORBIDDEN             = 403,
@@ -80,9 +82,14 @@ enum RPCErrorCode {
     RPC_WALLET_NOT_SPECIFIED            = -19, //!< No wallet specified (error when there are multiple wallets loaded)
 };
 
+// JSON RPC Versions
+enum class JSONRPCVersion {
+    V1_LEGACY,
+    V2
+};
+
 UniValue JSONRPCRequestObj(const std::string& strMethod, const UniValue& params, const UniValue& id);
-UniValue JSONRPCReplyObj(const UniValue& result, const UniValue& error, const UniValue& id);
-std::string JSONRPCReply(const UniValue& result, const UniValue& error, const UniValue& id);
+UniValue JSONRPCReplyObj(UniValue result, UniValue error, std::optional<UniValue> id, JSONRPCVersion jsonrpc_version);
 UniValue JSONRPCError(int code, const std::string& message);
 
 /** Get name of RPC authentication cookie file */

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -411,7 +411,7 @@ bool IsDeprecatedRPCEnabled(const std::string& method)
     return find(enabled_methods.begin(), enabled_methods.end(), method) != enabled_methods.end();
 }
 
-static UniValue JSONRPCExecOne(const UniValue& req)
+UniValue JSONRPCExec(const JSONRPCRequest& jreq, bool catch_errors)
 {
     UniValue rpc_result(UniValue::VOBJ);
 
@@ -428,7 +428,7 @@ static UniValue JSONRPCExecOne(const UniValue& req)
             JSONRPCError(RPC_PARSE_ERROR, e.what()), jreq.id);
     }
 
-    return rpc_result;
+    return JSONRPCReplyObj(std::move(result), NullUniValue, jreq.id, jreq.m_json_version);
 }
 
 std::string JSONRPCExecBatch(const UniValue& vReq)

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -383,14 +383,14 @@ void JSONRPCRequest::parse(const UniValue& valRequest)
 
     // Parse id now so errors from here on will have the id
     if (request.exists("id")) {
-        id = request.find_value("id");
+        id = find_value(request, "id");
     } else {
-        id = std::nullopt;
+        id = nullopt;
     }
 
     // Check for JSON-RPC 2.0 (default 1.1)
     m_json_version = JSONRPCVersion::V1_LEGACY;
-    const UniValue& jsonrpc_version = request.find_value("jsonrpc");
+    const UniValue& jsonrpc_version = find_value(request, "jsonrpc");
     if (!jsonrpc_version.isNull()) {
         if (!jsonrpc_version.isStr()) {
             throw JSONRPCError(RPC_INVALID_REQUEST, "jsonrpc field must be a string");

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -382,7 +382,30 @@ void JSONRPCRequest::parse(const UniValue& valRequest)
     const UniValue& request = valRequest.get_obj();
 
     // Parse id now so errors from here on will have the id
-    id = find_value(request, "id");
+    if (request.exists("id")) {
+        id = request.find_value("id");
+    } else {
+        id = std::nullopt;
+    }
+
+    // Check for JSON-RPC 2.0 (default 1.1)
+    m_json_version = JSONRPCVersion::V1_LEGACY;
+    const UniValue& jsonrpc_version = request.find_value("jsonrpc");
+    if (!jsonrpc_version.isNull()) {
+        if (!jsonrpc_version.isStr()) {
+            throw JSONRPCError(RPC_INVALID_REQUEST, "jsonrpc field must be a string");
+        }
+        // The "jsonrpc" key was added in the 2.0 spec, but some older documentation
+        // incorrectly included {"jsonrpc":"1.0"} in a request object, so we
+        // maintain that for backwards compatibility.
+        if (jsonrpc_version.get_str() == "1.0") {
+            m_json_version = JSONRPCVersion::V1_LEGACY;
+        } else if (jsonrpc_version.get_str() == "2.0") {
+            m_json_version = JSONRPCVersion::V2;
+        } else {
+            throw JSONRPCError(RPC_INVALID_REQUEST, "JSON-RPC version not supported");
+        }
+    }
 
     // Parse method
     UniValue valMethod = find_value(request, "method");
@@ -413,31 +436,20 @@ bool IsDeprecatedRPCEnabled(const std::string& method)
 
 UniValue JSONRPCExec(const JSONRPCRequest& jreq, bool catch_errors)
 {
-    UniValue rpc_result(UniValue::VOBJ);
-
-    JSONRPCRequest jreq;
-    try {
-        jreq.parse(req);
-
-        UniValue result = tableRPC.execute(jreq);
-        rpc_result = JSONRPCReplyObj(result, NullUniValue, jreq.id);
-    } catch (const UniValue& objError) {
-        rpc_result = JSONRPCReplyObj(NullUniValue, objError, jreq.id);
-    } catch (const std::exception& e) {
-        rpc_result = JSONRPCReplyObj(NullUniValue,
-            JSONRPCError(RPC_PARSE_ERROR, e.what()), jreq.id);
+    UniValue result;
+    if (catch_errors) {
+        try {
+            result = tableRPC.execute(jreq);
+        } catch (UniValue& e) {
+            return JSONRPCReplyObj(NullUniValue, std::move(e), jreq.id, jreq.m_json_version);
+        } catch (const std::exception& e) {
+            return JSONRPCReplyObj(NullUniValue, JSONRPCError(RPC_MISC_ERROR, e.what()), jreq.id, jreq.m_json_version);
+        }
+    } else {
+        result = tableRPC.execute(jreq);
     }
 
     return JSONRPCReplyObj(std::move(result), NullUniValue, jreq.id, jreq.m_json_version);
-}
-
-std::string JSONRPCExecBatch(const UniValue& vReq)
-{
-    UniValue ret(UniValue::VARR);
-    for (unsigned int reqIdx = 0; reqIdx < vReq.size(); reqIdx++)
-        ret.push_back(JSONRPCExecOne(vReq[reqIdx]));
-
-    return ret.write() + "\n";
 }
 
 /**
@@ -531,7 +543,7 @@ std::string HelpExampleCli(std::string methodname, std::string args)
 
 std::string HelpExampleRpc(std::string methodname, std::string args)
 {
-    return "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", "
+    return "> curl --user myusername --data-binary '{\"jsonrpc\": \"2.0\", \"id\":\"curltest\", "
            "\"method\": \"" +
            methodname + "\", \"params\": [" + args + "] }' -H 'content-type: text/plain;' http://127.0.0.1:51473/\n";
 }

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -13,6 +13,7 @@
 
 #include <list>
 #include <map>
+#include <optional>
 #include <stdint.h>
 #include <string>
 
@@ -42,15 +43,17 @@ struct UniValueType {
 class JSONRPCRequest
 {
 public:
-    UniValue id;
+    std::optional<UniValue> id = UniValue::VNULL;
     std::string strMethod;
     UniValue params;
     bool fHelp;
     std::string URI;
     std::string authUser;
+    JSONRPCVersion m_json_version = JSONRPCVersion::V1_LEGACY;
 
     JSONRPCRequest() { id = NullUniValue; params = NullUniValue; fHelp = false; }
     void parse(const UniValue& valRequest);
+    [[nodiscard]] bool IsNotification() const { return !id.has_value() && m_json_version == JSONRPCVersion::V2; };
 };
 
 /** Query whether RPC is running */
@@ -201,7 +204,6 @@ bool StartRPC();
 void InterruptRPC();
 void StopRPC();
 UniValue JSONRPCExec(const JSONRPCRequest& jreq, bool catch_errors);
-std::string JSONRPCExecBatch(const UniValue& vReq);
 void RPCNotifyBlockChange(bool fInitialDownload, const CBlockIndex* pindex);
 
 #endif // PIVX_RPC_SERVER_H

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -200,6 +200,7 @@ extern std::string HelpExampleRpc(std::string methodname, std::string args);
 bool StartRPC();
 void InterruptRPC();
 void StopRPC();
+UniValue JSONRPCExec(const JSONRPCRequest& jreq, bool catch_errors);
 std::string JSONRPCExecBatch(const UniValue& vReq);
 void RPCNotifyBlockChange(bool fInitialDownload, const CBlockIndex* pindex);
 

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -13,7 +13,7 @@
 
 #include <list>
 #include <map>
-#include <optional>
+#include "optional.h"
 #include <stdint.h>
 #include <string>
 
@@ -43,7 +43,7 @@ struct UniValueType {
 class JSONRPCRequest
 {
 public:
-    std::optional<UniValue> id = UniValue::VNULL;
+    Optional<UniValue> id = UniValue(UniValue::VNULL);
     std::string strMethod;
     UniValue params;
     bool fHelp;

--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -136,7 +136,7 @@ class AuthServiceProxy():
 
     def __call__(self, *args, **argsn):
         postdata = json.dumps(self.get_request(*args, **argsn), default=EncodeDecimal, ensure_ascii=self.ensure_ascii)
-        response = self._request('POST', self.__url.path, postdata.encode('utf-8'))
+        response, status = self._request('POST', self.__url.path, postdata.encode('utf-8'))
         if response['error'] is not None:
             raise JSONRPCException(response['error'])
         elif 'result' not in response:

--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -35,6 +35,7 @@ ServiceProxy class:
 
 import base64
 import decimal
+from http import HTTPStatus
 import http.client
 import json
 import logging
@@ -46,6 +47,7 @@ HTTP_TIMEOUT = 300
 USER_AGENT = "AuthServiceProxy/0.1"
 
 log = logging.getLogger("BitcoinRPC")
+
 
 class JSONRPCException(Exception):
     def __init__(self, rpc_error):
@@ -61,6 +63,7 @@ def EncodeDecimal(o):
     if isinstance(o, decimal.Decimal):
         return str(o)
     raise TypeError(repr(o) + " is not JSON serializable")
+
 
 class AuthServiceProxy():
     __id_count = 0


### PR DESCRIPTION
PIVX Core is currently working with a mix of 1.0, 1.1 and 2.0 behaviors for the JSON RPC server. 

@duddino was having issues with a rust json rpc library interfacing with our daemon because of the responses not aligning to the JSON-RPC 2.0 standard behaviors. This backport was identified and has been applied to ensure JSON-RPC 2.0 compatibility.

Behavior changes:
- Return HTTP 200 "OK" unless there is an error or malformed message
- Return `"error"` or `"result"` not both
- Streamlined behavior for single and batch requests