### PR TITLE
[Cleanup] Declare single-argument (non-converting) constructors "explicit"

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -72,6 +72,64 @@ jobs:
             test/lint/commit-script-check.sh $COMMIT_RANGE
           fi
 
+  # Extended lint using cppcheck. Other jobs do NOT require this to pass.
+  extended-lint:
+    env:
+      CPPCHECK_VERSION: 2.14.0
+      CPPCHECK_BIN_DIR: ${{ github.workspace }}/.cppcheck
+      CPPCHECK_BUILD_DIR: ${{ github.workspace }}/.ci-cppcheck
+      LC_ALL: C
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Initialize Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+
+      - name: cppcheck cache files
+        uses: actions/cache@v4
+        with:
+          path: |
+            .cppcheck
+            .ci-cppcheck
+          key: ci-cppcheck
+          restore-keys: ci-cppcheck
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+
+          mkdir -p ${CPPCHECK_BIN_DIR}
+          curl -s https://codeload.github.com/danmar/cppcheck/tar.gz/${CPPCHECK_VERSION} | tar -zxf - --directory ${CPPCHECK_BIN_DIR}/
+          cd ${CPPCHECK_BIN_DIR}/cppcheck-${CPPCHECK_VERSION}/
+          make -j 3 MATCHCOMPILER=yes FILESDIR=${CPPCHECK_BIN_DIR}/cppcheck-${CPPCHECK_VERSION}/cfg/
+
+      - name: Set TRAVIS_BRANCH workaround env variable
+        if: github.event_name == 'pull_request'
+        run: echo "TRAVIS_BRANCH=${{ github.base_ref }}" >> $GITHUB_ENV
+
+      - name: Build cppcheck cache
+        run: |
+          export PATH="${CPPCHECK_BIN_DIR}/cppcheck-${CPPCHECK_VERSION}:${PATH}"
+          git checkout -qf -B master refs/remotes/origin/master
+          git checkout -qf $GITHUB_SHA
+
+          # Build or rebuild the cppcheck cache.
+          test/lint/cppcheck/lint-all.sh --setup
+
+      - name: Lint
+        run: |
+          # Run the remainder of lint tests in `test/lint/`.
+          test/lint/cppcheck/lint-all.sh
+
   # CMake build jobs to ensure building with CMake remains viable.
   # Currently this only supports native linux and macOS.
   cmake:

--- a/src/addrdb.h
+++ b/src/addrdb.h
@@ -39,7 +39,7 @@ public:
         SetNull();
     }
 
