### PR TITLE
[Tests] Actually wait for nodes to connect

### DIFF
--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -26,7 +26,6 @@ from test_framework.mininode import (
 from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
     assert_equal,
-    connect_nodes,
     wait_until,
 )
 
@@ -111,7 +110,7 @@ class ExampleTest(PivxTestFramework):
         # In this test, we're not connecting node2 to node0 or node1. Calls to
         # sync_all() should not include node2, since we're not expecting it to
         # sync.
-        connect_nodes(self.nodes[0], 1)
+        self.connect_nodes(0, 1)
         self.sync_all(self.nodes[0:1])
 
     # Use setup_nodes() to customize the node start behaviour (for example if
@@ -182,7 +181,7 @@ class ExampleTest(PivxTestFramework):
         self.nodes[1].waitforblockheight(11)
 
         self.log.info("Connect node2 and node1")
-        connect_nodes(self.nodes[1], 2)
+        self.connect_nodes(1, 2)
 
         self.log.info("Add P2P connection to node2")
         self.nodes[0].disconnect_p2ps()

--- a/test/functional/feature_abortnode.py
+++ b/test/functional/feature_abortnode.py
@@ -13,7 +13,7 @@
 import os
 
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import wait_until, get_datadir_path, connect_nodes
+from test_framework.util import wait_until, get_datadir_path
 
 
 class AbortNodeTest(PivxTestFramework):
@@ -37,7 +37,7 @@ class AbortNodeTest(PivxTestFramework):
         # attempt.
         self.nodes[1].generate(3)
         with self.nodes[0].assert_debug_log(["Failed to disconnect block"]):
-            connect_nodes(self.nodes[0], 1)
+            self.connect_nodes(0, 1)
             self.nodes[1].generate(1)
 
             # Check that node0 aborted

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -10,7 +10,7 @@ import random
 from test_framework.messages import CTransaction, CTxIn, CTxOut, COutPoint, ToHex, COIN
 from test_framework.script import CScript, OP_1, OP_DROP, OP_2, OP_HASH160, OP_EQUAL, hash160, OP_TRUE
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import connect_nodes, satoshi_round
+from test_framework.util import satoshi_round
 
 
 # Use as minTxFee
@@ -247,9 +247,9 @@ class EstimateFeeTest(PivxTestFramework):
         # so the estimates would not be affected by the splitting transactions
         self.start_node(1)
         self.start_node(2)
-        connect_nodes(self.nodes[1], 0)
-        connect_nodes(self.nodes[0], 2)
-        connect_nodes(self.nodes[2], 1)
+        self.connect_nodes(1, 0)
+        self.connect_nodes(0, 2)
+        self.connect_nodes(2, 1)
 
         self.sync_all()
 

--- a/test/functional/feature_minchainwork.py
+++ b/test/functional/feature_minchainwork.py
@@ -18,7 +18,7 @@ only succeeds past a given node once its nMinimumChainWork has been exceeded.
 import time
 
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import connect_nodes, assert_equal
+from test_framework.util import assert_equal
 
 
 # 2 hashes required per regtest block (with no difficulty adjustment)
@@ -40,7 +40,7 @@ class MinimumChainWorkTest(PivxTestFramework):
         # block relay to inbound peers.
         self.setup_nodes()
         for i in range(self.num_nodes-1):
-            connect_nodes(self.nodes[i+1], i)
+            self.connect_nodes(i+1, i)
 
     def run_test(self):
         # Start building a chain on node0.  node2 shouldn't be able to sync until node1's

--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -9,8 +9,7 @@ import os
 from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
     assert_equal,
-    wait_until,
-    connect_nodes,
+    wait_until
 )
 
 
@@ -66,7 +65,7 @@ class NotificationsTest(PivxTestFramework):
             self.log.info("test -walletnotify after rescan")
             # restart node to rescan to force wallet notifications
             self.start_node(1)
-            connect_nodes(self.nodes[0], 1)
+            self.connect_nodes(0, 1)
 
             wait_until(lambda: len(os.listdir(self.walletnotify_dir)) == block_count, timeout=10)
 

--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -13,7 +13,7 @@ from struct import unpack, pack
 import urllib.parse
 
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import assert_equal, assert_greater_than, connect_nodes, hex_str_to_bytes
+from test_framework.util import assert_equal, assert_greater_than, hex_str_to_bytes
 
 
 def deser_uint256(f):
@@ -52,7 +52,7 @@ class RESTTest (PivxTestFramework):
 
     def setup_network(self, split=False):
         super().setup_network()
-        connect_nodes(self.nodes[0], 2)
+        self.connect_nodes(0, 2)
 
     def run_test(self):
         url = urllib.parse.urlparse(self.nodes[0].url)

--- a/test/functional/mining_pos_reorg.py
+++ b/test/functional/mining_pos_reorg.py
@@ -7,9 +7,6 @@ from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
-    connect_nodes,
-    connect_nodes_clique,
-    disconnect_nodes,
     set_node_times,
     DecimalAmt,
 )
@@ -28,7 +25,7 @@ class ReorgStakeTest(PivxTestFramework):
     def setup_network(self):
         # connect all nodes between each other
         self.setup_nodes()
-        connect_nodes_clique(self.nodes)
+        self.connect_nodes_clique(self.nodes)
         self.sync_all()
 
     def log_title(self):
@@ -42,7 +39,7 @@ class ReorgStakeTest(PivxTestFramework):
         for i in range(self.num_nodes):
             for j in range(self.num_nodes):
                 if j != i:
-                    disconnect_nodes(self.nodes[i], j)
+                    self.disconnect_nodes(i, j)
         self.log.info("Nodes disconnected")
 
     def get_tot_balance(self, nodeid):
@@ -109,7 +106,7 @@ class ReorgStakeTest(PivxTestFramework):
 
         # Connect with node 2 and sync
         self.log.info("Reconnecting node 0 and node 2")
-        connect_nodes(self.nodes[0], 2)
+        self.connect_nodes(0, 2)
         self.sync_blocks([self.nodes[i] for i in [0, 2]])
 
         # verify that the stakeinput can't be spent
@@ -140,7 +137,7 @@ class ReorgStakeTest(PivxTestFramework):
         new_best_hash = self.nodes[1].getbestblockhash()
         self.log.info("Connecting and syncing nodes...")
         set_node_times(self.nodes, self.mocktime)
-        connect_nodes_clique(self.nodes)
+        self.connect_nodes_clique(self.nodes)
         self.sync_blocks()
         for i in [0, 2]:
             assert_equal(self.nodes[i].getbestblockhash(), new_best_hash)

--- a/test/functional/p2p_disconnect_ban.py
+++ b/test/functional/p2p_disconnect_ban.py
@@ -9,7 +9,6 @@ import time
 from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
     assert_equal,
-    connect_nodes,
     assert_raises_rpc_error,
     wait_until,
 )
@@ -21,8 +20,8 @@ class DisconnectBanTest(PivxTestFramework):
 
     def run_test(self):
         self.log.info("Connect nodes both way")
-        connect_nodes(self.nodes[0], 1)
-        connect_nodes(self.nodes[1], 0)
+        self.connect_nodes(0, 1)
+        self.connect_nodes(1, 0)
 
         self.log.info("Test setban and listbanned RPCs")
 
