### PR TITLE
[Net]: Add compatibility for miniupnpc 2.2.8

### DIFF
--- a/src/mapport.cpp
+++ b/src/mapport.cpp
@@ -166,8 +166,11 @@ static bool ProcessUpnp()
     struct UPNPUrls urls{};
     struct IGDdatas data{};
     int r;
-
+#if MINIUPNPC_API_VERSION <= 17
     r = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr));
+#else
+    r = UPNP_GetValidIGD(devlist, &urls, &data, lanaddr, sizeof(lanaddr), nullptr, 0);
+#endif
     if (r == 1) {
         if (fDiscover) {
             char externalIPAddress[40];


### PR DESCRIPTION
See: https://github.com/miniupnp/miniupnp/commit/c0a50ce33e3b99ce8a96fd43049bb5b53ffac62f

The return value of 2 now indicates:
"A valid connected IGD has been found but its IP address is reserved (non routable)"

We continue to ignore any return value other than 1.

---

Upstream: https://github.com/bitcoin/bitcoin/pull/30283