### PR TITLE
[CI][Build] Update for new github actions rules

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -95,7 +95,7 @@ jobs:
           python-version: '3.8'
 
       - name: cppcheck cache files
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .cppcheck
@@ -208,7 +208,7 @@ jobs:
           cmake-version: '3.31.6'
 
       - name: ccache cache files
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .ccache
           key: ${{ runner.os }}-cmake-${{ matrix.config.name }}-ccache
@@ -338,7 +338,7 @@ jobs:
           sudo ./contrib/install_db4.sh /usr/local true
 
       - name: ccache cache files
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .ccache
           key: ${{ runner.os }}-${{ matrix.config.id }}-native-ccache
@@ -568,7 +568,7 @@ jobs:
           cmake-version: '3.31.6'
 
       - name: depends cache files
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             depends/built
@@ -699,7 +699,7 @@ jobs:
 
       - name: depends cache files
         if: matrix.config.no_depends != 1
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             depends/built
@@ -709,7 +709,7 @@ jobs:
           restore-keys: ${{ runner.os }}-depends-${{ matrix.config.host }}-v2
 
       - name: ccache cache files
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .ccache
           key: ${{ runner.os }}-depbuild-${{ matrix.config.id }}-ccache

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -164,7 +164,7 @@ jobs:
             cxx: g++
 
           - name: macOS
-            os: macos-13
+            os: macos-15-intel
             python-version: '3.10'
             packages: autoconf automake libtool boost miniupnpc libnatpmp pkg-config qt@5 zmq libevent qrencode gmp libsodium
             boost_root: true
@@ -172,7 +172,7 @@ jobs:
             cxx: clang++
 
           - name: macOS-latest
-            os: macos-14
+            os: macos-15
             python-version: '3.12'
             packages: autoconf automake libtool boost miniupnpc libnatpmp pkg-config qt@5 zmq libevent qrencode gmp libsodium
             boost_root: true
@@ -215,7 +215,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cmake-${{ matrix.config.name }}-ccache
 
       - name: Set Xcode Version
-        if: matrix.config.os == 'macos-14'
+        if: matrix.config.os == 'macos-15'
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '15.0.1'
@@ -291,7 +291,7 @@ jobs:
 
           - name: x64-macOS
             id: macOS-nodepends
-            os: macos-13
+            os: macos-15-intel
             python-version: '3.10'
             packages: autoconf automake ccache libtool boost miniupnpc libnatpmp pkg-config qt@5 zmq libevent qrencode gmp libsodium librsvg
             unit_tests: true
@@ -303,7 +303,7 @@ jobs:
 
           - name: arm64-macOS-latest
             id: macOS-nodepends-latest
-            os: macos-14
+            os: macos-15
             python-version: '3.12'
             packages: autoconf automake ccache libtool boost miniupnpc libnatpmp pkg-config qt@5 zmq libevent qrencode gmp libsodium librsvg
             unit_tests: true
@@ -345,7 +345,7 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.config.id }}-native-ccache
 
       - name: Set Xcode Version
-        if: matrix.config.os == 'macos-14'
+        if: matrix.config.os == 'macos-15'
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '15.0.1'
@@ -454,13 +454,13 @@ jobs:
 
           - name: x64-macOS
             id: macOS-nodepends
-            os: macos-13
+            os: macos-15-intel
             python-version: '3.10'
             packages: boost miniupnpc libnatpmp pkg-config zmq libevent qrencode gmp libsodium
 
           - name: arm64-macOS-latest
             id: macOS-nodepends-latest
-            os: macos-14
+            os: macos-15
             python-version: '3.12'
             packages: boost miniupnpc libnatpmp pkg-config zmq libevent qrencode gmp libsodium
 
@@ -846,7 +846,7 @@ jobs:
 
           - name: x86_64 macOS [Full Functional Tests]
             id: macos-x86_64-tests
-            os: macos-13
+            os: macos-15-intel
             host: x86_64-apple-darwin16
             packages: None
             test_runner_extra: "--all --exclude feature_dbcrash"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -421,7 +421,7 @@ jobs:
 
       - name: Upload Build Artifact
         if: matrix.config.functional_tests == true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: native-${{ matrix.config.os }}-built
           path: native-${{ matrix.config.os }}-built.tar
@@ -809,7 +809,7 @@ jobs:
 
       - name: Upload Build Artifact
         if: matrix.config.functional_tests == true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.config.host }}-built
           path: ${{ matrix.config.host }}-built.tar

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Initialize Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.8'
 
@@ -90,7 +90,7 @@ jobs:
           fetch-depth: 0
 
       - name: Initialize Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.8'
 
@@ -184,7 +184,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Initialize Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.config.python-version }}
 
@@ -318,7 +318,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Initialize Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.config.python-version }}
 
@@ -466,7 +466,7 @@ jobs:
 
     steps:
       - name: Initialize Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.config.python-version }}
 
@@ -553,7 +553,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Initialize Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.8'
 
@@ -688,7 +688,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Initialize Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.8'
 