@@ -81,8 +80,8 @@ class DisconnectBanTest(PivxTestFramework):
         # Clear ban lists
         self.nodes[1].clearbanned()
         self.log.info("Connect nodes both way")
-        connect_nodes(self.nodes[0], 1)
-        connect_nodes(self.nodes[1], 0)
+        self.connect_nodes(0, 1)
+        self.connect_nodes(1, 0)
 
         self.log.info("Test disconnectnode RPCs")
 
@@ -101,7 +100,7 @@ class DisconnectBanTest(PivxTestFramework):
         assert not [node for node in self.nodes[0].getpeerinfo() if node['addr'] == address1]
 
         self.log.info("disconnectnode: successfully reconnect node")
-        connect_nodes(self.nodes[0], 1)  # reconnect the node
+        self.connect_nodes(0, 1)  # reconnect the node
         assert_equal(len(self.nodes[0].getpeerinfo()), 2)
         assert [node for node in self.nodes[0].getpeerinfo() if node['addr'] == address1]
 

--- a/test/functional/p2p_quorum_connect.py
+++ b/test/functional/p2p_quorum_connect.py
@@ -13,7 +13,6 @@ from test_framework.mininode import P2PInterface
 from test_framework.messages import msg_version
 from test_framework.util import (
     assert_equal,
-    connect_nodes,
     hash256,
     wait_until,
 )
@@ -174,7 +173,7 @@ class DMNConnectionTest(PivxDMNTestFramework):
         self.clean_conns_and_disconnect(mn6_node)
 
         # Create the regular connection
-        connect_nodes(mn5_node, mn6.idx)
+        self.connect_nodes(mn5.idx, mn6.idx)
         self.wait_for_peers_count([mn5_node], 1)
         assert self.has_single_regular_connection(mn5_node)
         assert self.has_single_regular_connection(mn6_node)

--- a/test/functional/p2p_sendheaders.py
+++ b/test/functional/p2p_sendheaders.py
@@ -88,7 +88,7 @@ from test_framework.messages import (
 )
 from test_framework.mininode import mininode_lock, NetworkThread, P2PInterface
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import assert_equal, wait_until, connect_nodes, p2p_port
+from test_framework.util import assert_equal, wait_until, p2p_port
 
 
 direct_fetch_response_time = 0.05
@@ -242,7 +242,7 @@ class SendHeadersTest(PivxTestFramework):
     def setup_network(self):
         self.nodes = []
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [["-debug", "-logtimemicros=1"]]*2)
-        connect_nodes(self.nodes[0], 1)
+        self.connect_nodes(0, 1)
 
     # mine count blocks and return the new tip
     def mine_blocks(self, count):

--- a/test/functional/p2p_time_offset.py
+++ b/test/functional/p2p_time_offset.py
@@ -9,6 +9,7 @@ from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
     assert_equal,
     set_node_times,
+    wait_until,
 )
 
 
@@ -22,9 +23,9 @@ class TimeOffsetTest(PivxTestFramework):
         # don't connect nodes yet
         self.setup_nodes()
 
-    def connect_nodes_bi(self, a, b):
-        self.connect_nodes(a, b)
-        self.connect_nodes(b, a)
+    def connect_nodes_bi(self, a, b, wait_for_connect = True):
+        self.connect_nodes(a, b, wait_for_connect)
+        self.connect_nodes(b, a, wait_for_connect)
 
     def check_connected_nodes(self):
         ni = [node.getnetworkinfo() for node in self.connected_nodes]
@@ -96,9 +97,9 @@ class TimeOffsetTest(PivxTestFramework):
 
         # try to connect node 5 and check that it can't
         self.log.info("Trying to connect with node-5 (+30 s)...")
-        self.connect_nodes_bi(0, 5)
-        ni = self.nodes[0].getnetworkinfo()
-        assert_equal(ni['connections'], 10)
+        # Don't wait for a connection that will never be established.
+        self.connect_nodes_bi(0, 5, False)
+        wait_until(lambda: self.nodes[0].getnetworkinfo()['connections'] == 10)
         assert_equal(ni['timeoffset'], 15)
         self.log.info("Not connected.")
         self.log.info("Node-0 nTimeOffset: +%d seconds" % ni['timeoffset'])

--- a/test/functional/p2p_time_offset.py
+++ b/test/functional/p2p_time_offset.py
@@ -8,14 +8,9 @@ import time
 from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
     assert_equal,
-    connect_nodes,
     set_node_times,
 )
 
-
-def connect_nodes_bi(nodes, a, b):
-    connect_nodes(nodes[a], b)
-    connect_nodes(nodes[b], a)
 
 class TimeOffsetTest(PivxTestFramework):
     def set_test_params(self):
@@ -26,6 +21,10 @@ class TimeOffsetTest(PivxTestFramework):
     def setup_network(self):
         # don't connect nodes yet
         self.setup_nodes()
+
+    def connect_nodes_bi(self, a, b):
+        self.connect_nodes(a, b)
+        self.connect_nodes(b, a)
 
     def check_connected_nodes(self):
         ni = [node.getnetworkinfo() for node in self.connected_nodes]
@@ -52,8 +51,8 @@ class TimeOffsetTest(PivxTestFramework):
 
         # connect nodes 1 and 2
         self.log.info("Connecting with node-1 (+10 s) and node-2 (+15 s)...")
-        connect_nodes_bi(self.nodes, 0, 1)
-        connect_nodes_bi(self.nodes, 0, 2)
+        self.connect_nodes_bi(0, 1)
+        self.connect_nodes_bi(0, 2)
         self.log.info("--> samples = [+0, +10, (+10), +15, +15]")
         ni = self.nodes[0].getnetworkinfo()
         assert_equal(ni['connections'], 4)
@@ -64,7 +63,7 @@ class TimeOffsetTest(PivxTestFramework):
 
         # connect node 3
         self.log.info("Connecting with node-3 (+20 s). This will print the warning...")
-        connect_nodes_bi(self.nodes, 0, 3)
+        self.connect_nodes_bi(0, 3)
         self.log.info("--> samples = [+0, +10, +10, (+15), +15, +20, +20]")
         ni = self.nodes[0].getnetworkinfo()
         assert_equal(ni['connections'], 6)
@@ -75,7 +74,7 @@ class TimeOffsetTest(PivxTestFramework):
 
         # connect node 6
         self.log.info("Connecting with node-6 (-5 s)...")
-        connect_nodes_bi(self.nodes, 0, 6)
+        self.connect_nodes_bi(0, 6)
         self.log.info("--> samples = [-5, -5, +0, +10, (+10), +15, +15, +20, +20]")
         ni = self.nodes[0].getnetworkinfo()
         assert_equal(ni['connections'], 8)
@@ -86,7 +85,7 @@ class TimeOffsetTest(PivxTestFramework):
 
         # connect node 4
         self.log.info("Connecting with node-4 (+25 s). This will print the warning...")
-        connect_nodes_bi(self.nodes, 0, 4)
+        self.connect_nodes_bi(0, 4)
         self.log.info("--> samples = [-5, -5, +0, +10, +10, (+15), +15, +20, +20, +25, +25]")
         ni = self.nodes[0].getnetworkinfo()
         assert_equal(ni['connections'], 10)
@@ -97,7 +96,7 @@ class TimeOffsetTest(PivxTestFramework):
 
         # try to connect node 5 and check that it can't
         self.log.info("Trying to connect with node-5 (+30 s)...")
