### PR TITLE
[Consensus] Reject ProRegTx that spends its own collateral

### DIFF
--- a/src/evo/specialtx_validation.cpp
+++ b/src/evo/specialtx_validation.cpp
@@ -143,6 +143,20 @@ static bool CheckProRegTx(const CTransaction& tx, const CBlockIndex* pindexPrev,
         // This is checked only when pindexPrev is not null (thus during ConnectBlock-->CheckSpecialTx),
         // because this is a contextual check: we need the updated utxo set, to verify that
         // the coin exists and it is unspent.
+
+        // Spending the declared collateral in the same tx halts block production.
+        // AcceptToMemoryPool calls this before applying inputs to the view, so GetUTXOCoin
+        // below still finds the coin and the tx is accepted. ConnectBlock runs UpdateCoins
+        // (validation.cpp:1602) before ProcessSpecialTxsInBlock (:1671), so by then the coin
+        // is spent, CheckSpecialTx fails, and BlockAssembler throws instead of dropping the
+        // tx (blockassembler.cpp:253). Reject at mempool time. Checked ahead of GetUTXOCoin
+        // so the reject reason names the real cause at both call sites.
+        for (const CTxIn& txin : tx.vin) {
+            if (txin.prevout == pl.collateralOutpoint) {
+                return state.DoS(10, false, REJECT_INVALID, "bad-protx-collateral-used-as-input");
+            }
+        }
+
         Coin coin;
         if (!view->GetUTXOCoin(pl.collateralOutpoint, coin)) {
             return state.DoS(10, false, REJECT_INVALID, "bad-protx-collateral");

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -467,6 +467,39 @@ BOOST_FIXTURE_TEST_CASE(dip3_protx, TestChain400Setup)
         BOOST_CHECK(!WITH_LOCK(cs_main, return CheckSpecialTx(tx, chainTip, view, state); ));
         BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-protx-collateral");
     }
+    // Try to register spending the declared external collateral in the same tx.
+    // Without the guard this reaches the mempool, because AcceptToMemoryPool validates
+    // before applying inputs to the view, and then halts block production: ConnectBlock
+    // runs UpdateCoins first, so the collateral is spent by the time CheckSpecialTx runs
+    // and BlockAssembler throws rather than dropping the tx.
+    {
+        CMutableTransaction mtx;
+        const COutPoint& coll_out = CreateNewUTXO(utxos, mtx, coinbaseKey, Params().GetConsensus().nMNCollateralAmt);
+        CreateAndProcessBlock({mtx}, coinbaseKey);
+        chainTip = chainActive.Tip();
+        BOOST_CHECK_EQUAL(chainTip->nHeight, ++nHeight);
+        Coin coll_coin;
+        BOOST_CHECK(view->GetUTXOCoin(coll_out, coll_coin));
+
+        auto tx = CreateProRegTx(Optional<COutPoint>(coll_out), utxos, port, GenerateRandomAddress(), coinbaseKey, GetRandomKey(), GetRandomBLSKey().GetPublicKey());
+        // Spend the collateral, then make the tx valid in every other respect: refresh the
+        // inputs hash and prove collateral ownership. Without a fully valid tx this would
+        // be rejected by CheckStringSig and never exercise the collateral rule at all.
+        tx.vin.emplace_back(coll_out);
+        ProRegPL pl;
+        BOOST_CHECK(GetTxPayload(tx, pl));
+        pl.inputsHash = CalcTxInputsHash(CTransaction(tx));
+        pl.vchSig.clear();
+        BOOST_CHECK(CMessageSigner::SignMessage(pl.MakeSignString(), pl.vchSig, coinbaseKey));
+        SetTxPayload(tx, pl);
+        SignTransaction(tx, coinbaseKey);
+
+        CValidationState state;
+        BOOST_CHECK(!WITH_LOCK(cs_main, return CheckSpecialTx(tx, chainTip, view, state); ));
+        BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-protx-collateral-used-as-input");
+
+        utxos.emplace(coll_out, std::make_pair(coll_coin.nHeight, coll_coin.out.nValue));
+    }
     // Try to register with invalid internal collateral
     {
         auto tx = CreateProRegTx(nullopt, utxos, port, GenerateRandomAddress(), coinbaseKey, GetRandomKey(), GetRandomBLSKey().GetPublicKey(), 0, true);


### PR DESCRIPTION
A ProRegTx whose VIN includes the collateral outpoint it declares passes full validation today and halts block production when ProRegTx is enabled.

## Path

`AcceptToMemoryPool` calls `CheckSpecialTx` (validation.cpp:491) before the tx's inputs are applied to the view, so `GetUTXOCoin` still finds the collateral and the tx is accepted to the mempool.

`ConnectBlock` runs `UpdateCoins` before `ProcessSpecialTxsInBlock`. By then, the collateral is spent, `CheckProRegTx` fails, and `BlockAssembler` throws on the `TestBlockValidity` failure rather than dropping the tx. Block production stops for as long as the tx is in the mempool.

`existsProviderTxConflict` does not catch it: `mapNextTx` records other transactions' inputs and cannot see the candidate's own.

## Fix

Rejecting the tx at mempool time with `bad-protx-collateral-used-as-input`.

Placed ahead of `GetUTXOCoin` so the reject reason names the real cause at both call sites. After it, the ConnectBlock path reports `bad-protx-collateral` instead, which sends you looking at the UTXO set.

Only the external-collateral branch needs it. When `collateralOutpoint.hash` is null, the collateral is an output of this same tx and cannot also be one of its inputs.

## Test

The regression test builds a fully valid ProRegTx, collateral ownership signature included. `CreateProRegTx` never sets `vchSig`, so no existing test constructs a valid external-collateral ProRegTx, and a test without it is rejected by `CheckStringSig` and never reaches the collateral rule.

Without this commit, `CheckSpecialTx` returns true for that tx with an empty reject reason. With it, `bad-protx-collateral-used-as

Verified locally: 11/11 cases pass across `determinis `evo_specialtx_tests` and `evo_trivialvalidation`.

## Origin

Extracted from #2804, where it is one commit inside a 4500-line GUI change. #2804 will drop this on rebase.