@@ -853,7 +853,7 @@ jobs:
 
     steps:
       - name: Initialize Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.8'
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -218,7 +218,7 @@ jobs:
         if: matrix.config.os == 'macos-15'
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.0.1'
+          xcode-version: '16.0.0'
 
       - name: Configure CMake Wallet
         run: |
@@ -348,7 +348,7 @@ jobs:
         if: matrix.config.os == 'macos-15'
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.0.1'
+          xcode-version: '16.0.0'
 
       - name: Configure Native Wallet
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -85,7 +85,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -181,7 +181,7 @@ jobs:
 
     steps:
       - name: Get Source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize Python
         uses: actions/setup-python@v5
@@ -315,7 +315,7 @@ jobs:
 
     steps:
       - name: Get Source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize Python
         uses: actions/setup-python@v5
@@ -550,7 +550,7 @@ jobs:
 
     steps:
       - name: Get Source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize Python
         uses: actions/setup-python@v5
@@ -685,7 +685,7 @@ jobs:
 
     steps:
       - name: Get Source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize Python
         uses: actions/setup-python@v5

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -152,14 +152,14 @@ jobs:
           - name: Linux
             os: ubuntu-22.04
             python-version: '3.8'
-            packages: python3-zmq qttools5-dev qtbase5-dev qttools5-dev-tools libqt5svg5-dev libqt5charts5-dev qt5-image-formats-plugins libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libminiupnpc-dev libzmq3-dev libqrencode-dev libgmp-dev libsodium-dev cargo
+            packages: python3-zmq qttools5-dev qtbase5-dev qttools5-dev-tools libqt5svg5-dev libqt5charts5-dev qt5-image-formats-plugins libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev libqrencode-dev libgmp-dev libsodium-dev cargo
             cc: gcc
             cxx: g++
 
           - name: Linux-latest
             os: ubuntu-24.04
             python-version: '3.8'
-            packages: python3-zmq qttools5-dev qtbase5-dev qttools5-dev-tools libqt5svg5-dev libqt5charts5-dev qt5-image-formats-plugins libevent-dev bsdmainutils libboost-system1.74-dev libboost-filesystem1.74-dev libboost-chrono1.74-dev libboost-test1.74-dev libboost-thread1.74-dev libminiupnpc-dev libzmq3-dev libqrencode-dev libgmp-dev libsodium-dev cargo
+            packages: python3-zmq qttools5-dev qtbase5-dev qttools5-dev-tools libqt5svg5-dev libqt5charts5-dev qt5-image-formats-plugins libevent-dev bsdmainutils libboost-system1.74-dev libboost-filesystem1.74-dev libboost-chrono1.74-dev libboost-test1.74-dev libboost-thread1.74-dev libminiupnpc-dev libnatpmp-dev libzmq3-dev libqrencode-dev libgmp-dev libsodium-dev cargo
             cc: gcc
             cxx: g++
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -166,7 +166,7 @@ jobs:
           - name: macOS
             os: macos-15-intel
             python-version: '3.10'
-            packages: autoconf automake libtool boost miniupnpc libnatpmp pkg-config qt@5 zmq libevent qrencode gmp libsodium
+            packages: autoconf automake libtool boost@1.85 miniupnpc libnatpmp pkg-config qt@5 zmq libevent qrencode gmp libsodium
             boost_root: true
             cc: clang
             cxx: clang++
@@ -174,7 +174,7 @@ jobs:
           - name: macOS-latest
             os: macos-15
             python-version: '3.12'
-            packages: autoconf automake libtool boost miniupnpc libnatpmp pkg-config qt@5 zmq libevent qrencode gmp libsodium
+            packages: autoconf automake libtool boost@1.85 miniupnpc libnatpmp pkg-config qt@5 zmq libevent qrencode gmp libsodium
             boost_root: true
             cc: clang
             cxx: clang++
@@ -293,25 +293,25 @@ jobs:
             id: macOS-nodepends
             os: macos-15-intel
             python-version: '3.10'
-            packages: autoconf automake ccache libtool boost miniupnpc libnatpmp pkg-config qt@5 zmq libevent qrencode gmp libsodium librsvg
+            packages: autoconf automake ccache libtool boost@1.85 miniupnpc libnatpmp pkg-config qt@5 zmq libevent qrencode gmp libsodium librsvg
             unit_tests: true
             functional_tests: true
             goal: deploy
             cc: clang
             cxx: clang++
-            BITCOIN_CONFIG: "--enable-zmq --enable-gui --enable-reduce-exports --enable-werror --enable-debug --with-boost=/usr/local/opt/boost"
+            BITCOIN_CONFIG: "--enable-zmq --enable-gui --enable-reduce-exports --enable-werror --enable-debug"
 
           - name: arm64-macOS-latest
             id: macOS-nodepends-latest
             os: macos-15
             python-version: '3.12'
-            packages: autoconf automake ccache libtool boost miniupnpc libnatpmp pkg-config qt@5 zmq libevent qrencode gmp libsodium librsvg
+            packages: autoconf automake ccache libtool boost@1.85 miniupnpc libnatpmp pkg-config qt@5 zmq libevent qrencode gmp libsodium librsvg
             unit_tests: true
             functional_tests: true
             goal: deploy
             cc: clang
             cxx: clang++
