### PR TITLE
[Build] fix be32enc redefinition on macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -779,6 +779,14 @@ AC_CHECK_DECLS([bswap_16, bswap_32, bswap_64],,,
                  #include <byteswap.h>
                  #endif])
 
+dnl FreeBSD and recent macOS SDKs declare be32enc in sys/endian.h; older ones do
+dnl not. crypto/scrypt.cpp defines its own when the platform does not, so the test
+dnl has to be for the declaration rather than for the operating system.
+AC_CHECK_DECLS([be32enc],,,
+		[#if HAVE_SYS_ENDIAN_H
+                 #include <sys/endian.h>
+                 #endif])
+
 AC_CHECK_DECLS([__builtin_clz, __builtin_clzl, __builtin_clzll])
 
 dnl Check for MSG_NOSIGNAL

--- a/src/crypto/scrypt.cpp
+++ b/src/crypto/scrypt.cpp
@@ -34,12 +34,20 @@
 #include "uint256.h"
 #include "utilstrencodings.h"
 
+#if defined(HAVE_CONFIG_H)
+#include <config/pivx-config.h>
+#endif
+
 #include <string>
 
 #include <string.h>
 #include <stdint.h>
 
-#ifndef __FreeBSD__
+// FreeBSD and recent macOS SDKs declare this in sys/endian.h, older macOS SDKs do
+// not, so the test is for the declaration and not for the platform. Guarding on
+// __APPLE__ alone broke every macOS CI job: the definition was excluded on runners
+// whose SDK does not provide one.
+#if !HAVE_DECL_BE32ENC
 static inline void be32enc(void *pp, uint32_t x)
 {
     uint8_t *p = (uint8_t *)pp;


### PR DESCRIPTION
Current macOS SDKs declare be32enc in sys/endian.h, so guarding on __FreeBSD__ alone no longer holds and the native build fails.