-        connect_nodes_bi(self.nodes, 0, 5)
+        self.connect_nodes_bi(0, 5)
         ni = self.nodes[0].getnetworkinfo()
         assert_equal(ni['connections'], 10)
         assert_equal(ni['timeoffset'], 15)
@@ -106,7 +105,7 @@ class TimeOffsetTest(PivxTestFramework):
 
         # connect node 7
         self.log.info("Connecting with node-7 (-10 s)...")
-        connect_nodes_bi(self.nodes, 0, 7)
+        self.connect_nodes_bi(0, 7)
         self.log.info("--> samples = [-10, -10, -5, -5, +0, +10, (+10), +15, +15, +20, +20, +25, +25]")
         ni = self.nodes[0].getnetworkinfo()
         assert_equal(ni['connections'], 12)

--- a/test/functional/p2p_unrequested_blocks.py
+++ b/test/functional/p2p_unrequested_blocks.py
@@ -58,7 +58,7 @@ from test_framework.blocktools import create_block, create_coinbase, create_tran
 from test_framework.messages import CBlockHeader, CInv, msg_block, msg_headers, msg_inv
 from test_framework.mininode import mininode_lock, P2PInterface
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import assert_equal, assert_raises_rpc_error, connect_nodes
+from test_framework.util import assert_equal, assert_raises_rpc_error
 
 
 class AcceptBlockTest(PivxTestFramework):
@@ -311,7 +311,7 @@ class AcceptBlockTest(PivxTestFramework):
         test_node.wait_for_disconnect()
 
         # 9. Connect node1 to node0 and ensure it is able to sync
-        connect_nodes(self.nodes[0], 1)
+        self.connect_nodes(0, 1)
         self.sync_blocks([self.nodes[0], self.nodes[1]])
         self.log.info("Successfully synced nodes 1 and 0")
 

--- a/test/functional/rpc_invalidateblock.py
+++ b/test/functional/rpc_invalidateblock.py
@@ -5,7 +5,7 @@
 """Test the invalidateblock RPC."""
 
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import assert_equal, connect_nodes, wait_until
+from test_framework.util import assert_equal, wait_until
 
 
 class InvalidateTest(PivxTestFramework):
@@ -29,7 +29,7 @@ class InvalidateTest(PivxTestFramework):
         assert_equal(self.nodes[1].getblockcount(), 6)
 
         self.log.info("Connect nodes to force a reorg")
-        connect_nodes(self.nodes[0], 1)
+        self.connect_nodes(0, 1)
         self.sync_blocks(self.nodes[0:2])
         assert_equal(self.nodes[0].getblockcount(), 6)
         badhash = self.nodes[1].getblockhash(2)
@@ -40,7 +40,7 @@ class InvalidateTest(PivxTestFramework):
         assert_equal(self.nodes[0].getbestblockhash(), besthash_n0)
 
         self.log.info("Make sure we won't reorg to a lower work chain:")
-        connect_nodes(self.nodes[1], 2)
+        self.connect_nodes(1, 2)
         self.log.info("Sync node 2 to node 1 so both have 6 blocks")
         self.sync_blocks(self.nodes[1:3])
         assert_equal(self.nodes[2].getblockcount(), 6)

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -15,8 +15,6 @@ from test_framework.util import (
     assert_greater_than_or_equal,
     assert_greater_than,
     assert_raises_rpc_error,
-    connect_nodes,
-    disconnect_nodes,
     p2p_port,
     wait_until,
 )
@@ -28,8 +26,8 @@ class NetTest(PivxTestFramework):
 
     def run_test(self):
         self.log.info("Connect nodes both way")
-        connect_nodes(self.nodes[0], 1)
-        connect_nodes(self.nodes[1], 0)
+        self.connect_nodes(0, 1)
+        self.connect_nodes(1, 0)
 
         self._test_connection_count()
         self._test_getnettotals()
@@ -69,13 +67,13 @@ class NetTest(PivxTestFramework):
     def _test_getnetworkinginfo(self):
         assert_equal(self.nodes[0].getnetworkinfo()['connections'], 2)
 
-        disconnect_nodes(self.nodes[0], 1)
+        self.disconnect_nodes(0, 1)
         # Wait a bit for all sockets to close
         wait_until(lambda: self.nodes[0].getnetworkinfo()['connections'] == 0, timeout=3)
 
         self.log.info("Connect nodes both way")
-        connect_nodes(self.nodes[0], 1)
-        connect_nodes(self.nodes[1], 0)
+        self.connect_nodes(0, 1)
+        self.connect_nodes(1, 0)
         assert_equal(self.nodes[0].getnetworkinfo()['connections'], 2)
 
     def _test_getaddednodeinfo(self):

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -18,7 +18,6 @@ from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
-    connect_nodes
 )
 
 
@@ -48,7 +47,7 @@ class RawTransactionsTest(PivxTestFramework):
 
     def setup_network(self, split=False):
         super().setup_network()
-        connect_nodes(self.nodes[0], 2)
+        self.connect_nodes(0, 2)
 
     def run_test(self):
 

--- a/test/functional/sapling_wallet.py
+++ b/test/functional/sapling_wallet.py
@@ -11,8 +11,6 @@ from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
-    connect_nodes,
-    disconnect_nodes,
     satoshi_round,
     get_coinstake_address,
     wait_until,
@@ -77,7 +75,7 @@ class WalletSaplingTest(PivxTestFramework):
         self.restart_node(0, extra_args=self.extra_args[0]+['-minrelaytxfee=0.0000001'])
         rawtx_hex = self.nodes[0].rawshieldsendmany("from_transparent", recipients, 1)
         self.restart_node(0, extra_args=self.extra_args[0])
-        connect_nodes(self.nodes[0], 1)
+        self.connect_nodes(0, 1)
         assert_raises_rpc_error(-26, "insufficient fee",
                                 self.nodes[0].sendrawtransaction, rawtx_hex)
         self.log.info("Good. Not accepted in the mempool.")
@@ -132,7 +130,7 @@ class WalletSaplingTest(PivxTestFramework):
         self.log.info("Balances check out")
 
         # Now disconnect the block, activate SPORK_20, and try to reconnect it
-        disconnect_nodes(self.nodes[0], 1)
+        self.disconnect_nodes(0, 1)
         tip_hash = self.nodes[0].getbestblockhash()
         self.nodes[0].invalidateblock(tip_hash)
         assert tip_hash != self.nodes[0].getbestblockhash()
@@ -152,7 +150,7 @@ class WalletSaplingTest(PivxTestFramework):
         assert_equal(tip_hash, self.nodes[0].getbestblockhash())    # Block connected
         assert_equal(self.nodes[0].getshieldbalance(saplingAddr0), Decimal('30'))
         self.log.info("Reconnected after deactivation of SPORK_20. Balance restored.")
-        connect_nodes(self.nodes[0], 1)
+        self.connect_nodes(0, 1)
 
         # Node 0 sends some shield funds to node 1
         # Sapling -> Sapling

--- a/test/functional/sapling_wallet_anchorfork.py
+++ b/test/functional/sapling_wallet_anchorfork.py
@@ -7,7 +7,7 @@
 from decimal import Decimal
 
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import assert_equal, connect_nodes, get_coinstake_address
+from test_framework.util import assert_equal, get_coinstake_address
 
 class WalletAnchorForkTest(PivxTestFramework):
 
