### PR TITLE
[GA] Bump standard macOS runners to macos-13

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -115,7 +115,7 @@ jobs:
 
           - name: macOS-latest
             os: macos-14
-            python-version: '3.10'
+            python-version: '3.12'
             packages: llvm@14 autoconf automake berkeley-db@4 libtool boost miniupnpc libnatpmp pkg-config qt@5 zmq libevent qrencode gmp libsodium
             boost_root: true
             cc: $(brew --prefix llvm@14)/bin/clang
@@ -239,7 +239,7 @@ jobs:
           - name: arm64-macOS-latest
             id: macOS-nodepends-latest
             os: macos-14
-            python-version: '3.10'
+            python-version: '3.12'
             packages: autoconf automake ccache berkeley-db@4 libtool boost miniupnpc libnatpmp pkg-config qt@5 zmq libevent qrencode gmp libsodium librsvg
             unit_tests: true
             functional_tests: true
@@ -392,7 +392,7 @@ jobs:
           - name: arm64-macOS-latest
             id: macOS-nodepends-latest
             os: macos-14
-            python-version: '3.10'
+            python-version: '3.12'
             packages: berkeley-db@4 boost miniupnpc libnatpmp pkg-config zmq libevent qrencode gmp libsodium
 
     steps:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -106,12 +106,12 @@ jobs:
             cxx: g++
 
           - name: macOS
-            os: macos-12
-            python-version: '3.8'
-            packages: llvm@13 autoconf automake berkeley-db@4 libtool boost miniupnpc libnatpmp pkg-config qt@5 zmq libevent qrencode gmp libsodium
+            os: macos-13
+            python-version: '3.10'
+            packages: llvm@14 autoconf automake berkeley-db@4 libtool boost miniupnpc libnatpmp pkg-config qt@5 zmq libevent qrencode gmp libsodium
             boost_root: true
-            cc: $(brew --prefix llvm@13)/bin/clang
-            cxx: $(brew --prefix llvm@13)/bin/clang++
+            cc: $(brew --prefix llvm@14)/bin/clang
+            cxx: $(brew --prefix llvm@14)/bin/clang++
 
           - name: macOS-latest
             os: macos-14
@@ -226,11 +226,12 @@ jobs:
 
           - name: x64-macOS
             id: macOS-nodepends
-            os: macos-12
-            python-version: '3.8'
+            os: macos-13
+            python-version: '3.10'
             packages: autoconf automake ccache berkeley-db@4 libtool boost miniupnpc libnatpmp pkg-config qt@5 zmq libevent qrencode gmp libsodium librsvg
             unit_tests: true
             functional_tests: true
+            goal: deploy
             cc: clang
             cxx: clang++
             BITCOIN_CONFIG: "--enable-zmq --enable-gui --enable-reduce-exports --enable-werror --enable-debug --with-boost=/usr/local/opt/boost"
@@ -294,11 +295,6 @@ jobs:
             CXX=${{ matrix.config.cxx }}
             export CC
             export CXX
-          fi
-
-          if [ "${{ matrix.config.os }}" = "macos-12" ]; then
-            export CPPFLAGS="-I/usr/local/opt/boost/include -I/usr/local/opt/berkeley-db@4/include"
-            export LDFLAGS="-L/usr/local/opt/boost/lib -L/usr/local/opt/berkeley-db@4/lib"
           fi
 
           if [[ ${{ matrix.config.os }} = ubuntu* ]]; then
@@ -389,8 +385,8 @@ jobs:
 
           - name: x64-macOS
             id: macOS-nodepends
-            os: macos-12
-            python-version: '3.8'
+            os: macos-13
+            python-version: '3.10'
             packages: berkeley-db@4 boost miniupnpc libnatpmp pkg-config zmq libevent qrencode gmp libsodium
 
           - name: arm64-macOS-latest
@@ -775,7 +771,7 @@ jobs:
 
           - name: x86_64 macOS [Full Functional Tests]
             id: macos-x86_64-tests
-            os: macos-12
+            os: macos-13
             host: x86_64-apple-darwin16
             packages: None
             test_runner_extra: "--all --exclude feature_dbcrash"


### PR DESCRIPTION
GA had deprecated `macos-12` runners and will be removing them in December.

This migrates our current `macos-12` runners to use `macos-13`.

The second commit is added because due to GA removing support for python 3.9 and 3.10 in their macos arm64 based runners later this month due to a dependency mismatch with their packaging systems. We currently use arm64 based `macos-14` runners.