-    CBanEntry(int64_t nCreateTimeIn)
+    explicit CBanEntry(int64_t nCreateTimeIn)
     {
         SetNull();
         nCreateTime = nCreateTimeIn;

--- a/src/blockassembler.h
+++ b/src/blockassembler.h
@@ -34,7 +34,7 @@ struct CBlockTemplate
 // Container for tracking updates to ancestor feerate as we include (parent)
 // transactions in a block
 struct CTxMemPoolModifiedEntry {
-    CTxMemPoolModifiedEntry(CTxMemPool::txiter entry)
+    explicit CTxMemPoolModifiedEntry(CTxMemPool::txiter entry)
     {
         iter = entry;
         nSizeWithAncestors = entry->GetSizeWithAncestors();
@@ -117,7 +117,7 @@ typedef indexed_modified_transaction_set::index<ancestor_score>::type::iterator 
 
 struct update_for_parent_inclusion
 {
-    update_for_parent_inclusion(CTxMemPool::txiter it) : iter(it) {}
+    explicit update_for_parent_inclusion(CTxMemPool::txiter it) : iter(it) {}
 
     void operator() (CTxMemPoolModifiedEntry &e)
     {

--- a/src/bls/bls_worker.h
+++ b/src/bls/bls_worker.h
@@ -156,7 +156,7 @@ private:
     std::map<uint256, std::shared_future<CBLSPublicKey> > publicKeyShareCache;
 
 public:
-    CBLSWorkerCache(CBLSWorker& _worker) :
+    explicit CBLSWorkerCache(CBLSWorker& _worker) :
         worker(_worker) {}
 
     BLSVerificationVectorPtr BuildQuorumVerificationVector(const uint256& cacheKey, const std::vector<BLSVerificationVectorPtr>& vvecs)

--- a/src/chain.h
+++ b/src/chain.h
@@ -205,7 +205,7 @@ public:
     unsigned int nTimeMax{0};
 
     CBlockIndex() {}
-    CBlockIndex(const CBlock& block);
+    explicit CBlockIndex(const CBlock& block);
 
     std::string ToString() const;
 

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -20,7 +20,7 @@
 struct CDNSSeedData {
     std::string host;
     bool supportsServiceBitsFiltering;
-    CDNSSeedData(const std::string& strHost, bool supportsServiceBitsFilteringIn = false) : host(strHost), supportsServiceBitsFiltering(supportsServiceBitsFilteringIn) {}
+    explicit CDNSSeedData(const std::string& strHost, bool supportsServiceBitsFilteringIn = false) : host(strHost), supportsServiceBitsFiltering(supportsServiceBitsFilteringIn) {}
 };
 
 typedef std::map<int, uint256> MapCheckpoints;

--- a/src/checkqueue.h
+++ b/src/checkqueue.h
@@ -175,7 +175,7 @@ private:
     bool fDone;
 
 public:
-    CCheckQueueControl(CCheckQueue<T>* pqueueIn) : pqueue(pqueueIn), fDone(false)
+    explicit CCheckQueueControl(CCheckQueue<T>* pqueueIn) : pqueue(pqueueIn), fDone(false)
     {
         // passed queue is supposed to be unused, or nullptr
         if (pqueue != nullptr) {

--- a/src/crypto/aes.h
+++ b/src/crypto/aes.h
@@ -22,7 +22,7 @@ private:
     AES128_ctx ctx;
 
 public:
-    AES128Encrypt(const unsigned char key[16]);
+    explicit AES128Encrypt(const unsigned char key[16]);
     ~AES128Encrypt();
     void Encrypt(unsigned char ciphertext[16], const unsigned char plaintext[16]) const;
 };
@@ -34,7 +34,7 @@ private:
     AES128_ctx ctx;
 
 public:
-    AES128Decrypt(const unsigned char key[16]);
+    explicit AES128Decrypt(const unsigned char key[16]);
     ~AES128Decrypt();
     void Decrypt(unsigned char plaintext[16], const unsigned char ciphertext[16]) const;
 };
@@ -46,7 +46,7 @@ private:
     AES256_ctx ctx;
 
 public:
-    AES256Encrypt(const unsigned char key[32]);
+    explicit AES256Encrypt(const unsigned char key[32]);
     ~AES256Encrypt();
     void Encrypt(unsigned char ciphertext[16], const unsigned char plaintext[16]) const;
 };
@@ -58,7 +58,7 @@ private:
     AES256_ctx ctx;
 
 public:
-    AES256Decrypt(const unsigned char key[32]);
+    explicit AES256Decrypt(const unsigned char key[32]);
     ~AES256Decrypt();
     void Decrypt(unsigned char plaintext[16], const unsigned char ciphertext[16]) const;
 };

--- a/src/ctpl_stl.h
+++ b/src/ctpl_stl.h
@@ -73,7 +73,7 @@ namespace ctpl {
     public:
 
         thread_pool() { this->init(); }
-        thread_pool(int nThreads) { this->init(); this->resize(nThreads); }
+        explicit thread_pool(int nThreads) { this->init(); this->resize(nThreads); }
 
         // the destructor waits for all the functions in the queue to be finished
         ~thread_pool() {

--- a/src/cxxtimer.h
+++ b/src/cxxtimer.h
@@ -45,7 +45,7 @@ public:
      *          If true, the timer is started just after construction.
      *          Otherwise, it will not be automatically started.
      */
-    Timer(bool start = false);
+    explicit Timer(bool start = false);
 
     /**
      * Copy constructor.

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -25,7 +25,7 @@ static const size_t DBWRAPPER_PREALLOC_VALUE_SIZE = 1024;
 class dbwrapper_error : public std::runtime_error
 {
 public:
-    dbwrapper_error(const std::string& msg) : std::runtime_error(msg) {}
+    explicit dbwrapper_error(const std::string& msg) : std::runtime_error(msg) {}
 };
 
 class CDBWrapper;

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -184,7 +184,7 @@ private:
 
 public:
     CDeterministicMN() = delete; // no default constructor, must specify internalId
-    CDeterministicMN(uint64_t _internalId) : internalId(_internalId)
+    explicit CDeterministicMN(uint64_t _internalId) : internalId(_internalId)
     {
         // only non-initial values
         assert(_internalId != std::numeric_limits<uint64_t>::max());

--- a/src/hash.h
+++ b/src/hash.h
@@ -257,7 +257,7 @@ private:
     Source* source;
 
 public:
-    CHashVerifier(Source* source_) : CHashWriter(source_->GetType(), source_->GetVersion()), source(source_) {}
+    explicit CHashVerifier(Source* source_) : CHashWriter(source_->GetType(), source_->GetVersion()), source(source_) {}
 
     void read(char* pch, size_t nSize)
     {

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -40,7 +40,7 @@ private:
 class HTTPRPCTimerInterface : public RPCTimerInterface
 {
 public:
-    HTTPRPCTimerInterface(struct event_base* base) : base(base)
+    explicit HTTPRPCTimerInterface(struct event_base* base) : base(base)
     {
     }
     const char* Name()

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -62,7 +62,7 @@ private:
     bool replySent;
 
 public:
-    HTTPRequest(struct evhttp_request* req);
+    explicit HTTPRequest(struct evhttp_request* req);
     ~HTTPRequest();
 
     enum RequestMethod {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -160,7 +160,7 @@ NODISCARD static bool CreatePidFile()
 class CCoinsViewErrorCatcher : public CCoinsViewBacked
 {
 public:
-    CCoinsViewErrorCatcher(CCoinsView* view) : CCoinsViewBacked(view) {}
+    explicit CCoinsViewErrorCatcher(CCoinsView* view) : CCoinsViewBacked(view) {}
     bool GetCoin(const COutPoint& outpoint, Coin& coin) const override
     {
         try {

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -22,7 +22,7 @@ namespace
         const CChainParams::Base58Type m_addrType;
 
     public:
-        DestinationEncoder(const CChainParams& params, const CChainParams::Base58Type _addrType = CChainParams::PUBKEY_ADDRESS) : m_params(params), m_addrType(_addrType) {}
+        explicit DestinationEncoder(const CChainParams& params, const CChainParams::Base58Type _addrType = CChainParams::PUBKEY_ADDRESS) : m_params(params), m_addrType(_addrType) {}
 
         std::string operator()(const CKeyID& id) const
         {

--- a/src/libzerocoin/Coin.h
+++ b/src/libzerocoin/Coin.h
@@ -30,7 +30,7 @@ namespace libzerocoin
     class InvalidSerialException : public std::exception {
     public:
         std::string message;
-        InvalidSerialException(const std::string &message) : message(message) {}
+        explicit InvalidSerialException(const std::string &message) : message(message) {}
     };
 
     int ExtractVersionFromSerial(const CBigNum& bnSerial);
@@ -54,7 +54,7 @@ public:
         strm >> *this;
     }
 
-    PublicCoin(const ZerocoinParams* p);
+    explicit PublicCoin(const ZerocoinParams* p);
 
     /**Generates a public coin
      *

--- a/src/libzerocoin/CoinRandomnessSchnorrSignature.h
+++ b/src/libzerocoin/CoinRandomnessSchnorrSignature.h
@@ -19,7 +19,7 @@ namespace libzerocoin {
 class CoinRandomnessSchnorrSignature {
 public:
     CoinRandomnessSchnorrSignature() {};
-    template <typename Stream> CoinRandomnessSchnorrSignature(Stream& strm) {strm >> *this;}
+    template <typename Stream> explicit CoinRandomnessSchnorrSignature(Stream& strm) {strm >> *this;}
 
     /** Creates a Schnorr signature object using the randomness of a public coin as private key sk.
      *

--- a/src/libzerocoin/CoinSpend.h
+++ b/src/libzerocoin/CoinSpend.h
@@ -80,7 +80,7 @@ class CoinSpend
 public:
 
     CoinSpend() {};
-    CoinSpend(CDataStream& strm) { strm >> *this; }
+    explicit CoinSpend(CDataStream& strm) { strm >> *this; }
     virtual ~CoinSpend(){};
 
     const CBigNum& getCoinSerialNumber() const { return this->coinSerialNumber; }

--- a/src/libzerocoin/Params.h
+++ b/src/libzerocoin/Params.h
@@ -156,8 +156,7 @@ public:
 	* compromised. The integer "N" must be a MINIMUM of 1024
 	* in length. 3072 bits is strongly recommended.
 	**/
-	ZerocoinParams(CBigNum accumulatorModulus,
-	       uint32_t securityLevel = ZEROCOIN_DEFAULT_SECURITYLEVEL);
+        explicit ZerocoinParams(CBigNum accumulatorModulus, uint32_t securityLevel = ZEROCOIN_DEFAULT_SECURITYLEVEL);
 
 	bool initialized;
 

--- a/src/limitedmap.h
+++ b/src/limitedmap.h
@@ -28,7 +28,7 @@ protected:
     size_type nMaxSize;
 
 public:
-    limitedmap(size_type nMaxSizeIn = 0) { nMaxSize = nMaxSizeIn; }
+    explicit limitedmap(size_type nMaxSizeIn = 0) { nMaxSize = nMaxSizeIn; }
     const_iterator begin() const { return map.begin(); }
     const_iterator end() const { return map.end(); }
     size_type size() const { return map.size(); }

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -62,7 +62,7 @@ private:
     int64_t lastCleanupTime{0};
 
 public:
-    CChainLocksHandler(CScheduler* _scheduler);
+    explicit CChainLocksHandler(CScheduler* _scheduler);
     ~CChainLocksHandler();
     void Start();
     void Stop();

--- a/src/llmq/quorums_dkgsession.h
+++ b/src/llmq/quorums_dkgsession.h
@@ -95,7 +95,7 @@ public:
 
 public:
     CDKGComplaint() {}
-    CDKGComplaint(const Consensus::LLMQParams& params);
+    explicit CDKGComplaint(const Consensus::LLMQParams& params);
 
     SERIALIZE_METHODS(CDKGComplaint, obj)
     {
@@ -163,7 +163,7 @@ public:
 
 public:
     CDKGPrematureCommitment() {}
-    CDKGPrematureCommitment(const Consensus::LLMQParams& params);
+    explicit CDKGPrematureCommitment(const Consensus::LLMQParams& params);
 
     int CountValidMembers() const
     {

--- a/src/llmq/quorums_dkgsessionhandler.h
+++ b/src/llmq/quorums_dkgsessionhandler.h
@@ -45,7 +45,7 @@ private:
     std::set<uint256> seenMessages;
 
 public:
-    CDKGPendingMessages(size_t _maxMessagesPerNode);
+    explicit CDKGPendingMessages(size_t _maxMessagesPerNode);
 
     void PushPendingMessage(NodeId from, CDataStream& vRecv, int invType);
     std::list<BinaryMessage> PopPendingMessages(size_t maxCount);

--- a/src/llmq/quorums_signing.h
+++ b/src/llmq/quorums_signing.h
@@ -79,7 +79,7 @@ private:
     unordered_lru_cache<uint256, bool, StaticSaltedHasher, 30000> hasSigForHashCache;
 
 public:
-    CRecoveredSigsDb(CDBWrapper& _db);
+    explicit CRecoveredSigsDb(CDBWrapper& _db);
 
     bool HasRecoveredSig(Consensus::LLMQType llmqType, const uint256& id, const uint256& msgHash);
     bool HasRecoveredSigForId(Consensus::LLMQType llmqType, const uint256& id);

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -95,7 +95,7 @@ public:
         nBlockHeight = 0;
         vecPayments.clear();
     }
-    CMasternodeBlockPayees(int nBlockHeightIn)
+    explicit CMasternodeBlockPayees(int nBlockHeightIn)
     {
         nBlockHeight = nBlockHeightIn;
         vecPayments.clear();

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -244,7 +244,7 @@ class CMasternodeBroadcast : public CMasternode
 public:
     CMasternodeBroadcast();
     CMasternodeBroadcast(CService newAddr, CTxIn newVin, CPubKey newPubkey, CPubKey newPubkey2, int protocolVersionIn, const CMasternodePing& _lastPing);
-    CMasternodeBroadcast(const CMasternode& mn);
+    explicit CMasternodeBroadcast(const CMasternode& mn);
 
     bool CheckAndUpdate(int& nDoS);
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2361,7 +2361,7 @@ class CompareInvMempoolOrder
 {
     CTxMemPool *mp;
 public:
-    CompareInvMempoolOrder(CTxMemPool *_mempool)
+    explicit CompareInvMempoolOrder(CTxMemPool *_mempool)
     {
         mp = _mempool;
     }

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -37,7 +37,7 @@ private:
     CConnman* connman;
 
 public:
-    PeerLogicValidation(CConnman* connman);
+    explicit PeerLogicValidation(CConnman* connman);
     ~PeerLogicValidation() = default;
 
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex) override;

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -204,7 +204,7 @@ public:
     std::vector<unsigned char> GetAddrBytes() const;
     int GetReachabilityFrom(const CNetAddr* paddrPartner = nullptr) const;
 
-    CNetAddr(const struct in6_addr& pipv6Addr, const uint32_t scope = 0);
+    explicit CNetAddr(const struct in6_addr& pipv6Addr, const uint32_t scope = 0);
     bool GetIn6Addr(struct in6_addr* pipv6Addr) const;
 
     friend bool operator==(const CNetAddr& a, const CNetAddr& b);
@@ -489,7 +489,7 @@ public:
     CService();
     CService(const CNetAddr& ip, uint16_t port);
     CService(const struct in_addr& ipv4Addr, uint16_t port);
-    CService(const struct sockaddr_in& addr);
+    explicit CService(const struct sockaddr_in& addr);
     uint16_t GetPort() const;
     bool GetSockAddr(struct sockaddr* paddr, socklen_t* addrlen) const;
     bool SetSockAddr(const struct sockaddr* paddr);
@@ -502,7 +502,7 @@ public:
     std::string ToStringIPPort() const;
 
     CService(const struct in6_addr& ipv6Addr, uint16_t port);
-    CService(const struct sockaddr_in6& addr);
+    explicit CService(const struct sockaddr_in6& addr);
 
     SERIALIZE_METHODS(CService, obj)
     {

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -30,7 +30,7 @@ class proxyType
 {
 public:
     proxyType(): randomize_credentials(false) {}
-    proxyType(const CService &_proxy, bool _randomize_credentials=false): proxy(_proxy), randomize_credentials(_randomize_credentials) {}
+    explicit proxyType(const CService &_proxy, bool _randomize_credentials=false): proxy(_proxy), randomize_credentials(_randomize_credentials) {}
 
     bool IsValid() const { return proxy.IsValid(); }
 

--- a/src/netmessagemaker.h
+++ b/src/netmessagemaker.h
@@ -11,7 +11,7 @@
 class CNetMsgMaker
 {
 public:
-    CNetMsgMaker(int nVersionIn) : nVersion(nVersionIn){}
+    explicit CNetMsgMaker(int nVersionIn) : nVersion(nVersionIn){}
 
     template <typename... Args>
     CSerializedNetMsg Make(int nFlags, std::string sCommand, Args&&... args)

--- a/src/operationresult.h
+++ b/src/operationresult.h
@@ -36,8 +36,8 @@ private:
     Optional<T> m_obj_res{nullopt};
 public:
     CallResult() : OperationResult(false) {}
-    CallResult(T _obj) : OperationResult(true), m_obj_res(_obj) { }
-    CallResult(const std::string& error) : OperationResult(false, error) { }
+    explicit CallResult(T _obj) : OperationResult(true), m_obj_res(_obj) { }
+    explicit CallResult(const std::string& error) : OperationResult(false, error) { }
     const Optional<T>& getObjResult() const { return m_obj_res; }
 };
 

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -201,7 +201,7 @@ class CBlockPolicyEstimator
 {
 public:
     /** Create new BlockPolicyEstimator and initialize stats tracking classes with default values */
-    CBlockPolicyEstimator(const CFeeRate& minRelayFee);
+    explicit CBlockPolicyEstimator(const CFeeRate& minRelayFee);
 
     /** Process all the transactions that have been included in a block */
     void processBlock(unsigned int nBlockHeight,

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -156,7 +156,7 @@ struct CBlockLocator
 
     CBlockLocator() {}
 
-    CBlockLocator(const std::vector<uint256>& vHaveIn)
+    explicit CBlockLocator(const std::vector<uint256>& vHaveIn)
     {
         vHave = vHaveIn;
     }

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -39,7 +39,7 @@ class GUIException : public std::exception
 {
 public:
     std::string message;
-    GUIException(const std::string &message) : message(message) {}
+    explicit GUIException(const std::string &message) : message(message) {}
 };
 
 /** Utility functions used by the PIVX Qt UI.

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -44,7 +44,7 @@ class FreespaceChecker : public QObject
     Q_OBJECT
 
 public:
-    FreespaceChecker(Intro* intro);
+    explicit FreespaceChecker(Intro* intro);
 
     enum Status {
         ST_OK,

--- a/src/qt/notificator.cpp
+++ b/src/qt/notificator.cpp
@@ -70,7 +70,7 @@ class FreedesktopImage
 {
 public:
     FreedesktopImage() {}
-    FreedesktopImage(const QImage& img);
+    explicit FreedesktopImage(const QImage& img);
 
     static int metaType();
 

--- a/src/qt/paymentserver.h
+++ b/src/qt/paymentserver.h
@@ -65,7 +65,7 @@ public:
     static bool ipcSendCommandLine();
 
     // parent should be QApplication object
-    PaymentServer(QObject* parent, bool startLocalServer = true);
+    explicit PaymentServer(QObject* parent, bool startLocalServer = true);
     ~PaymentServer();
 
     // OptionsModel is used for getting proxy settings and display unit

--- a/src/qt/pivx/pfborderimage.h
+++ b/src/qt/pivx/pfborderimage.h
@@ -15,7 +15,7 @@ class PFBorderImage : public QFrame
     Q_OBJECT
 
 public:
-    PFBorderImage(QWidget *parent = nullptr) : QFrame(parent) {};
+    explicit PFBorderImage(QWidget *parent = nullptr) : QFrame(parent) {};
     ~PFBorderImage() {};
 
 #if defined(Q_OS_MAC)

--- a/src/qt/pivx/pwidget.cpp
+++ b/src/qt/pivx/pwidget.cpp
@@ -71,7 +71,7 @@ void PWidget::emitMessage(const QString& title, const QString& body, unsigned in
 class WorkerTask : public QRunnable
 {
 public:
-    WorkerTask(QPointer<Worker> worker) {
+    explicit WorkerTask(QPointer<Worker> worker) {
         this->worker = worker;
     }
 

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -108,7 +108,7 @@ public:
     /** Number of confirmation recommended for accepting a transaction */
     static const int RecommendedNumConfirmations = 6;
 
-    TransactionRecord(unsigned int size) : hash(), time(0), type(Other), address(""), debit(0), credit(0), size(size), idx(0)
+    explicit TransactionRecord(unsigned int size) : hash(), time(0), type(Other), address(""), debit(0), credit(0), size(size), idx(0)
     {
     }
 

--- a/src/qt/utilitydialog.h
+++ b/src/qt/utilitydialog.h
@@ -41,7 +41,7 @@ class ShutdownWindow : public QWidget
     Q_OBJECT
 
 public:
-    ShutdownWindow(QWidget* parent = nullptr, Qt::WindowFlags f = Qt::Widget);
+    explicit ShutdownWindow(QWidget* parent = nullptr, Qt::WindowFlags f = Qt::Widget);
     static void showShutdownWindow(QMainWindow* window);
 
 protected:

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -192,7 +192,7 @@ public:
     // Return status record for SendCoins, contains error id + information
     struct SendCoinsReturn {
         SendCoinsReturn(StatusCode status = OK) : status(status) {}
-        SendCoinsReturn(CWallet::CommitResult _commitRes) : commitRes(_commitRes)
+        explicit SendCoinsReturn(CWallet::CommitResult _commitRes) : commitRes(_commitRes)
         {
             status = (_commitRes.status == CWallet::CommitStatus::OK ? OK : TransactionCommitFailed);
         }

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -47,7 +47,7 @@ struct CCoin {
     CTxOut out;
 
     CCoin() : nHeight(0) {}
-    CCoin(Coin&& in) : nHeight(in.nHeight), out(std::move(in.out)) {}
+    explicit CCoin(Coin&& in) : nHeight(in.nHeight), out(std::move(in.out)) {}
 
     SERIALIZE_METHODS(CCoin, obj)
     {

--- a/src/reverse_iterate.h
+++ b/src/reverse_iterate.h
@@ -19,7 +19,7 @@ class reverse_range
     T &m_x;
 
 public:
-    reverse_range(T &x) : m_x(x) {}
+    explicit reverse_range(T &x) : m_x(x) {}
 
     auto begin() const -> decltype(this->m_x.rbegin())
     {

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -231,7 +231,7 @@ class DescribeAddressVisitor : public boost::static_visitor<UniValue>
 public:
     CWallet * const pwallet;
 
-    DescribeAddressVisitor(CWallet *_pwallet) : pwallet(_pwallet) {}
+    explicit DescribeAddressVisitor(CWallet *_pwallet) : pwallet(_pwallet) {}
 
     UniValue operator()(const CNoDestination &dest) const { return UniValue(UniValue::VOBJ); }
 

--- a/src/sapling/address.h
+++ b/src/sapling/address.h
@@ -52,7 +52,7 @@ public:
 class SaplingIncomingViewingKey : public uint256 {
 public:
     SaplingIncomingViewingKey() : uint256() { }
-    SaplingIncomingViewingKey(uint256 ivk) : uint256(ivk) { }
+    explicit SaplingIncomingViewingKey(uint256 ivk) : uint256(ivk) { }
 
     // Can pass in diversifier for Sapling addr
     Optional<SaplingPaymentAddress> address(diversifier_t d) const;
@@ -113,7 +113,7 @@ public:
 class SaplingSpendingKey : public uint256 {
 public:
     SaplingSpendingKey() : uint256() { }
-    SaplingSpendingKey(uint256 sk) : uint256(sk) { }
+    explicit SaplingSpendingKey(uint256 sk) : uint256(sk) { }
 
     static SaplingSpendingKey random();
 

--- a/src/sapling/incrementalmerkletree.cpp
+++ b/src/sapling/incrementalmerkletree.cpp
@@ -849,7 +849,7 @@ private:
     static EmptyMerkleRoots<Depth, Hash> emptyroots;
 public:
     PathFiller() : queue() { }
-    PathFiller(std::deque<Hash> queue) : queue(queue) { }
+    explicit PathFiller(std::deque<Hash> queue) : queue(queue) { }
 
     Hash next(size_t depth) {
         if (queue.size() > 0) {

--- a/src/sapling/incrementalmerkletree.h
+++ b/src/sapling/incrementalmerkletree.h
@@ -193,7 +193,7 @@ private:
     Optional<IncrementalMerkleTree<Depth, Hash>> cursor;
     size_t cursor_depth = 0;
     std::deque<Hash> partial_path() const;
-    IncrementalWitness(IncrementalMerkleTree<Depth, Hash> tree) : tree(tree) {}
+    explicit IncrementalWitness(IncrementalMerkleTree<Depth, Hash> tree) : tree(tree) {}
 };
 
 template<size_t Depth, typename Hash>

--- a/src/sapling/key_io_sapling.cpp
+++ b/src/sapling/key_io_sapling.cpp
@@ -23,7 +23,7 @@ private:
     const CChainParams& m_params;
 
 public:
-    PaymentAddressEncoder(const CChainParams& params) : m_params(params) {}
+    explicit PaymentAddressEncoder(const CChainParams& params) : m_params(params) {}
 
     std::string operator()(const libzcash::SaplingPaymentAddress& zaddr) const
     {
@@ -47,7 +47,7 @@ private:
     const CChainParams& m_params;
 
 public:
-    ViewingKeyEncoder(const CChainParams& params) : m_params(params) {}
+    explicit ViewingKeyEncoder(const CChainParams& params) : m_params(params) {}
 
     std::string operator()(const libzcash::SaplingExtendedFullViewingKey& extfvk) const
     {
@@ -74,7 +74,7 @@ private:
     const CChainParams& m_params;
 
 public:
-    SpendingKeyEncoder(const CChainParams& params) : m_params(params) {}
+    explicit SpendingKeyEncoder(const CChainParams& params) : m_params(params) {}
 
     std::string operator()(const libzcash::SaplingExtendedSpendingKey& zkey) const
     {

--- a/src/sapling/note.h
+++ b/src/sapling/note.h
@@ -24,7 +24,7 @@ protected:
     uint64_t value_{0};
 public:
     BaseNote() {}
-    BaseNote(uint64_t value) : value_(value) {};
+    explicit BaseNote(uint64_t value) : value_(value) {};
     virtual ~BaseNote() {};
 
     inline uint64_t value() const { return value_; };

--- a/src/sapling/sapling_operation.h
+++ b/src/sapling/sapling_operation.h
@@ -62,7 +62,7 @@ struct SendManyRecipient
     {}
 
     // Transparent recipient: OP_RETURN
-    SendManyRecipient(const uint256& message):
+    explicit SendManyRecipient(const uint256& message):
             recipient(new CRecipient(GetScriptForOpReturn(message), 0, false))
     {}
 };

--- a/src/sapling/saplingscriptpubkeyman.h
+++ b/src/sapling/saplingscriptpubkeyman.h
@@ -45,7 +45,7 @@ class SaplingNoteData
 public:
 
     SaplingNoteData() : nullifier() { }
-    SaplingNoteData(const libzcash::SaplingIncomingViewingKey& _ivk) : ivk {_ivk}, nullifier() { }
+    explicit SaplingNoteData(const libzcash::SaplingIncomingViewingKey& _ivk) : ivk {_ivk}, nullifier() { }
     SaplingNoteData(const libzcash::SaplingIncomingViewingKey& _ivk, const uint256& n) : ivk {_ivk}, nullifier(n) { }
 
     /* witnesses/ivk: only for own (received) outputs */
@@ -147,7 +147,7 @@ typedef std::map<SaplingOutPoint, SaplingNoteData> mapSaplingNoteData_t;
 class SaplingScriptPubKeyMan {
 
 public:
-    SaplingScriptPubKeyMan(CWallet *parent) : wallet(parent) {}
+    explicit SaplingScriptPubKeyMan(CWallet *parent) : wallet(parent) {}
 
     ~SaplingScriptPubKeyMan() {};
 

--- a/src/sapling/transaction_builder.h
+++ b/src/sapling/transaction_builder.h
@@ -71,8 +71,8 @@ private:
     Optional<std::string> maybeError;
 public:
     TransactionBuilderResult() = delete;
-    TransactionBuilderResult(const CTransaction& tx);
-    TransactionBuilderResult(const std::string& error);
+    explicit TransactionBuilderResult(const CTransaction& tx);
+    explicit TransactionBuilderResult(const std::string& error);
     bool IsTx();
     bool IsError();
     CTransaction GetTxOrThrow();
@@ -96,7 +96,7 @@ private:
     Optional<CTxDestination> tChangeAddr;
 
 public:
-    TransactionBuilder(
+    explicit TransactionBuilder(
         const Consensus::Params& consensusParams,
         CKeyStore* keyStore = nullptr);
 

--- a/src/sapling/zip32.h
+++ b/src/sapling/zip32.h
@@ -23,7 +23,7 @@ private:
 
 public:
     HDSeed() {}
-    HDSeed(const CPrivKey& seedIn) : seed(seedIn) {}
+    explicit HDSeed(const CPrivKey& seedIn) : seed(seedIn) {}
 
     static HDSeed Random(size_t len = 32);
     bool IsNull() const { return seed.empty(); };

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -63,7 +63,7 @@ class ConstPubkeyProvider final : public PubkeyProvider
     CPubKey m_pubkey;
 
 public:
-    ConstPubkeyProvider(const CPubKey& pubkey) : m_pubkey(pubkey) {}
+    explicit ConstPubkeyProvider(const CPubKey& pubkey) : m_pubkey(pubkey) {}
     bool GetPubKey(int pos, const SigningProvider& arg, CPubKey& out) const override
     {
         out = m_pubkey;
@@ -170,7 +170,7 @@ class AddressDescriptor final : public Descriptor
     CTxDestination m_destination;
 
 public:
-    AddressDescriptor(CTxDestination destination) : m_destination(std::move(destination)) {}
+    explicit AddressDescriptor(CTxDestination destination) : m_destination(std::move(destination)) {}
 
     bool IsRange() const override { return false; }
     std::string ToString() const override { return "addr(" + EncodeDestination(m_destination) + ")"; }
@@ -188,7 +188,7 @@ class RawDescriptor final : public Descriptor
     CScript m_script;
 
 public:
-    RawDescriptor(CScript script) : m_script(std::move(script)) {}
+    explicit RawDescriptor(CScript script) : m_script(std::move(script)) {}
 
     bool IsRange() const override { return false; }
     std::string ToString() const override { return "raw(" + HexStr(m_script) + ")"; }
@@ -328,7 +328,7 @@ class ComboDescriptor final : public Descriptor
     std::unique_ptr<PubkeyProvider> m_provider;
 
 public:
-    ComboDescriptor(std::unique_ptr<PubkeyProvider> provider) : m_provider(std::move(provider)) {}
+    explicit ComboDescriptor(std::unique_ptr<PubkeyProvider> provider) : m_provider(std::move(provider)) {}
 
     bool IsRange() const override { return m_provider->IsRange(); }
     std::string ToString() const override { return "combo(" + m_provider->ToString() + ")"; }

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -93,7 +93,7 @@ struct PrecomputedTransactionData
 {
     uint256 hashPrevouts, hashSequence, hashOutputs, hashShieldedSpends, hashShieldedOutputs;
 
-    PrecomputedTransactionData(const CTransaction& tx);
+    explicit PrecomputedTransactionData(const CTransaction& tx);
 };
 
 uint256 SignatureHash(const CScript &scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType, const CAmount& amount, SigVersion sigversion, const PrecomputedTransactionData* cache = nullptr);

--- a/src/script/ismine.cpp
+++ b/src/script/ismine.cpp
@@ -54,7 +54,7 @@ namespace
     private:
         const CKeyStore& keystore;
     public:
-        CWDestinationVisitor(const CKeyStore& _keystore) : keystore(_keystore) {}
+        explicit CWDestinationVisitor(const CKeyStore& _keystore) : keystore(_keystore) {}
 
         isminetype operator()(const CTxDestination& dest) const {
             return ::IsMine(keystore, dest);

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -415,7 +415,7 @@ public:
         return ret;
     }
 
-    CScript(int64_t b)        { operator<<(b); }
+    explicit CScript(int64_t b)        { operator<<(b); }
 
     explicit CScript(opcodetype b)     { operator<<(b); }
     explicit CScript(const CScriptNum& b) { operator<<(b); }

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -36,7 +36,7 @@ private:
     const SigningProvider* m_provider;
 
 public:
-    PublicOnlySigningProvider(const SigningProvider* provider) : m_provider(provider) {}
+    explicit PublicOnlySigningProvider(const SigningProvider* provider) : m_provider(provider) {}
     bool GetCScript(const CScriptID &scriptid, CScript& script) const;
     bool GetPubKey(const CKeyID &address, CPubKey& pubkey) const;
 };
@@ -60,7 +60,7 @@ protected:
     const CKeyStore* keystore;
 
 public:
-    BaseSignatureCreator(const CKeyStore* keystoreIn) : keystore(keystoreIn) {}
+    explicit BaseSignatureCreator(const CKeyStore* keystoreIn) : keystore(keystoreIn) {}
     const CKeyStore& KeyStore() const { return *keystore; };
     virtual ~BaseSignatureCreator() {}
     virtual const BaseSignatureChecker& Checker() const =0;
@@ -93,7 +93,7 @@ public:
 /** A signature creator that just produces 72-byte empty signatyres. */
 class DummySignatureCreator : public BaseSignatureCreator {
 public:
-    DummySignatureCreator(const CKeyStore* keystoreIn) : BaseSignatureCreator(keystoreIn) {}
+    explicit DummySignatureCreator(const CKeyStore* keystoreIn) : BaseSignatureCreator(keystoreIn) {}
     const BaseSignatureChecker& Checker() const;
     bool CreateSig(std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode, SigVersion sigversion) const;
 };

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -248,7 +248,7 @@ class CScriptVisitor : public boost::static_visitor<bool>
 private:
     CScript *script;
 public:
-    CScriptVisitor(CScript *scriptin) { script = scriptin; }
+    explicit CScriptVisitor(CScript *scriptin) { script = scriptin; }
 
     bool operator()(const CNoDestination &dest) const {
         script->clear();

--- a/src/sporkdb.h
+++ b/src/sporkdb.h
@@ -12,7 +12,7 @@
 class CSporkDB : public CDBWrapper
 {
 public:
-    CSporkDB(size_t nCacheSize, bool fMemory = false, bool fWipe = false);
+    explicit CSporkDB(size_t nCacheSize, bool fMemory = false, bool fWipe = false);
 
 private:
     CSporkDB(const CSporkDB&);

--- a/src/support/allocators/mt_pooled_secure.h
+++ b/src/support/allocators/mt_pooled_secure.h
@@ -26,7 +26,7 @@ struct mt_pooled_secure_allocator : public std::allocator<T> {
     typedef typename base::reference reference;
     typedef typename base::const_reference const_reference;
     typedef typename base::value_type value_type;
-    mt_pooled_secure_allocator(size_type nrequested_size = 32,
+    explicit mt_pooled_secure_allocator(size_type nrequested_size = 32,
                                size_type nnext_size = 32,
                                size_type nmax_size = 0) throw()
     {

--- a/src/support/allocators/pooled_secure.h
+++ b/src/support/allocators/pooled_secure.h
@@ -29,7 +29,7 @@ struct pooled_secure_allocator : public std::allocator<T> {
     typedef typename base::reference reference;
     typedef typename base::const_reference const_reference;
     typedef typename base::value_type value_type;
-    pooled_secure_allocator(const size_type nrequested_size = 32,
+    explicit pooled_secure_allocator(const size_type nrequested_size = 32,
                             const size_type nnext_size = 32,
                             const size_type nmax_size = 0) throw() :
                             pool(nrequested_size, nnext_size, nmax_size){}

--- a/src/support/lockedpool.h
+++ b/src/support/lockedpool.h
@@ -160,7 +160,7 @@ public:
      * If this callback is provided and returns false, the allocation fails (hard fail), if
      * it returns true the allocation proceeds, but it could warn.
      */
-    LockedPool(std::unique_ptr<LockedPageAllocator> allocator, LockingFailed_Callback lf_cb_in = 0);
+    explicit LockedPool(std::unique_ptr<LockedPageAllocator> allocator, LockingFailed_Callback lf_cb_in = 0);
     ~LockedPool();
 
     LockedPool(const LockedPool& other) = delete; // non construction-copyable
@@ -227,7 +227,7 @@ public:
     }
 
 private:
-    LockedPoolManager(std::unique_ptr<LockedPageAllocator> allocator);
+    explicit LockedPoolManager(std::unique_ptr<LockedPageAllocator> allocator);
 
     /** Create a new LockedPoolManager specialized to the OS */
     static void CreateInstance();

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -91,7 +91,7 @@ class TestAddrTypeVisitor : public boost::static_visitor<bool>
 private:
     std::string exp_addrType;
 public:
-    TestAddrTypeVisitor(const std::string &exp_addrType) : exp_addrType(exp_addrType) { }
+    explicit TestAddrTypeVisitor(const std::string &exp_addrType) : exp_addrType(exp_addrType) { }
     bool operator()(const CKeyID &id) const
     {
         return (exp_addrType == "pubkey");
@@ -116,7 +116,7 @@ class TestPayloadVisitor : public boost::static_visitor<bool>
 private:
     std::vector<unsigned char> exp_payload;
 public:
-    TestPayloadVisitor(std::vector<unsigned char> &exp_payload) : exp_payload(exp_payload) { }
+    explicit TestPayloadVisitor(std::vector<unsigned char> &exp_payload) : exp_payload(exp_payload) { }
     bool operator()(const CKeyID &id) const
     {
         uint160 exp_key(exp_payload);

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -22,7 +22,7 @@ struct TestVector {
     std::string strHexMaster;
     std::vector<TestDerivation> vDerive;
 
-    TestVector(std::string strHexMasterIn) : strHexMaster(strHexMasterIn) {}
+    explicit TestVector(std::string strHexMasterIn) : strHexMaster(strHexMasterIn) {}
 
     TestVector& operator()(std::string pub, std::string prv, unsigned int nChild) {
         vDerive.emplace_back();

--- a/src/test/bls_tests.cpp
+++ b/src/test/bls_tests.cpp
@@ -70,7 +70,7 @@ struct Member
     CBLSSecretKey sk;
     CBLSPublicKey pk;
 
-    Member(const CBLSId& _id): id(_id)
+    explicit Member(const CBLSId& _id): id(_id)
     {
         sk.MakeNewKey();
         pk = sk.GetPublicKey();

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -191,7 +191,7 @@ public:
 class CCoinsViewCacheTest : public CCoinsViewCache
 {
 public:
-    CCoinsViewCacheTest(CCoinsView* base) : CCoinsViewCache(base) {}
+    explicit CCoinsViewCacheTest(CCoinsView* base) : CCoinsViewCache(base) {}
 
     void SelfTest() const
     {

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -232,7 +232,7 @@ struct StringContentsSerializer {
     // This is a terrible idea
     std::string str;
     StringContentsSerializer() {}
-    StringContentsSerializer(const std::string& inp) : str(inp) {}
+    explicit StringContentsSerializer(const std::string& inp) : str(inp) {}
 
     StringContentsSerializer& operator+=(const std::string& s) {
         str += s;

--- a/src/test/librust/sapling_rpc_wallet_tests.cpp
+++ b/src/test/librust/sapling_rpc_wallet_tests.cpp
@@ -34,7 +34,7 @@ namespace {
     /** Set the working directory for the duration of the scope. */
     class PushCurrentDirectory {
     public:
-        PushCurrentDirectory(const std::string &new_cwd)
+        explicit PushCurrentDirectory(const std::string &new_cwd)
                 : old_cwd(fs::current_path()) {
             fs::current_path(new_cwd);
         }

--- a/src/test/librust/sapling_test_fixture.h
+++ b/src/test/librust/sapling_test_fixture.h
@@ -12,7 +12,7 @@
  */
 struct SaplingTestingSetup : public TestingSetup
 {
-    SaplingTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
+    explicit SaplingTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
     ~SaplingTestingSetup();
 };
 

--- a/src/test/test_pivx.h
+++ b/src/test/test_pivx.h
@@ -51,7 +51,7 @@ static inline std::vector<unsigned char> InsecureRandBytes(size_t len) { return 
 struct BasicTestingSetup {
     ECCVerifyHandle globalVerifyHandle;
 
-    BasicTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
+    explicit BasicTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
     ~BasicTestingSetup();
 
     fs::path SetDataDir(const std::string& name);
@@ -75,7 +75,7 @@ struct TestingSetup: public BasicTestingSetup
     CScheduler scheduler;
     std::unique_ptr<PeerLogicValidation> peerLogic;
 
-    TestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
+    explicit TestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
     ~TestingSetup();
 };
 
@@ -99,7 +99,7 @@ class CScript;
 // Test chain only available on regtest
 struct TestChainSetup : public TestingSetup
 {
-    TestChainSetup(int blockCount);
+    explicit TestChainSetup(int blockCount);
     ~TestChainSetup();
 
     // Create a new block with coinbase paying to scriptPubKey, and try to add it to the current chain.

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -24,7 +24,7 @@ BOOST_FIXTURE_TEST_SUITE(validation_block_tests, RegTestingSetup)
 struct TestSubscriber : public CValidationInterface {
     uint256 m_expected_tip;
 
-    TestSubscriber(uint256 tip) : m_expected_tip(std::move(tip)) {}
+    explicit TestSubscriber(uint256 tip) : m_expected_tip(std::move(tip)) {}
 
     void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload)
     {

--- a/src/tiertwo/netfulfilledman.h
+++ b/src/tiertwo/netfulfilledman.h
@@ -40,7 +40,7 @@ private:
     int64_t lastFilterCleanup{0};
 
 public:
-    CNetFulfilledRequestManager(unsigned int itemsFilterSize);
+    explicit CNetFulfilledRequestManager(unsigned int itemsFilterSize);
 
     SERIALIZE_METHODS(CNetFulfilledRequestManager, obj) {
         LOCK(obj.cs_mapFulfilledRequests);

--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -170,7 +170,7 @@ namespace tinyformat
 class format_error: public std::runtime_error
 {
 public:
-    format_error(const std::string &what): std::runtime_error(what) {
+    explicit format_error(const std::string &what): std::runtime_error(what) {
     }
 };
 
@@ -512,7 +512,7 @@ public:
     FormatArg() {}
 
     template<typename T>
-    FormatArg(const T& value)
+    explicit FormatArg(const T& value)
         : m_value(static_cast<const void*>(&value)),
         m_formatImpl(&formatImpl<T>),
         m_toIntImpl(&toIntImpl<T>)
@@ -871,7 +871,7 @@ class FormatListN : public FormatList
 public:
 #ifdef TINYFORMAT_USE_VARIADIC_TEMPLATES
     template<typename... Args>
-    FormatListN(const Args&... args)
+    explicit FormatListN(const Args&... args)
         : FormatList(&m_formatterStore[0], N),
         m_formatterStore { FormatArg(args)... }
     { static_assert(sizeof...(args) == N, "Number of args must be N"); }
@@ -880,7 +880,7 @@ public:
 #       define TINYFORMAT_MAKE_FORMATLIST_CONSTRUCTOR(n)       \
                                                            \
     template<TINYFORMAT_ARGTYPES(n)>                       \
-    FormatListN(TINYFORMAT_VARARGS(n))                     \
+    explicit FormatListN(TINYFORMAT_VARARGS(n))            \
         : FormatList(&m_formatterStore[0], n)              \
     { assert(n == N); init(0, TINYFORMAT_PASSARGS(n)); }   \
                                                            \

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -73,7 +73,7 @@ protected:
     CDBWrapper db;
 
 public:
-    CCoinsViewDB(size_t nCacheSize, bool fMemory = false, bool fWipe = false);
+    explicit CCoinsViewDB(size_t nCacheSize, bool fMemory = false, bool fWipe = false);
 
     bool GetCoin(const COutPoint& outpoint, Coin& coin) const override;
     bool HaveCoin(const COutPoint& outpoint) const override;
@@ -127,7 +127,7 @@ private:
 class CBlockTreeDB : public CDBWrapper
 {
 public:
-    CBlockTreeDB(size_t nCacheSize, bool fMemory = false, bool fWipe = false);
+    explicit CBlockTreeDB(size_t nCacheSize, bool fMemory = false, bool fWipe = false);
 
     CBlockTreeDB(const CBlockTreeDB&) = delete;
     CBlockTreeDB& operator=(const CBlockTreeDB&) = delete;
@@ -151,7 +151,7 @@ public:
 class CZerocoinDB : public CDBWrapper
 {
 public:
-    CZerocoinDB(size_t nCacheSize, bool fMemory = false, bool fWipe = false);
+    explicit CZerocoinDB(size_t nCacheSize, bool fMemory = false, bool fWipe = false);
 
 private:
     CZerocoinDB(const CZerocoinDB&);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -153,7 +153,7 @@ private:
 
 struct update_fee_delta
 {
-    update_fee_delta(int64_t _feeDelta) : feeDelta(_feeDelta) { }
+    explicit update_fee_delta(int64_t _feeDelta) : feeDelta(_feeDelta) { }
 
     void operator() (CTxMemPoolEntry &e) { e.UpdateFeeDelta(feeDelta); }
 
@@ -514,7 +514,7 @@ public:
      *  around what it "costs" to relay a transaction around the network and
      *  below which we would reasonably say a transaction has 0-effective-fee.
      */
-    CTxMemPool(const CFeeRate& _minReasonableRelayFee);
+    explicit CTxMemPool(const CFeeRate& _minReasonableRelayFee);
     ~CTxMemPool();
 
     /**

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -116,7 +116,7 @@ public:
 class blob88 : public base_blob<88> {
 public:
     blob88() {}
-    blob88(const base_blob<88>& b) : base_blob<88>(b) {}
+    explicit blob88(const base_blob<88>& b) : base_blob<88>(b) {}
     explicit blob88(const std::vector<unsigned char>& vch) : base_blob<88>(vch) {}
 };
 
@@ -184,7 +184,7 @@ const uint256 UINT256_MAX = uint256S("ffffffffffffffffffffffffffffffffffffffffff
 class uint512 : public base_blob<512> {
 public:
     uint512() {}
-    uint512(const base_blob<512>& b) : base_blob<512>(b) {}
+    explicit uint512(const base_blob<512>& b) : base_blob<512>(b) {}
     explicit uint512(const std::vector<unsigned char>& vch) : base_blob<512>(vch) {}
 };
 

--- a/src/util/blockstatecatcher.h
+++ b/src/util/blockstatecatcher.h
@@ -17,7 +17,7 @@ public:
     uint256 hash;
     bool found;
     CValidationState state;
-    BlockStateCatcher(const uint256& hashIn) : hash(hashIn), found(false), state(){};
+    explicit BlockStateCatcher(const uint256& hashIn) : hash(hashIn), found(false), state(){};
     void setBlockHash(const uint256& _hash) { clear(); hash = _hash; }
     void clear() { hash.SetNull(); found = false; state = CValidationState(); }
     bool stateErrorFound() { return found && state.IsError(); }

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -46,7 +46,7 @@ public:
     std::unordered_map<std::string, WalletDatabaseFileId> m_fileids;
     std::condition_variable_any m_db_in_use;
 
-    BerkeleyEnvironment(const fs::path& env_directory);
+    explicit BerkeleyEnvironment(const fs::path& env_directory);
     ~BerkeleyEnvironment();
     void Reset();
 
@@ -111,7 +111,7 @@ public:
     }
 
     /** Create DB handle to real database */
-    BerkeleyDatabase(const fs::path& wallet_path, bool mock = false) :
+    explicit BerkeleyDatabase(const fs::path& wallet_path, bool mock = false) :
         nUpdateCounter(0), nLastSeen(0), nLastFlushed(0), nLastWalletUpdate(0)
     {
         env = GetWalletEnv(wallet_path, strFile);

--- a/src/wallet/hdchain.h
+++ b/src/wallet/hdchain.h
@@ -37,7 +37,7 @@ public:
     // Chain counter type
     uint8_t chainType{HDChain::ChainCounterType::Standard};
 
-    CHDChain(const uint8_t& _chainType = HDChain::ChainCounterType::Standard) : chainType(_chainType) { SetNull(); }
+    explicit CHDChain(const uint8_t& _chainType = HDChain::ChainCounterType::Standard) : chainType(_chainType) { SetNull(); }
 
     SERIALIZE_METHODS(CHDChain, obj)
     {

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -24,7 +24,7 @@ static const uint32_t BIP32_HARDENED_KEY_LIMIT = 0x80000000;
 class ScriptPubKeyMan {
 
 public:
-    ScriptPubKeyMan(CWallet* parent) : wallet(parent) {}
+    explicit ScriptPubKeyMan(CWallet* parent) : wallet(parent) {}
     ~ScriptPubKeyMan() {};
 
     /* Set the HD chain model (chain child index counters) */

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -23,7 +23,7 @@ struct WalletTestingSetupBase : public SaplingTestingSetup
 
 struct WalletTestingSetup : public WalletTestingSetupBase
 {
-    WalletTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
+    explicit WalletTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
 };
 
 struct WalletRegTestingSetup : public WalletTestingSetup

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1261,7 +1261,7 @@ protected:
     CPubKey vchPubKey;
 
 public:
-    CReserveKey(CWallet* pwalletIn)
+    explicit CReserveKey(CWallet* pwalletIn)
     {
         nIndex = -1;
         pwallet = pwalletIn;

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -74,7 +74,8 @@ public:
     {
         SetNull();
     }
-    CKeyMetadata(int64_t nCreateTime_)
+
+    explicit CKeyMetadata(int64_t nCreateTime_)
     {
         SetNull();
         nCreateTime = nCreateTime_;

--- a/src/zpiv/zpivmodule.h
+++ b/src/zpiv/zpivmodule.h
@@ -24,7 +24,7 @@ static int const PUBSPEND_SCHNORR = 4;
 class PublicCoinSpend : public libzerocoin::CoinSpend {
 public:
 
-    PublicCoinSpend(libzerocoin::ZerocoinParams* params): pubCoin(params) {};
+    explicit PublicCoinSpend(libzerocoin::ZerocoinParams* params): pubCoin(params) {};
     template <typename Stream> PublicCoinSpend(libzerocoin::ZerocoinParams* params, Stream& strm);
 
     ~PublicCoinSpend(){};

--- a/test/lint/cppcheck/README.md
+++ b/test/lint/cppcheck/README.md
@@ -1,0 +1,30 @@
+This folder contains lint scripts intended for use with the cppcheck CLI program.
+
+Lint script naming convention should be in the form of `lint-<cppcheckrule>.sh`
+
+lint-noexplicitconstructor.sh
+======
+
+Checks for 1-argument (non-converting) class/struct constructors that are not
+marked as `explicit`. Allowing implicit conversion can lead to difficult to
+track down bugs and unintended behavior.
+
+run-cppcheck.sh
+======
+
+This script is responsible for building/rebuilding the cppcheck cache that
+all other lint scripts use. cppcheck is run in "project" mode, which creates
+a build cache to speed up subsequent runs. The result is output to a named
+`cppcheck.txt` file, used by other lint scripts.
+
+lint-all.sh
+======
+
+This is the base script used to initialize or run any lint script contained
+in this directory. It can take an optional argument of `--setup` to
+build/rebuild a cppcheck cache then exit, or be run with no arguments
+(provided a cppcache exists) to then run any lint script in this directory.
+
+Standard usage is to first run `./test/lint/cppcheck/lint-all.sh --setup` to
+create or rebuild the cppcheck cache, then run `./test/llint/cppcheck/lint-all.sh`
+with no arguments to perform any actual lint tests.

--- a/test/lint/cppcheck/lint-all.sh
+++ b/test/lint/cppcheck/lint-all.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019 The Bitcoin Core developers
+# Copyright (c) 2024 The PIVX Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# This script runs all test/lint/extended-lint-*.sh files, and fails if
+# any exit with a non-zero status code.
+
+# This script is intentionally locale dependent by not setting "export LC_ALL=C"
+# in order to allow for the executed lint scripts to opt in or opt out of locale
+# dependence themselves.
+
+set -u
+
+print_usage() {
+    echo "Usage: $0 --setup to create/refresh cppcheck's cache and exit. No argument to run lint tests."
+}
+
+SCRIPTDIR=$(dirname "${BASH_SOURCE[0]}")
+LINTALL=$(basename "${BASH_SOURCE[0]}")
+
+if [[ $# != 0 ]]; then
+    if [[ $1 == "--help" ]]; then
+        print_usage
+        exit 0
+    fi
+    if [[ $1 == "--setup" ]]; then
+        if ! "${SCRIPTDIR}"/run-cppcheck.sh; then
+          echo "cppcheck cache creation failed"
+          exit 1
+        fi
+        exit 0
+    fi
+fi
+
+for f in "${SCRIPTDIR}"/lint-*.sh; do
+  if [ "$(basename "$f")" != "$LINTALL" ]; then
+    echo "running $f"
+    if ! "$f"; then
+      echo "^---- failure generated from $f"
+      exit 1
+    fi
+  fi
+done

--- a/test/lint/cppcheck/lint-noexplicitconstructor.sh
+++ b/test/lint/cppcheck/lint-noexplicitconstructor.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019 The Bitcoin Core developers
+# Copyright (c) 2024 The PIVX Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+
+export LC_ALL=C
+
+ENABLED_CHECKS=(
+     "\[noExplicitConstructor\]"
+)
+
+IGNORED_WARNINGS=(
+    "src/immer/.*"
+    "src/chiabls/.*"
+    "src/arith_uint256.h:.* Class 'arith_uint160' has a constructor with 1 argument that is not explicit."
+    "src/arith_uint256.h:.* Class 'arith_uint256' has a constructor with 1 argument that is not explicit."
+    "src/arith_uint256.h:.* Class 'arith_uint512' has a constructor with 1 argument that is not explicit."
+    "src/arith_uint256.h:.* Class 'base_uint < 160 >' has a constructor with 1 argument that is not explicit."
+    "src/arith_uint256.h:.* Class 'base_uint < 256 >' has a constructor with 1 argument that is not explicit."
+    "src/arith_uint256.h:.* Class 'base_uint < 512 >' has a constructor with 1 argument that is not explicit."
+    "src/arith_uint256.h:.* Class 'base_uint' has a constructor with 1 argument that is not explicit."
+    "src/coins.h:.* Class 'CCoinsViewBacked' has a constructor with 1 argument that is not explicit."
+    "src/coins.h:.* Class 'CCoinsViewCache' has a constructor with 1 argument that is not explicit."
+    "src/bls/bls_wrapper.h:.* Struct 'CBLSIdImplicit' has a constructor with 1 argument that is not explicit."
+    "src/bls/bls_wrapper.h:.* Class 'CBLSId' has a constructor with 1 argument that is not explicit."
+    "src/bls/bls_wrapper.h:.* Class 'CBLSWrapper < CBLSIdImplicit , 32 , CBLSId >' has a constructor with 1 argument that is not explicit."
+    "src/bls/bls_wrapper.h:.* Class 'CBLSWrapper < bls :: G1Element , 48 , CBLSPublicKey >' has a constructor with 1 argument that is not explicit."
+    "src/bls/bls_wrapper.h:.* Class 'CBLSWrapper < bls :: G2Element , 96 , CBLSSignature >' has a constructor with 1 argument that is not explicit."
+    "src/bls/bls_wrapper.h:.* Class 'CBLSWrapper < bls :: PrivateKey , 32 , CBLSSecretKey >' has a constructor with 1 argument that is not explicit."
+    "src/operationresult.h:.* Class 'OperationResult' has a constructor with 1 argument that is not explicit."
+    "src/prevector.h:.* Class 'const_iterator' has a constructor with 1 argument that is not explicit."
+    "src/prevector.h:.* Class 'const_reverse_iterator' has a constructor with 1 argument that is not explicit."
+    "src/prevector.h:.* Class 'iterator' has a constructor with 1 argument that is not explicit."
+    "src/prevector.h:.* Class 'reverse_iterator' has a constructor with 1 argument that is not explicit."
+    "src/primitives/block.h:.* Class 'CBlock' has a constructor with 1 argument that is not explicit."
+    "src/primitives/transaction.h:.* Class 'CTransaction' has a constructor with 1 argument that is not explicit."
+    "src/primitives/transaction.h:.* Struct 'CMutableTransaction' has a constructor with 1 argument that is not explicit."
+    "src/libzerocoin/bignum.h:.* Class 'CBigNum' has a constructor with 1 argument that is not explicit."
+    "src/qt/walletmodel.h:.* Struct 'SendCoinsReturn' has a constructor with 1 argument that is not explicit."
+    "src/rpc/server.h:.* Struct 'UniValueType' has a constructor with 1 argument that is not explicit."
+    "src/sapling/incrementalmerkletree.h:.* Class 'PedersenHash' has a constructor with 1 argument that is not explicit."
+    "src/sapling/incrementalmerkletree.h:.* Class 'SHA256Compress' has a constructor with 1 argument that is not explicit."
+    "src/script/standard.h:.* Class 'CScriptID' has a constructor with 1 argument that is not explicit."
+    "src/span.h:.* Class 'Span' has a constructor with 1 argument that is not explicit."
+    "src/span.h:.* Class 'Span < const char >' has a constructor with 1 argument that is not explicit."
+    "src/span.h:.* Class 'Span < const uint8_t >' has a constructor with 1 argument that is not explicit."
+    "src/span.h:.* Class 'Span < const unsigned char >' has a constructor with 1 argument that is not explicit."
+    "src/span.h:.* Class 'Span < uint8_t >' has a constructor with 1 argument that is not explicit."
+    "src/span.h:.* Class 'Span < unsigned char >' has a constructor with 1 argument that is not explicit."
+    "src/support/allocators/secure.h:.* Struct 'secure_allocator < char >' has a constructor with 1 argument that is not explicit."
+    "src/support/allocators/secure.h:.* Struct 'secure_allocator < RNGState >' has a constructor with 1 argument that is not explicit."
+    "src/support/allocators/secure.h:.* Struct 'secure_allocator < unsigned char >' has a constructor with 1 argument that is not explicit."
+    "src/support/allocators/zeroafterfree.h:.* Struct 'zero_after_free_allocator < char >' has a constructor with 1 argument that is not explicit."
+    "src/wallet/wallet.h:.* Struct 'Confirmation' has a constructor with 1 argument that is not explicit."
+)
+
+if [ ! -f cppcheck.txt ]; then
+    echo "cppcheck.txt cache not found, skipping linting."
+    exit 1
+fi
+
+function join_array {
+    local IFS="$1"
+    shift
+    echo "$*"
+}
+
+ENABLED_CHECKS_REGEXP=$(join_array "|" "${ENABLED_CHECKS[@]}")
+IGNORED_WARNINGS_REGEXP=$(join_array "|" "${IGNORED_WARNINGS[@]}")
+
+WARNINGS=$(< cppcheck.txt grep -E "${ENABLED_CHECKS_REGEXP}" | grep -vE "${IGNORED_WARNINGS_REGEXP}")
+
+if [[ ${WARNINGS} != "" ]]; then
+    echo "${WARNINGS}"
+    echo
+    echo "Advice not applicable in this specific case? Add an exception by updating"
+    echo "IGNORED_WARNINGS in $0"
+    # Set to 1 to enforce the developer note policy "By default, declare single-argument constructors `explicit`"
+    exit 0
+fi
+echo "All checks passed!"
+exit 0

--- a/test/lint/cppcheck/run-cppcheck.sh
+++ b/test/lint/cppcheck/run-cppcheck.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2024 The PIVX Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+
+export LC_ALL=C
+
+CPPCHECK_BUILD_DIR=".ci-cppcheck"
+
+if ! command -v cppcheck > /dev/null; then
+    echo "Skipping cppcheck linting since cppcheck is not installed. Install by running \"apt install cppcheck\""
+    exit 1
+fi
+
+echo "Building cppcheck cache..."
+if [ ! -d "${CPPCHECK_BUILD_DIR}" ]; then
+  mkdir -p "${CPPCHECK_BUILD_DIR}"
+fi
+
+cppcheck --cppcheck-build-dir="${CPPCHECK_BUILD_DIR}" --enable=all -j "$(getconf _NPROCESSORS_ONLN)" \
+--language=c++ --std=c++14 --template=gcc --check-level=exhaustive --file-filter=*.cpp --file-filter=*.h -isrc/chiabls \
+-isrc/crc32c -isrc/immer -isrc/leveldb -isrc/secp256k1 -isrc/univalue -D__cplusplus -DCLIENT_VERSION_BUILD \
+-DCLIENT_VERSION_IS_RELEASE -DCLIENT_VERSION_MAJOR -DCLIENT_VERSION_MINOR -DCLIENT_VERSION_REVISION -DCOPYRIGHT_YEAR \
+-DDEBUG -DWITH_LOCK -DPACKAGE_NAME -DENABLE_MINING_RPC --library=boost --library=qt -I src/ -I src/qt/ src/ 2> >(sort -u > cppcheck.txt)
+
+echo "cppcheck cache built."
+
+exit 0


### PR DESCRIPTION
Declare single-argument (non-converting) constructors `explicit`.

In order to avoid unintended implicit conversions.

Coming from https://github.com/bitcoin/bitcoin/pull/10969

Added a new CI lint job that uses `cppcheck` to indicate any regressions or new introductions. This lint framework can be expanded on to catch other static analysis warnings in future PRs.