@@ -61,7 +61,7 @@ class WalletAnchorForkTest(PivxTestFramework):
         self.start_node(0, self.extra_args[0])
         self.start_node(1, self.extra_args[1])
         self.start_node(2, self.extra_args[2])
-        connect_nodes(self.nodes[1], 2)
+        self.connect_nodes(1, 2)
 
         # Partition B, node 1 mines an empty block
         self.nodes[1].generate(1)
@@ -95,9 +95,9 @@ class WalletAnchorForkTest(PivxTestFramework):
 
         # Relaunch nodes and reconnect the entire network
         self.start_nodes()
-        connect_nodes(self.nodes[0], 1)
-        connect_nodes(self.nodes[2], 1)
-        connect_nodes(self.nodes[2], 0)
+        self.connect_nodes(0, 1)
+        self.connect_nodes(2, 1)
+        self.connect_nodes(2, 0)
 
         # Mine a new block and let it propagate
         self.nodes[1].generate(1)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -342,17 +342,19 @@ class PivxTestFramework():
         self.nodes[i].process.wait(timeout)
 
     def connect_nodes(self, a, b):
-        def connect_nodes_helper(from_connection, node_num):
-            ip_port = "127.0.0.1:" + str(p2p_port(node_num))
-            from_connection.addnode(ip_port, "onetry")
-            # poll until version handshake complete to avoid race conditions
-            # with transaction relaying
-            # See comments in net_processing:
-            # * Must have a version message before anything else
-            # * Must have a verack message before anything else
-            wait_until(lambda: all(peer['version'] != 0 for peer in from_connection.getpeerinfo()))
-            wait_until(lambda: all(peer['bytesrecv_per_msg'].pop('verack', 0) == 24 for peer in from_connection.getpeerinfo()))
-        connect_nodes_helper(self.nodes[a], b)
+        from_connection = self.nodes[a]
+        to_connection = self.nodes[b]
+        ip_port = "127.0.0.1:" + str(p2p_port(b))
+        from_connection.addnode(ip_port, "onetry")
+        # poll until version handshake complete to avoid race conditions
+        # with transaction relaying
+        # See comments in net_processing:
+        # * Must have a version message before anything else
+        # * Must have a verack message before anything else
+        wait_until(lambda: all(peer['version'] != 0 for peer in from_connection.getpeerinfo()))
+        wait_until(lambda: all(peer['version'] != 0 for peer in to_connection.getpeerinfo()))
+        wait_until(lambda: all(peer['bytesrecv_per_msg'].pop('verack', 0) == 24 for peer in from_connection.getpeerinfo()))
+        wait_until(lambda: all(peer['bytesrecv_per_msg'].pop('verack', 0) == 24 for peer in to_connection.getpeerinfo()))
 
     def disconnect_nodes(self, a, b):
         def disconnect_nodes_helper(from_connection, node_num):

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -353,11 +353,6 @@ class PivxTestFramework():
         def find_conn(node, peer_subversion, inbound):
             return next(filter(lambda peer: peer['subver'] == peer_subversion and peer['inbound'] == inbound, node.getpeerinfo()), None)
 
-        # poll until version handshake complete to avoid race conditions
-        # with transaction relaying
-        # See comments in net_processing:
-        # * Must have a version message before anything else
-        # * Must have a verack message before anything else
         wait_until(lambda: find_conn(from_connection, to_connection_subver, inbound=False) is not None)
         wait_until(lambda: find_conn(to_connection, from_connection_subver, inbound=True) is not None)
 
@@ -365,11 +360,12 @@ class PivxTestFramework():
             assert peer is not None, "Error: peer disconnected"
             return peer['bytesrecv_per_msg'].pop(msg_type, 0) >= min_bytes_recv
 
-        wait_until(lambda: check_bytesrecv(find_conn(from_connection, to_connection_subver, inbound=False), 'verack', 21))
-        wait_until(lambda: check_bytesrecv(find_conn(to_connection, from_connection_subver, inbound=True), 'verack', 21))
-
-        # The message bytes are counted before processing the message, so make
-        # sure it was fully processed by waiting for a ping.
+        # Poll until version handshake (fSuccessfullyConnected) is complete to
+        # avoid race conditions, because some message types are blocked from
+        # being sent or received before fSuccessfullyConnected.
+        #
+        # As the flag fSuccessfullyConnected is not exposed, check it by
+        # waiting for a pong, which can only happen after the flag was set.
         wait_until(lambda: check_bytesrecv(find_conn(from_connection, to_connection_subver, inbound=False), 'pong', 29))
         wait_until(lambda: check_bytesrecv(find_conn(to_connection, from_connection_subver, inbound=True), 'pong', 29))
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -4,7 +4,6 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Base class for RPC testing."""
 
-from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from io import BytesIO
 import logging
@@ -373,22 +372,11 @@ class PivxTestFramework():
         disconnect_nodes_helper(self.nodes[a], b)
 
     def connect_nodes_clique(self, nodes):
-        # max_workers should be the maximum number of nodes that we have in the same functional test,
-        # 15 seems to be a good upper bound
-        parallel_exec = ThreadPoolExecutor(max_workers=15)
         l = len(nodes)
-
-        def connect_nodes_clique_internal(a):
-            for b in range(0, l):
-                self.connect_nodes(a, b)
-        jobs = []
         for a in range(l):
-            jobs.append(parallel_exec.submit(connect_nodes_clique_internal, a))
-
-        for job in jobs:
-            job.result()
-        jobs.clear()
-        parallel_exec.shutdown()
+            for b in range(a, l):
+                self.connect_nodes(a, b)
+                self.connect_nodes(b, a)
 
     def split_network(self):
         """

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -343,23 +343,35 @@ class PivxTestFramework():
     def connect_nodes(self, a, b):
         from_connection = self.nodes[a]
         to_connection = self.nodes[b]
-        from_num_peers = 1 + len(from_connection.getpeerinfo())
-        to_num_peers = 1 + len(to_connection.getpeerinfo())
         ip_port = "127.0.0.1:" + str(p2p_port(b))
         from_connection.addnode(ip_port, "onetry")
+
+        # Use subversion as peer id. Test nodes have their node number appended to the user agent string
+        from_connection_subver = from_connection.getnetworkinfo()['subversion']
+        to_connection_subver = to_connection.getnetworkinfo()['subversion']
+
+        def find_conn(node, peer_subversion, inbound):
+            return next(filter(lambda peer: peer['subver'] == peer_subversion and peer['inbound'] == inbound, node.getpeerinfo()), None)
+
         # poll until version handshake complete to avoid race conditions
         # with transaction relaying
         # See comments in net_processing:
         # * Must have a version message before anything else
         # * Must have a verack message before anything else