-            BITCOIN_CONFIG: "--enable-zmq --enable-gui --enable-reduce-exports --enable-werror --enable-debug --with-boost=/opt/homebrew/opt/boost"
+            BITCOIN_CONFIG: "--enable-zmq --enable-gui --enable-reduce-exports --enable-werror --enable-debug"
 
     steps:
       - name: Get Source
@@ -456,13 +456,13 @@ jobs:
             id: macOS-nodepends
             os: macos-15-intel
             python-version: '3.10'
-            packages: boost miniupnpc libnatpmp pkg-config zmq libevent qrencode gmp libsodium
+            packages: boost@1.85 miniupnpc libnatpmp pkg-config zmq libevent qrencode gmp libsodium
 
           - name: arm64-macOS-latest
             id: macOS-nodepends-latest
             os: macos-15
             python-version: '3.12'
-            packages: boost miniupnpc libnatpmp pkg-config zmq libevent qrencode gmp libsodium
+            packages: boost@1.85 miniupnpc libnatpmp pkg-config zmq libevent qrencode gmp libsodium
 
     steps:
       - name: Initialize Python

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -482,7 +482,7 @@ jobs:
           pip install pyzmq
 
       - name: Download Build Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: native-${{ matrix.config.os }}-built
 
@@ -871,7 +871,7 @@ jobs:
           pip install pyzmq
 
       - name: Download Build Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ matrix.config.host }}-built
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -5,6 +5,7 @@
 
 export LC_ALL=C
 set -e
+
 srcdir="$(dirname $0)"
 cd "$srcdir"
 if [ -z ${LIBTOOLIZE} ] && GLIBTOOLIZE="$(command -v glibtoolize)"; then
@@ -13,4 +14,11 @@ if [ -z ${LIBTOOLIZE} ] && GLIBTOOLIZE="$(command -v glibtoolize)"; then
 fi
 command -v autoreconf >/dev/null || \
   (echo "configuration failed, please install autoconf first" && exit 1)
-autoreconf --install --force --warnings=all
+
+if autoreconf --help | grep -q -- "--replace-handwritten"; then
+  echo "--replace-handwritten supported"
+  autoreconf --verbose --replace-handwritten --install --force --warnings=all
+else
+  echo "--replace-handwritten NOT supported"
+  autoreconf --verbose --install --force --warnings=all
+fi

--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -1,9 +1,22 @@
 #!/bin/sh
-
+# Copyright (c) 2017-2021 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
 # Install libdb4.8 (Berkeley DB).
-
 export LC_ALL=C
 set -e
+
+# Set C_FLAG for Mac OS version > 11.0.0
+# shellcheck disable=SC2039,SC2004
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  os_ver_str=$(sw_vers -productVersion)
+  os_ver=${os_ver_str//.}
+  required_ver=1100
+
+  if (($os_ver > $required_ver)); then
+	  export CFLAGS="-Wno-error=implicit-function-declaration"
+  fi
+fi
 
 if [ -z "${1}" ]; then
   echo "Usage: $0 <base-dir> [<ci-mode>] [<extra-bdb-configure-flag> ...]"
@@ -37,16 +50,17 @@ check_exists() {
 sha256_check() {
   # Args: <sha256_hash> <filename>
   #
-  if check_exists sha256sum; then
-    echo "${1}  ${2}" | sha256sum -c
-  elif check_exists sha256; then
-    if [ "$(uname)" = "FreeBSD" ]; then
-      sha256 -c "${1}" "${2}"
-    else
-      echo "${1}  ${2}" | sha256 -c
-    fi
-  else
+  if [ "$(uname)" = "FreeBSD" ]; then
+    # sha256sum exists on FreeBSD, but takes different arguments than the GNU version
+    sha256 -c "${1}" "${2}"
+  elif [ "$(uname)" = "Darwin" ]; then
     echo "${1}  ${2}" | shasum -a 256 -c
+  elif check_exists sha256sum; then
+    echo "${1} ${2}" | sha256sum -c
+  elif check_exists sha256; then
+    echo "${1} ${2}" | sha256 -c
+  else
+    echo "${1} ${2}" | shasum -a 256 -c
   fi
 }
 

--- a/params/install-params.sh
+++ b/params/install-params.sh
@@ -45,11 +45,14 @@ function install_params {
         filename="share/pivx/$filename"
     fi
 
-    if ! [ -f "$output" ]
-    then
+    if ! [ -f "$output" ]; then
+      if [ "$(uname)" = "Darwin" ]; then
+        echo "$expectedhash  $filename" | shasum -a 256 -c
+      else
         "$SHA256CMD" $SHA256ARGS -c <<EOF
 $expectedhash  $filename
 EOF
+      fi
 
         # Check the exit code of the shasum command:
         CHECKSUM_RESULT=$?


### PR DESCRIPTION
Updates the CI system to be compatible with recent changes to github actions:

- use new actions versions
- use macOS 15 instead of now-defunct older versions
- add a fix for newer versions of autoreconf