### PR TITLE
[LLMQ] Use a 20 member quorum for testnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -81,6 +81,30 @@ static Consensus::LLMQParams llmq_test = {
         .cacheDkgInterval = 60,
 };
 
+// Small quorum for networks with a masternode count in the tens. Sized well below
+// the fleet so that membership actually rotates between DKGs instead of every
+// masternode landing in every quorum.
+static Consensus::LLMQParams llmq20_60 = {
+        .type = Consensus::LLMQ_20_60,
+        .name = "llmq_20_60",
+        .size = 20,
+        .minSize = 16,
+        .threshold = 12,
+
+        .dkgInterval = 60, // one DKG per hour
+        .dkgPhaseBlocks = 6,
+        .dkgMiningWindowStart = 30, // dkgPhaseBlocks * 5 = after finalization
+        .dkgMiningWindowEnd = 40,
+        .dkgBadVotesThreshold = 16,
+
+        .signingActiveQuorumCount = 24, // a full day worth of LLMQs
+
+        .keepOldConnections = 25,
+        .recoveryMembers = 10,
+
+        .cacheDkgInterval = 600,
+};
+
 static Consensus::LLMQParams llmq50_60 = {
         .type = Consensus::LLMQ_50_60,
         .name = "llmq_50_60",
@@ -498,13 +522,14 @@ public:
         bech32HRPs[BLS_PUBLIC_KEY]               = "bls-pk-test";
 
         // long living quorum params
+        consensus.llmqs[Consensus::LLMQ_20_60] = llmq20_60;
         consensus.llmqs[Consensus::LLMQ_50_60] = llmq50_60;
         consensus.llmqs[Consensus::LLMQ_400_60] = llmq400_60;
         consensus.llmqs[Consensus::LLMQ_400_85] = llmq400_85;
 
         nLLMQConnectionRetryTimeout = 60;
 
-        consensus.llmqTypeChainLocks = Consensus::LLMQ_50_60;
+        consensus.llmqTypeChainLocks = Consensus::LLMQ_20_60;
 
         // Tier two
         nFulfilledRequestExpireTime = 60 * 60; // fulfilled requests expire in 1 hour

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -93,6 +93,7 @@ enum LLMQType : uint8_t
     LLMQ_50_60 = 1, // 50 members, 30 (60%) threshold, one per hour
     LLMQ_400_60 = 2, // 400 members, 240 (60%) threshold, one every 12 hours
     LLMQ_400_85 = 3, // 400 members, 340 (85%) threshold, one every 24 hours
+    LLMQ_20_60 = 4, // 20 members, 12 (60%) threshold, one per hour
 
     // for testing only
     LLMQ_TEST = 100, // 3 members, 2 (66%) threshold, one per hour. Params might differ when -llmqtestparams is used


### PR DESCRIPTION
Testnet chainlocks are on LLMQ_50_60, which needs 40 valid members. The testnet
fleet is around 40 masternodes, so every DKG has to enlist all of them, and one
node being offline is enough to kill the session. Membership never changes
either, since the quorum is the same size as the set it gets drawn from.

This adds LLMQ_20_60 with 20 members, a minimum of 16 and a threshold of 12,
keeping the same ratios the 50 member set uses, and points testnet chainlocks
at it. DKG interval, phase blocks and mining window are unchanged so the timing
stays the same.

With 40 masternodes, a 20 member quorum gets redrawn from the full list every
interval, so quorums actually rotate, and we can have 4 nodes offline without
stalling chainlocks.