-        wait_until(lambda: sum(peer['version'] != 0 for peer in from_connection.getpeerinfo()) == from_num_peers)
-        wait_until(lambda: sum(peer['version'] != 0 for peer in to_connection.getpeerinfo()) == to_num_peers)
-        wait_until(lambda: sum(peer['bytesrecv_per_msg'].pop('verack', 0) == 24 for peer in from_connection.getpeerinfo()) == from_num_peers)
-        wait_until(lambda: sum(peer['bytesrecv_per_msg'].pop('verack', 0) == 24 for peer in to_connection.getpeerinfo()) == to_num_peers)
+        wait_until(lambda: find_conn(from_connection, to_connection_subver, inbound=False) is not None)
+        wait_until(lambda: find_conn(to_connection, from_connection_subver, inbound=True) is not None)
+
+        def check_bytesrecv(peer, msg_type, min_bytes_recv):
+            assert peer is not None, "Error: peer disconnected"
+            return peer['bytesrecv_per_msg'].pop(msg_type, 0) >= min_bytes_recv
+
+        wait_until(lambda: check_bytesrecv(find_conn(from_connection, to_connection_subver, inbound=False), 'verack', 21))
+        wait_until(lambda: check_bytesrecv(find_conn(to_connection, from_connection_subver, inbound=True), 'verack', 21))
+
         # The message bytes are counted before processing the message, so make
         # sure it was fully processed by waiting for a ping.
-        wait_until(lambda: sum(peer["bytesrecv_per_msg"].pop("pong", 0) >= 32 for peer in from_connection.getpeerinfo()) == from_num_peers)
-        wait_until(lambda: sum(peer["bytesrecv_per_msg"].pop("pong", 0) >= 32 for peer in to_connection.getpeerinfo()) == to_num_peers)
+        wait_until(lambda: check_bytesrecv(find_conn(from_connection, to_connection_subver, inbound=False), 'pong', 29))
+        wait_until(lambda: check_bytesrecv(find_conn(to_connection, from_connection_subver, inbound=True), 'pong', 29))
 
     def disconnect_nodes(self, a, b):
         def disconnect_nodes_helper(from_connection, node_num):

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -374,7 +374,7 @@ class PivxTestFramework():
     def connect_nodes_clique(self, nodes):
         l = len(nodes)
         for a in range(l):
-            for b in range(a, l):
+            for b in range(a + 1, l):
                 self.connect_nodes(a, b)
                 self.connect_nodes(b, a)
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -343,6 +343,8 @@ class PivxTestFramework():
     def connect_nodes(self, a, b):
         from_connection = self.nodes[a]
         to_connection = self.nodes[b]
+        from_num_peers = 1 + len(from_connection.getpeerinfo())
+        to_num_peers = 1 + len(to_connection.getpeerinfo())
         ip_port = "127.0.0.1:" + str(p2p_port(b))
         from_connection.addnode(ip_port, "onetry")
         # poll until version handshake complete to avoid race conditions
@@ -350,10 +352,10 @@ class PivxTestFramework():
         # See comments in net_processing:
         # * Must have a version message before anything else
         # * Must have a verack message before anything else
-        wait_until(lambda: all(peer['version'] != 0 for peer in from_connection.getpeerinfo()))
-        wait_until(lambda: all(peer['version'] != 0 for peer in to_connection.getpeerinfo()))
-        wait_until(lambda: all(peer['bytesrecv_per_msg'].pop('verack', 0) == 24 for peer in from_connection.getpeerinfo()))
-        wait_until(lambda: all(peer['bytesrecv_per_msg'].pop('verack', 0) == 24 for peer in to_connection.getpeerinfo()))
+        wait_until(lambda: sum(peer['version'] != 0 for peer in from_connection.getpeerinfo()) == from_num_peers)
+        wait_until(lambda: sum(peer['version'] != 0 for peer in to_connection.getpeerinfo()) == to_num_peers)
+        wait_until(lambda: sum(peer['bytesrecv_per_msg'].pop('verack', 0) == 24 for peer in from_connection.getpeerinfo()) == from_num_peers)
+        wait_until(lambda: sum(peer['bytesrecv_per_msg'].pop('verack', 0) == 24 for peer in to_connection.getpeerinfo()) == to_num_peers)
 
     def disconnect_nodes(self, a, b):
         def disconnect_nodes_helper(from_connection, node_num):

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -340,11 +340,14 @@ class PivxTestFramework():
     def wait_for_node_exit(self, i, timeout):
         self.nodes[i].process.wait(timeout)
 
-    def connect_nodes(self, a, b):
+    def connect_nodes(self, a, b, wait_for_connect = True):
         from_connection = self.nodes[a]
         to_connection = self.nodes[b]
         ip_port = "127.0.0.1:" + str(p2p_port(b))
         from_connection.addnode(ip_port, "onetry")
+
+        if not wait_for_connect:
+            return
 
         # Use subversion as peer id. Test nodes have their node number appended to the user agent string
         from_connection_subver = from_connection.getnetworkinfo()['subversion']

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -356,6 +356,10 @@ class PivxTestFramework():
         wait_until(lambda: sum(peer['version'] != 0 for peer in to_connection.getpeerinfo()) == to_num_peers)
         wait_until(lambda: sum(peer['bytesrecv_per_msg'].pop('verack', 0) == 24 for peer in from_connection.getpeerinfo()) == from_num_peers)
         wait_until(lambda: sum(peer['bytesrecv_per_msg'].pop('verack', 0) == 24 for peer in to_connection.getpeerinfo()) == to_num_peers)
+        # The message bytes are counted before processing the message, so make
+        # sure it was fully processed by waiting for a ping.
+        wait_until(lambda: sum(peer["bytesrecv_per_msg"].pop("pong", 0) >= 32 for peer in from_connection.getpeerinfo()) == from_num_peers)
+        wait_until(lambda: sum(peer["bytesrecv_per_msg"].pop("pong", 0) >= 32 for peer in to_connection.getpeerinfo()) == to_num_peers)
 
     def disconnect_nodes(self, a, b):
         def disconnect_nodes_helper(from_connection, node_num):

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -79,7 +79,7 @@ class TestNode():
             "-debugexclude=libevent",
             "-debugexclude=leveldb",
             "-mocktime=" + str(mocktime),
-            "-uacomment=testnode%d" % i
+            "-uacomment=testnode%d" % i, # required for subversion uniqueness across peers
         ]
 
         self.cli = TestNodeCLI(os.getenv("BITCOINCLI", "pivx-cli"), self.datadir)

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -382,7 +382,11 @@ def connect_nodes(from_connection, node_num):
     from_connection.addnode(ip_port, "onetry")
     # poll until version handshake complete to avoid race conditions
     # with transaction relaying
-    wait_until(lambda:  all(peer['version'] != 0 for peer in from_connection.getpeerinfo()))
+    # See comments in net_processing:
+    # * Must have a version message before anything else
+    # * Must have a verack message before anything else
+    wait_until(lambda: all(peer['version'] != 0 for peer in from_connection.getpeerinfo()))
+    wait_until(lambda: all(peer['bytesrecv_per_msg'].pop('verack', 0) == 24 for peer in from_connection.getpeerinfo()))
 
 def connect_nodes_clique(nodes):
     # max_workers should be the maximum number of nodes that we have in the same functional test,

