### PR TITLE
Make install-params script work when called from other dirs

### DIFF
--- a/params/install-params.sh
+++ b/params/install-params.sh
@@ -21,6 +21,7 @@ fi
 
 SAPLING_SPEND_NAME='sapling-spend.params'
 SAPLING_OUTPUT_NAME='sapling-output.params'
+SAPLING_PATH=$(cd "$(dirname "$0")" && pwd)
 
 SHA256CMD="$(command -v sha256sum || echo shasum)"
 SHA256ARGS="$(command -v sha256sum >/dev/null || echo '-a 256')"
@@ -126,17 +127,11 @@ EOF
     if [ -d ".git" ] || [ -f autogen.sh ]
     then
         echo "Installing from source repo or dist tarball"
-        pushd params
     fi
 
     # Sapling parameters:
-    install_params "$SAPLING_SPEND_NAME" "$PARAMS_DIR/$SAPLING_SPEND_NAME" "8e48ffd23abb3a5fd9c5589204f32d9c31285a04b78096ba40a79b75677efc13"
-    install_params "$SAPLING_OUTPUT_NAME" "$PARAMS_DIR/$SAPLING_OUTPUT_NAME" "2f0ebbcbb9bb0bcffe95a397e7eba89c29eb4dde6191c339db88570e3f3fb0e4"
-
-    if [ -d ".git" ] || [ -f autogen.sh ]
-    then
-        popd
-    fi
+    install_params "$SAPLING_PATH/$SAPLING_SPEND_NAME" "$PARAMS_DIR/$SAPLING_SPEND_NAME" "8e48ffd23abb3a5fd9c5589204f32d9c31285a04b78096ba40a79b75677efc13"
+    install_params "$SAPLING_PATH/$SAPLING_OUTPUT_NAME" "$PARAMS_DIR/$SAPLING_OUTPUT_NAME" "2f0ebbcbb9bb0bcffe95a397e7eba89c29eb4dde6191c339db88570e3f3fb0e4"
 }
 
 main


### PR DESCRIPTION
Adjusts the installl-params.sh script to be able to function from outside the direct path.