--- a/test/functional/tiertwo_chainlocks.py
+++ b/test/functional/tiertwo_chainlocks.py
@@ -5,10 +5,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 from test_framework.test_framework import PivxDMNTestFramework
-from test_framework.util import (
-    assert_equal,
-    connect_nodes,
-)
+from test_framework.util import assert_equal
 import time
 
 '''
@@ -60,7 +57,7 @@ class ChainLocksTest(PivxDMNTestFramework):
         self.wait_for_chainlock_tip(self.nodes[1])
         assert self.nodes[0].getbestblockhash() == node0_tip
         self.nodes[0].setnetworkactive(True)
-        connect_nodes(self.nodes[0], 1)
+        self.connect_nodes(0, 1)
         self.nodes[1].generate(1)
         self.wait_for_chainlock(self.nodes[0], self.nodes[1].getbestblockhash())
 
@@ -72,7 +69,7 @@ class ChainLocksTest(PivxDMNTestFramework):
         self.wait_for_chainlock_tip(self.nodes[1])
         assert not self.nodes[0].getblock(self.nodes[0].getbestblockhash())["chainlock"]
         self.nodes[0].setnetworkactive(True)
-        connect_nodes(self.nodes[0], 1)
+        self.connect_nodes(0, 1)
         self.nodes[1].generate(1)
         self.wait_for_chainlock(self.nodes[0], self.nodes[1].getbestblockhash())
         assert self.nodes[0].getblock(self.nodes[0].getbestblockhash())["previousblockhash"] == good_tip
@@ -83,7 +80,7 @@ class ChainLocksTest(PivxDMNTestFramework):
         # Restart it so that it forgets all the chainlocks from the past
         self.stop_node(0)
         self.start_node(0, extra_args=self.extra_args[0])
-        connect_nodes(self.nodes[0], 1)
+        self.connect_nodes(0, 1)
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
         # Now try to reorg the chain
         self.nodes[0].generate(2)

--- a/test/functional/tiertwo_deterministicmns.py
+++ b/test/functional/tiertwo_deterministicmns.py
@@ -16,7 +16,6 @@ from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
     create_new_dmn,
-    connect_nodes,
     hex_str_to_bytes,
     is_coin_locked_by,
     spend_mn_collateral,
@@ -74,7 +73,7 @@ class DIP3Test(PivxTestFramework):
     def restart_controller(self):
         self.restart_node(self.controllerPos, extra_args=self.extra_args[self.controllerPos])
         self.connect_to_all(self.controllerPos)
-        connect_nodes(self.nodes[self.controllerPos], self.minerPos)
+        self.connect_nodes(self.controllerPos, self.minerPos)
         self.sync_all()
 
     def wait_until_mnsync_completed(self):

--- a/test/functional/tiertwo_governance_reorg.py
+++ b/test/functional/tiertwo_governance_reorg.py
@@ -10,8 +10,6 @@ import time
 from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
     assert_equal,
-    connect_nodes,
-    disconnect_nodes,
     p2p_port,
     set_node_times,
 )
@@ -183,17 +181,17 @@ class GovernanceReorgTest(PivxTestFramework):
     def split_network(self):
         for i in range(self.num_nodes):
             if i != self.minerBPos:
-                disconnect_nodes(self.nodes[i], self.minerBPos)
-                disconnect_nodes(self.nodes[self.minerBPos], i)
+                self.disconnect_nodes(i, self.minerBPos)
+                self.disconnect_nodes(self.minerBPos, i)
         # by-pass ring connection
         assert self.minerBPos > 0
-        connect_nodes(self.nodes[self.minerBPos-1], self.minerBPos+1)
+        self.connect_nodes(self.minerBPos-1, self.minerBPos+1)
 
     def reconnect_nodes(self):
         for i in range(self.num_nodes):
             if i != self.minerBPos:
-                connect_nodes(self.nodes[i], self.minerBPos)
-                connect_nodes(self.nodes[self.minerBPos], i)
+                self.connect_nodes(i, self.minerBPos)
+                self.connect_nodes(self.minerBPos, i)
 
     def create_and_check_superblock(self, node, next_superblock, payee):
         self.stake_and_ping(self.nodes.index(node), 1, [])

--- a/test/functional/tiertwo_governance_sync_basic.py
+++ b/test/functional/tiertwo_governance_sync_basic.py
@@ -18,7 +18,6 @@ from test_framework.test_framework import PivxTier2TestFramework
 from test_framework.util import (
     assert_equal,
     assert_true,
-    connect_nodes,
     get_datadir_path,
     satoshi_round
 )
@@ -129,10 +128,6 @@ class MasternodeGovernanceBasicTest(PivxTier2TestFramework):
         for i in range(self.num_nodes):
             assert_equal(self.nodes[i].getbudgetprojection(), expected)
             self.log.info("Budget projection valid for node %d" % i)
-
-    def connect_nodes_bi(self, nodes, a, b):
-        connect_nodes(nodes[a], b)
-        connect_nodes(nodes[b], a)
 
     def create_proposals_tx(self, props):
         nextSuperBlockHeight = self.miner.getnextsuperblock()

--- a/test/functional/tiertwo_masternode_activation.py
+++ b/test/functional/tiertwo_masternode_activation.py
@@ -17,8 +17,6 @@ import time
 
 from test_framework.test_framework import PivxTier2TestFramework
 from test_framework.util import (
-    connect_nodes_clique,
-    disconnect_nodes,
     wait_until,
 )
 
@@ -29,10 +27,10 @@ class MasternodeActivationTest(PivxTier2TestFramework):
         for i in [self.remoteOnePos, self.remoteTwoPos]:
             for j in range(self.num_nodes):
                 if i != j:
-                    disconnect_nodes(self.nodes[i], j)
+                    self.disconnect_nodes(i, j)
 
     def reconnect_remotes(self):
-        connect_nodes_clique(self.nodes)
+        self.connect_nodes_clique(self.nodes)
         self.sync_all()
 
     def reconnect_and_restart_masternodes(self):

--- a/test/functional/tiertwo_mn_compatibility.py
+++ b/test/functional/tiertwo_mn_compatibility.py
@@ -9,10 +9,7 @@ Test checking compatibility code between MN and DMN
 from decimal import Decimal
 
 from test_framework.test_framework import PivxTier2TestFramework
-from test_framework.util import (
-    assert_equal,
-    connect_nodes,
-)
+from test_framework.util import assert_equal
 
 
 class MasternodeCompatibilityTest(PivxTier2TestFramework):
@@ -105,9 +102,9 @@ class MasternodeCompatibilityTest(PivxTier2TestFramework):
         self.remoteDMN2 = self.nodes[self.remoteDMN2Pos]
         self.remoteDMN3 = self.nodes[self.remoteDMN3Pos]
         # add more direct connections to the miner
-        connect_nodes(self.miner, 2)
-        connect_nodes(self.remoteTwo, 0)
-        connect_nodes(self.remoteDMN2, 0)
+        self.connect_nodes(self.minerPos, 2)
+        self.connect_nodes(self.remoteTwoPos, 0)
+        self.connect_nodes(self.remoteDMN2Pos, 0)
         self.sync_all()
 
         # check mn list from miner

--- a/test/functional/tiertwo_reorg_mempool.py
+++ b/test/functional/tiertwo_reorg_mempool.py
@@ -20,8 +20,6 @@ from test_framework.util import (
     assert_greater_than,
     assert_raises_rpc_error,
     create_new_dmn,
-    connect_nodes,
-    disconnect_nodes,
     get_collateral_vout,
 )
 
@@ -40,13 +38,13 @@ class TiertwoReorgMempoolTest(PivxTestFramework):
         self.connect_all()
 
     def connect_all(self):
-        connect_nodes(self.nodes[0], 1)
-        connect_nodes(self.nodes[1], 0)
+        self.connect_nodes(0, 1)
+        self.connect_nodes(1, 0)
 
     def disconnect_all(self):
         self.log.info("Disconnecting nodes...")
-        disconnect_nodes(self.nodes[0], 1)
-        disconnect_nodes(self.nodes[1], 0)
+        self.disconnect_nodes(0, 1)
+        self.disconnect_nodes(1, 0)
         self.log.info("Nodes disconnected")
 
     def register_masternode(self, from_node, dmn, collateral_addr):

--- a/test/functional/wallet_abandonconflict.py
+++ b/test/functional/wallet_abandonconflict.py
@@ -7,9 +7,7 @@ from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
-    connect_nodes,
-    Decimal,
-    disconnect_nodes,
+    Decimal
 )
 
 class AbandonConflictTest(PivxTestFramework):
@@ -41,7 +39,7 @@ class AbandonConflictTest(PivxTestFramework):
         balance = newbalance
 
         # Disconnect nodes so node0's transactions don't get into node1's mempool
-        disconnect_nodes(self.nodes[0], 1)
+        self.disconnect_nodes(0, 1)
 
         # Identify the 10btc outputs
         nA = next(i for i, vout in enumerate(self.nodes[0].getrawtransaction(txA, 1)["vout"]) if vout["value"] == 10)
@@ -152,7 +150,7 @@ class AbandonConflictTest(PivxTestFramework):
         self.nodes[1].sendrawtransaction(signed["hex"])
         self.nodes[1].generate(1)
 
-        connect_nodes(self.nodes[0], 1)
+        self.connect_nodes(0, 1)
         self.sync_blocks()
 
         # Verify that B and C's 10 BTC outputs are available for spending again because AB1 is now conflicted

--- a/test/functional/wallet_backup.py
+++ b/test/functional/wallet_backup.py
@@ -40,7 +40,6 @@ from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
-    connect_nodes,
 )
 
 
@@ -53,10 +52,10 @@ class WalletBackupTest(PivxTestFramework):
 
     def setup_network(self, split=False):
         self.setup_nodes()
-        connect_nodes(self.nodes[0], 3)
-        connect_nodes(self.nodes[1], 3)
-        connect_nodes(self.nodes[2], 3)
-        connect_nodes(self.nodes[2], 0)
+        self.connect_nodes(0, 3)
+        self.connect_nodes(1, 3)
+        self.connect_nodes(2, 3)
+        self.connect_nodes(2, 0)
         self.sync_all()
 
     def one_send(self, from_node, to_address):
@@ -87,10 +86,10 @@ class WalletBackupTest(PivxTestFramework):
         self.start_node(0)
         self.start_node(1)
         self.start_node(2)
-        connect_nodes(self.nodes[0], 3)
-        connect_nodes(self.nodes[1], 3)
-        connect_nodes(self.nodes[2], 3)
-        connect_nodes(self.nodes[2], 0)
+        self.connect_nodes(0, 3)
+        self.connect_nodes(1, 3)
+        self.connect_nodes(2, 3)
+        self.connect_nodes(2, 0)
 
     def stop_three(self):
         self.stop_node(0)

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -10,7 +10,6 @@ from test_framework.util import (
     assert_equal,
     assert_fee_amount,
     assert_raises_rpc_error,
-    connect_nodes,
     Decimal,
     wait_until,
 )
@@ -25,9 +24,9 @@ class WalletTest(PivxTestFramework):
         self.start_node(0)
         self.start_node(1)
         self.start_node(2)
-        connect_nodes(self.nodes[0], 1)
-        connect_nodes(self.nodes[1], 2)
-        connect_nodes(self.nodes[0], 2)
+        self.connect_nodes(0, 1)
+        self.connect_nodes(1, 2)
+        self.connect_nodes(0, 2)
         self.sync_all(self.nodes[0:3])
 
     def get_vsize(self, txn):

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -10,7 +10,6 @@ import shutil
 from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
     assert_equal,
-    connect_nodes,
     assert_raises_rpc_error
 )
 
@@ -52,8 +51,8 @@ class WalletHDTest(PivxTestFramework):
 
     def start_and_connect_node1(self):
         self.start_node(1)
-        connect_nodes(self.nodes[0], 1)
-        connect_nodes(self.nodes[1], 0)
+        self.connect_nodes(0, 1)
+        self.connect_nodes(1, 0)
         self.sync_all()
 
     def check_addressbook(self, old_book, new_book):
@@ -120,7 +119,7 @@ class WalletHDTest(PivxTestFramework):
         self.stop_node(1)
         shutil.copyfile(os.path.join(self.nodes[1].datadir, "hd.bak"), os.path.join(self.nodes[1].datadir, "regtest", "wallet.dat"))
         self.start_node(1)
-        connect_nodes(self.nodes[0], 1)
+        self.connect_nodes(0, 1)
         self.sync_all()
         self.check_addressbook(addrbook_old, self.nodes[1].getaddressesbylabel(""))
 
@@ -140,8 +139,8 @@ class WalletHDTest(PivxTestFramework):
         z_add_2 = self.generate_shield_addr(masterkeyid, NUM_SHIELD_ADDS)
         assert_equal(z_add, z_add_2)
         # connect and sync
-        connect_nodes(self.nodes[0], 1)
-        connect_nodes(self.nodes[1], 0)
+        self.connect_nodes(0, 1)
+        self.connect_nodes(1, 0)
         self.sync_all()
         assert_equal(self.nodes[1].getbalance(), NUM_HD_ADDS + NUM_SHIELD_ADDS + 1)
 

--- a/test/functional/wallet_import_rescan.py
+++ b/test/functional/wallet_import_rescan.py
@@ -26,7 +26,6 @@ import itertools
 from test_framework.test_framework import PivxTestFramework
 from test_framework.util import (
     assert_raises_rpc_error,
-    connect_nodes,
     assert_equal,
     set_node_times
 )
@@ -126,7 +125,7 @@ class ImportRescanTest(PivxTestFramework):
         self.add_nodes(self.num_nodes, extra_args=extra_args)
         self.start_nodes()
         for i in range(1, self.num_nodes):
-            connect_nodes(self.nodes[i], 0)
+            self.connect_nodes(i, 0)
 
     def run_test(self):
         # Create one transaction on node 0 with a unique amount for

--- a/test/functional/wallet_keypool_topup.py
+++ b/test/functional/wallet_keypool_topup.py
@@ -15,10 +15,7 @@ Two nodes. Node1 is under test. Node0 is providing transactions and generating b
 import shutil
 
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import (
-    assert_equal,
-    connect_nodes,
-)
+from test_framework.util import assert_equal
 
 
 class KeypoolRestoreTest(PivxTestFramework):
@@ -38,7 +35,7 @@ class KeypoolRestoreTest(PivxTestFramework):
 
         shutil.copyfile(self.tmpdir + "/node1/regtest/wallets/wallet.dat", self.tmpdir + "/wallet.bak")
         self.start_node(1, self.extra_args[1])
-        connect_nodes(self.nodes[0], 1)
+        self.connect_nodes(0, 1)
 
         self.log.info("Generate keys for wallet")
 
@@ -64,7 +61,7 @@ class KeypoolRestoreTest(PivxTestFramework):
         self.log.info("Verify keypool is restored and balance is correct")
 
         self.start_node(1, self.extra_args[1])
-        connect_nodes(self.nodes[0], 1)
+        self.connect_nodes(0, 1)
         self.sync_all()
 
         # wallet was not backed-up after emptying the key pool.

--- a/test/functional/wallet_listsinceblock.py
+++ b/test/functional/wallet_listsinceblock.py
@@ -9,7 +9,6 @@ from test_framework.util import (
     assert_equal,
     assert_array_result,
     assert_raises_rpc_error,
-    connect_nodes,
 )
 
 class ListSinceBlockTest (PivxTestFramework):
@@ -20,7 +19,7 @@ class ListSinceBlockTest (PivxTestFramework):
     def run_test(self):
         # All nodes are in IBD from genesis, so they'll need the miner (node2) to be an outbound connection, or have
         # only one connection. (See fPreferredDownload in net_processing)
-        connect_nodes(self.nodes[1], 2)
+        self.connect_nodes(1, 2)
         self.nodes[2].generate(101)
         self.sync_all()
 

--- a/test/functional/wallet_reorgsrestore.py
+++ b/test/functional/wallet_reorgsrestore.py
@@ -18,11 +18,7 @@ import os
 import shutil
 
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import (
-        assert_equal,
-        connect_nodes,
-        disconnect_nodes,
-)
+from test_framework.util import assert_equal
 
 
 class ReorgsRestoreTest(PivxTestFramework):
@@ -39,9 +35,9 @@ class ReorgsRestoreTest(PivxTestFramework):
         self.sync_blocks()
 
         # Disconnect node1 from others to reorg its chain later
-        disconnect_nodes(self.nodes[0], 1)
-        disconnect_nodes(self.nodes[1], 2)
-        connect_nodes(self.nodes[0], 2)
+        self.disconnect_nodes(0, 1)
+        self.disconnect_nodes(1, 2)
+        self.connect_nodes(0, 2)
 
         # Send a tx to be unconfirmed later
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("10"))
@@ -51,7 +47,7 @@ class ReorgsRestoreTest(PivxTestFramework):
         assert_equal(tx_before_reorg["confirmations"], 4)
 
         # Disconnect node0 from node2 to broadcast a conflict on their respective chains
-        disconnect_nodes(self.nodes[0], 2)
+        self.disconnect_nodes(0, 2)
         nA = next(tx_out["vout"] for tx_out in self.nodes[0].gettransaction(txid_conflict_from)["details"] if tx_out["amount"] == Decimal("10"))
         inputs = []
         inputs.append({"txid": txid_conflict_from, "vout": nA})
@@ -70,7 +66,7 @@ class ReorgsRestoreTest(PivxTestFramework):
         self.nodes[2].generate(9)
 
         # Reconnect node0 and node2 and check that conflicted_txid is effectively conflicted
-        connect_nodes(self.nodes[0], 2)
+        self.connect_nodes(0, 2)
         self.sync_blocks([self.nodes[0], self.nodes[2]])
         conflicted = self.nodes[0].gettransaction(conflicted_txid)
         conflicting = self.nodes[0].gettransaction(conflicting_txid)

--- a/test/functional/wallet_txn_clone.py
+++ b/test/functional/wallet_txn_clone.py
@@ -8,8 +8,7 @@ import io
 
 from test_framework.messages import CTransaction, COIN
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import assert_equal, connect_nodes, disconnect_nodes
-
+from test_framework.util import assert_equal
 
 class TxnMallTest(PivxTestFramework):
     def set_test_params(self):
@@ -22,8 +21,8 @@ class TxnMallTest(PivxTestFramework):
     def setup_network(self):
         # Start with split network:
         super(TxnMallTest, self).setup_network()
-        disconnect_nodes(self.nodes[1], 2)
-        disconnect_nodes(self.nodes[2], 1)
+        self.disconnect_nodes(1, 2)
+        self.disconnect_nodes(2, 1)
 
     def run_test(self):
         # All nodes should start with 6,250 PIV:
@@ -108,10 +107,10 @@ class TxnMallTest(PivxTestFramework):
         self.nodes[2].generate(1)
 
         # Reconnect the split network, and sync chain:
-        connect_nodes(self.nodes[1], 2)
-        connect_nodes(self.nodes[0], 2)
-        connect_nodes(self.nodes[2], 0)
-        connect_nodes(self.nodes[2], 1)
+        self.connect_nodes(1, 2)
+        self.connect_nodes(0, 2)
+        self.connect_nodes(2, 0)
+        self.connect_nodes(2, 1)
 
         self.nodes[2].sendrawtransaction(node0_tx2["hex"])
         self.nodes[2].sendrawtransaction(tx2["hex"])

--- a/test/functional/wallet_txn_doublespend.py
+++ b/test/functional/wallet_txn_doublespend.py
@@ -7,7 +7,7 @@
 from decimal import Decimal
 
 from test_framework.test_framework import PivxTestFramework
-from test_framework.util import assert_equal, connect_nodes, disconnect_nodes, find_output
+from test_framework.util import assert_equal, find_output
 
 class TxnMallTest(PivxTestFramework):
     def set_test_params(self):
@@ -20,8 +20,8 @@ class TxnMallTest(PivxTestFramework):
     def setup_network(self):
         # Start with split network:
         super().setup_network()
-        disconnect_nodes(self.nodes[1], 2)
-        disconnect_nodes(self.nodes[2], 1)
+        self.disconnect_nodes(1, 2)
+        self.disconnect_nodes(2, 1)
 
     def run_test(self):
         # All nodes should start with 6,250 PIV:
@@ -102,10 +102,10 @@ class TxnMallTest(PivxTestFramework):
         self.nodes[2].generate(1)
 
         # Reconnect the split network, and sync chain:
-        connect_nodes(self.nodes[1], 2)
-        connect_nodes(self.nodes[0], 2)
-        connect_nodes(self.nodes[2], 0)
-        connect_nodes(self.nodes[2], 1)
+        self.connect_nodes(1, 2)
+        self.connect_nodes(0, 2)
+        self.connect_nodes(2, 0)
+        self.connect_nodes(2, 1)
         self.nodes[2].generate(1)  # Mine another block to make sure we sync
         self.sync_blocks()
         assert_equal(self.nodes[0].gettransaction(doublespend_txid)["confirmations"], 2)


### PR DESCRIPTION
This PR solves the failures of `wallet_listtransactions.py`, like the one of  https://github.com/PIVX-Project/PIVX/actions/runs/11705208154/job/32601252220?pr=2947.

They happen due to mempool sync timeout:
```
2024-11-06T14:58:03.8489793Z AssertionError: Mempool sync timed out after 60s:
2024-11-06T14:58:03.8490785Z   {'7364836e7eae24a75378b920373e303b99b4ff18db758defc4c057d784a43905'}
```

The issue is that the connection between nodes is established after the transaction is sent, as we can see from the logs:
```
2024-11-06T14:58:03.9085473Z 2024-11-06T14:57:02Z (mocktime: 2019-10-31T18:21:20Z) Relaying wtx 7364836e7eae24a75378b920373e303b99b4ff18db758defc4c057d784a43905
...
2024-11-06T14:58:03.9103287Z 2024-11-06T14:57:02Z (mocktime: 2019-10-31T18:21:20Z) New outbound peer connected: version: 70927, blocks=200, peer=0
```

Hence the newly connected node will never receive the transaction and the mempool will never be synced.

This bug is fixed by ensuring that `connect_nodes` actually wait for the connection to be established. As a consequence of those checks we cannot anymore connect nodes in parallel in `connect_nodes_clique` (which will make tests run slightly slower)

